### PR TITLE
Make our query builder faster than a SQL string

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 
 use backend::Backend;
-use query_builder::{AsQuery, QueryFragment};
+use query_builder::{AsQuery, QueryFragment, QueryId};
 use query_source::Queryable;
 use result::*;
 use types::HasSqlType;
@@ -69,7 +69,7 @@ pub trait Connection: SimpleConnection + Sized {
     #[doc(hidden)]
     fn query_one<T, U>(&self, source: T) -> QueryResult<U> where
         T: AsQuery,
-        T::Query: QueryFragment<Self::Backend>,
+        T::Query: QueryFragment<Self::Backend> + QueryId,
         Self::Backend: HasSqlType<T::SqlType>,
         U: Queryable<T::SqlType, Self::Backend>,
     {
@@ -80,13 +80,13 @@ pub trait Connection: SimpleConnection + Sized {
     #[doc(hidden)]
     fn query_all<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
         T: AsQuery,
-        T::Query: QueryFragment<Self::Backend>,
+        T::Query: QueryFragment<Self::Backend> + QueryId,
         Self::Backend: HasSqlType<T::SqlType>,
         U: Queryable<T::SqlType, Self::Backend>;
 
     #[doc(hidden)]
     fn execute_returning_count<T>(&self, source: &T) -> QueryResult<usize> where
-        T: QueryFragment<Self::Backend>;
+        T: QueryFragment<Self::Backend> + QueryId;
 
     #[doc(hidden)] fn silence_notices<F: FnOnce() -> T, T>(&self, f: F) -> T;
     #[doc(hidden)] fn begin_transaction(&self) -> QueryResult<()>;

--- a/diesel/src/expression/aliased.rs
+++ b/diesel/src/expression/aliased.rs
@@ -45,6 +45,14 @@ impl<'a, T, DB> QueryFragment<DB> for Aliased<'a, T> where
     }
 }
 
+impl<'a, T> QueryId for Aliased<'a, T> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
+        false
+    }
+}
+
 // FIXME This is incorrect, should only be selectable from WithQuerySource
 impl<'a, T, QS> SelectableExpression<QS> for Aliased<'a, T> where
     Aliased<'a, T>: Expression,

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -62,6 +62,8 @@ impl<T, U, DB> QueryFragment<DB> for In<T, U> where
     }
 }
 
+impl_query_id!(In<T, U>);
+
 use std::marker::PhantomData;
 use query_builder::SelectStatement;
 
@@ -132,6 +134,8 @@ impl<T, DB> QueryFragment<DB> for Many<T> where
     }
 }
 
+impl_query_id!(noop: Many<T>);
+
 pub struct Subselect<T, ST> {
     values: T,
     _sql_type: PhantomData<ST>,
@@ -163,3 +167,5 @@ impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST> where
         self.values.is_safe_to_cache_prepared()
     }
 }
+
+impl_query_id!(Subselect<T, ST>);

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -55,6 +55,14 @@ impl<T, U, DB> QueryFragment<DB> for Bound<T, U> where
     }
 }
 
+impl<T: QueryId, U> QueryId for Bound<T, U> {
+    type QueryId = Bound<T::QueryId, ()>;
+
+    fn has_static_query_id() -> bool {
+        T::has_static_query_id()
+    }
+}
+
 impl<T, U, QS> SelectableExpression<QS> for Bound<T, U> where
     Bound<T, U>: Expression,
 {

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -74,6 +74,8 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
     }
 }
 
+impl_query_id!(Count<T>);
+
 impl<T: Expression, QS> SelectableExpression<QS> for Count<T> {
 }
 
@@ -102,3 +104,5 @@ impl<DB: Backend> QueryFragment<DB> for CountStar {
 
 impl<QS> SelectableExpression<QS> for CountStar {
 }
+
+impl_query_id!(CountStar);

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -49,6 +49,8 @@ macro_rules! fold_function {
             }
         }
 
+        impl_query_id!($type_name<T>);
+
         impl<ST, T, QS> SelectableExpression<QS> for $type_name<T> where
             ST: Foldable,
             T: Expression<SqlType=ST>,

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -46,6 +46,8 @@ macro_rules! ord_function {
             }
         }
 
+        impl_query_id!($type_name<T>);
+
         impl<T: Expression, QS> SelectableExpression<QS> for $type_name<T> {
         }
     }

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -34,6 +34,8 @@ impl<DB: Backend> QueryFragment<DB> for now {
     }
 }
 
