### PR TITLE
Fix failures on latest nightlies

### DIFF
--- a/diesel/src/macros/as_changeset.rs
+++ b/diesel/src/macros/as_changeset.rs
@@ -71,12 +71,20 @@
 /// ```
 #[macro_export]
 macro_rules! AsChangeset {
+    ($($args:tt)*) => {
+        _AsChangeset!($($args)*);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _AsChangeset {
     // Provide a default value for treat_none_as_null if not provided
     (
         ($table_name:ident)
         $($body:tt)*
     ) => {
-        AsChangeset! {
+        _AsChangeset! {
             ($table_name, treat_none_as_null="false")
             $($body)*
         }
@@ -88,7 +96,7 @@ macro_rules! AsChangeset {
         $(#[$ignore:meta])*
         $(pub)* struct $($body:tt)*
     ) => {
-        AsChangeset! {
+        _AsChangeset! {
             $args
             $($body)*
         }
@@ -108,7 +116,7 @@ macro_rules! AsChangeset {
                 struct_ty = $struct_name<$($lifetime),*>,
                 lifetimes = ($($lifetime),*),
             ),
-            callback = AsChangeset,
+            callback = _AsChangeset,
             body = $body,
         }
     };
@@ -128,7 +136,7 @@ macro_rules! AsChangeset {
                 struct_ty = $struct_name,
                 lifetimes = ('a),
             ),
-            callback = AsChangeset,
+            callback = _AsChangeset,
             body = $body,
         }
     };
@@ -171,7 +179,7 @@ macro_rules! AsChangeset {
         ),
         changeset_ty = $changeset_ty:ty,
     ) => {
-        AsChangeset! {
+        _AsChangeset! {
             $($headers)*
             self_to_columns = $struct_name($(ref $column_name),+),
             columns = ($($column_name, $field_kind),+),
@@ -194,7 +202,7 @@ macro_rules! AsChangeset {
         ),
         changeset_ty = $changeset_ty:ty,
     ) => {
-        AsChangeset! {
+        _AsChangeset! {
             $($headers)*
             self_to_columns = $struct_name { $($field_name: ref $column_name,)+ ..},
             columns = ($($column_name, $field_kind),+),
@@ -311,7 +319,7 @@ macro_rules! AsChangeset_construct_changeset_ty {
         fields = [],
         changeset_ty = $changeset_ty:ty,
     ) => {
-        AsChangeset!($headers, changeset_ty = $changeset_ty,);
+        _AsChangeset!($headers, changeset_ty = $changeset_ty,);
     }
 }
 

--- a/diesel/src/macros/identifiable.rs
+++ b/diesel/src/macros/identifiable.rs
@@ -27,13 +27,21 @@
 /// ```
 #[macro_export]
 macro_rules! Identifiable {
+    ($($args:tt)*) => {
+        _Identifiable!($($args)*);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _Identifiable {
     // Extract table name from meta item
     (
         $(())*
         #[table_name($table_name:ident)]
         $($rest:tt)*
     ) => {
-        Identifiable! {
+        _Identifiable! {
             (table_name = $table_name,)
             $($rest)*
         }
@@ -45,7 +53,7 @@ macro_rules! Identifiable {
         #[$ignore:meta]
         $($rest:tt)*
     ) => {
-        Identifiable!($args $($rest)*);
+        _Identifiable!($args $($rest)*);
     };
 
     // Strip pub (if present) and struct from definition
@@ -54,7 +62,7 @@ macro_rules! Identifiable {
         $args:tt
         $(pub)* struct $($body:tt)*
     ) => {
-        Identifiable!($args $($body)*);
+        _Identifiable!($args $($body)*);
     };
 
     // We found the `id` field, return the final impl
@@ -94,7 +102,7 @@ macro_rules! Identifiable {
             field_kind: $field_kind:ident,
         } $($fields:tt)*],
     ) => {
-        Identifiable! {
+        _Identifiable! {
             $args,
             fields = [$($fields)*],
         }
@@ -111,7 +119,7 @@ macro_rules! Identifiable {
                 $($args)*
                 struct_ty = $struct_name,
             ),
-            callback = Identifiable,
+            callback = _Identifiable,
             body = $body,
         }
     };

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -61,13 +61,21 @@
 /// ```
 #[macro_export]
 macro_rules! Insertable {
+    ($($args:tt)*) => {
+        _Insertable!($($args)*);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _Insertable {
     // Strip meta items, pub (if present) and struct from definition
     (
         ($table_name:ident)
         $(#[$ignore:meta])*
         $(pub)* struct $($body:tt)*
     ) => {
-        Insertable! {
+        _Insertable! {
             ($table_name)
             $($body)*
         }
@@ -86,7 +94,7 @@ macro_rules! Insertable {
                 struct_ty = $struct_name<$($lifetime),*>,
                 lifetimes = ($($lifetime),*),
             ),
-            callback = Insertable,
+            callback = _Insertable,
             body = $body,
         }
     };
@@ -104,7 +112,7 @@ macro_rules! Insertable {
                 struct_ty = $struct_name,
                 lifetimes = (),
             ),
-            callback = Insertable,
+            callback = _Insertable,
             body = $body,
         }
     };
@@ -121,7 +129,7 @@ macro_rules! Insertable {
             field_kind: $field_kind:ident,
         })+],
     ) => {
-        Insertable! {
+        _Insertable! {
             $($headers)*
             self_to_columns = $struct_name($(ref $column_name),+),
             columns = ($($column_name, $field_ty, $field_kind),+),
@@ -141,7 +149,7 @@ macro_rules! Insertable {
             field_kind: $field_kind:ident,
         })+],
     ) => {
-        Insertable! {
+        _Insertable! {
             $($headers)*
             self_to_columns = $struct_name { $($field_name: ref $column_name),+ },
             columns = ($($column_name, $field_ty, $field_kind),+),

--- a/diesel/src/macros/queryable.rs
+++ b/diesel/src/macros/queryable.rs
@@ -22,9 +22,17 @@
 /// ```
 #[macro_export]
 macro_rules! Queryable {
+    ($($args:tt)*) => {
+        _Queryable!($($args)*);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _Queryable {
     // Strip empty argument list if given (Passed by custom_derive macro)
     (() $($body:tt)*) => {
-        Queryable! {
+        _Queryable! {
             $($body)*
         }
     };
@@ -34,7 +42,7 @@ macro_rules! Queryable {
         $(#[$ignore:meta])*
         $(pub)* struct $($body:tt)*
     ) => {
-        Queryable! {
+        _Queryable! {
             $($body)*
         }
     };
@@ -53,7 +61,7 @@ macro_rules! Queryable {
             field_kind: $field_kind:ident,
         })+],
     ) => {
-        Queryable! {
+        _Queryable! {
             $($headers)*
             row_ty = ($($field_ty,)+),
             row_pat = ($($field_name,)+),
@@ -72,7 +80,7 @@ macro_rules! Queryable {
             field_kind: $field_kind:ident,
         })+],
     ) => {
-        Queryable! {
+        _Queryable! {
             $headers,
             fields = [$({
                 field_ty: $field_ty,
@@ -92,7 +100,7 @@ macro_rules! Queryable {
             field_kind: $field_kind:ident,
         })+],
     ) => {
-        Queryable! {
+        _Queryable! {
             $($headers)*
             row_ty = ($($field_ty,)+),
             row_pat = ($($field_kind,)+),
@@ -134,7 +142,7 @@ macro_rules! Queryable {
                 generics = ($($generics),*),
                 lifetimes = (),
             ),
-            callback = Queryable,
+            callback = _Queryable,
             body = $body,
         }
     };
@@ -151,7 +159,7 @@ macro_rules! Queryable {
                 generics = (),
                 lifetimes = (),
             ),
-            callback = Queryable,
+            callback = _Queryable,
             body = $body,
         }
     };

--- a/diesel_codegen/src/as_changeset.rs
+++ b/diesel_codegen/src/as_changeset.rs
@@ -20,7 +20,7 @@ pub fn derive_as_changeset(item: syn::MacroInput) -> quote::Tokens {
         lifetimes.push(syn::LifetimeDef::new("'a"));
     }
 
-    quote!(AsChangeset! {
+    quote!(_AsChangeset! {
         (
             struct_name = #struct_name,
             table_name = #table_name,

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -12,7 +12,7 @@ pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
         panic!("Could not find a field named `id` on `{}`", &model.name);
     }
 
-    quote!(Identifiable! {
+    quote!(_Identifiable! {
         (
             table_name = #table_name,
             struct_ty = #struct_ty,

--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -21,7 +21,7 @@ pub fn derive_insertable(item: syn::MacroInput) -> quote::Tokens {
     let lifetimes = model.generics.lifetimes;
     let fields = model.attrs;
 
-    quote!(Insertable! {
+    quote!(_Insertable! {
         (
             struct_name = #struct_name,
             table_name = #table_name,

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -12,7 +12,7 @@ pub fn derive_queryable(item: syn::MacroInput) -> Tokens {
     let attrs = model.attrs;
     let lifetimes = &model.generics.lifetimes;
 
-    quote!(Queryable! {
+    quote!(_Queryable! {
         (
             struct_name = #struct_name,
             struct_ty = #struct_ty,

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 diesel = { version = "0.8.0", features = ["sqlite", "postgres"] }
 diesel_codegen = { version = "0.8.0" }
 compiletest_rs = "0.2.3"
+
+[replace]
+"diesel:0.8.0" = { path = "../diesel" }
+"diesel_codegen:0.8.0" = { path = "../diesel_codegen" }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -15,7 +15,7 @@ dotenv = "0.8.0"
 assert_matches = "1.0.1"
 chrono = { version = "^0.2.17" }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid"] }
-diesel_codegen = { version = "0.8.0", optional = true }
+diesel_codegen = { path = "../diesel_codegen", optional = true }
 dotenv = "0.8.0"
 quickcheck = { version = "0.3.1", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.4.0" }

--- a/examples/getting_started_step_1/Cargo.toml
+++ b/examples/getting_started_step_1/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 diesel = "0.8.0"
 diesel_codegen = { version = "0.8.0", features = ["postgres"] }
 dotenv = "0.8.0"
+
+[replace]
+"diesel:0.8.0" = { path = "../../diesel" }
+"diesel_codegen:0.8.0" = { path = "../../diesel_codegen" }

--- a/examples/getting_started_step_2/Cargo.toml
+++ b/examples/getting_started_step_2/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 diesel = "0.8.0"
 diesel_codegen = { version = "0.8.0", features = ["postgres"] }
 dotenv = "0.8.0"
+
+[replace]
+"diesel:0.8.0" = { path = "../../diesel" }
+"diesel_codegen:0.8.0" = { path = "../../diesel_codegen" }

--- a/examples/getting_started_step_3/Cargo.toml
+++ b/examples/getting_started_step_3/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 diesel = "0.8.0"
 diesel_codegen = { version = "0.8.0", features = ["postgres"] }
 dotenv = "0.8.0"
+
+[replace]
+"diesel:0.8.0" = { path = "../../diesel" }
+"diesel_codegen:0.8.0" = { path = "../../diesel_codegen" }

--- a/examples/getting_started_step_4/Cargo.toml
+++ b/examples/getting_started_step_4/Cargo.toml
@@ -17,3 +17,8 @@ dotenv = "0.8.0"
 default = ["nightly"]
 with-syntex = ["syntex", "diesel_codegen_syntex"]
 nightly = ["diesel/unstable", "diesel_codegen"]
+
+[replace]
+"diesel:0.8.0" = { path = "../../diesel" }
+"diesel_codegen:0.8.0" = { path = "../../diesel_codegen" }
+"diesel_codegen_syntex:0.8.0" = { path = "../../diesel_codegen_syntex" }


### PR DESCRIPTION
Macros 1.1 was changed so that bang macros and custom derive macros
share the same namespace. This causes problems for us, since we expose
and use a bang macro with the same name as the custom derive macro. I
was hoping we could have this changed upstream, but
https://github.com/rust-lang/rust/issues/35900#issuecomment-257190405
makes it seem like that's not going to happen. I'm not sure what my long
term plan for the bang macros are, but in the short term we can just
expose them under another name internally. Those who are using the bang
macros are likely not using them in conjunction with `diesel_codegen`.

Fixes #485.