### PR TITLE
Document `diesel::row::Row`

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -30,7 +30,6 @@ pub mod migrations;
 mod query_dsl;
 pub mod query_source;
 pub mod result;
-#[doc(hidden)]
 pub mod row;
 
 pub mod helper_types {

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -1,5 +1,9 @@
 use backend::Backend;
 
+/// The row trait which is used for [`FromSqlRow`][]. Apps should not need to
+/// concern themselves with this trait.
+///
+/// [`FromSqlRow`]: ../types/trait.FromSqlRow.html
 pub trait Row<DB: Backend> {
     fn take(&mut self) -> Option<&DB::RawValue>;
     fn next_is_null(&self, count: usize) -> bool;


### PR DESCRIPTION
I had excluded this trait, as I intended for it to be mostly internal. I
still think this should be the case, but until I can provide a proper
blanket impl for `FromSqlRow`, this type will need to be public.

Fixes #535.