### PR TITLE
Change associations to a Macros 1.1 compatible API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [bash completion]: https://github.com/diesel-rs/diesel/blob/b1a0d9901f0f2a8c8d530ccba8173b57f332b891/diesel_cli/README.md#bash-completion
 
+### Changed
+
+* Structs annotated with `#[has_many]` or `#[belongs_to]` now require
+  `#[derive(Associations)]`. This is to allow them to work with Macros 1.1.
+
 ### Fixed
 
 * `diesel migrations run` will now respect migration directories overridden by

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -14,14 +14,14 @@
 //! `#[belongs_to]`.
 //!
 //! ```ignore
-//! #[derive(Identifiable, Queryable)]
+//! #[derive(Identifiable, Queryable, Associations)]
 //! #[has_many(posts)]
 //! pub struct User {
 //!     id: i32,
 //!     name: String,
 //! }
 //!
-//! #[derive(Identifiable, Queryable)]
+//! #[derive(Identifiable, Queryable, Associations)]
 //! #[belongs_to(User)]
 //! pub struct Post {
 //!     id: i32,
@@ -29,6 +29,9 @@
 //!     title: String,
 //! }
 //! ```
+//!
+//! Note that in addition to the `#[has_many]` and `#[belongs_to]` annotations, we also need to
+//! `#[derive(Associations)]`
 //!
 //! `#[has_many]` should be passed the name of the table that the children will be loaded from,
 //! while `#[belongs_to]` is given the name of the struct that represents the parent. Both types

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -11,6 +11,10 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
     use syntax::parse::token::intern;
     use syntax::ext::base::MultiDecorator;
     reg.register_syntax_extension(
+        intern("derive_Associations"),
+        MultiDecorator(Box::new(associations::expand_derive_associations)),
+    );
+    reg.register_syntax_extension(
         intern("derive_Queryable"),
         MultiDecorator(Box::new(queryable::expand_derive_queryable))
     );
@@ -25,14 +29,6 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
     reg.register_syntax_extension(
         intern("changeset_for"),
         MultiDecorator(Box::new(update::expand_changeset_for)),
-    );
-    reg.register_syntax_extension(
-        intern("has_many"),
-        MultiDecorator(Box::new(associations::expand_has_many))
-    );
-    reg.register_syntax_extension(
-        intern("belongs_to"),
-        MultiDecorator(Box::new(associations::expand_belongs_to))
     );
     reg.register_macro("embed_migrations", migrations::expand_embed_migrations);
     reg.register_macro("infer_table_from_schema", schema_inference::expand_load_table);

--- a/diesel_codegen_syntex/src/associations/mod.rs
+++ b/diesel_codegen_syntex/src/associations/mod.rs
@@ -9,8 +9,26 @@ use model::{infer_association_name, Model};
 mod has_many;
 mod belongs_to;
 
