### PR TITLE
Re-implement `#[derive(Identifiable)]` using Macros 1.1

### DIFF
--- a/diesel_codegen/src/as_changeset.rs
+++ b/diesel_codegen/src/as_changeset.rs
@@ -1,0 +1,57 @@
+use syn;
+use quote;
+
+use model::Model;
+use util::attr_with_name;
+
+pub fn derive_as_changeset(item: syn::MacroInput) -> quote::Tokens {
+    let treat_none_as_null = format!("{}", treat_none_as_null(&item.attrs));
+    let model = t!(Model::from_item(&item, "AsChangeset"));
+
+    let struct_name = &model.name;
+    let table_name = model.table_name();
+    let struct_ty = &model.ty;
+    let mut lifetimes = item.generics.lifetimes;
+    let attrs = model.attrs.into_iter()
+        .filter(|a| a.column_name != Some(syn::Ident::new("id")))
+        .collect::<Vec<_>>();
+
+    if lifetimes.is_empty() {
+        lifetimes.push(syn::LifetimeDef::new("'a"));
+    }
+
+    quote!(AsChangeset! {
+        (
+            struct_name = #struct_name,
+            table_name = #table_name,
+            treat_none_as_null = #treat_none_as_null,
+            struct_ty = #struct_ty,
+            lifetimes = (#(lifetimes),*),
+        ),
+        fields = [#(attrs)*],
+    })
+}
+
+fn treat_none_as_null(attrs: &[syn::Attribute]) -> bool {
+    let options_attr = match attr_with_name(attrs, "changeset_options") {
+        Some(attr) => attr,
+        None => return false,
+    };
+
+    let usage_err = || panic!(r#"`#[changeset_options]` must be in the form \
+        `#[changeset_options(treat_none_as_null = "true")]`"#);
+
+    match options_attr.value {
+        syn::MetaItem::List(_, ref values) => {
+            if values.len() != 1 {
+                usage_err();
+            }
+            match values[0] {
+                syn::MetaItem::NameValue(ref name, syn::Lit::Str(ref value, _))
+                    if name == "treat_none_as_null" => value == "true",
+                _ => usage_err(),
+            }
+        }
+        _ => usage_err(),
+    }
+}

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -1,0 +1,22 @@
+use quote::Tokens;
+use syn;
+
+use model::Model;
+
+pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
+    let model = t!(Model::from_item(&item, "Identifiable"));
+    let table_name = model.table_name();
+    let struct_ty = &model.ty;
+    let fields = model.attrs;
+    if !fields.iter().any(|f| f.field_name == Some(syn::Ident::new("id"))) {
+        panic!("Could not find a field named `id` on `{}`", &model.name);
+    }
+
+    quote!(Identifiable! {
+        (
+            table_name = #table_name,
+            struct_ty = #struct_ty,
+        ),
+        fields = [#(fields)*],
+    })
+}

--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -1,0 +1,33 @@
+use syn;
+use quote;
+
+use model::Model;
+
+pub fn derive_insertable(item: syn::MacroInput) -> quote::Tokens {
+    let model = t!(Model::from_item(&item, "Insertable"));
+
+    if !model.has_table_name_annotation() {
+        panic!(r#"`#[derive(Insertable)]` requires the struct to be annotated \
+            with `#[table_name="something"]`"#);
+    }
+
+    if !model.generics.ty_params.is_empty() {
+        panic!("`#[derive(Insertable)]` does not support generic types");
+    }
+
+    let struct_name = &model.name;
+    let struct_ty = &model.ty;
+    let table_name = &model.table_name();
+    let lifetimes = model.generics.lifetimes;
+    let fields = model.attrs;
+
+    quote!(Insertable! {
+        (
+            struct_name = #struct_name,
+            table_name = #table_name,
+            struct_ty = #struct_ty,
+            lifetimes = (#(lifetimes),*),
+        ),
+        fields = [#(fields)*],
+    })
+}

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -15,24 +15,34 @@ extern crate quote;
 extern crate rustc_macro;
 extern crate syn;
 
+mod as_changeset;
 mod ast_builder;
 mod attr;
 mod identifiable;
+mod insertable;
 mod model;
 mod queryable;
 mod util;
 
 use rustc_macro::TokenStream;
 use syn::parse_macro_input;
-use util::{list_value_of_attr_with_name, strip_attributes};
+
+use self::util::{list_value_of_attr_with_name, strip_attributes, strip_field_attributes};
 
 const KNOWN_CUSTOM_DERIVES: &'static [&'static str] = &[
+    "AsChangeset",
     "Identifiable",
+    "Insertable",
     "Queryable",
 ];
 
 const KNOWN_CUSTOM_ATTRIBUTES: &'static [&'static str] = &[
     "table_name",
+    "changeset_options"
+];
+
+const KNOWN_FIELD_ATTRIBUTES: &'static [&'static str] = &[
+    "column_name",
 ];
 
 #[rustc_macro_derive(Queryable)]
@@ -43,6 +53,16 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 #[rustc_macro_derive(Identifiable)]
 pub fn derive_identifiable(input: TokenStream) -> TokenStream {
     expand_derive(input, identifiable::derive_identifiable)
+}
+
+#[rustc_macro_derive(Insertable)]
+pub fn derive_insertable(input: TokenStream) -> TokenStream {
+    expand_derive(input, insertable::derive_insertable)
+}
+
+#[rustc_macro_derive(AsChangeset)]
+pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
+    expand_derive(input, as_changeset::derive_as_changeset)
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) -> TokenStream {
@@ -59,6 +79,7 @@ fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) ->
 
     if finished_deriving_diesel_traits {
         item.attrs = strip_attributes(item.attrs, KNOWN_CUSTOM_ATTRIBUTES);
+        strip_field_attributes(&mut item, KNOWN_FIELD_ATTRIBUTES);
     }
 
     quote!(#item #output).to_string().parse().unwrap()

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -17,21 +17,49 @@ extern crate syn;
 
 mod ast_builder;
 mod attr;
+mod identifiable;
 mod model;
 mod queryable;
 mod util;
 
 use rustc_macro::TokenStream;
 use syn::parse_macro_input;
+use util::{list_value_of_attr_with_name, strip_attributes};
+
+const KNOWN_CUSTOM_DERIVES: &'static [&'static str] = &[
+    "Identifiable",
+    "Queryable",
+];
+
+const KNOWN_CUSTOM_ATTRIBUTES: &'static [&'static str] = &[
+    "table_name",
+];
 
 #[rustc_macro_derive(Queryable)]
 pub fn derive_queryable(input: TokenStream) -> TokenStream {
     expand_derive(input, queryable::derive_queryable)
 }
 
+#[rustc_macro_derive(Identifiable)]
+pub fn derive_identifiable(input: TokenStream) -> TokenStream {
+    expand_derive(input, identifiable::derive_identifiable)
+}
+
 fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) -> TokenStream {
-    let item = parse_macro_input(&input.to_string()).unwrap();
+    let mut item = parse_macro_input(&input.to_string()).unwrap();
     let output = f(item.clone());
+
+    let finished_deriving_diesel_traits = {
+        let remaining_derives = list_value_of_attr_with_name(&item.attrs, "derive");
+        !remaining_derives
+            .unwrap_or(Vec::new())
+            .iter()
+            .any(|trait_name| KNOWN_CUSTOM_DERIVES.contains(&trait_name.as_ref()))
+    };
+
+    if finished_deriving_diesel_traits {
+        item.attrs = strip_attributes(item.attrs, KNOWN_CUSTOM_ATTRIBUTES);
+    }
 
     quote!(#item #output).to_string().parse().unwrap()
 }

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -1,13 +1,14 @@
 use syn;
 
 use attr::Attr;
-use util::struct_ty;
+use util::{struct_ty, str_value_of_attr_with_name};
 
 pub struct Model {
     pub ty: syn::Ty,
     pub attrs: Vec<Attr>,
     pub name: syn::Ident,
     pub generics: syn::Generics,
+    table_name_from_annotation: Option<syn::Ident>,
 }
 
 impl Model {
@@ -21,12 +22,55 @@ impl Model {
         let ty = struct_ty(item.ident.clone(), &item.generics);
         let name = item.ident.clone();
         let generics = item.generics.clone();
+        let table_name_from_annotation = str_value_of_attr_with_name(
+            &item.attrs, "table_name").map(syn::Ident::new);
 
         Ok(Model {
             ty: ty,
             attrs: attrs,
             name: name,
             generics: generics,
+            table_name_from_annotation: table_name_from_annotation,
         })
     }
+
+    pub fn table_name(&self) -> syn::Ident {
+        self.table_name_from_annotation.clone().unwrap_or_else(|| {
+            syn::Ident::new(infer_table_name(self.name.as_ref()))
+        })
+    }
+}
+
+pub fn infer_association_name(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    result.push_str(&name[..1].to_lowercase());
+    for character in name[1..].chars() {
+        if character.is_uppercase() {
+            result.push('_');
+            for lowercase in character.to_lowercase() {
+                result.push(lowercase);
+            }
+        } else {
+            result.push(character);
+        }
+    }
+    result
+}
+
+fn infer_table_name(name: &str) -> String {
+    let mut result = infer_association_name(name);
+    result.push('s');
+    result
+}
+
+#[test]
+fn infer_table_name_pluralizes_and_downcases() {
+    assert_eq!("foos", &infer_table_name("Foo"));
+    assert_eq!("bars", &infer_table_name("Bar"));
+}
+
+#[test]
+fn infer_table_name_properly_handles_underscores() {
+    assert_eq!("foo_bars", &infer_table_name("FooBar"));
+    assert_eq!("foo_bar_bazs", &infer_table_name("FooBarBaz"));
 }

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -39,6 +39,10 @@ impl Model {
             syn::Ident::new(infer_table_name(self.name.as_ref()))
         })
     }
