### PR TITLE
Add a guide for association basics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* The initial APIs have been added in the form of `#[has_many]` and
+  `#[belongs_to]`. See [the module documentation][associations-module] for more
+  information.
+
 * The `Insertable!` macro can now be used instead of `#[insertable_into]` for
   those wishing to avoid syntax extensions from `diesel_codegen`. See
   http://docs.diesel.rs/diesel/macro.Insertable!.html for details.
@@ -56,6 +60,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `delete`. This means you can now write `delete(&user).execute(&connection)`
   instead of `delete(users.find(user.id)).execute(&connection)`
 
+[associations-module]: http://docs.diesel.rs/diesel/associations/index.html
 [syntex-split]: https://github.com/diesel-rs/diesel/commit/36b8801bf5e9594443743e6a7c62e29d3dce36b7
 
 ### Fixed

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -63,7 +63,7 @@
 //!
 //! [belonging-to]: prelude/trait.BelongingToDsl.html#tymethod.belonging_to
 //!
-//! ```rust
+//! ```ignore
 //! let user = try!(users::find(1).first(&connection));
 //! let posts = Post::belonging_to(&user).load(&connection);
 //! ```

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -2,15 +2,16 @@
 //! Traits related to relationships between multiple tables.
 //!
 //! **Note: This feature is under active development, and we are seeking feedback on the APIs that
-//! have been released. Please feel free to open issues, or join [our chat][gitter] to provide
-//! feedback.**
+//! have been released. Please feel free to [open issues][open-issue], or join [our chat][gitter]
+//! to provide feedback.**
 //!
+//! [open-issue]: https://github.com/diesel-rs/diesel/issues/new
 //! [gitter]: https://gitter.im/diesel-rs/diesel
 //!
 //! Note: This guide is written assuming the usage of `diesel_codegen` or `diesel_codegen_syntex`.
-//! If you are using [`custom_derive`] instead, you will need to replace `#[belongs_to(Foo)]` with
-//! `#[derive(BelongsTo(Foo, foreign_key = foo_id))]` and `#[has_many(bars)]` with
-//! `#[derive(HasMany(bars, foreign_key = bar_id))]`.
+//! If you are using [`custom_derive`][custom-derive] instead, you will need to replace
+//! `#[belongs_to(Foo)]` with `#[derive(BelongsTo(Foo, foreign_key = foo_id))]` and
+//! `#[has_many(bars)]` with `#[derive(HasMany(bars, foreign_key = bar_id))]`.
 //!
 //! Associations in Diesel are bidirectional, but primarily focus on the child-to-parent
 //! relationship. You can declare an association between two records with `#[has_many]` and
@@ -33,7 +34,7 @@
 //! }
 //! ```
 //!
-//! `#[has_many]` shoudld be passed the name of the table that the children will be loaded from,
+//! `#[has_many]` should be passed the name of the table that the children will be loaded from,
 //! while `#[belongs_to]` is given the name of the struct that represents the parent. Both types
 //! must implement the [`Identifiable`][identifiable] trait.
 //!
@@ -57,7 +58,7 @@
 //! the future.
 //!
 //! Typically however, queries are loaded in multiple queries. For most datasets, the reduced
-//! amount of duplicated information sent over the wire saves more than the the extra round trip
+//! amount of duplicated information sent over the wire saves more time than the extra round trip
 //! costs us. You can load the children for a single parent using the
 //! [`belonging_to`][belonging-to]
 //!
@@ -68,10 +69,13 @@
 //! let posts = Post::belonging_to(&user).load(&connection);
 //! ```
 //!
-//! If you're coming from most other ORMs, you'll notice that this design is quite different from
-//! most, where you would have an instance method on the parent, or have the children stored
-//! somewhere on the posts. This design leads to many problems, including N+1 query bugs, and
-//! runtime errors when accessing an association that isn't there.
+//! If you're coming from other ORMs, you'll notice that this design is quite different from most.
+//! There you would have an instance method on the parent, or have the children stored somewhere on
+//! the posts. This design leads to many problems, including [N+1 query
+//! bugs][load-your-entire-database-into-memory-lol], and runtime errors when accessing an
+//! association that isn't there.
+//!
+//! [load-your-entire-database-into-memory-lol]: http://stackoverflow.com/q/97197/1254484
 //!
 //! In Diesel, data and its associations are considered to be separate. If you want to pass around
 //! a user and all of its posts, that type is `(User, Vec<Post>)`.
