### PR TITLE
Add `ToSql<.., Debug>` for various date/time types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `#[derive(AsChangeset)]` no longer assumes that `use diesel::prelude::*` has
   been done.
 
+* `debug_sql!` can now properly be used with types from `chrono` or
+  `std::time`.
+
 ## [0.9.0] - 2016-12-08
 
 ### Added

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -72,6 +72,8 @@ impl ToSql<Timestamptz, Pg> for NaiveDateTime {
     }
 }
 
+debug_to_sql!(Timestamptz, NaiveDateTime);
+
 impl FromSql<Timestamptz, Pg> for DateTime<UTC> {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let naive_date_time = try!(<NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes));
@@ -82,6 +84,12 @@ impl FromSql<Timestamptz, Pg> for DateTime<UTC> {
 impl<TZ: TimeZone> ToSql<Timestamptz, Pg> for DateTime<TZ> {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<Timestamptz, Pg>::to_sql(&self.naive_utc(), out)
+    }
+}
+
+impl<TZ: TimeZone> ToSql<Timestamptz, ::backend::Debug> for DateTime<TZ> {
+    fn to_sql<W: Write>(&self, _: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+        Ok(IsNull::No)
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -111,6 +111,8 @@ impl ToSql<types::Timestamp, Pg> for PgTimestamp {
     }
 }
 
+debug_to_sql!(types::Timestamp, PgTimestamp);
+
 impl FromSql<types::Timestamp, Pg> for PgTimestamp {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         FromSql::<types::BigInt, Pg>::from_sql(bytes)
@@ -124,6 +126,8 @@ impl ToSql<types::Timestamptz, Pg> for PgTimestamp {
     }
 }
 
+debug_to_sql!(types::Timestamptz, PgTimestamp);
+
 impl FromSql<types::Timestamptz, Pg> for PgTimestamp {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         FromSql::<types::Timestamp, Pg>::from_sql(bytes)
@@ -135,6 +139,8 @@ impl ToSql<types::Date, Pg> for PgDate {
         ToSql::<types::Integer, Pg>::to_sql(&self.0, out)
     }
 }
+
+debug_to_sql!(types::Date, PgDate);
 
 impl FromSql<types::Date, Pg> for PgDate {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
@@ -148,6 +154,8 @@ impl ToSql<types::Time, Pg> for PgTime {
         ToSql::<types::BigInt, Pg>::to_sql(&self.0, out)
     }
 }
+
+debug_to_sql!(types::Time, PgTime);
 
 impl FromSql<types::Time, Pg> for PgTime {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
@@ -164,6 +172,8 @@ impl ToSql<types::Interval, Pg> for PgInterval {
         Ok(IsNull::No)
     }
 }
+
+debug_to_sql!(types::Interval, PgInterval);
 
 impl FromSql<types::Interval, Pg> for PgInterval {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {

--- a/diesel/src/types/impls/date_and_time.rs
+++ b/diesel/src/types/impls/date_and_time.rs
@@ -1,0 +1,11 @@
+debug_to_sql!(::types::Timestamp, ::std::time::SystemTime);
+
+#[cfg(feature="chrono")]
+mod chrono {
+    extern crate chrono;
+    use self::chrono::{NaiveDateTime, NaiveDate, NaiveTime};
+
+    debug_to_sql!(::types::Timestamp, NaiveDateTime);
+    debug_to_sql!(::types::Time, NaiveTime);
+    debug_to_sql!(::types::Date, NaiveDate);
+}

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -143,6 +143,17 @@ macro_rules! primitive_impls {
     }
 }
 
+macro_rules! debug_to_sql {
+    ($sql_type:ty, $ty:ty) => {
+        impl $crate::types::ToSql<$sql_type, $crate::backend::Debug> for $ty {
+            fn to_sql<W: ::std::io::Write>(&self, _: &mut W) -> Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
+                Ok($crate::types::IsNull::No)
+            }
+        }
+    };
+}
+
+mod date_and_time;
 pub mod floats;
 mod integers;
 pub mod option;


### PR DESCRIPTION
Most types do `impl<DB: Backend> ToSql<.., DB>`, but date/times have
backend specific implementations, and need an explicit impl for `Debug`.
I also noticed that we should have been calling `as_query` in the macro,
so that `debug_sql!(users)` can just work. I have left out tests for
this, mainly because I want to heavily revamp how the debug system works
so that this kind of mistake is completely impossible in the future.

Fixes #307.