### PR TITLE
[Issue #34] - removing more instances of .unwrap() from documentation in favor of try!()

### DIFF
--- a/diesel/src/expression/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/escape_expression_methods.rs
@@ -23,7 +23,7 @@ use types::VarChar;
 /// #     use diesel::insert;
 /// #     let connection = establish_connection();
 /// #     try!(insert(&NewUser { name: "Ha%%0r".into() }).into(users)
-/// #         .execute(&connection));
+/// #         .execute(&connection)xt);
 /// let users_with_percent = users.select(name)
 ///     .filter(name.like("%😀%%").escape('😀'))
 ///     .load(&connection);

--- a/diesel/src/expression/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/escape_expression_methods.rs
@@ -22,8 +22,8 @@ use types::VarChar;
 /// #     use self::users::dsl::*;
 /// #     use diesel::insert;
 /// #     let connection = establish_connection();
-/// #     insert(&NewUser { name: "Ha%%0r".into() }).into(users)
-/// #         .try!(execute(&connection));
+/// #     try!(insert(&NewUser { name: "Ha%%0r".into() }).into(users)
+/// #         .execute(&connection));
 /// let users_with_percent = users.select(name)
 ///     .filter(name.like("%😀%%").escape('😀'))
 ///     .load(&connection);

--- a/diesel/src/expression/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/escape_expression_methods.rs
@@ -23,7 +23,7 @@ use types::VarChar;
 /// #     use diesel::insert;
 /// #     let connection = establish_connection();
 /// #     insert(&NewUser { name: "Ha%%0r".into() }).into(users)
-/// #         .execute(&connection).unwrap();
+/// #         .try!(execute(&connection));
 /// let users_with_percent = users.select(name)
 ///     .filter(name.like("%😀%%").escape('😀'))
 ///     .load(&connection);

--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -97,8 +97,8 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # fn main() {
     /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// #     connection.execute("INSERT INTO users (name) VALUES
-    /// #         ('Jim')").unwrap();
+    /// #     try!(connection.execute("INSERT INTO users (name) VALUES
+    /// #         ('Jim')"));
     /// let data = users.select(id).filter(name.eq_any(vec!["Sean", "Jim"]));
     /// assert_eq!(Ok(vec![1, 3]), data.load(&connection));
     /// # }

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -31,7 +31,7 @@ use types::{Array, HasSqlType};
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = establish_connection();
-/// #     connection.execute("INSERT INTO users (name) VALUES ('Jim')").unwrap();
+/// #     try!(connection.execute("INSERT INTO users (name) VALUES ('Jim')"));
 /// let sean = (1, "Sean".to_string());
 /// let jim = (3, "Jim".to_string());
 /// let data = users.filter(name.eq(any(vec!["Sean", "Jim"])));

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -82,14 +82,14 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// # fn main() {
     /// #     use self::posts::dsl::*;
     /// #     let conn = establish_connection();
-    /// #     conn.execute("DROP TABLE IF EXISTS posts").unwrap();
-    /// #     conn.execute("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)").unwrap();
+    /// #     try!(conn.execute("DROP TABLE IF EXISTS posts"));
+    /// #     try!(conn.execute("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)"));
     /// #
     /// diesel::insert(&vec![
     ///     NewPost { tags: vec!["cool", "awesome"] },
     ///     NewPost { tags: vec!["awesome", "great"] },
     ///     NewPost { tags: vec!["cool", "great"] },
-    /// ]).into(posts).execute(&conn).unwrap();
+    /// ]).into(posts).try!(execute(&conn));
     ///
     /// let query = posts.select(id).filter(tags.overlaps_with(vec!["horrid", "cool"]));
     /// assert_eq!(Ok(vec![1, 3]), query.load(&conn));
@@ -136,12 +136,12 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// # fn main() {
     /// #     use self::posts::dsl::*;
     /// #     let conn = establish_connection();
-    /// #     conn.execute("DROP TABLE IF EXISTS posts").unwrap();
-    /// #     conn.execute("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)").unwrap();
+    /// #     try!(conn.execute("DROP TABLE IF EXISTS posts"));
+    /// #     try!(conn.execute("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)"));
     /// #
     /// diesel::insert(&vec![
     ///     NewPost { tags: vec!["cool", "awesome"] },
-    /// ]).into(posts).execute(&conn).unwrap();
+    /// ]).into(posts).try!(execute(&conn));
     ///
     /// let query = posts.select(id).filter(tags.contains(vec!["cool"]));
     /// assert_eq!(Ok(vec![1]), query.load(&conn));
@@ -186,12 +186,12 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// # fn main() {
     /// #     use self::posts::dsl::*;
     /// #     let conn = establish_connection();
-    /// #     conn.execute("DROP TABLE IF EXISTS posts").unwrap();
-    /// #     conn.execute("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)").unwrap();
+    /// #     try!(conn.execute("DROP TABLE IF EXISTS posts"));
+    /// #     try!(conn.execute("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)"));
     /// #
     /// diesel::insert(&vec![
     ///     NewPost { tags: vec!["cool", "awesome"] },
-    /// ]).into(posts).execute(&conn).unwrap();
+    /// ]).into(posts).try!(execute(&conn));
     ///
     /// let query = posts.select(id).filter(tags.is_contained_by(vec!["cool", "awesome", "amazing"]));
     /// assert_eq!(Ok(vec![1]), query.load(&conn));

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -261,7 +261,7 @@ mod tests {
 
                 let connection_url = ::std::env::var("DATABASE_URL")
                     .expect("DATABASE_URL must be set in order to run tests");
-                let connection = try!(PgConnection::establish(&connection_url));
+                let connection = PgConnection::establish(&connection_url).unwrap();
 
                 let sql_str = format!(concat!("'{} ", stringify!($units), "'::interval"), val);
                 let query = select(sql::<types::Interval>(&sql_str));

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -26,16 +26,16 @@ use data_types::PgInterval;
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = connection_no_data();
-/// #     connection.execute("CREATE TABLE users (id serial primary key, name
-/// #        varchar not null, created_at timestamp not null)").unwrap();
-/// connection.execute("INSERT INTO users (name, created_at) VALUES
+/// #     try!(connection.execute("CREATE TABLE users (id serial primary key, name
+/// #        varchar not null, created_at timestamp not null)"));
+/// try!(connection.execute("INSERT INTO users (name, created_at) VALUES
 ///     ('Sean', NOW()), ('Tess', NOW() - '5 minutes'::interval),
-///     ('Jim', NOW() - '10 minutes'::interval)").unwrap();
+///     ('Jim', NOW() - '10 minutes'::interval)"));
 ///
 /// let mut data: Vec<String> = users
 ///     .select(name)
 ///     .filter(created_at.gt(now - 7.minutes()))
-///     .load(&connection).unwrap();
+///     .try!(load(&connection));
 /// assert_eq!(2, data.len());
 /// assert_eq!("Sean".to_string(), data[0]);
 /// assert_eq!("Tess".to_string(), data[1]);
@@ -117,16 +117,16 @@ pub trait MicroIntervalDsl: Sized + Mul<Self, Output=Self> {
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = connection_no_data();
-/// #     connection.execute("CREATE TABLE users (id serial primary key, name
-/// #        varchar not null, created_at timestamp not null)").unwrap();
-/// connection.execute("INSERT INTO users (name, created_at) VALUES
+/// #     try!(connection.execute("CREATE TABLE users (id serial primary key, name
+/// #        varchar not null, created_at timestamp not null)"));
+/// try!(connection.execute("INSERT INTO users (name, created_at) VALUES
 ///     ('Sean', NOW()), ('Tess', NOW() - '5 days'::interval),
-///     ('Jim', NOW() - '10 days'::interval)").unwrap();
+///     ('Jim', NOW() - '10 days'::interval)"));
 ///
 /// let mut data: Vec<String> = users
 ///     .select(name)
 ///     .filter(created_at.gt(now - 7.days()))
-///     .load(&connection).unwrap();
+///     .try!(load(&connection));
 /// assert_eq!(2, data.len());
 /// assert_eq!("Sean".to_string(), data[0]);
 /// assert_eq!("Tess".to_string(), data[1]);
@@ -261,7 +261,7 @@ mod tests {
 
                 let connection_url = ::std::env::var("DATABASE_URL")
                     .expect("DATABASE_URL must be set in order to run tests");
-                let connection = PgConnection::establish(&connection_url).unwrap();
+                let connection = try!(PgConnection::establish(&connection_url));
 
                 let sql_str = format!(concat!("'{} ", stringify!($units), "'::interval"), val);
                 let query = select(sql::<types::Interval>(&sql_str));

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -20,9 +20,8 @@ use query_source::QuerySource;
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = establish_connection();
-/// #     connection.execute("DELETE FROM users").unwrap();
-/// connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Sean')")
-///     .unwrap();
+/// #     try!(connection.execute("DELETE FROM users"));
+/// try!(connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Sean')"));
 /// let names = users.select(name).load(&connection);
 /// let distinct_names = users.select(name).distinct().load(&connection);
 ///

--- a/diesel/src/sqlite/query_builder/functions.rs
+++ b/diesel/src/sqlite/query_builder/functions.rs
@@ -35,8 +35,8 @@ use super::nodes::Replace;
 /// #     use self::diesel::{insert, insert_or_replace};
 /// #     use self::diesel::sqlite::SqliteConnection;
 /// #
-/// #     let conn = SqliteConnection::establish(":memory:").unwrap();
-/// #     conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR)").unwrap();
+/// #     let conn = try!(SqliteConnection::establish(":memory:"));
+/// #     try!(conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR)"));
 /// insert(&NewUser::new("Sean")).into(users).execute(&conn).unwrap();
 /// insert(&NewUser::new("Tess")).into(users).execute(&conn).unwrap();
 ///


### PR DESCRIPTION
As per #34, there were still a few instances of .unwrap() left in documentation. So, this (hopefully) covers some more ground towards eliminating these instances. 

Please note that `try!()` is a new Rust idiom to me personally, but I think I was able to get the hang of it pretty quickly. There's definitely a chance I messed something up though!