@@ -84,30 +88,32 @@
 //!
 //! ```ignore
 //! fn first_twenty_users_and_their_posts(conn: &PgConnection) -> QueryResult<Vec<(User, Vec<Post>)>> {
-//!     let users = try!(users::limit(20).load::<User>(&conn));
-//!     let posts = try!(Post::belonging_to(&users).load::<Post>());
+//!     let users = try!(users::limit(20).load::<User>(conn));
+//!     let posts = try!(Post::belonging_to(&users).load::<Post>(conn));
 //!     let grouped_posts = posts.grouped_by(&users);
 //!     users.into_iter().zip(grouped_posts).collect()
 //! }
 //! ```
 //!
 //! [`grouped_by`][grouped-by] takes a `Vec<Child>` and a `Vec<Parent>` and returns a
-//! `Vec<Vec<Child>>` where the index of the children matches the index of the parent the belong
-//! to. Or to put it simply, it returns them in an order ready to be `zip`ed with the parents. You
+//! `Vec<Vec<Child>>` where the index of the children matches the index of the parent they belong
+//! to. Or to put it another way, it returns them in an order ready to be `zip`ed with the parents. You
 //! can do this multiple times. For example, if you wanted to load the comments for all the posts
-//! as well, you could do this:
+//! as well, you could do this: (explicit type annotations have been added for documentation
+//! purposes)
 //!
 //! ```ignore
-//! let posts = try!(Post::belonging_to(&users).load::<Post>());
-//! let comments = try!(Comment::belonging_to(&posts).load::<Comment>());
-//! let comments = comments.grouped_by(&posts);
-//! let posts_and_comments = posts.into_iter().zip(comments).grouped_by(&users);
-//! users.into_iter().zip(posts_and_comments).collect()
+//! let posts: Vec<Post> = try!(Post::belonging_to(&users).load());
+//! let comments: Vec<Comment> = try!(Comment::belonging_to(&posts).load());
+//! let comments: Vec<Vec<Comment>> = comments.grouped_by(&posts);
+//! let posts_and_comments: Vec<Vec<(Post, Vec<Comment>)>> = posts.into_iter().zip(comments).grouped_by(&users);
+//! let result: Vec<(User, Vec<(Post, Vec<Comment>)>)> = users.into_iter().zip(posts_and_comments).collect();
 //! ```
 //!
