### PR TITLE
Better document the `types` module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - psql -c 'create database diesel_schema;' -U postgres
 script:
 - |
-  (cd diesel && travis-cargo doc -- --features "postgres sqlite chrono" && echo "docs.diesel.rs" > target/doc/CNAME) &&
+  (cd diesel && travis-cargo doc -- --features "postgres sqlite chrono uuid" && echo "docs.diesel.rs" > target/doc/CNAME) &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
     (cd diesel && travis-cargo test -- --no-default-features --features "unstable chrono $BACKEND")
   else

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -3,7 +3,6 @@ pub mod expression;
 mod backend;
 mod query_builder;
 mod connection;
-#[doc(hidden)]
 pub mod types;
 
 pub use self::backend::{Pg, PgTypeMetadata};

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -6,16 +6,66 @@ mod primitives;
 #[cfg(feature = "uuid")]
 mod uuid;
 
-#[doc(hidden)]
+/// PostgreSQL specific SQL types
+///
+/// Note: All types in this module can be accessed through `diesel::types`
 pub mod sql_types {
+    /// The OID SQL type. This is a PostgreSQL specific type.
+    ///
+    /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+    ///
+    /// - [`u32`][u32]
+    ///
+    /// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+    ///
+    /// - [`u32`][u32]
+    ///
+    /// [u32]: https://doc.rust-lang.org/nightly/std/primitive.u32.html
     #[derive(Debug, Clone, Copy, Default)] pub struct Oid;
-    #[derive(Debug, Clone, Copy, Default)] pub struct Array<T>(T);
+
+    /// The Array SQL type. This wraps another type to represent a SQL array of
+    /// that type. Multidimensional arrays are not supported, nor are arrays
+    /// containing null.
+    ///
+    /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+    ///
+    /// - [`Vec<T>`][Vec] for any `T` which implements `ToSql<ST>`
+    /// - [`&[T]`][slice] for any `T` which implements `ToSql<ST>`
+    ///
+    /// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+    ///
+    /// - [`Vec<T>`][Vec] for any `T` which implements `ToSql<ST>`
+    ///
+    /// [Vec]: https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html
+    /// [slice]: https://doc.rust-lang.org/nightly/std/primitive.slice.html
+    #[derive(Debug, Clone, Copy, Default)] pub struct Array<ST>(ST);
+
+    /// Alias for SmallInt
     pub type SmallSerial = ::types::SmallInt;
+
+    /// Alias for Integer
     pub type Serial = ::types::Integer;
+
+    /// Alias for BigInt
     pub type BigSerial = ::types::BigInt;
+
     #[cfg(feature = "uuid")]
+    /// The UUID SQL type. This type can only be used with `feature = "uuid"`
+    ///
+    /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+    ///
+    /// - [`uuid::Uuid`][Uuid]
+    ///
+    /// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+    ///
+    /// - [`uuid::Uuid`][Uuid]
+    ///
+    /// [Vec]: https://doc.rust-lang.org/uuid/uuid/struct.Uuid.html
     #[derive(Debug, Clone, Copy, Default)] pub struct Uuid;
+
+    /// Alias for `Binary`, to ensure `infer_schema!` works
     pub type Bytea = ::types::Binary;
+
     #[doc(hidden)]
     pub type Bpchar = ::types::VarChar;
 }

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -1,5 +1,17 @@
 //! Types which represent a native SQL data type, and the conversions between
-//! them and Rust primitives. Additional types can be added by other crates.
+//! them and Rust primitives. The structs in this module are *only* used as
+//! markers to represent a SQL type, and shouldn't be used in your structs. See
+//! the documentation for each type to see the Rust types that can be used with
+//! a corresponding SQL type. Additional types can be added by other crates.
+//!
+//! To see which Rust types can be used with a given SQL type, see the
+//! "Implementors" section of the [`ToSql`][ToSql] and [`FromSql`][FromSql]
+//! traits, or see the documentation for that SQL type.
+//!
+//! [ToSql]: /diesel/types/trait.ToSql.html
+//! [FromSql]: /diesel/types/trait.FromSql.html
+//!
+//! Any backend specific types are re-exported through this module
 pub mod ops;
 mod ord;
 #[macro_use]
@@ -31,36 +43,210 @@ use row::Row;
 use std::error::Error;
 use std::io::Write;
 
+/// The boolean SQL type. On SQLite this is emulated with an integer.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`bool`][bool]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`bool`][bool]
+///
+/// [bool]: https://doc.rust-lang.org/nightly/std/primitive.bool.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Bool;
 
+/// The small integer SQL type.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`i16`][i16]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`i16`][i16]
+///
+/// [i16]: https://doc.rust-lang.org/nightly/std/primitive.i16.html
 #[derive(Debug, Clone, Copy, Default)] pub struct SmallInt;
 #[doc(hidden)] pub type Int2 = SmallInt;
