### PR TITLE
Allow structs with composite primary keys to implement `Identifiable`

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -137,19 +137,21 @@ impl<'a, T: HasTable> HasTable for &'a T {
 
 /// Represents a struct which can be identified on a single table in the
 /// database. This must be implemented to use associations, and some features of
-/// updating.
+/// updating. This trait is usually implemented on a reference to a struct, not
+/// the struct itself.
 ///
 /// ### Deriving
 ///
 /// This trait can be automatically derived using `diesel_codegen` by adding
-/// `#[derive(Identifiable)]` to your struct. The primary key will be assumed to be a field and
-/// column called `id`. By default the table will be assumed to be the plural form of the struct
-/// name (using *very* dumb pluralization -- it just adds an `s` at the end). If your table name
-/// differs from that convention, or requires complex pluralization, it can be specified using
-/// `#[table_name = "some_table_name"]`. The inferred table name is considered public API and will
-/// never change without a major version bump.
+/// `#[derive(Identifiable)]` to your struct. The primary key will be assumed to
+/// be a field and column called `id`. By default the table will be assumed to
+/// be the plural form of the struct name (using *very* dumb pluralization -- it
+/// just adds an `s` at the end). If your table name differs from that
+/// convention, or requires complex pluralization, it can be specified using
+/// `#[table_name = "some_table_name"]`. The inferred table name is considered
+/// public API and will never change without a major version bump.
 pub trait Identifiable: HasTable {
     type Id: Hash + Eq;
 
-    fn id(&self) -> &Self::Id;
+    fn id(self) -> Self::Id;
 }

--- a/diesel/src/macros/identifiable.rs
+++ b/diesel/src/macros/identifiable.rs
@@ -1,5 +1,6 @@
-/// Implements the [`Identifiable`][identifiable] trait for a given struct. This
-/// macro should be called by copy/pasting the definition of the struct into it.
+/// Implements the [`Identifiable`][identifiable] trait for a reference to a
+/// given struct. This macro should be called by copy/pasting the definition of
+/// the struct into it.
 ///
 /// The struct must have a field called `id`, and the type of that field must be
 /// `Copy`. This macro does not work with tuple structs.
@@ -87,10 +88,10 @@ macro_rules! _Identifiable {
             }
         }
 
-        impl $crate::associations::Identifiable for $struct_ty {
-            type Id = $field_ty;
+        impl<'a> $crate::associations::Identifiable for &'a $struct_ty {
+            type Id = &'a $field_ty;
 
-            fn id(&self) -> &Self::Id {
+            fn id(self) -> Self::Id {
                 &self.id
             }
         }
@@ -146,6 +147,7 @@ table! {
 fn derive_identifiable_on_simple_struct() {
     use associations::Identifiable;
 
+    #[allow(missing_debug_implementations, missing_copy_implementations)]
     struct Foo {
         id: i32,
         #[allow(dead_code)]
@@ -170,6 +172,7 @@ fn derive_identifiable_on_simple_struct() {
 fn derive_identifiable_when_id_is_not_first_field() {
     use associations::Identifiable;
 
+    #[allow(missing_debug_implementations, missing_copy_implementations)]
     struct Foo {
         #[allow(dead_code)]
         foo: i32,
@@ -194,6 +197,7 @@ fn derive_identifiable_when_id_is_not_first_field() {
 fn derive_identifiable_on_struct_with_non_integer_pk() {
     use associations::Identifiable;
 
+    #[allow(missing_debug_implementations, missing_copy_implementations)]
     struct Foo {
         id: &'static str,
         #[allow(dead_code)]

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -15,9 +15,9 @@ pub trait IntoUpdateTarget: HasTable {
     fn into_update_target(self) -> UpdateTarget<Self::Table, Self::WhereClause>;
 }
 
-impl<'a, T: Identifiable, V> IntoUpdateTarget for &'a T where
-    T::Table: FindDsl<&'a T::Id>,
-    Find<T::Table, &'a T::Id>: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
+impl<T: Identifiable, V> IntoUpdateTarget for T where
+    T::Table: FindDsl<T::Id>,
+    Find<T::Table, T::Id>: IntoUpdateTarget<Table=T::Table, WhereClause=V>,
 {
     type WhereClause = V;
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -1,4 +1,4 @@
-use associations::{BelongsTo, Identifiable};
+use associations::BelongsTo;
 use backend::{Backend, SupportsDefaultKeyword};
 use expression::{Expression, SelectableExpression, NonAggregate};
 use persistable::{ColumnInsertValue, InsertValues};
@@ -282,7 +282,6 @@ macro_rules! tuple_impls {
 
             impl<$($T,)+ Parent> BelongsTo<Parent> for ($($T,)+) where
                 A: BelongsTo<Parent>,
-                Parent: Identifiable,
             {
                 type ForeignKey = A::ForeignKey;
                 type ForeignKeyColumn = A::ForeignKeyColumn;

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -49,6 +49,32 @@ impl Comment {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct Following {
+    pub user_id: i32,
+    pub post_id: i32,
+    pub email_notifications: bool,
+}
+
+impl ::diesel::associations::HasTable for Following {
+    type Table = followings::table;
+
+    fn table() -> Self::Table {
+        followings::table
+    }
+}
+
+// Test to ensure a proper implementation of `Identifiable` can be written for composite types.
+// This will eventually be replaced with a derive.
+impl<'a> ::diesel::associations::Identifiable for &'a Following {
+    type Id = (&'a i32, &'a i32);
+
+    fn id(self) -> Self::Id {
+        (&self.user_id, &self.post_id)
+    }
+}
+
 #[cfg(feature = "postgres")]
 #[path="postgres_specific_schema.rs"]
 mod backend_specifics;


### PR DESCRIPTION
The fundamental problem is that right now we're assuming the primary key
is something that you can return a reference to. However, for composite
keys you'll likely want to return a tuple of references. In a perfect
world we would use an associated type constructor for this, but we don't
have those. Instead we're going through these contortions to make it
work.

These signatures are going to be significantly less clear to newcomers
now, and I'm not looking forward to answering "why am I seeing that
`User` doesn't implement `Identifiable` in gitter, but this is our only
option at the moment.