### PR TITLE
Support nullable foreign keys in associations

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -8,7 +8,7 @@ use super::Identifiable;
 pub trait BelongsTo<Parent: Identifiable> {
     type ForeignKeyColumn: Column;
 
-    fn foreign_key(&self) -> &Parent::Id;
+    fn foreign_key(&self) -> Option<&Parent::Id>;
     fn foreign_key_column() -> Self::ForeignKeyColumn;
 }
 
@@ -27,8 +27,9 @@ impl<Parent, Child, Iter> GroupedBy<Parent> for Iter where
         let id_indices: HashMap<_, _> = parents.iter().enumerate().map(|(i, u)| (u.id(), i)).collect();
         let mut result = parents.iter().map(|_| Vec::new()).collect::<Vec<_>>();
         for child in self {
-            let index = id_indices[child.foreign_key()];
-            result[index].push(child);
+            if let Some(index) = child.foreign_key().map(|i| id_indices[i]) {
+                result[index].push(child);
+            }
         }
         result
     }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -486,6 +486,7 @@ macro_rules! print_sql {
 // Utililty macros which don't call any others need to come first.
 #[macro_use] mod parse;
 #[macro_use] mod query_id;
+#[macro_use] mod static_cond;
 
 #[macro_use] mod as_changeset;
 #[macro_use] mod associations;

--- a/diesel/src/macros/parse.rs
+++ b/diesel/src/macros/parse.rs
@@ -293,3 +293,34 @@ macro_rules! __diesel_parse_struct_body {
 macro_rules!  __diesel_parse_as_item {
     ($i:item) => { $i }
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __diesel_field_with_column_name {
+    (
+        $headers:tt,
+        callback = $callback:ident,
+        target = $target_column_name:ident,
+        fields = [$({
+            field_name: $field_name:ident,
+            column_name: $column_name:ident,
+            $($field_info:tt)*
+        })*],
+    ) => {
+        $(
+            static_cond! {
+                if $target_column_name == $column_name {
+                    $callback! {
+                        $headers,
+                        found_field_with_column_name = $column_name,
+                        field = {
+                            field_name: $field_name,
+                            column_name: $column_name,
+                            $($field_info)*
+                        },
+                    }
+                }
+            }
+        )*
+    };
+}

--- a/diesel/src/macros/static_cond.rs
+++ b/diesel/src/macros/static_cond.rs
@@ -1,0 +1,36 @@
+// Vendored from the static-cond crate as macro re-exports are not available in stable Rust.
+// https://github.com/durka/static-cond/blob/36aa2dd/src/lib.rs
+//
+// Code is dual licensed under MIT/Apache-2.0
+// Copyright (c) 2016 Alex Burka
+#[macro_export]
+#[doc(hidden)]
+macro_rules! static_cond {
+    // private rule to define and call the local macro
+    (@go $lhs:tt $rhs:tt $arm1:tt $arm2:tt) => {        // note that the inner macro has no captures (it can't, because there's no way to escape `$`)
+        macro_rules! __static_cond {
+            ($lhs $lhs) => $arm1;
+            ($lhs $rhs) => $arm2
+        }
+
+        __static_cond!($lhs $rhs);
+    };
+
+    // no else condition provided: fall through with empty else
+    (if $lhs:tt == $rhs:tt $then:tt) => {
+        static_cond!(if $lhs == $rhs $then else { });
+    };
+    (if $lhs:tt != $rhs:tt $then:tt) => {
+        static_cond!(if $lhs != $rhs $then else { });
+    };
+
+    // we evaluate a conditional by generating a new macro (in an inner scope, so name shadowing is
+    // not a big concern) and calling it
+    (if $lhs:tt == $rhs:tt $then:tt else $els:tt) => {
+        static_cond!(@go $lhs $rhs $then $els);
+    };
+    (if $lhs:tt != $rhs:tt $then:tt else $els:tt) => {
+        static_cond!(@go $lhs $rhs $els $then);
+    };
+}
+

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -1,4 +1,5 @@
 use associations::Identifiable;
+use helper_types::Find;
 use query_dsl::FindDsl;
 use query_source::Table;
 
@@ -9,7 +10,6 @@ pub struct UpdateTarget<Table, WhereClause> {
     pub where_clause: Option<WhereClause>,
 }
 
-#[doc(hidden)]
 pub trait IntoUpdateTarget {
     type Table: Table;
     type WhereClause;
@@ -18,7 +18,7 @@ pub trait IntoUpdateTarget {
 }
 
 impl<'a, T: Identifiable, V> IntoUpdateTarget for &'a T where
-    <T::Table as FindDsl<&'a T::Id>>::Output: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
+    Find<T::Table, &'a T::Id>: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
 {
     type Table = T::Table;
     type WhereClause = V;

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -286,8 +286,8 @@ macro_rules! tuple_impls {
             {
                 type ForeignKeyColumn = A::ForeignKeyColumn;
 
-                fn foreign_key(&self) -> &Parent::Id {
-                    &self.0.foreign_key()
+                fn foreign_key(&self) -> Option<&Parent::Id> {
+                    self.0.foreign_key()
                 }
 
                 fn foreign_key_column() -> Self::ForeignKeyColumn {

--- a/diesel_codegen_syntex/src/associations/belongs_to.rs
+++ b/diesel_codegen_syntex/src/associations/belongs_to.rs
@@ -3,7 +3,6 @@ use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
 
 use super::{parse_association_options, to_foreign_key};
-use util::is_option_ty;
 
 #[allow(unused_imports)]
 pub fn expand_belongs_to(
@@ -20,14 +19,6 @@ pub fn expand_belongs_to(
 
         let foreign_key_name = options.foreign_key_name.unwrap_or_else(||
             to_foreign_key(&parent_struct.name.as_str()));
-
-        let foreign_key = model.attr_named(foreign_key_name);
-        let optional_fk = if foreign_key.map(|a| is_option_ty(&a.ty)).unwrap_or(false) {
-            quote_tokens!(cx, "true")
-        } else {
-            quote_tokens!(cx, "false")
-        };
-
         let child_table_name = model.table_name();
         let fields = model.field_tokens_for_stable_macro(cx);
         push(Annotatable::Item(quote_item!(cx, BelongsTo! {
@@ -35,7 +26,6 @@ pub fn expand_belongs_to(
                 struct_name = $struct_name,
                 parent_struct = $parent_struct,
                 foreign_key_name = $foreign_key_name,
-                optional_foreign_key = $optional_fk,
                 child_table_name = $child_table_name,
             ),
             fields = [$fields],


### PR DESCRIPTION
The `BelongsTo!` macro now does crazy hacks to pull out the foreign key field
from the list given, checks if it's an option type, and will generate different
code as a result. The types that `BelongingToDsl` and `GroupedBy` get
implemented for are the same as if the foreign key was not nullable.
`GroupedBy` will simply discard any records with `None` for the foreign key
(which it is unlikely to receive in the first place since the result of
`BelongingToDsl` implicitly never returns records with a null value for the
foreign key.)

This differs from the direction I had previously discussed, where we would
implement the various traits for `Option<Parent>`. There are two main reasons
for this:

- The impl of `BelongingToDsl` would be gross, as we now have to care about
  `NULL` appearing anywhere and give it special handling.
- In the real world, you're never dealing with "records belonging to these 3
  parents, and records which have no parent".

For simplication in the code, I've set up `BelongsTo` to always return an
option for the foreign key. This causes an unneccesary conditional to appear in
the body of `GroupedBy`. However, I'm fairly certain that conditional will get
optimized away after inlining. I have not checked the generated ASM or LLVM IR
to confirm this.