+impl_query_id!(now);
+
 operator_allowed!(now, Add, add);
 operator_allowed!(now, Sub, sub);
 sql_function!(date, date_t, (x: Timestamp) -> Date,

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -58,6 +58,8 @@ macro_rules! sql_function_body {
             }
         }
 
+        impl_query_id!($struct_name<$($arg_name),+>);
+
         #[allow(non_camel_case_types)]
         impl<$($arg_name),*, QS> $crate::expression::SelectableExpression<QS> for $struct_name<$($arg_name),*> where
             $($arg_name: $crate::expression::SelectableExpression<QS>,)*
@@ -134,6 +136,8 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
 
         impl $crate::expression::NonAggregate for $type_name {
         }
+
+        impl_query_id!($type_name);
     }
 }
 

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -27,6 +27,8 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
     }
 }
 
+impl_query_id!(Grouped<T>);
+
 impl<T, QS> SelectableExpression<QS> for Grouped<T> where
     T: SelectableExpression<QS>,
     Grouped<T>: Expression,

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -136,7 +136,7 @@ impl<T: NonAggregate + ?Sized> NonAggregate for Box<T> {
 impl<'a, T: NonAggregate + ?Sized> NonAggregate for &'a T {
 }
 
-use query_builder::QueryFragment;
+use query_builder::{QueryFragment, QueryId};
 
 /// Helper trait used when boxing expressions. This exists to work around the
 /// fact that Rust will not let us use non-core types as bounds on a trait
@@ -156,4 +156,12 @@ impl<QS, T, ST, DB> BoxableExpression<QS, ST, DB> for T where
     T: NonAggregate,
     T: QueryFragment<DB>,
 {
+}
+
+impl<QS, ST, DB> QueryId for BoxableExpression<QS, ST, DB, SqlType=ST> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
+        false
+    }
 }

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -42,6 +42,14 @@ impl<T, QS> SelectableExpression<QS> for Nullable<T> where
 {
 }
 
+impl<T: QueryId> QueryId for Nullable<T> {
+    type QueryId = T::QueryId;
+
+    fn has_static_query_id() -> bool {
+        T::has_static_query_id()
+    }
+}
+
 impl<T> NonAggregate for Nullable<T> where
     T: NonAggregate,
     Nullable<T>: Expression,

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -51,6 +51,8 @@ macro_rules! numeric_operation {
             }
         }
 
+        impl_query_id!($name<Lhs, Rhs>);
+
         impl<Lhs, Rhs, QS> SelectableExpression<QS> for $name<Lhs, Rhs> where
             Lhs: SelectableExpression<QS>,
             Rhs: SelectableExpression<QS>,

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -17,6 +17,8 @@ macro_rules! infix_predicate_body {
             }
         }
 
+        impl_query_id!($name<T, U>);
+
         impl<T, U> $crate::expression::Expression for $name<T, U> where
             T: $crate::expression::Expression,
             U: $crate::expression::Expression,
@@ -180,6 +182,8 @@ macro_rules! postfix_predicate_body {
                 }
             }
         }
+
+        impl_query_id!($name<T>);
 
         impl<T> $crate::expression::Expression for $name<T> where
             T: $crate::expression::Expression,

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -44,6 +44,8 @@ impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST> where
     }
 }
 
+impl_query_id!(noop: SqlLiteral<ST>);
+
 impl<ST> Query for SqlLiteral<ST> {
     type SqlType = ST;
 }

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -3,6 +3,12 @@
 //! found in the README.
 #![deny(warnings)]
 #![cfg_attr(feature = "unstable", feature(specialization))]
+
+#[macro_use]
+mod macros;
+#[macro_use]
+pub mod query_builder;
+
 pub mod backend;
 pub mod connection;
 #[macro_use]
@@ -17,11 +23,7 @@ pub mod pg;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
-#[macro_use]
-mod macros;
-
 pub mod migrations;
-pub mod query_builder;
 mod query_dsl;
 pub mod query_source;
 pub mod result;

--- a/diesel/src/macros.rs
+++ b/diesel/src/macros.rs
@@ -35,6 +35,8 @@ macro_rules! column {
             }
         }
 
+        impl_query_id!($column_name);
+
         impl $crate::expression::SelectableExpression<$($table)::*> for $column_name {}
 
         impl<'a, ST, Left, Right> SelectableExpression<
@@ -240,6 +242,8 @@ macro_rules! table_body {
                     ($($column_name,)+)
                 }
             }
