### PR TITLE
Remove the `FindDsl` constraint from `Identifiable`

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -117,7 +117,6 @@ mod belongs_to;
 
 use std::hash::Hash;
 
-use query_dsl::FindDsl;
 use query_source::Table;
 
 pub use self::belongs_to::{BelongsTo, GroupedBy};
@@ -137,7 +136,7 @@ pub use self::belongs_to::{BelongsTo, GroupedBy};
 /// never change without a major version bump.
 pub trait Identifiable {
     type Id: Hash + Eq;
-    type Table: Table + for<'a> FindDsl<&'a Self::Id>;
+    type Table: Table;
 
     fn table() -> Self::Table;
     fn id(&self) -> &Self::Id;

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -18,6 +18,7 @@ pub trait IntoUpdateTarget {
 }
 
 impl<'a, T: Identifiable, V> IntoUpdateTarget for &'a T where
+    T::Table: FindDsl<&'a T::Id>,
     Find<T::Table, &'a T::Id>: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
 {
     type Table = T::Table;

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -32,14 +32,12 @@ impl<'a, T, ST, Conn> SaveChangesDsl<Conn, ST> for &'a T where
 
 #[cfg(feature = "sqlite")]
 use sqlite::{SqliteConnection, Sqlite};
-#[cfg(feature = "sqlite")]
-use query_builder::AsQuery;
 
 #[cfg(feature = "sqlite")]
 impl<'a, T, ST> SaveChangesDsl<SqliteConnection, ST> for &'a T where
     Sqlite: HasSqlType<ST>,
     T: Identifiable,
-    T::Table: AsQuery<SqlType=ST>,
+    T::Table: FindDsl<&'a T::Id, SqlType=ST>,
     &'a T: AsChangeset<Target=T::Table> + IntoUpdateTarget<Table=T::Table>,
     Update<&'a T, &'a T>: ExecuteDsl<SqliteConnection>,
     Find<T::Table, &'a T::Id>: LoadDsl<SqliteConnection, SqlType=ST>,

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -9,5 +9,5 @@ diesel_codegen = { version = "0.8.1" }
 compiletest_rs = "0.2.3"
 
 [replace]
-"diesel:0.8.1" = { path = "../diesel" }
-"diesel_codegen:0.8.1" = { path = "../diesel_codegen" }
+"diesel:0.8.2" = { path = "../diesel" }
+"diesel_codegen:0.8.2" = { path = "../diesel_codegen" }


### PR DESCRIPTION
Turns out we don't rely on it in as many places as we used to, and its
presence is making other refactorings difficult. I think I originally
added it to make the where clause on the impl of `SaveChangesDsl` less
gnarly, but it turns out it's more or less exactly the same anyway.