### PR TITLE
Add the ability to load and group a child association for many parents

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -1,0 +1,32 @@
+use std::hash::Hash;
+
+pub trait Identifiable {
+    type Id: Hash + Eq + Copy;
+
+    fn id(&self) -> Self::Id;
+}
+
+pub trait BelongsTo<Parent: Identifiable> {
+    fn foreign_key(&self) -> Parent::Id;
+}
+
+pub trait GroupedBy<Parent>: IntoIterator + Sized {
+    fn grouped_by(self, parents: &[Parent]) -> Vec<Vec<Self::Item>>;
+}
+
+impl<Parent, Child> GroupedBy<Parent> for Vec<Child> where
+    Child: BelongsTo<Parent>,
+    Parent: Identifiable,
+{
+    fn grouped_by(self, parents: &[Parent]) -> Vec<Vec<Child>> {
+        use std::collections::HashMap;
+
+        let id_indices: HashMap<_, _> = parents.iter().enumerate().map(|(i, u)| (u.id(), i)).collect();
+        let mut result = parents.iter().map(|_| Vec::new()).collect::<Vec<_>>();
+        for child in self {
+            let index = id_indices[&child.foreign_key()];
+            result[index].push(child);
+        }
+        result
+    }
+}

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,5 +1,6 @@
 use backend::Backend;
 use expression::*;
+use expression::helper_types::SqlTypeOf;
 use query_builder::{QueryBuilder, QueryFragment, BuildQueryResult};
 use result::QueryResult;
 use types::Bool;
@@ -8,6 +9,8 @@ pub struct In<T, U> {
     left: T,
     values: U,
 }
