### PR TITLE
Don't use `impl_` macros in doctests anymore.

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "^0.2.17", optional = true }
 uuid = { version = ">=0.2.0, <0.4.0", optional = true, features = ["use_std"] }
 
 [dev-dependencies]
-diesel_codegen = { path = "../diesel_codegen" }
+diesel_codegen = "0.9.0"
 quickcheck = "0.3.1"
 dotenv = "0.8.0"
 tempdir = "^0.3.4"

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "^0.2.17", optional = true }
 uuid = { version = ">=0.2.0, <0.4.0", optional = true, features = ["use_std"] }
 
 [dev-dependencies]
+diesel_codegen = { path = "../diesel_codegen" }
 quickcheck = "0.3.1"
 dotenv = "0.8.0"
 tempdir = "^0.3.4"

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -61,6 +61,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("src/doctest_setup.rs");
     /// #
     /// # table! {
@@ -78,8 +79,9 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// #     }
     /// # }
     /// #
+    /// # #[derive(Insertable)]
+    /// # #[table_name="posts"]
     /// # struct NewPost<'a> { tags: Vec<&'a str> }
-    /// # impl_Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
     /// #
     /// # fn main() {
     /// #     use self::posts::dsl::*;
@@ -115,6 +117,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("src/doctest_setup.rs");
     /// #
     /// # table! {
@@ -132,8 +135,9 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// #     }
     /// # }
     /// #
+    /// # #[derive(Insertable)]
+    /// # #[table_name="posts"]
     /// # struct NewPost<'a> { tags: Vec<&'a str> }
-    /// # impl_Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
     /// #
     /// # fn main() {
     /// #     use self::posts::dsl::*;
@@ -165,6 +169,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("src/doctest_setup.rs");
     /// #
     /// # table! {
@@ -182,8 +187,9 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// #     }
     /// # }
     /// #
+    /// # #[derive(Insertable)]
+    /// # #[table_name="posts"]
     /// # struct NewPost<'a> { tags: Vec<&'a str> }
-    /// # impl_Insertable! { (posts) struct NewPost<'a> { tags: Vec<&'a str>, } }
     /// #
     /// # fn main() {
     /// #     use self::posts::dsl::*;
@@ -225,6 +231,7 @@ pub trait SortExpressionMethods : Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("src/doctest_setup.rs");
     /// #
     /// # table! {
@@ -267,6 +274,7 @@ pub trait SortExpressionMethods : Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("src/doctest_setup.rs");
     /// #
     /// # table! {

--- a/diesel/src/sqlite/query_builder/functions.rs
+++ b/diesel/src/sqlite/query_builder/functions.rs
@@ -17,18 +17,13 @@ use super::nodes::Replace;
 /// #     }
 /// # }
 /// #
+/// # #[derive(Insertable)]
+/// # #[table_name="users"]
 /// # struct User<'a> {
 /// #     id: i32,
 /// #     name: &'a str,
 /// # }
 /// #
-/// # impl_Insertable! {
-/// #     (users)
-/// #     struct User<'a> {
-/// #         id: i32,
-/// #         name: &'a str,
-/// #     }
-/// # }
 /// #
 /// # fn main() {
 /// #     use self::users::dsl::*;

--- a/diesel/src/sqlite/query_builder/functions.rs
+++ b/diesel/src/sqlite/query_builder/functions.rs
@@ -8,6 +8,7 @@ use super::nodes::Replace;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
+/// # #[macro_use] extern crate diesel_codegen;
 /// # include!("src/doctest_setup.rs");
 /// #
 /// # table! {


### PR DESCRIPTION
Change use of `impl_Insertable`, `impl_Queryable`, etc., to use procedural macros now that Macros 1.1 is just around the corner. This should fix #576.