+
+            impl_query_id!(table);
 
             pub mod columns {
                 use super::table;

--- a/diesel/src/pg/connection/stmt/cache.rs
+++ b/diesel/src/pg/connection/stmt/cache.rs
@@ -1,10 +1,14 @@
+use std::any::TypeId;
 use std::cell::RefCell;
 use std::collections::HashMap;
 #[cfg(test)]
 use std::ffi::CString;
 use std::rc::Rc;
 
+use pg::{Pg, PgQueryBuilder};
+use query_builder::{QueryFragment, QueryId};
 use result::QueryResult;
+use result::Error::QueryBuilderError;
 use super::{Query, RawConnection};
 
 pub struct StatementCache {
@@ -12,9 +16,28 @@ pub struct StatementCache {
 }
 
 #[derive(Hash, PartialEq, Eq)]
-struct StatementCacheKey {
-    sql: String,
-    bind_types: Vec<u32>,
+enum StatementCacheKey {
+    Type(TypeId),
+    Query {
+        sql: String,
+        bind_types: Vec<u32>,
+    }
+}
+
+impl StatementCacheKey {
+    fn sql(&self) -> Option<&str> {
+        match self {
+            &StatementCacheKey::Query { ref sql, .. } => Some(&*sql),
+            _ => None
+        }
+    }
+
+    fn bind_types(&self) -> Option<&Vec<u32>> {
+        match self {
+            &StatementCacheKey::Query { ref bind_types, .. } => Some(bind_types),
+            _ => None
+        }
+    }
 }
 
 impl StatementCache {
@@ -24,30 +47,37 @@ impl StatementCache {
         }
     }
 
-    pub fn cached_query(
+    pub fn cached_query<T: QueryFragment<Pg> + QueryId>(
         &self,
-        conn: &RawConnection,
-        sql: String,
+        conn: &Rc<RawConnection>,
+        source: &T,
         bind_types: Vec<u32>,
     ) -> QueryResult<Rc<Query>> {
-        let mut cache = self.cache.borrow_mut();
-        let cache_key = StatementCacheKey {
-            sql: sql,
-            bind_types: bind_types
-        };
+        use std::borrow::Cow;
 
+        let mut cache = self.cache.borrow_mut();
+        let (cache_key, maybe_binds) = try!(cache_key(conn, source, bind_types));
         // FIXME: This can be cleaned up once https://github.com/rust-lang/rust/issues/32281
         // is stable
         if cache.contains_key(&cache_key) {
             Ok(cache[&cache_key].clone())
         } else {
             let name = format!("__diesel_stmt_{}", cache.len() + 1);
-            let statement = Rc::new(try!(Query::prepare(
-                conn,
-                &cache_key.sql,
-                &name,
-                &cache_key.bind_types,
-            )));
+            let statement = {
+                let sql = match cache_key.sql() {
+                    Some(sql) => Cow::Borrowed(sql),
+                    None => Cow::Owned(try!(to_sql(conn, source))),
+                };
+                let bind_types = cache_key.bind_types()
+                    .or(maybe_binds.as_ref()).unwrap();
+
+                Rc::new(try!(Query::prepare(
+                    conn,
+                    &sql,
+                    &name,
+                    &bind_types,
+                )))
+            };
             let entry = cache.entry(cache_key);
             Ok(entry.or_insert(statement).clone())
         }
@@ -67,5 +97,30 @@ impl StatementCache {
             }).collect::<Vec<_>>();
         statement_names.dedup();
         statement_names
+    }
+}
+
+fn to_sql<T: QueryFragment<Pg>>(conn: &Rc<RawConnection>, source: &T)
+    -> QueryResult<String>
+{
+    let mut query_builder = PgQueryBuilder::new(conn);
+    try!(source.to_sql(&mut query_builder).map_err(QueryBuilderError));
+    Ok(query_builder.sql)
+}
+
+fn cache_key<T: QueryFragment<Pg> + QueryId>(
+    conn: &Rc<RawConnection>,
+    source: &T,
+    bind_types: Vec<u32>,
+) -> QueryResult<(StatementCacheKey, Option<Vec<u32>>)> {
+    match T::query_id() {
+        Some(id) => Ok((StatementCacheKey::Type(id), Some(bind_types))),
+        None => Ok((
+            StatementCacheKey::Query {
+                sql: try!(to_sql(conn, source)),
+                bind_types: bind_types
+            },
+            None,
+        )),
     }
 }

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -107,6 +107,8 @@ impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
     }
 }
 
