### PR TITLE
Re-implement `#[derive(Associations)]` using Macros 1.1

### DIFF
--- a/diesel_codegen/src/associations.rs
+++ b/diesel_codegen/src/associations.rs
@@ -1,0 +1,103 @@
+use syn;
+use quote;
+
+use model::{Model, infer_association_name};
+use util::str_value_of_meta_item;
+
+pub fn derive_associations(input: syn::MacroInput) -> quote::Tokens {
+    let mut derived_associations = Vec::new();
+    let model = t!(Model::from_item(&input, "Associations"));
+
+    for attr in &input.attrs {
+        if attr.name() == "has_many" {
+            let options = t!(build_association_options(attr, "has_many"));
+            derived_associations.push(expand_has_many(&model, options))
+        }
+
+        if attr.name() == "belongs_to" {
+            let options = t!(build_association_options(attr, "belongs_to"));
+            derived_associations.push(expand_belongs_to(&model, options))
+        }
+    }
+
+    quote!(#(derived_associations)*)
+}
+
+fn expand_belongs_to(model: &Model, options: AssociationOptions) -> quote::Tokens {
+    let parent_struct = options.name;
+    let struct_name = &model.name;
+
+    let foreign_key_name = options.foreign_key_name.unwrap_or_else(||
+        to_foreign_key(&parent_struct.as_ref()));
+    let child_table_name = model.table_name();
+    let fields = &model.attrs;
+
+    quote!(BelongsTo! {
+        (
+            struct_name = #struct_name,
+            parent_struct = #parent_struct,
+            foreign_key_name = #foreign_key_name,
+            child_table_name = #child_table_name,
+        ),
+        fields = [#(fields)*],
+    })
+}
+
+fn expand_has_many(model: &Model, options: AssociationOptions) -> quote::Tokens {
+    let parent_table_name = model.table_name();
+    let child_table_name = options.name;
+    let foreign_key_name = options.foreign_key_name.unwrap_or_else(||
+        to_foreign_key(&model.name.as_ref()));
+    let fields = &model.attrs;
+
+    quote!(HasMany! {
+        (
+            parent_table_name = #parent_table_name,
+            child_table = #child_table_name::table,
+            foreign_key = #child_table_name::#foreign_key_name,
+        ),
+        fields = [#(fields)*],
+    })
+}
+
+struct AssociationOptions {
+    name: syn::Ident,
+    foreign_key_name: Option<syn::Ident>,
+}
+
+fn build_association_options(
+    attr: &syn::Attribute,
+    association_kind: &str,
+) -> Result<AssociationOptions, String> {
+    let usage_error = Err(format!(
+            "`#[{}]` must be in the form `#[{}(table_name, option=value)]`",
+            association_kind, association_kind));
+    match attr.value {
+        syn::MetaItem::List(_, ref options) if options.len() >= 1 => {
+            let association_name = match options[0] {
+                syn::MetaItem::Word(ref name) => name.clone(),
+                _ => return usage_error,
+            };
+            let foreign_key_name = options.iter().find(|a| a.name() == "foreign_key")
+                .map(|a| str_value_of_meta_item(a, "foreign_key"))
+                .map(syn::Ident::new);
+
+            Ok(AssociationOptions {
+                name: association_name,
+                foreign_key_name: foreign_key_name,
+            })
+        }
+        _ => usage_error,
+    }
+}
+
+fn to_foreign_key(model_name: &str) -> syn::Ident {
+    let lower_cased = infer_association_name(model_name);
+    syn::Ident::new(format!("{}_id", &lower_cased))
+}
+
+#[test]
+fn to_foreign_key_properly_handles_underscores() {
+    assert_eq!(str_to_ident("foo_bar_id"), to_foreign_key("FooBar"));
+    assert_eq!(str_to_ident("foo_bar_baz_id"), to_foreign_key("FooBarBaz"));
+}

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -16,6 +16,7 @@ extern crate rustc_macro;
 extern crate syn;
 
 mod as_changeset;
+mod associations;
 mod ast_builder;
 mod attr;
 mod identifiable;
@@ -31,14 +32,17 @@ use self::util::{list_value_of_attr_with_name, strip_attributes, strip_field_att
 
 const KNOWN_CUSTOM_DERIVES: &'static [&'static str] = &[
     "AsChangeset",
+    "Associations",
     "Identifiable",
     "Insertable",
     "Queryable",
 ];
 
 const KNOWN_CUSTOM_ATTRIBUTES: &'static [&'static str] = &[
+    "belongs_to",
+    "changeset_options",
+    "has_many",
     "table_name",
-    "changeset_options"
 ];
 
 const KNOWN_FIELD_ATTRIBUTES: &'static [&'static str] = &[
@@ -63,6 +67,11 @@ pub fn derive_insertable(input: TokenStream) -> TokenStream {
 #[rustc_macro_derive(AsChangeset)]
 pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
     expand_derive(input, as_changeset::derive_as_changeset)
+}
+
+#[rustc_macro_derive(Associations)]
+pub fn derive_associations(input: TokenStream) -> TokenStream {
+    expand_derive(input, associations::derive_associations)
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) -> TokenStream {

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -54,7 +54,11 @@ pub fn attr_with_name<'a>(
 }
 
 fn str_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> &'a str {
-    match attr.value {
+    str_value_of_meta_item(&attr.value, name)
+}
+
+pub fn str_value_of_meta_item<'a>(item: &'a MetaItem, name: &str) -> &'a str {
+    match *item {
         MetaItem::NameValue(_, Lit::Str(ref value, _)) => &*value,
         _ => panic!(r#"`{}` must be in the form `#[{}="something"]`"#, name, name),
     }

--- a/diesel_codegen_old/src/lib.rs
+++ b/diesel_codegen_old/src/lib.rs
@@ -8,12 +8,6 @@ use diesel_codegen_syntex::*;
 
 #[plugin_registrar]
 pub fn register(reg: &mut rustc_plugin::Registry) {
-    use syntax::parse::token::intern;
-    use syntax::ext::base::MultiDecorator;
-    reg.register_syntax_extension(
-        intern("derive_Associations"),
-        MultiDecorator(Box::new(associations::expand_derive_associations)),
-    );
     reg.register_macro("embed_migrations", migrations::expand_embed_migrations);
     reg.register_macro("infer_table_from_schema", schema_inference::expand_load_table);
     reg.register_macro("infer_schema", schema_inference::expand_infer_schema);

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "unstable", feature(custom_derive, plugin, custom_attribute, rustc_macro))]
+#![cfg_attr(feature = "unstable", feature(plugin, rustc_macro))]
 #![cfg_attr(feature = "unstable", plugin(diesel_codegen_old, dotenv_macros))]
 
 extern crate quickcheck;


### PR DESCRIPTION
Going forward Macros 1.1 is the intended path of stabilization for
procedural macros, so `diesel_codegen` will need to be rewritten to use
it.

Much of the helper code around this is a direct port of the libsyntax
version of our code, rewritten to use `syn` instead.

We're cloning the attributes, as `quote!` only works for repetition with
`T where for<'a> &'a T: IntoIterator`. I think this is a bug and will
address upstream.