### PR TITLE
Execute Benchmarks for 0, 1, 10, 100, 1k, 10k Rows

### DIFF
--- a/diesel_tests/tests/bench.rs
+++ b/diesel_tests/tests/bench.rs
@@ -1,5 +1,8 @@
 #![feature(custom_derive, plugin, custom_attribute, test)]
 #![plugin(diesel_codegen, dotenv_macros)]
+
+#![allow(non_snake_case)]
+
 #[macro_use]
 extern crate diesel;
 extern crate test;
@@ -22,90 +25,103 @@ fn connection() -> TestConnection {
     schema::connection()
 }
 
-#[bench]
-fn bench_selecting_0_rows_with_trivial_query(b: &mut Bencher) {
-    let conn = connection();
+macro_rules! bench_trivial_query {
+    ($n:expr, $name:ident, $name_boxed:ident) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let conn = connection();
 
-    b.iter(|| {
-        users::table.load::<User>(&conn).unwrap();
-    })
+            let data: Vec<_> = (0..$n).map(|i| {
+                NewUser::new(&format!("User {}", i), None)
+            }).collect();
+            batch_insert(&data, users::table, &conn);
+
+            b.iter(|| {
+                users::table.load::<User>(&conn).unwrap()
+            })
+        }
+
+        #[bench]
+        fn $name_boxed(b: &mut Bencher) {
+            let conn = connection();
+
+            let data: Vec<_> = (0..$n).map(|i| {
+                NewUser::new(&format!("User {}", i), None)
+            }).collect();
+            batch_insert(&data, users::table, &conn);
+
+            b.iter(|| {
+                users::table.into_boxed().load::<User>(&conn).unwrap()
+            })
+        }
+    };
 }
 
-#[bench]
-fn bench_selecting_10k_rows_with_trivial_query(b: &mut Bencher) {
-    let conn = connection();
-    let data: Vec<_> = (0..10_000).map(|i| {
-        NewUser::new(&format!("User {}", i), None)
-    }).collect();
-    batch_insert(&data, users::table, &conn);
+bench_trivial_query!(0,
+    bench_trivial_query_selecting______0_rows, bench_trivial_query_selecting______0_rows_boxed);
+bench_trivial_query!(1,
+    bench_trivial_query_selecting______1_row, bench_trivial_query_selecting______1_row_boxed);
+bench_trivial_query!(10,
+    bench_trivial_query_selecting_____10_rows, bench_trivial_query_selecting_____10_rows_boxed);
+bench_trivial_query!(100,
+    bench_trivial_query_selecting____100_rows, bench_trivial_query_selecting____100_rows_boxed);
+bench_trivial_query!(1_000,
+    bench_trivial_query_selecting__1_000_rows, bench_trivial_query_selecting__1_000_rows_boxed);
+bench_trivial_query!(10_000,
+    bench_trivial_query_selecting_10_000_rows, bench_trivial_query_selecting_10_000_rows_boxed);
 
-    b.iter(|| {
-        users::table.load::<User>(&conn).unwrap()
-    })
+macro_rules! bench_medium_complex_query {
+    ($n:expr, $name:ident, $name_boxed:ident) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let conn = connection();
+
+            let data: Vec<_> = (0..$n).map(|i| {
+                let hair_color = if i % 2 == 0 { "black" } else { "brown" };
+                NewUser::new(&format!("User {}", i), Some(hair_color))
+            }).collect();
+            batch_insert(&data, users::table, &conn);
+
+            b.iter(|| {
+                use schema::users::dsl::*;
+                let target = users.left_outer_join(posts::table)
+                    .filter(hair_color.eq("black"))
+                    .order(name.desc());
+                target.load::<(User, Option<Post>)>(&conn).unwrap()
+            })
+        }
+
+        #[bench]
+        fn $name_boxed(b: &mut Bencher) {
+            let conn = connection();
+
+            let data: Vec<_> = (0..$n).map(|i| {
+                let hair_color = if i % 2 == 0 { "black" } else { "brown" };
+                NewUser::new(&format!("User {}", i), Some(hair_color))
+            }).collect();
+            batch_insert(&data, users::table, &conn);
+
+            b.iter(|| {
+                use schema::users::dsl::*;
+                let target = users.left_outer_join(posts::table)
+                    .filter(hair_color.eq("black"))
+                    .order(name.desc())
+                    .into_boxed();
+                target.load::<(User, Option<Post>)>(&conn).unwrap()
+            })
+        }
+    };
 }
 