+impl_query_id!(Any<Expr, ST>);
+
 impl<Expr, ST, QS> SelectableExpression<QS> for Any<Expr, ST> where
     Pg: HasSqlType<ST>,
     Any<Expr, ST>: Expression,

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -54,6 +54,8 @@ impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz> where
     }
 }
 
+impl_query_id!(AtTimeZone<Ts, Tz>);
+
 impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
     Ts: QueryFragment<Debug>,
     Tz: QueryFragment<Debug>,

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -5,7 +5,7 @@ pub mod extensions;
 #[doc(hidden)]
 pub mod predicates;
 
-mod date_and_time;
+pub mod date_and_time;
 
 /// PostgreSQL specific expression DSL methods. This module will be glob
 /// imported by [`expression::dsl`](../../expression/dsl/index.html) when

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -5,7 +5,7 @@ pub mod extensions;
 #[doc(hidden)]
 pub mod predicates;
 
-pub mod date_and_time;
+mod date_and_time;
 
 /// PostgreSQL specific expression DSL methods. This module will be glob
 /// imported by [`expression::dsl`](../../expression/dsl/index.html) when

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -26,6 +26,8 @@ impl<T> HasSqlType<Array<T>> for Debug where
     fn metadata() {}
 }
 
+impl_query_id!(Array<T>);
+
 impl<T> NotNull for Array<T> {
 }
 

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -21,6 +21,8 @@ macro_rules! simple_clause {
             }
         }
 
+        impl_query_id!($no_clause);
+
         #[derive(Debug, Clone, Copy)]
         pub struct $clause<Expr>(pub Expr);
 
@@ -41,5 +43,7 @@ macro_rules! simple_clause {
                 self.0.is_safe_to_cache_prepared()
             }
         }
+
+        impl_query_id!($clause<Expr>);
     }
 }

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -41,3 +41,4 @@ impl<T, DB> QueryFragment<DB> for DeleteStatement<T> where
     }
 }
 
+impl_query_id!(noop: DeleteStatement<T>);

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use query_builder::{QueryFragment, QueryBuilder, BuildQueryResult};
+use query_builder::*;
 use result::QueryResult;
 
 #[derive(Debug, Clone, Copy)]
@@ -21,6 +21,8 @@ impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
     }
 }
 
+impl_query_id!(NoDistinctClause);
+
 impl<DB: Backend> QueryFragment<DB> for DistinctClause {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         out.push_sql("DISTINCT ");
@@ -35,3 +37,5 @@ impl<DB: Backend> QueryFragment<DB> for DistinctClause {
         true
     }
 }
+
+impl_query_id!(DistinctClause);

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -64,6 +64,8 @@ impl<T, U, DB> QueryFragment<DB> for InsertStatement<T, U> where
     }
 }
 
+impl_query_id!(noop: InsertStatement<T, U>);
+
 impl<T, U> AsQuery for InsertStatement<T, U> where
     T: Table,
     InsertQuery<T::AllColumns, InsertStatement<T, U>>: Query,
@@ -159,3 +161,5 @@ impl<T, U, DB> QueryFragment<DB> for InsertQuery<T, U> where
         false
     }
 }
+
+impl_query_id!(noop: InsertQuery<T, U>);

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -1,25 +1,29 @@
 //! Contains traits responsible for the actual construction of SQL statements
 pub mod debug;
 
+#[macro_use]
+mod query_id;
+#[macro_use]
+mod clause_macro;
+
 pub mod bind_collector;
 mod delete_statement;
 #[doc(hidden)]
 pub mod functions;
 #[doc(hidden)]
 pub mod nodes;
-#[macro_use]
-mod clause_macro;
 mod distinct_clause;
 mod group_by_clause;
 mod limit_clause;
 mod offset_clause;
 mod order_clause;
 mod select_statement;
-mod where_clause;
+pub mod where_clause;
 pub mod insert_statement;
 pub mod update_statement;
 
 pub use self::bind_collector::BindCollector;
