### PR TITLE
Implement `BelongingToDsl` generically

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -1,0 +1,81 @@
+use expression::AsExpression;
+use expression::helper_types::{Eq, EqAny};
+use expression::array_comparison::AsInExpression;
+use helper_types::{FindBy, Filter};
+use prelude::*;
+use super::Identifiable;
+
+pub trait BelongsTo<Parent: Identifiable> {
+    type ForeignKeyColumn: Column;
+
+    fn foreign_key(&self) -> Parent::Id;
+    fn foreign_key_column() -> Self::ForeignKeyColumn;
+}
+
+pub trait GroupedBy<Parent>: IntoIterator + Sized {
+    fn grouped_by(self, parents: &[Parent]) -> Vec<Vec<Self::Item>>;
+}
+
+impl<Parent, Child> GroupedBy<Parent> for Vec<Child> where
+    Child: BelongsTo<Parent>,
+    Parent: Identifiable,
+{
+    fn grouped_by(self, parents: &[Parent]) -> Vec<Vec<Child>> {
+        use std::collections::HashMap;
+
+        let id_indices: HashMap<_, _> = parents.iter().enumerate().map(|(i, u)| (u.id(), i)).collect();
+        let mut result = parents.iter().map(|_| Vec::new()).collect::<Vec<_>>();
+        for child in self {
+            let index = id_indices[&child.foreign_key()];
+            result[index].push(child);
+        }
+        result
+    }
+}
+
+impl<Parent, Child> BelongingToDsl<Parent> for Child where
+    Parent: Identifiable,
+    Child: Identifiable + BelongsTo<Parent>,
+    Parent::Id: AsExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
+    <Child as Identifiable>::Table: FilterDsl<Eq<Child::ForeignKeyColumn, Parent::Id>>,
+{
+    type Output = FindBy<
+        Child::Table,
+        Child::ForeignKeyColumn,
+        Parent::Id,
+    >;
+
+    fn belonging_to(parent: &Parent) -> Self::Output {
+        Child::table().filter(Child::foreign_key_column().eq(parent.id()))
+    }
+}
+
+impl<Parent, Child> BelongingToDsl<[Parent]> for Child where
+    Parent: Identifiable,
+    Child: Identifiable + BelongsTo<Parent>,
+    Vec<Parent::Id>: AsInExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
+    <Child as Identifiable>::Table: FilterDsl<EqAny<Child::ForeignKeyColumn, Vec<Parent::Id>>>,
+{
+    type Output = Filter<
+        Child::Table,
+        EqAny<
+            Child::ForeignKeyColumn,
+            Vec<Parent::Id>,
+        >,
+    >;
+
+    fn belonging_to(parents: &[Parent]) -> Self::Output {
+        let ids = parents.iter().map(Parent::id).collect::<Vec<_>>();
+        Child::table().filter(Child::foreign_key_column().eq_any(ids))
+    }
+}
+
+impl<Parent, Child> BelongingToDsl<Vec<Parent>> for Child where
+    Child: BelongingToDsl<[Parent]>,
+{
+    type Output = Child::Output;
+
+    fn belonging_to(parents: &Vec<Parent>) -> Self::Output {
+        Self::belonging_to(&**parents)
+    }
+}

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -1,7 +1,11 @@
+mod belongs_to;
+
 use std::hash::Hash;
 
 use query_dsl::FindDsl;
 use query_source::Table;
+
+pub use self::belongs_to::{BelongsTo, GroupedBy};
 
 pub trait Identifiable {
     type Id: Hash + Eq + Copy;
@@ -9,29 +13,4 @@ pub trait Identifiable {
 
     fn table() -> Self::Table;
     fn id(&self) -> Self::Id;
-}
-
-pub trait BelongsTo<Parent: Identifiable> {
-    fn foreign_key(&self) -> Parent::Id;
-}
-
-pub trait GroupedBy<Parent>: IntoIterator + Sized {
-    fn grouped_by(self, parents: &[Parent]) -> Vec<Vec<Self::Item>>;
-}
-
-impl<Parent, Child> GroupedBy<Parent> for Vec<Child> where
-    Child: BelongsTo<Parent>,
-    Parent: Identifiable,
-{
-    fn grouped_by(self, parents: &[Parent]) -> Vec<Vec<Child>> {
-        use std::collections::HashMap;
-
-        let id_indices: HashMap<_, _> = parents.iter().enumerate().map(|(i, u)| (u.id(), i)).collect();
-        let mut result = parents.iter().map(|_| Vec::new()).collect::<Vec<_>>();
-        for child in self {
-            let index = id_indices[&child.foreign_key()];
-            result[index].push(child);
-        }
-        result
-    }
 }

--- a/diesel/src/macros/identifiable.rs
+++ b/diesel/src/macros/identifiable.rs
@@ -97,7 +97,6 @@ macro_rules! Identifiable {
         }
     };
 
-
     // Handle struct with no generics
     (
         ($table_name:ident)

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -3,7 +3,7 @@ use schema::*;
 
 #[test]
 fn association_where_struct_name_doesnt_match_table_name() {
-    #[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
     #[belongs_to(post)]
     #[table_name="comments"]
     struct OtherComment {
@@ -51,7 +51,7 @@ fn association_where_parent_and_child_have_underscores() {
         }
     }
 
-    #[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
     #[belongs_to(special_post)]
     struct SpecialComment {
         id: i32,
@@ -112,6 +112,7 @@ mod associations_can_have_nullable_foreign_keys {
     }
 
     #[belongs_to(foo)]
+    #[derive(Identifiable)]
     pub struct Bar {
         id: i32,
         foo_id: Option<i32>,

--- a/diesel_tests/tests/sqlite_specific_schema.rs
+++ b/diesel_tests/tests/sqlite_specific_schema.rs
@@ -1,7 +1,7 @@
 use diesel::*;
 use super::{User, posts, comments, users};
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
 #[has_many(comments)]
 #[belongs_to(user)]
 pub struct Post {


### PR DESCRIPTION
I'm working on the non-procedural macro implementation of associations,
and this thing would have been a pain to do from a normal macro. The
only thing we needed that we didn't already have on other traits was the
foreign key. I've thrown the appropriate method on the `BelongsTo`
trait.

The where clause is a touch hairier than I'd like. I really need a
concise way to express "this is a table, and this is a column on this
table, everything that stems from just these two will be valid"