### PR TITLE
Load custom schemas from `infer_schema!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
   The generated module will still be called `table_1`.
 
+* The `infer_table_from_schema!` macro now allows custom schemas to be
+  specified. Example:
+
+  ```rust
+  infer_table_from_schema!("dotenv:DATABASE_URL", "schema_1.table_1");
+  ```
+
+* The `infer_schema!` optionally allows a schema name as the second argument. Any
+  schemas other than `public` will be wrapped in a module with the same name as
+  the schema. For example, `schema_1.table_1` would be referenced as
+  `schema_1::table_1`.
+
 * Added support for batch insert on SQLite. This means that you can now pass a
   slice or vector to [`diesel::insert`][insert] on all backends.
 

--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -1,11 +1,13 @@
 #[macro_export]
 /// Queries the database for the names of all tables, and calls
 /// [`infer_table_from_schema!`](macro.infer_table_from_schema!.html) for each
-/// one.
+/// one. A schema name can optionally be passed to load from schemas other than
+/// the default. If a schema name is given, the inferred tables will be wrapped
+/// in a module with the same name.
 ///
-/// Attempting to use the `env!` or `dotenv!` macros here will not work due to limitations of
-/// the Macros 1.1 system, but you can pass a string in the form `"env:SOME_ENV_VAR"` or
-/// `"dotenv:SOME_ENV_VAR"` to achieve the same effect.
+/// Attempting to use the `env!` or `dotenv!` macros here will not work due to
+/// limitations of the Macros 1.1 system, but you can pass a string in the form
+/// `"env:SOME_ENV_VAR"` or `"dotenv:SOME_ENV_VAR"` to achieve the same effect.
 ///
 /// This macro can only be used in combination with the `diesel_codegen` or
 /// `diesel_codegen_syntex` crates. It will not work on its own.
@@ -17,20 +19,33 @@ macro_rules! infer_schema {
             struct _Dummy;
         }
         pub use self::__diesel_infer_schema::*;
-    }
+    };
+
+    ($database_url: expr, $schema_name: expr) => {
+        mod __diesel_infer_schema {
+            #[derive(InferSchema)]
+            #[options(database_url=$database_url, schema_name=$schema_name)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_schema::*;
+    };
 }
 
 #[macro_export]
-/// Establishes a database connection at compile time, loads the schema information about a table's
-/// columns, and invokes [`table!`](macro.table!.html) for you automatically.
+/// Establishes a database connection at compile time, loads the schema
+/// information about a table's columns, and invokes
+/// [`table!`](macro.table!.html) for you automatically. For tables in a schema
+/// other than the default, the table name should be given as
+/// `"schema_name.table_name"`.
 ///
-/// Attempting to use the `env!` or `dotenv!` macros here will not work due to limitations of the
-/// Macros 1.1 system, but you can pass a string in the form `"env:SOME_ENV_VAR"` or
-/// `"dotenv:SOME_ENV_VAR"` to achieve the same effect.
+/// Attempting to use the `env!` or `dotenv!` macros here will not work due to
+/// limitations of the Macros 1.1 system, but you can pass a string in the form
+/// `"env:SOME_ENV_VAR"` or `"dotenv:SOME_ENV_VAR"` to achieve the same effect.
 ///
-/// At this time, the schema inference macros do not support types from third party crates, and
-/// having any columns with a type not supported by the diesel core crate will result in a compiler
-/// error (please [open an issue](https://github.com/diesel-rs/diesel/issues/new) if this happens
+/// At this time, the schema inference macros do not support types from third
+/// party crates, and having any columns with a type not supported by the diesel
+/// core crate will result in a compiler error (please [open an
+/// issue](https://github.com/diesel-rs/diesel/issues/new) if this happens
 /// unexpectedly for a type listed in our docs.)
 ///
 /// This macro can only be used in combination with the `diesel_codegen` or

--- a/diesel_codegen/src/util.rs
+++ b/diesel_codegen/src/util.rs
@@ -122,7 +122,14 @@ pub fn get_option<'a>(
     option_name: &str,
     on_bug: fn() -> !,
 ) -> &'a str {
+    get_optional_option(options, option_name)
+        .unwrap_or_else(|| on_bug())
+}
+
+pub fn get_optional_option<'a>(
+    options: &'a [MetaItem],
+    option_name: &str,
+) -> Option<&'a str> {
     options.iter().find(|a| a.name() == option_name)
         .map(|a| str_value_of_meta_item(a, option_name))
-        .unwrap_or_else(|| on_bug())
 }

--- a/diesel_codegen_shared/src/schema_inference/mod.rs
+++ b/diesel_codegen_shared/src/schema_inference/mod.rs
@@ -12,14 +12,16 @@ use InferConnection;
 use database_url::extract_database_url;
 pub use self::data_structures::{ColumnInformation, ColumnType};
 
-pub fn load_table_names(database_url: &str) -> Result<Vec<String>, Box<Error>> {
+pub fn load_table_names(database_url: &str, schema_name: Option<&str>)
+    -> Result<Vec<String>, Box<Error>>
+{
     let connection = try!(establish_connection(database_url));
 
     match connection {
         #[cfg(feature = "sqlite")]
-        InferConnection::Sqlite(c) => sqlite::load_table_names(&c),
+        InferConnection::Sqlite(c) => sqlite::load_table_names(&c, schema_name),
         #[cfg(feature = "postgres")]
-        InferConnection::Pg(c) => pg::load_table_names(&c),
+        InferConnection::Pg(c) => pg::load_table_names(&c, schema_name),
     }
 }
 
@@ -106,4 +108,3 @@ pub fn get_primary_keys(
         Ok(primary_keys)
     }
 }
-

--- a/diesel_tests/tests/custom_schemas.rs
+++ b/diesel_tests/tests/custom_schemas.rs
@@ -1,0 +1,22 @@
+use diesel::*;
+use schema::connection;
+
+infer_schema!("dotenv:DATABASE_URL", "custom_schema");
+use self::custom_schema::users;
+
+#[derive(Insertable)]
+#[table_name="users"]
+struct NewUser {
+    id: i32,
+}
+
+#[test]
+fn custom_schemas_are_loaded_by_infer_schema() {
+    let conn = connection();
+    insert(&NewUser { id: 1 }).into(users::table)
+        .execute(&conn).unwrap();
+    let users = users::table.select(users::id)
+        .load(&conn);
+
+    assert_eq!(Ok(vec![1]), users);
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -15,6 +15,11 @@ include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
 mod boxed_queries;
 mod connection;
+// This should be in lib.in.rs restricted to PG, but
+// syntex compiles the file even if the feature is unset,
+// and the macro call is invalid on SQLite.
+#[cfg(all(feature = "unstable", feature = "postgres"))]
+mod custom_schemas;
 mod debug;
 mod delete;
 mod errors;

--- a/migrations/postgresql/20161206123630_create_table_custom_schema/down.sql
+++ b/migrations/postgresql/20161206123630_create_table_custom_schema/down.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA custom_schema CASCADE;

--- a/migrations/postgresql/20161206123630_create_table_custom_schema/up.sql
+++ b/migrations/postgresql/20161206123630_create_table_custom_schema/up.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA custom_schema;
+CREATE TABLE custom_schema.users (id SERIAL PRIMARY KEY);


### PR DESCRIPTION
This changes `infer_table_from_schema!` to optionally take a custom
schema in the form `schema_name.table_name`, and generate different code
accordingly. `infer_schema!` will now load the names of all custom
schemas, and generate the code accordingly. Any schemas other than the
default will be wrapped in a module.

Unresolved Questions
--------------------

On basically every backend other than PG, the term "schema" is
interchangeable with "database". We almost certainly never want to load
the schemas for other databases by default. Instead of automatically
picking up the schema names, should we instead require that the schema
name be passed to `infer_schema!`? That would mean it looks something
like:

```rust
infer_schema!("dotenv:DATABASE_URL");
infer_schema!("dotenv:DATABASE_URL", "custom_schema");
```

Fixes #447.