### PR TITLE
Rename all bang derive macros to `impl_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [insert]: http://docs.diesel.rs/diesel/fn.insert.html
 
+### Changed
+
+* All macros with the same name as traits we can derive (e.g. `Queryable!`) have
+  been renamed to `impl_Queryable!` or similar.
+
 ### Fixed
 
 * `#[derive(Identifiable)]` now works on structs with lifetimes

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -66,7 +66,7 @@ impl NewUser {
     }
 }
 
-Insertable! {
+impl_Insertable! {
     (users)
     struct NewUser {
         name: String,

--- a/diesel/src/macros/as_changeset.rs
+++ b/diesel/src/macros/as_changeset.rs
@@ -26,7 +26,7 @@
 ///     name: String,
 /// }
 ///
-/// AsChangeset! {
+/// impl_AsChangeset! {
 ///     (users)
 ///     struct User {
 ///         id: i32,
@@ -34,7 +34,7 @@
 ///     }
 /// }
 ///
-/// # Queryable! {
+/// # impl_Queryable! {
 /// #     struct User {
 /// #         id: i32,
 /// #         name: String,
@@ -70,21 +70,13 @@
 /// # }
 /// ```
 #[macro_export]
-macro_rules! AsChangeset {
-    ($($args:tt)*) => {
-        _AsChangeset!($($args)*);
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _AsChangeset {
+macro_rules! impl_AsChangeset {
     // Provide a default value for treat_none_as_null if not provided
     (
         ($table_name:ident)
         $($body:tt)*
     ) => {
-        _AsChangeset! {
+        impl_AsChangeset! {
             ($table_name, treat_none_as_null="false")
             $($body)*
         }
@@ -96,7 +88,7 @@ macro_rules! _AsChangeset {
         $(#[$ignore:meta])*
         $(pub)* struct $($body:tt)*
     ) => {
-        _AsChangeset! {
+        impl_AsChangeset! {
             $args
             $($body)*
         }
@@ -116,7 +108,7 @@ macro_rules! _AsChangeset {
                 struct_ty = $struct_name<$($lifetime),*>,
                 lifetimes = ($($lifetime),*),
             ),
-            callback = _AsChangeset,
+            callback = impl_AsChangeset,
             body = $body,
         }
     };
@@ -136,7 +128,7 @@ macro_rules! _AsChangeset {
                 struct_ty = $struct_name,
                 lifetimes = ('a),
             ),
-            callback = _AsChangeset,
+            callback = impl_AsChangeset,
             body = $body,
         }
     };
@@ -151,7 +143,7 @@ macro_rules! _AsChangeset {
         ),
         fields = [$($field:tt)+],
     ) => {
-        _AsChangeset! {
+        impl_AsChangeset! {
             (
                 fields = [$($field)+],
                 struct_name = $struct_name,
@@ -183,7 +175,7 @@ macro_rules! _AsChangeset {
         ),
         changeset_ty = $changeset_ty:ty,
     ) => {
-        _AsChangeset! {
+        impl_AsChangeset! {
             $($headers)*
             self_to_columns = $struct_name($(ref $column_name),+),
             columns = ($($column_name, $field_kind),+),
@@ -207,7 +199,7 @@ macro_rules! _AsChangeset {
         ),
         changeset_ty = $changeset_ty:ty,
     ) => {
-        _AsChangeset! {
+        impl_AsChangeset! {
             $($headers)*
             self_to_columns = $struct_name { $($field_name: ref $column_name,)+ ..},
             columns = ($($column_name, $field_kind),+),

--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -21,13 +21,13 @@
 /// pub struct User {
 ///     id: i32,
 /// }
-/// # Identifiable! { #[table_name(users)] struct User { id: i32, } }
+/// # impl_Identifiable! { #[table_name(users)] struct User { id: i32, } }
 ///
 /// pub struct Post {
 ///     id: i32,
 ///     user_id: i32,
 /// }
-/// # Identifiable! { #[table_name(posts)] struct Post { id: i32, user_id: i32, } }
+/// # impl_Identifiable! { #[table_name(posts)] struct Post { id: i32, user_id: i32, } }
 ///
 /// BelongsTo! {
 ///     (User, foreign_key = user_id)

--- a/diesel/src/macros/associations/has_many.rs
+++ b/diesel/src/macros/associations/has_many.rs
@@ -21,13 +21,13 @@
 /// pub struct User {
 ///     id: i32,
 /// }
-/// # Identifiable! { #[table_name(users)] struct User { id: i32, } }
+/// # impl_Identifiable! { #[table_name(users)] struct User { id: i32, } }
 ///
 /// pub struct Post {
 ///     id: i32,
 ///     user_id: i32,
 /// }
-/// # Identifiable! { #[table_name(posts)] struct Post { id: i32, user_id: i32, } }
+/// # impl_Identifiable! { #[table_name(posts)] struct Post { id: i32, user_id: i32, } }
 ///
 /// HasMany! {
 ///     (posts, foreign_key = user_id)

--- a/diesel/src/macros/identifiable.rs
+++ b/diesel/src/macros/identifiable.rs
@@ -17,7 +17,7 @@
 ///     name: String,
 /// }
 ///
-/// Identifiable! {
+/// impl_Identifiable! {
 ///     #[table_name(users)]
 ///     struct User {
 ///         id: i32,
@@ -27,22 +27,14 @@
 /// # fn main() {}
 /// ```
 #[macro_export]
-macro_rules! Identifiable {
-    ($($args:tt)*) => {
-        _Identifiable!($($args)*);
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _Identifiable {
+macro_rules! impl_Identifiable {
     // Extract table name from meta item
     (
         $(())*
         #[table_name($table_name:ident)]
         $($rest:tt)*
     ) => {
-        _Identifiable! {
+        impl_Identifiable! {
             (table_name = $table_name,)
             $($rest)*
         }
@@ -54,7 +46,7 @@ macro_rules! _Identifiable {
         #[$ignore:meta]
         $($rest:tt)*
     ) => {
-        _Identifiable!($args $($rest)*);
+        impl_Identifiable!($args $($rest)*);
     };
 
     // Strip pub (if present) and struct from definition
@@ -63,7 +55,7 @@ macro_rules! _Identifiable {
         $args:tt
         $(pub)* struct $($body:tt)*
     ) => {
-        _Identifiable!($args $($body)*);
+        impl_Identifiable!($args $($body)*);
     };
 
     // We found the `id` field, return the final impl
@@ -109,7 +101,7 @@ macro_rules! _Identifiable {
             $($rest:tt)*
         } $($fields:tt)*],
     ) => {
-        _Identifiable! {
+        impl_Identifiable! {
             $args,
             fields = [$($fields)*],
         }
@@ -127,7 +119,7 @@ macro_rules! _Identifiable {
                 struct_ty = $struct_name<$($lifetimes),*>,
                 lifetimes = ($($lifetimes),*),
             ),
-            callback = _Identifiable,
+            callback = impl_Identifiable,
             body = $body,
         }
     };
@@ -144,7 +136,7 @@ macro_rules! _Identifiable {
                 struct_ty = $struct_name,
                 lifetimes = (),
             ),
-            callback = _Identifiable,
+            callback = impl_Identifiable,
             body = $body,
         }
     };
@@ -173,7 +165,7 @@ fn derive_identifiable_on_simple_struct() {
         foo: i32,
     }
 
-    Identifiable! {
+    impl_Identifiable! {
         #[table_name(foos)]
         struct Foo {
             id: i32,
@@ -198,7 +190,7 @@ fn derive_identifiable_when_id_is_not_first_field() {
         id: i32,
     }
 
-    Identifiable! {
+    impl_Identifiable! {
         #[table_name(foos)]
         struct Foo {
             foo: i32,
@@ -223,7 +215,7 @@ fn derive_identifiable_on_struct_with_non_integer_pk() {
         foo: i32,
     }
 
-    Identifiable! {
+    impl_Identifiable! {
         #[table_name(bars)]
         struct Foo {
             id: &'static str,
@@ -248,7 +240,7 @@ fn derive_identifiable_on_struct_with_lifetime() {
         foo: i32,
     }
 
-    Identifiable! {
+    impl_Identifiable! {
         #[table_name(bars)]
         struct Foo<'a> {
             id: &'a str,

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -14,7 +14,7 @@
 ///     hair_color: &'a str,
 /// }
 ///
-/// Insertable! {
+/// impl_Insertable! {
 ///     (users)
 ///     struct NewUser<'a> {
 ///         name: &'a str,
@@ -48,7 +48,7 @@
 /// # table! { users { id -> Integer, name -> VarChar, hair_color -> Nullable<VarChar>, } }
 /// struct NewUser<'a>(&'a str, Option<&'a str>);
 ///
-/// Insertable! {
+/// impl_Insertable! {
 ///     (users)
 ///     struct NewUser<'a>(
 ///         #[column_name(name)]
@@ -60,22 +60,14 @@
 /// # fn main() {}
 /// ```
 #[macro_export]
-macro_rules! Insertable {
-    ($($args:tt)*) => {
-        _Insertable!($($args)*);
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _Insertable {
+macro_rules! impl_Insertable {
     // Strip meta items, pub (if present) and struct from definition
     (
         ($table_name:ident)
         $(#[$ignore:meta])*
         $(pub)* struct $($body:tt)*
     ) => {
-        _Insertable! {
+        impl_Insertable! {
             ($table_name)
             $($body)*
         }
@@ -94,7 +86,7 @@ macro_rules! _Insertable {
                 struct_ty = $struct_name<$($lifetime),*>,
                 lifetimes = ($($lifetime),*),
             ),
-            callback = _Insertable,
+            callback = impl_Insertable,
             body = $body,
         }
     };
@@ -112,7 +104,7 @@ macro_rules! _Insertable {
                 struct_ty = $struct_name,
                 lifetimes = (),
             ),
-            callback = _Insertable,
+            callback = impl_Insertable,
             body = $body,
         }
     };
@@ -130,7 +122,7 @@ macro_rules! _Insertable {
             $($rest:tt)*
         })+],
     ) => {
-        _Insertable! {
+        impl_Insertable! {
             $($headers)*
             self_to_columns = $struct_name($(ref $column_name),+),
             columns = ($($column_name, $field_ty, $field_kind),+),
@@ -151,7 +143,7 @@ macro_rules! _Insertable {
             $($rest:tt)*
         })+],
     ) => {
-        _Insertable! {
+        impl_Insertable! {
             $($headers)*
             self_to_columns = $struct_name { $($field_name: ref $column_name),+ },
             columns = ($($column_name, $field_ty, $field_kind),+),
@@ -257,7 +249,7 @@ mod tests {
             hair_color: String,
         }
 
-        Insertable! {
+        impl_Insertable! {
             (users)
             struct NewUser {
                 name: String,
@@ -288,7 +280,7 @@ mod tests {
                 __diesel_parse_as_item!($($struct_def)*);
             #[test]
             fn $test_name() {
-                Insertable! {
+                impl_Insertable! {
                     (users)
                     $($struct_def)*
                 }
@@ -361,7 +353,7 @@ mod tests {
             hair_color: String,
         }
 
-        Insertable! {
+        impl_Insertable! {
             (users)
             struct NewUser {
                 #[column_name(name)]
@@ -387,7 +379,7 @@ mod tests {
             my_hair_color: Option<String>,
         }
 
-        Insertable! {
+        impl_Insertable! {
             (users)
             struct NewUser {
                 #[column_name(name)]
@@ -414,7 +406,7 @@ mod tests {
             Option<&'a str>,
         );
 
-        Insertable! {
+        impl_Insertable! {
             (users)
             struct NewUser<'a>(
                 #[column_name(name)]
@@ -441,7 +433,7 @@ mod tests {
             Option<&'a str>
         );
 
-        Insertable! {
+        impl_Insertable! {
             (users)
             struct NewUser<'a>(
                 #[column_name(name)]
@@ -474,7 +466,7 @@ mod tests {
     #[test]
     fn insertable_with_slice_of_borrowed() {
         struct NewPost<'a> { tags: &'a [&'a str], }
-        Insertable! { (posts) struct NewPost<'a> { tags: &'a [&'a str], } }
+        impl_Insertable! { (posts) struct NewPost<'a> { tags: &'a [&'a str], } }
 
         let conn = ::test_helpers::pg_helpers::connection();
         conn.execute("DROP TABLE IF EXISTS posts").unwrap();

--- a/diesel/src/macros/queryable.rs
+++ b/diesel/src/macros/queryable.rs
@@ -12,7 +12,7 @@
 ///     hair_color: Option<String>,
 /// }
 ///
-/// Queryable! {
+/// impl_Queryable! {
 ///     struct User {
 ///         name: String,
 ///         hair_color: Option<String>,
@@ -21,18 +21,10 @@
 /// # fn main() {}
 /// ```
 #[macro_export]
-macro_rules! Queryable {
-    ($($args:tt)*) => {
-        _Queryable!($($args)*);
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _Queryable {
+macro_rules! impl_Queryable {
     // Strip empty argument list if given (Passed by custom_derive macro)
     (() $($body:tt)*) => {
-        _Queryable! {
+        impl_Queryable! {
             $($body)*
         }
     };
@@ -42,7 +34,7 @@ macro_rules! _Queryable {
         $(#[$ignore:meta])*
         $(pub)* struct $($body:tt)*
     ) => {
-        _Queryable! {
+        impl_Queryable! {
             $($body)*
         }
     };
@@ -62,7 +54,7 @@ macro_rules! _Queryable {
             $($rest:tt)*
         })+],
     ) => {
-        _Queryable! {
+        impl_Queryable! {
             $($headers)*
             row_ty = ($($field_ty,)+),
             row_pat = ($($field_name,)+),
@@ -82,7 +74,7 @@ macro_rules! _Queryable {
             $($rest:tt)*
         })+],
     ) => {
-        _Queryable! {
+        impl_Queryable! {
             $headers,
             fields = [$({
                 field_ty: $field_ty,
@@ -104,7 +96,7 @@ macro_rules! _Queryable {
             $($rest:tt)*
         })+],
     ) => {
-        _Queryable! {
+        impl_Queryable! {
             $($headers)*
             row_ty = ($($field_ty,)+),
             row_pat = ($($field_kind,)+),
@@ -146,7 +138,7 @@ macro_rules! _Queryable {
                 generics = ($($generics),*),
                 lifetimes = (),
             ),
-            callback = _Queryable,
+            callback = impl_Queryable,
             body = $body,
         }
     };
@@ -163,7 +155,7 @@ macro_rules! _Queryable {
                 generics = (),
                 lifetimes = (),
             ),
-            callback = _Queryable,
+            callback = impl_Queryable,
             body = $body,
         }
     };
@@ -184,7 +176,7 @@ mod tests {
             bar: i32,
         }
 
-        Queryable! {
+        impl_Queryable! {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
             struct MyStruct {
                 foo: i32,
@@ -202,7 +194,7 @@ mod tests {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         struct MyStruct(i32, i32);
 
-        Queryable! {
+        impl_Queryable! {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
             struct MyStruct(#[column_name(foo)] i32, #[column_name(bar)] i32);
         }
@@ -217,7 +209,7 @@ mod tests {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         struct MyStruct(i32, i32);
 
-        Queryable! {
+        impl_Queryable! {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
             struct MyStruct(i32, i32);
         }

--- a/diesel/src/migrations/schema.rs
+++ b/diesel/src/migrations/schema.rs
@@ -7,7 +7,7 @@ table! {
 
 #[derive(Debug, Copy, Clone)]
 pub struct NewMigration<'a>(pub &'a str);
-Insertable! {
+impl_Insertable! {
     (__diesel_schema_migrations)
     pub struct NewMigration<'a>(
         #[column_name(version)]

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -79,7 +79,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// # }
     /// #
     /// # struct NewPost<'a> { tags: Vec<&'a str> }
-    /// # Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
+    /// # impl_Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
     /// #
     /// # fn main() {
     /// #     use self::posts::dsl::*;
@@ -133,7 +133,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// # }
     /// #
     /// # struct NewPost<'a> { tags: Vec<&'a str> }
-    /// # Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
+    /// # impl_Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
     /// #
     /// # fn main() {
     /// #     use self::posts::dsl::*;
@@ -183,7 +183,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// # }
     /// #
     /// # struct NewPost<'a> { tags: Vec<&'a str> }
-    /// # Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
+    /// # impl_Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
     /// #
     /// # fn main() {
     /// #     use self::posts::dsl::*;

--- a/diesel/src/sqlite/query_builder/functions.rs
+++ b/diesel/src/sqlite/query_builder/functions.rs
@@ -22,7 +22,7 @@ use super::nodes::Replace;
 /// #     name: &'a str,
 /// # }
 /// #
-/// # Insertable! {
+/// # impl_Insertable! {
 /// #     (users)
 /// #     struct User<'a> {
 /// #         id: i32,

--- a/diesel_codegen/src/as_changeset.rs
+++ b/diesel_codegen/src/as_changeset.rs
@@ -20,7 +20,7 @@ pub fn derive_as_changeset(item: syn::MacroInput) -> quote::Tokens {
         lifetimes.push(syn::LifetimeDef::new("'a"));
     }
 
-    quote!(_AsChangeset! {
+    quote!(impl_AsChangeset! {
         (
             struct_name = #struct_name,
             table_name = #table_name,

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -13,7 +13,7 @@ pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
         panic!("Could not find a field named `id` on `{}`", &model.name);
     }
 
-    quote!(_Identifiable! {
+    quote!(impl_Identifiable! {
         (
             table_name = #table_name,
             struct_ty = #struct_ty,

--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -21,7 +21,7 @@ pub fn derive_insertable(item: syn::MacroInput) -> quote::Tokens {
     let lifetimes = model.generics.lifetimes;
     let fields = model.attrs;
 
-    quote!(_Insertable! {
+    quote!(impl_Insertable! {
         (
             struct_name = #struct_name,
             table_name = #table_name,

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -12,7 +12,7 @@ pub fn derive_queryable(item: syn::MacroInput) -> Tokens {
     let attrs = model.attrs;
     let lifetimes = &model.generics.lifetimes;
 
-    quote!(_Queryable! {
+    quote!(impl_Queryable! {
         (
             struct_name = #struct_name,
             struct_ty = #struct_ty,

--- a/diesel_codegen_shared/src/schema_inference/sqlite.rs
+++ b/diesel_codegen_shared/src/schema_inference/sqlite.rs
@@ -49,7 +49,7 @@ struct FullTableInfo {
     primary_key: bool,
 }
 
-Queryable! {
+impl_Queryable! {
     struct FullTableInfo {
         _cid: i32,
         name: String,

--- a/diesel_codegen_syntex/src/identifiable.rs
+++ b/diesel_codegen_syntex/src/identifiable.rs
@@ -19,7 +19,7 @@ pub fn expand_derive_identifiable(
         let lifetimes = lifetime_list_tokens(&model.generics.lifetimes, span);
         let fields = model.field_tokens_for_stable_macro(cx);
         if model.attr_named(str_to_ident("id")).is_some() {
-            push(Annotatable::Item(quote_item!(cx, Identifiable! {
+            push(Annotatable::Item(quote_item!(cx, impl_Identifiable! {
                 (
                     table_name = $table_name,
                     struct_ty = $struct_ty,

--- a/diesel_codegen_syntex/src/insertable.rs
+++ b/diesel_codegen_syntex/src/insertable.rs
@@ -38,7 +38,7 @@ fn insertable_impl(
     let lifetimes = lifetime_list_tokens(&model.generics.lifetimes, span);
     let fields = model.attrs.iter().map(|a| a.to_stable_macro_tokens(cx)).collect::<Vec<_>>();
 
-    quote_item!(cx, Insertable! {
+    quote_item!(cx, impl_Insertable! {
         (
             struct_name = $struct_name,
             table_name = $table_name,

--- a/diesel_codegen_syntex/src/update.rs
+++ b/diesel_codegen_syntex/src/update.rs
@@ -105,7 +105,7 @@ fn changeset_impl(
         .map(|a| a.to_stable_macro_tokens(cx))
         .collect::<Vec<_>>();
 
-    quote_item!(cx, AsChangeset! {
+    quote_item!(cx, impl_AsChangeset! {
         (
             struct_name = $struct_name,
             table_name = $table_name,

--- a/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -35,7 +35,7 @@ impl<DB: Backend> Queryable<(Integer, VarChar), DB> for User where
 
 pub struct NewUser(String);
 
-Insertable! {
+impl_Insertable! {
     (users)
     pub struct NewUser(#[column_name(name)] String,);
 }

--- a/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
+++ b/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
@@ -12,7 +12,7 @@ table! {
 
 pub struct NewUser(String);
 
-Insertable! {
+impl_Insertable! {
     (users)
     pub struct NewUser(#[column_name(name)] String,);
 }

--- a/diesel_compile_tests/tests/compile-fail/returning_clause_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/returning_clause_requires_selectable_expression.rs
@@ -13,7 +13,7 @@ table! {
 
 pub struct NewUser(String);
 
-Insertable! {
+impl_Insertable! {
     (users)
     pub struct NewUser(#[column_name(name)] String,);
 }


### PR DESCRIPTION
Since all macro types share a single namespace now, even just declaring
these macros can cause problems even if they're never used.

Fixes #495.