### PR TITLE
Use a cargo workspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
     if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
       (cd examples && ./test_nightly)
     else
-      (cd examples && TRAVIS_RUST_VERSION=$TRAVIS_RUST_VERSION./test_stable)
+      (cd examples && ./test_stable)
     fi
   fi &&
   (cd diesel_cli && travis-cargo test -- --no-default-features --features "$BACKEND") &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
     if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
       (cd examples && ./test_nightly)
     else
-      (cd examples && TRAVIS_RUST_VERSION=$TRAVIS_RUST_VERSION./test_stable)
+      (cd examples && env TRAVIS_RUST_VERSION=$TRAVIS_RUST_VERSION ./test_stable)
     fi
   fi &&
   (cd diesel_cli && travis-cargo test -- --no-default-features --features "$BACKEND") &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ before_script:
   - psql -c 'create database diesel_schema;' -U postgres
 script:
 - |
-  (cd diesel && travis-cargo doc -- --features "postgres sqlite chrono uuid" && echo "docs.diesel.rs" > target/doc/CNAME) &&
+  (cd diesel && travis-cargo doc -- --features "postgres sqlite chrono uuid")
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    (echo "docs.diesel.rs" > diesel/target/doc/CNAME)
+  fi &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
     (cd diesel && travis-cargo test -- --no-default-features --features "unstable chrono $BACKEND")
   else
@@ -48,7 +51,7 @@ env:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
 after_success:
-  - travis-cargo --only stable doc-upload
+  - (cd diesel && travis-cargo --only stable doc-upload)
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ before_script:
   - psql -c 'create database diesel_schema;' -U postgres
 script:
 - |
-  (cd diesel && travis-cargo doc -- --features "postgres sqlite chrono uuid")
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    (echo "docs.diesel.rs" > diesel/target/doc/CNAME)
-  fi &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
     (cd diesel && travis-cargo test -- --no-default-features --features "unstable chrono $BACKEND")
   else
@@ -51,7 +47,12 @@ env:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
 after_success:
-  - (cd diesel && travis-cargo --only stable doc-upload)
+- |
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    (cd diesel && travis-cargo doc -- --features "postgres sqlite chrono uuid")
+    (echo "docs.diesel.rs" > diesel/target/doc/CNAME)
+    (cd diesel && travis-cargo doc-upload)
+  fi
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
     if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
       (cd examples && ./test_nightly)
     else
-      (cd examples && env TRAVIS_RUST_VERSION=$TRAVIS_RUST_VERSION ./test_stable)
+      (cd examples && TRAVIS_RUST_VERSION=$TRAVIS_RUST_VERSION./test_stable)
     fi
   fi &&
   (cd diesel_cli && travis-cargo test -- --no-default-features --features "$BACKEND") &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
     if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
       (cd examples && ./test_nightly)
     else
-      (cd examples && ./test_stable)
+      (cd examples && TRAVIS_RUST_VERSION=$TRAVIS_RUST_VERSION./test_stable)
     fi
   fi &&
   (cd diesel_cli && travis-cargo test -- --no-default-features --features "$BACKEND") &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
 after_success:
