### PR TITLE
Prevent unused variable warning in embed_migrations macro.

### DIFF
--- a/diesel_codegen_syntex/src/migrations.rs
+++ b/diesel_codegen_syntex/src/migrations.rs
@@ -45,7 +45,7 @@ pub fn expand_embed_migrations<'cx>(
                 conn.batch_execute(self.up_sql).map_err(Into::into)
             }
 
-            fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+            fn revert(&self, _conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
                 unreachable!()
             }
         }


### PR DESCRIPTION
Simple to change to prevent:

```
warning: unused variable: `conn`, #[warn(unused_variables)] on by default
  --> src/main.rs:62:1
   |
62 | embed_migrations!();
   | ^^^^^^^^^^^^^^^^^^^^
src/main.rs:62:1: 62:21 note: in this expansion of embed_migrations! (defined in src/main.rs)
```