### PR TITLE
Make database URL tests work in parallel.

### DIFF
--- a/diesel_codegen_shared/src/database_url.rs
+++ b/diesel_codegen_shared/src/database_url.rs
@@ -41,14 +41,14 @@ fn extract_database_url_returns_the_given_string() {
 
 #[test]
 fn extract_database_url_returns_env_vars() {
-    env::set_var("foo", "lololol");
-    env::set_var("bar", "trolololol");
-    assert_eq!("lololol", extract_database_url("env:foo").unwrap());
-    assert_eq!("trolololol", extract_database_url("env:bar").unwrap());
+    env::set_var("lolvar", "lololol");
+    env::set_var("trolvar", "trolololol");
+    assert_eq!("lololol", extract_database_url("env:lolvar").unwrap());
+    assert_eq!("trolololol", extract_database_url("env:trolvar").unwrap());
 }
 
 #[test]
 fn extract_database_url_errors_if_env_var_is_unset() {
-    env::remove_var("foo");
-    assert!(extract_database_url("env:foo").is_err());
+    env::remove_var("selfdestructvar");
+    assert!(extract_database_url("env:selfdestructvar").is_err());
 }


### PR DESCRIPTION
There was a collision on the name of the environment variable "foo"
between two tests. One would set it (extract_database_url_returns_env_vars) and other (extract_database_url_errors_if_env_var_is_unset) would unset it.
As Cargo runs tests in parallel this would lead to this set of test
having intermittent failures.

Changed the names of the environment variables used in the tests to make
them unique between tests, hence able to run in parallel.

Should close #475 