### PR TITLE
fix(macros): rename column! -> __diesel_column!

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -7,7 +7,7 @@ macro_rules! diesel_internal_expr_conversion {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! column {
+macro_rules! __diesel_column {
     ($($table:ident)::*, $column_name:ident -> $Type:ty) => {
         #[allow(non_camel_case_types, dead_code)]
         #[derive(Debug, Clone, Copy)]
@@ -360,7 +360,7 @@ macro_rules! table_body {
 
                 impl SelectableExpression<table> for star {}
 
-                $(column!(table, $column_name -> $column_ty);)+
+                $(__diesel_column!(table, $column_name -> $column_ty);)+
             }
         }
     }


### PR DESCRIPTION
Avoids conflict with the `column!` macro from std: https://doc.rust-lang.org/std/macro.column!.html.