### PR TITLE
Add Bpchar type aliased to VarChar

### DIFF
--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -16,5 +16,6 @@ pub mod sql_types {
     #[cfg(feature = "uuid")]
     #[derive(Debug, Clone, Copy, Default)] pub struct Uuid;
     pub type Bytea = ::types::Binary;
+    #[doc(hidden)]
     pub type Bpchar = ::types::VarChar;
 }

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -16,4 +16,5 @@ pub mod sql_types {
     #[cfg(feature = "uuid")]
     #[derive(Debug, Clone, Copy, Default)] pub struct Uuid;
     pub type Bytea = ::types::Binary;
+    pub type Bpchar = ::types::VarChar;
 }


### PR DESCRIPTION
I ran into errors using `char` fields (these are padded fixed length char strings). They are rarely used but can be useful e.g. country codes (2-char). Externally they behave like varchars but internally they are stored differently.

Because they appear the same as varchar externally, I believe it's safe just to alias VarChar