### PR TITLE
Allow custom primary keys to be specified for `Identifiable`

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -289,7 +289,7 @@ macro_rules! table_body {
             pub const all_columns: ($($column_name,)+) = ($($column_name,)+);
 
             #[allow(non_camel_case_types, missing_debug_implementations)]
-            #[derive(Clone, Copy)]
+            #[derive(Debug, Clone, Copy)]
             pub struct table;
 
             impl table {

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -8,14 +8,16 @@ pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
     let table_name = model.table_name();
     let struct_ty = &model.ty;
     let lifetimes = model.generics.lifetimes;
+    let primary_key_name = model.primary_key_name;
     let fields = model.attrs;
-    if !fields.iter().any(|f| f.field_name == Some(syn::Ident::new("id"))) {
-        panic!("Could not find a field named `id` on `{}`", &model.name);
+    if !fields.iter().any(|f| f.field_name.as_ref() == Some(&primary_key_name)) {
+        panic!("Could not find a field named `{}` on `{}`", primary_key_name, &model.name);
     }
 
     quote!(impl_Identifiable! {
         (
             table_name = #table_name,
+            primary_key_name = #primary_key_name,
             struct_ty = #struct_ty,
             lifetimes = (#(#lifetimes),*),
         ),

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -38,7 +38,7 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
     expand_derive(input, queryable::derive_queryable)
 }
 
-#[proc_macro_derive(Identifiable, attributes(table_name))]
+#[proc_macro_derive(Identifiable, attributes(table_name, primary_key))]
 pub fn derive_identifiable(input: TokenStream) -> TokenStream {
     expand_derive(input, identifiable::derive_identifiable)
 }

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -1,13 +1,14 @@
 use syn;
 
 use attr::Attr;
-use util::{struct_ty, str_value_of_attr_with_name};
+use util::*;
 
 pub struct Model {
     pub ty: syn::Ty,
     pub attrs: Vec<Attr>,
     pub name: syn::Ident,
     pub generics: syn::Generics,
+    pub primary_key_name: syn::Ident,
     table_name_from_annotation: Option<syn::Ident>,
 }
 
@@ -22,6 +23,9 @@ impl Model {
         let ty = struct_ty(item.ident.clone(), &item.generics);
         let name = item.ident.clone();
         let generics = item.generics.clone();
+        let primary_key_name = ident_value_of_attr_with_name(&item.attrs, "primary_key")
+            .map(Clone::clone)
+            .unwrap_or(syn::Ident::new("id"));
         let table_name_from_annotation = str_value_of_attr_with_name(
             &item.attrs, "table_name").map(syn::Ident::new);
 
@@ -30,6 +34,7 @@ impl Model {
             attrs: attrs,
             name: name,
             generics: generics,
+            primary_key_name: primary_key_name,
             table_name_from_annotation: table_name_from_annotation,
         })
     }

--- a/diesel_codegen_syntex/src/identifiable.rs
+++ b/diesel_codegen_syntex/src/identifiable.rs
@@ -1,7 +1,6 @@
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::parse::token::str_to_ident;
 
 use model::Model;
 use util::lifetime_list_tokens;
@@ -17,18 +16,20 @@ pub fn expand_derive_identifiable(
         let table_name = model.table_name();
         let struct_ty = &model.ty;
         let lifetimes = lifetime_list_tokens(&model.generics.lifetimes, span);
+        let primary_key_name = model.primary_key_name;
         let fields = model.field_tokens_for_stable_macro(cx);
-        if model.attr_named(str_to_ident("id")).is_some() {
+        if model.attr_named(primary_key_name).is_some() {
             push(Annotatable::Item(quote_item!(cx, impl_Identifiable! {
                 (
                     table_name = $table_name,
+                    primary_key_name = $primary_key_name,
                     struct_ty = $struct_ty,
                     lifetimes = ($lifetimes),
                 ),
                 fields = [$fields],
             }).unwrap()));
         } else {
-            cx.span_err(span, &format!("Could not find a field named `id` on `{}`", model.name));
+            cx.span_err(span, &format!("Could not find a field named `{}` on `{}`", primary_key_name, model.name));
         }
     }
 }

--- a/diesel_codegen_syntex/src/model.rs
+++ b/diesel_codegen_syntex/src/model.rs
@@ -6,13 +6,14 @@ use syntax::parse::token::str_to_ident;
 use syntax::tokenstream::TokenTree;
 
 use attr::Attr;
-use util::{str_value_of_attr_with_name, struct_ty};
+use util::*;
 
 pub struct Model {
     pub ty: P<ast::Ty>,
     pub attrs: Vec<Attr>,
     pub name: ast::Ident,
     pub generics: ast::Generics,
+    pub primary_key_name: ast::Ident,
     table_name_from_annotation: Option<ast::Ident>,
 }
 
@@ -25,6 +26,9 @@ impl Model {
         if let Annotatable::Item(ref item) = *annotatable {
             let table_name_from_annotation =
                 str_value_of_attr_with_name(cx, &item.attrs, "table_name");
+            let primary_key_name =
+                ident_value_of_attr_with_name(cx, &item.attrs, "primary_key")
+                    .unwrap_or(str_to_ident("id"));
             Attr::from_item(cx, item).map(|(generics, attrs)| {
                 let ty = struct_ty(cx, span, item.ident, &generics);
                 Model {
@@ -32,6 +36,7 @@ impl Model {
                     attrs: attrs,
                     name: item.ident,
                     generics: generics,
+                    primary_key_name: primary_key_name,
                     table_name_from_annotation: table_name_from_annotation,
                 }
             })
@@ -41,7 +46,7 @@ impl Model {
     }
 
     pub fn primary_key_name(&self) -> ast::Ident {
-        str_to_ident("id")
+        self.primary_key_name
     }
 
     pub fn table_name(&self) -> ast::Ident {

--- a/diesel_codegen_syntex/src/util.rs
+++ b/diesel_codegen_syntex/src/util.rs
@@ -72,6 +72,7 @@ const KNOWN_ATTRIBUTES: &'static [&'static str] = &[
     "column_name",
     "has_many",
     "table_name",
+    "primary_key",
 ];
 
 pub fn strip_attributes(krate: ast::Crate) -> ast::Crate {

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -172,3 +172,25 @@ mod derive_identifiable_with_lifetime {
         id: &'a i32
     }
 }
+
+#[test]
+fn derive_identifiable_with_non_standard_pk() {
+    use diesel::associations::*;
+
+    #[derive(Identifiable)]
+    #[table_name="posts"]
+    #[primary_key(foo_id)]
+    #[allow(dead_code)]
+    struct Foo<'a> {
+        id: i32,
+        foo_id: &'a str,
+        foo: i32,
+    }
+
+    let foo1 = Foo { id: 1, foo_id: "hi", foo: 2 };
+    let foo2 = Foo { id: 2, foo_id: "there", foo: 3 };
+    assert_eq!(&"hi", foo1.id());
+    assert_eq!(&"there", foo2.id());
+    // Fails to compile if wrong table is generated.
+    let _: posts::table = Foo::<'static>::table();
+}


### PR DESCRIPTION
This is the first half of implementing `#[derive(Identifiable)]` with
composite primary keys. The second half will be to allow keys with more
than one name. The bulk of the code is actually for the "copy your
struct definition into this macro" code path, which we will probably get
rid of soon. Still, until macros 1.1 is actually stable, I want to keep
it around, which means we should keep feature parity.