### PR TITLE
Construct error messages properly when libpq returns `NULL` result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `debug_sql!` can now properly be used with types from `chrono` or
   `std::time`.
 
+* When using PostgreSQL, attempting to get the error message of a query which
+  could not be transmitted to the server (such as a query with greater than
+  65535 bind parameters) will no longer panic.
+
 ## [0.9.0] - 2016-12-08
 
 ### Added

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -41,7 +41,7 @@ impl SimpleConnection for PgConnection {
         let inner_result = unsafe {
             self.raw_connection.exec(query.as_ptr())
         };
-        try!(PgResult::new(inner_result));
+        try!(PgResult::new(inner_result?));
         Ok(())
     }
 }

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -63,7 +63,7 @@ impl Query {
             }
         };
 
-        PgResult::new(internal_res)
+        PgResult::new(internal_res?)
     }
 
     pub fn sql(sql: &str, param_types: Option<Vec<u32>>) -> QueryResult<Self> {
@@ -90,7 +90,7 @@ impl Query {
                 param_types_to_ptr(Some(&param_types)),
             )
         };
-        try!(PgResult::new(internal_result));
+        try!(PgResult::new(internal_result?));
 
         Ok(Query::Prepared {
             name: name,

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -26,6 +26,7 @@ pub enum Error {
 /// bump.
 pub enum DatabaseErrorKind {
     UniqueViolation,
+    UnableToSendCommand,
     #[doc(hidden)]
     __Unknown, // Match against _ instead, more variants may be added in the future
 }

--- a/diesel_tests/tests/internal_details.rs
+++ b/diesel_tests/tests/internal_details.rs
@@ -11,3 +11,23 @@ fn bind_params_are_passed_for_null_when_not_inserting() {
         .filter(AsExpression::<Nullable<Integer>>::as_expression(None::<i32>).is_null());
     assert_eq!(Ok(1), query.first(&connection));
 }
+
+#[test]
+#[cfg(feature = "postgres")]
+fn query_which_cannot_be_transmitted_gives_proper_error_message() {
+    use schema::comments::dsl::*;
+    use diesel::result::Error::DatabaseError;
+    use diesel::result::DatabaseErrorKind::UnableToSendCommand;
+
+    // Create a query with 90000 binds, 2 binds per row
+    let data: &[NewComment<'static>] = &[NewComment(1, "hi"); 45_000];
+    let query_with_to_many_binds = insert(data).into(comments);
+
+    match query_with_to_many_binds.execute(&connection()) {
+        Ok(_) => panic!("We successfully executed a query with 90k binds. \
+            We need to find a new query to test which can't be represented by \
+            the wire protocol."),
+        Err(DatabaseError(UnableToSendCommand, info)) => assert_ne!("", info.message()),
+        Err(_) => panic!("We got back the wrong kind of error. This test is invalid."),
+    }
+}

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -126,7 +126,7 @@ impl NewPost {
     }
 }
 
-#[derive(Insertable)]
+#[derive(Debug, Clone, Copy, Insertable)]
 #[table_name="comments"]
 pub struct NewComment<'a>(
     #[column_name(post_id)]


### PR DESCRIPTION
I had originally thought that this was some weird condition that was the
result of the server getting a query with more than `34464` (`i16::MAX`)
bind parameters, where we got back an error but it had no message. We
panic in that case, as PG is documented that all errors have a message.
It turns out I was wrong for two reasons.

First, the number is 65535 (`u16::MAX`), not `34464`. (This might have
been something changed on the PG side in 9.6 which was released since I
last looked at this). Second, we were not getting back an error with no
message, we were getting a `NULL` return value from libpq. From [their
docs][]:

[their docs]: https://www.postgresql.org/docs/9.6/static/libpq-exec.html#LIBPQ-PQPREPARE

> A null result indicates out-of-memory or inability to send the command
> at all. Use PQerrorMessage to get more information about such errors.

`PQerrorMessage` means the error is on the connection. The reason that
we had no result was that the PG wire protocol uses a `u16` for the
number of bind parameters, so there's no way for the driver to have even
sent the message to the server.

Once we realized the error condition that we were seeing is more general
than just the bind parameter case, I've refactored the code to perform a
not null check as early as possible, and hide the `*mut PGresult`.

The test itself is written in a somewhat strange fashion. We're
constructing a query that has 70_000 bind parameters, as this is the
only case that I know of which will always cause libpq to return null. I
don't care what the error message is, just that it's not an empty
string. I've also written the test to explicitly match instead of unwrap
and use `#[should_panic]` because I want to be sure that it *didn't*
panic.

Ideally we would never see `*mut PGresult` anywhere in the code, and use
`Unique<PGresult>` instead. However, it is currently unstable. I had
originally implemented this to use `Unique` if `feature = "unstable"`
was set, but deleted it as the `#[cfg]` branches made the code harder to
comprehend. The only real benefit `Unique` gives us here is clarity of
intent. For the not-null and non-aliased hints to result in any
optimization by the compiler would require libpq to be statically
linked, and LTO to be happening at the LLVM layer, neither of which are
commonly true.

We know that `Send` and `Sync` are safe to implement on our new struct,
because the pointer is unaliased. We can delete those impls if we switch
to using `Unique` in the future, as it already implements those traits.

Fixes #446.