+
+    pub fn has_table_name_annotation(&self) -> bool {
+        self.table_name_from_annotation.is_some()
+    }
 }
 
 pub fn infer_association_name(name: &str) -> String {

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use syn::*;
 
 use ast_builder::ty_ident;
@@ -103,4 +104,19 @@ pub fn strip_attributes(attrs: Vec<Attribute>, names_to_strip: &[&str]) -> Vec<A
     attrs.into_iter().filter(|attr| {
         !names_to_strip.contains(&attr.name())
     }).collect()
+}
+
+pub fn strip_field_attributes(item: &mut MacroInput, names_to_strip: &[&str]) {
+    let fields = match item.body {
+        Body::Struct(VariantData::Struct(ref mut fields)) |
+        Body::Struct(VariantData::Tuple(ref mut fields)) => fields,
+        _ => return,
+    };
+
+    let mut attrs = Vec::new();
+    for field in fields {
+        mem::swap(&mut attrs, &mut field.attrs);
+        attrs = strip_attributes(attrs, names_to_strip);
+        mem::swap(&mut attrs, &mut field.attrs);
+    }
 }

--- a/diesel_codegen_old/src/lib.rs
+++ b/diesel_codegen_old/src/lib.rs
@@ -19,10 +19,6 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
         MultiDecorator(Box::new(update::expand_derive_as_changeset)),
     );
     reg.register_syntax_extension(
-        intern("derive_Identifiable"),
-        MultiDecorator(Box::new(identifiable::expand_derive_identifiable))
-    );
-    reg.register_syntax_extension(
         intern("derive_Insertable"),
         MultiDecorator(Box::new(insertable::expand_derive_insertable))
     );