+
+pub type EqAny<T, U> = In<T, <U as AsInExpression<SqlTypeOf<T>>>::InExpression>;
 
 impl<T, U> In<T, U> {
     pub fn new(left: T, values: U) -> Self {

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -4,7 +4,8 @@
 use super::{Expression, AsExpression};
 use types;
 
-pub type AsExpr<Item, TargetExpr> = AsExprOf<Item, <TargetExpr as Expression>::SqlType>;
+pub type SqlTypeOf<Expr> = <Expr as Expression>::SqlType;
+pub type AsExpr<Item, TargetExpr> = AsExprOf<Item, SqlTypeOf<TargetExpr>>;
 pub type AsExprOf<Item, Type> = <Item as AsExpression<Type>>::Expression;
 
 macro_rules! gen_helper_type {
@@ -35,4 +36,7 @@ pub type Between<Lhs, Rhs> = super::predicates::Between<Lhs,
 pub type NotBetween<Lhs, Rhs> = super::predicates::NotBetween<Lhs,
     super::predicates::And<AsExpr<Rhs, Lhs>, AsExpr<Rhs, Lhs>>>;
 
+#[doc(inline)]
 pub use super::predicates::{IsNull, IsNotNull, Asc, Desc};
+#[doc(inline)]
+pub use super::array_comparison::EqAny;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -9,6 +9,7 @@ mod macros;
 #[macro_use]
 pub mod query_builder;
 
+pub mod associations;
 pub mod backend;
 pub mod connection;
 #[macro_use]
@@ -72,6 +73,7 @@ pub mod helper_types {
 
 pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using Diesel.
+    pub use associations::GroupedBy;
     pub use connection::Connection;
     pub use expression::{Expression, SelectableExpression, BoxableExpression};
     pub use expression::expression_methods::*;

--- a/diesel/src/query_dsl/belonging_to_dsl.rs
+++ b/diesel/src/query_dsl/belonging_to_dsl.rs
@@ -1,6 +1,6 @@
 use query_builder::AsQuery;
 
-pub trait BelongingToDsl<T> {
+pub trait BelongingToDsl<T: ?Sized> {
     type Output: AsQuery;
 
     fn belonging_to(other: &T) -> Self::Output;

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -1,0 +1,42 @@
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::ext::base::{Annotatable, ExtCtxt};
+use syntax::ext::build::AstBuilder;
+
+use model::Model;
+
+pub fn expand_derive_identifiable(
+    cx: &mut ExtCtxt,
+    span: Span,
+    _meta_item: &ast::MetaItem,
+    annotatable: &Annotatable,
+    push: &mut FnMut(Annotatable)
+) {
+    if let Some(model) = Model::from_annotable(cx, span, annotatable) {
+        let struct_name = model.name;
+        let primary_key_name = model.primary_key_name();
+        let primary_key_type = match model.attr_named(primary_key_name) {
+            Some(a) => a.ty.clone(),
+            None => {
+                let err_msg = format!(
+                    "Could not find a field named `{}` on `{}`",
+                    primary_key_name,
+                    struct_name,
+                );
+                cx.span_err(span, &err_msg);
+                return;
+            }
+        };
+
+        let item = quote_item!(cx,
+            impl ::diesel::associations::Identifiable for $struct_name {
+                type Id = $primary_key_type;
+
+                fn id(&self) -> Self::Id {
+                    self.$primary_key_name
+                }
+            }
+        ).unwrap();
+        push(Annotatable::Item(item));
+    }
+}

--- a/diesel_codegen/src/lib.in.rs
+++ b/diesel_codegen/src/lib.in.rs
@@ -1,5 +1,6 @@
 mod associations;
 mod attr;
+mod identifiable;
 mod insertable;
 mod migrations;
 mod model;

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -29,6 +29,7 @@ pub fn register(reg: &mut syntex::Registry) {
     reg.add_attr("feature(custom_attribute)");
 
     reg.add_decorator("derive_Queryable", queryable::expand_derive_queryable);
+    reg.add_decorator("derive_Identifiable", identifiable::expand_derive_identifiable);
     reg.add_decorator("insertable_into", insertable::expand_insert);
     reg.add_decorator("changeset_for", update::expand_changeset_for);
     reg.add_decorator("has_many", associations::expand_has_many);
@@ -48,6 +49,10 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
     reg.register_syntax_extension(
         intern("derive_Queryable"),
         MultiDecorator(Box::new(queryable::expand_derive_queryable))
+    );
+    reg.register_syntax_extension(
+        intern("derive_Identifiable"),
+        MultiDecorator(Box::new(identifiable::expand_derive_identifiable))
     );
     reg.register_syntax_extension(
         intern("insertable_into"),

--- a/diesel_compile_tests/tests/compile-fail/identifiable_requires_primary_key_field.rs
+++ b/diesel_compile_tests/tests/compile-fail/identifiable_requires_primary_key_field.rs
@@ -1,0 +1,13 @@
+#![feature(custom_derive, custom_attribute, plugin)]
+#![plugin(diesel_codegen)]
+
+#[macro_use]
+extern crate diesel;
+
+#[derive(Identifiable)] //~ ERROR Could not find a field named `id` on `User`
+pub struct User {
+    name: String,
+    hair_color: Option<String>,
+}
+
+fn main() {}

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -27,7 +27,7 @@ fn association_where_struct_name_doesnt_match_table_name() {
 
 #[test]
 fn association_where_parent_and_child_have_underscores() {
-    #[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
     #[has_many(special_comments)]
     #[belongs_to(user)]
     struct SpecialPost {
@@ -106,6 +106,7 @@ mod associations_can_have_nullable_foreign_keys {
     }
     // This test has no assertions, as it is for compilation purposes only.
     #[has_many(bars)]
+    #[derive(Identifiable)]
     pub struct Foo {
         id: i32,
     }

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -3,14 +3,8 @@ use diesel::*;
 
 #[test]
 fn one_to_many_returns_query_source_for_association() {
-    let connection = connection_with_sean_and_tess_in_users_table();
+    let (connection, sean, tess, _) = conn_with_test_data();
 
-    let sean = find_user_by_name("Sean", &connection);
-    let tess = find_user_by_name("Tess", &connection);
-    let new_posts = vec![sean.new_post("Hello", None), sean.new_post("World", None)];
-    batch_insert(&new_posts, posts::table, &connection);
-    let new_posts = vec![tess.new_post("Hello 2", None), tess.new_post("World 2", None)];
-    batch_insert(&new_posts, posts::table, &connection);
     let seans_posts = posts::table.filter(posts::user_id.eq(sean.id))
         .load::<Post>(&connection)
         .unwrap();
@@ -23,4 +17,63 @@ fn one_to_many_returns_query_source_for_association() {
 
     let found_posts: Vec<_> = Post::belonging_to(&tess).load(&connection).unwrap();
     assert_eq!(tess_posts, found_posts);
+}
+
+#[test]
+fn eager_loading_associations_for_multiple_records() {
+    let (connection, sean, tess, _) = conn_with_test_data();
+
+    let users = vec![sean.clone(), tess.clone()];
+    let posts = Post::belonging_to(&users).load::<Post>(&connection).unwrap()
+        .grouped_by(&users);
+    let users_and_posts = users.into_iter().zip(posts).collect::<Vec<_>>();
+
+    let seans_posts = Post::belonging_to(&sean).load(&connection).unwrap();
+    let tess_posts = Post::belonging_to(&tess).load(&connection).unwrap();
+    let expected_data = vec![(sean, seans_posts), (tess, tess_posts)];
+    assert_eq!(expected_data, users_and_posts);
+}
+
+#[test]
+fn grouping_associations_maintains_ordering() {
+    let (connection, sean, tess, _) = conn_with_test_data();
+
+    let users = vec![sean.clone(), tess.clone()];
+    let posts = Post::belonging_to(&users)
+        .order(posts::title.desc())
+        .load::<Post>(&connection).unwrap()
+        .grouped_by(&users);
+    let users_and_posts = users.into_iter().zip(posts).collect::<Vec<_>>();
+
+    let seans_posts = Post::belonging_to(&sean).order(posts::title.desc()).load(&connection).unwrap();
+    let tess_posts = Post::belonging_to(&tess).order(posts::title.desc()).load(&connection).unwrap();
+    let expected_data = vec![(sean.clone(), seans_posts), (tess.clone(), tess_posts)];
+    assert_eq!(expected_data, users_and_posts);
+
+    // Test when sorted manually
+    let users = vec![sean.clone(), tess.clone()];
+    let mut posts = Post::belonging_to(&users)
+        .load::<Post>(&connection).unwrap();
+    posts.sort_by(|a, b| b.title.cmp(&a.title));
+    let posts = posts.grouped_by(&users);
+    let users_and_posts = users.into_iter().zip(posts).collect::<Vec<_>>();
+
+    assert_eq!(expected_data, users_and_posts);
+}
+
+fn conn_with_test_data() -> (TestConnection, User, User, User) {
+    let connection = connection_with_sean_and_tess_in_users_table();
+    insert(&NewUser::new("Jim", None)).into(users::table).execute(&connection).unwrap();
+
+    let sean = find_user_by_name("Sean", &connection);
+    let tess = find_user_by_name("Tess", &connection);
+    let jim = find_user_by_name("Jim", &connection);
+    let new_posts = vec![sean.new_post("Hello", None), sean.new_post("World", None)];
+    batch_insert(&new_posts, posts::table, &connection);
+    let new_posts = vec![tess.new_post("Hello 2", None), tess.new_post("World 2", None)];
+    batch_insert(&new_posts, posts::table, &connection);
+    let new_posts = vec![jim.new_post("Hello 3", None), jim.new_post("World 3", None)];
+    batch_insert(&new_posts, posts::table, &connection);
+
+    (connection, sean, tess, jim)
 }

--- a/diesel_tests/tests/postgres_specific_schema.rs
+++ b/diesel_tests/tests/postgres_specific_schema.rs
@@ -1,7 +1,7 @@
 use diesel::*;
 use super::{User, posts, comments, users};
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
 #[has_many(comments)]
 #[belongs_to(user)]
 pub struct Post {

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -2,7 +2,7 @@ use diesel::*;
 
 infer_schema!(dotenv!("DATABASE_URL"));
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
 #[changeset_for(users)]
 #[has_many(posts)]
 pub struct User {


### PR DESCRIPTION
This is somewhat analogous to the `includes` method from Active Record.
However, it does not allow arbitrarily deep nesting. That means you can
load as many child associations for the parent as you want, but not
grandchildren or great grandchildren (you can certainly use this
infrastructure to do that, we just don't provide helpers for it out of
the box)

There's still several enhancements I'd like to make. For instance,
having to write `#[derive(Identifiable)]` feels funky, as you'd never
use that on its own. We could maybe do it on `#[derive(Queryable)]` if
the model has a field with the same name as the primary key, but that
feels really gross. Probably the best place for us to do it
automatically would be in `#[has_many]`, but that can be a separate PR.

This also does not generate the optimal query for PG, as it creates an
`IN` statement instead of `= ANY`. We eventually want to change the node
returned by `eq_any` to do the right thing for PG, but it needs
specialization to be done cleanly. Perhaps for 0.7 we can do that
optimization if `feature = "unstable"`.

This does not handle cases where the foreign key is nullable. We skip
implementing `BelongsTo` in that case, meaning the associations can be
loaded but not grouped. I have some ideas on how we can handle this in
the future, but that will be a separate PR.

I'd like to find a way to eliminate the need to specify the struct type
for the association twice. This could either be by moving
`BelongingToDsl` over to the table, or by somehow carrying the type that
the method was called on.

Finally, I think we can add an additional layer on top of this to handle
the common case of "load and group the associations without additional
filtering" into something like `users.load_associated::<Post>(&conn)`

An example of what this might look like in the wild:
```rust
// Get the first 10 users, all the posts they've published, and all the comments they've written
fn load_stuff(conn: &Connection) -> QueryResult<Vec<(User, Vec<Post>, Vec<Comment>)>> {
    let users = users::table.limit(10).load::<User>(conn)?;
    let posts = Post::belonging_to(&users).load::<Post>(conn)?.grouped_by(&users);
    let comments = Comment::belonging_to(&users).load::<Comment>(conn)?.grouped_by(&users);
    Ok(users.into_iter().zip3(posts, comments).collect())
}