### PR TITLE
fix(split_pg_connection_string): only available with `postgres` feature

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -171,6 +171,7 @@ pub fn backend(database_url: &String) -> &str {
     }
 }
 
+#[cfg(feature = "postgres")]
 fn split_pg_connection_string(database_url: &String) -> (String, String) {
     let mut split: Vec<&str> = database_url.split("/").collect();
     let database = split.pop().unwrap();
@@ -183,7 +184,7 @@ fn handle_error<E: Error, T>(error: E) -> T {
     ::std::process::exit(1);
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "postgres"))]
 mod tests {
     use super::split_pg_connection_string;
 

--- a/diesel_cli/tests/exit_codes.rs
+++ b/diesel_cli/tests/exit_codes.rs
@@ -1,4 +1,4 @@
-use support::{database, project};
+use support::project;
 
 #[test]
 fn errors_dont_cause_panic() {


### PR DESCRIPTION
I received this warning when building the cli as such:

```
cargo install diesel_cli --no-default-features --features sqlite
...

warning: function is never used: `split_pg_connection_string`, #[warn(dead_code)] on by default
   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/diesel_cli-0.8.0/src/database.rs:174:1
    |
174 |   fn split_pg_connection_string(database_url: &String) -> (String, String) {
    |  _^ starting here...
175 | |     let mut split: Vec<&str> = database_url.split("/").collect();
176 | |     let database = split.pop().unwrap();
177 | |     let postgres_url = format!("{}/{}", split.join("/"), "postgres");
178 | |     (database.to_owned(), postgres_url)
179 | | }
    | |_^ ...ending here
```