### PR TITLE
remove usage of sqlite3_errstr

### DIFF
--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -13,7 +13,6 @@ use std::any::TypeId;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::ffi::CStr;
 
 use connection::{SimpleConnection, Connection};
 use query_builder::*;
@@ -205,11 +204,7 @@ fn to_sql<T: QueryFragment<Sqlite>>(source: &T) -> QueryResult<String> {
 }
 
 fn error_message(err_code: libc::c_int) -> &'static str {
-    unsafe {
-        let message_ptr = ffi::sqlite3_errstr(err_code);
-        let result = CStr::from_ptr(message_ptr);
-        result.to_str().unwrap()
-    }
+    ffi::code_to_str(err_code)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I'm stuck with an older version of sqlite (3.6). It appears that the only newer feature actually used is `sqlite3_errstr` in `diesel::sqlite::connection::error_message`.

`libsqlite3-sys` provides a comparable function `libsqlite3-sys::code_to_str` that should be able to be used in place of `sqlite3_errstr`. Would it be possible to switch this out?

I've modified this locally and everything seems to be working great&mdash;

This issue also relates to #238 and #167.

Thanks for considering&mdash;Diesel looks great!