### PR TITLE
Make macros public to allow easily implementing traits outside of diesel

### DIFF
--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -9,6 +9,8 @@ macro_rules! not_none {
     }
 }
 
+#[doc(hidden)]
+#[macro_export]
 macro_rules! expression_impls {
     ($($Source:ident -> $Target:ty),+,) => {
         $(
@@ -56,6 +58,8 @@ macro_rules! expression_impls {
     }
 }
 
+#[doc(hidden)]
+#[macro_export]
 macro_rules! queryable_impls {
     ($($Source:ident -> $Target:ty),+,) => {$(
         impl<DB> $crate::types::FromSqlRow<types::$Source, DB> for $Target where
@@ -90,6 +94,8 @@ macro_rules! queryable_impls {
     )+}
 }
 
+#[doc(hidden)]
+#[macro_export]
 macro_rules! primitive_impls {
     ($Source:ident -> ($Target:ty, pg: ($oid:expr, $array_oid:expr), sqlite: ($tpe:ident))) => {
         #[cfg(feature = "sqlite")]


### PR DESCRIPTION
This makes the `expression_impls!`, `queryable_impls!`, and `primitive_impls!` macros public, so programs (or other crates) can more easily implement the `Expression`, `Queriable`, and `QueryId` traits without duplicating the code from the macros.

These may change before diesel 1.0, so as discussed in #562, they are hidden from the documentation for now.