### PR TITLE
Refactor `AsChangeset!` now that macros in type positions are stable

### DIFF
--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -31,6 +31,10 @@ stable_sqlite = ["with-syntex", "sqlite", "diesel_codegen_syntex/sqlite"]
 unstable_postgres = ["unstable", "postgres", "diesel_codegen/postgres"]
 unstable_sqlite = ["unstable", "sqlite", "diesel_codegen/sqlite"]
 
+[lib]
+name = "integration_tests"
+path = "tests/lib.rs"
+
 [[test]]
 name = "integration_tests"
 path = "tests/lib.rs"


### PR DESCRIPTION
Cleaner code, less recursion. We can just return the type now!