### PR TITLE
Give a more helpful error on no-op updates

### DIFF
--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -35,7 +35,7 @@ impl RawConnection {
         last_error_message(self.internal_connection)
     }
 
-    pub fn escape_identifier(&self, identifier: &str) -> QueryResult<PgString> {
+    pub fn escape_identifier(&self, identifier: &str) -> Result<PgString, String> {
         let result_ptr = unsafe { PQescapeIdentifier(
             self.internal_connection,
             identifier.as_ptr() as *const libc::c_char,
@@ -43,10 +43,7 @@ impl RawConnection {
         ) };
 
         if result_ptr.is_null() {
-            Err(Error::DatabaseError(
-                DatabaseErrorKind::__Unknown,
-                Box::new(last_error_message(self.internal_connection)),
-            ))
+            Err(last_error_message(self.internal_connection))
         } else {
             unsafe {
                 Ok(PgString::new(result_ptr))

--- a/diesel/src/pg/query_builder.rs
+++ b/diesel/src/pg/query_builder.rs
@@ -27,10 +27,7 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
     }
 
     fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
-        let escaped_identifier = match self.conn.escape_identifier(identifier) {
-            Ok(v) => v,
-            Err(e) => return Err(Box::new(e)),
-        };
+        let escaped_identifier = try!(self.conn.escape_identifier(identifier));
         Ok(self.push_sql(&escaped_identifier))
     }
 

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -45,7 +45,7 @@ use result::QueryResult;
 
 #[doc(hidden)]
 pub type Binds = Vec<Option<Vec<u8>>>;
-pub type BuildQueryResult = Result<(), Box<Error+Send>>;
+pub type BuildQueryResult = Result<(), Box<Error+Send+Sync>>;
 
 /// Apps should not need to concern themselves with this trait.
 ///

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -51,6 +51,11 @@ impl<T, U, V, DB> QueryFragment<DB> for UpdateStatement<T, U, V> where
     V: changeset::Changeset<DB>,
 {
     fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        if self.values.is_noop() {
+            return Err("There are no changes to save. This \
+                       query cannot be built".into())
+        }
+
         out.push_sql("UPDATE ");
         try!(self.table.from_clause().to_sql(out));
         out.push_sql(" SET ");

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -11,7 +11,7 @@ pub enum Error {
     InvalidCString(NulError),
     DatabaseError(DatabaseErrorKind, Box<DatabaseErrorInformation+Send>),
     NotFound,
-    QueryBuilderError(Box<StdError+Send>),
+    QueryBuilderError(Box<StdError+Send+Sync>),
     DeserializationError(Box<StdError+Send+Sync>),
     SerializationError(Box<StdError+Send+Sync>),
     #[doc(hidden)]

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use schema::*;
 use diesel::*;
 
@@ -256,4 +258,19 @@ fn struct_with_option_fields_treated_as_null() {
 
     assert_eq!(Ok(&expected_post), updated_post.as_ref());
     assert_eq!(Ok(&expected_post), post_in_database.as_ref());
+}
+
+#[test]
+#[should_panic="There are no changes to save."]
+fn update_with_no_changes() {
+    #[derive(AsChangeset)]
+    #[table_name="users"]
+    struct Changes {
+        name: Option<String>,
+        hair_color: Option<String>,
+    }
+
+    let connection = connection();
+    let changes = Changes { name: None, hair_color: None, };
+    update(users::table).set(&changes).execute(&connection).unwrap();
 }


### PR DESCRIPTION
Prior to this commit, an update with no changes would generate invalid
SQL which would result in a database error. Even if the resulting error
were handled, the transaction would be aborted at that point, which may
not be desired. With this change, we provide a more useful error message
and don't risk aborting the current transaction.