### PR TITLE
Update `FindDsl` to work with composite primary keys

### DIFF
--- a/diesel/src/expression/expression_methods/eq_all.rs
+++ b/diesel/src/expression/expression_methods/eq_all.rs
@@ -1,0 +1,57 @@
+use expression::Expression;
+use expression::predicates::And;
+use expression::expression_methods::*;
+use types::Bool;
+
+/// This method is used by `FindDsl` to work with tuples. Because we cannot
+/// express this without specialization or overlapping impls, it is brute force
+/// implemented on columns in the `column!` macro.
+#[doc(hidden)]
+pub trait EqAll<Rhs> {
+    type Output: Expression<SqlType=Bool>;
+
+    fn eq_all(self, rhs: Rhs) -> Self::Output;
+}
+
+// FIXME: This is much easier to represent with a macro once macro types are stable
+// which appears to be slated for 1.13
+impl<L1, L2, R1, R2> EqAll<(R1, R2)> for (L1, L2) where
+    L1: EqAll<R1>,
+    L2: EqAll<R2>,
+{
+    type Output = And<<L1 as EqAll<R1>>::Output, <L2 as EqAll<R2>>::Output>;
+
+    fn eq_all(self, rhs: (R1, R2)) -> Self::Output {
+        self.0.eq_all(rhs.0).and(self.1.eq_all(rhs.1))
+    }
+}
+
+impl<L1, L2, L3, R1, R2, R3> EqAll<(R1, R2, R3)> for (L1, L2, L3) where
+    L1: EqAll<R1>,
+    L2: EqAll<R2>,
+    L3: EqAll<R3>,
+{
+    type Output = And<<L1 as EqAll<R1>>::Output, And<<L2 as EqAll<R2>>::Output, <L3 as EqAll<R3>>::Output>>;
+
+    fn eq_all(self, rhs: (R1, R2, R3)) -> Self::Output {
+        self.0.eq_all(rhs.0).and(
+            self.1.eq_all(rhs.1).and(self.2.eq_all(rhs.2)))
+    }
+}
+
+impl<L1, L2, L3, L4, R1, R2, R3, R4> EqAll<(R1, R2, R3, R4)> for (L1, L2, L3, L4) where
+    L1: EqAll<R1>,
+    L2: EqAll<R2>,
+    L3: EqAll<R3>,
+    L4: EqAll<R4>,
+{
+    type Output = And<<L1 as EqAll<R1>>::Output, And<<L2 as EqAll<R2>>::Output, And<<L3 as EqAll<R3>>::Output, <L4 as EqAll<R4>>::Output>>>;
+
+    fn eq_all(self, rhs: (R1, R2, R3, R4)) -> Self::Output {
+        self.0.eq_all(rhs.0).and(
+            self.1.eq_all(rhs.1).and(
+            self.2.eq_all(rhs.2).and(
+            self.3.eq_all(rhs.3)
+            )))
+    }
+}

--- a/diesel/src/expression/expression_methods/mod.rs
+++ b/diesel/src/expression/expression_methods/mod.rs
@@ -8,11 +8,15 @@ pub mod bool_expression_methods;
 pub mod escape_expression_methods;
 pub mod global_expression_methods;
 pub mod text_expression_methods;
+#[doc(hidden)]
+pub mod eq_all;
 
 pub use self::bool_expression_methods::BoolExpressionMethods;
 pub use self::escape_expression_methods::EscapeExpressionMethods;
 pub use self::global_expression_methods::ExpressionMethods;
 pub use self::text_expression_methods::TextExpressionMethods;
+#[doc(hidden)]
+pub use self::eq_all::EqAll;
 
 #[cfg(feature = "postgres")]
 pub use pg::expression::expression_methods::*;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -61,6 +61,17 @@ macro_rules! __diesel_column {
                 stringify!($column_name)
             }
         }
+
+        impl<T> $crate::EqAll<T> for $column_name where
+            T: $crate::expression::AsExpression<$Type>,
+            $crate::expression::helper_types::Eq<$column_name, T>: $crate::Expression<SqlType=$crate::types::Bool>,
+        {
+            type Output = $crate::expression::helper_types::Eq<Self, T>;
+
+            fn eq_all(self, rhs: T) -> Self::Output {
+                $crate::ExpressionMethods::eq(self, rhs)
+            }
+        }
     }
 }
 

--- a/diesel_codegen_shared/src/schema_inference/mod.rs
+++ b/diesel_codegen_shared/src/schema_inference/mod.rs
@@ -96,6 +96,12 @@ pub fn get_primary_keys(
     if primary_keys.is_empty() {
         Err(format!("Diesel only supports tables with primary keys. \
                     Table {} has no primary key", table_name).into())
+    } else if primary_keys.len() > 4 {
+        Err(format!("Diesel does not currently support tables with \
+                     primary keys consisting of more than 4 columns. \
+                     Table {} has {} columns in its primary key. \
+                     Please open an issue and we will increase the \
+                     limit.", table_name, primary_keys.len()).into())
     } else {
         Ok(primary_keys)
     }

--- a/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -29,5 +29,4 @@ fn main() {
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -31,10 +31,6 @@ stable_sqlite = ["with-syntex", "sqlite", "diesel_codegen_syntex/sqlite"]
 unstable_postgres = ["unstable", "postgres", "diesel_codegen/postgres"]
 unstable_sqlite = ["unstable", "sqlite", "diesel_codegen/sqlite"]
 
-[lib]
-name = "integration_tests"
-path = "tests/lib.rs"
-
 [[test]]
 name = "integration_tests"
 path = "tests/lib.rs"

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -35,3 +35,20 @@ fn find_with_non_serial_pk() {
     assert_eq!(Ok(("Tess".to_string(),)), users.find("Tess".to_string()).first(&connection));
     assert_eq!(Ok(None::<(String,)>), users.find("Wibble").first(&connection).optional());
 }
+
+#[test]
+fn find_with_composite_pk() {
+    use schema::followings::dsl::*;
+
+    let first_following = Following { user_id: 1, post_id: 1, email_notifications: true };
+    let second_following = Following { user_id: 1, post_id: 2, email_notifications: false };
+    let third_following = Following { user_id: 2, post_id: 1, email_notifications: false };
+
+    let connection = connection();
+    batch_insert(&[first_following, second_following, third_following], followings, &connection);
+
+    assert_eq!(Ok(first_following), followings.find((1, 1)).first(&connection));
+    assert_eq!(Ok(second_following), followings.find((1, 2)).first(&connection));
+    assert_eq!(Ok(third_following), followings.find((2, 1)).first(&connection));
+    assert_eq!(Ok(None::<Following>), followings.find((2, 2)).first(&connection).optional());
+}

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -49,8 +49,8 @@ impl Comment {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable)]
+#[table_name="followings"]
 pub struct Following {
     pub user_id: i32,
     pub post_id: i32,


### PR DESCRIPTION
This introduces a new expression method, `eq_all` which is not in the
public API. For single values, it is identical to `eq`. For tuples, it
represents all of the tuple elements matching.

I unfortunately could not implement `eq_all` for all types, as the base
impl would always overlap with the tuple impls. Since this is meant to
be used with `FindDsl` for now, which always has a column as the left
hand side, we brute force it.

Additionally, I couldn't easily implement this for arbitrarily large
tuples with a macro. This might get a bit easier when macro types lands
(but the code might still be complex enough to not warrant it). The
overwhelming majority of cases here will be 2 element tuples. I've
manually done it for 4 elements just to be safe.
