### PR TITLE
Rejigger procedural macros to simply call the stable macros

### DIFF
--- a/diesel/src/macros/associations/has_many.rs
+++ b/diesel/src/macros/associations/has_many.rs
@@ -100,7 +100,6 @@ macro_rules! HasMany {
     // These patterns must appear above those which start with an ident to compile
     (
         (
-            struct_name = $struct_name:ident,
             parent_table_name = $parent_table_name:ident,
             child_table = $child_table:path,
             foreign_key = $foreign_key:path,
@@ -135,15 +134,12 @@ macro_rules! HasMany {
 
     // Handle struct with no generics
     (
-        ($($args:tt)*)
+        $args:tt
         $struct_name:ident
         $body:tt $(;)*
     ) => {
         __diesel_parse_struct_body! {
-            (
-                struct_name = $struct_name,
-                $($args)*
-            ),
+            $args,
             callback = HasMany,
             body = $body,
         }

--- a/diesel_codegen/src/associations/belongs_to.rs
+++ b/diesel_codegen/src/associations/belongs_to.rs
@@ -4,13 +4,9 @@ use syntax::ast::{
 };
 use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::parse::token::str_to_ident;
-use syntax::ptr::P;
 
-use model::Model;
-use super::{parse_association_options, AssociationOptions, to_foreign_key};
-use util::{ty_param_of_option, is_option_ty};
+use super::{parse_association_options, to_foreign_key};
 
 pub fn expand_belongs_to(
     cx: &mut ExtCtxt,
@@ -21,82 +17,27 @@ pub fn expand_belongs_to(
 ) {
     let options = parse_association_options("belongs_to", cx, span, meta_item, annotatable);
     if let Some((model, options)) = options {
-        let builder = BelongsToAssociationBuilder {
-            model: model,
-            options: options,
-            cx: cx,
-            span: span,
-        };
-
-        push(Annotatable::Item(join_to_impl(&builder)));
-        if let Some(item) = belongs_to_impl(&builder) {
-            push(Annotatable::Item(item));
-        }
-        for item in selectable_column_hack(&builder) {
-            push(Annotatable::Item(item));
-        }
+        let association_name = options.name.name.as_str();
+        let struct_name = model.name;
+        let parent_struct = parent_struct_name(&association_name);
+        let foreign_key_name = to_foreign_key(&association_name);
+        let child_table_name = model.table_name();
+        let fields = model.field_tokens_for_stable_macro(cx);
+        push(Annotatable::Item(quote_item!(cx, BelongsTo! {
+            (
+                struct_name = $struct_name,
+                parent_struct = $parent_struct,
+                foreign_key_name = $foreign_key_name,
+                child_table_name = $child_table_name,
+            ),
+            fields = [$fields],
+        }).unwrap()));
     }
 }
 
-struct BelongsToAssociationBuilder<'a, 'b: 'a> {
-    pub options: AssociationOptions,
-    pub model: Model,
-    pub cx: &'a mut ExtCtxt<'b>,
-    pub span: Span,
-}
-
-impl<'a, 'b> BelongsToAssociationBuilder<'a, 'b> {
-    fn parent_struct_name(&self) -> ast::Ident {
-        let association_name = self.options.name.name.as_str();
-        let struct_name = capitalize_from_association_name(association_name.to_string());
-        str_to_ident(&struct_name)
-    }
-
-    fn child_struct_name(&self) -> ast::Ident {
-        self.model.name
-    }
-
-    fn child_table_name(&self) -> ast::Ident {
-        self.model.table_name()
-    }
-
-    fn child_table(&self) -> ast::Path {
-        self.cx.path(self.span, vec![self.child_table_name(), str_to_ident("table")])
-    }
-
-    fn parent_table_name(&self) -> ast::Ident {
-        let pluralized = format!("{}s", &self.options.name.name.as_str());
-        str_to_ident(&pluralized)
-    }
-
-    fn parent_table(&self) -> ast::Path {
-        self.cx.path(self.span, vec![self.parent_table_name(), str_to_ident("table")])
-    }
-
-    fn foreign_key_name(&self) -> ast::Ident {
-        to_foreign_key(&self.options.name.name.as_str())
-    }
-
-    fn foreign_key(&self) -> ast::Path {
-        self.cx.path(self.span, vec![self.child_table_name(), self.foreign_key_name()])
-    }
-
-    fn foreign_key_type(&self) -> P<ast::Ty> {
-        let name = self.foreign_key_name();
-        self.model.attr_named(name)
-            .expect(&format!("Couldn't find an attr named {}", name))
-            .ty.clone()
-    }
-
-    fn primary_key_type(&self) -> P<ast::Ty> {
-        let ty = self.foreign_key_type();
-        ty_param_of_option(&ty).map(|t| t.clone())
-            .unwrap_or(ty)
-    }
-
-    fn column_path(&self, column_name: ast::Ident) -> ast::Path {
-        self.cx.path(self.span, vec![self.child_table_name(), column_name])
-    }
+fn parent_struct_name(association_name: &str) -> ast::Ident {
+    let struct_name = capitalize_from_association_name(association_name.to_string());
+    str_to_ident(&struct_name)
 }
 
 fn capitalize_from_association_name(name: String) -> String {
@@ -109,59 +50,4 @@ fn capitalize_from_association_name(name: String) -> String {
     }
 
     result
-}
-
-fn belongs_to_impl(builder: &BelongsToAssociationBuilder) -> Option<P<ast::Item>> {
-    let parent_struct_name = builder.parent_struct_name();
-    let child_struct_name = builder.child_struct_name();
-    let primary_key_type = builder.primary_key_type();
-    let foreign_key_name = builder.foreign_key_name();
-    let foreign_key = builder.foreign_key();
-
-    if is_option_ty(&builder.foreign_key_type()) {
-        None
-    } else {
-        Some(quote_item!(builder.cx,
-            impl ::diesel::associations::BelongsTo<$parent_struct_name> for $child_struct_name {
-                type ForeignKeyColumn = $foreign_key;
-
-                fn foreign_key(&self) -> $primary_key_type {
-                    self.$foreign_key_name
-                }
-
-                fn foreign_key_column() -> Self::ForeignKeyColumn {
-                    $foreign_key
-                }
-            }
-        ).unwrap())
-    }
-}
-
-fn join_to_impl(builder: &BelongsToAssociationBuilder) -> P<ast::Item> {
-    let child_table = builder.child_table();
-    let parent_table = builder.parent_table();
-    let foreign_key = builder.foreign_key();
-
-    quote_item!(builder.cx,
-        joinable_inner!($child_table => $parent_table : ($foreign_key = $parent_table));
-    ).unwrap()
-}
-
-fn selectable_column_hack(builder: &BelongsToAssociationBuilder) -> Vec<P<ast::Item>> {
-    let mut result = builder.model.attrs.iter().flat_map(|attr| {
-        selectable_column_impl(builder, attr.column_name)
-    }).collect::<Vec<_>>();
-    result.append(&mut selectable_column_impl(builder, str_to_ident("star")));
-    result
-}
-
-fn selectable_column_impl(
-    builder: &BelongsToAssociationBuilder,
-    column_name: ast::Ident,
-) -> Vec<P<ast::Item>> {
-    let parent_table = builder.parent_table();
-    let child_table = builder.child_table();
-    let column = builder.column_path(column_name);
-
-    [quote_item!(builder.cx, select_column_inner!($child_table, $parent_table, $column);).unwrap()].to_vec()
 }

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -1,6 +1,7 @@
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
+use syntax::parse::token::str_to_ident;
 
 use model::Model;
 
@@ -15,13 +16,16 @@ pub fn expand_derive_identifiable(
         let table_name = model.table_name();
         let struct_ty = &model.ty;
         let fields = model.field_tokens_for_stable_macro(cx);
-
-        push(Annotatable::Item(quote_item!(cx, Identifiable! {
-            (
-                table_name = $table_name,
-                struct_ty = $struct_ty,
-            ),
-            fields = [$fields],
-        }).unwrap()));
+        if model.attr_named(str_to_ident("id")).is_some() {
+            push(Annotatable::Item(quote_item!(cx, Identifiable! {
+                (
+                    table_name = $table_name,
+                    struct_ty = $struct_ty,
+                ),
+                fields = [$fields],
+            }).unwrap()));
+        } else {
+            cx.span_err(span, &format!("Could not find a field named `id` on `{}`", model.name));
+        }
     }
 }

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -12,36 +12,16 @@ pub fn expand_derive_identifiable(
     push: &mut FnMut(Annotatable)
 ) {
     if let Some(model) = Model::from_annotable(cx, span, annotatable) {
-        let struct_name = model.name;
         let table_name = model.table_name();
-        let primary_key_name = model.primary_key_name();
-        let primary_key_type = match model.attr_named(primary_key_name) {
-            Some(a) => a.ty.clone(),
-            None => {
-                let err_msg = format!(
-                    "Could not find a field named `{}` on `{}`",
-                    primary_key_name,
-                    struct_name,
-                );
-                cx.span_err(span, &err_msg);
-                return;
-            }
-        };
+        let struct_ty = &model.ty;
+        let fields = model.field_tokens_for_stable_macro(cx);
 
-        let item = quote_item!(cx,
-            impl ::diesel::associations::Identifiable for $struct_name {
-                type Id = $primary_key_type;
-                type Table = $table_name::table;
-
-                fn table() -> Self::Table {
-                    $table_name::table
-                }
-
-                fn id(&self) -> Self::Id {
-                    self.$primary_key_name
-                }
-            }
-        ).unwrap();
-        push(Annotatable::Item(item));
+        push(Annotatable::Item(quote_item!(cx, Identifiable! {
+            (
+                table_name = $table_name,
+                struct_ty = $struct_ty,
+            ),
+            fields = [$fields],
+        }).unwrap()));
     }
 }

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -3,6 +3,7 @@ use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax::ptr::P;
 use syntax::parse::token::str_to_ident;
+use syntax::tokenstream::TokenTree;
 
 use attr::Attr;
 use util::{str_value_of_attr_with_name, struct_ty};
@@ -11,6 +12,7 @@ pub struct Model {
     pub ty: P<ast::Ty>,
     pub attrs: Vec<Attr>,
     pub name: ast::Ident,
+    pub generics: ast::Generics,
     table_name_from_annotation: Option<ast::Ident>,
 }
 
@@ -29,6 +31,7 @@ impl Model {
                     ty: ty,
                     attrs: attrs,
                     name: item.ident,
+                    generics: generics,
                     table_name_from_annotation: table_name_from_annotation,
                 }
             })
@@ -47,10 +50,8 @@ impl Model {
         })
     }
 
-    pub fn attr_named(&self, name: ast::Ident) -> Option<&Attr> {
-        self.attrs.iter().find(|attr| {
-            attr.field_name.map(|f| f.name) == Some(name.name)
-        })
+    pub fn field_tokens_for_stable_macro(&self, cx: &mut ExtCtxt) -> Vec<Vec<TokenTree>> {
+        self.attrs.iter().map(|a| a.to_stable_macro_tokens(cx)).collect()
     }
 }
 

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -50,6 +50,12 @@ impl Model {
         })
     }
 