+pub use self::query_id::QueryId;
 #[doc(hidden)]
 pub use self::select_statement::{SelectStatement, BoxedSelectStatement};
 #[doc(inline)]

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -1,0 +1,144 @@
+use std::any::{Any, TypeId};
+use super::QueryFragment;
+
+pub trait QueryId {
+    type QueryId: Any;
+    fn has_static_query_id() -> bool;
+
+    fn query_id() -> Option<TypeId> {
+        if Self::has_static_query_id() {
+            Some(TypeId::of::<Self::QueryId>())
+        } else {
+            None
+        }
+    }
+}
+
+impl QueryId for () {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
+        true
+    }
+}
+
+impl<T: QueryId + ?Sized> QueryId for Box<T> {
+    type QueryId = T::QueryId;
+
+    fn has_static_query_id() -> bool {
+        T::has_static_query_id()
+    }
+}
+
+
+impl<'a, T: QueryId + ?Sized> QueryId for &'a T {
+    type QueryId = T::QueryId;
+
+    fn has_static_query_id() -> bool {
+        T::has_static_query_id()
+    }
+}
+
+impl<DB> QueryId for QueryFragment<DB> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
+        false
+    }
+}
+
+#[macro_export]
+macro_rules! impl_query_id {
+    ($name: ident) => {
+        impl $crate::query_builder::QueryId for $name {
+            type QueryId = Self;
+
+            fn has_static_query_id() -> bool {
+                true
+            }
+        }
+    };
+
+    ($name: ident<$($ty_param: ident),+>) => {
+        #[allow(non_camel_case_types)]
+        impl<$($ty_param),*> $crate::query_builder::QueryId for $name<$($ty_param),*> where
+            $($ty_param: $crate::query_builder::QueryId),*
+        {
+            type QueryId = $name<$($ty_param::QueryId),*>;
+
+            fn has_static_query_id() -> bool {
+                $($ty_param::has_static_query_id() &&)* true
+            }
+        }
+    };
+
+    (noop: $name: ident) => {
+        impl $crate::query_builder::QueryId for $name {
+            type QueryId = ();
+
+            fn has_static_query_id() -> bool {
+                false
+            }
+        }
+    };
+
+    (noop: $name: ident<$($ty_param: ident),+>) => {
+        #[allow(non_camel_case_types)]
+        impl<$($ty_param),*> $crate::query_builder::QueryId for $name<$($ty_param),*> {
+            type QueryId = ();
+
+            fn has_static_query_id() -> bool {
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::TypeId;
+
+    use backend::Debug;
+    use prelude::*;
+    use super::QueryId;
+
+    table! {
+        users {
+            id -> Integer,
+            name -> VarChar,
+        }
+    }
+
+    fn query_id<T: QueryId>(_: T) -> Option<TypeId> {
+        T::query_id()
+    }
+
+    #[test]
+    fn queries_with_no_dynamic_elements_have_a_static_id() {
+        use self::users::dsl::*;
+        assert!(query_id(users).is_some());
+        assert!(query_id(users.select(name)).is_some());
+        assert!(query_id(users.filter(name.eq("Sean"))).is_some());
+    }
+
+    #[test]
+    fn queries_with_different_types_have_different_ids() {
+        let id1 = query_id(users::table.select(users::name));
+        let id2 = query_id(users::table.select(users::id));
+        assert!(id1 != id2);
+    }
+
+    #[test]
+    fn bind_params_use_only_sql_type_for_query_id() {
+        use self::users::dsl::*;
+        let id1 = query_id(users.filter(name.eq("Sean")));
+        let id2 = query_id(users.filter(name.eq("Tess".to_string())));
+
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn boxed_queries_do_not_have_static_query_id() {
+        assert!(query_id(users::table.into_boxed::<Debug>()).is_none());
+    }
+}

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -108,6 +108,14 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
     }
 }
 
+impl<'a, ST, QS, DB> QueryId for BoxedSelectStatement<'a, ST, QS, DB> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
+        false
+    }
+}
+
 impl<'a, ST, QS, DB, Type, Selection> SelectDsl<Selection, Type>
     for BoxedSelectStatement<'a, ST, QS, DB> where
         DB: Backend + HasSqlType<Type>,

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -234,6 +234,8 @@ impl<ST, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
     }
 }
 
+impl_query_id!(SelectStatement<ST, S, F, D, W, O, L, Of, G>);
+
 impl<ST, S, F, D, W, O, L, Of, G, QS> SelectableExpression<QS>
     for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
         SelectStatement<ST, S, F, D, W, O, L, Of, G>: Expression,

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -71,6 +71,8 @@ impl<T, U, DB> QueryFragment<DB> for UpdateStatement<T, U> where
     }
 }
 
+impl_query_id!(noop: UpdateStatement<T, U>);
+
 impl<T, U> AsQuery for UpdateStatement<T, U> where
     T: UpdateTarget,
     UpdateQuery<<T::Table as Table>::AllColumns, UpdateStatement<T, U>>: Query,
@@ -162,3 +164,5 @@ impl<T, U, DB> QueryFragment<DB> for UpdateQuery<T, U> where
         false
     }
 }
