### PR TITLE
Add initial support for composite primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* Added support for composite primary keys.
+
 * Added support for PostgreSQL `NULLS FIRST` and `NULLS LAST` when sorting.
   See http://docs.diesel.rs/diesel/prelude/trait.SortExpressionMethods.html
   for details.

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -85,7 +85,8 @@ macro_rules! column {
 /// ```
 ///
 /// You may also specify a primary key if it's called something other than `id`.
-/// Tables with no primary key, or composite primary keys aren't yet supported.
+/// Tables with no primary key, or composite primary containing more than 3
+/// columns are not supported.
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
@@ -97,6 +98,27 @@ macro_rules! column {
 ///     }
 /// }
 /// # fn main() {}
+/// ```
+///
+/// For tables with composite primary keys, list all of the columns in the
+/// primary key.
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// table! {
+///     followings (user_id, post_id) {
+///         user_id -> Integer,
+///         post_id -> Integer,
+///         favorited -> Bool,
+///     }
+/// }
+/// # fn main() {
+/// #     use diesel::prelude::*;
+/// #     use self::followings::dsl::*;
+/// #     // Poor man's assert_eq! -- since this is type level this would fail
+/// #     // to compile if the wrong primary key were generated
+/// #     let (user_id {}, post_id {}) = followings.primary_key();
+/// # }
 /// ```
 ///
 /// This module will also contain several helper types:

--- a/diesel_codegen_syntex/src/util.rs
+++ b/diesel_codegen_syntex/src/util.rs
@@ -120,12 +120,17 @@ pub fn is_option_ty(ty: &ast::Ty) -> bool {
 }
 
 pub fn lifetime_list_tokens(lifetimes: &[ast::LifetimeDef], span: Span) -> Vec<TokenTree> {
-    lifetimes.iter()
-        .map(|ld| {
-            let name = ld.lifetime.name;
-            let lt = token::Lifetime(ast::Ident::with_empty_ctxt(name));
-            [TokenTree::Token(span, lt)]
-        })
+    let lifetime_tokens = lifetimes.iter().map(|ld| {
+        let name = ld.lifetime.name;
+        token::Lifetime(ast::Ident::with_empty_ctxt(name))
+    });
+    comma_delimited_tokens(lifetime_tokens, span)
+}
+
+pub fn comma_delimited_tokens<T>(tokens: T, span: Span) -> Vec<TokenTree> where
+    T: IntoIterator<Item=token::Token>,
+{
+    tokens.into_iter().map(|token| [TokenTree::Token(span, token)])
         .collect::<Vec<_>>()
         .join(&TokenTree::Token(span, token::Comma))
 }

--- a/migrations/postgresql/20160825135747_create_followings/down.sql
+++ b/migrations/postgresql/20160825135747_create_followings/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE followings;

--- a/migrations/postgresql/20160825135747_create_followings/up.sql
+++ b/migrations/postgresql/20160825135747_create_followings/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE followings (
+  user_id INTEGER NOT NULL,
+  post_id INTEGER NOT NULL,
+  email_notifications BOOLEAN NOT NULL DEFAULT 'f',
+  PRIMARY KEY (user_id, post_id)
+);

--- a/migrations/sqlite/20160825135747_create_followings/down.sql
+++ b/migrations/sqlite/20160825135747_create_followings/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE followings;

--- a/migrations/sqlite/20160825135747_create_followings/up.sql
+++ b/migrations/sqlite/20160825135747_create_followings/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE followings (
+  user_id INTEGER NOT NULL,
+  post_id INTEGER NOT NULL,
+  email_notifications BOOLEAN NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, post_id)
+);


### PR DESCRIPTION
This pull request allows the `table!` macro and codegen to handle tables
which use more than one column for their primary key. At the moment they
are fairly useless, but they will compile.

The methods in question are primarily used for `FindDsl` and
associations. Things like update are defined in terms of `FindDsl` and
`Identifiable`. Since the generators for those traits don't handle
composite primary keys, none of that can be used (yet).

Working on this also made me realize a bit of a hole in our type system.
We implement `Expression` for a tuple of expressions as a comma
delimited list. However, a comma delimited list isn't always valid. In
particular a composite table *does* actually implement `FindDsl` for an
expression that matches it's primary key -- and would generate invalid
SQL like `pk1, pk2 = $1, $2`. Luckily, we're saved by the fact that
tuples don't implement `AsExpression`, so trying to do `.find((1, 2))`
won't compile.

I'm not sure if we should fix this or not, but the fix would basically
mean separating out "arbitrary expression" from "expression valid as a
select or returning clause", and potentially other places where tuples
appear such as set clauses and in expressions. For now though, as long
as the inproper code doesn't compile for the reasonable cases, I'm not
super worried. We should fix this eventually though, as I don't like
something that we can statically determine is invalid SQL compiling.

Ref #42