### PR TITLE
Implement `UNION` and `UNION ALL` combination queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   those wishing to avoid syntax extensions from `diesel_codegen`. See
   http://docs.diesel.rs/diesel/macro.Insertable!.html for details.
 
+* Added support for `UNION` and `UNION ALL` query combinations.
+
 ### Changed
 
 * `infer_schema!` on SQLite now accepts a larger range of type names

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -21,6 +21,7 @@ mod select_statement;
 pub mod where_clause;
 pub mod insert_statement;
 pub mod update_statement;
+mod union_query;
 
 pub use self::bind_collector::BindCollector;
 pub use self::query_id::QueryId;
@@ -30,6 +31,8 @@ pub use self::select_statement::{SelectStatement, BoxedSelectStatement};
 pub use self::update_statement::{IncompleteUpdateStatement, AsChangeset, Changeset, UpdateTarget};
 #[doc(inline)]
 pub use self::insert_statement::IncompleteInsertStatement;
+#[doc(inline)]
+pub use self::union_query::UnionQuery;
 
 use std::error::Error;
 
@@ -140,3 +143,6 @@ impl<T: Query> AsQuery for T {
         self
     }
 }
+
+#[doc(hidden)]
+pub trait CombinableQuery: Query {}

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -15,7 +15,7 @@ use super::limit_clause::NoLimitClause;
 use super::offset_clause::NoOffsetClause;
 use super::order_clause::NoOrderClause;
 use super::where_clause::NoWhereClause;
-use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult};
+use super::{Query, CombinableQuery, QueryBuilder, QueryFragment, BuildQueryResult};
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -120,6 +120,11 @@ impl<ST, S, F, D, W, O, L, Of, G> Query
         S: SelectableExpression<F, ST>,
 {
     type SqlType = ST;
+}
+
+impl<ST, S, F, W, O, L, Of, G> CombinableQuery for SelectStatement<ST, S, F, W, O, L, Of, G> where
+    SelectStatement<ST, S, F, W, O, L, Of, G>: Query,
+{
 }
 
 #[cfg(feature = "postgres")]

--- a/diesel/src/query_builder/union_query.rs
+++ b/diesel/src/query_builder/union_query.rs
@@ -1,0 +1,61 @@
+use backend::Backend;
+use result::QueryResult;
+use super::{Query, CombinableQuery, QueryBuilder, QueryFragment, BuildQueryResult};
+
+#[derive(Debug)]
+pub struct UnionQuery<L, R> {
+    left: L,
+    right: R,
+    all: bool,
+}
+
+impl<L, R> UnionQuery<L, R> {
+    pub fn new(left: L, right: R, all: bool) -> Self {
+        UnionQuery {
+            left: left,
+            right: right,
+            all: all,
+        }
+    }
+}
+
+impl<L, R> Query for UnionQuery<L, R> where
+    L: CombinableQuery,
+    R: CombinableQuery<SqlType=L::SqlType>,
+{
+    type SqlType = <L as Query>::SqlType;
+}
+
+impl<L, R> CombinableQuery for UnionQuery<L, R> where
+    UnionQuery<L, R>: Query,
+{
+}
+
+impl<L, R, DB> QueryFragment<DB> for UnionQuery<L, R> where
+    DB: Backend,
+    L: QueryFragment<DB>,
+    R: QueryFragment<DB>,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        try!(self.left.to_sql(out));
+        if self.all {
+            out.push_sql(" UNION ALL ");
+        } else {
+            out.push_sql(" UNION ");
+        }
+        try!(self.right.to_sql(out));
+        Ok(())
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        try!(self.left.collect_binds(out));
+        try!(self.right.collect_binds(out));
+        Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.left.is_safe_to_cache_prepared() && self.right.is_safe_to_cache_prepared()
+    }
+}
+
+impl_query_id!(UnionQuery<L, R>);

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -16,6 +16,7 @@ mod save_changes_dsl;
 mod offset_dsl;
 mod order_dsl;
 mod with_dsl;
+mod union_dsl;
 
 pub use self::belonging_to_dsl::BelongingToDsl;
 pub use self::boxed_dsl::BoxedDsl;
@@ -31,3 +32,4 @@ pub use self::order_dsl::OrderDsl;
 pub use self::save_changes_dsl::SaveChangesDsl;
 pub use self::select_dsl::{SelectDsl, SelectSqlDsl};
 pub use self::with_dsl::{WithDsl, WithQuerySource};
+pub use self::union_dsl::UnionDsl;

--- a/diesel/src/query_dsl/union_dsl.rs
+++ b/diesel/src/query_dsl/union_dsl.rs
@@ -1,0 +1,23 @@
+use query_builder::{CombinableQuery, UnionQuery};
+
+pub trait UnionDsl<U: CombinableQuery<SqlType=Self::SqlType>>: CombinableQuery {
+    type Output: CombinableQuery<SqlType=Self::SqlType>;
+
+    fn union(self, query: U) -> Self::Output;
+    fn union_all(self, query: U) -> Self::Output;
+}
+
+impl<T, U> UnionDsl<U> for T where
+    T: CombinableQuery,
+    U: CombinableQuery<SqlType=T::SqlType>,
+{
+    type Output = UnionQuery<T, U>;
+
+    fn union(self, other: U) -> Self::Output {
+        UnionQuery::new(self, other, false)
+    }
+
+    fn union_all(self, other: U) -> Self::Output {
+        UnionQuery::new(self, other, true)
+    }
+}

