### PR TITLE
Add the getting started guide to examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ script:
   else
     (cd diesel && travis-cargo test -- --no-default-features --features "chrono $BACKEND")
   fi &&
+  if [[ "$BACKEND" == postgres ]]; then
+    if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
+      (cd examples && ./test_nightly)
+    else
+      (cd examples && ./test_stable)
+    fi
+  fi &&
   (cd diesel_cli && travis-cargo test -- --no-default-features --features "$BACKEND") &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
     (cd diesel_codegen_syntex && travis-cargo test -- --no-default-features --features "$BACKEND")
@@ -45,7 +52,9 @@ env:
     - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
 matrix:
   allow_failures:
-    - rust: nightly
+    - rust:
+      - nightly
+      - beta
 after_success:
   - "(cd diesel && travis-cargo --only stable doc-upload)"
 branches:

--- a/bin/test
+++ b/bin/test
@@ -9,6 +9,7 @@ elif [ "$1" == "compile" ]; then
   (cd diesel_compile_tests && cargo test)
 else
   (cd diesel && cargo test --features "unstable chrono sqlite")
+  (cd examples && ./test_nightly)
   (cd diesel_cli && cargo test --features "postgres" --no-default-features)
   (cd diesel_cli && cargo test --features "sqlite" --no-default-features)
   (cd diesel_codegen_syntex && cargo test --no-default-features --features "postgres")

--- a/examples/getting_started_step_1/Cargo.toml
+++ b/examples/getting_started_step_1/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "diesel_demo"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+
+[dependencies]
+diesel = { version = "0.7.0", features = ["postgres"] }
+diesel_codegen = { version = "0.7.0", features = ["postgres"] }
+dotenv = "0.8.0"
+dotenv_macros = "0.9.0"

--- a/examples/getting_started_step_1/migrations/20160815133237_create_posts/down.sql
+++ b/examples/getting_started_step_1/migrations/20160815133237_create_posts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE posts

--- a/examples/getting_started_step_1/migrations/20160815133237_create_posts/up.sql
+++ b/examples/getting_started_step_1/migrations/20160815133237_create_posts/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE posts (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR NOT NULL,
+  body TEXT NOT NULL,
+  published BOOLEAN NOT NULL DEFAULT 'f'
+)

--- a/examples/getting_started_step_1/src/bin/show_posts.rs
+++ b/examples/getting_started_step_1/src/bin/show_posts.rs
@@ -1,0 +1,23 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel_demo::*;
+use diesel_demo::models::*;
+use diesel::prelude::*;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::*;
+
+    let connection = establish_connection();
+    let results = posts.filter(published.eq(true))
+        .limit(5)
+        .load::<Post>(&connection)
+        .expect("Error loading posts");
+
+    println!("Displaying {} posts", results.len());
+    for post in results {
+        println!("{}", post.title);
+        println!("-----------\n");
+        println!("{}", post.body);
+    }
+}

--- a/examples/getting_started_step_1/src/lib.rs
+++ b/examples/getting_started_step_1/src/lib.rs
@@ -1,0 +1,22 @@
+#![feature(custom_derive, custom_attribute, plugin)]
+#![plugin(diesel_codegen, dotenv_macros)]
+
+#[macro_use] extern crate diesel;
+extern crate dotenv;
+
+pub mod schema;
+pub mod models;
+
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use dotenv::dotenv;
+use std::env;
+
+pub fn establish_connection() -> PgConnection {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    PgConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url))
+}

--- a/examples/getting_started_step_1/src/models.rs
+++ b/examples/getting_started_step_1/src/models.rs
@@ -1,0 +1,7 @@
+#[derive(Queryable)]
+pub struct Post {
+    pub id: i32,
+    pub title: String,
+    pub body: String,
+    pub published: bool,
+}

--- a/examples/getting_started_step_1/src/schema.rs
+++ b/examples/getting_started_step_1/src/schema.rs
@@ -1,0 +1,1 @@
+infer_schema!(dotenv!("DATABASE_URL"));

--- a/examples/getting_started_step_2/Cargo.toml
+++ b/examples/getting_started_step_2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "diesel_demo"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+
+[dependencies]
+diesel = { version = "0.7.0", features = ["postgres"] }
+diesel_codegen = { version = "0.7.0", features = ["postgres"] }
+dotenv = "0.8.0"
+dotenv_macros = "0.9.0"

