### PR TITLE
Re-implement `#[derive(Queryable)]` using Macros 1.1

### DIFF
--- a/diesel/src/macros/queryable.rs
+++ b/diesel/src/macros/queryable.rs
@@ -104,11 +104,12 @@ macro_rules! Queryable {
     (
         struct_ty = $struct_ty:ty,
         generics = ($($generics:ident),*),
+        lifetimes = ($($lifetimes:tt),*),
         row_ty = $row_ty:ty,
         row_pat = $row_pat:pat,
         build_expr = $build_expr:expr,
     ) => {
-        impl<$($generics,)* __DB, __ST> $crate::Queryable<__ST, __DB> for $struct_ty where
+        impl<$($lifetimes,)* $($generics,)* __DB, __ST> $crate::Queryable<__ST, __DB> for $struct_ty where
             __DB: $crate::backend::Backend + $crate::types::HasSqlType<__ST>,
             $row_ty: $crate::types::FromSqlRow<__ST, __DB>,
         {
@@ -131,6 +132,7 @@ macro_rules! Queryable {
                 struct_name = $struct_name,
                 struct_ty = $struct_name<$($generics),*>,
                 generics = ($($generics),*),
+                lifetimes = (),
             ),
             callback = Queryable,
             body = $body,
@@ -147,6 +149,7 @@ macro_rules! Queryable {
                 struct_name = $struct_name,
                 struct_ty = $struct_name,
                 generics = (),
+                lifetimes = (),
             ),
             callback = Queryable,
             body = $body,

--- a/diesel_codegen/src/ast_builder.rs
+++ b/diesel_codegen/src/ast_builder.rs
@@ -1,0 +1,16 @@
+use syn::{Ident, Ty, Path, PathSegment};
+
+pub fn ty_ident(ident: Ident) -> Ty {
+    ty_path(path_ident(ident))
+}
+
+pub fn ty_path(path: Path) -> Ty {
+    Ty::Path(None, path)
+}
+
+pub fn path_ident(ident: Ident) -> Path {
+    Path {
+        global: false,
+        segments: vec![PathSegment::ident(ident)],
+    }
+}

--- a/diesel_codegen/src/attr.rs
+++ b/diesel_codegen/src/attr.rs
@@ -1,0 +1,59 @@
+use quote;
+use syn;
+
+use util::{ident_value_of_attr_with_name, is_option_ty};
+
+pub struct Attr {
+    pub column_name: Option<syn::Ident>,
+    pub field_name: Option<syn::Ident>,
+    pub ty: syn::Ty,
+}
+
+impl Attr {
+    pub fn from_struct_field(field: &syn::Field) -> Self {
+        let field_name = field.ident.clone();
+        let column_name = ident_value_of_attr_with_name(&field.attrs, "column_name")
+            .map(Clone::clone)
+            .or_else(|| field_name.clone());
+        let ty = field.ty.clone();
+
+        Attr {
+            column_name: column_name,
+            field_name: field_name,
+            ty: ty,
+        }
+    }
+
+    fn field_kind(&self) -> &str {
+        if is_option_ty(&self.ty) {
+            "option"
+        } else if self.column_name.is_none() && self.field_name.is_none() {
+            "bare"
+        } else {
+            "regular"
+        }
+    }
+}
+
+impl quote::ToTokens for Attr {
+    fn to_tokens(&self, tokens: &mut quote::Tokens) {
+        tokens.append("{");
+        if let Some(ref name) = self.field_name {
+            tokens.append("field_name: ");
+            name.to_tokens(tokens);
+            tokens.append(", ");
+        }
+        if let Some(ref name) = self.column_name {
+            tokens.append("column_name: ");
+            name.to_tokens(tokens);
+            tokens.append(", ");
+        }
+        tokens.append("field_ty: ");
+        self.ty.to_tokens(tokens);
+        tokens.append(", ");
+        tokens.append("field_kind: ");
+        tokens.append(self.field_kind());
+        tokens.append(", ");
+        tokens.append("}");
+    }
+}

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -1,13 +1,37 @@
 #![feature(rustc_macro, rustc_macro_lib)]
+#![deny(warnings)]
+
+macro_rules! t {
+    ($expr:expr) => {
+        match $expr {
+            Ok(val) => val,
+            Err(e) => panic!("{}", e),
+        }
+    };
+}
 
 #[macro_use]
 extern crate quote;
 extern crate rustc_macro;
 extern crate syn;
 
-use rustc_macro::TokenStream;
+mod ast_builder;
+mod attr;
+mod model;
+mod queryable;
+mod util;
 
-#[rustc_macro_derive(Dummy)]
-pub fn placeholder(input: TokenStream) -> TokenStream {
-    input
+use rustc_macro::TokenStream;
+use syn::parse_macro_input;
+
+#[rustc_macro_derive(Queryable)]
+pub fn derive_queryable(input: TokenStream) -> TokenStream {
+    expand_derive(input, queryable::derive_queryable)
+}
+
+fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) -> TokenStream {
+    let item = parse_macro_input(&input.to_string()).unwrap();
+    let output = f(item.clone());
+
+    quote!(#item #output).to_string().parse().unwrap()
 }

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -1,0 +1,32 @@
+use syn;
+
+use attr::Attr;
+use util::struct_ty;
+
+pub struct Model {
+    pub ty: syn::Ty,
+    pub attrs: Vec<Attr>,
+    pub name: syn::Ident,
+    pub generics: syn::Generics,
+}
+
+impl Model {
+    pub fn from_item(item: &syn::MacroInput, derived_from: &str) -> Result<Self, String> {
+        let fields = match item.body {
+            syn::Body::Enum(..) => return Err(format!(
+                "#[derive({})] cannot be used with enums", derived_from)),
+            syn::Body::Struct(ref fields) => fields.fields(),
+        };
+        let attrs = fields.into_iter().map(Attr::from_struct_field).collect();
+        let ty = struct_ty(item.ident.clone(), &item.generics);
+        let name = item.ident.clone();
+        let generics = item.generics.clone();
+
+        Ok(Model {
+            ty: ty,
+            attrs: attrs,
+            name: name,
+            generics: generics,
+        })
+    }
+}

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -1,0 +1,24 @@
+use quote::Tokens;
+use syn;
+
+use model::Model;
+
+pub fn derive_queryable(item: syn::MacroInput) -> Tokens {
+    let model = t!(Model::from_item(&item, "Queryable"));
+
+    let struct_ty = &model.ty;
+    let struct_name = &model.name;
+    let ty_params = &model.generics.ty_params;
+    let attrs = model.attrs;
+    let lifetimes = &model.generics.lifetimes;
+
+    quote!(Queryable! {
+        (
+            struct_name = #struct_name,
+            struct_ty = #struct_ty,
+            generics = (#(ty_params),*),
+            lifetimes = (#(lifetimes),*),
+        ),
+        fields = [#(attrs)*],
+    })
+}

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -1,0 +1,67 @@
+use syn::*;
+
+use ast_builder::ty_ident;
+
+pub fn struct_ty(name: Ident, generics: &Generics) -> Ty {
+    let lifetimes = generics.lifetimes.iter().map(|lt| lt.lifetime.clone()).collect();
+    let ty_params = generics.ty_params.iter()
+        .map(|param| ty_ident(param.ident.clone()))
+        .collect();
+    let parameter_data = AngleBracketedParameterData {
+        lifetimes: lifetimes,
+        types: ty_params,
+        bindings: Vec::new(),
+    };
+    let parameters = PathParameters::AngleBracketed(parameter_data);
+    Ty::Path(None, Path {
+        global: false,
+        segments: vec![
+            PathSegment {
+                ident: name,
+                parameters: parameters,
+            },
+        ],
+    })
+}
+
+pub fn ident_value_of_attr_with_name<'a>(
+    attrs: &'a [Attribute],
+    name: &str,
+) -> Option<&'a Ident> {
+    attr_with_name(attrs, name).map(|attr| single_arg_value_of_attr(attr, name))
+}
+
+pub fn attr_with_name<'a>(
+    attrs: &'a [Attribute],
+    name: &str,
+) -> Option<&'a Attribute> {
+    attrs.into_iter().find(|attr| attr.name() == name)
+}
+
+fn single_arg_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> &'a Ident {
+    let usage_err = || panic!(r#"`{}` must be in the form `#[{}(something)]`"#, name, name);
+    match attr.value {
+        MetaItem::List(_, ref items) => {
+            if items.len() != 1 {
+                return usage_err();
+            }
+            match items[0] {
+                MetaItem::Word(ref name) => name,
+                _ => usage_err(),
+            }
+        }
+        _ => usage_err(),
+    }
+}
+
+pub fn is_option_ty(ty: &Ty) -> bool {
+    let option_ident = Ident::new("Option");
+    match *ty {
+        Ty::Path(_, ref path) => {
+            path.segments.first()
+                .map(|s| s.ident == option_ident)
+                .unwrap_or(false)
+        }
+        _ => false,
+    }
+}

--- a/diesel_codegen_old/src/lib.rs
+++ b/diesel_codegen_old/src/lib.rs
@@ -26,10 +26,6 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
         intern("derive_Insertable"),
         MultiDecorator(Box::new(insertable::expand_derive_insertable))
     );
-    reg.register_syntax_extension(
-        intern("derive_Queryable"),
-        MultiDecorator(Box::new(queryable::expand_derive_queryable))
-    );
     reg.register_macro("embed_migrations", migrations::expand_embed_migrations);
     reg.register_macro("infer_table_from_schema", schema_inference::expand_load_table);
     reg.register_macro("infer_schema", schema_inference::expand_infer_schema);


### PR DESCRIPTION
This was extracted from #453. Going forward Macros 1.1 is the intended
path of stabilization for procedural macros, so `diesel_codegen` will
need to be rewritten to use it.

Much of the helper code around this is a direct port of the libsyntax
version of our code, rewritten to use `syn` instead.

/cc @killercup @dtolnay I'm going to merge once CI is green, but if either of you want to take a quick look go for it. This is all straight up extracted from the other PR>