### PR TITLE
Reimplement `embed_migrations!` using Macros 1.1

### DIFF
--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -1,0 +1,43 @@
+#[macro_export]
+/// This macro can only be used in combination with the `diesel_codegen` or
+/// `diesel_codegen_syntex` crates. It will not work on its own.
+///
+/// FIXME: Oh look we have a place to actually document this now.
+macro_rules! infer_schema {
+    ($database_url: expr) => {
+        #[derive(InferSchema)]
+        #[options(database_url=$database_url)]
+        struct _Dummy;
+    }
+}
+
+#[macro_export]
+/// This macro can only be used in combination with the `diesel_codegen` or
+/// `diesel_codegen_syntex` crates. It will not work on its own.
+///
+/// FIXME: Oh look we have a place to actually document this now.
+macro_rules! infer_table_from_schema {
+    ($database_url: expr, $table_name: expr) => {
+        #[derive(InferTableFromSchema)]
+        #[options(database_url=$database_url, table_name=$table_name)]
+        struct _Dummy;
+    }
+}
+
+#[macro_export]
+/// This macro can only be used in combination with the `diesel_codegen` or
+/// `diesel_codegen_syntex` crates. It will not work on its own.
+///
+/// FIXME: Oh look we have a place to actually document this now.
+macro_rules! embed_migrations {
+    () => {
+        #[derive(EmbedMigrations)]
+        struct _Dummy;
+    };
+
+    ($migrations_path: expr) => {
+        #[derive(EmbedMigrations)]
+        #[options(migrations_path=$migrations_path)]
+        struct _Dummy;
+    }
+}

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -552,37 +552,12 @@ macro_rules! print_sql {
     };
 }
 
-#[macro_export]
-/// This macro can only be used in combination with the `diesel_codegen` or
-/// `diesel_codegen_syntex` crates. It will not work on its own.
-///
-/// FIXME: Oh look we have a place to actually document this now.
-macro_rules! infer_schema {
-    ($database_url: expr) => {
-        #[derive(InferSchema)]
-        #[options(database_url=$database_url)]
-        struct _Dummy;
-    }
-}
-
-#[macro_export]
-/// This macro can only be used in combination with the `diesel_codegen` or
-/// `diesel_codegen_syntex` crates. It will not work on its own.
-///
-/// FIXME: Oh look we have a place to actually document this now.
-macro_rules! infer_table_from_schema {
-    ($database_url: expr, $table_name: expr) => {
-        #[derive(InferTableFromSchema)]
-        #[options(database_url=$database_url, table_name=$table_name)]
-        struct _Dummy;
-    }
-}
-
 // The order of these modules is important (at least for those which have tests).
 // Utililty macros which don't call any others need to come first.
 #[macro_use] mod parse;
 #[macro_use] mod query_id;
 #[macro_use] mod static_cond;
+#[macro_use] mod macros_from_codegen;
 
 #[macro_use] mod as_changeset;
 #[macro_use] mod associations;

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 syn = "0.8.5"
 quote = "0.2.1"
+diesel = { version = "0.7.1", default-features = false }
 diesel_codegen_shared = { path = "../diesel_codegen_shared", default-features = false }
 
 [lib]

