### PR TITLE
Allow `#[derive(Identifiable)]` to work with composite primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [exists]: http://docs.diesel.rs/diesel/expression/dsl/fn.sql.html
 
+* `#[derive(Identifiable)]` can be used with structs that have primary keys
+  other than `id`, as well as structs with composite primary keys. You can now
+  annotate the struct with `#[primary_key(nonstandard)]` or `#[primary_key(foo,
+  bar)]`.
+
 ### Changed
 
 * All macros with the same name as traits we can derive (e.g. `Queryable!`) have

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -8,16 +8,18 @@ pub fn derive_identifiable(item: syn::MacroInput) -> Tokens {
     let table_name = model.table_name();
     let struct_ty = &model.ty;
     let lifetimes = model.generics.lifetimes;
-    let primary_key_name = model.primary_key_name;
+    let primary_key_names = model.primary_key_names;
     let fields = model.attrs;
-    if !fields.iter().any(|f| f.field_name.as_ref() == Some(&primary_key_name)) {
-        panic!("Could not find a field named `{}` on `{}`", primary_key_name, &model.name);
+    for pk in &primary_key_names {
+        if !fields.iter().any(|f| f.field_name.as_ref() == Some(pk)) {
+            panic!("Could not find a field named `{}` on `{}`", pk, &model.name);
+        }
     }
 
     quote!(impl_Identifiable! {
         (
             table_name = #table_name,
-            primary_key_name = #primary_key_name,
+            primary_key_names = (#(#primary_key_names),*),
             struct_ty = #struct_ty,
             lifetimes = (#(#lifetimes),*),
         ),

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -8,7 +8,7 @@ pub struct Model {
     pub attrs: Vec<Attr>,
     pub name: syn::Ident,
     pub generics: syn::Generics,
-    pub primary_key_name: syn::Ident,
+    pub primary_key_names: Vec<syn::Ident>,
     table_name_from_annotation: Option<syn::Ident>,
 }
 
@@ -23,9 +23,9 @@ impl Model {
         let ty = struct_ty(item.ident.clone(), &item.generics);
         let name = item.ident.clone();
         let generics = item.generics.clone();
-        let primary_key_name = ident_value_of_attr_with_name(&item.attrs, "primary_key")
-            .map(Clone::clone)
-            .unwrap_or(syn::Ident::new("id"));
+        let primary_key_names = list_value_of_attr_with_name(&item.attrs, "primary_key")
+            .map(|v| v.into_iter().map(Clone::clone).collect())
+            .unwrap_or_else(|| vec![syn::Ident::new("id")]);
         let table_name_from_annotation = str_value_of_attr_with_name(
             &item.attrs, "table_name").map(syn::Ident::new);
 
@@ -34,7 +34,7 @@ impl Model {
             attrs: attrs,
             name: name,
             generics: generics,
-            primary_key_name: primary_key_name,
+            primary_key_names: primary_key_names,
             table_name_from_annotation: table_name_from_annotation,
         })
     }

--- a/diesel_codegen_syntex/src/identifiable.rs
+++ b/diesel_codegen_syntex/src/identifiable.rs
@@ -1,9 +1,10 @@
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::ext::base::{Annotatable, ExtCtxt};
+use syntax::parse::token;
 
 use model::Model;
-use util::lifetime_list_tokens;
+use util::{lifetime_list_tokens, comma_delimited_tokens};
 
 pub fn expand_derive_identifiable(
     cx: &mut ExtCtxt,
@@ -16,20 +17,25 @@ pub fn expand_derive_identifiable(
         let table_name = model.table_name();
         let struct_ty = &model.ty;
         let lifetimes = lifetime_list_tokens(&model.generics.lifetimes, span);
-        let primary_key_name = model.primary_key_name;
+        let primary_key_names = model.primary_key_names();
         let fields = model.field_tokens_for_stable_macro(cx);
-        if model.attr_named(primary_key_name).is_some() {
-            push(Annotatable::Item(quote_item!(cx, impl_Identifiable! {
-                (
-                    table_name = $table_name,
-                    primary_key_name = $primary_key_name,
-                    struct_ty = $struct_ty,
-                    lifetimes = ($lifetimes),
-                ),
-                fields = [$fields],
-            }).unwrap()));
-        } else {
-            cx.span_err(span, &format!("Could not find a field named `{}` on `{}`", primary_key_name, model.name));
+        for name in primary_key_names {
+            if model.attr_named(*name).is_none() {
+                cx.span_err(span, &format!("Could not find a field named `{}` on `{}`", name, model.name));
+                return;
+            }
         }
+
+        let primary_key_names = comma_delimited_tokens(
+            primary_key_names.into_iter().map(|n| token::Ident(*n)), span);
+        push(Annotatable::Item(quote_item!(cx, impl_Identifiable! {
+            (
+                table_name = $table_name,
+                primary_key_names = ($primary_key_names),
+                struct_ty = $struct_ty,
+                lifetimes = ($lifetimes),
+            ),
+            fields = [$fields],
+        }).unwrap()));
     }
 }

--- a/diesel_codegen_syntex/src/model.rs
+++ b/diesel_codegen_syntex/src/model.rs
@@ -13,7 +13,7 @@ pub struct Model {
     pub attrs: Vec<Attr>,
     pub name: ast::Ident,
     pub generics: ast::Generics,
-    pub primary_key_name: ast::Ident,
+    pub primary_key_names: Vec<ast::Ident>,
     table_name_from_annotation: Option<ast::Ident>,
 }
 
@@ -26,9 +26,9 @@ impl Model {
         if let Annotatable::Item(ref item) = *annotatable {
             let table_name_from_annotation =
                 str_value_of_attr_with_name(cx, &item.attrs, "table_name");
-            let primary_key_name =
-                ident_value_of_attr_with_name(cx, &item.attrs, "primary_key")
-                    .unwrap_or(str_to_ident("id"));
+            let primary_key_names =
+                list_value_of_attr_with_name(cx, &item.attrs, "primary_key")
+                    .unwrap_or_else(|| vec![str_to_ident("id")]);
             Attr::from_item(cx, item).map(|(generics, attrs)| {
                 let ty = struct_ty(cx, span, item.ident, &generics);
                 Model {
@@ -36,7 +36,7 @@ impl Model {
                     attrs: attrs,
                     name: item.ident,
                     generics: generics,
-                    primary_key_name: primary_key_name,
+                    primary_key_names: primary_key_names,
                     table_name_from_annotation: table_name_from_annotation,
                 }
             })
@@ -45,8 +45,8 @@ impl Model {
         }
     }
 
-    pub fn primary_key_name(&self) -> ast::Ident {
-        self.primary_key_name
+    pub fn primary_key_names(&self) -> &[ast::Ident] {
+        &self.primary_key_names
     }
 
     pub fn table_name(&self) -> ast::Ident {

--- a/diesel_codegen_syntex/src/update.rs
+++ b/diesel_codegen_syntex/src/update.rs
@@ -99,9 +99,9 @@ fn changeset_impl(
     let struct_ty = &model.ty;
     let lifetimes = lifetime_list_tokens(&model.generics.lifetimes, span);
 
-    let pk = model.primary_key_name();
+    let pks = model.primary_key_names();
     let fields = model.attrs.iter()
-        .filter(|a| a.column_name.name != pk.name)
+        .filter(|a| pks.iter().all(|pk| a.column_name.name != pk.name))
         .map(|a| a.to_stable_macro_tokens(cx))
         .collect::<Vec<_>>();
 

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -194,3 +194,24 @@ fn derive_identifiable_with_non_standard_pk() {
     // Fails to compile if wrong table is generated.
     let _: posts::table = Foo::<'static>::table();
 }
+
+#[test]
+fn derive_identifiable_with_composite_pk() {
+    use diesel::associations::Identifiable;
+
+    #[derive(Identifiable)]
+    #[primary_key(foo_id, bar_id)]
+    #[table_name="posts"]
+    #[allow(dead_code)]
+    struct Foo {
+        id: i32,
+        foo_id: i32,
+        bar_id: i32,
+        foo: i32,
+    }
+
+    let foo1 = Foo { id: 1, foo_id: 2, bar_id: 3, foo: 4 };
+    let foo2 = Foo { id: 5, foo_id: 6, bar_id: 7, foo: 8 };
+    assert_eq!((&2, &3), foo1.id());
+    assert_eq!((&6, &7), foo2.id());
+}


### PR DESCRIPTION
This is a tad bit magic in the macro piece. We're expecting the primary
keys *not to* have a trailing comma, so we can rely on the fact that
`(T)` is equivalent to `T`, but if there's more than one element it
would be a tuple.

Beyond that everything was quite straightforward with the ground work
that we've laid.

Fixes #42.