### PR TITLE
Simplify the structure and codegen of `UpdateStatement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Changed
 
+* Most structs that implement `Queryable` will now also need
+  `#[derive(Identifiable)]`.
+
 * `infer_schema!` on SQLite now accepts a larger range of type names
 
 * `types::VarChar` is now an alias for `types::Text`. Most code should be
@@ -34,6 +37,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   http://docs.diesel.rs/diesel/result/enum.Error.html and
   http://docs.diesel.rs/diesel/result/trait.DatabaseErrorInformation.html for
   more information
+
+* Structs which implement `Identifiable` can now be passed to `update` and
+  `delete`. This means you can now write `delete(&user).execute(&connection)`
+  instead of `delete(users.find(user.id)).execute(&connection)`
 
 ### Fixed
 

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -1,8 +1,13 @@
 use std::hash::Hash;
 
+use query_dsl::FindDsl;
+use query_source::Table;
+
 pub trait Identifiable {
     type Id: Hash + Eq + Copy;
+    type Table: Table + FindDsl<Self::Id>;
 
+    fn table() -> Self::Table;
     fn id(&self) -> Self::Id;
 }
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -74,6 +74,14 @@ pub mod helper_types {
 
     /// Represents the return type of `.with(aliased_expr)`
     pub type With<'a, Source, Other> = <Source as WithDsl<'a, Other>>::Output;
+
+    use super::query_builder::{UpdateStatement, IntoUpdateTarget, AsChangeset};
+    /// Represents the return type of `update(lhs).set(rhs)`
+    pub type Update<Target, Changes> = UpdateStatement<
+        <Target as IntoUpdateTarget>::Table,
+        <Target as IntoUpdateTarget>::WhereClause,
+        <Changes as AsChangeset>::Changeset,
+    >;
 }
 
 pub mod prelude {

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -243,6 +243,18 @@ macro_rules! table_body {
                 }
             }
 
