### PR TITLE
Add support for `NOT IN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## [0.8.2] - 2016-11-22
 
+### Added
+
+* Added support for SQL `NOT IN` using the `ne_any` method.
+
 ### Changed
 
 * Fixed support for nightlies later than 2016-11-07

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -31,10 +31,6 @@ stable_sqlite = ["with-syntex", "sqlite", "diesel_codegen_syntex/sqlite"]
 unstable_postgres = ["unstable", "postgres", "diesel_codegen/postgres"]
 unstable_sqlite = ["unstable", "sqlite", "diesel_codegen/sqlite"]
 
-[lib]
-name = "integration_tests"
-path = "tests/lib.rs"
-
 [[test]]
 name = "integration_tests"
 path = "tests/lib.rs"


### PR DESCRIPTION
I will probably eventually re-implement this with an arbitrary `not`
function, but I didn't want to go there quite yet as I'm not sure if
we'll need to do anything with parenthesis for that.

This will add another case we have to deal with empty arrays for, but I
don't think this will affect the implementation other than requiring an
additional test. What I'm thinking we'll do is have the `In` expression
write out `1=0` when it sees an empty array. With this implementation
it'll be `NOT 1=0`, which is exactly what we want. (In empty set = no
rows, not in empty set = all rows)

Fixes #511