### PR TITLE
Add a logging Connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: rust
 sudo: required
 dist: trusty
@@ -28,8 +29,10 @@ script:
   fi &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
     (cd diesel_tests && travis-cargo test -- --no-default-features --features "unstable_$BACKEND")
+    (cd diesel_tests && RUST_TEST_THREADS=1 travis-cargo test -- --no-default-features --features "unstable_$BACKEND debug_$BACKEND")
   else
     (cd diesel_tests && travis-cargo test -- --no-default-features --features "stable_$BACKEND")
+    (cd diesel_tests && RUST_TEST_THREADS=1 travis-cargo test -- --no-default-features --features "stable_$BACKEND debug_$BACKEND")
   fi &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
     (cd diesel_compile_tests && travis-cargo test)

--- a/bin/test
+++ b/bin/test
@@ -13,6 +13,8 @@ else
   (cd diesel_cli && cargo test --features "sqlite" --no-default-features)
   (cd diesel_codegen_syntex && cargo test --no-default-features --features "postgres")
   (cd diesel_tests && cargo test --features "unstable_postgres" --no-default-features)
+  (cd diesel_tests && RUST_TEST_THREADS=1 cargo test --features "unstable_postgres debug_postgres" --no-default-features)
   (cd diesel_tests && DATABASE_URL=/tmp/test.db cargo test --features "unstable_sqlite" --no-default-features)
+  (cd diesel_tests && RUST_TEST_THREADS=1 DATABASE_URL=/tmp/test.db cargo test --features "unstable_sqlite debug_sqlite" --no-default-features)
   (cd diesel_compile_tests && cargo test)
 fi;

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "0.3.*"
 quickcheck = { version = "0.2.25", optional = true }
 chrono = { version = "^0.2.17", optional = true }
 uuid = { version = "^0.2.0", optional = true, features = ["use_std"] }