--- a/examples/getting_started_step_2/migrations/20160815133237_create_posts/down.sql
+++ b/examples/getting_started_step_2/migrations/20160815133237_create_posts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE posts

--- a/examples/getting_started_step_2/migrations/20160815133237_create_posts/up.sql
+++ b/examples/getting_started_step_2/migrations/20160815133237_create_posts/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE posts (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR NOT NULL,
+  body TEXT NOT NULL,
+  published BOOLEAN NOT NULL DEFAULT 'f'
+)

--- a/examples/getting_started_step_2/src/bin/show_posts.rs
+++ b/examples/getting_started_step_2/src/bin/show_posts.rs
@@ -1,0 +1,23 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel_demo::*;
+use diesel_demo::models::*;
+use diesel::prelude::*;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::*;
+
+    let connection = establish_connection();
+    let results = posts.filter(published.eq(true))
+        .limit(5)
+        .load::<Post>(&connection)
+        .expect("Error loading posts");
+
+    println!("Displaying {} posts", results.len());
+    for post in results {
+        println!("{}", post.title);
+        println!("-----------\n");
+        println!("{}", post.body);
+    }
+}

--- a/examples/getting_started_step_2/src/bin/write_post.rs
+++ b/examples/getting_started_step_2/src/bin/write_post.rs
@@ -1,0 +1,28 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use self::diesel_demo::*;
+use std::io::{stdin, Read};
+
+fn main() {
+    let connection = establish_connection();
+
+    let mut title = String::new();
+    let mut body = String::new();
+
+    println!("What would you like your title to be?");
+    stdin().read_line(&mut title).unwrap();
+    let title = title.trim_right(); // Remove the trailing newline
+
+    println!("\nOk! Let's write {} (Press {} when finished)\n", title, EOF);
+    stdin().read_to_string(&mut body).unwrap();
+
+    let post = create_post(&connection, title, &body);
+    println!("\nSaved draft {} with id {}", title, post.id);
+}
+
+#[cfg(not(windows))]
+const EOF: &'static str = "CTRL+D";
+
+#[cfg(windows)]
+const EOF: &'static str = "CTRL+Z";

--- a/examples/getting_started_step_2/src/lib.rs
+++ b/examples/getting_started_step_2/src/lib.rs
@@ -1,0 +1,37 @@
+#![feature(custom_derive, custom_attribute, plugin)]
+#![plugin(diesel_codegen, dotenv_macros)]
+
+#[macro_use] extern crate diesel;
+extern crate dotenv;
+
+pub mod schema;
+pub mod models;
+
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use dotenv::dotenv;
+use std::env;
+
+use self::models::{Post, NewPost};
+
+pub fn establish_connection() -> PgConnection {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    PgConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url))
+}
+
+pub fn create_post(conn: &PgConnection, title: &str, body: &str) -> Post {
+    use schema::posts;
+
+    let new_post = NewPost {
+        title: title,
+        body: body,
+    };
+
+    diesel::insert(&new_post).into(posts::table)
+        .get_result(conn)
+        .expect("Error saving new post")
+}

--- a/examples/getting_started_step_2/src/models.rs
+++ b/examples/getting_started_step_2/src/models.rs
@@ -1,0 +1,15 @@
+use schema::posts;
+
+#[derive(Queryable)]
+pub struct Post {
+    pub id: i32,
+    pub title: String,
+    pub body: String,
+    pub published: bool,
+}
+
+#[insertable_into(posts)]
+pub struct NewPost<'a> {
+    pub title: &'a str,
+    pub body: &'a str,
+}

--- a/examples/getting_started_step_2/src/schema.rs
+++ b/examples/getting_started_step_2/src/schema.rs
@@ -1,0 +1,1 @@
+infer_schema!(dotenv!("DATABASE_URL"));

--- a/examples/getting_started_step_3/Cargo.toml
+++ b/examples/getting_started_step_3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "diesel_demo"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+
+[dependencies]
+diesel = { version = "0.7.0", features = ["postgres"] }
+diesel_codegen = { version = "0.7.0", features = ["postgres"] }
+dotenv = "0.8.0"
+dotenv_macros = "0.9.0"

--- a/examples/getting_started_step_3/migrations/20160815133237_create_posts/down.sql
+++ b/examples/getting_started_step_3/migrations/20160815133237_create_posts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE posts

