### PR TITLE
cli: Use UTC for default migration version

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -154,7 +154,7 @@ fn run_migration_command(matches: &ArgMatches) {
 use std::fmt::Display;
 fn migration_version<'a>(matches: &'a ArgMatches) -> Box<Display + 'a> {
     matches.value_of("MIGRATION_VERSION").map(|s| Box::new(s) as Box<Display>)
-        .unwrap_or_else(|| Box::new(Local::now().format("%Y%m%d%H%M%S")))
+        .unwrap_or_else(|| Box::new(UTC::now().format("%Y%m%d%H%M%S")))
 }
 
 fn migrations_dir(matches: &ArgMatches) -> PathBuf {


### PR DESCRIPTION
Using local time may cause migrations to be sorted out of order when
created in different time zones. For example, Tom generates a migration
in Tokyo (UTC+09:00), and Cindy subsequently generates one in Chicago
(UTC-05:00). Relying on local time, Cindy's migration would appear
before Tom's despite having generated it after.