### PR TITLE
Refactor macros to always pass the "inner ty" of fields

### DIFF
--- a/diesel/src/macros/as_changeset.rs
+++ b/diesel/src/macros/as_changeset.rs
@@ -173,6 +173,7 @@ macro_rules! _AsChangeset {
                 column_name: $column_name:ident,
                 field_ty: $field_ty:ty,
                 field_kind: $field_kind:ident,
+                $($rest:tt)*
             })+],
             struct_name = $struct_name:ident,
             $($headers:tt)*
@@ -196,6 +197,7 @@ macro_rules! _AsChangeset {
                 column_name: $column_name:ident,
                 field_ty: $field_ty:ty,
                 field_kind: $field_kind:ident,
+                $($rest:tt)*
             })+],
             struct_name = $struct_name:ident,
             $($headers:tt)*
@@ -259,8 +261,10 @@ macro_rules! AsChangeset_construct_changeset_ty {
         fields = [{
             $(field_name: $field_name:ident,)*
             column_name: $column_name:ident,
-            field_ty: Option<$field_ty:ty>,
+            field_ty: $ignore:ty,
             field_kind: option,
+            inner_field_ty: $field_ty:ty,
+            $($rest:tt)*
         } $($tail:tt)*],
         changeset_ty = ($($changeset_ty:ty,)*),
     ) => {

--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -121,6 +121,7 @@ macro_rules! BelongsTo {
             column_name: $ignore3:ident,
             field_ty: $ignore4:ty,
             field_kind: $foreign_key_kind:ident,
+            $($rest:tt)*
         },
     ) => {
         BelongsTo! {
@@ -216,6 +217,7 @@ macro_rules! BelongsTo {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         })+],
     ) => {
         joinable_inner!(

--- a/diesel/src/macros/associations/has_many.rs
+++ b/diesel/src/macros/associations/has_many.rs
@@ -94,6 +94,7 @@ macro_rules! HasMany {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         })+],
     ) => {
         joinable_inner! {

--- a/diesel/src/macros/identifiable.rs
+++ b/diesel/src/macros/identifiable.rs
@@ -76,6 +76,7 @@ macro_rules! _Identifiable {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         } $($fields:tt)*],
     ) => {
         impl $crate::associations::HasTable for $struct_ty {
@@ -103,6 +104,7 @@ macro_rules! _Identifiable {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         } $($fields:tt)*],
     ) => {
         _Identifiable! {

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -127,6 +127,7 @@ macro_rules! _Insertable {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         })+],
     ) => {
         _Insertable! {
@@ -147,6 +148,7 @@ macro_rules! _Insertable {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         })+],
     ) => {
         _Insertable! {

--- a/diesel/src/macros/parse.rs
+++ b/diesel/src/macros/parse.rs
@@ -51,16 +51,19 @@
 ///         column_name: foo,
 ///         field_ty: i32,
 ///         field_kind: regular,
+///         inner_field_ty: i32,
 ///     }, {
 ///         field_name: bar,
 ///         column_name: bar,
 ///         field_ty: Option<i32>,
 ///         field_kind: option,
+///         inner_field_ty: i32,
 ///     }, {
 ///         field_name: baz,
 ///         column_name: other,
 ///         field_ty: String,
 ///         field_kind: regular,
+///         inner_field_ty: String,
 ///     }],
 /// }
 #[macro_export]
@@ -146,6 +149,7 @@ macro_rules! __diesel_parse_struct_body {
                 column_name: $column_name,
                 field_ty: Option<$field_ty>,
                 field_kind: option,
+                inner_field_ty: $field_ty,
             }],
             body = ($($tail)*),
         }
@@ -168,6 +172,7 @@ macro_rules! __diesel_parse_struct_body {
                 column_name: $column_name,
                 field_ty: $field_ty,
                 field_kind: regular,
+                inner_field_ty: $field_ty,
             }],
             body = ($($tail)*),
         }
@@ -221,6 +226,7 @@ macro_rules! __diesel_parse_struct_body {
                 column_name: $column_name,
                 field_ty: Option<$field_ty>,
                 field_kind: option,
+                inner_field_ty: $field_ty,
             }],
             body = ($($tail)*),
         }
@@ -241,6 +247,7 @@ macro_rules! __diesel_parse_struct_body {
                 column_name: $column_name,
                 field_ty: $field_ty,
                 field_kind: regular,
+                inner_field_ty: $field_ty,
             }],
             body = ($($tail)*),
         }
