### PR TITLE
Fix #384 (Invalid query on empty insert/select in)

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -64,6 +64,10 @@ impl<T, U, DB> QueryFragment<DB> for In<T, U> where
         self.left.is_safe_to_cache_prepared() &&
             self.values.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
 }
 
 impl_query_id!(In<T, U>);
@@ -119,9 +123,13 @@ impl<T, DB> QueryFragment<DB> for Many<T> where
     T: QueryFragment<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        try!(self.0[0].to_sql(out));
-        for value in self.0[1..].iter() {
-            out.push_sql(", ");
+        let mut first = true;
+        for value in self.0.iter() {
+            if first {
+                first = false;
+            } else {
+                out.push_sql(", ");
+            }
             try!(value.to_sql(out));
         }
         Ok(())
@@ -136,6 +144,10 @@ impl<T, DB> QueryFragment<DB> for Many<T> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
@@ -171,6 +183,10 @@ impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.values.is_safe_to_cache_prepared()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.values.is_empty()
     }
 }
 

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -74,6 +74,10 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.target.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.target.is_empty()
+    }
 }
 
 impl_query_id!(Count<T>);

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -47,6 +47,10 @@ macro_rules! fold_function {
             fn is_safe_to_cache_prepared(&self) -> bool {
                 self.target.is_safe_to_cache_prepared()
             }
+
+            fn is_empty(&self) -> bool {
+                self.target.is_empty()
+            }
         }
 
         impl_query_id!($type_name<T>);

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -44,6 +44,10 @@ macro_rules! ord_function {
             fn is_safe_to_cache_prepared(&self) -> bool {
                 self.target.is_safe_to_cache_prepared()
             }
+
+            fn is_empty(&self) -> bool {
+                self.target.is_empty()
+            }
         }
 
         impl_query_id!($type_name<T>);

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -26,6 +26,10 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.0.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl_query_id!(Grouped<T>);

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -35,6 +35,10 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.0.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl<T, QS> SelectableExpression<QS> for Nullable<T> where

--- a/diesel/src/persistable.rs
+++ b/diesel/src/persistable.rs
@@ -27,6 +27,7 @@ pub trait InsertValues<DB: Backend> {
     fn column_names(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
     fn values_clause(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
     fn values_bind_params(&self, out: &mut DB::BindCollector) -> QueryResult<()>;
+    fn is_empty(&self) -> bool;
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -96,5 +97,9 @@ impl<'a, T, U: 'a, DB> InsertValues<DB> for BatchInsertValues<'a, T, U, DB> wher
             try!(record.values().values_bind_params(out));
         }
         Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.values.is_empty()
     }
 }

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -122,6 +122,10 @@ impl<Expr, ST> QueryFragment<Pg> for Any<Expr, ST> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.expr.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.expr.is_empty()
+    }
 }
 
 impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
@@ -141,6 +145,10 @@ impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.expr.is_safe_to_cache_prepared()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.expr.is_empty()
     }
 }
 
@@ -200,6 +208,10 @@ impl<Expr, ST> QueryFragment<Pg> for All<Expr, ST> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.expr.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.expr.is_empty()
+    }
 }
 
 impl<Expr, ST> QueryFragment<Debug> for All<Expr, ST> where
@@ -219,6 +231,10 @@ impl<Expr, ST> QueryFragment<Debug> for All<Expr, ST> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.expr.is_safe_to_cache_prepared()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.expr.is_empty()
     }
 }
 

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -42,6 +42,10 @@ impl<T, U, DB> QueryFragment<DB> for DeleteStatement<T, U> where
         self.0.table.from_clause().is_safe_to_cache_prepared() &&
             self.0.where_clause.as_ref().map(|w| w.is_safe_to_cache_prepared()).unwrap_or(true)
     }
+
+    fn is_empty(&self) -> bool {
+        self.0.where_clause.as_ref().map(|w| w.is_empty()).unwrap_or(false)
+    }
 }
 
 impl_query_id!(noop: DeleteStatement<T, U>);