--- a/diesel_codegen_old/src/lib.rs
+++ b/diesel_codegen_old/src/lib.rs
@@ -14,14 +14,6 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
         intern("derive_Associations"),
         MultiDecorator(Box::new(associations::expand_derive_associations)),
     );
-    reg.register_syntax_extension(
-        intern("derive_AsChangeset"),
-        MultiDecorator(Box::new(update::expand_derive_as_changeset)),
-    );
-    reg.register_syntax_extension(
-        intern("derive_Insertable"),
-        MultiDecorator(Box::new(insertable::expand_derive_insertable))
-    );
     reg.register_macro("embed_migrations", migrations::expand_embed_migrations);
     reg.register_macro("infer_table_from_schema", schema_inference::expand_load_table);
     reg.register_macro("infer_schema", schema_inference::expand_infer_schema);

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -6,5 +6,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.7.1", features = ["sqlite", "postgres"] }
 diesel_codegen = { version = "0.7.2" }
-diesel_codegen_old = { path = "../diesel_codegen_old", features = ["postgres", "sqlite"] }
 compiletest_rs = "0.2.1"

--- a/diesel_compile_tests/tests/compile-fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
+++ b/diesel_compile_tests/tests/compile-fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
@@ -1,5 +1,5 @@
-#![feature(custom_derive, plugin, custom_attribute, rustc_macro)]
-#![plugin(diesel_codegen_old)]
+#![feature(rustc_macro)]
+
 #[macro_use]
 extern crate diesel;
 #[macro_use]

--- a/diesel_compile_tests/tests/compile-fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
+++ b/diesel_compile_tests/tests/compile-fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
@@ -16,7 +16,7 @@ table! {
     }
 }
 
-#[derive(Queryable, AsChangeset)] //~ WARNING
+#[derive(Queryable, AsChangeset)]
 #[table_name = "users"]
 pub struct User {
     name: String,

--- a/diesel_compile_tests/tests/compile-fail/custom_returning_requires_nonaggregate.rs
+++ b/diesel_compile_tests/tests/compile-fail/custom_returning_requires_nonaggregate.rs
@@ -1,5 +1,5 @@
-#![feature(custom_derive, plugin, custom_attribute, rustc_macro)]
-#![plugin(diesel_codegen_old)]
+#![feature(rustc_macro)]
+
 #[macro_use]
 extern crate diesel;
 #[macro_use]
@@ -15,7 +15,7 @@ table! {
     }
 }
 
