### PR TITLE
Separate the types of foreign and primary keys from belongs_to

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -5,10 +5,14 @@ use helper_types::{FindBy, Filter};
 use prelude::*;
 use super::{Identifiable, HasTable};
 
-pub trait BelongsTo<Parent: Identifiable> {
+use std::borrow::Borrow;
+use std::hash::Hash;
+
+pub trait BelongsTo<Parent> {
+    type ForeignKey: Hash + ::std::cmp::Eq;
     type ForeignKeyColumn: Column;
 
-    fn foreign_key(&self) -> Option<&Parent::Id>;
+    fn foreign_key(&self) -> Option<&Self::ForeignKey>;
     fn foreign_key_column() -> Self::ForeignKeyColumn;
 }
 
@@ -20,6 +24,7 @@ impl<Parent, Child, Iter> GroupedBy<Parent> for Iter where
     Iter: IntoIterator<Item=Child>,
     Child: BelongsTo<Parent>,
     Parent: Identifiable,
+    for<'a> &'a Parent::Id: Borrow<Child::ForeignKey>,
 {
     fn grouped_by(self, parents: &[Parent]) -> Vec<Vec<Child>> {
         use std::collections::HashMap;

--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -121,11 +121,13 @@ macro_rules! BelongsTo {
             column_name: $ignore3:ident,
             field_ty: $ignore4:ty,
             field_kind: $foreign_key_kind:ident,
+            inner_field_ty: $foreign_key_ty:ty,
             $($rest:tt)*
         },
     ) => {
         BelongsTo! {
             (
+                foreign_key_ty = $foreign_key_ty,
                 foreign_key_kind = $foreign_key_kind,
                 $($remaining_args)*
             ),
@@ -136,6 +138,7 @@ macro_rules! BelongsTo {
     // Generate code when FK is not optional
     (
         (
+            foreign_key_ty = $foreign_key_ty:ty,
             foreign_key_kind = regular,
             struct_name = $struct_name:ident,
             parent_struct = $parent_struct:ident,
@@ -145,9 +148,10 @@ macro_rules! BelongsTo {
         $($rest:tt)*
     ) => {
         impl $crate::associations::BelongsTo<$parent_struct> for $struct_name {
+            type ForeignKey = $foreign_key_ty;
             type ForeignKeyColumn = $child_table_name::$foreign_key_name;
 
-            fn foreign_key(&self) -> Option<&<$parent_struct as $crate::associations::Identifiable>::Id> {
+            fn foreign_key(&self) -> Option<&$foreign_key_ty> {
                 Some(&self.$foreign_key_name)
             }
 
@@ -171,6 +175,7 @@ macro_rules! BelongsTo {
     // Generate code when FK is optional
     (
         (
+            foreign_key_ty = $foreign_key_ty:ty,
             foreign_key_kind = option,
             struct_name = $struct_name:ident,
             parent_struct = $parent_struct:ident,
@@ -180,9 +185,10 @@ macro_rules! BelongsTo {
         $($rest:tt)*
     ) => {
         impl $crate::associations::BelongsTo<$parent_struct> for $struct_name {
+            type ForeignKey = $foreign_key_ty;
             type ForeignKeyColumn = $child_table_name::$foreign_key_name;
 
-            fn foreign_key(&self) -> Option<&<$parent_struct as $crate::associations::Identifiable>::Id> {
+            fn foreign_key(&self) -> Option<&$foreign_key_ty> {
                 self.$foreign_key_name.as_ref()
             }
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -284,9 +284,10 @@ macro_rules! tuple_impls {
                 A: BelongsTo<Parent>,
                 Parent: Identifiable,
             {
+                type ForeignKey = A::ForeignKey;
                 type ForeignKeyColumn = A::ForeignKeyColumn;
 
-                fn foreign_key(&self) -> Option<&Parent::Id> {
+                fn foreign_key(&self) -> Option<&Self::ForeignKey> {
                     self.0.foreign_key()
                 }
 


### PR DESCRIPTION
As part of the attempt to allow composite primary keys in
`Identifiable`, we either need ATCs or reference the lifetime at the
trait impl level either by adding it to the `Identifiable` trait or by
implementing the trait on a reference. However, no matter what I did I
would always end up with a lifetime error in [`grouped_by`][grouped-by]
about the child being borrowed for too long.

I've finally realized that the reason this was occurring was that we
were [insisting that the foreign key be the same type as the primary
key][fk-type]. When we bring an additional lifetime into the picture,
what we were effectively doing is "downcasting" the foreign key to be of
the type of the primary key. This ended up implying that the child had
to live at least as long as the hash map containing the primary keys.
What we're doing now is effectively upcasting the primary key when we do
the comparison, allowing the foreign key to live for a short as it needs
to.

This still does not do the actual lifting of the reference of the
primary key type, that will come following this piece, assuming I don't
run into any more walls.

[grouped-by]: https://github.com/diesel-rs/diesel/blob/7d2c9fa1c11e870065d5cbb4f5cb91b51d7ed5fc/diesel/src/associations/belongs_to.rs#L30-L32
[fk-type]: https://github.com/diesel-rs/diesel/blob/7d2c9fa1c11e870065d5cbb4f5cb91b51d7ed5fc/diesel/src/associations/belongs_to.rs#L11