--- a/diesel_codegen/src/embed_migrations.rs
+++ b/diesel_codegen/src/embed_migrations.rs
@@ -1,0 +1,91 @@
+use syn;
+use quote;
+
+use diesel::migrations::{migration_paths_in_directory, version_from_path};
+use diesel_codegen_shared::migration_directory_from_given_path;
+use std::error::Error;
+use std::path::Path;
+
+use util::{get_options_from_input, get_option};
+
+pub fn derive_embed_migrations(input: syn::MacroInput) -> quote::Tokens {
+    fn bug() -> ! {
+        panic!("This is a bug. Please open a Github issue \
+               with your invocation of `embed_migrations!");
+    }
+
+    let options = get_options_from_input(&input.attrs, bug);
+    let migrations_path_opt = options.map(|o| get_option(&o, "migrations_path", bug));
+    let migrations_expr = migration_directory_from_given_path(migrations_path_opt)
+        .and_then(|path| migration_literals_from_path(&path));
+    let migrations_expr = match migrations_expr {
+        Ok(v) => v,
+        Err(e) => panic!("Error reading migrations: {}", e),
+    };
+
+    // These are split into multiple `quote!` calls to avoid recursion limit
+    let embedded_migration_def = quote!(
+        struct EmbeddedMigration {
+            version: &'static str,
+            up_sql: &'static str,
+        }
+
+        impl Migration for EmbeddedMigration {
+            fn version(&self) -> &str {
+                self.version
+            }
+
+            fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+                conn.batch_execute(self.up_sql).map_err(Into::into)
+            }
+
+            fn revert(&self, _conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+                unreachable!()
+            }
+        }
+    );
+
+    let run_fns = quote!(
+        pub fn run<C: MigrationConnection>(conn: &C) -> Result<(), RunMigrationsError> {
+            run_with_output(conn, &mut io::sink())
+        }
+
+        pub fn run_with_output<C: MigrationConnection>(conn: &C, out: &mut io::Write)
+            -> Result<(), RunMigrationsError>
+        {
+            run_migrations(conn, ALL_MIGRATIONS.iter().map(|v| *v), out)
+        }
+    );
+
+    quote!(mod embedded_migrations {
+        extern crate diesel;
+
+        use self::diesel::migrations::*;
+        use self::diesel::connection::SimpleConnection;
+        use std::io;
+
+        const ALL_MIGRATIONS: &'static [&'static Migration] = &[#(migrations_expr),*];
+
+        #embedded_migration_def
+
+        #run_fns
+    })
+}
+
+fn migration_literals_from_path(path: &Path) -> Result<Vec<quote::Tokens>, Box<Error>> {
+    try!(migration_paths_in_directory(path))
+        .into_iter()
+        .map(|e| migration_literal_from_path(&e.path()))
+        .collect()
+}
+
+fn migration_literal_from_path(path: &Path) -> Result<quote::Tokens, Box<Error>> {
+    let version = try!(version_from_path(path));
+    let sql_file = path.join("up.sql");
+    let sql_file_path = sql_file.to_string_lossy();
+
+    Ok(quote!(&EmbeddedMigration {
+        version: #version,
+        up_sql: include_str!(#sql_file_path),
+    }))
+}

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -10,7 +10,6 @@ macro_rules! t {
     };
 }
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
 extern crate diesel_codegen_shared;
 extern crate diesel;
 #[macro_use]
@@ -97,7 +96,7 @@ pub fn derive_infer_table_from_schema(input: TokenStream) -> TokenStream {
 }
 
 #[rustc_macro_derive(EmbedMigrations)]
-pub fn derive_embed_migratoins(input: TokenStream) -> TokenStream {
+pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
     let item = parse_macro_input(&input.to_string()).unwrap();
     embed_migrations::derive_embed_migrations(item)
         .to_string().parse().unwrap()

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -12,6 +12,7 @@ macro_rules! t {
 
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 extern crate diesel_codegen_shared;
+extern crate diesel;
 #[macro_use]
 extern crate quote;
 extern crate rustc_macro;
@@ -21,6 +22,7 @@ mod as_changeset;
 mod associations;
 mod ast_builder;
 mod attr;
+mod embed_migrations;
 mod identifiable;
 mod insertable;
 mod model;
@@ -91,6 +93,13 @@ pub fn derive_infer_schema(input: TokenStream) -> TokenStream {
 pub fn derive_infer_table_from_schema(input: TokenStream) -> TokenStream {
     let item = parse_macro_input(&input.to_string()).unwrap();
     schema_inference::derive_infer_table_from_schema(item)
+        .to_string().parse().unwrap()
+}
+
+#[rustc_macro_derive(EmbedMigrations)]
+pub fn derive_embed_migratoins(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input(&input.to_string()).unwrap();
+    embed_migrations::derive_embed_migrations(item)
         .to_string().parse().unwrap()
 }
 

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -124,3 +124,24 @@ pub fn strip_field_attributes(item: &mut MacroInput, names_to_strip: &[&str]) {
         mem::swap(&mut attrs, &mut field.attrs);
     }
 }
+
+pub fn get_options_from_input(attrs: &[Attribute], on_bug: fn() -> !)
+    -> Option<&[MetaItem]>
+{
+    let options = attrs.iter().find(|a| a.name() == "options").map(|a| &a.value);
+    match options {
+        Some(&MetaItem::List(_, ref options)) => Some(options),
+        Some(_) => on_bug(),
+        None => None,
+    }
+}
+
+pub fn get_option<'a>(
+    options: &'a [MetaItem],
+    option_name: &str,
+    on_bug: fn() -> !,
+) -> &'a str {
+    options.iter().find(|a| a.name() == option_name)
+        .map(|a| str_value_of_meta_item(a, option_name))
+        .unwrap_or_else(|| on_bug())
+}

