### PR TITLE
Don't use libpq for identifier escaping

### DIFF
--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -28,7 +28,7 @@ use types::HasSqlType;
 /// http://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING
 #[allow(missing_debug_implementations)]
 pub struct PgConnection {
-    raw_connection: Rc<RawConnection>,
+    raw_connection: RawConnection,
     transaction_depth: Cell<i32>,
     statement_cache: StatementCache,
 }
@@ -52,7 +52,7 @@ impl Connection for PgConnection {
     fn establish(database_url: &str) -> ConnectionResult<PgConnection> {
         RawConnection::establish(database_url).map(|raw_conn| {
             PgConnection {
-                raw_connection: Rc::new(raw_conn),
+                raw_connection: raw_conn,
                 transaction_depth: Cell::new(0),
                 statement_cache: StatementCache::new(),
             }
@@ -154,7 +154,7 @@ impl PgConnection {
                 bind_types,
             ))
         } else {
-            let mut query_builder = PgQueryBuilder::new(&self.raw_connection);
+            let mut query_builder = PgQueryBuilder::new();
             try!(source.to_sql(&mut query_builder).map_err(Error::QueryBuilderError));
             Rc::new(try!(Query::sql(&query_builder.sql, Some(bind_types))))
         };

--- a/diesel/src/pg/query_builder.rs
+++ b/diesel/src/pg/query_builder.rs
@@ -1,20 +1,15 @@
-use std::rc::Rc;
-
 use super::backend::Pg;
-use super::connection::raw::RawConnection;
 use query_builder::{QueryBuilder, BuildQueryResult};
 
 #[allow(missing_debug_implementations)]
 pub struct PgQueryBuilder {
-    conn: Rc<RawConnection>,
     pub sql: String,
     bind_idx: u32,
 }
 
 impl PgQueryBuilder {
-    pub fn new(conn: &Rc<RawConnection>) -> Self {
+    pub fn new() -> Self {
         PgQueryBuilder {
-            conn: conn.clone(),
             sql: String::new(),
             bind_idx: 0,
         }
@@ -27,8 +22,10 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
     }
 
     fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
-        let escaped_identifier = try!(self.conn.escape_identifier(identifier));
-        Ok(self.push_sql(&escaped_identifier))
+        self.push_sql("\"");
+        self.push_sql(&identifier.replace('"', "\"\""));
+        self.push_sql("\"");
+        Ok(())
     }
 
     fn push_bind_param(&mut self) {


### PR DESCRIPTION
The implementation of `PQescapeIdentifier` actually does very little,
especially if we can assume that the connection's client encoding is
UTF-8, and that the identifier is valid UTF-8. Since I'd like to share
as much code between the current PG adapter, and the new async one, we
can just re-implement this function ourselves.

This was also the only place that required an `Rc` on the
`RawConnection`, which isn't a source of any major overhead but I'm glad
to see it go.

For some reason I thought that replace returned a `Cow<str>`, not
`String`. I may add our own version since this function could avoid
allocating the majority of the time.