### PR TITLE
Upgrade uuid to version 0.3

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -16,7 +16,7 @@ libsqlite3-sys = { version = "^0.4.0", optional = true }
 byteorder = "0.3.*"
 quickcheck = { version = "0.3.1", optional = true }
 chrono = { version = "^0.2.17", optional = true }
-uuid = { version = "^0.2.0", optional = true, features = ["use_std"] }
+uuid = { version = ">=0.2.0, <0.4.0", optional = true, features = ["use_std"] }
 
 [dev-dependencies]
 quickcheck = "0.3.1"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -19,7 +19,7 @@ diesel = { path = "../diesel", default-features = false, features = ["quickcheck
 diesel_codegen = { path = "../diesel_codegen", default-features = false, optional = true }
 dotenv_macros = { version = "0.9.0", optional = true }
 quickcheck = { version = "0.3.1", features = ["unstable"] }
-uuid = { version = "^0.2.0" }
+uuid = { version = ">=0.2.0, <0.4.0" }
 
 [features]
 default = ["with-syntex"]


### PR DESCRIPTION
Unblocks users of diesel's `uuid` feature from using version 0.3 of the `uuid` crate, which also unblocks `serde` 0.8 for `uuid` users.