### PR TITLE
Implement `HasMany` as a stable non-procedural macro

### DIFF
--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -10,9 +10,9 @@
 ///
 /// ## foreign_key
 ///
-/// Required. The name of the foreing key column for this association.
+/// Required. The name of the foreign key column for this association.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # #[macro_use] extern crate diesel;

--- a/diesel/src/macros/associations/has_many.rs
+++ b/diesel/src/macros/associations/has_many.rs
@@ -1,0 +1,151 @@
+/// Defines a one-to-many association for the parent table. This macro is only required if you need
+/// to join between the two tables. This macro should be called with the name of the child table,
+/// followed by any options, followed by the entire struct body. The struct *must* be annotated with
+/// `#[table_name(name_of_table)]`. Both the parent and child structs must implement
+/// [`Identifiable`][identifiable].
+///
+/// [identifiable]: prelude/trait.Identifiable.html
+///
+/// # Options
+///
+/// ## foreign_key
+///
+/// Required. The name of the foreign key column for this association.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[macro_use] extern crate diesel;
+/// # table! { users { id -> Integer, } }
+/// # table! { posts { id -> Integer, user_id -> Integer, } }
+/// pub struct User {
+///     id: i32,
+/// }
+/// # Identifiable! { #[table_name(users)] struct User { id: i32, } }
+///
+/// pub struct Post {
+///     id: i32,
+///     user_id: i32,
+/// }
+/// # Identifiable! { #[table_name(posts)] struct Post { id: i32, user_id: i32, } }
+///
+/// HasMany! {
+///     (posts, foreign_key = user_id)
+///     #[table_name(users)]
+///     struct User {
+///         id: i32,
+///     }
+/// }
+/// # fn main() {}
+/// ```
+///
+/// To avoid copying your struct definition, you can use the
+/// [custom_derive crate][custom_derive].
+///
+/// [custom_derive]: https://crates.io/crates/custom_derive
+///
+/// ```ignore
+/// custom_derive! {
+///     #[derive(HasMany(posts, foreign_key = user_id)]
+///     #[table_name(users)]
+///     struct User {
+///         id: i32,
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! HasMany {
+    // Format arguments
+    (
+        ($child_table_name:ident, foreign_key = $foreign_key_name:ident)
+        $($rest:tt)*
+    ) => {
+        HasMany! {
+            (
+                child_table = $child_table_name::table,
+                foreign_key = $child_table_name::$foreign_key_name,
+            )
+            $($rest)*
+        }
+    };
+
+    // Extract table name from struct
+    (
+        ($($args:tt)*)
+        #[table_name($table_name:ident)]
+        $($rest:tt)*
+    ) => {
+        HasMany! {
+            (
+                parent_table_name = $table_name,
+                $($args)*
+            )
+            $($rest)*
+        }
+    };
+
+    // Strip meta items, pub (if present) and struct from definition
+    (
+        $args:tt
+        $(#[$ignore:meta])*
+        $(pub)* struct $($body:tt)*
+    ) => {
+        HasMany! {
+            $args
+            $($body)*
+        }
+    };
+
+    // Receive parsed fields of normal struct from `__diesel_parse_struct_body`
+    // These patterns must appear above those which start with an ident to compile
+    (
+        (
+            struct_name = $struct_name:ident,
+            parent_table_name = $parent_table_name:ident,
+            child_table = $child_table:path,
+            foreign_key = $foreign_key:path,
+        ),
+        fields = [$({
+            field_name: $field_name:ident,
+            column_name: $column_name:ident,
+            field_ty: $field_ty:ty,
+            field_kind: $field_kind:ident,
+        })+],
+    ) => {
+        joinable_inner! {
+            left_table_ty = $parent_table_name::table,
+            right_table_ty = $child_table,
+            right_table_expr = $child_table,
+            foreign_key = $foreign_key,
+            primary_key_ty = <$parent_table_name::table as $crate::query_source::Table>::PrimaryKey,
+            primary_key_expr = $crate::Table::primary_key(&$parent_table_name::table),
+        }
+
+        $(select_column_inner!(
+            $parent_table_name::table,
+            $child_table,
+            $parent_table_name::$column_name,
+        );)+
+        select_column_inner!(
+            $parent_table_name::table,
+            $child_table,
+            $parent_table_name::star,
+        );
+    };
+
+    // Handle struct with no generics
+    (
+        ($($args:tt)*)
+        $struct_name:ident
+        $body:tt $(;)*
+    ) => {
+        __diesel_parse_struct_body! {
+            (
+                struct_name = $struct_name,
+                $($args)*
+            ),
+            callback = HasMany,
+            body = $body,
+        }
+    };
+}

--- a/diesel/src/macros/associations/mod.rs
+++ b/diesel/src/macros/associations/mod.rs
@@ -1,1 +1,2 @@
 #[macro_use] mod belongs_to;
+#[macro_use] mod has_many;


### PR DESCRIPTION
This follows the same approach as belongs to. I've also changed the
procedural form to more or less share code with the non-procedural, so
that we get access to `$crate`.

When I started this process, I was really hoping to have the procedural
version just parse the options and give better error messages if they
are invalid, then call the stable form. Unfortunately, because of how
macro expansion works, I can't just "insert the struct body into the
macro call", as at that point the struct is a single token and can't be
matched on. I'll probably end up still doing this eventually, and have
the procedural form just call the entry point that occurs after
`__diesel_parse_struct_body`.