-pub use self::has_many::expand_has_many;
-pub use self::belongs_to::expand_belongs_to;
+use self::has_many::expand_has_many;
+use self::belongs_to::expand_belongs_to;
+
+pub fn expand_derive_associations(
+    cx: &mut ExtCtxt,
+    span: Span,
+    _: &MetaItem,
+    annotatable: &Annotatable,
+    push: &mut FnMut(Annotatable)
+) {
+    for attr in annotatable.attrs() {
+        if attr.check_name("has_many") {
+            expand_has_many(cx, span, &attr.node.value, annotatable, push);
+        }
+
+        if attr.check_name("belongs_to") {
+            expand_belongs_to(cx, span, &attr.node.value, annotatable, push);
+        }
+    }
+}
 
 fn parse_association_options(
     association_kind: &str,

--- a/diesel_codegen_syntex/src/lib.rs
+++ b/diesel_codegen_syntex/src/lib.rs
@@ -30,10 +30,9 @@ pub fn register(reg: &mut syntex::Registry) {
 
     reg.add_decorator("derive_Queryable", queryable::expand_derive_queryable);
     reg.add_decorator("derive_Identifiable", identifiable::expand_derive_identifiable);
+    reg.add_decorator("derive_Associations", associations::expand_derive_associations);
     reg.add_decorator("insertable_into", insertable::expand_insert);
     reg.add_decorator("changeset_for", update::expand_changeset_for);
-    reg.add_decorator("has_many", associations::expand_has_many);
-    reg.add_decorator("belongs_to", associations::expand_belongs_to);
     reg.add_macro("embed_migrations", migrations::expand_embed_migrations);
     reg.add_macro("infer_table_from_schema", schema_inference::expand_load_table);
     reg.add_macro("infer_schema", schema_inference::expand_infer_schema);

--- a/diesel_codegen_syntex/src/util.rs
+++ b/diesel_codegen_syntex/src/util.rs
@@ -68,6 +68,14 @@ pub fn ident_value_of_attr_with_name(
 }
 
 #[cfg(feature = "with-syntex")]
+const KNOWN_ATTRIBUTES: &'static [&'static str] = &[
+    "table_name",
+    "column_name",
+    "has_many",
+    "belongs_to",
+];
+
+#[cfg(feature = "with-syntex")]
 pub fn strip_attributes(krate: ast::Crate) -> ast::Crate {
     use syntax::fold;
 
@@ -75,7 +83,7 @@ pub fn strip_attributes(krate: ast::Crate) -> ast::Crate {
 
     impl fold::Folder for StripAttributeFolder {
         fn fold_attribute(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
-            if attr.check_name("table_name") || attr.check_name("column_name") {
+            if KNOWN_ATTRIBUTES.iter().any(|name| attr.check_name(name)) {
                 None
             } else {
                 Some(attr)

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -6,7 +6,7 @@ use schema::*;
 // impls
 // #[test]
 // fn association_where_struct_name_doesnt_match_table_name() {
-//     #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
+//     #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 //     #[belongs_to(Post)]
 //     #[table_name(comments)]
 //     struct OtherComment {
@@ -29,7 +29,7 @@ use schema::*;
 
 #[test]
 fn association_where_parent_and_child_have_underscores() {
-    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
+    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
     #[has_many(special_comments)]
     #[belongs_to(User)]
     pub struct SpecialPost {
@@ -53,7 +53,7 @@ fn association_where_parent_and_child_have_underscores() {
         }
     }
 
-    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
+    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
     #[belongs_to(SpecialPost)]
     struct SpecialComment {
         id: i32,
@@ -107,13 +107,13 @@ mod associations_can_have_nullable_foreign_keys {
     }
     // This test has no assertions, as it is for compilation purposes only.
     #[has_many(bars)]
-    #[derive(Identifiable)]
+    #[derive(Identifiable, Associations)]
     pub struct Foo {
         id: i32,
     }
 
     #[belongs_to(Foo)]
-    #[derive(Identifiable)]
+    #[derive(Identifiable, Associations)]
     pub struct Bar {
         id: i32,
         foo_id: Option<i32>,
@@ -151,7 +151,7 @@ mod custom_foreign_keys_are_respected_on_belongs_to {
 
     table! { special_posts { id -> Integer, author_id -> Integer, } }
 
-    #[derive(Identifiable)]
+    #[derive(Identifiable, Associations)]
     #[belongs_to(User, foreign_key = "author_id")]
     pub struct SpecialPost {
         id: i32,

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -47,7 +47,7 @@ mod eager_loading_with_string_keys {
         id: String,
     }
 
-    #[derive(Queryable, Identifiable, Debug, PartialEq, Clone)]
+    #[derive(Queryable, Identifiable, Debug, PartialEq, Clone, Associations)]
     #[belongs_to(User)]
     pub struct Post {
         id: String,

--- a/diesel_tests/tests/postgres_specific_schema.rs
+++ b/diesel_tests/tests/postgres_specific_schema.rs
@@ -1,6 +1,6 @@
 use super::{User, posts, comments};
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 #[has_many(comments)]
 #[belongs_to(User)]
 pub struct Post {

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -2,7 +2,7 @@ use diesel::*;
 
 infer_schema!(dotenv!("DATABASE_URL"));
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 #[changeset_for(users)]
 #[insertable_into(users)]
 #[has_many(posts)]
@@ -30,7 +30,7 @@ impl User {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 #[belongs_to(Post)]
 pub struct Comment {
     id: i32,

--- a/diesel_tests/tests/sqlite_specific_schema.rs
+++ b/diesel_tests/tests/sqlite_specific_schema.rs
@@ -1,7 +1,7 @@
 use diesel::*;
 use super::{User, posts, comments, users};
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable)]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 #[has_many(comments)]
 #[belongs_to(User)]
 pub struct Post {


### PR DESCRIPTION
This does not re-implement associations to use Macros 1.1, but does include the
API change that will be required for them eventually. Macros 1.1 *only*
supports custom derive. We can do something crazy and dumb to make bang macros
work, but we cannot represent non-derive annotations. `#[as_changeset]` and
`#[insertable_into]` can both be represented nicely as derives, but
associations cannot individually be represented that way. So as a workaround
we'll just leave the annotations separate and require `#[derive(Associations)]`
to kick things off.

I have made this change for both syntex and nightly even though only nightly
requires it, as I want to keep those APIs in sync and deprecate syntex once
Macros 1.1 is on a path to stabilization.

The actual implementation is pretty straightforward, as we're just looping
through the attributes and calling out to what the macro system would have
called out to previously.

r? @diesel-rs/core 