### PR TITLE
Allow custom schema names in the `table!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for SQL `NOT IN` using the `ne_any` method.
 
+* The `table!` macro now allows custom schemas to be specified. Example:
+
+  ```rust
+  table! {
+    schema_1.table_1 {
+      id -> Integer,
+    }
+  }
+  ```
+
+  The generated module will still be called `table_1`.
+
 ### Fixed
 
 * `#[derive(Identifiable)]` now works on structs with lifetimes

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -46,7 +46,6 @@ pub trait Table: QuerySource + AsQuery + Sized {
     type PrimaryKey: SelectableExpression<Self> + NonAggregate;
     type AllColumns: SelectableExpression<Self> + NonAggregate;
 
-    fn name() -> &'static str;
     fn primary_key(&self) -> Self::PrimaryKey;
     fn all_columns() -> Self::AllColumns;
 


### PR DESCRIPTION
This does not add support for `infer_schema!` with tables on schemas
other than public, but it does lay the ground work by changing the
macros to support it. I removed the `name` function from the `Table`
trait, as any code that was using that function would be broken on
tables with custom schemas.

Partially fixes #447