### PR TITLE
Improve the consistency of our query DSL trait bounds.

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -7,7 +7,7 @@ use query_builder::limit_clause::*;
 use query_builder::offset_clause::*;
 use query_builder::order_clause::*;
 use query_builder::where_clause::*;
-use query_builder::{Query, QueryFragment, SelectStatement};
+use query_builder::{AsQuery, Query, QueryFragment, SelectStatement};
 use query_dsl::*;
 use query_dsl::boxed_dsl::InternalBoxedDsl;
 use super::BoxedSelectStatement;
@@ -35,7 +35,9 @@ impl<ST, S, F, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection, Type>
 }
 
 impl<ST, S, F, D, W, O, L, Of, G> DistinctDsl
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G>
+    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<ST, S, F, DistinctClause, W, O, L, Of, G>: AsQuery<SqlType=ST>,
 {
     type Output = SelectStatement<ST, S, F, DistinctClause, W, O, L, Of, G>;
 
@@ -55,9 +57,10 @@ impl<ST, S, F, D, W, O, L, Of, G> DistinctDsl
 
 impl<ST, S, F, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
     for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<ST, S, F, D, W::Output, O, L, Of, G>: Query<SqlType=ST>,
         Predicate: SelectableExpression<F, SqlType=Bool> + NonAggregate,
         W: WhereAnd<Predicate>,
-        SelectStatement<ST, S, F, D, W::Output, O, L, Of, G>: Query,
 {
     type Output = SelectStatement<ST, S, F, D, W::Output, O, L, Of, G>;
 
@@ -78,7 +81,8 @@ impl<ST, S, F, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
 impl<ST, S, F, D, W, O, L, Of, G, Expr> OrderDsl<Expr>
     for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
         Expr: SelectableExpression<F>,
-        SelectStatement<ST, S, F, D, W, OrderClause<Expr>, L, Of, G>: Query<SqlType=ST>,
+        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<ST, S, F, D, W, OrderClause<Expr>, L, Of, G>: AsQuery<SqlType=ST>,
 {
     type Output = SelectStatement<ST, S, F, D, W, OrderClause<Expr>, L, Of, G>;
 
@@ -102,6 +106,7 @@ pub type Limit = <i64 as AsExpression<types::BigInt>>::Expression;
 
 impl<ST, S, F, D, W, O, L, Of, G> LimitDsl
     for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
         SelectStatement<ST, S, F, D, W, O, LimitClause<Limit>, Of, G>: Query<SqlType=ST>,
 {
     type Output = SelectStatement<ST, S, F, D, W, O, LimitClause<Limit>, Of, G>;
@@ -126,7 +131,8 @@ pub type Offset = Limit;
 
 impl<ST, S, F, D, W, O, L, Of, G> OffsetDsl
     for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
-        SelectStatement<ST, S, F, D, W, O, L, OffsetClause<Offset>, G>: Query<SqlType=ST>,
+        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<ST, S, F, D, W, O, L, OffsetClause<Offset>, G>: AsQuery<SqlType=ST>,
 {
     type Output = SelectStatement<ST, S, F, D, W, O, L, OffsetClause<Offset>, G>;
 

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -31,14 +31,14 @@ use query_source::QuerySource;
 /// assert_eq!(Ok(vec![sean.clone()]), distinct_names);
 /// # }
 /// ```
-pub trait DistinctDsl {
-    type Output;
+pub trait DistinctDsl: AsQuery {
+    type Output: AsQuery<SqlType=Self::SqlType>;
     fn distinct(self) -> Self::Output;
 }
 
-impl<T> DistinctDsl for T where
-    T: AsQuery + QuerySource,
-    T::Query: DistinctDsl,
+impl<T, ST> DistinctDsl for T where
+    T: AsQuery<SqlType=ST> + QuerySource,
+    T::Query: DistinctDsl<SqlType=ST>,
 {
     type Output = <T::Query as DistinctDsl>::Output;
 

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -32,8 +32,8 @@ use types::Bool;
 /// assert_eq!(Ok(2), tess_id);
 /// # }
 /// ```
-pub trait FilterDsl<Predicate> {
-    type Output: AsQuery;
+pub trait FilterDsl<Predicate>: AsQuery {
+    type Output: AsQuery<SqlType=Self::SqlType>;
 
     fn filter(self, predicate: Predicate) -> Self::Output;
 }
@@ -41,10 +41,10 @@ pub trait FilterDsl<Predicate> {
 pub trait NotFiltered {
 }
 
-impl<T, Predicate> FilterDsl<Predicate> for T where
+impl<T, Predicate, ST> FilterDsl<Predicate> for T where
     Predicate: Expression<SqlType=Bool> + NonAggregate,
-    FilteredQuerySource<T, Predicate>: AsQuery,
-    T: NotFiltered,
+    FilteredQuerySource<T, Predicate>: AsQuery<SqlType=ST>,
+    T: AsQuery<SqlType=ST> + NotFiltered,
 {
     type Output = FilteredQuerySource<Self, Predicate>;
 
@@ -88,8 +88,8 @@ use helper_types::FindBy;
 /// assert_eq!(Err::<(i32, String), _>(NotFound), users.find(3).first(&connection));
 /// # }
 /// ```
-pub trait FindDsl<PK> {
-    type Output: AsQuery;
+pub trait FindDsl<PK>: AsQuery {
+    type Output: AsQuery<SqlType=Self::SqlType>;
 
     fn find(self, id: PK) -> Self::Output;
 }

--- a/diesel/src/query_dsl/limit_dsl.rs
+++ b/diesel/src/query_dsl/limit_dsl.rs
@@ -1,18 +1,18 @@
-use query_builder::{Query, AsQuery};
+use query_builder::AsQuery;
 use query_source::QuerySource;
 
 /// Sets the limit clause of a query. If there was already a limit clause, it
 /// will be overridden. This is automatically implemented for the various query
 /// builder types.
-pub trait LimitDsl {
-    type Output: Query;
+pub trait LimitDsl: AsQuery {
+    type Output: AsQuery<SqlType=Self::SqlType>;
 
     fn limit(self, limit: i64) -> Self::Output;
 }
 
-impl<T> LimitDsl for T where
-    T: QuerySource + AsQuery,
-    T::Query: LimitDsl,
+impl<T, ST> LimitDsl for T where
+    T: QuerySource + AsQuery<SqlType=ST>,
+    T::Query: LimitDsl<SqlType=ST>,
 {
     type Output = <T::Query as LimitDsl>::Output;
 

--- a/diesel/src/query_dsl/offset_dsl.rs
+++ b/diesel/src/query_dsl/offset_dsl.rs
@@ -1,18 +1,18 @@
-use query_builder::{Query, AsQuery};
+use query_builder::AsQuery;
 use query_source::QuerySource;
 
 /// Sets the offset clause of a query. If there was already a offset clause, it
 /// will be overridden. This is automatically implemented for the various query
 /// builder types.
-pub trait OffsetDsl {
-    type Output: Query;
+pub trait OffsetDsl: AsQuery {
+    type Output: AsQuery<SqlType=Self::SqlType>;
 
     fn offset(self, offset: i64) -> Self::Output;
 }
 
-impl<T> OffsetDsl for T where
-    T: QuerySource + AsQuery,
-    T::Query: OffsetDsl,
+impl<T, ST> OffsetDsl for T where
+    T: QuerySource + AsQuery<SqlType=ST>,
+    T::Query: OffsetDsl<SqlType=ST>,
 {
     type Output = <T::Query as OffsetDsl>::Output;
 

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -1,5 +1,5 @@
 use expression::Expression;
-use query_builder::{Query, AsQuery};
+use query_builder::AsQuery;
 use query_source::QuerySource;
 
 /// Sets the order clause of a query. If there was already a order clause, it
@@ -9,16 +9,16 @@ use query_source::QuerySource;
 /// and [`.asc()`](expression/expression_methods/global_expression_methods/trait.ExpressionMethods.html#method.asc)
 ///
 /// This is automatically implemented for the various query builder types.
-pub trait OrderDsl<Expr: Expression> {
-    type Output: Query;
+pub trait OrderDsl<Expr: Expression>: AsQuery {
+    type Output: AsQuery<SqlType=Self::SqlType>;
 
     fn order(self, expr: Expr) -> Self::Output;
 }
 
-impl<T, Expr> OrderDsl<Expr> for T where
+impl<T, Expr, ST> OrderDsl<Expr> for T where
     Expr: Expression,
-    T: QuerySource + AsQuery,
-    T::Query: OrderDsl<Expr>,
+    T: QuerySource + AsQuery<SqlType=ST>,
+    T::Query: OrderDsl<Expr, SqlType=ST>,
 {
     type Output = <T::Query as OrderDsl<Expr>>::Output;
 

--- a/diesel/src/query_source/filter.rs
+++ b/diesel/src/query_source/filter.rs
@@ -36,9 +36,10 @@ impl<Source, Predicate> AsQuery for FilteredQuerySource<Source, Predicate> where
     }
 }
 
-impl<Source, Predicate, NewPredicate> FilterDsl<NewPredicate>
+impl<Source, Predicate, NewPredicate, ST> FilterDsl<NewPredicate>
     for FilteredQuerySource<Source, Predicate> where
-        FilteredQuerySource<Source, And<Predicate, NewPredicate>>: AsQuery,
+        FilteredQuerySource<Source, Predicate>: AsQuery<SqlType=ST>,
+        FilteredQuerySource<Source, And<Predicate, NewPredicate>>: AsQuery<SqlType=ST>,
         Predicate: SelectableExpression<Source, SqlType=Bool>,
         NewPredicate: SelectableExpression<Source, SqlType=Bool> + NonAggregate,
 {


### PR DESCRIPTION
There were two goals here:

- Consistently put the constraint `AsQuery` on the output type. Many
  traits were using no bound or `Query` as the bound
- Enforce that the SQL type can't change for DSLs which shouldn't change
  the output type (which is basically everything except select and
  joins)

We shouldn't have to specify `SqlType=ST` in so many places, but we have
to do it here to work around
https://github.com/rust-lang/rust/issues/34257.

As part of this, I've also done the same cleanup of `LoadDsl` that we
did to `FindDsl` in #352, moving as many where clause constraints as
possible off of the trait definition and into the impl. This let us
implement `first` purely in terms of `limit` and methods from `LoadDsl`,
with a more reasonable where clause on that method. `first` was the only
place that referenced `LimitDsl` generically in our code base, and was
the original motivation for this change.