+            impl IntoUpdateTarget for table {
+                type Table = Self;
+                type WhereClause = ();
+
+                fn into_update_target(self) -> UpdateTarget<Self::Table, Self::WhereClause> {
+                    UpdateTarget {
+                        table: self,
+                        where_clause: None,
+                    }
+                }
+            }
+
             impl_query_id!(table);
 
             pub mod columns {

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -1,5 +1,5 @@
 use expression::Expression;
-use super::{UpdateTarget, IncompleteUpdateStatement, IncompleteInsertStatement, SelectStatement};
+use super::{IntoUpdateTarget, IncompleteUpdateStatement, IncompleteInsertStatement, SelectStatement};
 use super::delete_statement::DeleteStatement;
 use super::insert_statement::Insert;
 
@@ -38,8 +38,8 @@ use super::insert_statement::Insert;
 /// # #[cfg(not(feature = "postgres"))]
 /// # fn main() {}
 /// ```
-pub fn update<T: UpdateTarget>(source: T) -> IncompleteUpdateStatement<T> {
-    IncompleteUpdateStatement::new(source)
+pub fn update<T: IntoUpdateTarget>(source: T) -> IncompleteUpdateStatement<T::Table, T::WhereClause> {
+    IncompleteUpdateStatement::new(source.into_update_target())
 }
 
 /// Creates a delete statement. Will delete the records in the given set.
@@ -102,8 +102,8 @@ pub fn update<T: UpdateTarget>(source: T) -> IncompleteUpdateStatement<T> {
 /// # Ok(())
 /// # }
 /// ```
-pub fn delete<T: UpdateTarget>(source: T) -> DeleteStatement<T> {
-    DeleteStatement::new(source)
+pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::WhereClause> {
+    DeleteStatement::new(source.into_update_target())
 }
 
 /// Creates an insert statement. Will add the given data to a table. This

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -27,7 +27,14 @@ pub use self::query_id::QueryId;
 #[doc(hidden)]
 pub use self::select_statement::{SelectStatement, BoxedSelectStatement};
 #[doc(inline)]
-pub use self::update_statement::{IncompleteUpdateStatement, AsChangeset, Changeset, UpdateTarget};
+pub use self::update_statement::{
+    AsChangeset,
+    Changeset,
+    IncompleteUpdateStatement,
+    IntoUpdateTarget,
+    UpdateStatement,
+    UpdateTarget,
+};
 #[doc(inline)]
 pub use self::insert_statement::IncompleteInsertStatement;
 

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -22,7 +22,7 @@ pub trait LoadDsl<Conn: Connection>: AsQuery + Sized where
     /// `Result<Option<U>>`.
     fn first<U>(self, conn: &Conn) -> QueryResult<U> where
         Self: LimitDsl,
-        Limit<Self>: LoadDsl<Conn>,
+        Limit<Self>: LoadDsl<Conn, SqlType=Self::SqlType>,
         U: Queryable<Self::SqlType, Conn::Backend>,
     {
         self.limit(1).get_result(conn)

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -1,4 +1,9 @@
+use associations::Identifiable;
+use backend::SupportsReturningClause;
 use connection::Connection;
+use helper_types::*;
+use query_builder::{AsChangeset, IntoUpdateTarget};
+use query_dsl::*;
 use query_source::Queryable;
 use result::QueryResult;
 use types::HasSqlType;
@@ -7,6 +12,42 @@ pub trait SaveChangesDsl<Conn, ST> where
     Conn: Connection,
     Conn::Backend: HasSqlType<ST>,
 {
-    fn save_changes<T>(&self, connection: &Conn) -> QueryResult<T> where
+    fn save_changes<T>(self, connection: &Conn) -> QueryResult<T> where
         T: Queryable<ST, Conn::Backend>;
+}
+
+impl<'a, T, ST, Conn> SaveChangesDsl<Conn, ST> for &'a T where
+    Conn: Connection,
+    Conn::Backend: HasSqlType<ST> + SupportsReturningClause,
+    T: Identifiable,
+    &'a T: AsChangeset<Target=T::Table> + IntoUpdateTarget<Table=T::Table>,
+    Update<&'a T, &'a T>: LoadDsl<Conn, SqlType=ST>,
+{
+    fn save_changes<U>(self, conn: &Conn) -> QueryResult<U> where
+        U: Queryable<ST, Conn::Backend>,
+    {
+        ::update(self).set(self).get_result(conn)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+use sqlite::{SqliteConnection, Sqlite};
+#[cfg(feature = "sqlite")]
+use query_builder::AsQuery;
+
+#[cfg(feature = "sqlite")]
+impl<'a, T, ST> SaveChangesDsl<SqliteConnection, ST> for &'a T where
+    Sqlite: HasSqlType<ST>,
+    T: Identifiable,
+    T::Table: AsQuery<SqlType=ST>,
+    &'a T: AsChangeset<Target=T::Table> + IntoUpdateTarget<Table=T::Table>,
+    Update<&'a T, &'a T>: ExecuteDsl<SqliteConnection>,
+    Find<T::Table, T::Id>: LoadDsl<SqliteConnection, SqlType=ST>,
+{
+    fn save_changes<U>(self, conn: &SqliteConnection) -> QueryResult<U> where
+        U: Queryable<ST, Sqlite>,
+    {
+        try!(::update(self).set(self).execute(conn));
+        T::table().find(self.id()).get_result(conn)
+    }
 }

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -65,12 +65,3 @@ pub trait Table: QuerySource + AsQuery + Sized {
         LeftOuterJoinSource::new(self, other)
     }
 }
-
-impl<T: Table> UpdateTarget for T {
-    type Table = Self;
-    type WhereClause = ();
-
-    fn where_clause(&self) -> Option<&Self::WhereClause> {
-        None
-    }
-}

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -13,6 +13,7 @@ pub fn expand_derive_identifiable(
 ) {
     if let Some(model) = Model::from_annotable(cx, span, annotatable) {
         let struct_name = model.name;
+        let table_name = model.table_name();
         let primary_key_name = model.primary_key_name();
         let primary_key_type = match model.attr_named(primary_key_name) {
             Some(a) => a.ty.clone(),
@@ -30,6 +31,11 @@ pub fn expand_derive_identifiable(
         let item = quote_item!(cx,
             impl ::diesel::associations::Identifiable for $struct_name {
                 type Id = $primary_key_type;
+                type Table = $table_name::table;
+
+                fn table() -> Self::Table {
+                    $table_name::table
+                }
 
                 fn id(&self) -> Self::Id {
                     self.$primary_key_name

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -52,12 +52,6 @@ impl Model {
             attr.field_name.map(|f| f.name) == Some(name.name)
         })
     }
-
-    pub fn attr_for_column(&self, name: ast::Ident) -> Option<&Attr> {
-        self.attrs.iter().find(|attr| {
-            attr.column_name.name == name.name
-        })
-    }
 }
 
 pub fn infer_association_name(name: &str) -> String {

--- a/diesel_tests/tests/delete.rs
+++ b/diesel_tests/tests/delete.rs
@@ -1,0 +1,29 @@
+use diesel::*;
+use schema::*;
+
+#[test]
+fn delete_records() {
+    use schema::users::dsl::*;
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    let deleted_rows = delete(users.filter(name.eq("Sean"))).execute(&connection);
+
+    assert_eq!(Ok(1), deleted_rows);
+
+    let num_users = users.count().first(&connection);
+
+    assert_eq!(Ok(1), num_users);
+}
+
+#[test]
+fn delete_single_record() {
+    use schema::users::dsl::*;
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let data = users.load::<User>(&connection).unwrap();
+    let sean = data[0].clone();
+    let tess = data[1].clone();
+
+    delete(&sean).execute(&connection).unwrap();
+
+    assert_eq!(Ok(vec![tess]), users.load(&connection));
+}

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -162,20 +162,6 @@ fn insert_borrowed_content() {
 }
 
 #[test]
-fn delete_records() {
-    use schema::users::dsl::*;
-    let connection = connection_with_sean_and_tess_in_users_table();
-
-    let deleted_rows = delete(users.filter(name.eq("Sean"))).execute(&connection);
-
-    assert_eq!(Ok(1), deleted_rows);
-
-    let num_users = users.count().first(&connection);
-
-    assert_eq!(Ok(1), num_users);
-}
-
-#[test]
 #[cfg(feature = "sqlite")]
 fn insert_on_conflict_replace() {
     use schema::users::dsl::*;

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -15,6 +15,7 @@ mod associations;
 mod boxed_queries;
 mod connection;
 mod debug;
+mod delete;
 mod errors;
 mod expressions;
 mod filter;

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -231,6 +231,8 @@ fn can_update_with_struct_containing_single_field() {
 #[test]
 fn struct_with_option_fields_treated_as_null() {
     #[changeset_for(posts, treat_none_as_null="true")]
+    #[derive(Identifiable)]
+    #[table_name="posts"]
     struct UpdatePost {
         id: i32,
         title: String,


### PR DESCRIPTION
The main goal of this refactoring was to remove the implementations of
`SaveChangesDsl` from codegen and provide them generically instead.
Since I want the code outside of codegen to be as approachable as
possible, I made a few other changes to reduce the where clause of these
implementations. I still would like to reduce the where clause further,
but this is at a decent place. The following tree of changes were in
support of this goal:

- Identifiable needs to have the table. This is so we can generically do
  `table.find(id)` for `T: Identifiable`.
- Structs can now be passed directly to `update` and `delete`
  - This caused us to change `UpdateTarget` to be a struct, and
    introduce an `AsUpdateTarget` trait so that we can abstract over
    whether the fields on that struct are a reference or not

All of this will drastically simplify the non-procedural-macro form of
`#[derive(AsChangeset)]`, and hopefully lead to more refactoring in the
future.

It should be noted that this changes the query on SQLite from

```
UPDATE users SET ... WHERE id = 1;
SELECT * FROM users WHERE id = 1 LIMIT 1;
```

to

```
UPDATE users SET ... WHERE id = 1;
SELECT * FROM users WHERE id = 1;
```

I can get the `LIMIT 1` back in there if needed, but it makes the where clause more complex, and I don't think it matters to keep that here. I couldn't simplify it in the way I wanted to by pulling `first` into a separate trait because of https://github.com/rust-lang/rust/issues/34260