+
+impl_query_id!(noop: UpdateQuery<T, U>);

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -15,6 +15,8 @@ pub trait WhereAnd<Predicate> {
 #[derive(Debug, Clone, Copy)]
 pub struct NoWhereClause;
 
+impl_query_id!(NoWhereClause);
+
 impl<DB: Backend> QueryFragment<DB> for NoWhereClause {
     fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
         Ok(())
@@ -65,6 +67,8 @@ impl<DB, Expr> QueryFragment<DB> for WhereClause<Expr> where
         self.0.is_safe_to_cache_prepared()
     }
 }
+
+impl_query_id!(WhereClause<T>);
 
 impl<Expr, Predicate> WhereAnd<Predicate> for WhereClause<Expr> where
     Expr: Expression<SqlType=Bool>,

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,6 +1,6 @@
 use connection::Connection;
 use helper_types::Limit;
-use query_builder::{Query, QueryFragment, AsQuery};
+use query_builder::{Query, QueryFragment, AsQuery, QueryId};
 use query_source::Queryable;
 use result::QueryResult;
 use super::LimitDsl;
@@ -9,7 +9,7 @@ use types::HasSqlType;
 /// Methods to execute a query given a connection. These are automatically implemented for the
 /// various query types.
 pub trait LoadDsl<Conn: Connection>: AsQuery + Sized where
-    Self::Query: QueryFragment<Conn::Backend>,
+    Self::Query: QueryFragment<Conn::Backend> + QueryId,
     Conn::Backend: HasSqlType<Self::SqlType>,
 {
     /// Executes the given query, returning an `Iterator` over the returned
@@ -27,7 +27,7 @@ pub trait LoadDsl<Conn: Connection>: AsQuery + Sized where
     fn first<U>(self, conn: &Conn) -> QueryResult<U> where
         Self: LimitDsl,
         U: Queryable<<Limit<Self> as Query>::SqlType, Conn::Backend>,
-        Limit<Self>: QueryFragment<Conn::Backend>,
+        Limit<Self>: QueryFragment<Conn::Backend> + QueryId,
         Conn::Backend: HasSqlType<<Limit<Self> as Query>::SqlType>,
     {
         conn.query_one(self.limit(1))
@@ -52,12 +52,12 @@ pub trait LoadDsl<Conn: Connection>: AsQuery + Sized where
 }
 
 impl<Conn: Connection, T: AsQuery> LoadDsl<Conn> for T where
-    T::Query: QueryFragment<Conn::Backend>,
+    T::Query: QueryFragment<Conn::Backend> + QueryId,
     Conn::Backend: HasSqlType<T::SqlType>,
 {
 }
 
-pub trait ExecuteDsl<Conn: Connection>: Sized + QueryFragment<Conn::Backend> {
+pub trait ExecuteDsl<Conn: Connection>: Sized + QueryFragment<Conn::Backend> + QueryId {
     /// Executes the given command, returning the number of rows affected. Used
     /// in conjunction with
     /// [`update`](../query_builder/fn.update.html) and
@@ -69,6 +69,6 @@ pub trait ExecuteDsl<Conn: Connection>: Sized + QueryFragment<Conn::Backend> {
 
 impl<Conn, T> ExecuteDsl<Conn> for T where
     Conn: Connection,
-    T: QueryFragment<Conn::Backend>
+    T: QueryFragment<Conn::Backend> + QueryId,
 {
 }

--- a/diesel/src/query_dsl/with_dsl.rs
+++ b/diesel/src/query_dsl/with_dsl.rs
@@ -53,6 +53,14 @@ impl<'a, Left, Right> QuerySource for WithQuerySource<'a, Left, Right> where
     }
 }
 
+impl<'a, Left, Right> QueryId for WithQuerySource<'a, Left, Right> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
+        false
+    }
+}
+
 #[doc(hidden)]
 pub struct PgOnly<T>(T);
 

--- a/diesel/src/query_source/filter.rs
+++ b/diesel/src/query_source/filter.rs
@@ -59,6 +59,8 @@ impl<Source, Predicate> QuerySource for FilteredQuerySource<Source, Predicate> w
     }
 }
 
+impl_query_id!(FilteredQuerySource<Source, Predicate>);
+
 impl<Source, Predicate> UpdateTarget for FilteredQuerySource<Source, Predicate> where
     Source: UpdateTarget,
     Predicate: SelectableExpression<Source, SqlType=Bool>,

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -51,6 +51,8 @@ impl<Left, Right> AsQuery for InnerJoinSource<Left, Right> where
     }
 }
 
