### PR TITLE
Add a `debug_assert!` for integer size

### DIFF
--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -10,6 +10,8 @@ use types::{self, FromSql, ToSql, IsNull};
 impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let mut bytes = not_none!(bytes);
+        debug_assert!(bytes.len() <= 2, "Received more than 2 bytes decoding i16. \
+                      Was an Integer expression accidentally identified as SmallInt?");
         bytes.read_i16::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
@@ -25,6 +27,8 @@ impl<DB: Backend> ToSql<types::SmallInt, DB> for i16 {
 impl<DB: Backend<RawValue=[u8]>> FromSql<types::Integer, DB> for i32 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let mut bytes = not_none!(bytes);
+        debug_assert!(bytes.len() <= 4, "Received more than 4 bytes decoding i32. \
+                      Was a BigInteger expression accidentally identified as Integer?");
         bytes.read_i32::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
@@ -40,6 +44,8 @@ impl<DB: Backend> ToSql<types::Integer, DB> for i32 {
 impl<DB: Backend<RawValue=[u8]>> FromSql<types::BigInt, DB> for i64 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let mut bytes = not_none!(bytes);
+        debug_assert!(bytes.len() <= 8, "Received more than 8 bytes decoding i64. \
+                      Was an expression of a different type misidentified as BigInteger?");
         bytes.read_i64::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -468,3 +468,14 @@ fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
     );
     query.get_result(&connection).expect(&format!("Error comparing {}, {:?}", sql_str, value))
 }
+
+#[cfg(feature = "postgres")]
+#[test]
+#[should_panic(expected="Received more than 4 bytes decoding i32")]
+fn debug_check_catches_reading_bigint_as_i32_when_using_raw_sql() {
+    use diesel::expression::dsl::sql;
+    use diesel::types::Integer;
+
+    let connection = connection();
+    users::table.select(sql::<Integer>("COUNT(*)")).get_result::<i32>(&connection).unwrap();
+}


### PR DESCRIPTION
If a user ever does have to drop down to using the `sql` function
directly, it's easy to accidentally use the wrong type for an integer
field. A common mistake I see is trying to decode `COUNT(*)` into an
`i32` (The type of that expression should be `BigInt`, so it needs to be
decoded into an `i64`.) When this occurs, `0` will be read as the encoding is big endian.
This isn't a problem with the standard query builder, but for people trying to use
something like `group_by` they'll be writing the SQL manually.

Since this is a common mistake I've seen multiple times now, we should
explicitly check for it.

The assertion is checking `<=` instead of `==`, as if we get too few
bytes we'll fail to decode the field anyway, and I wanted the error
message to focus on the too many bytes case.