### PR TITLE
Respect overridden migration directories in `migration run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added support for the `timestamp with time zone` type in PostgreSQL (referred
   to as `diesel::types::Timestamptz`)
 
+### Fixed
+
+* `diesel migrations run` will now respect migration directories overridden by
+  command line argument or environment variable
+
 ## [0.7.2] - 2016-08-20
 
 * Updated nightly version and syntex support.

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -114,9 +114,10 @@ fn main() {
 
 fn run_migration_command(matches: &ArgMatches) {
     match matches.subcommand() {
-        ("run", Some(_)) => {
+        ("run", Some(args)) => {
             let database_url = database::database_url(matches);
-            call_with_conn!(database_url, migrations::run_pending_migrations)
+            let dir = migrations_dir(args);
+            call_with_conn!(database_url, migrations::run_pending_migrations_in_directory(&dir, &mut stdout()))
                 .unwrap_or_else(handle_error);
         }
         ("revert", Some(_)) => {


### PR DESCRIPTION
`revert` and `redo` are still not respecting them, but I will fix those
as a separate PR since they require code changes on the Diesel side.