### PR TITLE
Pin the nightly version again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ dist: trusty
 rust:
   - stable
   - beta
+  - nightly-2016-09-29
   - nightly
+matrix:
+  allow_failures:
+    - nightly
 cache: cargo
 addons:
   postgresql: '9.4'


### PR DESCRIPTION
<img width="402" alt="screen shot 2016-10-03 at 2 55 33 pm" src="https://cloud.githubusercontent.com/assets/1529387/19049826/04bdb1e6-897a-11e6-8d21-93189d94c41c.png">

3 hours later, there was a breaking change in nightly...