@@ -137,6 +141,10 @@ impl<T, U, DB> QueryFragment<DB> for DeleteQuery<T, U> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.statement.is_safe_to_cache_prepared() &&
             self.returning.is_safe_to_cache_prepared()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.statement.is_empty()
     }
 }
 

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -71,6 +71,10 @@ impl<T, U, Op, DB> QueryFragment<DB> for InsertStatement<T, U, Op> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
     }
+
+    fn is_empty(&self) -> bool {
+        self.records.values().is_empty()
+    }
 }
 
 impl_query_id!(noop: InsertStatement<T, U, Op>);
@@ -168,6 +172,10 @@ impl<T, U, DB> QueryFragment<DB> for InsertQuery<T, U> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
+    }
+
+    fn is_empty(&self) -> bool {
+        self.statement.is_empty()
     }
 }
 

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -79,6 +79,9 @@ pub trait QueryFragment<DB: Backend> {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
     fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()>;
     fn is_safe_to_cache_prepared(&self) -> bool;
+    fn is_empty(&self) -> bool {
+        false
+    }
 }
 
 impl<T: ?Sized, DB> QueryFragment<DB> for Box<T> where
@@ -96,6 +99,10 @@ impl<T: ?Sized, DB> QueryFragment<DB> for Box<T> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         QueryFragment::is_safe_to_cache_prepared(&**self)
     }
+
+    fn is_empty(&self) -> bool {
+        QueryFragment::is_empty(&**self)
+    }
 }
 
 impl<'a, T: ?Sized, DB> QueryFragment<DB> for &'a T where
@@ -112,6 +119,10 @@ impl<'a, T: ?Sized, DB> QueryFragment<DB> for &'a T where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         QueryFragment::is_safe_to_cache_prepared(&**self)
+    }
+
+    fn is_empty(&self) -> bool {
+        QueryFragment::is_empty(&**self)
     }
 }
 

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -107,6 +107,10 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
             self.limit.is_safe_to_cache_prepared() &&
             self.offset.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.where_clause.as_ref().map(|w| w.is_empty()).unwrap_or(false)
+    }
 }
 
 impl<'a, ST, QS, DB> QueryId for BoxedSelectStatement<'a, ST, QS, DB> {

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -187,6 +187,10 @@ impl<ST, S, F, D, W, O, L, Of, G, DB> QueryFragment<DB>
             self.limit.is_safe_to_cache_prepared() &&
             self.offset.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.where_clause.is_empty()
+    }
 }
 
 impl<ST, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
@@ -231,6 +235,10 @@ impl<ST, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
             self.order.is_safe_to_cache_prepared() &&
             self.limit.is_safe_to_cache_prepared() &&
             self.offset.is_safe_to_cache_prepared()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.where_clause.is_empty()
     }
 }
 

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -74,6 +74,10 @@ impl<T, U, V, DB> QueryFragment<DB> for UpdateStatement<T, U, V> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
     }
+
+    fn is_empty(&self) -> bool {
+        self.where_clause.as_ref().map(|w| w.is_empty()).unwrap_or(false)
+    }
 }
 
 impl_query_id!(noop: UpdateStatement<T, U, V>);
@@ -168,6 +172,10 @@ impl<T, U, DB> QueryFragment<DB> for UpdateQuery<T, U> where
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         false
+    }
+
+    fn is_empty(&self) -> bool {
+        self.statement.is_empty()
     }
 }
 

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -66,6 +66,10 @@ impl<DB, Expr> QueryFragment<DB> for WhereClause<Expr> where
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.0.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl_query_id!(WhereClause<T>);

--- a/diesel/src/query_dsl/with_dsl.rs
+++ b/diesel/src/query_dsl/with_dsl.rs
@@ -82,6 +82,10 @@ impl<T: QueryFragment<Pg>> QueryFragment<Pg> for PgOnly<T> {
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.0.is_safe_to_cache_prepared()
     }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 use backend::*;
