### PR TITLE
Cleanup prepared statement caching #388

### DIFF
--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -166,7 +166,7 @@ impl SqliteConnection {
             Occupied(entry) => Ok(entry.get().clone()),
             Vacant(entry) => {
                 let statement = {
-                    let sql = try!(sql_from_cache_key(&cache_key, source));
+                    let sql = try!(sql_from_cache_key(&entry.key(), source));
 
                     Statement::prepare(&self.raw_connection, &sql)
                         .map(StatementUse::new)
@@ -176,7 +176,7 @@ impl SqliteConnection {
                     return statement;
                 }
 
-                Ok(entry.insert(statement).clone())
+                Ok(entry.insert(try!(statement)).clone())
             }
         }
     }


### PR DESCRIPTION
Hello there @killercup @sgrif @gsquire!

This is my first PR to Diesel project.

As stated in the #388 rust 1.10 now has stabilized  `std::collections::hash_map::Entry::{Occupied, Vacant}` so there's no need for an if block.

Any feedback is more than welcome.

Cheers!
