### PR TITLE
Unify `InsertStatement` and `InsertQuery` into a single struct

### DIFF
--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -1,5 +1,9 @@
 macro_rules! simple_clause {
     ($no_clause:ident, $clause:ident, $sql:expr) => {
+        simple_clause!($no_clause, $clause, $sql, backend_bounds = );
+    };
+
+    ($no_clause:ident, $clause:ident, $sql:expr, backend_bounds = $($backend_bounds:ident),*) => {
         use backend::Backend;
         use result::QueryResult;
         use super::{QueryFragment, QueryBuilder, BuildQueryResult};
@@ -27,7 +31,7 @@ macro_rules! simple_clause {
         pub struct $clause<Expr>(pub Expr);
 
         impl<Expr, DB> QueryFragment<DB> for $clause<Expr> where
-            DB: Backend,
+            DB: Backend $(+ $backend_bounds)*,
             Expr: QueryFragment<DB>,
         {
             fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -17,6 +17,7 @@ mod group_by_clause;
 mod limit_clause;
 mod offset_clause;
 mod order_clause;
+mod returning_clause;
 mod select_statement;
 pub mod where_clause;
 pub mod insert_statement;

--- a/diesel/src/query_builder/returning_clause.rs
+++ b/diesel/src/query_builder/returning_clause.rs
@@ -1,0 +1,3 @@
+use backend::SupportsReturningClause;
+
+simple_clause!(NoReturningClause, ReturningClause, " RETURNING ", backend_bounds = SupportsReturningClause);

--- a/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -51,6 +51,6 @@ fn main() {
     insert(&NewUser("Hello".into()))
         .into(users::table)
         .returning(users::name)
-        .get_result(&connection);
+        .get_result::<String>(&connection);
     //~^ ERROR: SupportsReturningClause
 }

--- a/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
+++ b/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
@@ -1,0 +1,41 @@
+#[macro_use] extern crate diesel;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+pub struct NewUser(String);
+
+Insertable! {
+    (users)
+    pub struct NewUser(#[column_name(name)] String,);
+}
+
+fn main() {
+    use self::users::dsl::*;
+
+    let connection = PgConnection::establish("").unwrap();
+
+    let query = delete(users.filter(name.eq("Bill")))
+        .returning(id);
+    query.returning(name);
+    //~^ ERROR: no method named `returning`
+
+    let query = insert(&NewUser("Hello".into()))
+        .into(users)
+        .returning(id);
+    query.returning(name);
+    //~^ ERROR: no method named `returning`
+
+    let query = update(users)
+        .set(name.eq("Bill"))
+        .returning(id);
+    query.returning(name);
+    //~^ ERROR: no method named `returning`
+}


### PR DESCRIPTION
I'm working on adding support for batch insert on SQLite, and fixing the
insert empty slice bug (#384). My approach is to override `ExecuteDsl`
and `LoadDsl` at the point where `InsertStatement` currently lives.
I expect that we'll have `into` perform some polymorphic dispatch to get
back either a `SingleInsertStatement` or `BatchInsertStatement`. If we
also have `InsertQuery` on top of that, the amount of redundant structs
and impls will get quite large. This change should make that refactoring
much easier.

I also took this opportunity to make sure our compile tests were up to
snuff around this, and made sure that the tests failed in the expected
fashion when I introduced some mistakes as part of this refactor.