### PR TITLE
Implement a stable version of `BelongsTo`

### DIFF
--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -1,0 +1,200 @@
+/// Defines a one-to-one association for the child table. This macro should be
+/// called with the name of the parent struct, followed by any options, followed
+/// by the entire struct body. The struct *must* be annotated with
+/// `#[table_name(name_of_table)]`. Both the parent and child structs must
+/// implement [`Identifiable`][identifiable].
+///
+/// [identifiable]: prelude/trait.Identifiable.html
+///
+/// # Options
+///
+/// ## foreign_key
+///
+/// Required. The name of the foreing key column for this association.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[macro_use] extern crate diesel;
+/// # table! { users { id -> Integer, } }
+/// # table! { posts { id -> Integer, user_id -> Integer, } }
+/// pub struct User {
+///     id: i32,
+/// }
+/// # Identifiable! { #[table_name(users)] struct User { id: i32, } }
+///
+/// pub struct Post {
+///     id: i32,
+///     user_id: i32,
+/// }
+/// # Identifiable! { #[table_name(posts)] struct Post { id: i32, user_id: i32, } }
+///
+/// BelongsTo! {
+///     (User, foreign_key = user_id)
+///     #[table_name(posts)]
+///     struct Post {
+///         id: i32,
+///         user_id: i32,
+///     }
+/// }
+/// # fn main() {}
+/// ```
+///
+/// To avoid copying your struct definition, you can use the
+/// [custom_derive crate][custom_derive].
+///
+/// [custom_derive]: https://crates.io/crates/custom_derive
+///
+/// ```ignore
+/// custom_derive! {
+///     #[derive(BelongsTo(User, foreign_key = user_id)]
+///     #[table_name(posts)]
+///     struct Post {
+///         id: i32,
+///         user_id: i32,
+///     }
+/// }
+/// ```
+///
+/// This macro cannot be used with tuple structs.
+#[macro_export]
+macro_rules! BelongsTo {
+    // Format arguments
+    (
+        ($parent_struct:ident, foreign_key = $foreign_key_name:ident)
+        $($rest:tt)*
+    ) => {
+        BelongsTo! {
+            (
+                parent_struct = $parent_struct,
+                foreign_key_name = $foreign_key_name,
+            )
+            $($rest)*
+        }
+    };
+
+    // Extract table name from struct
+    (
+        ($($args:tt)*)
+        #[table_name($table_name:ident)]
+        $($rest:tt)*
+    ) => {
+        BelongsTo! {
+            (
+                $($args)*
+                child_table_name = $table_name,
+            )
+            $($rest)*
+        }
+    };
+
+    // Strip meta items, pub (if present) and struct from definition
+    (
+        $args:tt
+        $(#[$ignore:meta])*
+        $(pub)* struct $($body:tt)*
+    ) => {
+        BelongsTo! {
+            $args
+            $($body)*
+        }
+    };
+
+    // Receive parsed fields of normal struct from `__diesel_parse_struct_body`
+    // These patterns must appear above those which start with an ident to compile
+    (
+        (
+            struct_name = $struct_name:ident,
+            parent_struct = $parent_struct:ident,
+            foreign_key_name = $foreign_key_name:ident,
+            child_table_name = $child_table_name:ident,
+        ),
+        fields = [$({
+            field_name: $field_name:ident,
+            column_name: $column_name:ident,
+            field_ty: $field_ty:ty,
+            field_kind: $field_kind:ident,
+        })+],
+    ) => {
+        impl $crate::associations::BelongsTo<$parent_struct> for $struct_name {
+            type ForeignKeyColumn = $child_table_name::$foreign_key_name;
+
+            fn foreign_key(&self) -> <$parent_struct as $crate::associations::Identifiable>::Id {
+                self.$foreign_key_name
+            }
+
+            fn foreign_key_column() -> Self::ForeignKeyColumn {
+                $child_table_name::$foreign_key_name
+            }
+        }
+
+        __diesel_belongs_to_joinable_impl!(
+            parent_table_ty = <$parent_struct as $crate::associations::Identifiable>::Table,
+            parent_table_expr = <$parent_struct as $crate::associations::Identifiable>::table(),
+            child_table = $child_table_name::table,
+            foreign_key = $child_table_name::$foreign_key_name,
+        );
+
+        $(select_column_inner!(
+            $child_table_name::table,
+            <$parent_struct as $crate::associations::Identifiable>::Table,
+            $child_table_name::$column_name,
+        );)+
+        select_column_inner!(
+            $child_table_name::table,
+            <$parent_struct as $crate::associations::Identifiable>::Table,
+            $child_table_name::star,
+        );
+    };
+
+    // Handle struct with no generics
+    (
+        ($($args:tt)*)
+        $struct_name:ident
+        $body:tt $(;)*
+    ) => {
+        __diesel_parse_struct_body! {
+            (
+                struct_name = $struct_name,
+                $($args)*
+            ),
+            callback = BelongsTo,
+            body = $body,
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __diesel_belongs_to_joinable_impl {
+    (
+        parent_table_ty = $parent_table_ty:ty,
+        parent_table_expr = $parent_table_expr:expr,
+        child_table = $child_table:path,
+        foreign_key = $foreign_key:path,
+    ) => {
+        impl<JoinType> $crate::JoinTo<$parent_table_ty, JoinType> for $child_table {
+            type JoinClause = $crate::query_builder::nodes::Join<
+                <$child_table as $crate::QuerySource>::FromClause,
+                <$parent_table_ty as $crate::QuerySource>::FromClause,
+                $crate::expression::helper_types::Eq<
+                    $crate::expression::nullable::Nullable<$foreign_key>,
+                    $crate::expression::nullable::Nullable<
+                        <$parent_table_ty as $crate::query_source::Table>::PrimaryKey>,
+                >,
+                JoinType,
+            >;
+
+            fn join_clause(&self, join_type: JoinType) -> Self::JoinClause {
+                use $crate::{QuerySource, Table, ExpressionMethods};
+
+                $crate::query_builder::nodes::Join::new(
+                    self.from_clause(),
+                    $parent_table_expr.from_clause(),
+                    $foreign_key.nullable().eq($parent_table_expr.primary_key().nullable()),
+                    join_type,
+                )
+            }
+        }
+    };
+}

--- a/diesel/src/macros/associations/mod.rs
+++ b/diesel/src/macros/associations/mod.rs
@@ -1,0 +1,1 @@
+#[macro_use] mod belongs_to;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -340,38 +340,38 @@ macro_rules! joinable_inner {
 #[doc(hidden)]
 macro_rules! select_column_workaround {
     ($parent:ident -> $child:ident ($($column_name:ident),+)) => {
-        $(select_column_inner!($parent -> $child $column_name);)+
-        select_column_inner!($parent -> $child star);
+        $(select_column_inner!($parent::table, $child::table, $parent::$column_name);)+
+        select_column_inner!($parent::table, $child::table, $parent::star);
     }
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! select_column_inner {
-    ($parent:ident -> $child:ident $column_name:ident) => {
+    ($parent:ty, $child:ty, $column:ty $(,)*) => {
         impl $crate::expression::SelectableExpression<
-            $crate::query_source::InnerJoinSource<$child::table, $parent::table>,
-        > for $parent::$column_name
+            $crate::query_source::InnerJoinSource<$child, $parent>,
+        > for $column
         {
         }
 
         impl $crate::expression::SelectableExpression<
-            $crate::query_source::InnerJoinSource<$parent::table, $child::table>,
-        > for $parent::$column_name
+            $crate::query_source::InnerJoinSource<$parent, $child>,
+        > for $column
         {
         }
 
         impl $crate::expression::SelectableExpression<
-            $crate::query_source::LeftOuterJoinSource<$child::table, $parent::table>,
-            <<$parent::$column_name as $crate::Expression>::SqlType
+            $crate::query_source::LeftOuterJoinSource<$child, $parent>,
+            <<$column as $crate::Expression>::SqlType
                 as $crate::types::IntoNullable>::Nullable,
-        > for $parent::$column_name
+        > for $column
         {
         }
 
         impl $crate::expression::SelectableExpression<
-            $crate::query_source::LeftOuterJoinSource<$parent::table, $child::table>,
-        > for $parent::$column_name
+            $crate::query_source::LeftOuterJoinSource<$parent, $child>,
+        > for $column
         {
         }
     }
@@ -470,6 +470,7 @@ macro_rules! print_sql {
 #[macro_use] mod parse;
 #[macro_use] mod query_id;
 
+#[macro_use] mod associations;
 #[macro_use] mod identifiable;
 #[macro_use] mod insertable;
 #[macro_use] mod queryable;

--- a/diesel_codegen/src/associations/belongs_to.rs
+++ b/diesel_codegen/src/associations/belongs_to.rs
@@ -163,23 +163,5 @@ fn selectable_column_impl(
     let child_table = builder.child_table();
     let column = builder.column_path(column_name);
 
-    [quote_item!(builder.cx,
-        impl ::diesel::expression::SelectableExpression<
-            ::diesel::query_source::InnerJoinSource<$parent_table, $child_table>
-        > for $column {}
-    ).unwrap(), quote_item!(builder.cx,
-        impl ::diesel::expression::SelectableExpression<
-            ::diesel::query_source::InnerJoinSource<$child_table, $parent_table>
-        > for $column {}
-    ).unwrap(), quote_item!(builder.cx,
-        impl ::diesel::expression::SelectableExpression<
-            ::diesel::query_source::LeftOuterJoinSource<$child_table, $parent_table>,
-        > for $column {}
-    ).unwrap(), quote_item!(builder.cx,
-        impl ::diesel::expression::SelectableExpression<
-            ::diesel::query_source::LeftOuterJoinSource<$parent_table, $child_table>,
-            <<$column as ::diesel::Expression>::SqlType
-                as ::diesel::types::IntoNullable>::Nullable,
-        > for $column {}
-    ).unwrap()].to_vec()
+    [quote_item!(builder.cx, select_column_inner!($child_table, $parent_table, $column);).unwrap()].to_vec()
 }

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -30,7 +30,7 @@ impl User {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
 pub struct Comment {
     id: i32,
     post_id: i32,

--- a/diesel_tests/tests/sqlite_specific_schema.rs
+++ b/diesel_tests/tests/sqlite_specific_schema.rs
@@ -3,12 +3,22 @@ use super::{User, posts, comments, users};
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
 #[has_many(comments)]
-#[belongs_to(user)]
 pub struct Post {
     pub id: i32,
     pub user_id: i32,
     pub title: String,
     pub body: Option<String>,
+}
+
+BelongsTo! {
+    (User, foreign_key = user_id)
+    #[table_name(posts)]
+    pub struct Post {
+        pub id: i32,
+        pub user_id: i32,
+        pub title: String,
+        pub body: Option<String>,
+    }
 }
 
 impl Post {


### PR DESCRIPTION
This requires a bit more information to be explicitly given in the
options, as we can no longer infer the table name or the foreign key
from the relevant struct names. This differs from the procedural form,
as you state the name of the struct that you belong to, not a lower
cased singular form of the table (I'm considering changing the
procedural form to match)

Since we need the table name potentially available in multiple places,
I've modified the only other place that is related and explititly needs
it (Identifiable) to match with a new annotation. As usual, I've had to
do `#[table_name(value)]` instead of `#[table_name="value"]`, as there's
no way for me to match the second form as an ident.

Due to the proposed changes in [RFC 1681][rfc-1681], I'm considering
eventually having the "public API" form of this use annotations simlar
to the current procedural macros, and then an `Associations!` macro
which walks over each of them, which would look something like this:

    #[derive(associations)]
    #[has_many(Comment, foreign_key = post_id)]
    #[belongs_to(User, foreign_key = user_id)]
    #[table_name(posts)]
    pub struct Comment {
        id: i32,
        user_id: i32,
    }

As I write this, I am realizing that the way I'm passing the foreign key
isn't actually a valid meta item once this goes to stable, and I have
no way to pattern match on it. I'll probably need to change it to
`foreign_key(post_id)` in the future...

Anyway the change to that form can still call this macro under the hood,
it would only need to be a documentation change, so I think we can move
forward with this interface for now.

[rfc-1681]: https://github.com/rust-lang/rfcs/pull/1681