+impl_query_id!(InnerJoinSource<Left, Right>);
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct LeftOuterJoinSource<Left, Right> {
@@ -98,6 +100,8 @@ impl<Left, Right> AsQuery for LeftOuterJoinSource<Left, Right> where
         SelectStatement::simple((Left::all_columns(), Right::all_columns()), self)
     }
 }
+
+impl_query_id!(LeftOuterJoinSource<Left, Right>);
 
 /// Indicates that two tables can be used together in a JOIN clause.
 /// Implementations of this trait will be generated for you automatically by

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -127,6 +127,14 @@ macro_rules! primitive_impls {
             fn metadata() {}
         }
 
+        impl $crate::query_builder::QueryId for types::$Source {
+            type QueryId = Self;
+
+            fn has_static_query_id() -> bool {
+                true
+            }
+        }
+
         impl types::NotNull for types::$Source {
         }
     }

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use backend::Backend;
 use expression::*;
 use expression::bound::Bound;
+use query_builder::QueryId;
 use query_source::Queryable;
 use types::{HasSqlType, FromSql, FromSqlRow, Nullable, ToSql, IsNull, NotNull};
 
@@ -13,6 +14,16 @@ impl<T, DB> HasSqlType<Nullable<T>> for DB where
 {
     fn metadata() -> DB::TypeMetadata{
         <DB as HasSqlType<T>>::metadata()
+    }
+}
+
+impl<T> QueryId for Nullable<T> where
+    T: QueryId + NotNull,
+{
+    type QueryId = T::QueryId;
+
+    fn has_static_query_id() -> bool {
+        T::has_static_query_id()
     }
 }
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -1,7 +1,7 @@
 use backend::{Backend, SupportsDefaultKeyword};
 use expression::{Expression, SelectableExpression, NonAggregate};
 use persistable::{ColumnInsertValue, InsertValues};
-use query_builder::{Changeset, AsChangeset, QueryBuilder, BuildQueryResult, QueryFragment};
+use query_builder::*;
 use query_source::{QuerySource, Queryable, Table, Column};
 use result::QueryResult;
 use row::Row;
@@ -96,6 +96,14 @@ macro_rules! tuple_impls {
 
                 fn is_safe_to_cache_prepared(&self) -> bool {
                     $(e!(self.$idx.is_safe_to_cache_prepared()) &&)+ true
+                }
+            }
+
+            impl<$($T: QueryId),+> QueryId for ($($T,)+) {
+                type QueryId = ($($T::QueryId,)+);
+
+                fn has_static_query_id() -> bool {
+                    $($T::has_static_query_id() &&)+ true
                 }
             }
 

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -94,6 +94,14 @@ impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols> where
     }
 }
 
+impl<'a, Cols> QueryId for CreateTable<'a, Cols> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
+        false
+    }
+}
+
 impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
     DB: Backend,
 {
@@ -109,6 +117,14 @@ impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
     }
 
     fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
+}
+
+impl<'a, Cols> QueryId for Column<'a, Cols> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
         false
     }
 }
@@ -133,6 +149,8 @@ impl<DB, Col> QueryFragment<DB> for PrimaryKey<Col> where
     }
 }
 
+impl_query_id!(noop: PrimaryKey<Col>);
+
 #[cfg(feature = "sqlite")]
 impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
     Col: QueryFragment<Sqlite>,
@@ -152,6 +170,8 @@ impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
         false
     }
 }
+
+impl_query_id!(noop: AutoIncrement<Col>);
 
 #[cfg(feature = "postgres")]
 impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
@@ -190,6 +210,8 @@ impl<DB, Col> QueryFragment<DB> for NotNull<Col> where
     }
 }
 
+impl_query_id!(noop: NotNull<Col>);
+
 impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
     DB: Backend,
     Col: QueryFragment<DB>,
@@ -207,6 +229,14 @@ impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
     }
 
     fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
+}
+
+impl<'a, Col> QueryId for Default<'a, Col> {
+    type QueryId = ();
+
+    fn has_static_query_id() -> bool {
         false
     }
 }

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -419,6 +419,8 @@ fn third_party_crates_can_add_new_types() {
         }
     }
 
+    impl_query_id!(MyInt);
+
     assert_eq!(0, query_single_value::<MyInt, i32>("0"));
     assert_eq!(-1, query_single_value::<MyInt, i32>("-1"));
     assert_eq!(70000, query_single_value::<MyInt, i32>("70000"));