+
+/// The integer SQL type.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`i32`][i32]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`i32`][i32]
+///
+/// [i32]: https://doc.rust-lang.org/nightly/std/primitive.i32.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Integer;
 #[doc(hidden)] pub type Int4 = Integer;
+
+/// The big integer SQL type.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`i64`][i64]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`i64`][i64]
+///
+/// [i64]: https://doc.rust-lang.org/nightly/std/primitive.i64.html
 #[derive(Debug, Clone, Copy, Default)] pub struct BigInt;
 #[doc(hidden)] pub type Int8 = BigInt;
 
+/// The float SQL type.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`f32`][f32]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`f32`][f32]
+///
+/// [f32]: https://doc.rust-lang.org/nightly/std/primitive.f32.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Float;
 #[doc(hidden)] pub type Float4 = Float;
+
+/// The double precision float SQL type.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`f64`][f64]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`f64`][f64]
+///
+/// [f64]: https://doc.rust-lang.org/nightly/std/primitive.f64.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Double;
 #[doc(hidden)] pub type Float8 = Double;
+
+/// The numeric SQL type.
+///
+/// This type does not currently have any corresponding Rust types. On SQLite,
+/// [`Double`](struct.Double.html) should be used instead.
 #[derive(Debug, Clone, Copy, Default)] pub struct Numeric;
 
+/// The text SQL type.
+///
+/// On all backends strings must be valid UTF-8.
+/// On PostgreSQL strings must not include nul bytes.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`String`][String]
+/// - [`&str`][str]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`String`][String]
+///
+/// [String]: https://doc.rust-lang.org/nightly/std/string/struct.String.html
+/// [str]: https://doc.rust-lang.org/nightly/std/primitive.str.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Text;
 pub type VarChar = Text;
 #[doc(hidden)] pub type Varchar = VarChar;
 
+/// The binary SQL type.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`Vec<u8>`][Vec]
+/// - [`&[u8]`][slice]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`Vec<u8>`][Vec]
+///
+/// [Vec]: https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html
+/// [slice]: https://doc.rust-lang.org/nightly/std/primitive.slice.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Binary;
 
+/// The date SQL type.
+///
+/// This type is currently only implemented for PostgreSQL.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`chrono::NaiveDate`][NaiveDate] with `feature = "chrono"`
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`chrono::NaiveDate`][NaiveDate] with `feature = "chrono"`
+///
+/// [NaiveDate]: https://lifthrasiir.github.io/rust-chrono/chrono/naive/date/struct.NaiveDate.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Date;
+
+/// The interval SQL type.
+///
+/// This type is currently only implemented for PostgreSQL.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`PgInterval`][PgInterval] which can be constructed using the [interval
+///   DSLs][interval dsls]
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`PgInterval`][PgInterval] which can be constructed using the [interval
+///   DSLs][interval dsls]
+///
+/// [PgInterval]: /diesel/pg/data_types/struct.PgInterval.html
+/// [interval dsls]: /diesel/pg/expression/extensions/index.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Interval;
+
+/// The time SQL type.
+///
+/// This type is currently only implemented for PostgreSQL.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`chrono::NaiveTime`][NaiveTime] with `feature = "chrono"`
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`chrono::NaiveTime`][NaiveTime] with `feature = "chrono"`
+///
+/// [NaiveTime]: https://lifthrasiir.github.io/rust-chrono/chrono/naive/time/struct.NaiveTime.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Time;
+
+/// The timestamp/datetime SQL type.
+///
+/// This type is currently only implemented for PostgreSQL.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`std::time::SystemTime`][SystemTime]
+/// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`std::time::SystemTime`][SystemTime]
+/// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
+///
+/// [SystemTime]: https://doc.rust-lang.org/nightly/std/time/struct.SystemTime.html
+/// [NaiveDateTime]: https://lifthrasiir.github.io/rust-chrono/chrono/naive/datetime/struct.NaiveDateTime.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Timestamp;
 
-#[derive(Debug, Clone, Copy, Default)] pub struct Nullable<T: NotNull>(T);
+/// The nullable SQL type. This wraps another SQL type to indicate that it can
+/// be null. By default all values are assumed to be `NOT NULL`.
+///
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - Any `T` which implements `ToSql<ST>`
+/// - `Option<T>` for any `T` which implements `ToSql<ST>`
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - `Option<T>` for any `T` which implements `FromSql<ST>`
+#[derive(Debug, Clone, Copy, Default)] pub struct Nullable<ST: NotNull>(ST);
 
 #[cfg(feature = "postgres")]
-#[doc(inline)]
 pub use pg::types::sql_types::*;
 
 pub trait HasSqlType<ST>: TypeMetadata {


### PR DESCRIPTION
I've seen a lot of people making the mistake of trying to put things
like `diesel::types::Timestamp` in their structs. This attempts to
better document the role of the `types` module, and documents any
`ToSql` and `FromSql` impls that are provided. I've un-inlined the pg
types module, as stating "this is a postgres specific type" in the
documentation over and over again didn't feel right. I've also made sure
that the UUID feature is turned on when generating docs.

Fixes #251.