### PR TITLE
Fix breakage in latest nightlies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Changed
+
+* Fixed support for nightlies later than ???
+
+* Removed support for nightlies earlier than ???
+
+* Calls to `infer_table_from_schema!` will need to be wrapped in a module if
+  called more than once. This change is to work around further limitations of
+  the Macros 1.1 system. Example:
+
+  ```rust
+  mod infer_users {
+      infer_table_from_schema!("dotenv:DATABASE_URL", "users");
+  }
+  pub use self::infer_users::*;
+  ```
+
 ## [0.8.1] - 2016-11-01
 
 ### Added

--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -11,9 +11,12 @@
 /// `diesel_codegen_syntex` crates. It will not work on its own.
 macro_rules! infer_schema {
     ($database_url: expr) => {
-        #[derive(InferSchema)]
-        #[options(database_url=$database_url)]
-        struct _Dummy;
+        mod __diesel_infer_schema {
+            #[derive(InferSchema)]
+            #[options(database_url=$database_url)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_schema::*;
     }
 }
 
@@ -36,7 +39,7 @@ macro_rules! infer_table_from_schema {
     ($database_url: expr, $table_name: expr) => {
         #[derive(InferTableFromSchema)]
         #[options(database_url=$database_url, table_name=$table_name)]
-        struct _Dummy;
+        struct __DieselInferTableFromSchema;
     }
 }
 
@@ -56,13 +59,17 @@ macro_rules! infer_table_from_schema {
 /// `diesel_codegen_syntex` crates. It will not work on its own.
 macro_rules! embed_migrations {
     () => {
-        #[derive(EmbedMigrations)]
-        struct _Dummy;
+        mod embedded_migrations {
+            #[derive(EmbedMigrations)]
+            struct _Dummy;
+        }
     };
 
     ($migrations_path: expr) => {
-        #[derive(EmbedMigrations)]
-        #[options(migrations_path=$migrations_path)]
-        struct _Dummy;
+        mod embedded_migrations {
+            #[derive(EmbedMigrations)]
+            #[options(migrations_path=$migrations_path)]
+            struct _Dummy;
+        }
     }
 }

--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -69,8 +69,9 @@ impl CommandResult {
 }
 
 fn path_to_diesel_cli() -> PathBuf {
-    env::current_exe().unwrap()
-        .parent().unwrap()
+    Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap())
+        .join("target")
+        .join("debug")
         .join("diesel")
 }
 

--- a/diesel_codegen/src/embed_migrations.rs
+++ b/diesel_codegen/src/embed_migrations.rs
@@ -57,7 +57,7 @@ pub fn derive_embed_migrations(input: syn::MacroInput) -> quote::Tokens {
         }
     );
 
-    quote!(mod embedded_migrations {
+    quote! {
         extern crate diesel;
 
         use self::diesel::migrations::*;
@@ -69,7 +69,7 @@ pub fn derive_embed_migrations(input: syn::MacroInput) -> quote::Tokens {
         #embedded_migration_def
 
         #run_fns
-    })
+    }
 }
 
 fn migration_literals_from_path(path: &Path) -> Result<Vec<quote::Tokens>, Box<Error>> {

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -33,91 +33,49 @@ mod util;
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
-use self::util::{list_value_of_attr_with_name, strip_attributes, strip_field_attributes};
-
-const KNOWN_CUSTOM_DERIVES: &'static [&'static str] = &[
-    "AsChangeset",
-    "Associations",
-    "Identifiable",
-    "Insertable",
-    "Queryable",
-];
-
-const KNOWN_CUSTOM_ATTRIBUTES: &'static [&'static str] = &[
-    "belongs_to",
-    "changeset_options",
-    "has_many",
-    "table_name",
-];
-
-const KNOWN_FIELD_ATTRIBUTES: &'static [&'static str] = &[
-    "column_name",
-];
-
 #[proc_macro_derive(Queryable)]
 pub fn derive_queryable(input: TokenStream) -> TokenStream {
     expand_derive(input, queryable::derive_queryable)
 }
 
-#[proc_macro_derive(Identifiable)]
+#[proc_macro_derive(Identifiable, attributes(table_name))]
 pub fn derive_identifiable(input: TokenStream) -> TokenStream {
     expand_derive(input, identifiable::derive_identifiable)
 }
 
-#[proc_macro_derive(Insertable)]
+#[proc_macro_derive(Insertable, attributes(table_name, column_name))]
 pub fn derive_insertable(input: TokenStream) -> TokenStream {
     expand_derive(input, insertable::derive_insertable)
 }
 
-#[proc_macro_derive(AsChangeset)]
+#[proc_macro_derive(AsChangeset, attributes(table_name, column_name, changeset_options))]
 pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
     expand_derive(input, as_changeset::derive_as_changeset)
 }
 
-#[proc_macro_derive(Associations)]
+#[proc_macro_derive(Associations, attributes(table_name, has_many, belongs_to))]
 pub fn derive_associations(input: TokenStream) -> TokenStream {
     expand_derive(input, associations::derive_associations)
 }
 
-#[proc_macro_derive(InferSchema)]
+#[proc_macro_derive(InferSchema, attributes(options))]
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub fn derive_infer_schema(input: TokenStream) -> TokenStream {
-    let item = parse_macro_input(&input.to_string()).unwrap();
-    schema_inference::derive_infer_schema(item)
-        .to_string().parse().unwrap()
+    expand_derive(input, schema_inference::derive_infer_schema)
 }
 
-#[proc_macro_derive(InferTableFromSchema)]
+#[proc_macro_derive(InferTableFromSchema, attributes(options))]
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub fn derive_infer_table_from_schema(input: TokenStream) -> TokenStream {
-    let item = parse_macro_input(&input.to_string()).unwrap();
-    schema_inference::derive_infer_table_from_schema(item)
-        .to_string().parse().unwrap()
+    expand_derive(input, schema_inference::derive_infer_table_from_schema)
 }
 
