### PR TITLE
Implement prepared statement caching for PG

### DIFF
--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -81,6 +81,42 @@ impl RawConnection {
             result_format,
         )
     }
+
+    pub unsafe fn exec_prepared(
+        &self,
+        stmt_name: *const libc::c_char,
+        param_count: libc::c_int,
+        param_values: *const *const libc::c_char,
+        param_lengths: *const libc::c_int,
+        param_formats: *const libc::c_int,
+        result_format: libc::c_int,
+    ) -> *mut PGresult {
+        PQexecPrepared(
+            self.internal_connection,
+            stmt_name,
+            param_count,
+            param_values,
+            param_lengths,
+            param_formats,
+            result_format,
+        )
+    }
+
+    pub unsafe fn prepare(
+        &self,
+        stmt_name: *const libc::c_char,
+        query: *const libc::c_char,
+        param_count: libc::c_int,
+        param_types: *const Oid,
+    ) -> *mut PGresult {
+        PQprepare(
+            self.internal_connection,
+            stmt_name,
+            query,
+            param_count,
+            param_types,
+        )
+    }
 }
 
 pub type NoticeProcessor = extern "C" fn(arg: *mut libc::c_void, message: *const libc::c_char);

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -2,7 +2,7 @@ extern crate pq_sys;
 extern crate libc;
 
 use result::{Error, QueryResult};
-use super::PgConnection;
+use super::raw::RawConnection;
 use super::row::PgRow;
 
 use self::pq_sys::*;
