### PR TITLE
Move the trait bounds for `FindDsl` onto the impl

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -59,6 +59,9 @@ pub mod helper_types {
     pub type FindBy<Source, Column, Value> =
         Filter<Source, Eq<Column, Value>>;
 
+    /// Represents the return type of `.find(pk)`
+    pub type Find<Source, PK> = <Source as FindDsl<PK>>::Output;
+
     /// Represents the return type of `.order(ordering)`
     pub type Order<Source, Ordering> =
         <Source as OrderDsl<Ordering>>::Output;

--- a/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -21,10 +21,7 @@ fn main() {
     int_primary_key::table.find("1").first(&connection).unwrap();
     //~^ ERROR no method named `first` found for type `diesel::query_source::filter::FilteredQuerySource<int_primary_key::table, diesel::expression::predicates::Eq<int_primary_key::columns::id, &str>>` in the current scope
     //~| ERROR E0277
-    //~| ERROR E0277
     string_primary_key::table.find(1).first(&connection).unwrap();
     //~^ ERROR no method named `first` found for type `diesel::query_source::filter::FilteredQuerySource<string_primary_key::table, diesel::expression::predicates::Eq<string_primary_key::columns::id, _>>` in the current scope
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
 }


### PR DESCRIPTION
Since Rust does not infer the where clasue of traits when using that
trait as a bound, you effectively have to restate the entire where
clause every time you want to reference that trait. This makes `FindDsl`
basically impossible to actually abstract over in practice.

This promotes it to the same place that the rest of the query DSL is,
where it has an abstract output and a helper type to follow the return
type chain through multiple levels.

This is part of a larger audit of this module to ensure consistency and
ease of abstraction throughout.