--- a/diesel_codegen_old/Cargo.toml
+++ b/diesel_codegen_old/Cargo.toml
@@ -9,14 +9,11 @@ homepage = "http://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_codegen"
 keywords = ["orm", "database", "postgres", "sql", "codegen"]
 
-[dependencies]
-diesel_codegen_syntex = { path = "../diesel_codegen_syntex", default-features = false }
-
 [features]
 default = ["postgres", "dotenv"]
-dotenv = ["diesel_codegen_syntex/dotenv"]
-postgres = ["diesel_codegen_syntex/postgres"]
-sqlite = ["diesel_codegen_syntex/sqlite"]
+dotenv = []
+postgres = []
+sqlite = []
 
 [lib]
 plugin = true

--- a/diesel_codegen_old/src/lib.rs
+++ b/diesel_codegen_old/src/lib.rs
@@ -1,12 +1,8 @@
 #![feature(rustc_private, plugin_registrar)]
 
-extern crate diesel_codegen_syntex;
 extern crate syntax;
 extern crate rustc_plugin;
 
-use diesel_codegen_syntex::*;
-
 #[plugin_registrar]
-pub fn register(reg: &mut rustc_plugin::Registry) {
-    reg.register_macro("embed_migrations", migrations::expand_embed_migrations);
+pub fn register(_reg: &mut rustc_plugin::Registry) {
 }

--- a/diesel_codegen_shared/src/lib.rs
+++ b/diesel_codegen_shared/src/lib.rs
@@ -9,10 +9,12 @@ use diesel::pg::PgConnection;
 use diesel::sqlite::SqliteConnection;
 
 mod database_url;
+mod migrations;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 mod schema_inference;
 
 pub use self::database_url::extract_database_url;
+pub use self::migrations::*;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use self::schema_inference::*;
 

--- a/diesel_codegen_shared/src/migrations.rs
+++ b/diesel_codegen_shared/src/migrations.rs
@@ -1,0 +1,106 @@
+use diesel::migrations::search_for_migrations_directory;
+
+use std::path::{PathBuf, Path};
+use std::error::Error;
+use std::env;
+
+pub fn migration_directory_from_given_path(given_path: Option<&str>)
+    -> Result<PathBuf, Box<Error>>
+{
+    let cargo_toml_directory = try!(env::var("CARGO_MANIFEST_DIR"));
+    let cargo_manifest_path = Path::new(&cargo_toml_directory);
+    let migrations_path = given_path.as_ref().map(Path::new);
+    resolve_migrations_directory(cargo_manifest_path, migrations_path)
+}
+
+fn resolve_migrations_directory(
+    cargo_manifest_dir: &Path,
+    relative_path_to_migrations: Option<&Path>,
+) -> Result<PathBuf, Box<Error>> {
+    let result = match relative_path_to_migrations {
+        Some(dir) => cargo_manifest_dir.join(dir),
+        None => {
+            // People commonly put their migrations in src/migrations
+            // so start the search there rather than the project root
+            let src_dir = cargo_manifest_dir.join("src");
+            try!(search_for_migrations_directory(&src_dir))
+        }
+    };
+
+    result.canonicalize().map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate tempdir;
+
+    use self::tempdir::TempDir;
+    use std::fs;
+    use std::path::Path;
+    use super::resolve_migrations_directory;
+
+    #[test]
+    fn migrations_directory_resolved_relative_to_cargo_manifest_dir() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/special_migrations")).unwrap();
+        let cargo_manifest_dir = tempdir.path().join("foo");
+        let relative_path = Some(Path::new("special_migrations"));
+
+        assert_eq!(
+            tempdir.path().join("foo/special_migrations").canonicalize().ok(),
+            resolve_migrations_directory(&cargo_manifest_dir, relative_path).ok()
+        );
+    }
+
+    #[test]
+    fn migrations_directory_canonicalizes_result() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/migrations/bar")).unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
+        let cargo_manifest_dir = tempdir.path().join("foo/bar");
+        let relative_path = Some(Path::new("../migrations/bar"));
+
+        assert_eq!(
+            tempdir.path().join("foo/migrations/bar").canonicalize().ok(),
+            resolve_migrations_directory(&cargo_manifest_dir, relative_path).ok()
+        );
+    }
+
+    #[test]
+    fn migrations_directory_defaults_to_searching_migrations_path() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
+        let cargo_manifest_dir = tempdir.path().join("foo/bar");
+
+        assert_eq!(
+            tempdir.path().join("foo/migrations").canonicalize().ok(),
+            resolve_migrations_directory(&cargo_manifest_dir, None).ok()
+        );
+    }
+
+    #[test]
+    fn migrations_directory_searches_src_migrations_if_present() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/src/migrations")).unwrap();
+        fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
+        let cargo_manifest_dir = tempdir.path().join("foo");
+
+        assert_eq!(
+            tempdir.path().join("foo/src/migrations").canonicalize().ok(),
+            resolve_migrations_directory(&cargo_manifest_dir, None).ok()
+        );
+    }
+
+    #[test]
+    fn migrations_directory_allows_no_parent_dir_for_cargo_manifest_dir() {
+        let tempdir = TempDir::new("diesel").unwrap();
+        fs::create_dir_all(tempdir.path().join("special_migrations")).unwrap();
+        let cargo_manifest_dir = tempdir.path().to_owned();
+        let relative_path = Some(Path::new("special_migrations"));
+        assert_eq!(
+            tempdir.path().join("special_migrations").canonicalize().ok(),
+            resolve_migrations_directory(&cargo_manifest_dir, relative_path).ok()
+        );
+    }
+}