@@ -97,5 +101,9 @@ impl<T: QueryFragment<Debug>> QueryFragment<Debug> for PgOnly<T> {
 
     fn is_safe_to_cache_prepared(&self) -> bool {
         self.0.is_safe_to_cache_prepared()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -156,6 +156,10 @@ macro_rules! tuple_impls {
                     )+
                     Ok(())
                 }
+
+                fn is_empty(&self) -> bool {
+                    false
+                }
             }
 
             #[cfg(feature = "sqlite")]
@@ -216,6 +220,10 @@ macro_rules! tuple_impls {
                         }
                     )+
                     Ok(())
+                }
+
+                fn is_empty(&self) -> bool {
+                    false
                 }
             }
 

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -139,6 +139,52 @@ fn filter_by_in() {
         users.filter(name.eq_any(borrowed_names)).load(&connection).unwrap());
 }
 
+#[test]
+fn filter_by_in_empty() {
+    use schema::users::dsl::*;
+
+    let connection = connection_with_3_users();
+
+    let owned_names = Vec::<&str>::new();
+    let borrowed_names: &[&str] = &[];
+    print_sql!(select(name.eq_any(owned_names.clone())));
+    assert_eq!(Vec::<User>::new(),
+        users.filter(name.eq_any(owned_names)).load(&connection).unwrap());
+    assert_eq!(Vec::<User>::new(),
+        users.filter(name.eq_any(borrowed_names)).load(&connection).unwrap());
+}
+
+#[test]
+fn filter_by_in_empty_and() {
+    use schema::users::dsl::*;
+
+    let connection = connection_with_3_users();
+
+    let owned_names = Vec::<&str>::new();
+    let borrowed_names: &[&str] = &[];
+    print_sql!(select(name.eq_any(owned_names.clone()).and(name.eq("Jim"))));
+    assert_eq!(Vec::<User>::new(),
+        users.filter(name.eq_any(owned_names).and(name.eq("Jim"))).load(&connection).unwrap());
+    assert_eq!(Vec::<User>::new(),
+        users.filter(name.eq_any(borrowed_names).and((name.eq("Jim")))).load(&connection).unwrap());
+}
+
+#[test]
+fn filter_by_in_empty_or() {
+    use schema::users::dsl::*;
+
+    let connection = connection_with_3_users();
+    let r = vec![User::new(3, "Jim")];
+
+    let owned_names = Vec::<&str>::new();
+    let borrowed_names: &[&str] = &[];
+    print_sql!(select(name.eq_any(owned_names.clone()).or(name.eq("Jim"))));
+    assert_eq!(r,
+        users.filter(name.eq_any(owned_names).or(name.eq("Jim"))).load(&connection).unwrap());
+    assert_eq!(r,
+        users.filter(name.eq_any(borrowed_names).or(name.eq("Jim"))).load(&connection).unwrap());
+}
+
 fn connection_with_3_users() -> TestConnection {
     let connection = connection_with_sean_and_tess_in_users_table();
     connection.execute("INSERT INTO users (id, name) VALUES (3, 'Jim')").unwrap();

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -182,3 +182,17 @@ fn insert_on_conflict_replace() {
     let names = users.select(name).order(id).load::<String>(&connection);
     assert_eq!(Ok(expected_names), names);
 }
+
+
+#[test]
+fn insert_records_empty_array() {
+    use schema::users::table as users;
+    let connection = connection();
+    let new_users: &[NewUser] = &[];
+
+    batch_insert(new_users, users, &connection);
+    let actual_users: Vec<User> = users.load::<User>(&connection).unwrap();
+
+    let expected_users: Vec<User> = vec![];
+    assert_eq!(expected_users, actual_users);
+}


### PR DESCRIPTION
 Check if a queryresult would be empty
- do not execute such queries, because they are invalid, instead simply
  return nothing

Fix #384