+    pub fn attr_named(&self, name: ast::Ident) -> Option<&Attr> {
+        self.attrs.iter().find(|attr| {
+            attr.column_name.name == name.name
+        })
+    }
+
     pub fn field_tokens_for_stable_macro(&self, cx: &mut ExtCtxt) -> Vec<Vec<TokenTree>> {
         self.attrs.iter().map(|a| a.to_stable_macro_tokens(cx)).collect()
     }

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -1,11 +1,12 @@
-use syntax::ast;
 use syntax::ast::TyKind;
+use syntax::ast;
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
-use syntax::parse::token::{str_to_ident, intern_and_get_ident};
+use syntax::parse::token::{self, str_to_ident, intern_and_get_ident};
 use syntax::ptr::P;
+use syntax::tokenstream::TokenTree;
 
 fn str_value_of_attr(
     cx: &mut ExtCtxt,
@@ -116,4 +117,15 @@ pub fn ty_param_of_option(ty: &ast::Ty) -> Option<&P<ast::Ty>> {
 
 pub fn is_option_ty(ty: &ast::Ty) -> bool {
     ty_param_of_option(ty).is_some()
+}
+
+pub fn lifetime_list_tokens(lifetimes: &[ast::LifetimeDef], span: Span) -> Vec<TokenTree> {
+    lifetimes.iter()
+        .map(|ld| {
+            let name = ld.lifetime.name;
+            let lt = token::Lifetime(ast::Ident::with_empty_ctxt(name));
+            [TokenTree::Token(span, lt)]
+        })
+        .collect::<Vec<_>>()
+        .join(&TokenTree::Token(span, token::Comma))
 }


### PR DESCRIPTION
This implements a procedural version of `__diesel_parse_struct_body`,
and calls into the stable equivalent of each macro at the entry point
after that step in the non-procedural process. This affects all
procedural macros that have stable equivalents except `Queryable`, which
appears to have some divergence in terms of what is supported that I
need to address, and `AsChangeset`, which isn't yet merged.