@@ -14,7 +14,7 @@ pub struct PgResult {
 }
 
 impl PgResult {
-    pub fn new(conn: &PgConnection, internal_result: *mut PGresult) -> QueryResult<Self> {
+    pub fn new(conn: &RawConnection, internal_result: *mut PGresult) -> QueryResult<Self> {
         let result_status = unsafe { PQresultStatus(internal_result) };
         match result_status {
             PGRES_COMMAND_OK | PGRES_TUPLES_OK => {

--- a/diesel/src/pg/connection/stmt/cache.rs
+++ b/diesel/src/pg/connection/stmt/cache.rs
@@ -1,0 +1,71 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+#[cfg(test)]
+use std::ffi::CString;
+use std::rc::Rc;
+
+use result::QueryResult;
+use super::{Query, RawConnection};
+
+pub struct StatementCache {
+    cache: RefCell<HashMap<StatementCacheKey, Rc<Query>>>,
+}
+
+#[derive(Hash, PartialEq, Eq)]
+struct StatementCacheKey {
+    sql: String,
+    bind_types: Vec<u32>,
+}
+
+impl StatementCache {
+    pub fn new() -> Self {
+        StatementCache {
+            cache: RefCell::new(HashMap::new()),
+        }
+    }
+
+    pub fn cached_query(
+        &self,
+        conn: &RawConnection,
+        sql: String,
+        bind_types: Vec<u32>,
+    ) -> QueryResult<Rc<Query>> {
+        let mut cache = self.cache.borrow_mut();
+        let cache_key = StatementCacheKey {
+            sql: sql,
+            bind_types: bind_types
+        };
+
+        // FIXME: This can be cleaned up once https://github.com/rust-lang/rust/issues/32281
+        // is stable
+        if cache.contains_key(&cache_key) {
+            Ok(cache[&cache_key].clone())
+        } else {
+            let name = format!("__diesel_stmt_{}", cache.len() + 1);
+            let statement = Rc::new(try!(Query::prepare(
+                conn,
+                &cache_key.sql,
+                &name,
+                &cache_key.bind_types,
+            )));
+            let entry = cache.entry(cache_key);
+            Ok(entry.or_insert(statement).clone())
+        }
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.cache.borrow().len()
+    }
+
+    #[cfg(test)]
+    pub fn statement_names(&self) -> Vec<CString> {
+        let mut statement_names = self.cache.borrow().iter()
+            .map(|(_, v)| match **v {
+                Query::Prepared { ref name, .. } => name.clone(),
+                _ => unreachable!(),
+            }).collect::<Vec<_>>();
+        statement_names.dedup();
+        statement_names
+    }
+}

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -1,0 +1,106 @@
+extern crate pq_sys;
+extern crate libc;
+
+mod cache;
+
+use std::ffi::CString;
+use std::ptr;
+
+use super::result::PgResult;
+use result::QueryResult;
+
+pub use self::cache::StatementCache;
+pub use super::raw::RawConnection;
+
+pub enum Query {
+    Prepared {
+        name: CString,
+        param_formats: Vec<libc::c_int>,
+    },
+    Sql {
+        query: CString,
+        param_types: Option<Vec<u32>>,
+    },
+}
+
+impl Query {
+    pub fn execute(
+        &self,
+        conn: &RawConnection,
+        param_data: &Vec<Option<Vec<u8>>>,
+    ) -> QueryResult<PgResult> {
+        let params_pointer = param_data.iter()
+            .map(|data| data.as_ref().map(|d| d.as_ptr() as *const libc::c_char)
+                 .unwrap_or(ptr::null()))
+            .collect::<Vec<_>>();
+        let param_lengths = param_data.iter()
+            .map(|data| data.as_ref().map(|d| d.len() as libc::c_int)
+                 .unwrap_or(0))
+            .collect::<Vec<_>>();
+        let internal_res = match *self {
+            Query::Prepared { ref name, ref param_formats } => unsafe {
+                conn.exec_prepared(
+                    name.as_ptr(),
+                    params_pointer.len() as libc::c_int,
+                    params_pointer.as_ptr(),
+                    param_lengths.as_ptr(),
+                    param_formats.as_ptr(),
+                    1,
+                )
+            },
+            Query::Sql { ref query, ref param_types } => {
+                let param_types_ptr = param_types_to_ptr(param_types.as_ref());
+                let param_formats = vec![1; param_data.len()];
+                unsafe { conn.exec_params(
+                    query.as_ptr(),
+                    params_pointer.len() as libc::c_int,
+                    param_types_ptr,
+                    params_pointer.as_ptr(),
+                    param_lengths.as_ptr(),
+                    param_formats.as_ptr(),
+                    1,
+                ) }
+            }
+        };
+
+        PgResult::new(conn, internal_res)
+    }
+
+    pub fn sql(sql: &str, param_types: Option<Vec<u32>>) -> QueryResult<Self> {
+        Ok(Query::Sql {
+            query: try!(CString::new(sql)),
+            param_types: param_types,
+        })
+    }
+
+    pub fn prepare(
+        conn: &RawConnection,
+        sql: &str,
+        name: &str,
+        param_types: &Vec<u32>,
+    ) -> QueryResult<Self> {
+        let name = try!(CString::new(name));
+        let sql = try!(CString::new(sql));
+
+        let internal_result = unsafe {
+            conn.prepare(
+                name.as_ptr(),
+                sql.as_ptr(),
+                param_types.len() as libc::c_int,
+                param_types_to_ptr(Some(&param_types)),
+            )
+        };
+        try!(PgResult::new(conn, internal_result));
+
+        Ok(Query::Prepared {
+            name: name,
+            param_formats: vec![1; param_types.len()],
+        })
+    }
+}
+
+fn param_types_to_ptr(param_types: Option<&Vec<u32>>) -> *const pq_sys::Oid {
+    param_types
+        .map(|types| types.as_ptr())
+        .unwrap_or(ptr::null())
+}


### PR DESCRIPTION
The overall structure is somewhat similar to that for SQLite. I have a
few issues with the implementation, but all of them point to some larger
issues with the pg::connection module and I feel that they're outside of
the scope of this PR. In particular, I don't like how much
`RawConnection` needed to leak for this to be factored well. That struct
lives at a really weird layer of abstraction, to the point that I'm
unsure it should exist at all. I need to give the pg module an update,
as it's full of warts from before `Connection` was generic. That will be
done as a separate PR.

I think there's a common ground between how we implemented this for
SQLite and how we implemented this for PG that I want to eventually
refactor both towards. This may even result in sufficiently generic code
that we can make it part of the `Connection` trait to make this easier
for third party adapters to hook into.

Once again, this results in a healthy performance boost across the
board.

```
name                                                      old ns/iter  new ns/iter    diff ns/iter   diff %
bench_selecting_0_rows_with_medium_complex_query          223,674      119,463            -104,211  -46.59%
bench_selecting_0_rows_with_trivial_query                 77,281       51,273              -26,008  -33.65%
bench_selecting_10k_rows_with_medium_complex_query        57,555,386   55,233,745       -2,321,641   -4.03%
bench_selecting_10k_rows_with_medium_complex_query_boxed  58,937,340   54,434,717       -4,502,623   -7.64%
bench_selecting_10k_rows_with_trivial_query               4,739,991    4,559,375          -180,616   -3.81%
bench_selecting_10k_rows_with_trivial_query_boxed         4,610,084    4,466,172          -143,912   -3.12%
```