### PR TITLE
Provide a syntax extension free alternative to `#[insertable_into]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* The `Insertable!` macro can now be used instead of `#[insertable_into]` for
+  those wishing to avoid syntax extensions from `diesel_codegen`. See
+  http://docs.diesel.rs/diesel/macro.Insertable!.html for details.
+
 ### Changed
 
 * `infer_schema!` on SQLite now accepts a larger range of type names

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -61,36 +61,17 @@ struct NewUser {
     name: String,
 }
 
-struct NewUserValues {
-    name: String,
-}
-
-impl<DB> InsertValues<DB> for NewUserValues where
-    DB: diesel::backend::Backend,
-{
-    fn column_names(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_sql("name");
-        Ok(())
-    }
-
-    fn values_clause(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_sql(&format!("('{}')", self.name));
-        Ok(())
-    }
-
-    fn values_bind_params(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
-        Ok(())
-    }
-}
-
-impl<'a, DB> Insertable<users::table, DB> for &'a NewUser where
-    DB: diesel::backend::Backend,
-{
-    type Values = NewUserValues;
-
-    fn values(self) -> Self::Values {
-        NewUserValues {
-            name: self.name.clone(),
+impl NewUser {
+    pub fn new(name: &str) -> Self {
+        NewUser {
+            name: name.into(),
         }
+    }
+}
+
+Insertable! {
+    (users)
+    struct NewUser {
+        name: String,
     }
 }

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -6,8 +6,6 @@
 
 #[macro_use]
 mod macros;
-#[macro_use]
-pub mod query_builder;
 
 pub mod associations;
 pub mod backend;
@@ -16,6 +14,7 @@ pub mod connection;
 pub mod expression;
 #[doc(hidden)]
 pub mod persistable;
+pub mod query_builder;
 #[macro_use]
 pub mod types;
 

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -210,6 +210,7 @@ macro_rules! Insertable_column_expr {
 }
 
 #[cfg(test)]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
 mod tests {
     use prelude::*;
 

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -1,0 +1,421 @@
+/// Implements the [`Insertable`][insertable] trait for a given struct. This
+/// macro should be called with the name of the table you wish to use the struct
+/// with, followed by the entire struct body.
+///
+/// [insertable]: prelude/trait.Insertable.html
+///
+/// # Example
+///
+/// ```no_run
+/// # #[macro_use] extern crate diesel;
+/// # table! { users { id -> Integer, name -> VarChar, hair_color -> Nullable<VarChar>, } }
+/// struct NewUser<'a> {
+///     name: &'a str,
+///     hair_color: &'a str,
+/// }
+///
+/// Insertable! {
+///     (users)
+///     struct NewUser<'a> {
+///         name: &'a str,
+///         hair_color: &'a str,
+///     }
+/// }
+/// # fn main() {}
+/// ```
+///
+/// To avoid copying your struct definition, you can use the
+/// [custom_derive crate][custom_derive].
+///
+/// ```ignore
+/// custom_derive! {
+///     #[derive(Insertable(users))]
+///     struct NewUser<'a> {
+///         name: &'a str,
+///         hair_color: &'a str,
+///     }
+/// }
+/// ```
+///
+/// You can also use this macro with tuple structs, but *all* fields must be
+/// annotated with `#[column_name(name)]`. Additionally, a trailing comma after
+/// the last field is required.
+///
+/// ```no_run
+/// # #[macro_use] extern crate diesel;
+/// # table! { users { id -> Integer, name -> VarChar, hair_color -> Nullable<VarChar>, } }
+/// struct NewUser<'a>(&'a str, Option<&'a str>);
+///
+/// Insertable! {
+///     (users)
+///     struct NewUser<'a>(
+///         #[column_name(name)]
+///         &'a str,
+///         #[column_name(hair_color)]
+///         Option<&'a str>,
+///     );
+/// }
+/// # fn main() {}
+/// ```
+#[macro_export]
+macro_rules! Insertable {
+    // Strip meta items, pub (if present) and struct from definition
+    (
+        ($table_name:ident)
+        $(#[$ignore:meta])*
+        $(pub)* struct $($body:tt)*
+    ) => {
+        Insertable! {
+            ($table_name)
+            $($body)*
+        }
+    };
+
+    // Handle struct with lifetimes
+    (
+        ($table_name:ident)
+        $struct_name:ident <$($lifetime:tt),*>
+        $body:tt $(;)*
+    ) => {
+        __diesel_parse_struct_body! {
+            (
+                struct_name = $struct_name,
+                table_name = $table_name,
+                struct_ty = $struct_name<$($lifetime),*>,
+                lifetimes = ($($lifetime),*),
+            ),
+            callback = Insertable,
+            body = $body,
+        }
+    };
+
+    // Handle named struct with no lifetimes
+    (
+        ($table_name:ident)
+        $struct_name:ident
+        $body:tt $(;)*
+    ) => {
+        __diesel_parse_struct_body! {
+            (
+                struct_name = $struct_name,
+                table_name = $table_name,
+                struct_ty = $struct_name,
+                lifetimes = (),
+            ),
+            callback = Insertable,
+            body = $body,
+        }
+    };
+
+    // Receive parsed fields of tuple struct from `__diesel_parse_struct_body`
+    (
+        (
+            struct_name = $struct_name:ident,
+            $($headers:tt)*
+        ),
+        fields = [$({
+            column_name: $column_name:ident,
+            field_ty: $field_ty:ty,
+            field_kind: $field_kind:ident,
+        })+],
+    ) => {
+        Insertable! {
+            $($headers)*
+            self_to_columns = $struct_name($(ref $column_name),+),
+            columns = ($($column_name, $field_ty, $field_kind),+),
+        }
+    };
+
+    // Receive parsed fields of normal struct from `__diesel_parse_struct_body`
+    (
+        (
+            struct_name = $struct_name:ident,
+            $($headers:tt)*
+        ),
+        fields = [$({
+            field_name: $field_name:ident,
+            column_name: $column_name:ident,
+            field_ty: $field_ty:ty,
+            field_kind: $field_kind:ident,
+        })+],
+    ) => {
+        Insertable! {
+            $($headers)*
+            self_to_columns = $struct_name { $($field_name: ref $column_name),+ },
+            columns = ($($column_name, $field_ty, $field_kind),+),
+        }
+    };
+
+    (
+        table_name = $table_name:ident,
+        struct_ty = $struct_ty:ty,
+        lifetimes = ($($lifetime:tt),*),
+        self_to_columns = $self_to_columns:pat,
+        columns = ($($column_name:ident, $field_ty:ty, $field_kind:ident),+),
+    ) => { __diesel_parse_as_item! {
+        impl<$($lifetime,)* 'insert, DB> $crate::persistable::Insertable<$table_name::table, DB>
+            for &'insert $struct_ty where
+                DB: $crate::backend::Backend,
+                $('insert: $lifetime,)*
+                ($(
+                    $crate::persistable::ColumnInsertValue<
+                        $table_name::$column_name,
+                        $crate::expression::bound::Bound<
+                            <$table_name::$column_name as $crate::expression::Expression>::SqlType,
+                            &'insert $field_ty,
+                        >,
+                    >
+                ,)+): $crate::persistable::InsertValues<DB>,
+        {
+            type Values = ($(
+                $crate::persistable::ColumnInsertValue<
+                    $table_name::$column_name,
+                    $crate::expression::bound::Bound<
+                        <$table_name::$column_name as $crate::expression::Expression>::SqlType,
+                        &'insert $field_ty,
+                    >,
+                >
+            ,)+);
+
+            #[allow(non_shorthand_field_patterns)]
+            fn values(self) -> Self::Values {
+                use $crate::expression::{AsExpression, Expression};
+                use $crate::persistable::ColumnInsertValue;
+                let $self_to_columns = *self;
+                ($(
+                    Insertable_column_expr!($table_name::$column_name, $column_name, $field_kind)
+                ,)+)
+            }
+        }
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! Insertable_column_expr {
+    ($column:path, $field_access:expr, option) => {
+        match $field_access {
+            &Some(ref value) => Insertable_column_expr!($column, value, regular),
+            &None => ColumnInsertValue::Default($column),
+        }
+    };
+
+    ($column:path, $field_access:expr, regular) => {
+        ColumnInsertValue::Expression(
+            $column,
+            AsExpression::<<$column as Expression>::SqlType>
+                ::as_expression($field_access),
+        )
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use prelude::*;
+
+    table! {
+        users {
+            id -> Integer,
+            name -> VarChar,
+            hair_color -> Nullable<VarChar>,
+        }
+    }
+
+    #[test]
+    fn simple_struct_definition() {
+        struct NewUser {
+            name: String,
+            hair_color: String,
+        }
+
+        Insertable! {
+            (users)
+            struct NewUser {
+                name: String,
+                hair_color: String,
+            }
+        }
+
+        let conn = connection();
+        let new_user = NewUser { name: "Sean".into(), hair_color: "Black".into() };
+        ::insert(&new_user).into(users::table).execute(&conn).unwrap();
+
+        let saved = users::table.select((users::name, users::hair_color))
+            .load::<(String, Option<String>)>(&conn);
+        let expected = vec![("Sean".to_string(), Some("Black".to_string()))];
+        assert_eq!(Ok(expected), saved);
+    }
+
+    macro_rules! test_struct_definition {
+        ($test_name:ident, $($struct_def:tt)*) => {
+            #[test]
+            fn $test_name() {
+                __diesel_parse_as_item!($($struct_def)*);
+
+                Insertable! {
+                    (users)
+                    $($struct_def)*
+                }
+
+                let conn = connection();
+                let new_user = NewUser { name: "Sean".into(), hair_color: None };
+                ::insert(&new_user).into(users::table).execute(&conn).unwrap();
+
+                let saved = users::table.select((users::name, users::hair_color))
+                    .load::<(String, Option<String>)>(&conn);
+                let expected = vec![("Sean".to_string(), Some("Green".to_string()))];
+                assert_eq!(Ok(expected), saved);
+            }
+        }
+    }
+
+    test_struct_definition! {
+        struct_with_option_field,
+        struct NewUser {
+            name: String,
+            hair_color: Option<String>,
+        }
+    }
+
+    test_struct_definition! {
+        pub_struct_definition,
+        pub struct NewUser {
+            name: String,
+            hair_color: Option<String>,
+        }
+    }
+
+    test_struct_definition! {
+        struct_with_pub_field,
+        pub struct NewUser {
+            pub name: String,
+            hair_color: Option<String>,
+        }
+    }
+
+    test_struct_definition! {
+        struct_with_pub_option_field,
+        pub struct NewUser {
+            name: String,
+            pub hair_color: Option<String>,
+        }
+    }
+
+    test_struct_definition! {
+        named_struct_with_borrowed_body,
+        struct NewUser<'a> {
+            name: &'a str,
+            hair_color: Option<&'a str>,
+        }
+    }
+
+    #[test]
+    fn named_struct_with_renamed_field() {
+        struct NewUser {
+            my_name: String,
+            hair_color: String,
+        }
+
+        Insertable! {
+            (users)
+            struct NewUser {
+                #[column_name(name)]
+                my_name: String,
+                hair_color: String,
+            }
+        }
+
+        let conn = connection();
+        let new_user = NewUser { my_name: "Sean".into(), hair_color: "Black".into() };
+        ::insert(&new_user).into(users::table).execute(&conn).unwrap();
+
+        let saved = users::table.select((users::name, users::hair_color))
+            .load::<(String, Option<String>)>(&conn);
+        let expected = vec![("Sean".to_string(), Some("Black".to_string()))];
+        assert_eq!(Ok(expected), saved);
+    }
+
+    #[test]
+    fn named_struct_with_renamed_option_field() {
+        struct NewUser {
+            my_name: String,
+            my_hair_color: Option<String>,
+        }
+
+        Insertable! {
+            (users)
+            struct NewUser {
+                #[column_name(name)]
+                my_name: String,
+                #[column_name(hair_color)]
+                my_hair_color: Option<String>,
+            }
+        }
+
+        let conn = connection();
+        let new_user = NewUser { my_name: "Sean".into(), my_hair_color: None };
+        ::insert(&new_user).into(users::table).execute(&conn).unwrap();
+
+        let saved = users::table.select((users::name, users::hair_color))
+            .load::<(String, Option<String>)>(&conn);
+        let expected = vec![("Sean".to_string(), Some("Green".to_string()))];
+        assert_eq!(Ok(expected), saved);
+    }
+
+    #[test]
+    fn tuple_struct() {
+        struct NewUser<'a>(
+            pub &'a str,
+            Option<&'a str>,
+        );
+
+        Insertable! {
+            (users)
+            struct NewUser<'a>(
+                #[column_name(name)]
+                pub &'a str,
+                #[column_name(hair_color)]
+                Option<&'a str>,
+            );
+        }
+
+        let conn = connection();
+        let new_user = NewUser("Sean", None);
+        ::insert(&new_user).into(users::table).execute(&conn).unwrap();
+
+        let saved = users::table.select((users::name, users::hair_color))
+            .load::<(String, Option<String>)>(&conn);
+        let expected = vec![("Sean".to_string(), Some("Green".to_string()))];
+        assert_eq!(Ok(expected), saved);
+    }
+
+    #[cfg(feature = "sqlite")]
+    use sqlite::SqliteConnection;
+
+    #[cfg(feature = "sqlite")]
+    fn connection() -> SqliteConnection {
+        let conn = SqliteConnection::establish(":memory:").unwrap();
+        conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR NOT NULL, hair_color VARCHAR DEFAULT 'Green')").unwrap();
+        conn
+    }
+
+    #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
+    use pg::PgConnection;
+    #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
+    extern crate dotenv;
+
+    #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
+    fn connection() -> PgConnection {
+        use self::dotenv::dotenv;
+        use std::env;
+
+        dotenv().ok();
+        let database_url = env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set to run tests");
+        let conn = PgConnection::establish(&database_url).unwrap();
+        conn.begin_test_transaction().unwrap();
+        conn.execute("DROP TABLE IF EXISTS users").unwrap();
+        conn.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR NOT NULL, hair_color VARCHAR DEFAULT 'Green')").unwrap();
+        conn
+    }
+}

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -249,10 +249,17 @@ mod tests {
 
     macro_rules! test_struct_definition {
         ($test_name:ident, $($struct_def:tt)*) => {
+            // FIXME: This module is to work around rust-lang/rust#31776
+            // Remove the module and move the struct definition into the test function once
+            // 1.9 is released. The `use` statements can be removed.
+            //
+            // The indentation is intentionally weird to avoid git churn when this is fixed.
+            mod $test_name {
+                use super::{users, connection};
+                use prelude::*;
+                __diesel_parse_as_item!($($struct_def)*);
             #[test]
             fn $test_name() {
-                __diesel_parse_as_item!($($struct_def)*);
-
                 Insertable! {
                     (users)
                     $($struct_def)*
@@ -266,6 +273,7 @@ mod tests {
                     .load::<(String, Option<String>)>(&conn);
                 let expected = vec![("Sean".to_string(), Some("Green".to_string()))];
                 assert_eq!(Ok(expected), saved);
+            }
             }
         }
     }
@@ -366,7 +374,7 @@ mod tests {
     #[test]
     fn tuple_struct() {
         struct NewUser<'a>(
-            pub &'a str,
+            &'a str,
             Option<&'a str>,
         );
 

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -452,3 +452,9 @@ macro_rules! print_sql {
         println!("{}", &debug_sql!($query));
     };
 }
+
+// The order of these modules is important (at least for those which have tests).
+// Utililty macros which don't call any others need to come first.
+#[macro_use] mod parse;
+#[macro_use] mod query_id;
+#[macro_use] mod insertable;

--- a/diesel/src/macros/parse.rs
+++ b/diesel/src/macros/parse.rs
@@ -1,0 +1,254 @@
+/// Parses the body of a struct field, extracting the relevant information the
+/// relevant information that we care about. This macro can handle either named
+/// structs or tuple structs. It does not handle unit structs.
+///
+/// When calling this macro from the outside, it takes three arguments. The
+/// first is a single token tree of passthrough information, which will be given
+/// to the callback unchanged. The second is the name of the macro to call with
+/// the parsed field. The third is the *entire* body of the struct, including
+/// either the curly braces or parens.
+///
+/// If a tuple struct is given, all fields *must* be annotated with
+/// `#[column_name(name)]`. Due to the nature of non-procedural macros, we
+/// cannot give a helpful error message in this case.
+///
+/// The callback will be called with the given headers, and a list of fields
+/// in record form with the following properties:
+///
+/// - `field_name` is the name of the field on the struct. This will not be
+///   present if the struct is a tuple struct.
+/// - `column_name` is the column the field corresponds to. This will either be
+///   the value of a `#[column_name]` attribute on the field, or the field name
+///   if not present.
+/// - `field_type` is the type of the field on the struct.
+/// - `field_kind` Will be either `regular` or `option` depending on whether
+///   the type of the field was an option or not.
+///
+/// # Example
+///
+/// If this macro is called with:
+///
+/// ```ignore
+/// __diesel_parse_struct_body {
+///     (my original arguments),
+///     callback = my_macro,
+///     body = {
+///         pub foo: i32,
+///         bar: Option<i32>,
+///         #[column_name(other)]
+///         baz: String,
+///     }
+/// }
+/// ```
+///
+/// Then the resulting expansion will be:
+///
+/// ```ignore
+/// my_macro! {
+///     (my original arguments),
+///     fields = [{
+///         field_name: foo,
+///         column_name: foo,
+///         field_ty: i32,
+///         field_kind: regular,
+///     }, {
+///         field_name: bar,
+///         column_name: bar,
+///         field_ty: i32,
+///         field_kind: option,
+///     }, {
+///         field_name: baz,
+///         column_name: other,
+///         field_ty: String,
+///         field_kind: regular,
+///     }],
+/// }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __diesel_parse_struct_body {
+    // Entry point for named structs
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        body = {$($body:tt)*},
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = [],
+            body = ($($body)*),
+        }
+    };
+
+    // Entry point for tuple structs
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        body = $body:tt,
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = [],
+            body = $body,
+        }
+    };
+
+    // FIXME: Replace with `vis` specifier if relevant RFC lands
+    // First, strip `pub` if it exists
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = $fields:tt,
+        body = (
+            $(#$meta:tt)*
+            pub $($tail:tt)*),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = $fields,
+            body = ($(#$meta)* $($tail)*),
+        }
+    };
+
+    // When we find #[column_name] followed by an option type, handle the
+    // tuple struct field
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = [$($fields:tt)*],
+        body = (
+            #[column_name($column_name:ident)]
+            Option<$field_ty:ty> , $($tail:tt)*),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = [$($fields)* {
+                column_name: $column_name,
+                field_ty: $field_ty,
+                field_kind: option,
+            }],
+            body = ($($tail)*),
+        }
+    };
+
+    // When we find #[column_name] followed by a type, handle the tuple struct
+    // field
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = [$($fields:tt)*],
+        body = (
+            #[column_name($column_name:ident)]
+            $field_ty:ty , $($tail:tt)*),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = [$($fields)* {
+                column_name: $column_name,
+                field_ty: $field_ty,
+                field_kind: regular,
+            }],
+            body = ($($tail)*),
+        }
+    };
+
+    // When we find #[column_name] followed by a named field, handle it
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = $fields:tt,
+        body = (
+            #[column_name($column_name:ident)]
+            $field_name:ident : $($tail:tt)*),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = $fields,
+            body = ($field_name as $column_name : $($tail)*),
+        }
+    };
+
+    // If we got here and didn't have a #[column_name] attr,
+    // then the column name is the same as the field name
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = $fields:tt,
+        body = ($field_name:ident : $($tail:tt)*),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = $fields,
+            body = ($field_name as $field_name : $($tail)*),
+        }
+    };
+
+    // At this point we know the column and field name, handle when the type is option
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = [$($fields:tt)*],
+        body = ($field_name:ident as $column_name:ident : Option<$field_ty:ty>, $($tail:tt)*),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = [$($fields)* {
+                field_name: $field_name,
+                column_name: $column_name,
+                field_ty: $field_ty,
+                field_kind: option,
+            }],
+            body = ($($tail)*),
+        }
+    };
+
+    // Handle any type other than option
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = [$($fields:tt)*],
+        body = ($field_name:ident as $column_name:ident : $field_ty:ty, $($tail:tt)*),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = [$($fields)* {
+                field_name: $field_name,
+                column_name: $column_name,
+                field_ty: $field_ty,
+                field_kind: regular,
+            }],
+            body = ($($tail)*),
+        }
+    };
+
+    // At this point we've parsed the entire body. We create the pattern
+    // for destructuring, and pass all the information back to the main macro
+    // to generate the final impl
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = $fields:tt,
+        body = (),
+    ) => {
+        $callback! {
+            $headers,
+            fields = $fields,
+        }
+    };
+}
+
+/// Hack to tell the compiler that something is in fact an item. This is needed
+/// when `tt` fragments are used in specific positions.
+#[doc(hidden)]
+#[macro_export]
+macro_rules!  __diesel_parse_as_item {
+    ($i:item) => { $i }
+}

