### PR TITLE
Add sqlite support for chrono's Naive{DateTime,Date,Time} types

### DIFF
--- a/diesel/src/sqlite/types/date_and_time.rs
+++ b/diesel/src/sqlite/types/date_and_time.rs
@@ -18,3 +18,79 @@ impl types::HasSqlType<types::Timestamp> for Sqlite {
         SqliteType::Text
     }
 }
+
+#[cfg(feature = "chrono")]
+mod chrono {
+    extern crate chrono;
+
+    use std::error::Error;
+    use std::io::Write;
+    use self::chrono::{NaiveDateTime, NaiveDate, NaiveTime};
+
+    use sqlite::Sqlite;
+    use sqlite::connection::SqliteValue;
+    use types::{self, Date, FromSql, IsNull, Time, Timestamp, ToSql, Text};
+
+    const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S";
+    const SQLITE_DATE_FMT: &'static str = "%Y-%m-%d";
+    const SQLITE_TIME_FMT: &'static str = "%H:%M:%S";
+
+    expression_impls! {
+        Date -> NaiveDate,
+        Time -> NaiveTime,
+        Timestamp -> NaiveDateTime,
+    }
+
+    queryable_impls! {
+        Date -> NaiveDate,
+        Time -> NaiveTime,
+        Timestamp -> NaiveDateTime,
+    }
+
+    impl FromSql<Date, Sqlite> for NaiveDate {
+        fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error+Send+Sync>> {
+            let text = not_none!(value).read_text();
+            let date = try!(NaiveDate::parse_from_str(text, SQLITE_DATE_FMT));
+            Ok(date)
+        }
+    }
+
+    impl ToSql<Timestamp, Sqlite> for NaiveDate {
+        fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+            let s = format!("{}", self.format(SQLITE_DATE_FMT));
+            ToSql::<Text, Sqlite>::to_sql(&s, out)
+        }
+    }
+
+    impl FromSql<Time, Sqlite> for NaiveTime {
+        fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error+Send+Sync>> {
+            let text = not_none!(value).read_text();
+            let time = try!(NaiveTime::parse_from_str(text, SQLITE_TIME_FMT));
+            Ok(time)
+        }
+    }
+
+    impl ToSql<Time, Sqlite> for NaiveTime {
+        fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+            let s = format!("{}", self.format(SQLITE_TIME_FMT));
+            ToSql::<Text, Sqlite>::to_sql(&s, out)
+        }
+    }
+
+    impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
+        fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error+Send+Sync>> {
+            let text = not_none!(value).read_text();
+            let datetime = try!(NaiveDateTime::parse_from_str(text, SQLITE_DATETIME_FMT));
+            Ok(datetime)
+        }
+    }
+
+    impl ToSql<Timestamp, Sqlite> for NaiveDateTime {
+        fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+            let s = format!("{}", self.format(SQLITE_DATETIME_FMT));
+            ToSql::<Text, Sqlite>::to_sql(&s, out)
+        }
+    }
+
+
+}

--- a/diesel/src/sqlite/types/date_and_time.rs
+++ b/diesel/src/sqlite/types/date_and_time.rs
@@ -29,18 +29,24 @@ mod chrono {
 
     use sqlite::Sqlite;
     use sqlite::connection::SqliteValue;
-    use types::{self, Date, FromSql, IsNull, Time, Timestamp, ToSql, Text};
+    use types::{Date, FromSql, IsNull, Time, Timestamp, ToSql, Text};
+
+    #[cfg(not(feature = "postgres"))]
+    use types;
+
 
     const SQLITE_DATETIME_FMT: &'static str = "%Y-%m-%d %H:%M:%S";
     const SQLITE_DATE_FMT: &'static str = "%Y-%m-%d";
     const SQLITE_TIME_FMT: &'static str = "%H:%M:%S";
 
+    #[cfg(not(feature = "postgres"))]
     expression_impls! {
         Date -> NaiveDate,
         Time -> NaiveTime,
         Timestamp -> NaiveDateTime,
     }
 
+    #[cfg(not(feature = "postgres"))]
     queryable_impls! {
         Date -> NaiveDate,
         Time -> NaiveTime,


### PR DESCRIPTION
Adds initial `chrono` support for sqlite. Uses the text representations of dates/times/datetimes as apparently preferred by sqlite (e.g., those created by `DATETIME('now')`).
