### PR TITLE
Make the API of procedural `belongs_to` mirror that of non-procedural

### DIFF
--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -4,7 +4,7 @@ use schema::*;
 #[test]
 fn association_where_struct_name_doesnt_match_table_name() {
     #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
-    #[belongs_to(post)]
+    #[belongs_to(Post)]
     #[table_name="comments"]
     struct OtherComment {
         id: i32,
@@ -29,7 +29,7 @@ fn association_where_struct_name_doesnt_match_table_name() {
 fn association_where_parent_and_child_have_underscores() {
     #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
     #[has_many(special_comments)]
-    #[belongs_to(user)]
+    #[belongs_to(User)]
     struct SpecialPost {
         id: i32,
         user_id: i32,
@@ -52,7 +52,7 @@ fn association_where_parent_and_child_have_underscores() {
     }
 
     #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
-    #[belongs_to(special_post)]
+    #[belongs_to(SpecialPost)]
     struct SpecialComment {
         id: i32,
         special_post_id: i32,
@@ -111,7 +111,7 @@ mod associations_can_have_nullable_foreign_keys {
         id: i32,
     }
 
-    #[belongs_to(foo)]
+    #[belongs_to(Foo)]
     #[derive(Identifiable)]
     pub struct Bar {
         id: i32,

--- a/diesel_tests/tests/postgres_specific_schema.rs
+++ b/diesel_tests/tests/postgres_specific_schema.rs
@@ -3,7 +3,7 @@ use super::{User, posts, comments, users};
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
 #[has_many(comments)]
-#[belongs_to(user)]
+#[belongs_to(User)]
 pub struct Post {
     pub id: i32,
     pub user_id: i32,

--- a/diesel_tests/tests/sqlite_specific_schema.rs
+++ b/diesel_tests/tests/sqlite_specific_schema.rs
@@ -3,22 +3,12 @@ use super::{User, posts, comments, users};
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
 #[has_many(comments)]
+#[belongs_to(User)]
 pub struct Post {
     pub id: i32,
     pub user_id: i32,
     pub title: String,
     pub body: Option<String>,
-}
-
-BelongsTo! {
-    (User, foreign_key = user_id)
-    #[table_name(posts)]
-    pub struct Post {
-        pub id: i32,
-        pub user_id: i32,
-        pub title: String,
-        pub body: Option<String>,
-    }
 }
 
 impl Post {


### PR DESCRIPTION
The stable macro had to take the struct name as the argument, and this
is the API I want to go with going forward. I'm hoping to converge the
procedural and non-procedural forms as much as possible.