### PR TITLE
Resolve paths given to `embed_migrations` as relative to Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Structs annotated with `#[has_many]` or `#[belongs_to]` now require
   `#[derive(Associations)]`. This is to allow them to work with Macros 1.1.
 
+* `embed_migrations!` now resolves paths relative to `Cargo.toml` instead of the
+  file the macro was called from. This change is required to allow this macro to
+  work with Macros 1.1.
+
 ### Fixed
 
 * `diesel migrations run` will now respect migration directories overridden by

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -128,7 +128,7 @@ pub fn connection_without_transaction() -> TestConnection {
 }
 
 #[cfg(feature = "sqlite")]
-embed_migrations!("../../migrations/sqlite");
+embed_migrations!("../migrations/sqlite");
 
 #[cfg(feature = "sqlite")]
 pub fn connection_without_transaction() -> TestConnection {


### PR DESCRIPTION
Macros 1.1 does not give us any way to access the file the macro was
invoked from. In order to make the API compatible with this new system,
we instead resolve paths given as relative to the only stable path we
have access to, which is the location of Cargo.toml. Since it is
somewhat common for people to place their migrations in
`src/migrations`, we will continue to search that path if no specific
path is given. However, we will no longer find paths such as
`src/foo/migrations`.

This is based on code from #470, and I've committed as the author of that PR to ensure @weiznich is credited.