### PR TITLE
Add Missing Link to Documentation

### DIFF
--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -27,6 +27,8 @@
 /// To avoid copying your struct definition, you can use the
 /// [custom_derive crate][custom_derive].
 ///
+/// [custom_derive]: https://crates.io/crates/custom_derive
+///
 /// ```ignore
 /// custom_derive! {
 ///     #[derive(Insertable(users))]


### PR DESCRIPTION
This add a missing link to ~~evolution~~<ins>documentation</ins> of the `Insertable!` documentation.