### PR TITLE
Change the format of `#[column_name]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   unaffected by this. PG array columns are treated slightly differently,
   however. If you are using `varchar[]`, you should switch to `text[]` instead.
 
+* Struct fields annotated with `#[column_name="name"]` should be changed to
+  `#[column_name(name)]`.
+
 ## [0.6.1] 2016-04-14
 
 ### Added

--- a/diesel_codegen/src/attr.rs
+++ b/diesel_codegen/src/attr.rs
@@ -3,7 +3,7 @@ use syntax::ast::ItemKind;
 use syntax::ext::base::ExtCtxt;
 use syntax::ptr::P;
 
-use util::str_value_of_attr_with_name;
+use util::ident_value_of_attr_with_name;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Attr {
@@ -16,7 +16,7 @@ impl Attr {
     pub fn from_struct_field(cx: &mut ExtCtxt, field: &ast::StructField) -> Option<Self> {
         let field_name = field.ident;
         let column_name =
-            str_value_of_attr_with_name(cx, &field.attrs, "column_name");
+            ident_value_of_attr_with_name(cx, &field.attrs, "column_name");
         let ty = field.ty.clone();
 
         match (column_name, field_name) {
@@ -32,7 +32,7 @@ impl Attr {
             }),
             (None, None) => {
                 cx.span_err(field.span,
-                    r#"Field must be named or annotated with #[column_name="something"]"#);
+                    r#"Field must be named or annotated with #[column_name(something)]"#);
                 None
             }
         }

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -89,9 +89,9 @@ impl NewPost {
 
 #[insertable_into(comments)]
 pub struct NewComment<'a>(
-    #[column_name="post_id"]
+    #[column_name(post_id)]
     pub i32,
-    #[column_name="text"]
+    #[column_name(text)]
     pub &'a str,
 );
 


### PR DESCRIPTION
This is entirely to support the move from syntax extensions to normal
macros on stable. We cannot match the RHS of `#[column_name="name"]` and
use the result in an `ident` position. We can, however, handle
`#[column_name(name)]`.

I prefer the old form, but it would require changes to the rust compiler
to support without syntax extensions, which defeats the purpose of
moving to stable.