-#[derive(Insertable)] //~ WARNING
+#[derive(Insertable)]
 #[table_name="users"]
 pub struct NewUser {
     name: String,

--- a/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
@@ -1,5 +1,5 @@
-#![feature(custom_derive, plugin, custom_attribute, rustc_macro)]
-#![plugin(diesel_codegen_old)]
+#![feature(rustc_macro)]
+
 #[macro_use]
 extern crate diesel;
 #[macro_use]
@@ -21,7 +21,7 @@ table! {
     }
 }
 
-#[derive(Insertable)] //~ WARNING
+#[derive(Insertable)]
 #[table_name="users"]
 pub struct NewUser {
     name: String,

--- a/diesel_compile_tests/tests/compile-fail/identifiable_requires_primary_key_field.rs
+++ b/diesel_compile_tests/tests/compile-fail/identifiable_requires_primary_key_field.rs
@@ -1,13 +1,13 @@
-#![feature(custom_derive, plugin, custom_attribute, rustc_macro)]
-#![plugin(diesel_codegen_old)]
+#![feature(rustc_macro)]
 
 #[macro_use]
 extern crate diesel;
 #[macro_use]
 extern crate diesel_codegen;
 
-#[derive(Identifiable)] //~ ERROR Could not find a field named `id` on `User`
-//~^ WARNING
+#[derive(Identifiable)]
+//~^ ERROR custom derive attribute panicked
+//~| HELP Could not find a field named `id` on `User`
 pub struct User {
     name: String,
     hair_color: Option<String>,

--- a/diesel_compile_tests/tests/compile-fail/insertable_into_does_not_support_generics.rs
+++ b/diesel_compile_tests/tests/compile-fail/insertable_into_does_not_support_generics.rs
@@ -1,5 +1,4 @@
-#![feature(custom_derive, plugin, custom_attribute, rustc_macro)]
-#![plugin(diesel_codegen_old)]
+#![feature(rustc_macro)]
 
 #[macro_use]
 extern crate diesel;
@@ -13,8 +12,9 @@ table! {
     }
 }
 
-#[derive(Insertable)] //~ WARNING
-//~^ ERROR #[derive(Insertable)] does not support generic types
+#[derive(Insertable)]
+//~^ ERROR custom derive attribute panicked
+//~| HELP `#[derive(Insertable)]` does not support generic types
 #[table_name="users"]
 pub struct NewUser<T> {
     name: T,

--- a/diesel_compile_tests/tests/compile-fail/sqlite_upsert_cannot_be_used_on_pg.rs
+++ b/diesel_compile_tests/tests/compile-fail/sqlite_upsert_cannot_be_used_on_pg.rs
@@ -1,5 +1,4 @@
-#![feature(custom_derive, plugin, custom_attribute, rustc_macro)]
-#![plugin(diesel_codegen_old)]
+#![feature(rustc_macro)]
 
 #[macro_use]
 extern crate diesel;
@@ -15,7 +14,7 @@ table! {
     }
 }
 
-#[derive(Insertable)] //~ WARNING
+#[derive(Insertable)]
 #[table_name="users"]
 struct User {
     id: i32,

--- a/examples/getting_started_step_1/src/lib.rs
+++ b/examples/getting_started_step_1/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(custom_derive, custom_attribute, plugin, rustc_macro)]
+#![feature(plugin, rustc_macro)]
 #![plugin(diesel_codegen_old, dotenv_macros)]
 
 #[macro_use] extern crate diesel;

--- a/examples/getting_started_step_2/src/lib.rs
+++ b/examples/getting_started_step_2/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(custom_derive, custom_attribute, plugin, rustc_macro)]
+#![feature(plugin, rustc_macro)]
 #![plugin(diesel_codegen_old, dotenv_macros)]
 
 #[macro_use] extern crate diesel;

--- a/examples/getting_started_step_3/src/lib.rs
+++ b/examples/getting_started_step_3/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(custom_derive, custom_attribute, plugin, rustc_macro)]
+#![feature(plugin, rustc_macro)]
 #![plugin(diesel_codegen_old, dotenv_macros)]
 
 #[macro_use] extern crate diesel;

--- a/examples/getting_started_step_4/src/lib.rs
+++ b/examples/getting_started_step_4/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(custom_derive, custom_attribute, plugin, rustc_macro))]
+#![cfg_attr(feature = "nightly", feature(plugin, rustc_macro))]
 #![cfg_attr(feature = "nightly", plugin(diesel_codegen_old, dotenv_macros))]
 
 #[macro_use] extern crate diesel;


### PR DESCRIPTION
This was extracted from #453.

Going forward Macros 1.1 is the intended path of stabilization for
procedural macros, so `diesel_codegen` will need to be rewritten to use
it.

Much of the helper code around this is a direct port of the libsyntax
version of our code, rewritten to use `syn` instead.

Close #453.