### PR TITLE
Make CI scripts nicer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,31 +12,19 @@ before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH
   - psql -c 'create database diesel_schema;' -U postgres
+  - source bin/ci_helpers.sh
 script:
-- |
-  if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-    (cd diesel && travis-cargo test -- --no-default-features --features "unstable chrono $BACKEND")
-  else
-    (cd diesel && travis-cargo test -- --no-default-features --features "chrono $BACKEND")
-  fi &&
-  if [[ "$BACKEND" == postgres ]]; then
-    if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-      (cd examples && ./test_nightly)
-    else
-      (cd examples && ./test_stable)
-    fi
-  fi &&
-  (cd diesel_cli && travis-cargo test -- --no-default-features --features "$BACKEND") &&
-  (cd diesel_codegen_shared && travis-cargo test -- --no-default-features --features "dotenv $BACKEND") &&
-  (cd diesel_codegen_syntex && travis-cargo test -- --no-default-features --features "$BACKEND") &&
-  if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-    (cd diesel_tests && travis-cargo test -- --no-default-features --features "unstable_$BACKEND")
-  else
-    (cd diesel_tests && travis-cargo test -- --no-default-features --features "stable_$BACKEND")
-  fi &&
-  if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-    (cd diesel_compile_tests && travis-cargo test)
-  fi
+  - in_dir "diesel" on_stable cargo_test chrono $BACKEND
+  - in_dir "diesel" on_nightly cargo_test unstable chrono $BACKEND
+  - in_dir "examples" on_stable using_postgres "./test_stable"
+  - in_dir "examples" on_nightly using_postgres "./test_nightly"
+  - in_dir "diesel_cli" cargo_test $BACKEND
+  - in_dir "diesel_codegen_shared" cargo_test $BACKEND
+  - in_dir "diesel_codegen_shared" cargo_test dotenv $BACKEND
+  - in_dir "diesel_codegen_syntex" cargo_test $BACKEND
+  - in_dir "diesel_tests" on_stable cargo_test "stable_$BACKEND"
+  - in_dir "diesel_tests" on_nightly cargo_test "unstable_$BACKEND"
+  - in_dir "diesel_compile_tests" on_nightly cargo_test
 env:
   matrix:
     - BACKEND=sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ env:
     - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
 after_success:
 - |
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]] && [[ "$TRAVIS_BRANCH" == master ]]; then
     (cd diesel && travis-cargo doc -- --features "postgres sqlite chrono uuid")
-    (echo "docs.diesel.rs" > diesel/target/doc/CNAME)
-    (cd diesel && travis-cargo doc-upload)
+    (echo "docs.diesel.rs" > target/doc/CNAME)
+    (travis-cargo doc-upload)
   fi
 branches:
   only:

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+source ci_helpers.sh
+
+in_dir "diesel" on_stable cargo_test chrono $BACKEND
+in_dir "diesel" on_nightly cargo_test unstable chrono $BACKEND
+in_dir "examples" on_stable using_postgres "./test_stable"
+in_dir "examples" on_nightly using_postgres "./test_nightly"
+in_dir "diesel_cli" cargo_test $BACKEND
+in_dir "diesel_codegen_shared" cargo_test $BACKEND
+in_dir "diesel_codegen_shared" cargo_test dotenv $BACKEND
+in_dir "diesel_codegen_syntex" cargo_test $BACKEND
+in_dir "diesel_tests" on_stable cargo_test "stable_$BACKEND"
+in_dir "diesel_tests" on_nightly cargo_test "unstable_$BACKEND"
+in_dir "diesel_compile_tests" on_nightly cargo_test

--- a/bin/ci_helpers.sh
+++ b/bin/ci_helpers.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+
+###
+# Environment
+###
+
+ROOT=`pwd`
+
+if [[ $TRAVIS == "true" ]]; then
+  CARGO_TEST="travis-cargo test --"
+  RUST_VERSION=$TRAVIS_RUST_VERSION
+else
+  CARGO_TEST="cargo test"
+  RUST_VERSION=stable
+  BACKEND=sqlite
+fi
+
+echo "RUST_VERSION: $RUST_VERSION"
+echo "BACKEND: $BACKEND"
+
+###
+# Helpers
+#
+# The following helpers are written to be composed together to form an chain of
+# commands that reads nicely and makes it obvious under which conditions a test
+# command will be executed.
+###
+
+# Execute something in a specific directory
+#
+# This is used to start a chain of commands, thus is includes some logging.
+in_dir() {
+  printf "=> in directory \``pwd`\` "
+  (cd "$ROOT/$1" && ${@:2})
+  echo "========================================"
+}
+
+# Just a separater to make the logging output nicer
+run() {
+  printf "run "
+  $@
+}
+
+# Only execute the commands following it if we are using a nightly rustc version
+on_nightly() {
+  if [[ "$RUST_VERSION" == nightly* ]]; then
+    printf "on nightly "
+    $@
+  else
+    printf "do nothing (not on nightly)\n"
+  fi
+}
+
+# Only execute the commands following it if we are using a non-nightly rustc
+#
+# (This way, beta counts as stable as it does not have the nightly features.)
+on_stable() {
+  if [[ "$RUST_VERSION" == stable ]] || [[ "$RUST_VERSION" == beta ]]; then
+    printf "on stable "
+    $@
+  else
+    printf "do nothing (not on stable)\n"
+  fi
+}
+
+# Only execute the commands following it if we are using PostgreSQL as a backend
+using_postgres() {
+  if [[ "$BACKEND" == postgres ]]; then
+    printf "using postgres "
+    $@ postgres
+  else
+    printf "do nothing (not using postgres)\n"
+  fi
+}
+
+# Only execute the commands following it if we are using SQLite as a backend
+using_sqlite() {
+  if [[ "$BACKEND" == sqlite ]]; then
+    printf "using sqlite "
+    $@ sqlite
+  else
+    printf "do nothing (not using sqlite)\n"
+  fi
+}
+
+# Execute a cargo test command
+cargo_test() {
+  printf "test with features \`$*\`\n"
+  echo "----------------------------------------"
+  $CARGO_TEST --no-default-features --features "$*"
+}


### PR DESCRIPTION
Just had the epiphany that bash scripts can become pretty readable if I
abuse `$@` enough times... So, of course I needed to try this out!

The idea is to make this nice to look at in travis (using a bit of
logging and hopefully also making travis group the scripts). Changing
the travis config to have multiple script entries will make this execute
all steps regardless of whether some failed. It does _not_ fail fast
anymore.