### PR TITLE
Allow inserting empty slices

### DIFF
--- a/diesel/src/persistable.rs
+++ b/diesel/src/persistable.rs
@@ -17,10 +17,21 @@ pub trait Insertable<T: Table, DB: Backend> {
     fn values(self) -> Self::Values;
 }
 
+/// Values that can be inserted into a row
 pub trait InsertValues<DB: Backend> {
+    /// Add column names to `out` query
     fn column_names(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
+
+    /// Add list of values to `out` query
     fn values_clause(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
+
+    /// Add value bind params to `out` bind collector
     fn values_bind_params(&self, out: &mut DB::BindCollector) -> QueryResult<()>;
+
+    /// Determine if this list of values is actually empty
+    ///
+    /// This will be used to determine whether the `INSERT` can be skipped
+    fn is_empty(&self) -> bool { false }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -60,6 +71,7 @@ impl<'a, T, U, DB> Insertable<T, DB> for &'a Vec<U> where
     }
 }
 
+/// Represents multiple rows that will be inserted at the same time
 #[derive(Debug, Copy, Clone)]
 pub struct BatchInsertValues<'a, T, U: 'a, DB> {
     values: &'a [U],
@@ -90,5 +102,9 @@ impl<'a, T, U: 'a, DB> InsertValues<DB> for BatchInsertValues<'a, T, U, DB> wher
             try!(record.values().values_bind_params(out));
         }
         Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.values.is_empty()
     }
 }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -147,6 +147,9 @@ impl PgConnection {
         } else {
             let mut query_builder = PgQueryBuilder::new(&self.raw_connection);
             try!(source.to_sql(&mut query_builder).map_err(Error::QueryBuilderError));
+            if query_builder.sql.is_empty() {
+                return Err(Error::EmptyQuery);
+            }
             Rc::new(try!(Query::sql(&query_builder.sql, Some(bind_types))))
         };
 

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -71,6 +71,10 @@ impl<T, U, Op, DB> QueryFragment<DB> for InsertStatement<T, U, Op> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
     }
+
+    fn is_empty(&self) -> bool {
+        self.records.values().is_empty()
+    }
 }
 
 impl_query_id!(noop: InsertStatement<T, U, Op>);
@@ -168,6 +172,10 @@ impl<T, U, DB> QueryFragment<DB> for InsertQuery<T, U> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
+    }
+
+    fn is_empty(&self) -> bool {
+        self.statement.is_empty()
     }
 }
 

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -3,7 +3,7 @@ use expression::{Expression, SelectableExpression, NonAggregate};
 use persistable::{Insertable, InsertValues};
 use query_builder::*;
 use query_source::Table;
-use result::QueryResult;
+use result::{QueryResult};
 
 /// The structure returned by [`insert`](fn.insert.html). The only thing that can be done with it
 /// is call `into`.
@@ -50,6 +50,12 @@ impl<T, U, Op, DB> QueryFragment<DB> for InsertStatement<T, U, Op> where
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
         let values = self.records.values();
+
+        if values.is_empty() {
+            // return Err(Box::new(Error::QueryAborted));
+            return Ok(());
+        }
+
         try!(self.operator.to_sql(out));
         out.push_sql(" INTO ");
         try!(self.target.from_clause().to_sql(out));
@@ -70,10 +76,6 @@ impl<T, U, Op, DB> QueryFragment<DB> for InsertStatement<T, U, Op> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
-    }
-
-    fn is_empty(&self) -> bool {
-        self.records.values().is_empty()
     }
 }
 
@@ -172,10 +174,6 @@ impl<T, U, DB> QueryFragment<DB> for InsertQuery<T, U> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
-    }
-
-    fn is_empty(&self) -> bool {
-        self.statement.is_empty()
     }
 }
 

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -84,11 +84,6 @@ pub trait QueryFragment<DB: Backend> {
 
     /// Determine whether this query fragment can be cached
     fn is_safe_to_cache_prepared(&self) -> bool;
-
-    /// Determine whether this query fragment is actually empty
-    ///
-    /// This will be used to see if the query can be skipped
-    fn is_empty(&self) -> bool { false }
 }
 
 impl<T: ?Sized, DB> QueryFragment<DB> for Box<T> where

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -76,9 +76,19 @@ impl<'a, T: Query> Query for &'a T {
 /// [`Connection`](../struct.Connection.html) that execute a query require this
 /// trait to be implemented.
 pub trait QueryFragment<DB: Backend> {
+    /// Convert this query fragment to SQL and add it to the query builder
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
+
+    /// Collect param bindings and add them to the bind collector
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()>;
+
+    /// Determine whether this query fragment can be cached
     fn is_safe_to_cache_prepared(&self) -> bool;
+
+    /// Determine whether this query fragment is actually empty
+    ///
+    /// This will be used to see if the query can be skipped
+    fn is_empty(&self) -> bool { false }
 }
 
 impl<T: ?Sized, DB> QueryFragment<DB> for Box<T> where

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -66,6 +66,11 @@ pub trait ExecuteDsl<Conn: Connection>: Sized + QueryFragment<Conn::Backend> + Q
     /// [`update`](../query_builder/fn.update.html) and
     /// [`delete`](../query_builder/fn.delete.html)
     fn execute(&self, conn: &Conn) -> QueryResult<usize> {
+        // Skip query if it doesn't contain any values
+        if self.is_empty() {
+            return Ok(0);
+        }
+
         conn.execute_returning_count(self)
     }
 }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -12,6 +12,7 @@ pub enum Error {
     DatabaseError(DatabaseErrorKind, Box<DatabaseErrorInformation+Send>),
     NotFound,
     QueryBuilderError(Box<StdError+Send>),
+    EmptyQuery,
     DeserializationError(Box<StdError+Send+Sync>),
     SerializationError(Box<StdError+Send+Sync>),
     #[doc(hidden)]
@@ -121,6 +122,7 @@ impl Display for Error {
             &Error::DatabaseError(_, ref e) => write!(f, "{}", e.message()),
             &Error::NotFound => f.write_str("NotFound"),
             &Error::QueryBuilderError(ref e) => e.fmt(f),
+            &Error::EmptyQuery => f.write_str("EmptyQuery"),
             &Error::DeserializationError(ref e) => e.fmt(f),
             &Error::SerializationError(ref e) => e.fmt(f),
             &Error::__Nonexhaustive => unreachable!(),
@@ -135,6 +137,7 @@ impl StdError for Error {
             &Error::DatabaseError(_, ref e) => e.message(),
             &Error::NotFound => "Record not found",
             &Error::QueryBuilderError(ref e) => e.description(),
+            &Error::EmptyQuery => "Empty query",
             &Error::DeserializationError(ref e) => e.description(),
             &Error::SerializationError(ref e) => e.description(),
             &Error::__Nonexhaustive => unreachable!(),

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -21,6 +21,19 @@ fn insert_records() {
 }
 
 #[test]
+fn insert_records_empty_array() {
+    use schema::users::table as users;
+    let connection = connection();
+    let new_users: &[NewUser] = &[];
+
+    batch_insert(new_users, users, &connection);
+    let actual_users: Vec<User> = users.load::<User>(&connection).unwrap();
+
+    let expected_users: Vec<User> = vec![];
+    assert_eq!(expected_users, actual_users);
+}
+
+#[test]
 #[cfg(not(feature = "sqlite"))]
 fn insert_records_using_returning_clause() {
     use schema::users::table as users;


### PR DESCRIPTION
Handle the case where an empty slice is to be inserted into a table. The expected behaviour is to just skip the execution of the query. This crashed previously when trying to get the column names of the fields.

Fixes #384