--- a/diesel_codegen_syntex/src/migrations.rs
+++ b/diesel_codegen_syntex/src/migrations.rs
@@ -1,6 +1,5 @@
-use diesel::migrations::search_for_migrations_directory;
+use diesel_codegen_shared::migration_directory_from_given_path;
 use std::error::Error;
-use std::env;
 use std::path::{Path, PathBuf};
 use syntax::ast;
 use syntax::codemap::Span;
@@ -71,7 +70,6 @@ fn migrations_directory_from_args(
     sp: Span,
     tts: &[tokenstream::TokenTree],
 ) -> Result<PathBuf, Box<Error>> {
-    let cargo_toml_directory = try!(env::var("CARGO_MANIFEST_DIR"));
     let relative_path_to_migrations = if tts.is_empty() {
         None
     } else {
@@ -80,26 +78,7 @@ fn migrations_directory_from_args(
             value => value,
         }
     };
-    let cargo_manifest_path = Path::new(&cargo_toml_directory);
-    let migrations_path = relative_path_to_migrations.as_ref().map(Path::new);
-    resolve_migrations_directory(cargo_manifest_path, migrations_path)
-}
-
-fn resolve_migrations_directory(
-    cargo_manifest_dir: &Path,
-    relative_path_to_migrations: Option<&Path>,
-) -> Result<PathBuf, Box<Error>> {
-    let result = match relative_path_to_migrations {
-        Some(dir) => cargo_manifest_dir.join(dir),
-        None => {
-            // People commonly put their migrations in src/migrations
-            // so start the search there rather than the project root
-            let src_dir = cargo_manifest_dir.join("src");
-            try!(search_for_migrations_directory(&src_dir))
-        }
-    };
-
-    result.canonicalize().map_err(Into::into)
+    migration_directory_from_given_path(relative_path_to_migrations.as_ref().map(|v| &**v))
 }
 
 fn migration_literals_from_path(
@@ -129,79 +108,4 @@ fn migration_literal_from_path(
         version: $version,
         up_sql: include_str!($sql_file_path),
     }))
