### PR TITLE
Use constants instead of string literals

### DIFF
--- a/diesel_codegen/src/as_changeset.rs
+++ b/diesel_codegen/src/as_changeset.rs
@@ -1,28 +1,24 @@
 use syn;
 use quote;
 
-use constants::custom_attrs::CHANGESET_OPTIONS;
-use constants::custom_attr_options::TREAT_NONE_AS_NULL;
-use constants::custom_derives::AS_CHANGESET;
-use constants::syntax::{ID, LIFETIME_A};
-use constants::values::TRUE;
+use constants::{custom_attrs, custom_attr_options, custom_derives, syntax, values};
 use model::Model;
 use util::attr_with_name;
 
 pub fn derive_as_changeset(item: syn::MacroInput) -> quote::Tokens {
     let treat_none_as_null = format!("{}", treat_none_as_null(&item.attrs));
-    let model = t!(Model::from_item(&item, AS_CHANGESET));
+    let model = t!(Model::from_item(&item, custom_derives::AS_CHANGESET));
 
     let struct_name = &model.name;
     let table_name = model.table_name();
     let struct_ty = &model.ty;
     let mut lifetimes = item.generics.lifetimes;
     let attrs = model.attrs.into_iter()
-        .filter(|a| a.column_name != Some(syn::Ident::new(ID)))
+        .filter(|a| a.column_name != Some(syn::Ident::new(syntax::ID)))
         .collect::<Vec<_>>();
 
     if lifetimes.is_empty() {
-        lifetimes.push(syn::LifetimeDef::new(LIFETIME_A));
+        lifetimes.push(syn::LifetimeDef::new(syntax::LIFETIME_A));
     }
 
     quote!(AsChangeset! {
@@ -38,14 +34,14 @@ pub fn derive_as_changeset(item: syn::MacroInput) -> quote::Tokens {
 }
 
 fn treat_none_as_null(attrs: &[syn::Attribute]) -> bool {
-    let options_attr = match attr_with_name(attrs, CHANGESET_OPTIONS) {
+    let options_attr = match attr_with_name(attrs, custom_attrs::CHANGESET_OPTIONS) {
         Some(attr) => attr,
         None => return false,
     };
 
     let usage_err = || panic!(r#"`#[{}]` must be in the form \
-        `#[{}({} = "{}")]`"#, CHANGESET_OPTIONS,
-        CHANGESET_OPTIONS, TREAT_NONE_AS_NULL, TRUE);
+        `#[{}({} = "{}")]`"#, custom_attrs::CHANGESET_OPTIONS,
+        custom_attrs::CHANGESET_OPTIONS, custom_attr_options::TREAT_NONE_AS_NULL, values::TRUE);
 
     match options_attr.value {
         syn::MetaItem::List(_, ref values) => {
@@ -54,7 +50,7 @@ fn treat_none_as_null(attrs: &[syn::Attribute]) -> bool {
             }
             match values[0] {
                 syn::MetaItem::NameValue(ref name, syn::Lit::Str(ref value, _))
-                    if name == TREAT_NONE_AS_NULL => value == TRUE,
+                    if name == custom_attr_options::TREAT_NONE_AS_NULL => value == values::TRUE,
                 _ => usage_err(),
             }
         }

--- a/diesel_codegen/src/associations.rs
+++ b/diesel_codegen/src/associations.rs
@@ -1,24 +1,22 @@
 use syn;
 use quote;
 
-use constants::custom_attrs::{BELONGS_TO, HAS_MANY};
-use constants::custom_attr_options::{FOREIGN_KEY, TABLE_NAME};
-use constants::custom_derives::ASSOCIATIONS;
+use constants::{custom_attrs, custom_attr_options, custom_derives};
 use model::{Model, infer_association_name};
 use util::str_value_of_meta_item;
 
 pub fn derive_associations(input: syn::MacroInput) -> quote::Tokens {
     let mut derived_associations = Vec::new();
-    let model = t!(Model::from_item(&input, ASSOCIATIONS));
+    let model = t!(Model::from_item(&input, custom_derives::ASSOCIATIONS));
 
     for attr in &input.attrs {
-        if attr.name() == HAS_MANY {
-            let options = t!(build_association_options(attr, HAS_MANY));
+        if attr.name() == custom_attrs::HAS_MANY {
+            let options = t!(build_association_options(attr, custom_attrs::HAS_MANY));
             derived_associations.push(expand_has_many(&model, options))
         }
 
-        if attr.name() == BELONGS_TO {
-            let options = t!(build_association_options(attr, BELONGS_TO));
+        if attr.name() == custom_attrs::BELONGS_TO {
+            let options = t!(build_association_options(attr, custom_attrs::BELONGS_TO));
             derived_associations.push(expand_belongs_to(&model, options))
         }
     }
@@ -74,15 +72,16 @@ fn build_association_options(
 ) -> Result<AssociationOptions, String> {
     let usage_error = Err(format!(
             "`#[{}]` must be in the form `#[{}({}, option=value)]`",
-            association_kind, association_kind, TABLE_NAME));
+            association_kind, association_kind, custom_attr_options::TABLE_NAME));
     match attr.value {
         syn::MetaItem::List(_, ref options) if options.len() >= 1 => {
             let association_name = match options[0] {
                 syn::MetaItem::Word(ref name) => name.clone(),
                 _ => return usage_error,
             };
-            let foreign_key_name = options.iter().find(|a| a.name() == FOREIGN_KEY)
-                .map(|a| str_value_of_meta_item(a, FOREIGN_KEY))
+            let foreign_key_name = options.iter()
+                .find(|a| a.name() == custom_attr_options::FOREIGN_KEY)
+                .map(|a| str_value_of_meta_item(a, custom_attr_options::FOREIGN_KEY))
                 .map(syn::Ident::new);
 
             Ok(AssociationOptions {

--- a/diesel_codegen/src/associations.rs
+++ b/diesel_codegen/src/associations.rs
@@ -1,21 +1,24 @@
 use syn;
 use quote;
 
+use constants::custom_attrs::{BELONGS_TO, HAS_MANY};
+use constants::custom_attr_options::{FOREIGN_KEY, TABLE_NAME};
+use constants::custom_derives::ASSOCIATIONS;
 use model::{Model, infer_association_name};
 use util::str_value_of_meta_item;
 
 pub fn derive_associations(input: syn::MacroInput) -> quote::Tokens {
     let mut derived_associations = Vec::new();
-    let model = t!(Model::from_item(&input, "Associations"));
+    let model = t!(Model::from_item(&input, ASSOCIATIONS));
 
     for attr in &input.attrs {
-        if attr.name() == "has_many" {
-            let options = t!(build_association_options(attr, "has_many"));
+        if attr.name() == HAS_MANY {
+            let options = t!(build_association_options(attr, HAS_MANY));
             derived_associations.push(expand_has_many(&model, options))
         }
 
-        if attr.name() == "belongs_to" {
-            let options = t!(build_association_options(attr, "belongs_to"));
+        if attr.name() == BELONGS_TO {
+            let options = t!(build_association_options(attr, BELONGS_TO));
             derived_associations.push(expand_belongs_to(&model, options))
         }
     }
@@ -70,16 +73,16 @@ fn build_association_options(
     association_kind: &str,
 ) -> Result<AssociationOptions, String> {
     let usage_error = Err(format!(
-            "`#[{}]` must be in the form `#[{}(table_name, option=value)]`",
-            association_kind, association_kind));
+            "`#[{}]` must be in the form `#[{}({}, option=value)]`",
+            association_kind, association_kind, TABLE_NAME));
     match attr.value {
         syn::MetaItem::List(_, ref options) if options.len() >= 1 => {
             let association_name = match options[0] {
                 syn::MetaItem::Word(ref name) => name.clone(),
                 _ => return usage_error,
             };
-            let foreign_key_name = options.iter().find(|a| a.name() == "foreign_key")
-                .map(|a| str_value_of_meta_item(a, "foreign_key"))
+            let foreign_key_name = options.iter().find(|a| a.name() == FOREIGN_KEY)
+                .map(|a| str_value_of_meta_item(a, FOREIGN_KEY))
                 .map(syn::Ident::new);
 
             Ok(AssociationOptions {

--- a/diesel_codegen/src/attr.rs
+++ b/diesel_codegen/src/attr.rs
@@ -1,6 +1,9 @@
 use quote;
 use syn;
 
+use constants::field_attrs::COLUMN_NAME;
+use constants::field_types::*;
+use constants::syntax;
 use util::{ident_value_of_attr_with_name, is_option_ty};
 
 pub struct Attr {
@@ -12,7 +15,7 @@ pub struct Attr {
 impl Attr {
     pub fn from_struct_field(field: &syn::Field) -> Self {
         let field_name = field.ident.clone();
-        let column_name = ident_value_of_attr_with_name(&field.attrs, "column_name")
+        let column_name = ident_value_of_attr_with_name(&field.attrs, COLUMN_NAME)
             .map(Clone::clone)
             .or_else(|| field_name.clone());
         let ty = field.ty.clone();
@@ -26,11 +29,11 @@ impl Attr {
 
     fn field_kind(&self) -> &str {
         if is_option_ty(&self.ty) {
-            "option"
+            OPTION
         } else if self.column_name.is_none() && self.field_name.is_none() {
-            "bare"
+            BARE
         } else {
-            "regular"
+            REGULAR
         }
     }
 }
@@ -39,19 +42,19 @@ impl quote::ToTokens for Attr {
     fn to_tokens(&self, tokens: &mut quote::Tokens) {
         tokens.append("{");
         if let Some(ref name) = self.field_name {
-            tokens.append("field_name: ");
+            tokens.append(&format!("{}: ", syntax::FIELD_NAME));
             name.to_tokens(tokens);
             tokens.append(", ");
         }
         if let Some(ref name) = self.column_name {
-            tokens.append("column_name: ");
+            tokens.append(&format!("{}: ", syntax::COLUMN_NAME));
             name.to_tokens(tokens);
             tokens.append(", ");
         }
-        tokens.append("field_ty: ");
+        tokens.append(&format!("{}: ", syntax::FIELD_TY));
         self.ty.to_tokens(tokens);
         tokens.append(", ");
-        tokens.append("field_kind: ");
+        tokens.append(&format!("{}: ", syntax::FIELD_KIND));
         tokens.append(self.field_kind());
         tokens.append(", ");
         tokens.append("}");

--- a/diesel_codegen/src/attr.rs
+++ b/diesel_codegen/src/attr.rs
@@ -1,9 +1,7 @@
 use quote;
 use syn;
 
-use constants::field_attrs::COLUMN_NAME;
-use constants::field_types::*;
-use constants::syntax;
+use constants::{field_attrs, field_types, syntax};
 use util::{ident_value_of_attr_with_name, is_option_ty};
 
 pub struct Attr {
@@ -15,7 +13,7 @@ pub struct Attr {
 impl Attr {
     pub fn from_struct_field(field: &syn::Field) -> Self {
         let field_name = field.ident.clone();
-        let column_name = ident_value_of_attr_with_name(&field.attrs, COLUMN_NAME)
+        let column_name = ident_value_of_attr_with_name(&field.attrs, field_attrs::COLUMN_NAME)
             .map(Clone::clone)
             .or_else(|| field_name.clone());
         let ty = field.ty.clone();
@@ -29,11 +27,11 @@ impl Attr {
 
     fn field_kind(&self) -> &str {
         if is_option_ty(&self.ty) {
-            OPTION
+            field_types::OPTION
         } else if self.column_name.is_none() && self.field_name.is_none() {
-            BARE
+            field_types::BARE
         } else {
-            REGULAR
+            field_types::REGULAR
         }
     }
 }

--- a/diesel_codegen/src/constants.rs
+++ b/diesel_codegen/src/constants.rs
@@ -1,0 +1,102 @@
+macro_rules! str_consts {
+    ($name:ident [$($key:ident => $val:expr),+]) => {
+        pub mod $name {
+            $(
+                pub const $key: &'static str = $val;
+            )+
+        }
+    };
+
+    ($name:ident [$($key:ident => $val:expr),+], $all:ident) => {
+        str_consts! {
+            $name [
+                $($key => $val),+
+            ]
+        }
+
+        pub const $all: &'static [&'static str] = &[
+            $(
+                $name::$key,
+            )+
+        ];
+    }
+}
+
+str_consts! {
+    custom_derives [
+        AS_CHANGESET => "AsChangeset",
+        ASSOCIATIONS => "Associations",
+        IDENTIFIABLE => "Identifiable",
+        INSERTABLE   => "Insertable",
+        QUERYABLE    => "Queryable"
+    ],
+
+    KNOWN_CUSTOM_DERIVES
+}
+
+str_consts! {
+    custom_attrs [
+        BELONGS_TO        => "belongs_to",
+        CHANGESET_OPTIONS => "changeset_options",
+        HAS_MANY          => "has_many",
+        TABLE_NAME        => "table_name"
+    ],
+
+    KNOWN_CUSTOM_ATTRS
+}
+
+str_consts! {
+    field_attrs [
+        COLUMN_NAME => "column_name"
+    ],
+
+    KNOWN_FIELD_ATTRS
+}
+
+str_consts! {
+    attrs [
+        DERIVE  => "derive",
+        OPTIONS => "options"
+    ]
+}
+
+str_consts! {
+    custom_attr_options [
+        FOREIGN_KEY        => "foreign_key",
+        DATABASE_URL       => "database_url",
+        TABLE_NAME         => "table_name",
+        TREAT_NONE_AS_NULL => "treat_none_as_null"
+    ]
+}
+
+str_consts! {
+    macro_options [
+        MIGRATIONS_PATH => "migrations_path"
+    ]
+}
+
+str_consts! {
+    values [
+        TRUE => "true"
+    ]
+}
+
+str_consts! {
+    syntax [
+        ID          => "id",
+        OPTION_TY   => "Option",
+        LIFETIME_A  => "'a'",
+        COLUMN_NAME => "column_name",
+        FIELD_KIND  => "field_kind",
+        FIELD_NAME  => "field_name",
+        FIELD_TY    => "field_ty"
+    ]
+}
+
+str_consts! {
+    field_types [
+        BARE    => "bare",
+        OPTION  => "option",
+        REGULAR => "regular"
+    ]
+}

--- a/diesel_codegen/src/embed_migrations.rs
+++ b/diesel_codegen/src/embed_migrations.rs
@@ -6,6 +6,7 @@ use diesel_codegen_shared::migration_directory_from_given_path;
 use std::error::Error;
 use std::path::Path;
 
+use constants::macro_options::MIGRATIONS_PATH;
 use util::{get_options_from_input, get_option};
 
 pub fn derive_embed_migrations(input: syn::MacroInput) -> quote::Tokens {
@@ -15,7 +16,7 @@ pub fn derive_embed_migrations(input: syn::MacroInput) -> quote::Tokens {
     }
 
     let options = get_options_from_input(&input.attrs, bug);
-    let migrations_path_opt = options.map(|o| get_option(&o, "migrations_path", bug));
+    let migrations_path_opt = options.map(|o| get_option(&o, MIGRATIONS_PATH, bug));
     let migrations_expr = migration_directory_from_given_path(migrations_path_opt)
         .and_then(|path| migration_literals_from_path(&path));
     let migrations_expr = match migrations_expr {

--- a/diesel_codegen/src/embed_migrations.rs
+++ b/diesel_codegen/src/embed_migrations.rs
@@ -6,7 +6,7 @@ use diesel_codegen_shared::migration_directory_from_given_path;
 use std::error::Error;
 use std::path::Path;
 
-use constants::macro_options::MIGRATIONS_PATH;
+use constants::macro_options;
 use util::{get_options_from_input, get_option};
 
 pub fn derive_embed_migrations(input: syn::MacroInput) -> quote::Tokens {
@@ -16,7 +16,7 @@ pub fn derive_embed_migrations(input: syn::MacroInput) -> quote::Tokens {
     }
 
     let options = get_options_from_input(&input.attrs, bug);
-    let migrations_path_opt = options.map(|o| get_option(&o, MIGRATIONS_PATH, bug));
+    let migrations_path_opt = options.map(|o| get_option(&o, macro_options::MIGRATIONS_PATH, bug));
     let migrations_expr = migration_directory_from_given_path(migrations_path_opt)
         .and_then(|path| migration_literals_from_path(&path));
     let migrations_expr = match migrations_expr {

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -1,15 +1,17 @@
 use quote::Tokens;
 use syn;
 
+use constants::custom_derives::IDENTIFIABLE;
+use constants::syntax::ID;
 use model::Model;
 
 pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
-    let model = t!(Model::from_item(&item, "Identifiable"));
+    let model = t!(Model::from_item(&item, IDENTIFIABLE));
     let table_name = model.table_name();
     let struct_ty = &model.ty;
     let fields = model.attrs;
-    if !fields.iter().any(|f| f.field_name == Some(syn::Ident::new("id"))) {
-        panic!("Could not find a field named `id` on `{}`", &model.name);
+    if !fields.iter().any(|f| f.field_name == Some(syn::Ident::new(ID))) {
+        panic!("Could not find a field named `{}` on `{}`", ID, &model.name);
     }
 
     quote!(Identifiable! {

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -1,17 +1,16 @@
 use quote::Tokens;
 use syn;
 
-use constants::custom_derives::IDENTIFIABLE;
-use constants::syntax::ID;
+use constants::{custom_derives, syntax};
 use model::Model;
 
 pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
-    let model = t!(Model::from_item(&item, IDENTIFIABLE));
+    let model = t!(Model::from_item(&item, custom_derives::IDENTIFIABLE));
     let table_name = model.table_name();
     let struct_ty = &model.ty;
     let fields = model.attrs;
-    if !fields.iter().any(|f| f.field_name == Some(syn::Ident::new(ID))) {
-        panic!("Could not find a field named `{}` on `{}`", ID, &model.name);
+    if !fields.iter().any(|f| f.field_name == Some(syn::Ident::new(syntax::ID))) {
+        panic!("Could not find a field named `{}` on `{}`", syntax::ID, &model.name);
     }
 
     quote!(Identifiable! {

--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -1,21 +1,21 @@
 use syn;
 use quote;
 
-use constants::attrs::DERIVE;
-use constants::custom_attrs::TABLE_NAME;
-use constants::custom_derives::INSERTABLE;
+use constants::{attrs, custom_attrs, custom_derives};
 use model::Model;
 
 pub fn derive_insertable(item: syn::MacroInput) -> quote::Tokens {
-    let model = t!(Model::from_item(&item, INSERTABLE));
+    let model = t!(Model::from_item(&item, custom_derives::INSERTABLE));
 
     if !model.has_table_name_annotation() {
         panic!(r#"`#[{}({})]` requires the struct to be annotated \
-            with `#[{}="something"]`"#, DERIVE, INSERTABLE, TABLE_NAME);
+            with `#[{}="something"]`"#, attrs::DERIVE, custom_derives::INSERTABLE,
+            custom_attrs::TABLE_NAME);
     }
 
     if !model.generics.ty_params.is_empty() {
-        panic!("`#[{}({})]` does not support generic types", DERIVE, INSERTABLE);
+        panic!("`#[{}({})]` does not support generic types", attrs::DERIVE,
+            custom_derives::INSERTABLE);
     }
 
     let struct_name = &model.name;

--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -1,18 +1,21 @@
 use syn;
 use quote;
 
+use constants::attrs::DERIVE;
+use constants::custom_attrs::TABLE_NAME;
+use constants::custom_derives::INSERTABLE;
 use model::Model;
 
 pub fn derive_insertable(item: syn::MacroInput) -> quote::Tokens {
-    let model = t!(Model::from_item(&item, "Insertable"));
+    let model = t!(Model::from_item(&item, INSERTABLE));
 
     if !model.has_table_name_annotation() {
-        panic!(r#"`#[derive(Insertable)]` requires the struct to be annotated \
-            with `#[table_name="something"]`"#);
+        panic!(r#"`#[{}({})]` requires the struct to be annotated \
+            with `#[{}="something"]`"#, DERIVE, INSERTABLE, TABLE_NAME);
     }
 
     if !model.generics.ty_params.is_empty() {
-        panic!("`#[derive(Insertable)]` does not support generic types");
+        panic!("`#[{}({})]` does not support generic types", DERIVE, INSERTABLE);
     }
 
     let struct_name = &model.name;

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -35,7 +35,7 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 use constants::{KNOWN_CUSTOM_ATTRS, KNOWN_CUSTOM_DERIVES, KNOWN_FIELD_ATTRS};
-use constants::attrs::DERIVE;
+use constants::attrs;
 use self::util::{list_value_of_attr_with_name, strip_attributes, strip_field_attributes};
 
 #[proc_macro_derive(Queryable)]
@@ -91,7 +91,7 @@ fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) ->
     let output = f(item.clone());
 
     let finished_deriving_diesel_traits = {
-        let remaining_derives = list_value_of_attr_with_name(&item.attrs, DERIVE);
+        let remaining_derives = list_value_of_attr_with_name(&item.attrs, attrs::DERIVE);
         !remaining_derives
             .unwrap_or(Vec::new())
             .iter()

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -21,6 +21,7 @@ mod as_changeset;
 mod associations;
 mod ast_builder;
 mod attr;
+mod constants;
 mod embed_migrations;
 mod identifiable;
 mod insertable;
@@ -33,26 +34,9 @@ mod util;
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
+use constants::{KNOWN_CUSTOM_ATTRS, KNOWN_CUSTOM_DERIVES, KNOWN_FIELD_ATTRS};
+use constants::attrs::DERIVE;
 use self::util::{list_value_of_attr_with_name, strip_attributes, strip_field_attributes};
-
-const KNOWN_CUSTOM_DERIVES: &'static [&'static str] = &[
-    "AsChangeset",
-    "Associations",
-    "Identifiable",
-    "Insertable",
-    "Queryable",
-];
-
-const KNOWN_CUSTOM_ATTRIBUTES: &'static [&'static str] = &[
-    "belongs_to",
-    "changeset_options",
-    "has_many",
-    "table_name",
-];
-
-const KNOWN_FIELD_ATTRIBUTES: &'static [&'static str] = &[
-    "column_name",
-];
 
 #[proc_macro_derive(Queryable)]
 pub fn derive_queryable(input: TokenStream) -> TokenStream {
@@ -107,7 +91,7 @@ fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) ->
     let output = f(item.clone());
 
     let finished_deriving_diesel_traits = {
-        let remaining_derives = list_value_of_attr_with_name(&item.attrs, "derive");
+        let remaining_derives = list_value_of_attr_with_name(&item.attrs, DERIVE);
         !remaining_derives
             .unwrap_or(Vec::new())
             .iter()
@@ -115,8 +99,8 @@ fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) ->
     };
 
     if finished_deriving_diesel_traits {
-        item.attrs = strip_attributes(item.attrs, KNOWN_CUSTOM_ATTRIBUTES);
-        strip_field_attributes(&mut item, KNOWN_FIELD_ATTRIBUTES);
+        item.attrs = strip_attributes(item.attrs, KNOWN_CUSTOM_ATTRS);
+        strip_field_attributes(&mut item, KNOWN_FIELD_ATTRS);
     }
 
     quote!(#item #output).to_string().parse().unwrap()

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -1,6 +1,8 @@
 use syn;
 
 use attr::Attr;
+use constants::attrs::DERIVE;
+use constants::custom_attrs::TABLE_NAME;
 use util::{struct_ty, str_value_of_attr_with_name};
 
 pub struct Model {
@@ -15,7 +17,7 @@ impl Model {
     pub fn from_item(item: &syn::MacroInput, derived_from: &str) -> Result<Self, String> {
         let fields = match item.body {
             syn::Body::Enum(..) => return Err(format!(
-                "#[derive({})] cannot be used with enums", derived_from)),
+                "#[{}({})] cannot be used with enums", DERIVE, derived_from)),
             syn::Body::Struct(ref fields) => fields.fields(),
         };
         let attrs = fields.into_iter().map(Attr::from_struct_field).collect();
@@ -23,7 +25,7 @@ impl Model {
         let name = item.ident.clone();
         let generics = item.generics.clone();
         let table_name_from_annotation = str_value_of_attr_with_name(
-            &item.attrs, "table_name").map(syn::Ident::new);
+            &item.attrs, TABLE_NAME).map(syn::Ident::new);
 
         Ok(Model {
             ty: ty,

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -1,8 +1,7 @@
 use syn;
 
 use attr::Attr;
-use constants::attrs::DERIVE;
-use constants::custom_attrs::TABLE_NAME;
+use constants::{attrs, custom_attrs};
 use util::{struct_ty, str_value_of_attr_with_name};
 
 pub struct Model {
@@ -17,7 +16,7 @@ impl Model {
     pub fn from_item(item: &syn::MacroInput, derived_from: &str) -> Result<Self, String> {
         let fields = match item.body {
             syn::Body::Enum(..) => return Err(format!(
-                "#[{}({})] cannot be used with enums", DERIVE, derived_from)),
+                "#[{}({})] cannot be used with enums", attrs::DERIVE, derived_from)),
             syn::Body::Struct(ref fields) => fields.fields(),
         };
         let attrs = fields.into_iter().map(Attr::from_struct_field).collect();
@@ -25,7 +24,7 @@ impl Model {
         let name = item.ident.clone();
         let generics = item.generics.clone();
         let table_name_from_annotation = str_value_of_attr_with_name(
-            &item.attrs, TABLE_NAME).map(syn::Ident::new);
+            &item.attrs, custom_attrs::TABLE_NAME).map(syn::Ident::new);
 
         Ok(Model {
             ty: ty,

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -1,10 +1,11 @@
 use quote::Tokens;
 use syn;
 
+use constants::custom_derives::QUERYABLE;
 use model::Model;
 
 pub fn derive_queryable(item: syn::MacroInput) -> Tokens {
-    let model = t!(Model::from_item(&item, "Queryable"));
+    let model = t!(Model::from_item(&item, QUERYABLE));
 
     let struct_ty = &model.ty;
     let struct_name = &model.name;

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -1,11 +1,11 @@
 use quote::Tokens;
 use syn;
 
-use constants::custom_derives::QUERYABLE;
+use constants::custom_derives;
 use model::Model;
 
 pub fn derive_queryable(item: syn::MacroInput) -> Tokens {
-    let model = t!(Model::from_item(&item, QUERYABLE));
+    let model = t!(Model::from_item(&item, custom_derives::QUERYABLE));
 
     let struct_ty = &model.ty;
     let struct_name = &model.name;

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -3,6 +3,7 @@ use quote;
 
 use diesel_codegen_shared::*;
 
+use constants::custom_attr_options::{DATABASE_URL, TABLE_NAME};
 use util::{get_options_from_input, get_option};
 
 pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
@@ -12,7 +13,7 @@ pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
     }
 
     let options = get_options_from_input(&input.attrs, bug).unwrap_or_else(|| bug());
-    let database_url = get_option(&options, "database_url", bug);
+    let database_url = get_option(&options, DATABASE_URL, bug);
 
     let table_names = load_table_names(&database_url).unwrap();
     let schema_inferences = table_names.into_iter().map(|table_name| {
@@ -29,8 +30,8 @@ pub fn derive_infer_table_from_schema(input: syn::MacroInput) -> quote::Tokens {
     }
 
     let options = get_options_from_input(&input.attrs, bug).unwrap_or_else(|| bug());
-    let database_url = get_option(options, "database_url", bug);
-    let table_name = get_option(options, "table_name", bug);
+    let database_url = get_option(options, DATABASE_URL, bug);
+    let table_name = get_option(options, TABLE_NAME, bug);
 
     let connection = establish_connection(database_url).unwrap();
     let data = get_table_data(&connection, table_name).unwrap();

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -3,7 +3,7 @@ use quote;
 
 use diesel_codegen_shared::*;
 
-use constants::custom_attr_options::{DATABASE_URL, TABLE_NAME};
+use constants::custom_attr_options;
 use util::{get_options_from_input, get_option};
 
 pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
@@ -13,7 +13,7 @@ pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
     }
 
     let options = get_options_from_input(&input.attrs, bug).unwrap_or_else(|| bug());
-    let database_url = get_option(&options, DATABASE_URL, bug);
+    let database_url = get_option(&options, custom_attr_options::DATABASE_URL, bug);
 
     let table_names = load_table_names(&database_url).unwrap();
     let schema_inferences = table_names.into_iter().map(|table_name| {
@@ -30,8 +30,8 @@ pub fn derive_infer_table_from_schema(input: syn::MacroInput) -> quote::Tokens {
     }
 
     let options = get_options_from_input(&input.attrs, bug).unwrap_or_else(|| bug());
-    let database_url = get_option(options, DATABASE_URL, bug);
-    let table_name = get_option(options, TABLE_NAME, bug);
+    let database_url = get_option(options, custom_attr_options::DATABASE_URL, bug);
+    let table_name = get_option(options, custom_attr_options::TABLE_NAME, bug);
 
     let connection = establish_connection(database_url).unwrap();
     let data = get_table_data(&connection, table_name).unwrap();

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -2,8 +2,7 @@ use std::mem;
 use syn::*;
 
 use ast_builder::ty_ident;
-use constants::attrs::OPTIONS;
-use constants::syntax::OPTION_TY;
+use constants::{attrs, syntax};
 
 pub fn struct_ty(name: Ident, generics: &Generics) -> Ty {
     let lifetimes = generics.lifetimes.iter().map(|lt| lt.lifetime.clone()).collect();
@@ -95,7 +94,7 @@ fn list_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> Vec<&'a Ident> {
 }
 
 pub fn is_option_ty(ty: &Ty) -> bool {
-    let option_ident = Ident::new(OPTION_TY);
+    let option_ident = Ident::new(syntax::OPTION_TY);
     match *ty {
         Ty::Path(_, ref path) => {
             path.segments.first()
@@ -130,7 +129,7 @@ pub fn strip_field_attributes(item: &mut MacroInput, names_to_strip: &[&str]) {
 pub fn get_options_from_input(attrs: &[Attribute], on_bug: fn() -> !)
     -> Option<&[MetaItem]>
 {
-    let options = attrs.iter().find(|a| a.name() == OPTIONS).map(|a| &a.value);
+    let options = attrs.iter().find(|a| a.name() == attrs::OPTIONS).map(|a| &a.value);
     match options {
         Some(&MetaItem::List(_, ref options)) => Some(options),
         Some(_) => on_bug(),

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -2,6 +2,8 @@ use std::mem;
 use syn::*;
 
 use ast_builder::ty_ident;
+use constants::attrs::OPTIONS;
+use constants::syntax::OPTION_TY;
 
 pub fn struct_ty(name: Ident, generics: &Generics) -> Ty {
     let lifetimes = generics.lifetimes.iter().map(|lt| lt.lifetime.clone()).collect();
@@ -93,7 +95,7 @@ fn list_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> Vec<&'a Ident> {
 }
 
 pub fn is_option_ty(ty: &Ty) -> bool {
-    let option_ident = Ident::new("Option");
+    let option_ident = Ident::new(OPTION_TY);
     match *ty {
         Ty::Path(_, ref path) => {
             path.segments.first()
@@ -128,7 +130,7 @@ pub fn strip_field_attributes(item: &mut MacroInput, names_to_strip: &[&str]) {
 pub fn get_options_from_input(attrs: &[Attribute], on_bug: fn() -> !)
     -> Option<&[MetaItem]>
 {
-    let options = attrs.iter().find(|a| a.name() == "options").map(|a| &a.value);
+    let options = attrs.iter().find(|a| a.name() == OPTIONS).map(|a| &a.value);
     match options {
         Some(&MetaItem::List(_, ref options)) => Some(options),
         Some(_) => on_bug(),


### PR DESCRIPTION
I moved most string literals into `diesel_codegen/src/constants.rs`, and tried to group them in a way that makes sense. I may have gone too namespace-happy, though.

Closes #468.
