### PR TITLE
Use DATETIME('now')^W^W^W CURRENT_TIMESTAMP instead of relying on implicit conversion

### DIFF
--- a/diesel/src/migrations/mod.rs
+++ b/diesel/src/migrations/mod.rs
@@ -164,7 +164,7 @@ fn create_schema_migrations_table_if_needed<Conn: Connection>(conn: &Conn) -> Qu
     conn.silence_notices(|| {
         conn.execute("CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (
             version VARCHAR PRIMARY KEY NOT NULL,
-            run_on TIMESTAMP NOT NULL DEFAULT 'now'
+            run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         )")
     })
 }

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -1,4 +1,7 @@
 use support::{database, project};
+use diesel::{select, LoadDsl};
+use diesel::expression::sql;
+use diesel::types::Bool;
 
 #[test]
 fn migration_run_runs_pending_migrations() {
@@ -24,4 +27,56 @@ fn migration_run_runs_pending_migrations() {
     assert!(result.stdout().contains("Running migration 12345"),
         "Unexpected stdout {}", result.stdout());
     assert!(db.table_exists("users"));
+}
+
+#[test]
+fn migration_run_inserts_run_on_timestamps() {
+    let p = project("migration_run_on_timestamps")
+        .folder("migrations")
+        .build();
+    let db = database(&p.database_url());
+
+    // Make sure the project is setup.
+    p.command("setup").run();
+
+    p.create_migration("12345_create_users_table",
+                       "CREATE TABLE users ( id INTEGER )",
+                       "DROP TABLE users");
+
+    let migrations_done: bool = select(sql::<Bool>(
+            "EXISTS (SELECT * FROM __diesel_schema_migrations)"))
+        .get_result(&db.conn())
+        .unwrap();
+    assert!(!migrations_done, "Migrations table should be empty");
+
+    let result = p.command("migration")
+        .arg("run")
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(db.table_exists("users"));
+
+    // By running a query that compares timestamps, we are also checking
+    // that the auto-inserted values for the "run_on" column are valid.
+
+    #[cfg(feature = "sqlite")]
+    fn valid_run_on_timestamp(db: &database::Database) -> bool {
+        select(sql::<Bool>("EXISTS (SELECT run_on < DATETIME('now', '-1 hour') \
+                                    FROM __diesel_schema_migrations)"))
+            .get_result(&db.conn())
+            .unwrap()
+    }
+
+    #[cfg(feature = "postgres")]
+    fn valid_run_on_timestamp(db: &database::Database) -> bool {
+        select(sql::<Bool>("EXISTS (SELECT \
+                              run_on < (CAST('now' AS TIMESTAMP) - \
+                                        CAST('1 hour' AS INTERVAL)) \
+                              FROM __diesel_schema_migrations)"))
+            .get_result(&db.conn())
+            .unwrap()
+    }
+
+    assert!(valid_run_on_timestamp(&db),
+            "Running a migration did not insert an updated run_on value");
 }


### PR DESCRIPTION
In the `__diesel_schema_migrations` tables, the `run_on` column was defined as:

```sql
  run_on TIMESTAMP NOT NULL DEFAULT 'now'
```

Instead, this patch uses ~~`DATETIME('now')`~~ `CURRENT_TIMESTAMP`, which works both for SQLite and PostgreSQL by explicitly building a `TIMESTAMP` value, without relying on the the database making an implicit cast.

While PostgreSQL worked fine, the old definition did now work in SQLite as expected because it does not really store typed data in the columns (everything is  internally `TEXT`, the type being a hint on how to interpret it), and it was actually storing the `'now'` string value:

```
  % sqlite3 test.db
  sqlite> CREATE TABLE foo (v INTEGER, t DATETIME DEFAULT 'now');
  sqlite> INSERT INTO foo (v) VALUES (42);
  sqlite> SELECT * FROM foo;
  42|'now'
  sqlite>
```

On the other hand, with the updated code:

```
  sqlite> CREATE TABLE bar (v INTEGER, t DATETIME DEFAULT CURRENT_TIMESTAMP);
  sqlite> INSERT INTO bar (v) VALUES (10);
  sqlite> SELECT * FROM bar;
  10|2017-01-02 15:01:14
  sqlite>
```