### PR TITLE
Implement `Queryable` as a standard non-procedural macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   those wishing to avoid syntax extensions from `diesel_codegen`. See
   http://docs.diesel.rs/diesel/macro.Insertable!.html for details.
 
+* The `Queryable!` macro can now be used instead of `#[derive(Queryable)]` for
+  those wishing to avoid syntax extensions from `diesel_codegen`. See
+  http://docs.diesel.rs/diesel/macro.Queryable!.html for details.
+
 ### Changed
 
 * `infer_schema!` on SQLite now accepts a larger range of type names

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -7,6 +7,9 @@
 #[macro_use]
 mod macros;
 
+#[cfg(test)]
+pub mod test_helpers;
+
 pub mod associations;
 pub mod backend;
 pub mod connection;

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -197,7 +197,7 @@ macro_rules! Insertable {
 macro_rules! Insertable_column_expr {
     ($column:path, $field_access:expr, option) => {
         match $field_access {
-            &Some(ref value) => Insertable_column_expr!($column, value, regular),
+            value @ &Some(_) => Insertable_column_expr!($column, value, regular),
             &None => ColumnInsertValue::Default($column),
         }
     };

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -91,7 +91,7 @@ macro_rules! Insertable {
         }
     };
 
-    // Handle named struct with no lifetimes
+    // Handle struct with no lifetimes
     (
         ($table_name:ident)
         $struct_name:ident
@@ -401,30 +401,15 @@ mod tests {
     }
 
     #[cfg(feature = "sqlite")]
-    use sqlite::SqliteConnection;
-
-    #[cfg(feature = "sqlite")]
-    fn connection() -> SqliteConnection {
-        let conn = SqliteConnection::establish(":memory:").unwrap();
+    fn connection() -> ::test_helpers::TestConnection {
+        let conn = ::test_helpers::connection();
         conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR NOT NULL, hair_color VARCHAR DEFAULT 'Green')").unwrap();
         conn
     }
 
     #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
-    use pg::PgConnection;
-    #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
-    extern crate dotenv;
-
-    #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
-    fn connection() -> PgConnection {
-        use self::dotenv::dotenv;
-        use std::env;
-
-        dotenv().ok();
-        let database_url = env::var("DATABASE_URL")
-            .expect("DATABASE_URL must be set to run tests");
-        let conn = PgConnection::establish(&database_url).unwrap();
-        conn.begin_test_transaction().unwrap();
+    fn connection() -> ::test_helpers::TestConnection {
+        let conn = ::test_helpers::connection();
         conn.execute("DROP TABLE IF EXISTS users").unwrap();
         conn.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR NOT NULL, hair_color VARCHAR DEFAULT 'Green')").unwrap();
         conn

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -320,6 +320,14 @@ mod tests {
         }
     }
 
+    test_struct_definition! {
+        named_struct_without_trailing_comma,
+        struct NewUser<'a> {
+            name: &'a str,
+            hair_color: Option<&'a str>
+        }
+    }
+
     #[test]
     fn named_struct_with_renamed_field() {
         struct NewUser {
@@ -399,6 +407,34 @@ mod tests {
         let expected = vec![("Sean".to_string(), Some("Green".to_string()))];
         assert_eq!(Ok(expected), saved);
     }
+
+    #[test]
+    fn tuple_struct_without_trailing_comma() {
+        struct NewUser<'a>(
+            &'a str,
+            Option<&'a str>
+        );
+
+        Insertable! {
+            (users)
+            struct NewUser<'a>(
+                #[column_name(name)]
+                pub &'a str,
+                #[column_name(hair_color)]
+                Option<&'a str>
+            );
+        }
+
+        let conn = connection();
+        let new_user = NewUser("Sean", None);
+        ::insert(&new_user).into(users::table).execute(&conn).unwrap();
+
+        let saved = users::table.select((users::name, users::hair_color))
+            .load::<(String, Option<String>)>(&conn);
+        let expected = vec![("Sean".to_string(), Some("Green".to_string()))];
+        assert_eq!(Ok(expected), saved);
+    }
+
 
     #[cfg(feature = "sqlite")]
     fn connection() -> ::test_helpers::TestConnection {

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -458,3 +458,4 @@ macro_rules! print_sql {
 #[macro_use] mod parse;
 #[macro_use] mod query_id;
 #[macro_use] mod insertable;
+#[macro_use] mod queryable;

--- a/diesel/src/macros/parse.rs
+++ b/diesel/src/macros/parse.rs
@@ -54,7 +54,7 @@
 ///     }, {
 ///         field_name: bar,
 ///         column_name: bar,
-///         field_ty: i32,
+///         field_ty: Option<i32>,
 ///         field_kind: option,
 ///     }, {
 ///         field_name: baz,
@@ -127,7 +127,7 @@ macro_rules! __diesel_parse_struct_body {
             callback = $callback,
             fields = [$($fields)* {
                 column_name: $column_name,
-                field_ty: $field_ty,
+                field_ty: Option<$field_ty>,
                 field_kind: option,
             }],
             body = ($($tail)*),
@@ -202,7 +202,7 @@ macro_rules! __diesel_parse_struct_body {
             fields = [$($fields)* {
                 field_name: $field_name,
                 column_name: $column_name,
-                field_ty: $field_ty,
+                field_ty: Option<$field_ty>,
                 field_kind: option,
             }],
             body = ($($tail)*),

--- a/diesel/src/macros/parse.rs
+++ b/diesel/src/macros/parse.rs
@@ -76,7 +76,7 @@ macro_rules! __diesel_parse_struct_body {
             $headers,
             callback = $callback,
             fields = [],
-            body = ($($body)*),
+            body = ($($body)*,),
         }
     };
 
@@ -84,13 +84,13 @@ macro_rules! __diesel_parse_struct_body {
     (
         $headers:tt,
         callback = $callback:ident,
-        body = $body:tt,
+        body = ($($body:tt)*),
     ) => {
         __diesel_parse_struct_body! {
             $headers,
             callback = $callback,
             fields = [],
-            body = $body,
+            body = ($($body)*,),
         }
     };
 
@@ -109,6 +109,23 @@ macro_rules! __diesel_parse_struct_body {
             callback = $callback,
             fields = $fields,
             body = ($(#$meta)* $($tail)*),
+        }
+    };
+
+    // Since we blindly add a comma to the end of the body, we might have a
+    // double trailing comma.  If it's the only token left, that's what
+    // happened. Strip it.
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        fields = $fields:tt,
+        body = (,),
+    ) => {
+        __diesel_parse_struct_body! {
+            $headers,
+            callback = $callback,
+            fields = $fields,
+            body = (),
         }
     };
 

--- a/diesel/src/macros/queryable.rs
+++ b/diesel/src/macros/queryable.rs
@@ -1,0 +1,229 @@
+/// Implements the [`Queryable`][queryable] trait for a given struct. This macro
+/// should be called by copy/pasting the definition of the struct into it.
+///
+/// [queryable]: query_source/trait.Queryable.html
+///
+/// # Example
+///
+/// ```no_run
+/// # #[macro_use] extern crate diesel;
+/// struct User {
+///     name: String,
+///     hair_color: Option<String>,
+/// }
+///
+/// Queryable! {
+///     struct User {
+///         name: String,
+///         hair_color: Option<String>,
+///     }
+/// }
+/// # fn main() {}
+/// ```
+///
+/// To avoid copying your struct definition, you can use the
+/// [custom_derive crate][custom_derive].
+///
+/// [custom_derive]: https://crates.io/crates/custom_derive
+///
+/// ```ignore
+/// custom_derive! {
+///     #[derive(Queryable)]
+///     struct User {
+///         name: String,
+///         hair_color: Option<String>,
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! Queryable {
+    // Strip empty argument list if given (Passed by custom_derive macro)
+    (() $($body:tt)*) => {
+        Queryable! {
+            $($body)*
+        }
+    };
+
+    // Strip meta items, pub (if present) and struct from definition
+    (
+        $(#[$ignore:meta])*
+        $(pub)* struct $($body:tt)*
+    ) => {
+        Queryable! {
+            $($body)*
+        }
+    };
+
+    // Receive parsed fields of normal struct from `__diesel_parse_struct_body`
+    // These patterns must appear above those which start with an ident to compile
+    (
+        (
+            struct_name = $struct_name:ident,
+            $($headers:tt)*
+        ),
+        fields = [$({
+            field_name: $field_name:ident,
+            column_name: $column_name:ident,
+            field_ty: $field_ty:ty,
+            field_kind: $field_kind:ident,
+        })+],
+    ) => {
+        Queryable! {
+            $($headers)*
+            row_ty = ($($field_ty,)+),
+            row_pat = ($($field_name,)+),
+            build_expr = $struct_name { $($field_name: $field_name),+ },
+        }
+    };
+
+    // Receive parsed fields of tuple struct from `__diesel_parse_struct_body`
+    // where the fields were annotated with `#[column_name]`. We don't need the
+    // name, so toss it out.
+    (
+        $headers:tt,
+        fields = [$({
+            column_name: $column_name:ident,
+            field_ty: $field_ty:ty,
+            field_kind: $field_kind:ident,
+        })+],
+    ) => {
+        Queryable! {
+            $headers,
+            fields = [$({
+                field_ty: $field_ty,
+                field_kind: $field_kind,
+            })+],
+        }
+    };
+
+    // Receive parsed fields of tuple struct from `__diesel_parse_struct_body`
+    (
+        (
+            struct_name = $struct_name:ident,
+            $($headers:tt)*
+        ),
+        fields = [$({
+            field_ty: $field_ty:ty,
+            field_kind: $field_kind:ident,
+        })+],
+    ) => {
+        Queryable! {
+            $($headers)*
+            row_ty = ($($field_ty,)+),
+            row_pat = ($($field_kind,)+),
+            build_expr = $struct_name($($field_kind),+),
+        }
+    };
+
+    // Construct the final impl
+    (
+        struct_ty = $struct_ty:ty,
+        generics = ($($generics:ident),*),
+        row_ty = $row_ty:ty,
+        row_pat = $row_pat:pat,
+        build_expr = $build_expr:expr,
+    ) => {
+        impl<$($generics,)* __DB, __ST> $crate::Queryable<__ST, __DB> for $struct_ty where
+            __DB: $crate::backend::Backend + $crate::types::HasSqlType<__ST>,
+            $row_ty: $crate::types::FromSqlRow<__ST, __DB>,
+        {
+            type Row = $row_ty;
+
+            fn build(row: Self::Row) -> Self {
+                let $row_pat = row;
+                $build_expr
+            }
+        }
+    };
+
+    // Handle struct with generics
+    (
+        $struct_name:ident <$($generics:ident),*>
+        $body:tt $(;)*
+    ) => {
+        __diesel_parse_struct_body! {
+            (
+                struct_name = $struct_name,
+                struct_ty = $struct_name<$($generics),*>,
+                generics = ($($generics),*),
+            ),
+            callback = Queryable,
+            body = $body,
+        }
+    };
+
+    // Handle struct with no generics
+    (
+        $struct_name:ident
+        $body:tt $(;)*
+    ) => {
+        __diesel_parse_struct_body! {
+            (
+                struct_name = $struct_name,
+                struct_ty = $struct_name,
+                generics = (),
+            ),
+            callback = Queryable,
+            body = $body,
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use expression::dsl::sql;
+    use prelude::*;
+    use test_helpers::connection;
+    use types::Integer;
+
+    #[test]
+    fn named_struct_definition() {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        struct MyStruct {
+            foo: i32,
+            bar: i32,
+        }
+
+        Queryable! {
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            struct MyStruct {
+                foo: i32,
+                bar: i32,
+            }
+        }
+
+        let conn = connection();
+        let data = ::select(sql::<(Integer, Integer)>("1, 2")).get_result(&conn);
+        assert_eq!(Ok(MyStruct { foo: 1, bar: 2 }), data);
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        struct MyStruct(i32, i32);
+
+        Queryable! {
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            struct MyStruct(#[column_name(foo)] i32, #[column_name(bar)] i32);
+        }
+
+        let conn = connection();
+        let data = ::select(sql::<(Integer, Integer)>("1, 2")).get_result(&conn);
+        assert_eq!(Ok(MyStruct(1, 2)), data);
+    }
+
+    #[test]
+    fn tuple_struct_without_column_name_annotations() {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        struct MyStruct(i32, i32);
+
+        Queryable! {
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            struct MyStruct(i32, i32);
+        }
+
+        let conn = connection();
+        let data = ::select(sql::<(Integer, Integer)>("1, 2")).get_result(&conn);
+        assert_eq!(Ok(MyStruct(1, 2)), data);
+    }
+}

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -1,0 +1,35 @@
+#[cfg(feature = "sqlite")]
+mod database_specific_helpers {
+    use prelude::*;
+    use sqlite::SqliteConnection;
+
+    pub type TestConnection = SqliteConnection;
+
+    pub fn connection() -> TestConnection {
+        SqliteConnection::establish(":memory:").unwrap()
+    }
+}
+
+#[cfg(all(feature = "postgres", not(feature = "sqlite")))]
+mod database_specific_helpers {
+    extern crate dotenv;
+
+    use self::dotenv::dotenv;
+    use std::env;
+
+    use pg::PgConnection;
+    use prelude::*;
+
+    pub type TestConnection = PgConnection;
+
+    pub fn connection() -> TestConnection {
+        dotenv().ok();
+        let database_url = env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set to run tests");
+        let conn = PgConnection::establish(&database_url).unwrap();
+        conn.begin_test_transaction().unwrap();
+        conn
+    }
+}
+
+pub use self::database_specific_helpers::*;


### PR DESCRIPTION
Queryable is fairly simple to derive compared ot some of the other
cases, so the macro definition is fairly uninteresting. I needed to make
some changes to the parse code to support this additional case, but I've
kept those as separate commits which have more context around each
change.

The most surprising piece here is that we were able to make this work
without requiring the `#[column_name(name)]` annotation. Due to the way
that we parse the struct, the `$field_kind` variable actually acts as a
fresh ident, due to macro hygiene. So even if the resulting code *looks*
like it's using the same name more than once, the parser treats them as
separate.