-//! And that's it. This module will be expanded in the future with more complex joins, and ability
-//! to define "through" associations. However, the goal is to provide simple building blocks which
-//! can be used to construct the complex behavior applications need.
+//! And that's it. This module will be expanded in the future with more complex joins, and the
+//! ability to define "through" associations (e.g. load all the comments left on any posts written
+//! by a user in a single query). However, the goal is to provide simple building blocks which can
+//! be used to construct the complex behavior applications need.
 mod belongs_to;
 
 use std::hash::Hash;

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -1,3 +1,113 @@
+// FIXME: Replace these examples with executable tests
+//! Traits related to relationships between multiple tables.
+//!
+//! **Note: This feature is under active development, and we are seeking feedback on the APIs that
+//! have been released. Please feel free to open issues, or join [our chat][gitter] to provide
+//! feedback.**
+//!
+//! [gitter]: https://gitter.im/diesel-rs/diesel
+//!
+//! Note: This guide is written assuming the usage of `diesel_codegen` or `diesel_codegen_syntex`.
+//! If you are using [`custom_derive`] instead, you will need to replace `#[belongs_to(Foo)]` with
+//! `#[derive(BelongsTo(Foo, foreign_key = foo_id))]` and `#[has_many(bars)]` with
+//! `#[derive(HasMany(bars, foreign_key = bar_id))]`.
+//!
+//! Associations in Diesel are bidirectional, but primarily focus on the child-to-parent
+//! relationship. You can declare an association between two records with `#[has_many]` and
+//! `#[belongs_to]`.
+//!
+//! ```ignore
+//! #[derive(Identifiable, Queryable)]
+//! #[has_many(posts)]
+//! pub struct User {
+//!     id: i32,
+//!     name: String,
+//! }
+//!
+//! #[derive(Identifiable, Queryable)]
+//! #[belongs_to(User)]
+//! pub struct Post {
+//!     id: i32,
+//!     user_id: i32,
+//!     title: String,
+//! }
+//! ```
+//!
+//! `#[has_many]` shoudld be passed the name of the table that the children will be loaded from,
+//! while `#[belongs_to]` is given the name of the struct that represents the parent. Both types
+//! must implement the [`Identifiable`][identifiable] trait.
+//!
+//! [Identifiable]: associations/trait.Identifiable.html
+//!
+//! `#[has_many]` actually has no behavior on its own. It only enables joining between the two
+//! tables. If you are only accessing data through the [`belonging_to`][belonging-to] method, you
+//! only need to define the `#[belongs_to]` side.
+//!
+//! Once the associations are defined, you can join between the two tables using the
+//! [`inner_join`][inner-join] or [`left_outer_join`][left-outer-join].
+//!
+//! [inner-join]: query_source/trait.Table.html#method.inner_join
+//! [left-outer-join]: query_source/trait.Table.html#method.left_outer_join
+//!
+//! ```ignore
+//! let data: Vec<(User, Post)> = users::table.inner_join(posts::table).load(&connection);
+//! ```
+//!
+//! Note: Due to language limitations, only two tables can be joined per query. This will change in
+//! the future.
+//!
+//! Typically however, queries are loaded in multiple queries. For most datasets, the reduced
+//! amount of duplicated information sent over the wire saves more than the the extra round trip
+//! costs us. You can load the children for a single parent using the
+//! [`belonging_to`][belonging-to]
+//!
+//! [belonging-to]: prelude/trait.BelongingToDsl.html#tymethod.belonging_to
+//!
+//! ```rust
+//! let user = try!(users::find(1).first(&connection));
+//! let posts = Post::belonging_to(&user).load(&connection);
+//! ```
+//!
+//! If you're coming from most other ORMs, you'll notice that this design is quite different from
+//! most, where you would have an instance method on the parent, or have the children stored
+//! somewhere on the posts. This design leads to many problems, including N+1 query bugs, and
+//! runtime errors when accessing an association that isn't there.
+//!
+//! In Diesel, data and its associations are considered to be separate. If you want to pass around
+//! a user and all of its posts, that type is `(User, Vec<Post>)`.
+//!
+//! Next lets look at how to load the children for more than one parent record.
+//! [`belonging_to`][belonging-to] can be used to load the data, but we'll also need to group it
+//! with its parents. For this we use an additional method [`grouped_by`][grouped-by]
+//!
+//! [grouped-by]: associations/trait.GroupedBy.html#tymethod.grouped_by
+//!
+//! ```ignore
+//! fn first_twenty_users_and_their_posts(conn: &PgConnection) -> QueryResult<Vec<(User, Vec<Post>)>> {
+//!     let users = try!(users::limit(20).load::<User>(&conn));
+//!     let posts = try!(Post::belonging_to(&users).load::<Post>());
+//!     let grouped_posts = posts.grouped_by(&users);
+//!     users.into_iter().zip(grouped_posts).collect()
+//! }
+//! ```
+//!
+//! [`grouped_by`][grouped-by] takes a `Vec<Child>` and a `Vec<Parent>` and returns a
+//! `Vec<Vec<Child>>` where the index of the children matches the index of the parent the belong
+//! to. Or to put it simply, it returns them in an order ready to be `zip`ed with the parents. You
+//! can do this multiple times. For example, if you wanted to load the comments for all the posts
+//! as well, you could do this:
+//!
+//! ```ignore
+//! let posts = try!(Post::belonging_to(&users).load::<Post>());
+//! let comments = try!(Comment::belonging_to(&posts).load::<Comment>());
+//! let comments = comments.grouped_by(&posts);
+//! let posts_and_comments = posts.into_iter().zip(comments).grouped_by(&users);
+//! users.into_iter().zip(posts_and_comments).collect()
+//! ```
+//!
+//! And that's it. This module will be expanded in the future with more complex joins, and ability
+//! to define "through" associations. However, the goal is to provide simple building blocks which
+//! can be used to construct the complex behavior applications need.
 mod belongs_to;
 
 use std::hash::Hash;


### PR DESCRIPTION
This covers the public APIs for associations which have been added for
0.7.0. The language is a little "guidey" for module documentation, but I
think I'd like to leave it this way until the module is "finalized" in
1.0, and I can flesh out a deeper guide on the website.

The examples aren't run as doctests. This is something I want to do, but
I don't want to block the release on it.

Review? @diesel-rs/contributors 