### PR TITLE
Follow convention for new AST pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 rust:
   - stable
   - beta
-  - nightly-2016-04-08
+  - nightly-2016-04-25
   - nightly
 addons:
   postgresql: '9.4'

--- a/diesel_codegen/README.md
+++ b/diesel_codegen/README.md
@@ -9,7 +9,7 @@ boilerplate needing to be written. It can be used through `rustc_plugin`, or
 Using on nightly
 ----------------
 
-Make sure you're on a nightly from 2016-03-11 or later, we don't compile on earlier versions. To use with nightly, you'll want to turn off the default features. Add this
+Make sure you're on a nightly from 2016-04-25 or later, we don't compile on earlier versions. To use with nightly, you'll want to turn off the default features. Add this
 line to your dependencies section in `Cargo.toml`
 
 ```toml

--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -83,7 +83,7 @@ fn insertable_impl(
     let insert_lifetime = cx.lifetime_def(span, intern("'insert"), lifetimes);
     generics.lifetimes.push(insert_lifetime);
     generics.ty_params = P::from_vec(vec![
-        cx.typaram(span, str_to_ident("DB"), P::empty(), None),
+        cx.typaram(span, str_to_ident("DB"), P::new(), None),
     ]);
 
     quote_item!(cx,

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -61,7 +61,7 @@ pub fn expand_derive_queryable(
 }
 
 fn ty_param_with_name(cx: &mut ExtCtxt, span: Span, name: &str) -> ast::TyParam {
-    cx.typaram(span, str_to_ident(name), P::empty(), None)
+    cx.typaram(span, str_to_ident(name), P::new(), None)
 }
 
 fn struct_literal_with_fields_assigned_to_row_elements(


### PR DESCRIPTION
I had to change these in order to use diesel_codegen on `rustc 1.10.0-nightly (bd938166d 2016-04-25)`.
The diesel_compile_tests all pass with this change but I'm not sure if there's anything else to check, I'm only just starting out with diesel_demo at the moment.

Old empty() method removed in
https://github.com/rust-lang/rust/commit/9108fb7bae11f18715d971eeae1e5ca84662e1ee