### PR TITLE
Remove the `Copy` constraint from `Identifiable`

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -8,7 +8,7 @@ use super::Identifiable;
 pub trait BelongsTo<Parent: Identifiable> {
     type ForeignKeyColumn: Column;
 
-    fn foreign_key(&self) -> Parent::Id;
+    fn foreign_key(&self) -> &Parent::Id;
     fn foreign_key_column() -> Self::ForeignKeyColumn;
 }
 
@@ -27,56 +27,56 @@ impl<Parent, Child, Iter> GroupedBy<Parent> for Iter where
         let id_indices: HashMap<_, _> = parents.iter().enumerate().map(|(i, u)| (u.id(), i)).collect();
         let mut result = parents.iter().map(|_| Vec::new()).collect::<Vec<_>>();
         for child in self {
-            let index = id_indices[&child.foreign_key()];
+            let index = id_indices[child.foreign_key()];
             result[index].push(child);
         }
         result
     }
 }
 
-impl<Parent, Child> BelongingToDsl<Parent> for Child where
+impl<'a, Parent, Child> BelongingToDsl<&'a Parent> for Child where
     Parent: Identifiable,
     Child: Identifiable + BelongsTo<Parent>,
-    Parent::Id: AsExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
-    <Child as Identifiable>::Table: FilterDsl<Eq<Child::ForeignKeyColumn, Parent::Id>>,
+    &'a Parent::Id: AsExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
+    <Child as Identifiable>::Table: FilterDsl<Eq<Child::ForeignKeyColumn, &'a Parent::Id>>,
 {
     type Output = FindBy<
         Child::Table,
         Child::ForeignKeyColumn,
-        Parent::Id,
+        &'a Parent::Id,
     >;
 
-    fn belonging_to(parent: &Parent) -> Self::Output {
+    fn belonging_to(parent: &'a Parent) -> Self::Output {
         Child::table().filter(Child::foreign_key_column().eq(parent.id()))
     }
 }
 
-impl<Parent, Child> BelongingToDsl<[Parent]> for Child where
+impl<'a, Parent, Child> BelongingToDsl<&'a [Parent]> for Child where
     Parent: Identifiable,
     Child: Identifiable + BelongsTo<Parent>,
-    Vec<Parent::Id>: AsInExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
-    <Child as Identifiable>::Table: FilterDsl<EqAny<Child::ForeignKeyColumn, Vec<Parent::Id>>>,
+    Vec<&'a Parent::Id>: AsInExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
+    <Child as Identifiable>::Table: FilterDsl<EqAny<Child::ForeignKeyColumn, Vec<&'a Parent::Id>>>,
 {
     type Output = Filter<
         Child::Table,
         EqAny<
             Child::ForeignKeyColumn,
-            Vec<Parent::Id>,
+            Vec<&'a Parent::Id>,
         >,
     >;
 
-    fn belonging_to(parents: &[Parent]) -> Self::Output {
+    fn belonging_to(parents: &'a [Parent]) -> Self::Output {
         let ids = parents.iter().map(Parent::id).collect::<Vec<_>>();
         Child::table().filter(Child::foreign_key_column().eq_any(ids))
     }
 }
 
-impl<Parent, Child> BelongingToDsl<Vec<Parent>> for Child where
-    Child: BelongingToDsl<[Parent]>,
+impl<'a, Parent, Child> BelongingToDsl<&'a Vec<Parent>> for Child where
+    Child: BelongingToDsl<&'a [Parent]>,
 {
     type Output = Child::Output;
 
-    fn belonging_to(parents: &Vec<Parent>) -> Self::Output {
+    fn belonging_to(parents: &'a Vec<Parent>) -> Self::Output {
         Self::belonging_to(&**parents)
     }
 }

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -126,9 +126,9 @@ use query_source::Table;
 pub use self::belongs_to::{BelongsTo, GroupedBy};
 
 pub trait Identifiable {
-    type Id: Hash + Eq + Copy;
-    type Table: Table + FindDsl<Self::Id>;
+    type Id: Hash + Eq;
+    type Table: Table + for<'a> FindDsl<&'a Self::Id>;
 
     fn table() -> Self::Table;
-    fn id(&self) -> Self::Id;
+    fn id(&self) -> &Self::Id;
 }

--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -116,8 +116,8 @@ macro_rules! BelongsTo {
         impl $crate::associations::BelongsTo<$parent_struct> for $struct_name {
             type ForeignKeyColumn = $child_table_name::$foreign_key_name;
 
-            fn foreign_key(&self) -> <$parent_struct as $crate::associations::Identifiable>::Id {
-                self.$foreign_key_name
+            fn foreign_key(&self) -> &<$parent_struct as $crate::associations::Identifiable>::Id {
+                &self.$foreign_key_name
             }
 
             fn foreign_key_column() -> Self::ForeignKeyColumn {

--- a/diesel/src/macros/identifiable.rs
+++ b/diesel/src/macros/identifiable.rs
@@ -94,8 +94,8 @@ macro_rules! Identifiable {
                 $table_name::table
             }
 
-            fn id(&self) -> Self::Id {
-                self.id
+            fn id(&self) -> &Self::Id {
+                &self.id
             }
         }
     };
@@ -165,8 +165,8 @@ fn derive_identifiable_on_simple_struct() {
 
     let foo1 = Foo { id: 1, foo: 2 };
     let foo2 = Foo { id: 2, foo: 3 };
-    assert_eq!(1, foo1.id());
-    assert_eq!(2, foo2.id());
+    assert_eq!(&1, foo1.id());
+    assert_eq!(&2, foo2.id());
 }
 
 #[test]
@@ -189,8 +189,8 @@ fn derive_identifiable_when_id_is_not_first_field() {
 
     let foo1 = Foo { id: 1, foo: 2 };
     let foo2 = Foo { id: 2, foo: 3 };
-    assert_eq!(1, foo1.id());
-    assert_eq!(2, foo2.id());
+    assert_eq!(&1, foo1.id());
+    assert_eq!(&2, foo2.id());
 }
 
 #[test]
@@ -213,6 +213,6 @@ fn derive_identifiable_on_struct_with_non_integer_pk() {
 
     let foo1 = Foo { id: "hi", foo: 2 };
     let foo2 = Foo { id: "there", foo: 3 };
-    assert_eq!("hi", foo1.id());
-    assert_eq!("there", foo2.id());
+    assert_eq!(&"hi", foo1.id());
+    assert_eq!(&"there", foo2.id());
 }

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -18,7 +18,7 @@ pub trait IntoUpdateTarget {
 }
 
 impl<'a, T: Identifiable, V> IntoUpdateTarget for &'a T where
-    <T::Table as FindDsl<T::Id>>::Output: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
+    <T::Table as FindDsl<&'a T::Id>>::Output: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
 {
     type Table = T::Table;
     type WhereClause = V;

--- a/diesel/src/query_dsl/belonging_to_dsl.rs
+++ b/diesel/src/query_dsl/belonging_to_dsl.rs
@@ -1,7 +1,7 @@
 use query_builder::AsQuery;
 
-pub trait BelongingToDsl<T: ?Sized> {
+pub trait BelongingToDsl<T> {
     type Output: AsQuery;
 
-    fn belonging_to(other: &T) -> Self::Output;
+    fn belonging_to(other: T) -> Self::Output;
 }

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -42,7 +42,7 @@ impl<'a, T, ST> SaveChangesDsl<SqliteConnection, ST> for &'a T where
     T::Table: AsQuery<SqlType=ST>,
     &'a T: AsChangeset<Target=T::Table> + IntoUpdateTarget<Table=T::Table>,
     Update<&'a T, &'a T>: ExecuteDsl<SqliteConnection>,
-    Find<T::Table, T::Id>: LoadDsl<SqliteConnection, SqlType=ST>,
+    Find<T::Table, &'a T::Id>: LoadDsl<SqliteConnection, SqlType=ST>,
 {
     fn save_changes<U>(self, conn: &SqliteConnection) -> QueryResult<U> where
         U: Queryable<ST, Sqlite>,

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -20,7 +20,7 @@ macro_rules! expression_impls {
                 }
             }
 
-            impl<'a: 'expr, 'expr> $crate::expression::AsExpression<types::$Source> for &'expr $Target {
+            impl<'a, 'expr> $crate::expression::AsExpression<types::$Source> for &'expr $Target {
                 type Expression = $crate::expression::bound::Bound<types::$Source, Self>;
 
                 fn as_expression(self) -> Self::Expression {
@@ -36,7 +36,7 @@ macro_rules! expression_impls {
                 }
             }
 
-            impl<'a: 'expr, 'expr> $crate::expression::AsExpression<$crate::types::Nullable<types::$Source>> for &'a $Target {
+            impl<'a, 'expr> $crate::expression::AsExpression<$crate::types::Nullable<types::$Source>> for &'a $Target {
                 type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<types::$Source>, Self>;
 
                 fn as_expression(self) -> Self::Expression {

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -286,8 +286,8 @@ macro_rules! tuple_impls {
             {
                 type ForeignKeyColumn = A::ForeignKeyColumn;
 
-                fn foreign_key(&self) -> Parent::Id {
-                    self.0.foreign_key()
+                fn foreign_key(&self) -> &Parent::Id {
+                    &self.0.foreign_key()
                 }
 
                 fn foreign_key_column() -> Self::ForeignKeyColumn {

--- a/diesel_tests/tests/lib.in.rs
+++ b/diesel_tests/tests/lib.in.rs
@@ -1,5 +1,6 @@
 #[cfg(not(feature = "sqlite"))]
 mod annotations;
+mod associations;
 mod deserialization;
 mod insert;
 mod schema;

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -11,7 +11,6 @@ include!("lib.in.rs");
 #[cfg(not(feature = "unstable"))]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
-mod associations;
 mod boxed_queries;
 mod connection;
 mod debug;


### PR DESCRIPTION
I had originally wanted to returned owned values here because I'm
thinking that when we eventually add support for composite primary keys,
I'll need to return a tuple of two fields from this method. I've gone
back and forth on a bunch of different options, but ultimately I think
I'm going to change this to return `Cow<'a, Self::Id>`. However, I don't
want to make that change pre-emptively, as I'm still not sure exactly
what composite primary keys will look like.

Other alternatives:

- Implement `Identifiable` on `&'a T` -- makes reasoning about it a pain
- Change `Identifiable` to be `Identifiable<'a>` -- makes referencing it
  a pain
- Change `id` to `with_id`, and have it take a `FnOnce(&Self::Id)`. This
  would work, but would be really weird and just returning `Cow<'a,
  Self::Id>` makes way more sense.

Review? @diesel-rs/contributors 