+log = { version = "0.3", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.2.25"

--- a/diesel/src/debug_connection/mod.rs
+++ b/diesel/src/debug_connection/mod.rs
@@ -1,0 +1,123 @@
+use connection::{SimpleConnection, Connection};
+use result::*;
+use query_builder::{QueryFragment, QueryId};
+use types::HasSqlType;
+use query_source::Queryable;
+#[cfg(feature = "log")]
+use connection::DebugSql;
+
+#[cfg(not(feature = "log"))]
+#[macro_use]
+mod no_log{
+    #[macro_export]
+    macro_rules! debug {
+        (target: $target:expr, $($arg:tt)*) => {};
+        ($($arg:tt)*) => {};
+    }
+
+}
+
+
+/// Wrapper to add logging statements to a connection. When calling a
+/// function on this Connection there will be a call to the debug! macro
+/// of the log crate. Logging is only enabled if diesel is build with the log
+/// feature flag.
+///
+/// Example usage
+/// -------------
+///
+/// ```rust
+/// # extern crate diesel;
+/// # #[cfg(feature = "postgres")]
+/// # type ActualConnection = ::diesel::pg::PgConnection;
+/// # #[cfg(not(feature = "postgres"))]
+/// # type ActualConnection = ::diesel::sqlite::SqliteConnection;
+/// # use diesel::Connection;
+/// # fn main() {
+/// #     use diesel::debug_connection::DebugConnection;
+/// let conn = DebugConnection::<ActualConnection>::establish("your-database-url");
+/// // Use the debug connection normally
+/// # }
+/// ```
+#[allow(missing_debug_implementations)]
+pub struct DebugConnection<Conn: Connection> {
+    inner_connection: Conn,
+}
+
+
+impl<Conn: Connection> SimpleConnection for DebugConnection<Conn> {
+    fn batch_execute(&self, query: &str) -> QueryResult<()> {
+        debug!("batch execute: {}", query);
+        self.inner_connection.batch_execute(query)
+    }
+}
+
+impl<Conn: Connection> Connection for DebugConnection<Conn> {
+    type Backend = Conn::Backend;
+    type RawConnection = Conn::RawConnection;
+    type PreparedQuery = Conn::PreparedQuery;
+
+    fn establish(database_url: &str) -> ConnectionResult<Self> {
+        debug!("establish connection to {}", database_url);
+        let inner = try!(Conn::establish(database_url));
+        Ok(DebugConnection { inner_connection: inner })
+    }
+
+    fn execute(&self, query: &str) -> QueryResult<usize> {
+        debug!("execute query: {}", query);
+        self.inner_connection.execute(query)
+    }
+
+    fn _query_all<ST, U>(&self, prepared: Self::PreparedQuery) -> QueryResult<Vec<U>>  where
+        Self::Backend: HasSqlType<ST>,
+        U: Queryable<ST, Self::Backend>
+    {
+        debug!("QueryAll: {}", prepared.get_debug_sql(self._get_raw_connection()));
+        self.inner_connection._query_all::<ST, U>(prepared)
+    }
+
+    fn _execute_returning_count(&self, prepared: Self::PreparedQuery) -> QueryResult<usize>
+    {
+        debug!("execute_returing_count: {}", prepared.get_debug_sql(self._get_raw_connection()));
+        self.inner_connection._execute_returning_count(prepared)
+    }
+
+    fn silence_notices<F: FnOnce() -> T, T>(&self, f: F) -> T {
+        self.inner_connection.silence_notices(f)
+    }
+
+    fn begin_transaction(&self) -> QueryResult<()> {
+        debug!("begin transaction!");
+        self.inner_connection.begin_transaction()
+    }
+
+    fn rollback_transaction(&self) -> QueryResult<()> {
+        debug!("rollback transaction!");
+        self.inner_connection.rollback_transaction()
+    }
+
+    fn commit_transaction(&self) -> QueryResult<()> {
+        debug!("commit transaction!");
+        self.inner_connection.commit_transaction()
+    }
+
+    fn get_transaction_depth(&self) -> i32 {
+        let res = self.inner_connection.get_transaction_depth();
+        debug!("get transaction depth: {}", res);
+        res
+    }
+
+    fn setup_helper_functions(&self) {
+        debug!("setup helper functions! {}", "todo what?");
+        self.inner_connection.setup_helper_functions();
+    }
+
+    fn prepare_query<T: QueryFragment<Self::Backend> + QueryId>(&self, source: &T)
+        -> QueryResult<Self::PreparedQuery> {
+        self.inner_connection.prepare_query(source)
+    }
+
+    fn _get_raw_connection(&self) -> &Self::RawConnection {
+        self.inner_connection._get_raw_connection()
+    }
+}

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -3,7 +3,9 @@
 //! found on our website.
 #![deny(warnings, missing_debug_implementations, missing_copy_implementations)]
 #![cfg_attr(feature = "unstable", feature(specialization))]
-
+#[cfg(feature = "log")]
+#[macro_use]
+extern crate log;
 #[macro_use]
 mod macros;
 
@@ -32,6 +34,7 @@ pub mod query_source;
 pub mod result;
 #[doc(hidden)]
 pub mod row;
+pub mod debug_connection;
 
 pub mod helper_types {
     //! Provide helper types for concisely writing the return type of functions.

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -8,6 +8,7 @@ use self::pq_sys::*;
 use std::ffi::CStr;
 use std::{str, slice, mem};
 
+#[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct PgResult {
     internal_result: *mut PGresult,
 }

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -2,6 +2,7 @@ use pg::Pg;
 use row::Row;
 use super::result::PgResult;
 
+#[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct PgRow<'a> {
     db_result: &'a PgResult,
     row_idx: usize,

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -12,6 +12,7 @@ pub struct SqliteValue {
     col_index: libc::c_int,
 }
 
+#[allow(missing_debug_implementations)]
 pub struct SqliteRow {
     value: SqliteValue,
     next_col_index: libc::c_int,

--- a/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
@@ -3,6 +3,7 @@ extern crate diesel;
 
 use diesel::*;
 use diesel::sqlite::SqliteConnection;
+use diesel::debug_connection::DebugConnection;
 use diesel::types::*;
 use diesel::expression::dsl::*;
 
@@ -19,18 +20,31 @@ sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 fn main() {
     use self::users::dsl::*;
     let connection = SqliteConnection::establish(":memory:").unwrap();
+    let debug_connection = DebugConnection::<SqliteConnection>::establish(":memory:").unwrap();
 
     users.select(id).filter(name.eq(any(Vec::<String>::new())))
         .load::<i32>(&connection);
     //~^ ERROR type mismatch resolving `<diesel::sqlite::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
+    users.select(id).filter(name.eq(any(Vec::<String>::new())))
+        .load::<i32>(&debug_connection);
+    //~^ ERROR type mismatch resolving `<diesel::debug_connection::DebugConnection<diesel::sqlite::SqliteConnection> as diesel::Connection>::Backend == diesel::pg::Pg`
     users.select(id).filter(name.is_not_distinct_from("Sean"))
         .load::<i32>(&connection);
+    //~^ ERROR E0277
+    users.select(id).filter(name.is_not_distinct_from("Sean"))
+        .load::<i32>(&debug_connection);
     //~^ ERROR E0277
     let n = lower("sean").aliased("n");
     users.with(n).select(id)
         .load::<i32>(&connection);
     //~^ ERROR E0277
+    users.with(n).select(id)
+        .load::<i32>(&debug_connection);
+    //~^ ERROR E0277
     users.select(id).filter(now.eq(now.at_time_zone("UTC")))
         .load::<i32>(&connection);
+    //~^ ERROR E0277
+    users.select(id).filter(now.eq(now.at_time_zone("UTC")))
+        .load::<i32>(&debug_connection);
     //~^ ERROR E0277
 }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -20,17 +20,25 @@ diesel_codegen = { path = "../diesel_codegen", default-features = false, optiona
 dotenv_macros = { version = "0.9.0", optional = true }
 quickcheck = "0.2.25"
 uuid = { version = "^0.2.0" }
+log = { version = "0.3", optional = true }
+lazy_static = "0.2.1"
+
 
 [features]
 default = ["with-syntex"]
 unstable = ["diesel/unstable", "dotenv_macros", "diesel_codegen"]
 with-syntex = ["syntex", "dotenv_codegen", "diesel_codegen_syntex"]
-postgres = ["diesel/postgres"]
-sqlite = ["diesel/sqlite"]
-stable_postgres = ["with-syntex", "postgres", "diesel_codegen_syntex/postgres"]
-stable_sqlite = ["with-syntex", "sqlite", "diesel_codegen_syntex/sqlite"]
-unstable_postgres = ["unstable", "postgres", "diesel_codegen/postgres"]
-unstable_sqlite = ["unstable", "sqlite", "diesel_codegen/sqlite"]
+postgres = ["pg"]
+sqlite = ["sq"]
+pg = ["diesel/postgres"]
+sq = ["diesel/sqlite"]
+stable_postgres = ["with-syntex", "pg", "diesel_codegen_syntex/postgres"]
+stable_sqlite = ["with-syntex", "sq", "diesel_codegen_syntex/sqlite"]
+unstable_postgres = ["unstable", "pg", "diesel_codegen/postgres"]
+unstable_sqlite = ["unstable", "sq", "diesel_codegen/sqlite"]
+debug_sqlite = ["debug", "sq"]
+debug = ["diesel/log", "log"]
+debug_postgres = ["debug", "pg"]
 
 [[test]]
 name = "integration_tests"

--- a/diesel_tests/build.rs
+++ b/diesel_tests/build.rs
@@ -31,9 +31,9 @@ use self::diesel::*;
 use self::dotenv::dotenv;
 use std::io;
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 use self::diesel::pg::PgConnection;
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn connection() -> PgConnection {
     dotenv().ok();
     let database_url = ::std::env::var("DATABASE_URL")
@@ -41,9 +41,10 @@ fn connection() -> PgConnection {
     PgConnection::establish(&database_url).unwrap()
 }
 
-#[cfg(feature = "sqlite")]
+
+#[cfg(feature = "sq")]
 use self::diesel::sqlite::SqliteConnection;
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "sq")]
 fn connection() -> SqliteConnection {
     dotenv().ok();
     let database_url = ::std::env::var("DATABASE_URL")
@@ -52,10 +53,10 @@ fn connection() -> SqliteConnection {
 }
 
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 const MIGRATION_SUBDIR: &'static str = "postgresql";
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "sq")]
 const MIGRATION_SUBDIR: &'static str = "sqlite";
 
 fn main() {

--- a/diesel_tests/tests/bench.rs
+++ b/diesel_tests/tests/bench.rs
@@ -13,14 +13,14 @@ use self::test::Bencher;
 use self::schema::{users, NewUser, User, Post, TestConnection, posts, batch_insert};
 use diesel::*;
 
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(feature = "sq"))]
 fn connection() -> TestConnection {
     let conn = schema::connection();
     conn.execute("TRUNCATE TABLE USERS").unwrap();
     conn
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "sq")]
 fn connection() -> TestConnection {
     schema::connection()
 }

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -11,7 +11,7 @@ table! {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn managing_updated_at_for_table() {
     use self::auto_time::columns::*;
     use self::auto_time::table as auto_time;

--- a/diesel_tests/tests/debug/debug_connection_test.rs
+++ b/diesel_tests/tests/debug/debug_connection_test.rs
@@ -1,0 +1,92 @@
+extern crate log;
+use self::log::{LogRecord, LogLevel, LogMetadata, SetLoggerError, LogLevelFilter};
+use std::sync::Mutex;
+
+use diesel::*;
+use schema::*;
+
+lazy_static! {
+    static ref MESSAGE_BUFFER: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    static ref LEVEL_BUFFER: Mutex<Vec<LogLevel>> = Mutex::new(Vec::new());
+}
+
+struct TestLogger;
+
+impl log::Log for TestLogger {
+    fn enabled(&self, _metadata: &LogMetadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &LogRecord) {
+        let mut m = MESSAGE_BUFFER.try_lock().unwrap();
+        m.push(format!("{}",record.args()));
+        let mut l = LEVEL_BUFFER.try_lock().unwrap();
+        l.push(record.level());
+    }
+}
+
+impl TestLogger {
+    fn init() -> Result<(), SetLoggerError> {
+        log::set_logger(|max_log_level| {
+            max_log_level.set(LogLevelFilter::Trace);
+            Box::new(TestLogger)
+        })
+    }
+}
+
+
+fn with_logging<F>(work: F) -> (Vec<String>, Vec<LogLevel>) where F: FnOnce() -> () {
+    let _ = TestLogger::init();
+    {
+        let mut m = MESSAGE_BUFFER.lock().unwrap();
+        m.clear();
+        let mut l = LEVEL_BUFFER.lock().unwrap();
+        l.clear();
+    }
+    work();
+    let mut m = MESSAGE_BUFFER.lock().unwrap();
+    let mut l = LEVEL_BUFFER.lock().unwrap();
+    let messages = m.clone();
+    let levels = l.clone();
+    m.clear();
+    l.clear();
+    (messages, levels)
+}
+
+#[test]
+fn simple_select_log() {
+    use schema::users::dsl::*;
+    let connection = connection();
+
+    let (messages, levels) = with_logging(||{
+        let _ = users.load::<User>(&connection).unwrap();
+        let _ = users.filter(id.eq(1)).load::<User>(&connection).unwrap();
+    });
+    assert_eq!(levels, vec![LogLevel::Debug, LogLevel::Debug]);
+    if cfg!(feature = "pg"){
+        assert_eq!(messages, vec!["QueryAll: SELECT \"users\".\"id\", \"users\".\"name\", \"users\".\"hair_color\" FROM \"users\"", "QueryAll: SELECT \"users\".\"id\", \"users\".\"name\", \"users\".\"hair_color\" FROM \"users\" WHERE \"users\".\"id\" = $1"]);
+    } else if cfg!(feature = "sq"){
+        assert_eq!(messages, vec!["QueryAll: SELECT `users`.`id`, `users`.`name`, `users`.`hair_color` FROM `users`", "QueryAll: SELECT `users`.`id`, `users`.`name`, `users`.`hair_color` FROM `users` WHERE `users`.`id` = ?"])
+    } else {
+        panic!("unknown database system");
+    }
+}
+
+#[test]
+fn simple_insert_log() {
+    use schema::users::dsl::*;
+    let connection = connection();
+
+    let (messages, levels) = with_logging(||{
+        let u = NewUser::new("Sean", Some("Black"));
+        insert(&u).into(users).execute(&connection).unwrap();
+    });
+    assert_eq!(levels, vec![LogLevel::Debug]);
+    if cfg!(feature = "pg") {
+        assert_eq!(messages, vec!["execute_returing_count: INSERT INTO \"users\" (\"name\", \"hair_color\") VALUES ($1, $2)"]);
+    } else if cfg!(feature = "sq") {
+        assert_eq!(messages, vec!["execute_returing_count: INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?)"]);
+    } else {
+        panic!("unknown database system");
+    }
+}

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -13,3 +13,6 @@ fn test_debug_output() {
     let command = update(users.filter(id.eq(1))).set(name.eq("new_name"));
     assert_eq!(debug_sql!(command), "UPDATE `users` SET `name` = ? WHERE `users`.`id` = ?")
 }
+
+#[cfg(feature = "debug")]
+mod debug_connection_test;

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -1,6 +1,6 @@
 use schema::connection;
 use diesel::*;
-use diesel::pg::PgConnection;
+use schema::TestConnection;
 use diesel::data_types::*;
 use diesel::expression::dsl::*;
 
@@ -113,7 +113,7 @@ fn adding_interval_to_timestamp() {
     assert_eq!(expected_data, actual_data);
 }
 
-fn setup_test_table(conn: &PgConnection) {
+fn setup_test_table(conn: &TestConnection) {
     conn.execute("CREATE TABLE has_timestamps (
         id SERIAL PRIMARY KEY,
         created_at TIMESTAMP NOT NULL,

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "postgres")] // FIXME: We need to test this on SQLite when we support these types
+#[cfg(feature = "pg")] // FIXME: We need to test this on SQLite when we support these types
 mod date_and_time;
 mod ops;
 
@@ -36,7 +36,7 @@ use diesel::types::VarChar;
 sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn test_with_expression_aliased() {
     let n = lower("sean").aliased("n");
     assert_eq!(
@@ -261,7 +261,7 @@ fn test_avg_for_nullable() {
 }
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: We need to test this on SQLite when we support these types
+#[cfg(feature = "pg")] // FIXME: We need to test this on SQLite when we support these types
 fn test_avg_for_integer() {
     use self::numbers::columns::*;
     use self::numbers::table as numbers;
@@ -296,7 +296,7 @@ table! {
 }
 
 #[test]
-#[cfg(feature = "postgres")] // FIXME: We need to test this on SQLite
+#[cfg(feature = "pg")] // FIXME: We need to test this on SQLite
 fn test_avg_for_numeric() {
     use self::numeric::columns::*;
     use self::numeric::table as numeric;

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -104,7 +104,7 @@ fn filter_by_like() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn filter_by_any() {
     use schema::users::dsl::*;
     use diesel::expression::dsl::any;

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -21,7 +21,7 @@ fn insert_records() {
 }
 
 #[test]
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(feature = "sq"))]
 fn insert_records_using_returning_clause() {
     use schema::users::table as users;
     let connection = connection();
@@ -40,7 +40,7 @@ fn insert_records_using_returning_clause() {
 }
 
 #[test]
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(feature = "sq"))]
 fn insert_records_with_custom_returning_clause() {
     use schema::users::dsl::*;
 
@@ -64,7 +64,7 @@ fn insert_records_with_custom_returning_clause() {
 }
 
 #[test]
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(feature = "sq"))]
 fn batch_insert_with_defaults() {
     use schema::users::table as users;
     let connection = connection();

--- a/diesel_tests/tests/lib.in.rs
+++ b/diesel_tests/tests/lib.in.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(feature = "sq"))]
 mod annotations;
 mod deserialization;
 mod insert;

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -4,6 +4,7 @@
 extern crate quickcheck;
 #[macro_use] extern crate assert_matches;
 #[macro_use] extern crate diesel;
+#[macro_use] extern crate lazy_static;
 
 #[cfg(feature = "unstable")]
 include!("lib.in.rs");

--- a/diesel_tests/tests/macros.rs
+++ b/diesel_tests/tests/macros.rs
@@ -2,7 +2,7 @@
 // probably need to change to deal with how SQLite handles functions. I do not
 // think we need to generically support creation of these functions, as it's
 // different enough in SQLite to avoid.
-#![cfg(feature = "postgres")]
+#![cfg(feature = "pg")]
 use schema::*;
 use diesel::*;
 use diesel::types::{VarChar, BigInt};

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -68,9 +68,9 @@ use diesel::backend::*;
 use diesel::query_builder::*;
 use diesel::result::QueryResult;
 use diesel::types::Integer;
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 use diesel::pg::Pg;
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "sq")]
 use diesel::sqlite::Sqlite;
 
 impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols> where
@@ -153,7 +153,7 @@ impl<DB, Col> QueryFragment<DB> for PrimaryKey<Col> where
 
 impl_query_id!(noop: PrimaryKey<Col>);
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "sq")]
 impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
     Col: QueryFragment<Sqlite>,
 {
@@ -175,7 +175,7 @@ impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
 
 impl_query_id!(noop: AutoIncrement<Col>);
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
     fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
         try!(out.push_identifier((self.0).0.name));

--- a/diesel_tests/tests/transactions.rs
+++ b/diesel_tests/tests/transactions.rs
@@ -11,7 +11,7 @@ macro_rules! try_no_coerce {
 }
 
 #[test]
-#[cfg(not(feature = "sqlite"))] // FIXME: This test is only valid when operating on a file and not :memory:
+#[cfg(not(feature = "sq"))] // FIXME: This test is only valid when operating on a file and not :memory:
 fn transaction_executes_fn_in_a_sql_transaction() {
     let conn1 = connection_without_transaction();
     let conn2 = connection_without_transaction();

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -3,7 +3,7 @@ extern crate chrono;
 
 use schema::*;
 use diesel::*;
-#[cfg(feature="postgres")]
+#[cfg(feature="pg")]
 use diesel::pg::Pg;
 use diesel::types::*;
 
@@ -15,7 +15,7 @@ table! {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn errors_during_deserialization_do_not_panic() {
     use self::chrono::NaiveDateTime;
     use self::has_timestamps::dsl::*;
@@ -38,14 +38,14 @@ fn errors_during_deserialization_do_not_panic() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn boolean_from_sql() {
     assert_eq!(true, query_single_value::<Bool, bool>("'t'::bool"));
     assert_eq!(false, query_single_value::<Bool, bool>("'f'::bool"));
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn boolean_treats_null_as_false_when_predicates_return_null() {
     let connection = connection();
     let one = AsExpression::<Nullable<Integer>>::as_expression(Some(1));
@@ -54,7 +54,7 @@ fn boolean_treats_null_as_false_when_predicates_return_null() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn boolean_to_sql() {
     assert!(query_to_sql_equality::<Bool, bool>("'t'::bool", true));
     assert!(query_to_sql_equality::<Bool, bool>("'f'::bool", false));
@@ -63,7 +63,7 @@ fn boolean_to_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn i16_from_sql() {
     assert_eq!(0, query_single_value::<SmallInt, i16>("0::int2"));
     assert_eq!(-1, query_single_value::<SmallInt, i16>("-1::int2"));
@@ -71,7 +71,7 @@ fn i16_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn i16_to_sql_smallint() {
     assert!(query_to_sql_equality::<SmallInt, i16>("0::int2", 0));
     assert!(query_to_sql_equality::<SmallInt, i16>("-1::int2", -1));
@@ -97,7 +97,7 @@ fn i32_to_sql_integer() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn i64_from_sql() {
     assert_eq!(0, query_single_value::<BigInt, i64>("0::int8"));
     assert_eq!(-1, query_single_value::<BigInt, i64>("-1::int8"));
@@ -106,7 +106,7 @@ fn i64_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn i64_to_sql_bigint() {
     assert!(query_to_sql_equality::<BigInt, i64>("0::int8", 0));
     assert!(query_to_sql_equality::<BigInt, i64>("-1::int8", -1));
@@ -118,7 +118,7 @@ fn i64_to_sql_bigint() {
 use std::{f32, f64};
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn f32_from_sql() {
     assert_eq!(0.0, query_single_value::<Float, f32>("0.0::real"));
     assert_eq!(0.5, query_single_value::<Float, f32>("0.5::real"));
@@ -131,7 +131,7 @@ fn f32_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn f32_to_sql_float() {
     assert!(query_to_sql_equality::<Float, f32>("0.0::real", 0.0));
     assert!(query_to_sql_equality::<Float, f32>("0.5::real", 0.5));
@@ -145,7 +145,7 @@ fn f32_to_sql_float() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn f64_from_sql() {
     assert_eq!(0.0, query_single_value::<Double, f64>("0.0::double precision"));
     assert_eq!(0.5, query_single_value::<Double, f64>("0.5::double precision"));
@@ -158,7 +158,7 @@ fn f64_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn f64_to_sql_float() {
     assert!(query_to_sql_equality::<Double, f64>("0.0::double precision", 0.0));
     assert!(query_to_sql_equality::<Double, f64>("0.5::double precision", 0.5));
@@ -195,7 +195,7 @@ fn string_to_sql_varchar() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn binary_from_sql() {
     let invalid_utf8_bytes = vec![0x1Fu8, 0x8Bu8];
     assert_eq!(invalid_utf8_bytes,
@@ -207,7 +207,7 @@ fn binary_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn bytes_to_sql_binary() {
     let invalid_utf8_bytes = vec![0x1Fu8, 0x8Bu8];
     assert!(query_to_sql_equality::<Binary, Vec<u8>>("E'\\\\x1F8B'::bytea",
@@ -221,7 +221,7 @@ fn bytes_to_sql_binary() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_specific_option_from_sql() {
     assert_eq!(Some(true),
     query_single_value::<Nullable<Bool>, Option<bool>>("'t'::bool"));
@@ -244,7 +244,7 @@ fn option_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_specific_option_to_sql() {
     assert!(query_to_sql_equality::<Nullable<Bool>, Option<bool>>("'t'::bool", Some(true)));
     assert!(!query_to_sql_equality::<Nullable<Bool>, Option<bool>>("'f'::bool", Some(true)));
@@ -264,7 +264,7 @@ fn option_to_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_array_from_sql() {
     assert_eq!(vec![true, false, true],
                query_single_value::<Array<Bool>, Vec<bool>>(
@@ -277,7 +277,7 @@ fn pg_array_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn to_sql_array() {
     assert!(query_to_sql_equality::<Array<Bool>, Vec<bool>>(
             "ARRAY['t', 'f', 't']::bool[]", vec![true, false, true]));
@@ -292,7 +292,7 @@ fn to_sql_array() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_array_containing_null() {
     let query = "ARRAY['Hello', '', NULL, 'world']";
     let data = query_single_value::<Array<Nullable<VarChar>>, Vec<Option<String>>>(query);
@@ -306,7 +306,7 @@ fn pg_array_containing_null() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn timestamp_from_sql() {
     use diesel::data_types::PgTimestamp;
 
@@ -319,7 +319,7 @@ fn timestamp_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_timestamp_to_sql_timestamp() {
     use diesel::data_types::PgTimestamp;
 
@@ -334,7 +334,7 @@ fn pg_timestamp_to_sql_timestamp() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_numeric_from_sql() {
     use diesel::data_types::PgNumeric;
 
@@ -358,7 +358,7 @@ fn pg_numeric_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_uuid_from_sql() {
     extern crate uuid;
 
@@ -371,7 +371,7 @@ fn pg_uuid_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn pg_uuid_to_sql_uuid() {
     extern crate uuid;
 
@@ -386,7 +386,7 @@ fn pg_uuid_to_sql_uuid() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn text_array_can_be_assigned_to_varchar_array_column() {
     let conn = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &conn);
@@ -401,7 +401,7 @@ fn text_array_can_be_assigned_to_varchar_array_column() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 fn third_party_crates_can_add_new_types() {
     use std::error::Error;
     use std::io::prelude::*;

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -56,13 +56,13 @@ macro_rules! test_round_trip {
                 test_type_round_trips::<Nullable<types::$sql_type>, _>(val)
             }
 
-            #[cfg(feature = "postgres")]
+            #[cfg(feature = "pg")]
             fn vec_round_trip(val: Vec<$tpe>) -> bool {
                 let val: Vec<_> = val.into_iter().map($map_fn).collect();
                 test_type_round_trips::<types::Array<types::$sql_type>, _>(val)
             }
 
-            #[cfg(not(feature = "postgres"))]
+            #[cfg(not(feature = "pg"))]
             fn vec_round_trip(_: Vec<$tpe>) -> bool {
                 true
             }
@@ -83,7 +83,7 @@ test_round_trip!(string_roundtrips, VarChar, String);
 test_round_trip!(text_roundtrips, Text, String);
 test_round_trip!(binary_roundtrips, Binary, Vec<u8>);
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "pg")]
 mod pg_types {
     extern crate uuid;
     use super::*;
@@ -123,7 +123,7 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
 }
 
 // FIXME: Needs https://github.com/BurntSushi/quickcheck/pull/128
-// #[cfg(all(feature = "unstable", feature = "postgres"))]
+// #[cfg(all(feature = "unstable", feature = "pg"))]
 // mod unstable_types {
 //     use super::*;
 //     use std::time::*;

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -71,7 +71,7 @@ fn test_updating_multiple_columns() {
 }
 
 #[test]
-#[cfg(not(feature="sqlite"))]
+#[cfg(not(feature="sq"))]
 fn update_returning_struct() {
     use schema::users::dsl::*;
 
@@ -85,7 +85,7 @@ fn update_returning_struct() {
 }
 
 #[test]
-#[cfg(not(feature="sqlite"))]
+#[cfg(not(feature="sq"))]
 fn update_with_custom_returning_clause() {
     use schema::users::dsl::*;
 
@@ -133,6 +133,7 @@ fn update_with_struct_does_not_set_primary_key() {
     assert_eq!(Ok(expected_user), user);
 }
 
+#[cfg(not(feature="sq"))]
 #[test]
 fn save_on_struct_with_primary_key_changes_that_struct() {
     use schema::users::dsl::*;
@@ -146,6 +147,7 @@ fn save_on_struct_with_primary_key_changes_that_struct() {
     assert_eq!(user, user_in_db);
 }
 
+#[cfg(not(feature="sq"))]
 #[test]
 fn option_fields_on_structs_are_not_assigned() {
     use schema::users::dsl::*;
@@ -228,6 +230,7 @@ fn can_update_with_struct_containing_single_field() {
     assert_eq!(expected_post, post);
 }
 
+#[cfg(not(feature="sq"))]
 #[test]
 fn struct_with_option_fields_treated_as_null() {
     #[changeset_for(posts, treat_none_as_null="true")]


### PR DESCRIPTION
- Add a Connectionwrapper that logs each executed sql statement
- Use the native Querybuilder to build the sql queries
- Make logging optional even if DebugConnection is used