-}
-
-#[cfg(test)]
-mod tests {
-    extern crate tempdir;
-
-    use self::tempdir::TempDir;
-    use std::fs;
-    use std::path::Path;
-    use super::resolve_migrations_directory;
-
-    #[test]
-    fn migrations_directory_resolved_relative_to_cargo_manifest_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
-        fs::create_dir_all(tempdir.path().join("foo/special_migrations")).unwrap();
-        let cargo_manifest_dir = tempdir.path().join("foo");
-        let relative_path = Some(Path::new("special_migrations"));
-
-        assert_eq!(
-            tempdir.path().join("foo/special_migrations").canonicalize().ok(),
-            resolve_migrations_directory(&cargo_manifest_dir, relative_path).ok()
-        );
-    }
-
-    #[test]
-    fn migrations_directory_canonicalizes_result() {
-        let tempdir = TempDir::new("diesel").unwrap();
-        fs::create_dir_all(tempdir.path().join("foo/migrations/bar")).unwrap();
-        fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
-        let cargo_manifest_dir = tempdir.path().join("foo/bar");
-        let relative_path = Some(Path::new("../migrations/bar"));
-
-        assert_eq!(
-            tempdir.path().join("foo/migrations/bar").canonicalize().ok(),
-            resolve_migrations_directory(&cargo_manifest_dir, relative_path).ok()
-        );
-    }
-
-    #[test]
-    fn migrations_directory_defaults_to_searching_migrations_path() {
-        let tempdir = TempDir::new("diesel").unwrap();
-        fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
-        fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
-        let cargo_manifest_dir = tempdir.path().join("foo/bar");
-
-        assert_eq!(
-            tempdir.path().join("foo/migrations").canonicalize().ok(),
-            resolve_migrations_directory(&cargo_manifest_dir, None).ok()
-        );
-    }
-
-    #[test]
-    fn migrations_directory_searches_src_migrations_if_present() {
-        let tempdir = TempDir::new("diesel").unwrap();
-        fs::create_dir_all(tempdir.path().join("foo/src/migrations")).unwrap();
-        fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
-        let cargo_manifest_dir = tempdir.path().join("foo");
-
-        assert_eq!(
-            tempdir.path().join("foo/src/migrations").canonicalize().ok(),
-            resolve_migrations_directory(&cargo_manifest_dir, None).ok()
-        );
-    }
-
-    #[test]
-    fn migrations_directory_allows_no_parent_dir_for_cargo_manifest_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
-        fs::create_dir_all(tempdir.path().join("special_migrations")).unwrap();
-        let cargo_manifest_dir = tempdir.path().to_owned();
-        let relative_path = Some(Path::new("special_migrations"));
-        assert_eq!(
-            tempdir.path().join("special_migrations").canonicalize().ok(),
-            resolve_migrations_directory(&cargo_manifest_dir, relative_path).ok()
-        );
-    }
 }


### PR DESCRIPTION
There wasn't a ton of code that could be shared between the old crate
and the new one, as the majority of the lines of code are just the setup
of the structs and functions used, which need to go into the respective
quote macro. In order to share that code, it'd have to be moved into
Diesel proper and out of the macro output, which I want to avoid. Since
the syntex crate will be removed once Macros 1.1 is stable, we can live
with the duplication for now.

This is based on code from #470, and I've committed as the author of that PR.