--- a/diesel/src/macros/query_id.rs
+++ b/diesel/src/macros/query_id.rs
@@ -1,0 +1,46 @@
+#[macro_export]
+macro_rules! impl_query_id {
+    ($name: ident) => {
+        impl $crate::query_builder::QueryId for $name {
+            type QueryId = Self;
+
+            fn has_static_query_id() -> bool {
+                true
+            }
+        }
+    };
+
+    ($name: ident<$($ty_param: ident),+>) => {
+        #[allow(non_camel_case_types)]
+        impl<$($ty_param),*> $crate::query_builder::QueryId for $name<$($ty_param),*> where
+            $($ty_param: $crate::query_builder::QueryId),*
+        {
+            type QueryId = $name<$($ty_param::QueryId),*>;
+
+            fn has_static_query_id() -> bool {
+                $($ty_param::has_static_query_id() &&)* true
+            }
+        }
+    };
+
+    (noop: $name: ident) => {
+        impl $crate::query_builder::QueryId for $name {
+            type QueryId = ();
+
+            fn has_static_query_id() -> bool {
+                false
+            }
+        }
+    };
+
+    (noop: $name: ident<$($ty_param: ident),+>) => {
+        #[allow(non_camel_case_types)]
+        impl<$($ty_param),*> $crate::query_builder::QueryId for $name<$($ty_param),*> {
+            type QueryId = ();
+
+            fn has_static_query_id() -> bool {
+                false
+            }
+        }
+    }
+}