--- a/examples/getting_started_step_3/migrations/20160815133237_create_posts/up.sql
+++ b/examples/getting_started_step_3/migrations/20160815133237_create_posts/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE posts (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR NOT NULL,
+  body TEXT NOT NULL,
+  published BOOLEAN NOT NULL DEFAULT 'f'
+)

--- a/examples/getting_started_step_3/src/bin/delete_post.rs
+++ b/examples/getting_started_step_3/src/bin/delete_post.rs
@@ -1,0 +1,20 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel::prelude::*;
+use diesel_demo::*;
+use std::env::args;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::*;
+
+    let target = args().nth(1).expect("Expected a target to match against");
+    let pattern = format!("%{}%", target);
+
+    let connection = establish_connection();
+    let num_deleted = diesel::delete(posts.filter(title.like(pattern)))
+        .execute(&connection)
+        .expect("Error deleting posts");
+
+    println!("Deleted {} posts", num_deleted);
+}

--- a/examples/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/getting_started_step_3/src/bin/publish_post.rs
@@ -1,0 +1,21 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel::prelude::*;
+use diesel_demo::*;
+use diesel_demo::models::Post;
+use std::env::args;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::{posts, published};
+
+    let id = args().nth(1).expect("publish_post requires a post id")
+        .parse::<i32>().expect("Invalid ID");
+    let connection = establish_connection();
+
+    let post = diesel::update(posts.find(id))
+        .set(published.eq(true))
+        .get_result::<Post>(&connection)
+        .expect(&format!("Unable to find post {}", id));
+    println!("Published post {}", post.title);
+}

--- a/examples/getting_started_step_3/src/bin/show_posts.rs
+++ b/examples/getting_started_step_3/src/bin/show_posts.rs
@@ -1,0 +1,23 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel_demo::*;
+use diesel_demo::models::*;
+use diesel::prelude::*;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::*;
+
+    let connection = establish_connection();
+    let results = posts.filter(published.eq(true))
+        .limit(5)
+        .load::<Post>(&connection)
+        .expect("Error loading posts");
+
+    println!("Displaying {} posts", results.len());
+    for post in results {
+        println!("{}", post.title);
+        println!("-----------\n");
+        println!("{}", post.body);
+    }
+}

--- a/examples/getting_started_step_3/src/bin/write_post.rs
+++ b/examples/getting_started_step_3/src/bin/write_post.rs
@@ -1,0 +1,28 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use self::diesel_demo::*;
+use std::io::{stdin, Read};
+
+fn main() {
+    let connection = establish_connection();
+
+    let mut title = String::new();
+    let mut body = String::new();
+
+    println!("What would you like your title to be?");
+    stdin().read_line(&mut title).unwrap();
+    let title = title.trim_right(); // Remove the trailing newline
+
+    println!("\nOk! Let's write {} (Press {} when finished)\n", title, EOF);
+    stdin().read_to_string(&mut body).unwrap();
+
+    let post = create_post(&connection, title, &body);
+    println!("\nSaved draft {} with id {}", title, post.id);
+}
+
+#[cfg(not(windows))]
+const EOF: &'static str = "CTRL+D";
+
+#[cfg(windows)]
+const EOF: &'static str = "CTRL+Z";

--- a/examples/getting_started_step_3/src/lib.rs
+++ b/examples/getting_started_step_3/src/lib.rs
@@ -1,0 +1,37 @@
+#![feature(custom_derive, custom_attribute, plugin)]
+#![plugin(diesel_codegen, dotenv_macros)]
+
+#[macro_use] extern crate diesel;
+extern crate dotenv;
+
+pub mod schema;
+pub mod models;
+
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use dotenv::dotenv;
+use std::env;
+
+use self::models::{Post, NewPost};
+
+pub fn establish_connection() -> PgConnection {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    PgConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url))
+}
+
+pub fn create_post(conn: &PgConnection, title: &str, body: &str) -> Post {
+    use schema::posts;
+
+    let new_post = NewPost {
+        title: title,
+        body: body,
+    };
+
+    diesel::insert(&new_post).into(posts::table)
+        .get_result(conn)
+        .expect("Error saving new post")
+}

--- a/examples/getting_started_step_3/src/models.rs
+++ b/examples/getting_started_step_3/src/models.rs
@@ -1,0 +1,15 @@
+use schema::posts;
+
+#[derive(Queryable)]
+pub struct Post {
+    pub id: i32,
+    pub title: String,
+    pub body: String,
+    pub published: bool,
+}
+
+#[insertable_into(posts)]
+pub struct NewPost<'a> {
+    pub title: &'a str,
+    pub body: &'a str,
+}

