### PR TITLE
Separate the `Table` type and function from `Identifiable`

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -3,7 +3,7 @@ use expression::helper_types::{Eq, EqAny};
 use expression::array_comparison::AsInExpression;
 use helper_types::{FindBy, Filter};
 use prelude::*;
-use super::Identifiable;
+use super::{Identifiable, HasTable};
 
 pub trait BelongsTo<Parent: Identifiable> {
     type ForeignKeyColumn: Column;
@@ -37,9 +37,9 @@ impl<Parent, Child, Iter> GroupedBy<Parent> for Iter where
 
 impl<'a, Parent, Child> BelongingToDsl<&'a Parent> for Child where
     Parent: Identifiable,
-    Child: Identifiable + BelongsTo<Parent>,
+    Child: HasTable + BelongsTo<Parent>,
     &'a Parent::Id: AsExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
-    <Child as Identifiable>::Table: FilterDsl<Eq<Child::ForeignKeyColumn, &'a Parent::Id>>,
+    <Child as HasTable>::Table: FilterDsl<Eq<Child::ForeignKeyColumn, &'a Parent::Id>>,
 {
     type Output = FindBy<
         Child::Table,
@@ -54,9 +54,9 @@ impl<'a, Parent, Child> BelongingToDsl<&'a Parent> for Child where
 
 impl<'a, Parent, Child> BelongingToDsl<&'a [Parent]> for Child where
     Parent: Identifiable,
-    Child: Identifiable + BelongsTo<Parent>,
+    Child: HasTable + BelongsTo<Parent>,
     Vec<&'a Parent::Id>: AsInExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
-    <Child as Identifiable>::Table: FilterDsl<EqAny<Child::ForeignKeyColumn, Vec<&'a Parent::Id>>>,
+    <Child as HasTable>::Table: FilterDsl<EqAny<Child::ForeignKeyColumn, Vec<&'a Parent::Id>>>,
 {
     type Output = Filter<
         Child::Table,

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -121,6 +121,20 @@ use query_source::Table;
 
 pub use self::belongs_to::{BelongsTo, GroupedBy};
 
+pub trait HasTable {
+    type Table: Table;
+
+    fn table() -> Self::Table;
+}
+
+impl<'a, T: HasTable> HasTable for &'a T {
+    type Table = T::Table;
+
+    fn table() -> Self::Table {
+        T::table()
+    }
+}
+
 /// Represents a struct which can be identified on a single table in the
 /// database. This must be implemented to use associations, and some features of
 /// updating.
@@ -134,10 +148,8 @@ pub use self::belongs_to::{BelongsTo, GroupedBy};
 /// differs from that convention, or requires complex pluralization, it can be specified using
 /// `#[table_name = "some_table_name"]`. The inferred table name is considered public API and will
 /// never change without a major version bump.
-pub trait Identifiable {
+pub trait Identifiable: HasTable {
     type Id: Hash + Eq;
-    type Table: Table;
 
-    fn table() -> Self::Table;
     fn id(&self) -> &Self::Id;
 }

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -75,10 +75,11 @@ pub mod helper_types {
     /// Represents the return type of `.with(aliased_expr)`
     pub type With<'a, Source, Other> = <Source as WithDsl<'a, Other>>::Output;
 
+    use super::associations::HasTable;
     use super::query_builder::{UpdateStatement, IntoUpdateTarget, AsChangeset};
     /// Represents the return type of `update(lhs).set(rhs)`
     pub type Update<Target, Changes> = UpdateStatement<
-        <Target as IntoUpdateTarget>::Table,
+        <Target as HasTable>::Table,
         <Target as IntoUpdateTarget>::WhereClause,
         <Changes as AsChangeset>::Changeset,
     >;

--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -220,21 +220,21 @@ macro_rules! BelongsTo {
     ) => {
         joinable_inner!(
             left_table_ty = $child_table_name::table,
-            right_table_ty = <$parent_struct as $crate::associations::Identifiable>::Table,
-            right_table_expr = <$parent_struct as $crate::associations::Identifiable>::table(),
+            right_table_ty = <$parent_struct as $crate::associations::HasTable>::Table,
+            right_table_expr = <$parent_struct as $crate::associations::HasTable>::table(),
             foreign_key = $child_table_name::$foreign_key_name,
-            primary_key_ty = <<$parent_struct as $crate::associations::Identifiable>::Table as $crate::Table>::PrimaryKey,
-            primary_key_expr = $crate::Table::primary_key(&<$parent_struct as $crate::associations::Identifiable>::table()),
+            primary_key_ty = <<$parent_struct as $crate::associations::HasTable>::Table as $crate::Table>::PrimaryKey,
+            primary_key_expr = $crate::Table::primary_key(&<$parent_struct as $crate::associations::HasTable>::table()),
         );
 
         $(select_column_inner!(
             $child_table_name::table,
-            <$parent_struct as $crate::associations::Identifiable>::Table,
+            <$parent_struct as $crate::associations::HasTable>::Table,
             $child_table_name::$column_name,
         );)+
         select_column_inner!(
             $child_table_name::table,
-            <$parent_struct as $crate::associations::Identifiable>::Table,
+            <$parent_struct as $crate::associations::HasTable>::Table,
             $child_table_name::star,
         );
     };

--- a/diesel/src/macros/identifiable.rs
+++ b/diesel/src/macros/identifiable.rs
@@ -78,13 +78,16 @@ macro_rules! _Identifiable {
             field_kind: $field_kind:ident,
         } $($fields:tt)*],
     ) => {
-        impl $crate::associations::Identifiable for $struct_ty {
-            type Id = $field_ty;
+        impl $crate::associations::HasTable for $struct_ty {
             type Table = $table_name::table;
 
             fn table() -> Self::Table {
                 $table_name::table
             }
+        }
+
+        impl $crate::associations::Identifiable for $struct_ty {
+            type Id = $field_ty;
 
             fn id(&self) -> &Self::Id {
                 &self.id

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -251,6 +251,7 @@ macro_rules! table_body {
                 QuerySource,
                 Table,
             };
+            use $crate::associations::HasTable;
             use $crate::query_builder::*;
             use $crate::query_builder::nodes::Identifier;
             use $crate::types::*;
@@ -313,8 +314,15 @@ macro_rules! table_body {
                 }
             }
 
-            impl IntoUpdateTarget for table {
+            impl HasTable for table {
                 type Table = Self;
+
+                fn table() -> Self::Table {
+                    table
+                }
+            }
+
+            impl IntoUpdateTarget for table {
                 type WhereClause = ();
 
                 fn into_update_target(self) -> UpdateTarget<Self::Table, Self::WhereClause> {

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -1,7 +1,6 @@
-use associations::Identifiable;
+use associations::{Identifiable, HasTable};
 use helper_types::Find;
 use query_dsl::FindDsl;
-use query_source::Table;
 
 #[doc(hidden)]
 #[derive(Debug)]
@@ -10,8 +9,7 @@ pub struct UpdateTarget<Table, WhereClause> {
     pub where_clause: Option<WhereClause>,
 }
 
-pub trait IntoUpdateTarget {
-    type Table: Table;
+pub trait IntoUpdateTarget: HasTable {
     type WhereClause;
 
     fn into_update_target(self) -> UpdateTarget<Self::Table, Self::WhereClause>;
@@ -21,7 +19,6 @@ impl<'a, T: Identifiable, V> IntoUpdateTarget for &'a T where
     T::Table: FindDsl<&'a T::Id>,
     Find<T::Table, &'a T::Id>: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
 {
-    type Table = T::Table;
     type WhereClause = V;
 
     fn into_update_target(self) -> UpdateTarget<Self::Table, Self::WhereClause> {


### PR DESCRIPTION
I'm trying to figure out the best way to get composite primary keys to
work with the `Identifiable` trait. The issue is that for single primary
keys, you'll want to return `&'a i32` for example, but for composite
primary keys you'll want `(&'a i32, &'a i32)`. Restricting primary keys
to `Copy` types is not an option, so we have to assume references.
Without some form of HKT or associated type constructors (see
https://github.com/rust-lang/rfcs/pull/1598), we'll need to change the
return type of `Identifiable#id` from `&Self::Id` to `Self::Id` and
reference the lifetime in the trait impl.

I'm not yet sure whether that means we want the lifetime on the trait
itself, or if we want to implement the trait on references, but in both
cases we want this change. In the case of putting the lifetime on the
trait, there are a few cases where we just don't want to reason about
the lifetime because we just need the table. In the case of implementing
the trait on references, we will end up having places where `T::Table`
is ambiguous between `Identifiable` and `IntoUpdateTarget`, so unifying
them makes sense.