### PR TITLE
Change `VarChar` to be an alias to `Text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `infer_schema!` on SQLite now accepts a larger range of type names
 
+* `types::VarChar` is now an alias for `types::Text`. Most code should be
+  unaffected by this. PG array columns are treated slightly differently,
+  however. If you are using `varchar[]`, you should switch to `text[]` instead.
+
 ## [0.6.1] 2016-04-14
 
 ### Added

--- a/diesel/src/expression/expression_methods/mod.rs
+++ b/diesel/src/expression/expression_methods/mod.rs
@@ -12,7 +12,7 @@ pub mod text_expression_methods;
 pub use self::bool_expression_methods::BoolExpressionMethods;
 pub use self::escape_expression_methods::EscapeExpressionMethods;
 pub use self::global_expression_methods::ExpressionMethods;
-pub use self::text_expression_methods::{TextExpressionMethods, VarCharExpressionMethods};
+pub use self::text_expression_methods::TextExpressionMethods;
 
 #[cfg(feature = "postgres")]
 pub use pg::expression::expression_methods::*;

--- a/diesel/src/expression/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/text_expression_methods.rs
@@ -1,20 +1,6 @@
 use expression::{Expression, AsExpression};
 use expression::predicates::{Like, NotLike};
-use types::{VarChar, Text};
-
-pub trait VarCharExpressionMethods: Expression<SqlType=VarChar> + Sized {
-    /// Returns a SQL `LIKE` expression
-    fn like<T: AsExpression<VarChar>>(self, other: T) -> Like<Self, T::Expression> {
-        Like::new(self.as_expression(), other.as_expression())
-    }
-
-    /// Returns a SQL `NOT LIKE` expression
-    fn not_like<T: AsExpression<VarChar>>(self, other: T) -> NotLike<Self, T::Expression> {
-        NotLike::new(self.as_expression(), other.as_expression())
-    }
-}
-
-impl<T: Expression<SqlType=VarChar>> VarCharExpressionMethods for T {}
+use types::Text;
 
 pub trait TextExpressionMethods: Expression<SqlType=Text> + Sized {
     /// Returns a SQL `LIKE` expression

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -46,9 +46,9 @@ use std::io::Write;
 #[doc(hidden)] pub type Float8 = Double;
 #[derive(Clone, Copy, Default)] pub struct Numeric;
 
-#[derive(Clone, Copy, Default)] pub struct VarChar;
-#[doc(hidden)] pub type Varchar = VarChar;
 #[derive(Clone, Copy, Default)] pub struct Text;
+pub type VarChar = Text;
+#[doc(hidden)] pub type Varchar = VarChar;
 
 #[derive(Clone, Copy, Default)] pub struct Binary;
 

--- a/diesel/src/types/ord.rs
+++ b/diesel/src/types/ord.rs
@@ -7,7 +7,6 @@ impl SqlOrd for types::Integer {}
 impl SqlOrd for types::BigInt {}
 impl SqlOrd for types::Float {}
 impl SqlOrd for types::Double {}
-impl SqlOrd for types::VarChar {}
 impl SqlOrd for types::Text {}
 impl SqlOrd for types::Date {}
 impl SqlOrd for types::Interval {}

--- a/diesel_codegen/src/schema_inference/sqlite.rs
+++ b/diesel_codegen/src/schema_inference/sqlite.rs
@@ -36,8 +36,6 @@ pub fn determine_column_type(cx: &mut ExtCtxt, attr: &ColumnInformation) -> P<as
         quote_ty!(cx, ::diesel::types::BigInt)
     } else if type_name.contains("int") {
         quote_ty!(cx, ::diesel::types::Integer)
-    } else if type_name.contains("char") {
-        quote_ty!(cx, ::diesel::types::VarChar)
     } else if is_text(&type_name) {
         quote_ty!(cx, ::diesel::types::Text)
     } else if type_name.contains("blob") || type_name.is_empty() {
@@ -59,6 +57,7 @@ pub fn determine_column_type(cx: &mut ExtCtxt, attr: &ColumnInformation) -> P<as
 }
 
 fn is_text(type_name: &str) -> bool {
+    type_name.contains("char") ||
     type_name.contains("clob") ||
         type_name.contains("text")
 }

--- a/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
@@ -19,7 +19,7 @@ fn main() {
     let select_name = users.select(name);
 
     let ids = select_name.load::<i32>(&connection);
-    //~^ ERROR the trait bound `i32: diesel::Queryable<diesel::types::VarChar, _>` is not satisfied
+    //~^ ERROR the trait bound `i32: diesel::Queryable<diesel::types::Text, _>` is not satisfied
     let names = select_id.load::<String>(&connection);
     //~^ ERROR the trait bound `std::string::String: diesel::Queryable<diesel::types::Integer, _>` is not satisfied
 }

--- a/diesel_tests/tests/schema_dsl/functions.rs
+++ b/diesel_tests/tests/schema_dsl/functions.rs
@@ -9,9 +9,9 @@ pub fn create_table<'a, Cols>(name: &'a str, columns: Cols)
 }
 
 pub fn integer<'a>(name: &'a str) -> Column<'a, types::Integer> {
-    Column::new(name, "INTEGER", types::Integer)
+    Column::new(name, "INTEGER")
 }
 
 pub fn string<'a>(name: &'a str) -> Column<'a, types::VarChar> {
-    Column::new(name, "VARCHAR", types::VarChar)
+    Column::new(name, "VARCHAR")
 }

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 pub struct CreateTable<'a, Cols> {
     name: &'a str,
     columns: Cols
@@ -15,15 +17,15 @@ impl<'a, Cols> CreateTable<'a, Cols> {
 pub struct Column<'a, T> {
     name: &'a str,
     type_name: &'a str,
-    _tpe: T,
+    _marker: PhantomData<T>,
 }
 
 impl<'a, T> Column<'a, T> {
-    pub fn new(name: &'a str, type_name: &'a str, tpe: T) -> Self {
+    pub fn new(name: &'a str, type_name: &'a str) -> Self {
         Column {
             name: name,
             type_name: type_name,
-            _tpe: tpe,
+            _marker: PhantomData,
         }
     }
 


### PR DESCRIPTION
This removes the `VarChar` type entirely, unifying it with text.
This simplifies the interaction with things like SQL functions, and
removes gotchas like `lower` not working with text columns. SQLite will
be unaffected by this change. PG is mostly unaffected. However, it
doesn't treat `varchar[]` arrays as equivalent to `text[]`. INSERT and
UPDATE will continue to work, but other operators/functions will error
out. Since they have identical representations in the database, I'm fine
with introducing the weird ideosynchracy of "use `text[]` instead of
`varchar[]`, as we remove some much larger warts.

There is some more in depth research/reasoning at #287.

One other visible effect here is that `VarChar` can no longer be
referenced in expression positions, as it is not a struct. This can be
seen in the change made to `diesel_tests::schema_dsl`. Since the structs
have no size and no method, there's never any reason to use them in
expression positions, and I've simply replaced that field entirely.

Close #287