--- a/diesel/src/migrations/schema.rs
+++ b/diesel/src/migrations/schema.rs
@@ -7,29 +7,10 @@ table! {
 
 #[derive(Debug, Copy, Clone)]
 pub struct NewMigration<'a>(pub &'a str);
-
-use backend::Backend;
-use expression::AsExpression;
-use expression::helper_types::AsExpr;
-use persistable::{Insertable, ColumnInsertValue, InsertValues};
-
-impl<'update: 'a, 'a, DB> Insertable<__diesel_schema_migrations::table, DB>
-    for &'update NewMigration<'a> where
-        DB: Backend,
-        (ColumnInsertValue<
-            __diesel_schema_migrations::version,
-            AsExpr<&'a str, __diesel_schema_migrations::version>,
-        >,): InsertValues<DB>,
-{
-    type Values = (ColumnInsertValue<
-        __diesel_schema_migrations::version,
-        AsExpr<&'a str, __diesel_schema_migrations::version>,
-    >,);
-
-    fn values(self) -> Self::Values {
-        (ColumnInsertValue::Expression(
-            __diesel_schema_migrations::version,
-            AsExpression::<::types::VarChar>::as_expression(self.0),
-        ),)
-    }
+Insertable! {
+    (__diesel_schema_migrations)
+    pub struct NewMigration<'a>(
+        #[column_name(version)]
+        pub &'a str,
+    );
 }

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -47,53 +47,6 @@ impl<DB> QueryId for QueryFragment<DB> {
     }
 }
 
