### PR TITLE
Bash completion

### DIFF
--- a/diesel_cli/Cargo.lock
+++ b/diesel_cli/Cargo.lock
@@ -3,7 +3,7 @@ name = "diesel_cli"
 version = "0.7.0"
 dependencies = [
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -20,12 +20,12 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.3.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -38,19 +38,25 @@ name = "chrono"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clap"
-version = "1.5.5"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -105,12 +111,12 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -118,7 +124,7 @@ name = "num-integer"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -127,12 +133,12 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -175,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -184,6 +190,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term_size"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,13 +228,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vec_map"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "diesel"
 
 [dependencies]
 chrono = "0.2.17"
-clap = "1.5.5"
+clap = "2.11"
 diesel = { version = "0.7.0", default-features = false }
 dotenv = "0.8.0"
 

--- a/diesel_cli/README.md
+++ b/diesel_cli/README.md
@@ -89,3 +89,23 @@ Runs the `down.sql` and then the `up.sql` for the most recent migration.
 
 [pending-migrations]: http://docs.diesel.rs/diesel/migrations/fn.run_pending_migrations.html
 [rust-dotenv]: https://github.com/slapresta/rust-dotenv#examples
+
+
+Bash completion
+---------------
+
+Diesel can generate a bash completion script for itself:
+
+#### linux
+
+```shell
+$ diesel bash-completion > /etc/bash_completion.d/diesel
+```
+
+
+#### os x (homebrew)
+
+```shell
+$ brew install bash-completion  # you may already have this installed
+$ diesel bash-completion > $(brew --prefix)/etc/bash_completion.d/diesel
+```

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -1,0 +1,86 @@
+use clap::{App, AppSettings, Arg, SubCommand};
+
+
+pub fn build_cli() -> App<'static, 'static> {
+    let database_arg = Arg::with_name("DATABASE_URL")
+        .long("database-url")
+        .help("Specifies the database URL to connect to. Falls back to \
+                   the DATABASE_URL environment variable if unspecified.")
+        .global(true)
+        .takes_value(true);
+
+    let migration_subcommand = SubCommand::with_name("migration")
+        .about("A group of commands for generating, running, and reverting \
+                migrations.")
+        .setting(AppSettings::VersionlessSubcommands)
+        .arg(Arg::with_name("MIGRATION_DIRECTORY")
+            .long("migration-dir")
+            .help("The location of your migration directory. By default this \
+                   will look for a directory called `migrations` in the \
+                   current directory and its parents.")
+            .takes_value(true)
+            .global(true)
+        ).subcommand(
+            SubCommand::with_name("run")
+                .about("Runs all pending migrations")
+        ).subcommand(
+            SubCommand::with_name("revert")
+                .about("Reverts the latest run migration")
+        ).subcommand(
+            SubCommand::with_name("redo")
+                .about("Reverts and re-runs the latest migration. Useful \
+                      for testing that a migration can in fact be reverted.")
+        ).subcommand(
+            SubCommand::with_name("generate")
+                .about("Generate a new migration with the given name, and \
+                      the current timestamp as the version")
+                .arg(Arg::with_name("MIGRATION_NAME")
+                     .help("The name of the migration to create")
+                     .required(true)
+                 )
+                .arg(Arg::with_name("MIGRATION_VERSION")
+                     .long("version")
+                     .help("The version number to use when generating the migration. \
+                            Defaults to the current timestamp, which should suffice \
+                            for most use cases.")
+                     .takes_value(true)
+                )
+        ).setting(AppSettings::SubcommandRequiredElseHelp);
+
+    let setup_subcommand = SubCommand::with_name("setup")
+        .about("Creates the migrations directory, creates the database \
+                specified in your DATABASE_URL, and runs existing migrations.");
+
+    let database_subcommand = SubCommand::with_name("database")
+        .about("A group of commands for setting up and resetting your database.")
+        .setting(AppSettings::VersionlessSubcommands)
+        .subcommand(
+            SubCommand::with_name("setup")
+                .about("Creates the database specified in your DATABASE_URL, \
+                        and then runs any existing migrations.")
+        ).subcommand(
+            SubCommand::with_name("reset")
+                .about("Resets your database by dropping the database specified \
+                        in your DATABASE_URL and then running `diesel database setup`.")
+        ).subcommand(
+            SubCommand::with_name("drop")
+                .about("Drops the database specified in your DATABASE_URL.")
+                .setting(AppSettings::Hidden)
+        ).setting(AppSettings::SubcommandRequiredElseHelp);
+
+    let generate_bash_completion_subcommand =
+        SubCommand::with_name("bash-completion")
+        .about("Generate bash completion script for the diesel command.")
+    ;
+
+    App::new("diesel")
+        .version(env!("CARGO_PKG_VERSION"))
+        .setting(AppSettings::VersionlessSubcommands)
+        .after_help("You can also run `diesel SUBCOMMAND -h` to get more information about that subcommand.")
+        .arg(database_arg)
+        .subcommand(migration_subcommand)
+        .subcommand(setup_subcommand)
+        .subcommand(database_subcommand)
+        .subcommand(generate_bash_completion_subcommand)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+}

--- a/diesel_cli/tests/completion_generation.rs
+++ b/diesel_cli/tests/completion_generation.rs
@@ -1,0 +1,15 @@
+use support::project;
+
+#[test]
+fn can_generate_bash_completion() {
+    let p = project("migration_redo")
+        .build();
+
+    let result = p.command("bash-completion").run();
+
+    let expected_last_line = "complete -F _diesel diesel";
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(result.stdout().contains(expected_last_line),
+        "Unexpected stdout {}", result.stdout());
+}

--- a/diesel_cli/tests/tests.rs
+++ b/diesel_cli/tests/tests.rs
@@ -12,3 +12,4 @@ mod database_drop;
 mod database_setup;
 mod database_reset;
 mod exit_codes;
+mod completion_generation;


### PR DESCRIPTION
clap can now generate bash completion. not sure what the best way to ship this is, but at least we can generate them

```
$ diesel<TAB>
--database-url  --version       -h              help            setup
--help          -V              database        migration

$ diesel migration generate<TAB>
--help            --version         -h                <MIGRATION_NAME>
```