### PR TITLE
Give an error message when an invalid PG url is given to CLI

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -153,10 +153,13 @@ pub fn database_url(matches: &ArgMatches) -> String {
 /// Returns a &str representing the type of backend being used, determined
 /// by the format of the database url.
 pub fn backend(database_url: &String) -> &str {
-    if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") {
+    if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") && cfg!(feature = "postgres") {
         "postgres"
-    } else {
+    } else if cfg!(feature = "sqlite") {
         "sqlite"
+    } else {
+        panic!("{:?} is not a valid PostgreSQL URL. It should start with\
+                `postgres://` or `postgresql://`", database_url);
     }
 }
 


### PR DESCRIPTION
Right now we assume URLs that aren't for PG are for SQLite instead.
However, the CLI crate can be compiled without SQLite support. In this
case, we end up hitting the `unreachable` branch in our match statement.
I'd like to eventually change this code to use an enum, similar to
codegen. In the short term though, we just need to improve the error
message.

Fixes #310