-#[bench]
-fn bench_selecting_10k_rows_with_trivial_query_boxed(b: &mut Bencher) {
-    let conn = connection();
-    let data: Vec<_> = (0..10_000).map(|i| {
-        NewUser::new(&format!("User {}", i), None)
-    }).collect();
-    batch_insert(&data, users::table, &conn);
-
-    b.iter(|| {
-        users::table.into_boxed().load::<User>(&conn).unwrap()
-    })
-}
-
-
-#[bench]
-fn bench_selecting_0_rows_with_medium_complex_query(b: &mut Bencher) {
-    let conn = connection();
-
-    b.iter(|| {
-        use schema::users::dsl::*;
-        let target = users.left_outer_join(posts::table)
-            .filter(hair_color.eq("black"))
-            .order(name.desc());
-        target.load::<(User, Option<Post>)>(&conn).unwrap()
-    })
-}
-
-#[bench]
-fn bench_selecting_10k_rows_with_medium_complex_query(b: &mut Bencher) {
-    let conn = connection();
-
-    let data: Vec<_> = (0..10_000).map(|i| {
-        let hair_color = if i % 2 == 0 { "black" } else { "brown" };
-        NewUser::new(&format!("User {}", i), Some(hair_color))
-    }).collect();
-    batch_insert(&data, users::table, &conn);
-
-    b.iter(|| {
-        use schema::users::dsl::*;
-        let target = users.left_outer_join(posts::table)
-            .filter(hair_color.eq("black"))
-            .order(name.desc());
-        target.load::<(User, Option<Post>)>(&conn).unwrap()
-    })
-}
-
-#[bench]
-fn bench_selecting_10k_rows_with_medium_complex_query_boxed(b: &mut Bencher) {
-    let conn = connection();
-
-    let data: Vec<_> = (0..10_000).map(|i| {
-        let hair_color = if i % 2 == 0 { "black" } else { "brown" };
-        NewUser::new(&format!("User {}", i), Some(hair_color))
-    }).collect();
-    batch_insert(&data, users::table, &conn);
-
-    b.iter(|| {
-        use schema::users::dsl::*;
-        let target = users.left_outer_join(posts::table)
-            .filter(hair_color.eq("black"))
-            .order(name.desc())
-            .into_boxed();
-        target.load::<(User, Option<Post>)>(&conn).unwrap()
-    })
-}
+bench_medium_complex_query!(0,
+    bench_medium_complex_query_selecting______0_rows, bench_medium_complex_query_selecting______0_rows_boxed);
+bench_medium_complex_query!(1,
+    bench_medium_complex_query_selecting______1_row, bench_medium_complex_query_selecting______1_row_boxed);
+bench_medium_complex_query!(10,
+    bench_medium_complex_query_selecting_____10_rows, bench_medium_complex_query_selecting_____10_rows_boxed);
+bench_medium_complex_query!(100,
+    bench_medium_complex_query_selecting____100_rows, bench_medium_complex_query_selecting____100_rows_boxed);
+bench_medium_complex_query!(1_000,
+    bench_medium_complex_query_selecting__1_000_rows, bench_medium_complex_query_selecting__1_000_rows_boxed);
+bench_medium_complex_query!(10_000,
+    bench_medium_complex_query_selecting_10_000_rows, bench_medium_complex_query_selecting_10_000_rows_boxed);


### PR DESCRIPTION
This moves benchmark code into macros to easily abstract over the number of rows to benchmark.

Because you can't use macros in function name position, we have to write each benchmark name ourselves. (I tried moving the fns into a named mod, but there were some visibility issues and I gave up on that.)

The final output looks like this (the actual times are totally screwed since I'm doing other stuff—incl. watching @sgrif's stream—at the same time):

```text
running 24 tests
test bench_medium_complex_query_selecting_10_000_rows       ... bench:  13,193,995 ns/iter (+/- 7,167,273)
test bench_medium_complex_query_selecting_10_000_rows_boxed ... bench:  13,001,051 ns/iter (+/- 4,904,166)
test bench_medium_complex_query_selecting__1_000_rows       ... bench:   1,113,618 ns/iter (+/- 560,993)
test bench_medium_complex_query_selecting__1_000_rows_boxed ... bench:   1,162,539 ns/iter (+/- 735,696)
test bench_medium_complex_query_selecting____100_rows       ... bench:     159,769 ns/iter (+/- 62,733)
test bench_medium_complex_query_selecting____100_rows_boxed ... bench:     170,054 ns/iter (+/- 107,642)
test bench_medium_complex_query_selecting_____10_rows       ... bench:      60,059 ns/iter (+/- 29,901)
test bench_medium_complex_query_selecting_____10_rows_boxed ... bench:      71,926 ns/iter (+/- 36,442)
test bench_medium_complex_query_selecting______0_rows       ... bench:       4,639 ns/iter (+/- 4,432)
test bench_medium_complex_query_selecting______0_rows_boxed ... bench:      13,534 ns/iter (+/- 13,648)
test bench_medium_complex_query_selecting______1_row        ... bench:      48,920 ns/iter (+/- 27,940)
test bench_medium_complex_query_selecting______1_row_boxed  ... bench:      56,033 ns/iter (+/- 21,060)
test bench_trivial_query_selecting_10_000_rows              ... bench:   6,637,456 ns/iter (+/- 10,654,968)
test bench_trivial_query_selecting_10_000_rows_boxed        ... bench:   6,489,666 ns/iter (+/- 9,187,709)
test bench_trivial_query_selecting__1_000_rows              ... bench:     771,187 ns/iter (+/- 4,666,322)
test bench_trivial_query_selecting__1_000_rows_boxed        ... bench:     652,489 ns/iter (+/- 1,172,967)
test bench_trivial_query_selecting____100_rows              ... bench:      71,229 ns/iter (+/- 87,046)
test bench_trivial_query_selecting____100_rows_boxed        ... bench:      61,548 ns/iter (+/- 81,419)
test bench_trivial_query_selecting_____10_rows              ... bench:       8,095 ns/iter (+/- 4,756)
test bench_trivial_query_selecting_____10_rows_boxed        ... bench:      10,789 ns/iter (+/- 11,514)
test bench_trivial_query_selecting______0_rows              ... bench:       1,429 ns/iter (+/- 1,198)
test bench_trivial_query_selecting______0_rows_boxed        ... bench:       6,341 ns/iter (+/- 15,519)
test bench_trivial_query_selecting______1_row               ... bench:       3,340 ns/iter (+/- 3,219)
test bench_trivial_query_selecting______1_row_boxed         ... bench:       5,742 ns/iter (+/- 2,939)

test result: ok. 0 passed; 0 failed; 0 ignored; 24 measured
```

This is pretty basic right now, as it's only the set of queries that were used before. Might be cool to extend this, and/or plot this to see asymptotical behaviour.