@@ -426,6 +428,7 @@ fn third_party_crates_can_add_new_types() {
 
 fn query_single_value<T, U: Queryable<T, TestBackend>>(sql_str: &str) -> U where
     TestBackend: HasSqlType<T>,
+    T: QueryId,
 {
     use diesel::expression::dsl::sql;
     let connection = connection();
@@ -434,12 +437,13 @@ fn query_single_value<T, U: Queryable<T, TestBackend>>(sql_str: &str) -> U where
 
 use std::fmt::Debug;
 use diesel::expression::AsExpression;
-use diesel::query_builder::QueryFragment;
+use diesel::query_builder::{QueryFragment, QueryId};
 
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
     TestBackend: HasSqlType<T>,
     U: AsExpression<T> + Debug + Clone,
-    U::Expression: SelectableExpression<(), T> + QueryFragment<TestBackend>,
+    U::Expression: SelectableExpression<(), T> + QueryFragment<TestBackend> + QueryId,
+    T: QueryId,
 {
     use diesel::expression::dsl::sql;
     let connection = connection();

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -11,12 +11,13 @@ pub use diesel::data_types::*;
 pub use diesel::types::{HasSqlType, ToSql, Nullable};
 
 use diesel::expression::AsExpression;
-use diesel::query_builder::QueryFragment;
+use diesel::query_builder::{QueryFragment, QueryId};
 
 pub fn test_type_round_trips<ST, T>(value: T) -> bool where
+    ST: QueryId,
     <TestConnection as Connection>::Backend: HasSqlType<ST>,
     T: AsExpression<ST> + Queryable<ST, <TestConnection as Connection>::Backend> + PartialEq + Clone + ::std::fmt::Debug,
-    <T as AsExpression<ST>>::Expression: SelectableExpression<()> + QueryFragment<<TestConnection as Connection>::Backend>,
+    <T as AsExpression<ST>>::Expression: SelectableExpression<()> + QueryFragment<<TestConnection as Connection>::Backend> + QueryId,
 {
     let connection = connection();
     let query = select(AsExpression::<ST>::as_expression(value.clone()));


### PR DESCRIPTION
We've added a new trait, `QueryId`, which must be implemented for all
AST nodes, and optionally returns a type which conforms to
`std::any::Any`. Nodes which have their SQL change without the type
changing (such as boxed nodes) will return `None` here. If we're able to
uniquely identify the query on the type alone, we use that for the cache
key rather than the SQL string. This allows us to skip the query
construction entirely. Additionally, a type identifier can be used for a
faster hash lookup than a string could, allowing us to actually beat the
string literal case.

My intent is that all types which implement `QueryFragment` also
implement `QueryId`. However, we can't make it a supertrait, as that
would require specifying the `QueryId` associated type when creating a
boxed trait object, which defeats the purpose entirely. Ironcially, we
actually implement `QueryId` for the trait object directly, so in theory
we should be able to separate them. I don't know if there's a way to
actually do this, though.

There's a handful of types which implement the "noop" form of `TypeId`
that could potentially be safe to implement for real. The main one that
comes to mind is `Aliased`. While the SQL from its implementation of
`QueryFragment` implies that the SQL can change without the type, I
think the type encapsulates enough information. It's a niche feature
though so I erred on the side of caution.

Here are the benchmark results:

```
name                                                                            old ns/iter  new ns/iter    diff ns/iter   diff %
pg::connection::tests::benchmarks::prepared_statement_lookup_query_builder      1,048        191                    -857  -81.77%
pg::connection::tests::benchmarks::prepared_statement_lookup_raw_sql            319          318                      -1   -0.31%
sqlite::connection::tests::benchmarks::prepared_statement_lookup_query_builder  743          123                    -620  -83.45%
sqlite::connection::tests::benchmarks::prepared_statement_lookup_raw_sql        183          180                      -3   -1.64%
```

These benchmarks measured creating/fetch the prepared statement, without
executing the query (calling `prepare_query` on both backends). I opted
to benchmark this as the inherent noise of a database round trip on PG
made it difficult to demonstrate the difference. The benchmarks are not
included in this PR as the code is messy and these aren't benchmarks
that I care to keep in the long term. For those interested in the seeing the
code or running it for themselves, you can apply this patch:
https://gist.github.com/sgrif/24ed31f66246d71a2f7356a806ebc57a

We could potentially gain a little bit more performance here. A type
identifier is a u64 internally, so can be used with a perfect hashing
function. This would change the lookup to be constant time. I believe
this could save us another 100 ns or so, bringing the query builder
close to 0.