--- a/examples/getting_started_step_3/src/schema.rs
+++ b/examples/getting_started_step_3/src/schema.rs
@@ -1,0 +1,1 @@
+infer_schema!(dotenv!("DATABASE_URL"));

--- a/examples/getting_started_step_4/Cargo.toml
+++ b/examples/getting_started_step_4/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "diesel_demo"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+build = "build.rs"
+
+[build-dependencies]
+syntex = { version = "0.38.0", optional = true }
+diesel_codegen_syntex = { version = "0.7.0", features = ["postgres"], optional = true }
+dotenv_codegen = { version = "0.9.0", optional = true }
+
+[dependencies]
+diesel = { version = "0.7.0", features = ["postgres"] }
+diesel_codegen = { version = "0.7.0", features = ["postgres"], optional = true }
+dotenv = "0.8.0"
+dotenv_macros = { version = "0.9.0", optional = true }
+
+[features]
+default = ["nightly"]
+with-syntex = ["syntex", "diesel_codegen_syntex", "dotenv_codegen"]
+nightly = ["diesel_codegen", "dotenv_macros"]

--- a/examples/getting_started_step_4/build.rs
+++ b/examples/getting_started_step_4/build.rs
@@ -1,0 +1,22 @@
+#[cfg(feature = "with-syntex")]
+fn main() {
+    extern crate syntex;
+    extern crate diesel_codegen_syntex as diesel_codegen;
+    extern crate dotenv_codegen;
+
+    use std::env;
+    use std::path::Path;
+
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let mut registry = syntex::Registry::new();
+    diesel_codegen::register(&mut registry);
+    dotenv_codegen::register(&mut registry);
+
+    let src = Path::new("src/lib.in.rs");
+    let dst = Path::new(&out_dir).join("lib.rs");
+
+    registry.expand("", &src, &dst).unwrap();
+}
+
+#[cfg(feature = "nightly")]
+fn main() {}

--- a/examples/getting_started_step_4/migrations/20160815133237_create_posts/down.sql
+++ b/examples/getting_started_step_4/migrations/20160815133237_create_posts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE posts

--- a/examples/getting_started_step_4/migrations/20160815133237_create_posts/up.sql
+++ b/examples/getting_started_step_4/migrations/20160815133237_create_posts/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE posts (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR NOT NULL,
+  body TEXT NOT NULL,
+  published BOOLEAN NOT NULL DEFAULT 'f'
+)

--- a/examples/getting_started_step_4/src/bin/delete_post.rs
+++ b/examples/getting_started_step_4/src/bin/delete_post.rs
@@ -1,0 +1,20 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel::prelude::*;
+use diesel_demo::*;
+use std::env::args;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::*;
+
+    let target = args().nth(1).expect("Expected a target to match against");
+    let pattern = format!("%{}%", target);
+
+    let connection = establish_connection();
+    let num_deleted = diesel::delete(posts.filter(title.like(pattern)))
+        .execute(&connection)
+        .expect("Error deleting posts");
+
+    println!("Deleted {} posts", num_deleted);
+}

--- a/examples/getting_started_step_4/src/bin/publish_post.rs
+++ b/examples/getting_started_step_4/src/bin/publish_post.rs
@@ -1,0 +1,21 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel::prelude::*;
+use diesel_demo::*;
+use diesel_demo::models::Post;
+use std::env::args;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::{posts, published};
+
+    let id = args().nth(1).expect("publish_post requires a post id")
+        .parse::<i32>().expect("Invalid ID");
+    let connection = establish_connection();
+
+    let post = diesel::update(posts.find(id))
+        .set(published.eq(true))
+        .get_result::<Post>(&connection)
+        .expect(&format!("Unable to find post {}", id));
+    println!("Published post {}", post.title);
+}

--- a/examples/getting_started_step_4/src/bin/show_posts.rs
+++ b/examples/getting_started_step_4/src/bin/show_posts.rs
@@ -1,0 +1,23 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use diesel_demo::*;
+use diesel_demo::models::*;
+use diesel::prelude::*;
+
+fn main() {
+    use diesel_demo::schema::posts::dsl::*;
+
+    let connection = establish_connection();
+    let results = posts.filter(published.eq(true))
+        .limit(5)
+        .load::<Post>(&connection)
+        .expect("Error loading posts");
+
+    println!("Displaying {} posts", results.len());
+    for post in results {
+        println!("{}", post.title);
+        println!("-----------\n");
+        println!("{}", post.body);
+    }
+}