--- a/diesel_compile_tests/tests/compile-fail/union_query_only_allowed_for_select_statment.rs
+++ b/diesel_compile_tests/tests/compile-fail/union_query_only_allowed_for_select_statment.rs
@@ -1,0 +1,33 @@
+#![feature(custom_derive, custom_attribute, plugin)]
+#![plugin(diesel_codegen)]
+
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+#[insertable_into(users)]
+struct NewUser<'a> {
+    name: &'a str,
+}
+
+fn main() {
+    use self::users::dsl::*;
+
+    let connection = PgConnection::establish("").unwrap();
+    let new_user = NewUser { name: "Robbie" };
+    let stmt = users.select(name);
+    insert(&new_user).into(users).returning(name).union(stmt);
+    //~^ ERROR no method named `union` found for type `diesel::query_builder::insert_statement::InsertQuery<users::columns::name, diesel::query_builder::insert_statement::InsertStatement<users::table, &NewUser<'_>, diesel::query_builder::insert_statement::Insert>>` in the current scope
+
+    update(users.find(1)).set(name.eq("Robert")).returning(name).union(stmt);
+    //~^ ERROR no method named `union` found for type `diesel::query_builder::update_statement::UpdateQuery<users::columns::name, diesel::query_builder::update_statement::UpdateStatement<diesel::query_source::filter::FilteredQuerySource<users::table, diesel::expression::predicates::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::types::Integer, i32>>>, diesel::expression::predicates::Eq<users::columns::name, diesel::expression::bound::Bound<diesel::types::Text, &str>>>>` in the current scope
+}

--- a/diesel_compile_tests/tests/compile-fail/union_query_requires_equal_sqltype_between_operands.rs
+++ b/diesel_compile_tests/tests/compile-fail/union_query_requires_equal_sqltype_between_operands.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::expression::AsExpression;
+
+table! {
+    numtest (n) {
+        n -> Integer,
+        updated_at -> Nullable<Timestamp>,
+    }
+}
+
+fn main() {
+    use self::numtest::dsl::*;
+
+    let zero = AsExpression::<types::Integer>::as_expression(0);
+    let stmt = numtest.select((n, zero));
+    let bad_stmt = numtest.select((n));
+    let union = stmt.union(bad_stmt);
+    //~^ ERROR type mismatch resolving `<diesel::query_builder::SelectStatement<diesel::types::Integer, numtest::columns::n, numtest::table> as diesel::query_builder::Query>::SqlType == (diesel::types::Integer, diesel::types::Integer)`
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -29,3 +29,4 @@ mod select;
 mod transactions;
 mod types;
 mod types_roundtrip;
+mod union;

--- a/diesel_tests/tests/union.rs
+++ b/diesel_tests/tests/union.rs
@@ -1,0 +1,85 @@
+use super::schema::*;
+use diesel::*;
+use schema_dsl::*;
+
+#[test]
+fn union_on_selects() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .unwrap();
+
+    let expected_data =
+        if cfg!(feature = "postgres") {
+            vec![
+                "Tess".to_string(),
+                "Sean".to_string(),
+            ]
+        } else if cfg!(feature = "sqlite") {
+            vec![
+                "Sean".to_string(),
+                "Tess".to_string(),
+            ]
+        } else {
+            vec![]
+        };
+    let query = users.select(name);
+    let union = query.union(query);
+    let actual_data: Vec<String> = union
+        .load(&connection)
+        .unwrap();
+    assert_eq!(expected_data, actual_data);
+}
+
+#[test]
+fn union_all_on_selects() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .unwrap();
+
+    let expected_data = vec![
+        "Sean".to_string(),
+        "Tess".to_string(),
+        "Sean".to_string(),
+        "Tess".to_string(),
+     ];
+    let query = users.select(name);
+    let union = query.union_all(query);
+    let actual_data: Vec<String> = union
+        .load(&connection)
+        .unwrap();
+    assert_eq!(expected_data, actual_data);
+}
+
+#[test]
+fn union_on_unions() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .unwrap();
+
+    let expected_data =
+        if cfg!(feature = "postgres") {
+            vec![
+                "Tess".to_string(),
+                "Sean".to_string(),
+            ]
+        } else if cfg!(feature = "sqlite") {
+            vec![
+                "Sean".to_string(),
+                "Tess".to_string(),
+            ]
+        } else {
+            vec![]
+        };
+    let query = users.select(name);
+    let union = query.union(query).union(query);
+    let actual_data: Vec<String> = union
+        .load(&connection)
+        .unwrap();
+    assert_eq!(expected_data, actual_data);
+}


### PR DESCRIPTION
First part and foundation of #33.

`CombinableQuery` is the marker trait that allows unions of `SelectStatements` and `UnionStatements`. This trait can be used in the future PRs for `EXCEPT` and `INTERSECT`.

Per [this comment](https://github.com/diesel-rs/diesel/issues/33#issuecomment-215920493), I decided to not write compile-fail tests for other query DSL methods yet.

Still left to do:
- [ ] Support `ORDER BY`, `LIMIT`, and `OFFSET` DSLs (per [SQLite Spec](https://www.sqlite.org/lang_select.html) and [Pg Spec](http://www.postgresql.org/docs/current/static/queries-order.html))
- [ ] Docs (and tests)
- [ ] Split `UnionQuery` by `all` flag
- [ ] More compile-fails (`GROUP BY`, `WHERE`, etc.)
