### PR TITLE
Add support for timestamp with time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   See http://docs.diesel.rs/diesel/prelude/trait.SortExpressionMethods.html
   for details.
 
+* Added support for the `timestamp with time zone` type in PostgreSQL (referred
+  to as `diesel::types::Timestamptz`)
+
 ## [0.7.1] - 2016-08-11
 
 ### Changed

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -3,7 +3,13 @@ use expression::{Expression, SelectableExpression, NonAggregate};
 use pg::{Pg, PgQueryBuilder};
 use query_builder::*;
 use result::QueryResult;
-use types::{Timestamp, VarChar};
+use types::{Timestamp, Timestamptz, Date, VarChar};
+
+/// Marker trait for types which are valid in `AT TIME ZONE` expressions
+pub trait DateTimeLike {}
+impl DateTimeLike for Date {}
+impl DateTimeLike for Timestamp {}
+impl DateTimeLike for Timestamptz {}
 
 #[derive(Debug, Copy, Clone)]
 pub struct AtTimeZone<Ts, Tz> {
@@ -21,10 +27,10 @@ impl<Ts, Tz> AtTimeZone<Ts, Tz> {
 }
 
 impl<Ts, Tz> Expression for AtTimeZone<Ts, Tz> where
-    Ts: Expression<SqlType=Timestamp>,
+    Ts: Expression,
+    Ts::SqlType: DateTimeLike,
     Tz: Expression<SqlType=VarChar>,
 {
-    // FIXME: This should be Timestamptz when we support that type
     type SqlType = Timestamp;
 }
 

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -36,11 +36,11 @@ pub trait PgExpressionMethods: Expression + Sized {
 
 impl<T: Expression> PgExpressionMethods for T {}
 
-use super::date_and_time::AtTimeZone;
-use types::{VarChar, Timestamp};
+use super::date_and_time::{AtTimeZone, DateTimeLike};
+use types::VarChar;
 
 #[doc(hidden)]
-pub trait PgTimestampExpressionMethods: Expression<SqlType=Timestamp> + Sized {
+pub trait PgTimestampExpressionMethods: Expression + Sized {
     /// Returns a PostgreSQL "AT TIME ZONE" expression
     fn at_time_zone<T>(self, timezone: T) -> AtTimeZone<Self, T::Expression> where
         T: AsExpression<VarChar>,
@@ -49,7 +49,9 @@ pub trait PgTimestampExpressionMethods: Expression<SqlType=Timestamp> + Sized {
     }
 }
 
-impl<T: Expression<SqlType=Timestamp>> PgTimestampExpressionMethods for T {}
+impl<T: Expression> PgTimestampExpressionMethods for T where
+    T::SqlType: DateTimeLike,
+{}
 
 pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// Compares two arrays for common elements, using the `&&` operator in

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -5,6 +5,9 @@ use std::ops::Add;
 use pg::{Pg, PgTypeMetadata};
 use types::{self, FromSql, ToSql, IsNull};
 
+primitive_impls!(Timestamptz -> (pg: (1184, 1185)));
+primitive_impls!(Timestamptz);
+
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
 #[cfg(feature = "unstable")]
@@ -66,9 +69,11 @@ impl PgInterval {
 queryable_impls!(Date -> PgDate,);
 queryable_impls!(Time -> PgTime,);
 queryable_impls!(Timestamp -> PgTimestamp,);
+queryable_impls!(Timestamptz -> PgTimestamp,);
 expression_impls!(Date -> PgDate,);
 expression_impls!(Time -> PgTime,);
 expression_impls!(Timestamp -> PgTimestamp,);
+expression_impls!(Timestamptz -> PgTimestamp,);
 
 primitive_impls!(Interval -> (PgInterval, pg: (1186, 1187)));
 
@@ -111,6 +116,18 @@ impl FromSql<types::Timestamp, Pg> for PgTimestamp {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         FromSql::<types::BigInt, Pg>::from_sql(bytes)
             .map(PgTimestamp)
+    }
+}
+
+impl ToSql<types::Timestamptz, Pg> for PgTimestamp {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::Timestamp, Pg>::to_sql(self, out)
+    }
+}
+
+impl FromSql<types::Timestamptz, Pg> for PgTimestamp {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
+        FromSql::<types::Timestamp, Pg>::from_sql(bytes)
     }
 }
 

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -8,13 +8,16 @@ mod uuid;
 
 #[doc(hidden)]
 pub mod sql_types {
-    #[derive(Debug, Clone, Copy, Default)] pub struct Oid;
     #[derive(Debug, Clone, Copy, Default)] pub struct Array<T>(T);
+    #[derive(Debug, Clone, Copy, Default)] pub struct Oid;
+    #[derive(Debug, Clone, Copy, Default)] pub struct Timestamptz;
+    #[cfg(feature = "uuid")]
+    #[derive(Debug, Clone, Copy, Default)] pub struct Uuid;
+
     pub type SmallSerial = ::types::SmallInt;
     pub type Serial = ::types::Integer;
     pub type BigSerial = ::types::BigInt;
-    #[cfg(feature = "uuid")]
-    #[derive(Debug, Clone, Copy, Default)] pub struct Uuid;
+
     pub type Bytea = ::types::Binary;
     #[doc(hidden)]
     pub type Bpchar = ::types::VarChar;

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -103,6 +103,11 @@ macro_rules! primitive_impls {
     };
 
     ($Source:ident -> ($Target:ty, pg: ($oid:expr, $array_oid:expr))) => {
+        primitive_impls!($Source -> (pg: ($oid, $array_oid)));
+        primitive_impls!($Source -> $Target);
+    };
+
+    ($Source:ident -> (pg: ($oid:expr, $array_oid:expr))) => {
         #[cfg(feature = "postgres")]
         impl types::HasSqlType<types::$Source> for $crate::pg::Pg {
             fn metadata() -> $crate::pg::PgTypeMetadata {
@@ -112,8 +117,6 @@ macro_rules! primitive_impls {
                 }
             }
         }
-
-        primitive_impls!($Source -> $Target);
     };
 
     ($Source:ident -> $Target:ty) => {

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -1,7 +1,7 @@
 extern crate chrono;
 
 pub use quickcheck::quickcheck;
-use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
+use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime, DateTime, UTC};
 use self::chrono::naive::date;
 
 pub use schema::{connection, TestConnection};
@@ -98,6 +98,7 @@ mod pg_types {
     test_round_trip!(naive_datetime_roundtrips, Timestamp, (i64, u32), mk_naive_datetime);
     test_round_trip!(naive_time_roundtrips, Time, (u32, u32), mk_naive_time);
     test_round_trip!(naive_date_roundtrips, Date, u32, mk_naive_date);
+    test_round_trip!(datetime_roundtrips, Timestamptz, (i64, u32), mk_datetime);
     test_round_trip!(uuid_roundtrips, Uuid, (u32, u16, u16, (u8, u8, u8, u8, u8, u8, u8, u8)), mk_uuid);
 
     fn mk_uuid(data: (u32, u16, u16, (u8, u8, u8, u8, u8, u8, u8, u8))) -> self::uuid::Uuid {
@@ -113,6 +114,10 @@ pub fn mk_naive_datetime(data: (i64, u32)) -> NaiveDateTime {
 
 pub fn mk_naive_time(data: (u32, u32)) -> NaiveTime {
     NaiveTime::from_num_seconds_from_midnight(data.0, data.1 / 1000)
+}
+
+pub fn mk_datetime(data: (i64, u32)) -> DateTime<UTC> {
+    DateTime::from_utc(mk_naive_datetime(data), UTC)
 }
 
 pub fn mk_naive_date(days: u32) -> NaiveDate {


### PR DESCRIPTION
This adds support for the `timestamp with time zone` type. This is part
of the SQL standard, but not supported explicitly by SQLite as far as I
can tell. As such I've made it a PG specific type for now.

timestamp with time zone does not actually mean that a time zone is
stored. It instead means that when dealing with strings, Postgres will
no longer ignore the time zone portion. It will convert the time zone to
UTC for storage. When transmitted as text, it will be converted to the
database's local time zone. When transmitted as binary, it will be sent
as UTC.

As such, I've provided `ToSql` implementations for basically all flavors
of `DateTime`, but I've only provided a `FromSql` implementation for
`DateTime<UTC>` and `NaiveDateTime`. I have not provided any
implementation for `std::time::SystemTime`, as it implies local time
zone for the machine and we do not have the tools to handle the
conversion in the standard library.

Fixes #106.
Fixes #295.
Fixes #402.