-#[macro_export]
-macro_rules! impl_query_id {
-    ($name: ident) => {
-        impl $crate::query_builder::QueryId for $name {
-            type QueryId = Self;
-
-            fn has_static_query_id() -> bool {
-                true
-            }
-        }
-    };
-
-    ($name: ident<$($ty_param: ident),+>) => {
-        #[allow(non_camel_case_types)]
-        impl<$($ty_param),*> $crate::query_builder::QueryId for $name<$($ty_param),*> where
-            $($ty_param: $crate::query_builder::QueryId),*
-        {
-            type QueryId = $name<$($ty_param::QueryId),*>;
-
-            fn has_static_query_id() -> bool {
-                $($ty_param::has_static_query_id() &&)* true
-            }
-        }
-    };
-
-    (noop: $name: ident) => {
-        impl $crate::query_builder::QueryId for $name {
-            type QueryId = ();
-
-            fn has_static_query_id() -> bool {
-                false
-            }
-        }
-    };
-
-    (noop: $name: ident<$($ty_param: ident),+>) => {
-        #[allow(non_camel_case_types)]
-        impl<$($ty_param),*> $crate::query_builder::QueryId for $name<$($ty_param),*> {
-            type QueryId = ();
-
-            fn has_static_query_id() -> bool {
-                false
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::any::TypeId;

--- a/diesel/src/sqlite/query_builder/functions.rs
+++ b/diesel/src/sqlite/query_builder/functions.rs
@@ -1,15 +1,42 @@
 use expression::predicates::Or;
 use query_builder::insert_statement::{IncompleteInsertStatement, Insert};
 use super::nodes::Replace;
-
-// FIXME: Replace this example with an actual running doctest once we have a
-// more reasonable story for `impl Insertable` and friends without codegen
 /// Creates a SQLite `INSERT OR REPLACE` statement. If a constraint violation
 /// fails, SQLite will attempt to replace the offending row instead.
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # include!("src/doctest_setup.rs");
+/// #
+/// # table! {
+/// #     users {
+/// #         id -> Integer,
+/// #         name -> VarChar,
+/// #     }
+/// # }
+/// #
+/// # struct User<'a> {
+/// #     id: i32,
+/// #     name: &'a str,
+/// # }
+/// #
+/// # Insertable! {
+/// #     (users)
+/// #     struct User<'a> {
+/// #         id: i32,
+/// #         name: &'a str,
+/// #     }
+/// # }
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// #     use self::diesel::{insert, insert_or_replace};
+/// #     use self::diesel::sqlite::SqliteConnection;
+/// #
+/// #     let conn = SqliteConnection::establish(":memory:").unwrap();
+/// #     conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR)").unwrap();
 /// insert(&NewUser::new("Sean")).into(users).execute(&conn).unwrap();
 /// insert(&NewUser::new("Tess")).into(users).execute(&conn).unwrap();
 ///
@@ -18,6 +45,7 @@ use super::nodes::Replace;
 ///
 /// let names = users.select(name).order(id).load::<String>(&conn);
 /// assert_eq!(Ok(vec!["Jim".into(), "Tess".into()]), names);
+/// # }
 /// ```
 pub fn insert_or_replace<'a, T: ?Sized>(records: &'a T)
     -> IncompleteInsertStatement<&'a T, Or<Insert, Replace>>

--- a/diesel_compile_tests/tests/compile-fail/batch_insert_is_not_supported_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/batch_insert_is_not_supported_on_sqlite.rs
@@ -15,32 +15,9 @@ table! {
 
 pub struct NewUser(String);
 
-use diesel::persistable::InsertValues;
-use diesel::query_builder::BuildQueryResult;
-
-// It doesn't actually matter if this would work. We're testing that insert fails
-// to compile here.
-pub struct MyValues;
-impl InsertValues<Sqlite> for MyValues {
-    fn column_names(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
-        Ok(())
-    }
-
-    fn values_clause(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
-        Ok(())
-    }
-
-    fn values_bind_params(&self, out: &mut <Sqlite as Backend>::BindCollector) -> QueryResult<()> {
-        Ok(())
-    }
-}
-
-impl<'a> Insertable<users::table, Sqlite> for &'a NewUser {
-    type Values = MyValues;
-
-    fn values(self) -> Self::Values {
-        MyValues
-    }
+Insertable! {
+    (users)
+    pub struct NewUser(#[column_name(name)] String,);
 }
 
 fn main() {

--- a/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -35,32 +35,9 @@ impl<DB: Backend> Queryable<(Integer, VarChar), DB> for User where
 
 pub struct NewUser(String);
 
-use diesel::persistable::InsertValues;
-use diesel::query_builder::BuildQueryResult;
-
-// It doesn't actually matter if this would work. We're testing that insert fails
-// to compile here.
-pub struct MyValues;
-impl InsertValues<Sqlite> for MyValues {
-    fn column_names(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
-        Ok(())
-    }
-
-    fn values_clause(&self, out: &mut SqliteQueryBuilder) -> BuildQueryResult {
-        Ok(())
-    }
-
-    fn values_bind_params(&self, out: &mut <Sqlite as Backend>::BindCollector) -> QueryResult<()> {
-        Ok(())
-    }
-}
-
-impl<'a> Insertable<users::table, Sqlite> for &'a NewUser {
-    type Values = MyValues;
-
-    fn values(self) -> Self::Values {
-        MyValues
-    }
+Insertable! {
+    (users)
+    pub struct NewUser(#[column_name(name)] String,);
 }
 
 fn main() {


### PR DESCRIPTION
This provides a pure stable alternative to the `#[insertable_into]`
annotation. The intention is to change the annotation to call this
macro, rather than `impl Insertable` directly. However, there are some
unaddressed issues for that, and I will submit that as a separate PR to
attempt to keep the PR size reasonable.

The tests for this are a bit messy, as the actual test body doesn't
change much -- Just the struct definition. I moved the most common case
out into a macro, but I opted to just leave the duplication for the
remaining 4-5 cases that didn't fit, instead of trying to make it so dry
it chafes.

We will continue to support syntex as an option on stable, as we can
provide much better error messages from a procedural macro. I would like
to improve the error messages in some cases if possible though (in
particular, we want to handle the case where a unit struct is passed or
where a tuple struct has unannotated fields).

The structure of the macro is intended to be compatible with the
`custom_derive` crate. This is untested, but will be fully tested once
I've moved all our annotations to stable macros. The goal is for any
struct definition to be copy pasted into this macro, and the macro
parses the struct body to create the proper implementation. For
sufficiently large structs, we can hit the recursion limit, but there's
really no way around that. People will just need to bump the limit.

One case that this macro *doesn't* handle is when there are annotations
on struct fields other than `#[column_name]`. I had originally planned
to handle these, but I realized that the only recognized annotation that
could be there on stable is `#[cfg]`, and we are *not* handling cfg
attributes. We might handle that in the future, but it'd look *really*
ugly.

Related to #99