### PR TITLE
Don't leak PGResult pointers when queries failed

### DIFF
--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -22,7 +22,11 @@ impl PgResult {
                     internal_result: internal_result,
                 })
             },
-            _ => Err(Error::DatabaseError(conn.last_error_message())),
+            _ => {
+                let error_message = conn.last_error_message();
+                unsafe { PQclear(internal_result) };
+                Err(Error::DatabaseError(error_message))
+            }
         }
     }
 


### PR DESCRIPTION
Noticed this memory leak while exploring #360. We're never freeing the
result in the error case. Ideally I'd like to have a test for this, but
I'm not entirely sure if we actually can.