-#[proc_macro_derive(EmbedMigrations)]
+#[proc_macro_derive(EmbedMigrations, attributes(options))]
 pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
-    let item = parse_macro_input(&input.to_string()).unwrap();
-    embed_migrations::derive_embed_migrations(item)
-        .to_string().parse().unwrap()
+    expand_derive(input, embed_migrations::derive_embed_migrations)
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) -> TokenStream {
-    let mut item = parse_macro_input(&input.to_string()).unwrap();
-    let output = f(item.clone());
-
-    let finished_deriving_diesel_traits = {
-        let remaining_derives = list_value_of_attr_with_name(&item.attrs, "derive");
-        !remaining_derives
-            .unwrap_or(Vec::new())
-            .iter()
-            .any(|trait_name| KNOWN_CUSTOM_DERIVES.contains(&trait_name.as_ref()))
-    };
-
-    if finished_deriving_diesel_traits {
-        item.attrs = strip_attributes(item.attrs, KNOWN_CUSTOM_ATTRIBUTES);
-        strip_field_attributes(&mut item, KNOWN_FIELD_ATTRIBUTES);
-    }
-
-    quote!(#item #output).to_string().parse().unwrap()
+    let item = parse_macro_input(&input.to_string()).unwrap();
+    f(item).to_string().parse().unwrap()
 }

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -16,7 +16,13 @@ pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
 
     let table_names = load_table_names(&database_url).unwrap();
     let schema_inferences = table_names.into_iter().map(|table_name| {
-        quote!(infer_table_from_schema!(#database_url, #table_name);)
+        let mod_ident = syn::Ident::new(format!("infer_{}", table_name));
+        quote! {
+            mod #mod_ident {
+                infer_table_from_schema!(#database_url, #table_name);
+            }
+            pub use self::#mod_ident::*;
+        }
     });
 
     quote!(#(schema_inferences)*)

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use syn::*;
 
 use ast_builder::ty_ident;
@@ -39,13 +38,6 @@ pub fn ident_value_of_attr_with_name<'a>(
     attr_with_name(attrs, name).map(|attr| single_arg_value_of_attr(attr, name))
 }
 
-pub fn list_value_of_attr_with_name<'a>(
-    attrs: &'a [Attribute],
-    name: &str,
-) -> Option<Vec<&'a Ident>> {
-    attr_with_name(attrs, name).map(|attr| list_value_of_attr(attr, name))
-}
-
 pub fn attr_with_name<'a>(
     attrs: &'a [Attribute],
     name: &str,
@@ -80,18 +72,6 @@ fn single_arg_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> &'a Ident {
     }
 }
 
-fn list_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> Vec<&'a Ident> {
-    match attr.value {
-        MetaItem::List(_, ref items) => {
-            items.iter().map(|item| match *item {
-                MetaItem::Word(ref name) => name,
-                _ => panic!("`{}` must be in the form `#[{}(something, something_else)]`", name, name),
-            }).collect()
-        }
-        _ => panic!("`{}` must be in the form `#[{}(something, something_else)]`", name, name),
-    }
-}
-
 pub fn is_option_ty(ty: &Ty) -> bool {
     let option_ident = Ident::new("Option");
     match *ty {
@@ -101,27 +81,6 @@ pub fn is_option_ty(ty: &Ty) -> bool {
                 .unwrap_or(false)
         }
         _ => false,
-    }
-}
-
-pub fn strip_attributes(attrs: Vec<Attribute>, names_to_strip: &[&str]) -> Vec<Attribute> {
-    attrs.into_iter().filter(|attr| {
-        !names_to_strip.contains(&attr.name())
-    }).collect()
-}
-
-pub fn strip_field_attributes(item: &mut MacroInput, names_to_strip: &[&str]) {
-    let fields = match item.body {
-        Body::Struct(VariantData::Struct(ref mut fields)) |
-        Body::Struct(VariantData::Tuple(ref mut fields)) => fields,
-        _ => return,
-    };
-
-    let mut attrs = Vec::new();
-    for field in fields {
-        mem::swap(&mut attrs, &mut field.attrs);
-        attrs = strip_attributes(attrs, names_to_strip);
-        mem::swap(&mut attrs, &mut field.attrs);
     }
 }
 


### PR DESCRIPTION
Note: This is not currently expected to pass CI, nor is it ready to be
merged. Nightly builds have been failing since a few days before this
change was made upstream. This is a PR that I *think* will fix it based
on testing from a local build, and I want to have this ready to go once
nightlies are building again.

The latest nightlies have added built-in support for custom attributes,
but have removed the ability to modify the input token stream. This
means that our bang macros now need to worry about namespace collisions.
For `embed_migrations` this doesn't matter, since the output is a module
with a known name. `infer_schema` is ok as well, since it's not expected
to be called more than once. However, `infer_table_from_schema` outputs
a module which differs, and the API currently takes a string which we
can't turn into a module name. Even if we changed the API to take an
ident instead of an expr, we can't then pass that ident into the
procedural macros. We can work around this in our invocation of it from
`infer_schema!`, but this will force this API change onto our users.

Since `infer_table_from_schema!` isn't highly used, I think this is OK,
but we might want to start looking at alternatives long term. There have
been murmurs of a proper bang macros 1.1, which is the best solution. We
could also go back to only allowing `infer_schema!` on nightly, and
change to a solution that involves Diesel CLI or build scripts, but both
of those will increase the barrier to entry for newcomers.

Either way this fixes the issue short term, and assuming all works when
nightlies are building again can be released immediately afterwards.