### PR TITLE
Feature/desc nulls last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+* Added support for PostgreSQL `NULLS FIRST` and `NULLS LAST` when sorting.
+  See http://docs.diesel.rs/diesel/prelude/trait.SortExpressionMethods.html
+  for details.
+
 ## [0.7.0] - 2016-08-01
 
 ### Added

--- a/diesel/src/pg/expression/predicates.rs
+++ b/diesel/src/pg/expression/predicates.rs
@@ -1,6 +1,9 @@
 use pg::Pg;
+use query_builder::QueryBuilder;
 
 infix_predicate!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
 infix_predicate!(OverlapsWith, " && ", backend: Pg);
 infix_predicate!(Contains, " @> ", backend: Pg);
 infix_predicate!(IsContainedBy, " <@ ", backend: Pg);
+postfix_expression!(NullsFirst, " NULLS FIRST", ());
+postfix_expression!(NullsLast, " NULLS LAST", ());


### PR DESCRIPTION
Add support for ordering with NULLS FIRST or NULLS LAST in postgres.

Methods nulls_first() and nulls_last() can be applied to the result of the asc() and desc() sorting order methods.