### PR TITLE
Don't panic when calling `eq_any` or `ne_any` with an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,27 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
   The generated module will still be called `table_1`.
 
+* Added support for batch insert on SQLite. This means that you can now pass a
+  slice or vector to [`diesel::insert`][insert] on all backends.
+
+[insert]: http://docs.diesel.rs/diesel/fn.insert.html
+
 ### Fixed
 
 * `#[derive(Identifiable)]` now works on structs with lifetimes
+
+* Attempting to insert an empty slice will no longer panic. It does not execute
+  any queries, but the result will indicate that we successfully inserted 0
+  rows.
+
+* Attempting to update a record with no changes will no longer generate invalid
+  SQL. The result of attempting to execute the query will still be an error, but
+  but it will be a `Error::QueryBuilderError`, rather than a database error.
+  This means that it will not abort the current transaction, and can be handled
+  by applications.
+
+* Calling `eq_any` or `ne_any` with an empty array no longer panics.
+  `eq_any(vec![])` will return no rows. `ne_any(vec![])` will return all rows.
 
 ## [0.8.2] - 2016-11-22
 

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -1,9 +1,6 @@
 extern crate dotenv;
 
-use diesel::backend;
-use diesel::persistable::{InsertValues};
 use diesel::prelude::*;
-use diesel::query_builder::{QueryBuilder, BuildQueryResult};
 use self::dotenv::dotenv;
 
 #[cfg(feature = "postgres")]

--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -101,6 +101,10 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #         ('Jim')").unwrap();
     /// let data = users.select(id).filter(name.eq_any(vec!["Sean", "Jim"]));
     /// assert_eq!(Ok(vec![1, 3]), data.load(&connection));
+    ///
+    /// // Calling `eq_any` with an empty array is the same as doing `WHERE 1=0`
+    /// let data = users.select(id).filter(name.eq_any(Vec::<String>::new()));
+    /// assert_eq!(Ok(vec![]), data.load::<i32>(&connection));
     /// # }
     /// ```
     fn eq_any<T>(self, values: T) -> In<Self, T::InExpression> where
@@ -134,8 +138,13 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #         ('Jim')").unwrap();
     /// let data = users.select(id).filter(name.ne_any(vec!["Sean", "Jim"]));
     /// assert_eq!(Ok(vec![2]), data.load(&connection));
+    ///
     /// let data = users.select(id).filter(name.ne_any(vec!["Tess"]));
     /// assert_eq!(Ok(vec![1, 3]), data.load(&connection));
+    ///
+    /// // Calling `ne_any` with an empty array is the same as doing `WHERE 1=1`
+    /// let data = users.select(id).filter(name.ne_any(Vec::<String>::new()));
+    /// assert_eq!(Ok(vec![1, 2, 3]), data.load(&connection));
     /// # }
     /// ```
     fn ne_any<T>(self, values: T) -> NotIn<Self, T::InExpression> where


### PR DESCRIPTION
I had hoped to avoid introducing a new trait or methods for this.
However, the earliest point in the query builder that we can handle this
without introducing some new method is after the opening parenthesis has
been emitted. I had attempted to do something like emit `SELECT 1 WHERE
1=0` or `SELECT NULL WHERE 1=0` but both cases can cause type errors.

Still, due to the nature of how `In` is implemented, we can at least add
the required methods in an extremely contained fashion.

I have also added CHANGELOG entries for other "empty array causes
crashes" commits that had preceded this one, as I had forgotten to do so
earlier and this is the last case that I'm aware of.

Fixes #520.