@@ -265,6 +272,7 @@ macro_rules! __diesel_parse_struct_body {
             fields = [$($fields)* {
                 field_ty: $field_ty,
                 field_kind: bare,
+                inner_field_ty: $field_ty,
             }],
             body = ($($tail)*),
         }

--- a/diesel/src/macros/queryable.rs
+++ b/diesel/src/macros/queryable.rs
@@ -59,6 +59,7 @@ macro_rules! _Queryable {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         })+],
     ) => {
         _Queryable! {
@@ -78,6 +79,7 @@ macro_rules! _Queryable {
             column_name: $column_name:ident,
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         })+],
     ) => {
         _Queryable! {
@@ -85,6 +87,7 @@ macro_rules! _Queryable {
             fields = [$({
                 field_ty: $field_ty,
                 field_kind: $field_kind,
+                $($rest:tt)*
             })+],
         }
     };
@@ -98,6 +101,7 @@ macro_rules! _Queryable {
         fields = [$({
             field_ty: $field_ty:ty,
             field_kind: $field_kind:ident,
+            $($rest:tt)*
         })+],
     ) => {
         _Queryable! {

--- a/diesel_codegen/src/attr.rs
+++ b/diesel_codegen/src/attr.rs
@@ -1,7 +1,7 @@
 use quote;
 use syn;
 
-use util::{ident_value_of_attr_with_name, is_option_ty};
+use util::*;
 
 pub struct Attr {
     pub column_name: Option<syn::Ident>,
@@ -53,6 +53,11 @@ impl quote::ToTokens for Attr {
         tokens.append(", ");
         tokens.append("field_kind: ");
         tokens.append(self.field_kind());
+        tokens.append(", ");
+        tokens.append("inner_field_ty: ");
+        inner_of_option_ty(&self.ty)
+            .unwrap_or(&self.ty)
+            .to_tokens(tokens);
         tokens.append(", ");
         tokens.append("}");
     }

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -84,6 +84,23 @@ pub fn is_option_ty(ty: &Ty) -> bool {
     }
 }
 
+pub fn inner_of_option_ty(ty: &Ty) -> Option<&Ty> {
+    use syn::PathParameters::AngleBracketed;
+
+    if !is_option_ty(ty) {
+        return None;
+    }
+
+    match *ty {
+        Ty::Path(_, Path { ref segments, .. }) =>
+            match segments[0].parameters {
+                AngleBracketed(ref data) => data.types.first(),
+                _ => None,
+            },
+        _ => None,
+    }
+}
+
 pub fn get_options_from_input(attrs: &[Attribute], on_bug: fn() -> !)
     -> Option<&[MetaItem]>
 {

--- a/diesel_codegen_syntex/src/attr.rs
+++ b/diesel_codegen_syntex/src/attr.rs
@@ -65,13 +65,16 @@ impl Attr {
     pub fn to_stable_macro_tokens(&self, cx: &mut ExtCtxt) -> Vec<TokenTree> {
         let field_kind;
         let field_ty;
+        let inner_field_ty;
         if let Some(option_ty) = ty_param_of_option(&self.ty) {
             field_kind = str_to_ident("option");
             field_ty = quote_tokens!(cx, Option<$option_ty>);
+            inner_field_ty = quote_tokens!(cx, $option_ty);
         } else {
             let ty = &self.ty;
             field_kind = str_to_ident("regular");
             field_ty = quote_tokens!(cx, $ty);
+            inner_field_ty = quote_tokens!(cx, $ty);
         }
 
         let column_name = self.column_name;
@@ -81,11 +84,13 @@ impl Attr {
                 column_name: $column_name,
                 field_ty: $field_ty,
                 field_kind: $field_kind,
+                inner_field_ty: $inner_field_ty,
             }),
             None => quote_tokens!(cx, {
                 column_name: $column_name,
                 field_ty: $field_ty,
                 field_kind: $field_kind,
+                inner_field_ty: $inner_field_ty,
             }),
         }
     }


### PR DESCRIPTION
Sometimes we need to differ in behavior based on whether we have an
option, but don't need the inner type. Sometimes we need to differ in
behavior, and we do need the inner type. I've been running into more of
the latter recently. The reason we do the `field_kind` dance in the
first place is because as soon as we match `Option<i32>` as a `:ty`, we
can no longer match on any of its individual tokens. Right now if we
want that inside type, we can't pass a field very far. This makes it
easier for future macros to do so, and future-proofs our existing macros
against additional information from Diesel's "shitty but probably good
enough struct parser"™