### PR TITLE
Properly derive `Identifiable` for structs with lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Fixed
+
+* `#[derive(Identifiable)]` now works on structs with lifetimes
+
 ## [0.8.2] - 2016-11-22
 
 ### Added

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -7,6 +7,7 @@ pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
     let model = t!(Model::from_item(&item, "Identifiable"));
     let table_name = model.table_name();
     let struct_ty = &model.ty;
+    let lifetimes = model.generics.lifetimes;
     let fields = model.attrs;
     if !fields.iter().any(|f| f.field_name == Some(syn::Ident::new("id"))) {
         panic!("Could not find a field named `id` on `{}`", &model.name);
@@ -16,6 +17,7 @@ pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
         (
             table_name = #table_name,
             struct_ty = #struct_ty,
+            lifetimes = (#(lifetimes),*),
         ),
         fields = [#(fields)*],
     })

--- a/diesel_codegen_syntex/src/identifiable.rs
+++ b/diesel_codegen_syntex/src/identifiable.rs
@@ -4,6 +4,7 @@ use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax::parse::token::str_to_ident;
 
 use model::Model;
+use util::lifetime_list_tokens;
 
 pub fn expand_derive_identifiable(
     cx: &mut ExtCtxt,
@@ -15,12 +16,14 @@ pub fn expand_derive_identifiable(
     if let Some(model) = Model::from_annotable(cx, span, annotatable) {
         let table_name = model.table_name();
         let struct_ty = &model.ty;
+        let lifetimes = lifetime_list_tokens(&model.generics.lifetimes, span);
         let fields = model.field_tokens_for_stable_macro(cx);
         if model.attr_named(str_to_ident("id")).is_some() {
             push(Annotatable::Item(quote_item!(cx, Identifiable! {
                 (
                     table_name = $table_name,
                     struct_ty = $struct_ty,
+                    lifetimes = ($lifetimes),
                 ),
                 fields = [$fields],
             }).unwrap()));

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -162,3 +162,13 @@ mod custom_foreign_keys_are_respected_on_belongs_to {
         author_id: i32,
     }
 }
+
+mod derive_identifiable_with_lifetime {
+    #![allow(dead_code)]
+    use schema::posts;
+
+    #[derive(Identifiable)]
+    pub struct Post<'a> {
+        id: &'a i32
+    }
+}


### PR DESCRIPTION
Fixes #502