### PR TITLE
Provide the ability to handle unique constraint violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Struct fields annotated with `#[column_name="name"]` should be changed to
   `#[column_name(name)]`.
 
+* The structure of `DatabaseError` has changed to hold more information. See
+  http://docs.diesel.rs/diesel/result/enum.Error.html and
+  http://docs.diesel.rs/diesel/result/trait.DatabaseErrorInformation.html for
+  more information
+
 ### Fixed
 
 * `&&[T]` can now be used in queries. This allows using slices with things like

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -43,7 +43,10 @@ impl RawConnection {
         ) };
 
         if result_ptr.is_null() {
-            Err(Error::DatabaseError(Box::new(last_error_message(self.internal_connection))))
+            Err(Error::DatabaseError(
+                DatabaseErrorKind::__Unknown,
+                Box::new(last_error_message(self.internal_connection)),
+            ))
         } else {
             unsafe {
                 Ok(PgString::new(result_ptr))

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -49,7 +49,8 @@ impl RawConnection {
 
         if !err_msg.is_null() {
             let msg = convert_to_string_and_free(err_msg);
-            Err(DatabaseError(Box::new(msg)))
+            let error_kind = DatabaseErrorKind::__Unknown;
+            Err(DatabaseError(error_kind, Box::new(msg)))
         } else {
             Ok(())
         }
@@ -62,6 +63,10 @@ impl RawConnection {
     pub fn last_error_message(&self) -> String {
         let c_str = unsafe { CStr::from_ptr(ffi::sqlite3_errmsg(self.internal_connection)) };
         c_str.to_string_lossy().into_owned()
+    }
+
+    pub fn last_error_code(&self) -> libc::c_int {
+        unsafe { ffi::sqlite3_extended_errcode(self.internal_connection) }
     }
 }
 

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -145,7 +145,12 @@ fn ensure_sqlite_ok(code: libc::c_int, raw_connection: &RawConnection) -> QueryR
 fn last_error(raw_connection: &RawConnection) -> Error {
     let error_message = raw_connection.last_error_message();
     let error_information = Box::new(error_message);
-    DatabaseError(error_information)
+    let error_kind = match raw_connection.last_error_code() {
+        ffi::SQLITE_CONSTRAINT_UNIQUE | ffi::SQLITE_CONSTRAINT_PRIMARYKEY =>
+            DatabaseErrorKind::UniqueViolation,
+        _ => DatabaseErrorKind::__Unknown,
+    };
+    DatabaseError(error_kind, error_information)
 }
 
 impl Drop for Statement {

--- a/diesel_tests/tests/errors.rs
+++ b/diesel_tests/tests/errors.rs
@@ -1,7 +1,39 @@
 use diesel;
 use diesel::prelude::*;
 use diesel::result::Error::DatabaseError;
+use diesel::result::DatabaseErrorKind::UniqueViolation;
 use schema::*;
+
+#[test]
+fn unique_constraints_are_detected() {
+    let connection = connection();
+    diesel::insert(&User::new(1, "Sean")).into(users::table)
+        .execute(&connection).unwrap();
+
+    let failure = diesel::insert(&User::new(1, "Jim")).into(users::table)
+        .execute(&connection);
+    assert_matches!(failure, Err(DatabaseError(UniqueViolation, _)));
+}
+
+#[test]
+#[cfg(feature = "postgres")]
+fn unique_constraints_report_correct_constraint_name() {
+    let connection = connection();
+    connection.execute("CREATE UNIQUE INDEX users_name ON users (name)").unwrap();
+    diesel::insert(&User::new(1, "Sean")).into(users::table)
+        .execute(&connection).unwrap();
+
+    let failure = diesel::insert(&User::new(2, "Sean")).into(users::table)
+        .execute(&connection);
+    match failure {
+        Err(DatabaseError(UniqueViolation, e)) => {
+            assert_eq!(Some("users"), e.table_name());
+            assert_eq!(None, e.column_name());
+            assert_eq!(Some("users_name"), e.constraint_name());
+        },
+        _ => panic!("{:?} did not match Err(DatabaseError(UniqueViolation, e))", failure),
+    };
+}
 
 macro_rules! try_no_coerce {
     ($e:expr) => ({
@@ -22,7 +54,7 @@ fn cached_prepared_statements_can_be_reused_after_error() {
         try_no_coerce!(query.execute(&connection));
 
         let failure = query.execute(&connection);
-        assert_matches!(failure, Err(DatabaseError(_)));
+        assert_matches!(failure, Err(DatabaseError(UniqueViolation, _)));
         Ok(())
     });
 

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -31,7 +31,7 @@ pub fn test_type_round_trips<ST, T>(value: T) -> bool where
                 true
             }
         }
-        Err(Error::DatabaseError(ref e))
+        Err(Error::DatabaseError(_, ref e))
             if e.message() == "invalid byte sequence for encoding \"UTF8\": 0x00" => true,
         Err(e) => panic!("Query failed: {:?}", e),
     }


### PR DESCRIPTION
This lays the groundwork for a more robust error handling story, but to
start we are only handling `UniqueViolation` specifically. SQLite
separates primary key violations from unique constraints, but I've opted
to group them together.

Due to how PG handles errors, we will only know one of the constraints
that was violated (if more than one was violated), and you can only get
the constraint name, not the column name (in the single column case).
SQLite provides none of this information, and the error message would
have to be parsed to determine which constraint failed.

Ultimately I think all of this is fine, as you rarely are expecting more
than exactly one constraint to fail in a given query.

Fixes #360