-  - "(cd diesel && travis-cargo --only stable doc-upload)"
+  - travis-cargo --only stable doc-upload
 branches:
   only:
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@ members = [
     "diesel",
     "diesel_cli",
     "diesel_codegen",
+    "diesel_codegen_shared",
     "diesel_codegen_syntex",
-    "diesel_compile_tests",
+    # FIXME: getting "multiple matching crates for `diesel`" because of the shared build directory
+    # "diesel_compile_tests",
     "diesel_tests",
     "examples/getting_started_step_1",
     "examples/getting_started_step_2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = [
+    "diesel",
+    "diesel_cli",
+    "diesel_codegen",
+    "diesel_codegen_syntex",
+    "diesel_compile_tests",
+    "diesel_tests"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,9 @@ members = [
     "diesel_codegen",
     "diesel_codegen_syntex",
     "diesel_compile_tests",
-    "diesel_tests"
+    "diesel_tests",
+    "examples/getting_started_step_1",
+    "examples/getting_started_step_2",
+    "examples/getting_started_step_3",
+    "examples/getting_started_step_4",
 ]

--- a/bin/test
+++ b/bin/test
@@ -9,12 +9,11 @@ elif [ "$1" == "compile" ]; then
   (cd diesel_compile_tests && cargo test)
 else
   (cd diesel && cargo test --features "unstable chrono sqlite")
+  (cd diesel_cli && cargo test --features "sqlite" --no-default-features)
+  (cd diesel_tests && DATABASE_URL=/tmp/test.db cargo test --features "unstable_sqlite" --no-default-features)
   (cd examples && ./test_nightly)
   (cd diesel_cli && cargo test --features "postgres" --no-default-features)
-  (cd diesel_cli && cargo test --features "sqlite" --no-default-features)
-  (cd diesel_codegen_shared && cargo test --features "postgres dotenv")
   (cd diesel_codegen_syntex && cargo test --no-default-features --features "postgres")
   (cd diesel_tests && cargo test --features "unstable_postgres" --no-default-features)
-  (cd diesel_tests && DATABASE_URL=/tmp/test.db cargo test --features "unstable_sqlite" --no-default-features)
   (cd diesel_compile_tests && cargo test)
 fi;

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -3,6 +3,8 @@ name = "diesel_compile_tests"
 version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
+[workspace]
+
 [dependencies]
 diesel = { version = "0.8.0", features = ["sqlite", "postgres"] }
 diesel_codegen = { version = "0.8.0" }

--- a/diesel_compile_tests/tests/compile_tests.rs
+++ b/diesel_compile_tests/tests/compile_tests.rs
@@ -9,7 +9,7 @@ fn run_mode(mode: &'static str) {
 
     let cfg_mode = mode.parse().expect("Invalid mode");
 
-    config.target_rustcflags = Some("-L ../target/debug/deps/".to_owned());
+    config.target_rustcflags = Some("-L target/debug/deps/".to_owned());
     if let Ok(name) = var::<&str>("TESTNAME") {
         let s : String = name.to_owned();
         config.filter = Some(s)

--- a/diesel_compile_tests/tests/compile_tests.rs
+++ b/diesel_compile_tests/tests/compile_tests.rs
@@ -9,7 +9,7 @@ fn run_mode(mode: &'static str) {
 
     let cfg_mode = mode.parse().expect("Invalid mode");
 
-    config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps/".to_owned());
+    config.target_rustcflags = Some("-L ../target/debug/deps/".to_owned());
     if let Ok(name) = var::<&str>("TESTNAME") {
         let s : String = name.to_owned();
         config.filter = Some(s)

--- a/examples/getting_started_step_1/Cargo.toml
+++ b/examples/getting_started_step_1/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diesel_demo"
+name = "diesel_demo_step_1"
 version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 

--- a/examples/getting_started_step_1/src/bin/show_posts.rs
+++ b/examples/getting_started_step_1/src/bin/show_posts.rs
@@ -1,12 +1,12 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_1;
 extern crate diesel;
 
-use diesel_demo::*;
-use diesel_demo::models::*;
+use diesel_demo_step_1::*;
+use diesel_demo_step_1::models::*;
 use diesel::prelude::*;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::*;
+    use diesel_demo_step_1::schema::posts::dsl::*;
 
     let connection = establish_connection();
     let results = posts.filter(published.eq(true))

--- a/examples/getting_started_step_2/Cargo.toml
+++ b/examples/getting_started_step_2/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diesel_demo"
+name = "diesel_demo_step_2"
 version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 

--- a/examples/getting_started_step_2/src/bin/show_posts.rs
+++ b/examples/getting_started_step_2/src/bin/show_posts.rs
@@ -1,12 +1,12 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_2;
 extern crate diesel;
 
-use diesel_demo::*;
-use diesel_demo::models::*;
+use diesel_demo_step_2::*;
+use diesel_demo_step_2::models::*;
 use diesel::prelude::*;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::*;
+    use diesel_demo_step_2::schema::posts::dsl::*;
 
     let connection = establish_connection();
     let results = posts.filter(published.eq(true))

--- a/examples/getting_started_step_2/src/bin/write_post.rs
+++ b/examples/getting_started_step_2/src/bin/write_post.rs
@@ -1,7 +1,7 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_2;
 extern crate diesel;
 
-use self::diesel_demo::*;
+use self::diesel_demo_step_2::*;
 use std::io::{stdin, Read};
 
 fn main() {

--- a/examples/getting_started_step_3/Cargo.toml
+++ b/examples/getting_started_step_3/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diesel_demo"
+name = "diesel_demo_step_3"
 version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 

--- a/examples/getting_started_step_3/src/bin/delete_post.rs
+++ b/examples/getting_started_step_3/src/bin/delete_post.rs
@@ -1,12 +1,12 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_3;
 extern crate diesel;
 
 use diesel::prelude::*;
-use diesel_demo::*;
+use diesel_demo_step_3::*;
 use std::env::args;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::*;
+    use diesel_demo_step_3::schema::posts::dsl::*;
 
     let target = args().nth(1).expect("Expected a target to match against");
     let pattern = format!("%{}%", target);

--- a/examples/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/getting_started_step_3/src/bin/publish_post.rs
@@ -1,13 +1,13 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_3;
 extern crate diesel;
 
 use diesel::prelude::*;
-use diesel_demo::*;
-use diesel_demo::models::Post;
+use diesel_demo_step_3::*;
+use diesel_demo_step_3::models::Post;
 use std::env::args;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::{posts, published};
+    use diesel_demo_step_3::schema::posts::dsl::{posts, published};
 
     let id = args().nth(1).expect("publish_post requires a post id")
         .parse::<i32>().expect("Invalid ID");

--- a/examples/getting_started_step_3/src/bin/show_posts.rs
+++ b/examples/getting_started_step_3/src/bin/show_posts.rs
@@ -1,12 +1,12 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_3;
 extern crate diesel;
 
-use diesel_demo::*;
-use diesel_demo::models::*;
+use diesel_demo_step_3::*;
+use diesel_demo_step_3::models::*;
 use diesel::prelude::*;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::*;
+    use diesel_demo_step_3::schema::posts::dsl::*;
 
     let connection = establish_connection();
     let results = posts.filter(published.eq(true))

--- a/examples/getting_started_step_3/src/bin/write_post.rs
+++ b/examples/getting_started_step_3/src/bin/write_post.rs
@@ -1,7 +1,7 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_3;
 extern crate diesel;
 
-use self::diesel_demo::*;
+use self::diesel_demo_step_3::*;
 use std::io::{stdin, Read};
 
 fn main() {

--- a/examples/getting_started_step_4/Cargo.toml
+++ b/examples/getting_started_step_4/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diesel_demo"
+name = "diesel_demo_step_4"
 version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 build = "build.rs"

--- a/examples/getting_started_step_4/src/bin/delete_post.rs
+++ b/examples/getting_started_step_4/src/bin/delete_post.rs
@@ -1,12 +1,12 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_4;
 extern crate diesel;
 
 use diesel::prelude::*;
-use diesel_demo::*;
+use diesel_demo_step_4::*;
 use std::env::args;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::*;
+    use diesel_demo_step_4::schema::posts::dsl::*;
 
     let target = args().nth(1).expect("Expected a target to match against");
     let pattern = format!("%{}%", target);

--- a/examples/getting_started_step_4/src/bin/publish_post.rs
+++ b/examples/getting_started_step_4/src/bin/publish_post.rs
@@ -1,13 +1,13 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_4;
 extern crate diesel;
 
 use diesel::prelude::*;
-use diesel_demo::*;
-use diesel_demo::models::Post;
+use diesel_demo_step_4::*;
+use diesel_demo_step_4::models::Post;
 use std::env::args;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::{posts, published};
+    use diesel_demo_step_4::schema::posts::dsl::{posts, published};
 
     let id = args().nth(1).expect("publish_post requires a post id")
         .parse::<i32>().expect("Invalid ID");

--- a/examples/getting_started_step_4/src/bin/show_posts.rs
+++ b/examples/getting_started_step_4/src/bin/show_posts.rs
@@ -1,12 +1,12 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_4;
 extern crate diesel;
 
-use diesel_demo::*;
-use diesel_demo::models::*;
+use diesel_demo_step_4::*;
+use diesel_demo_step_4::models::*;
 use diesel::prelude::*;
 
 fn main() {
-    use diesel_demo::schema::posts::dsl::*;
+    use diesel_demo_step_4::schema::posts::dsl::*;
 
     let connection = establish_connection();
     let results = posts.filter(published.eq(true))

--- a/examples/getting_started_step_4/src/bin/write_post.rs
+++ b/examples/getting_started_step_4/src/bin/write_post.rs
@@ -1,7 +1,7 @@
-extern crate diesel_demo;
+extern crate diesel_demo_step_4;
 extern crate diesel;
 
-use self::diesel_demo::*;
+use self::diesel_demo_step_4::*;
 use std::io::{stdin, Read};
 
 fn main() {

--- a/examples/test_nightly
+++ b/examples/test_nightly
@@ -8,7 +8,7 @@ export DATABASE_URL="postgres://localhost/diesel_examples"
 
 for dir in $(find . -type d -maxdepth 1 -mindepth 1); do
   cd $dir
-  ../../diesel_cli/target/debug/diesel database reset
+  ../../target/debug/diesel database reset
   cargo build
   cd ..
 done

--- a/examples/test_stable
+++ b/examples/test_stable
@@ -8,10 +8,5 @@ cd ../examples
 # Only step 4 can be run on stable
 cd getting_started_step_4
 export DATABASE_URL=postgres://localhost/diesel_getting_started_step_4
-# FIXME: remove this conditional once cargo workspaces are on stable
-if [[ "$TRAVIS_RUST_VERSION" == beta* ]]; then
-  ../../target/debug/diesel setup
-else
-  ../../diesel_cli/target/debug/diesel setup
-fi
+../../target/debug/diesel setup
 cargo build --no-default-features --features "with-syntex"

--- a/examples/test_stable
+++ b/examples/test_stable
@@ -8,5 +8,10 @@ cd ../examples
 # Only step 4 can be run on stable
 cd getting_started_step_4
 export DATABASE_URL=postgres://localhost/diesel_getting_started_step_4
-../../diesel_cli/target/debug/diesel setup
+# FIXME: remove this conditional once cargo workspaces are on stable
+if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+  ../../diesel_cli/target/debug/diesel setup
+else
+  ../../target/debug/diesel setup
+fi
 cargo build --no-default-features --features "with-syntex"

--- a/examples/test_stable
+++ b/examples/test_stable
@@ -9,9 +9,9 @@ cd ../examples
 cd getting_started_step_4
 export DATABASE_URL=postgres://localhost/diesel_getting_started_step_4
 # FIXME: remove this conditional once cargo workspaces are on stable
-if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-  ../../diesel_cli/target/debug/diesel setup
-else
+if [[ "$TRAVIS_RUST_VERSION" == beta* ]]; then
   ../../target/debug/diesel setup
+else
+  ../../diesel_cli/target/debug/diesel setup
 fi
 cargo build --no-default-features --features "with-syntex"


### PR DESCRIPTION
Fixes #411.

Uses a ["virtual" Cargo.toml](https://github.com/rust-lang/rfcs/blob/master/text/1525-cargo-workspace.md#virtual-cargotoml) as we don't have a root crate.
