### PR TITLE
Provide richer information from `DatabaseError`

### DIFF
--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -41,7 +41,7 @@ impl SimpleConnection for PgConnection {
         let inner_result = unsafe {
             self.raw_connection.exec(query.as_ptr())
         };
-        try!(PgResult::new(&self.raw_connection, inner_result));
+        try!(PgResult::new(inner_result));
         Ok(())
     }
 }

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -43,7 +43,7 @@ impl RawConnection {
         ) };
 
         if result_ptr.is_null() {
-            Err(Error::DatabaseError(last_error_message(self.internal_connection)))
+            Err(Error::DatabaseError(Box::new(last_error_message(self.internal_connection))))
         } else {
             unsafe {
                 Ok(PgString::new(result_ptr))

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -63,7 +63,7 @@ impl Query {
             }
         };
 
-        PgResult::new(conn, internal_res)
+        PgResult::new(internal_res)
     }
 
     pub fn sql(sql: &str, param_types: Option<Vec<u32>>) -> QueryResult<Self> {
@@ -90,7 +90,7 @@ impl Query {
                 param_types_to_ptr(Some(&param_types)),
             )
         };
-        try!(PgResult::new(conn, internal_result));
+        try!(PgResult::new(internal_result));
 
         Ok(Query::Prepared {
             name: name,

--- a/diesel/src/pg/query_builder.rs
+++ b/diesel/src/pg/query_builder.rs
@@ -27,7 +27,10 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
     }
 
     fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
-        let escaped_identifier = try!(self.conn.escape_identifier(identifier));
+        let escaped_identifier = match self.conn.escape_identifier(identifier) {
+            Ok(v) => v,
+            Err(e) => return Err(Box::new(e)),
+        };
         Ok(self.push_sql(&escaped_identifier))
     }
 

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -38,7 +38,7 @@ use result::QueryResult;
 
 #[doc(hidden)]
 pub type Binds = Vec<Option<Vec<u8>>>;
-pub type BuildQueryResult = Result<(), Box<Error+Send+Sync>>;
+pub type BuildQueryResult = Result<(), Box<Error+Send>>;
 
 /// Apps should not need to concern themselves with this trait.
 ///

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -49,7 +49,7 @@ impl RawConnection {
 
         if !err_msg.is_null() {
             let msg = convert_to_string_and_free(err_msg);
-            Err(DatabaseError(msg))
+            Err(DatabaseError(Box::new(msg)))
         } else {
             Ok(())
         }

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -39,7 +39,7 @@ impl Statement {
     pub fn run(&self) -> QueryResult<()> {
         match unsafe { ffi::sqlite3_step(self.inner_statement) } {
             ffi::SQLITE_DONE | ffi::SQLITE_ROW => Ok(()),
-            error => Err(DatabaseError(super::error_message(error).into()))
+            error => Err(DatabaseError(Box::new(super::error_message(error).to_owned())))
         }
     }
 
@@ -130,7 +130,7 @@ impl Statement {
 
 fn ensure_sqlite_ok(code: libc::c_int) -> QueryResult<()> {
     if code != ffi::SQLITE_OK {
-        Err(DatabaseError(super::error_message(code).into()))
+        Err(DatabaseError(Box::new(super::error_message(code).to_owned())))
     } else {
         Ok(())
     }

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -31,8 +31,8 @@ pub fn test_type_round_trips<ST, T>(value: T) -> bool where
                 true
             }
         }
-        Err(Error::DatabaseError(msg)) =>
-            &msg == "ERROR:  invalid byte sequence for encoding \"UTF8\": 0x00\n",
+        Err(Error::DatabaseError(ref e))
+            if e.message() == "invalid byte sequence for encoding \"UTF8\": 0x00" => true,
         Err(e) => panic!("Query failed: {:?}", e),
     }
 }


### PR DESCRIPTION
This is part of the restructuring required to give a reasonable solution
to #360. In the case of PG, we hold onto the result pointer, and expose
all of the most commonly relevant fields that can be returned from
`PQresultErrorField`. Of the fields we've chosen to expose, only the
primary message is guaranteed to be present.

As per libpq's documentation, no assumptions can be made about when any
other fields will or will not be present, so they unconditionally return
an option, instead of exposing a separate API for different error types
where we expect certain fields to always be present.

This works out with SQLite pretty well as well, since SQLite doesn't
actually give any additional information beyond the error code and
"extended error code". I think it might be possible for us to improve
the error message by using `sqlite3_errmsg` instead of `sqlite3_errstr`,
but that needs further exploration. Either way, short of parsing the
error message, we won't be able to populate any of the other fields so
we continue to return a string.

This restructuring has the side effect of encoding the fix for the leak
resolved by #361 in the type system, which should help to ensure that
it causes no further problems in the future.