--- a/examples/getting_started_step_4/src/bin/write_post.rs
+++ b/examples/getting_started_step_4/src/bin/write_post.rs
@@ -1,0 +1,28 @@
+extern crate diesel_demo;
+extern crate diesel;
+
+use self::diesel_demo::*;
+use std::io::{stdin, Read};
+
+fn main() {
+    let connection = establish_connection();
+
+    let mut title = String::new();
+    let mut body = String::new();
+
+    println!("What would you like your title to be?");
+    stdin().read_line(&mut title).unwrap();
+    let title = title.trim_right(); // Remove the trailing newline
+
+    println!("\nOk! Let's write {} (Press {} when finished)\n", title, EOF);
+    stdin().read_to_string(&mut body).unwrap();
+
+    let post = create_post(&connection, title, &body);
+    println!("\nSaved draft {} with id {}", title, post.id);
+}
+
+#[cfg(not(windows))]
+const EOF: &'static str = "CTRL+D";
+
+#[cfg(windows)]
+const EOF: &'static str = "CTRL+Z";

--- a/examples/getting_started_step_4/src/lib.in.rs
+++ b/examples/getting_started_step_4/src/lib.in.rs
@@ -1,0 +1,2 @@
+pub mod schema;
+pub mod models;

--- a/examples/getting_started_step_4/src/lib.rs
+++ b/examples/getting_started_step_4/src/lib.rs
@@ -1,0 +1,40 @@
+#![cfg_attr(feature = "nightly", feature(custom_derive, custom_attribute, plugin))]
+#![cfg_attr(feature = "nightly", plugin(diesel_codegen, dotenv_macros))]
+
+#[macro_use] extern crate diesel;
+extern crate dotenv;
+
+#[cfg(feature = "nightly")]
+include!("lib.in.rs");
+
+#[cfg(feature = "with-syntex")]
+include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use dotenv::dotenv;
+use std::env;
+
+use self::models::{Post, NewPost};
+
+pub fn establish_connection() -> PgConnection {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    PgConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url))
+}
+
+pub fn create_post(conn: &PgConnection, title: &str, body: &str) -> Post {
+    use schema::posts;
+
+    let new_post = NewPost {
+        title: title,
+        body: body,
+    };
+
+    diesel::insert(&new_post).into(posts::table)
+        .get_result(conn)
+        .expect("Error saving new post")
+}

--- a/examples/getting_started_step_4/src/models.rs
+++ b/examples/getting_started_step_4/src/models.rs
@@ -1,0 +1,15 @@
+use schema::posts;
+
+#[derive(Queryable)]
+pub struct Post {
+    pub id: i32,
+    pub title: String,
+    pub body: String,
+    pub published: bool,
+}
+
+#[insertable_into(posts)]
+pub struct NewPost<'a> {
+    pub title: &'a str,
+    pub body: &'a str,
+}

--- a/examples/getting_started_step_4/src/schema.rs
+++ b/examples/getting_started_step_4/src/schema.rs
@@ -1,0 +1,1 @@
+infer_schema!(dotenv!("DATABASE_URL"));

--- a/examples/test_nightly
+++ b/examples/test_nightly
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+cd ../diesel_cli
+cargo build
+cd ../examples
+export DATABASE_URL="postgres://localhost/diesel_examples"
+
+for dir in $(find . -type d -maxdepth 1 -mindepth 1); do
+  cd $dir
+  ../../diesel_cli/target/debug/diesel database reset
+  cargo build
+  cd ..
+done

--- a/examples/test_stable
+++ b/examples/test_stable
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+cd ../diesel_cli
+cargo build
+cd ../examples
+
+# Only step 4 can be run on stable
+cd getting_started_step_4
+export DATABASE_URL=postgres://localhost/diesel_getting_started_step_4
+../../diesel_cli/target/debug/diesel setup
+cargo build --no-default-features --features "with-syntex"


### PR DESCRIPTION
This code will differ slightly from the existing code in `diesel_demo` and on the website, as I rewrote it by following the guide instead of just copying the code over. This is intended to replace the demo repo, as I want this to be part of our test suite, and it gives me more stable URLs to link to from the guide.

I'm planning on changing the guide on the website to pull code snippets from this file automatically.