### PR TITLE
Support for Postgres enums

### DIFF
--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -88,3 +88,33 @@ macro_rules! embed_migrations {
         }
     }
 }
+
+#[macro_export]
+/// Queries the database for the names of all enum types and creates a Rust enum
+/// type for each one in the current namespace. The enum type name and variants
+/// of the database enum type will be translated from snake case to camel case
+/// (so enum_type::variant becomes EnumType::Variant). For types in a schema
+/// other than the default, the type will be created in a submodule with the
+/// schema name.
+///
+/// This macro can only be used in combination with the `diesel_codegen` or
+/// `diesel_codegen_syntex` crates. It will not work on its own.
+macro_rules! infer_enums {
+    ($database_url: expr) => {
+        mod __diesel_infer_enums {
+            #[derive(InferEnums)]
+            #[options(database_url=$database_url)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_enums::*;
+    };
+
+    ($database_url: expr, $schema_name: expr) => {
+        mod __diesel_infer_enums {
+            #[derive(InferEnums)]
+            #[options(databsae_url=$database_url, schema_name=$schema_name)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_enums::*;
+    };
+}

--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -12,6 +12,22 @@
 /// This macro can only be used in combination with the `diesel_codegen` or
 /// `diesel_codegen_syntex` crates. It will not work on its own.
 macro_rules! infer_schema {
+    (extra_types_module = $extra_types_module: expr, $database_url: expr) => {
+        mod __diesel_infer_schema {
+            #[derive(InferSchema)]
+            #[infer_schema_options(database_url=$database_url, extra_types_module=$extra_types_module)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_schema::*;
+    };
+    (extra_types_module = $extra_types_module: expr, $database_url: expr, $schema_name: expr) => {
+        mod __diesel_infer_schema {
+            #[derive(InferSchema)]
+            #[infer_schema_options(database_url=$database_url, schema_name=$schema_name, extra_types_module=$extra_types_module)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_schema::*;
+    };
     ($database_url: expr) => {
         mod __diesel_infer_schema {
             #[derive(InferSchema)]
@@ -51,11 +67,16 @@ macro_rules! infer_schema {
 /// This macro can only be used in combination with the `diesel_codegen` or
 /// `diesel_codegen_syntex` crates. It will not work on its own.
 macro_rules! infer_table_from_schema {
+    (extra_types_module = $extra_types_module: expr, $database_url: expr, $table_name: expr) => {
+        #[derive(InferTableFromSchema)]
+        #[infer_table_from_schema_options(database_url=$database_url, table_name=$table_name, extra_types_module=$extra_types_module)]
+        struct __DieselInferTableFromSchema;
+    };
     ($database_url: expr, $table_name: expr) => {
         #[derive(InferTableFromSchema)]
         #[infer_table_from_schema_options(database_url=$database_url, table_name=$table_name)]
         struct __DieselInferTableFromSchema;
-    }
+    };
 }
 
 #[macro_export]
@@ -103,7 +124,7 @@ macro_rules! infer_enums {
     ($database_url: expr) => {
         mod __diesel_infer_enums {
             #[derive(InferEnums)]
-            #[options(database_url=$database_url)]
+            #[infer_enum_options(database_url=$database_url)]
             struct _Dummy;
         }
         pub use self::__diesel_infer_enums::*;
@@ -112,7 +133,7 @@ macro_rules! infer_enums {
     ($database_url: expr, $schema_name: expr) => {
         mod __diesel_infer_enums {
             #[derive(InferEnums)]
-            #[options(databsae_url=$database_url, schema_name=$schema_name)]
+            #[infer_enum_options(databsae_url=$database_url, schema_name=$schema_name)]
             struct _Dummy;
         }
         pub use self::__diesel_infer_enums::*;

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -7,12 +7,12 @@ use expression::*;
 use expression::bound::Bound;
 use query_builder::QueryId;
 use query_source::Queryable;
-use types::{HasSqlType, FromSql, FromSqlRow, Nullable, ToSql, IsNull, NotNull};
+use types::{ProvidesSqlTypeFor, HasSqlType, FromSql, FromSqlRow, Nullable, ToSql, IsNull, NotNull};
 
-impl<T, DB> HasSqlType<Nullable<T>> for DB where
+impl<T, DB> ProvidesSqlTypeFor<DB> for Nullable<T> where
     DB: Backend + HasSqlType<T>, T: NotNull,
 {
-    fn metadata() -> DB::TypeMetadata{
+    fn self_metadata() -> DB::TypeMetadata{
         <DB as HasSqlType<T>>::metadata()
     }
 }

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -7,7 +7,7 @@ use query_source::{QuerySource, Queryable, Table, Column};
 use result::QueryResult;
 use row::Row;
 use std::error::Error;
-use types::{HasSqlType, FromSqlRow, Nullable, IntoNullable, NotNull};
+use types::{ProvidesSqlTypeFor, HasSqlType, FromSqlRow, Nullable, IntoNullable, NotNull};
 
 macro_rules! tuple_impls {
     ($(
@@ -16,11 +16,11 @@ macro_rules! tuple_impls {
         }
     )+) => {
         $(
-            impl<$($T),+, DB> HasSqlType<($($T,)+)> for DB where
+            impl<$($T),+, DB> ProvidesSqlTypeFor<DB> for ($($T,)+) where
                 $(DB: HasSqlType<$T>),+,
                 DB: Backend,
             {
-                fn metadata() -> DB::TypeMetadata {
+                fn self_metadata() -> DB::TypeMetadata {
                     unreachable!("Tuples should never implement `ToSql` directly");
                 }
             }

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -249,8 +249,18 @@ pub type VarChar = Text;
 #[cfg(feature = "postgres")]
 pub use pg::types::sql_types::*;
 
+pub trait ProvidesSqlTypeFor<DB> where DB: TypeMetadata {
+    fn self_metadata() -> DB::TypeMetadata;
+}
+
 pub trait HasSqlType<ST>: TypeMetadata {
     fn metadata() -> Self::TypeMetadata;
+}
+
+impl<ST, DB> HasSqlType<ST> for DB where DB: TypeMetadata, ST: ProvidesSqlTypeFor<DB> {
+    fn metadata() -> Self::TypeMetadata {
+        <ST as ProvidesSqlTypeFor<DB>>::self_metadata()
+    }
 }
 
 pub trait NotNull {

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -10,11 +10,14 @@ repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_codegen"
 keywords = ["orm", "database", "postgres", "sql", "codegen"]
 
 [dependencies]
-syn = "0.10.3"
 syntex_syntax = "0.52.0"
 quote = "0.3.10"
 diesel = { version = "0.9.0", default-features = false }
 diesel_codegen_shared = { version = "0.9.0", default-features = false }
+
+[dependencies.syn]
+version = "0.10.3"
+features = ["full"]
 
 [lib]
 proc-macro = true

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["orm", "database", "postgres", "sql", "codegen"]
 
 [dependencies]
 syn = "0.10.3"
+syntex_syntax = "0.52.0"
 quote = "0.3.10"
 diesel = { version = "0.9.0", default-features = false }
 diesel_codegen_shared = { version = "0.9.0", default-features = false }

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![recursion_limit = "196"]
 
 macro_rules! t {
     ($expr:expr) => {
@@ -27,6 +28,8 @@ mod model;
 mod queryable;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 mod schema_inference;
+#[cfg(feature = "postgres")]
+mod type_inference;
 mod util;
 
 use proc_macro::TokenStream;
@@ -72,6 +75,12 @@ pub fn derive_infer_table_from_schema(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(EmbedMigrations, attributes(embed_migrations_options))]
 pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
     expand_derive(input, embed_migrations::derive_embed_migrations)
+}
+
+#[proc_macro_derive(InferEnums, attributes(options))]
+#[cfg(feature = "postgres")]
+pub fn derive_infer_enums(input: TokenStream) -> TokenStream {
+    expand_derive(input, type_inference::derive_infer_enums)
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::MacroInput) -> quote::Tokens) -> TokenStream {

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![recursion_limit = "196"]
+#![recursion_limit = "256"]
 
 macro_rules! t {
     ($expr:expr) => {

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -78,7 +78,7 @@ pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
     expand_derive(input, embed_migrations::derive_embed_migrations)
 }
 
-#[proc_macro_derive(InferEnums, attributes(options))]
+#[proc_macro_derive(InferEnums, attributes(infer_enum_options))]
 #[cfg(feature = "postgres")]
 pub fn derive_infer_enums(input: TokenStream) -> TokenStream {
     expand_derive(input, type_inference::derive_infer_enums)

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 
 macro_rules! t {
     ($expr:expr) => {
@@ -14,6 +14,7 @@ extern crate diesel_codegen_shared;
 extern crate diesel;
 #[macro_use]
 extern crate quote;
+extern crate syntex_syntax;
 extern crate proc_macro;
 extern crate syn;
 

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -27,10 +27,10 @@ mod identifiable;
 mod insertable;
 mod model;
 mod queryable;
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-mod schema_inference;
 #[cfg(feature = "postgres")]
 mod type_inference;
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+mod schema_inference;
 mod util;
 
 use proc_macro::TokenStream;

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -16,8 +16,9 @@ pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
         .unwrap_or_else(|| bug());
     let database_url = get_option(&options, "database_url", bug);
     let schema_name = get_optional_option(&options, "schema_name");
+    let extra_types_module = get_optional_option(&options, "extra_types_module");
 
-    infer_schema_for_schema_name(&database_url, schema_name.as_ref().map(|s| &**s))
+    infer_schema_for_schema_name(&database_url, schema_name.as_ref().map(|s| &**s), extra_types_module)
 }
 
 pub fn derive_infer_table_from_schema(input: syn::MacroInput) -> quote::Tokens {
@@ -28,6 +29,7 @@ pub fn derive_infer_table_from_schema(input: syn::MacroInput) -> quote::Tokens {
 
     let options = get_options_from_input("infer_table_from_schema_options", &input.attrs, bug)
         .unwrap_or_else(|| bug());
+    let extra_types_module = get_optional_option(&options, "extra_types_module");
     let database_url = get_option(&options, "database_url", bug);
     let table_name = get_option(&options, "table_name", bug);
 
@@ -37,7 +39,7 @@ pub fn derive_infer_table_from_schema(input: syn::MacroInput) -> quote::Tokens {
         .into_iter().map(syn::Ident::new);
     let table_name = syn::Ident::new(table_name);
 
-    let tokens = data.iter().map(|a| column_def_tokens(a, &connection));
+    let tokens = data.iter().map(|a| column_def_tokens(extra_types_module, a, &connection));
 
     quote!(table! {
         #table_name (#(#primary_keys),*) {
@@ -46,7 +48,8 @@ pub fn derive_infer_table_from_schema(input: syn::MacroInput) -> quote::Tokens {
     })
 }
 
-fn infer_schema_for_schema_name(database_url: &str, schema_name: Option<&str>) -> quote::Tokens {
+fn infer_schema_for_schema_name(database_url: &str, schema_name: Option<&str>,
+                                extra_types_module: Option<&str>) -> quote::Tokens {
     let table_names = load_table_names(&database_url, schema_name).unwrap();
     let schema_inferences = table_names.into_iter().map(|table_name| {
         let mod_ident = syn::Ident::new(format!("infer_{}", table_name));
@@ -54,11 +57,19 @@ fn infer_schema_for_schema_name(database_url: &str, schema_name: Option<&str>) -
             Some(name) => format!("{}.{}", name, table_name),
             None => table_name,
         };
-        quote! {
-            mod #mod_ident {
-                infer_table_from_schema!(#database_url, #table_name);
-            }
-            pub use self::#mod_ident::*;
+        match extra_types_module {
+            Some(m) => quote! {
+                mod #mod_ident {
+                    infer_table_from_schema!(extra_types_module=#m, #database_url, #table_name);
+                }
+                pub use self::#mod_ident::*;
+            },
+            None => quote! {
+                mod #mod_ident {
+                    infer_table_from_schema!(#database_url, #table_name);
+                }
+                pub use self::#mod_ident::*;
+            },
         }
     });
 
@@ -72,24 +83,14 @@ fn infer_schema_for_schema_name(database_url: &str, schema_name: Option<&str>) -
 }
 
 fn column_def_tokens(
+    extra_types_module: Option<&str>,
     column: &ColumnInformation,
     connection: &InferConnection,
 ) -> quote::Tokens {
     let column_name = syn::Ident::new(&*column.column_name);
-    let column_type = determine_column_type(column, connection).unwrap();
-    let path_segments = column_type.path
-        .into_iter()
-        .map(
-             // if x == "self" {
-             //     syn::PathSegment {
-             //         ident: keywords::SelfValue.ident(),
-             //         parameters: syn::PathParameters::none(),
-             //     }
-             // } else {
-                 syn::PathSegment::from
-             // }
-)
-        .collect();
+    let column_type = determine_column_type(extra_types_module, column, connection).unwrap();
+    let path_segments =
+        column_type.path.into_iter().map(syn::PathSegment::from).collect();
     let tpe = syn::Path { global: column_type.is_builtin, segments: path_segments };
     let mut tpe = quote!(#tpe);
 

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -1,4 +1,5 @@
 use syn;
+// use syntex_syntax::symbol::keywords;
 use quote;
 
 use diesel_codegen_shared::*;
@@ -78,9 +79,18 @@ fn column_def_tokens(
     let column_type = determine_column_type(column, connection).unwrap();
     let path_segments = column_type.path
         .into_iter()
-        .map(syn::PathSegment::from)
+        .map(
+             // if x == "self" {
+             //     syn::PathSegment {
+             //         ident: keywords::SelfValue.ident(),
+             //         parameters: syn::PathParameters::none(),
+             //     }
+             // } else {
+                 syn::PathSegment::from
+             // }
+)
         .collect();
-    let tpe = syn::Path { global: true, segments: path_segments };
+    let tpe = syn::Path { global: column_type.is_builtin, segments: path_segments };
     let mut tpe = quote!(#tpe);
 
     if column_type.is_array {

--- a/diesel_codegen/src/type_inference.rs
+++ b/diesel_codegen/src/type_inference.rs
@@ -1,0 +1,182 @@
+use syn;
+use quote;
+
+use diesel_codegen_shared::*;
+
+use util::{get_options_from_input, get_option, get_optional_option};
+
+use std::collections::HashSet;
+
+pub fn derive_infer_enums(input: syn::MacroInput) -> quote::Tokens {
+    fn bug() -> ! {
+        panic!("This is a bug. Please open a Github issue with your invocation of `infer_enums!`");
+    }
+
+    let options = get_options_from_input(&input.attrs, bug).unwrap_or_else(|| bug());
+    let database_url = get_option(&options, "database_url", bug);
+    let schema_name = get_optional_option(&options, "schema_name");
+    let types = get_optional_option(&options, "types");
+
+    infer_enums_for_schema_name(&database_url,
+                                schema_name.as_ref().map(|s| &**s),
+                                types.as_ref().map(|s| &**s),
+                                true, true)
+}
+
+fn canonicalize_pg_type_name(type_name: &str) -> String {
+    type_name.trim().to_lowercase()
+}
+
+fn camel_cased(snake_case: &str) -> String {
+    snake_case.split("_").flat_map(
+        |s| s.chars().take(1).flat_map(|c| c.to_uppercase().into_iter()).chain(
+            s.chars().skip(1).flat_map(|c| c.to_lowercase())
+                .take_while(|&c| c != '_'))).collect()
+}
+
+fn infer_enums_for_schema_name(database_url: &str, schema_name: Option<&str>, types: Option<&str>,
+                               camel_case_types: bool, camel_case_variants: bool) -> quote::Tokens {
+    let mut acceptable_type_names = HashSet::new();
+    if let Some(type_names) = types.map(|csl| csl.split(",").map(|t| t.trim())) {
+        for type_name in type_names {
+            acceptable_type_names.insert(canonicalize_pg_type_name(type_name));
+        }
+        if acceptable_type_names.is_empty() {
+            panic!("acceptable_type_names should be non-empty if specified")
+        }
+    };
+    let acceptable_type_name_p = |s: &str| {
+        acceptable_type_names.is_empty() ||
+            acceptable_type_names.contains(&canonicalize_pg_type_name(s))
+    };
+    let connection = establish_connection(database_url).unwrap();
+    let inferred_enums = get_enum_information(&connection, schema_name).unwrap().into_iter()
+        .filter(|e| acceptable_type_name_p(&e.type_name))
+        .map(|EnumInformation { type_name, variants, oid, array_oid }| {
+            let final_type_name = if camel_case_types {
+                camel_cased(&type_name)
+            } else {
+                type_name
+            };
+            let final_variants = if camel_case_variants {
+                variants.into_iter().map(|s| camel_cased(&s)).collect()
+            } else {
+                variants
+            };
+            let enum_decl = generate_enum(&final_type_name, &final_variants, oid, array_oid);
+            match schema_name {
+                None => enum_decl,
+                Some(schema) => quote! {
+                    mod #schema { #enum_decl }
+                },
+            }
+        });
+    quote!(#(#inferred_enums)*)
+}
+
+fn generate_enum(type_name: &str, variants: &[String], oid: u32, array_oid: u32) -> quote::Tokens {
+    let has_sql_type = quote! {
+        ::diesel::types::HasSqlType<#type_name>
+    };
+    let backend = quote! {
+        ::diesel::backend::Backend
+    };
+    let box_error = quote! {
+        ::std::boxed::Box<::std::error::Error + ::std::marker::Send + ::std::marker::Sync>
+    };
+    quote! {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+        pub enum #type_name {
+            #(#variants),*
+        }
+
+        impl #has_sql_type for ::diesel::backend::Debug {
+            fn metadata() { }
+        }
+
+        impl #has_sql_type for ::diesel::backend::Pg {
+            fn metadata() -> ::diesel::pg::PgTypeMetadata {
+                ::diesel::pg::PgTypeMetadata {
+                    oid: #oid,
+                    array_oid: #array_oid,
+                }
+            }
+        }
+
+        impl ::diesel::query_builder::QueryId for #type_name {
+            type QueryId = Self;
+
+            fn has_static_query_id() -> bool {
+                true
+            }
+        }
+
+        impl ::diesel::types::NotNull for #type_name { }
+
+        impl<DB> ::diesel::types::ToSql<#type_name, DB> where DB: #backend + #has_sql_type {
+            fn to_sql<W: ::std::io::Write>(&self, out: &mut W)
+                                            -> ::std::result::Result<IsNull, #box_error> {
+                unimplemented!()
+            }
+        }
+
+        impl<DB> ::diesel::types::FromSql<#type_name, DB> for #type_name
+            where DB: #backend + #has_sql_type {
+            fn from_sql(bytes: Option<&DB::RawValue>) -> ::std::result::Result<Self, #box_error> {
+                unimplemented!()
+            }
+        }
+
+        impl<DB> ::diesel::types::FromSqlRow<#type_name, DB> for #type_name
+            where DB: #backend + #has_sql_type,
+                  #type_name: ::diesel::types::FromSql<#type_name, DB> {
+            fn build_from_row<T: Row<DB>>(row: &mut T) -> ::std::result::Result<Self, #box_error> {
+                FromSql::<#type_name, DB>::from_sql(row.take())
+            }
+        }
+
+        impl<DB> ::diesel::query_source::Queryable<#type_name, DB> for #type_name
+            where DB: #backend + #has_sql_type,
+                  (#type_name): ::diesel::types::FromSqlRow<#type_name, DB> {
+            type Row = Self;
+            fn build(row: Self::Row) -> Self {
+                row
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::camel_cased;
+
+    #[test]
+    fn camel_cased_empty() {
+        assert_eq!("", camel_cased(""));
+        assert_eq!("", camel_cased("_"));
+    }
+
+    #[test]
+    fn camel_cased_initial_caps() {
+        assert_eq!("Cased", camel_cased("CASED"));
+        assert_eq!("Cased", camel_cased("cased"));
+        assert_eq!("C", camel_cased("C"));
+        assert_eq!("C", camel_cased("c"));
+    }
+
+    #[test]
+    fn camel_cased_underscores() {
+        assert_eq!("CamelCased", camel_cased("camel_cased"));
+        assert_eq!("CamelCased", camel_cased("cAmEL_CAsEd"));
+        assert_eq!("CamelCased", camel_cased("camel_cased_"));
+        assert_eq!("CamelCased", camel_cased("_camel_cased"));
+        assert_eq!("CamelCased", camel_cased("_camel_cased_"));
+        assert_eq!("CamelCased", camel_cased("_camel__cased_"));
+    }
+
+    #[test]
+    fn camel_cased_i18n() {
+        assert_eq!("Außerdem", camel_cased("außerdem"));
+        assert_eq!("AuSSerdem", camel_cased("au_ßerdem"));
+    }
+}

--- a/diesel_codegen/src/type_inference.rs
+++ b/diesel_codegen/src/type_inference.rs
@@ -12,7 +12,8 @@ pub fn derive_infer_enums(input: syn::MacroInput) -> quote::Tokens {
         panic!("This is a bug. Please open a Github issue with your invocation of `infer_enums!`");
     }
 
-    let options = get_options_from_input(&input.attrs, bug).unwrap_or_else(|| bug());
+    let options = get_options_from_input("infer_enum_options", &input.attrs, bug)
+        .unwrap_or_else(|| bug());
     let database_url = get_option(&options, "database_url", bug);
     let schema_name = get_optional_option(&options, "schema_name");
     let types = get_optional_option(&options, "types");

--- a/diesel_codegen_shared/Cargo.toml
+++ b/diesel_codegen_shared/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/diesel-rs/diesel"
 [dependencies]
 diesel = { version = "0.9.0", default-features = false }
 dotenv = { version = "0.8.0", optional = true }
+itertools = { version = "0.5.*" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_codegen_shared/src/lib.rs
+++ b/diesel_codegen_shared/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate diesel;
 #[cfg(feature = "dotenv")]
 extern crate dotenv;
+extern crate itertools;
 
 #[cfg(feature = "postgres")]
 use diesel::pg::PgConnection;

--- a/diesel_codegen_shared/src/lib.rs
+++ b/diesel_codegen_shared/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate diesel;
 #[cfg(feature = "dotenv")]
 extern crate dotenv;
+#[cfg(feature = "postgres")]
 extern crate itertools;
 
 #[cfg(feature = "postgres")]

--- a/diesel_codegen_shared/src/schema_inference/data_structures.rs
+++ b/diesel_codegen_shared/src/schema_inference/data_structures.rs
@@ -14,6 +14,7 @@ pub struct ColumnInformation {
 
 pub struct ColumnType {
     pub path: Vec<String>,
+    pub is_builtin: bool,
     pub is_array: bool,
     pub is_nullable: bool,
 }

--- a/diesel_codegen_shared/src/schema_inference/data_structures.rs
+++ b/diesel_codegen_shared/src/schema_inference/data_structures.rs
@@ -49,3 +49,12 @@ impl<ST> Queryable<ST, Sqlite> for ColumnInformation where
         }
     }
 }
+
+#[cfg(feature = "postgres")]
+pub struct EnumInformation {
+    pub type_name: String,
+    pub variants: Vec<String>,
+    pub oid: u32,
+    pub array_oid: u32,
+}
+

--- a/diesel_codegen_shared/src/schema_inference/mod.rs
+++ b/diesel_codegen_shared/src/schema_inference/mod.rs
@@ -6,6 +6,7 @@ mod sqlite;
 
 use diesel::Connection;
 use diesel::result::Error::NotFound;
+#[cfg(feature = "postgres")]
 use itertools::Itertools;
 use std::error::Error;
 
@@ -14,6 +15,8 @@ use database_url::extract_database_url;
 pub use self::data_structures::{ColumnInformation, ColumnType};
 #[cfg(feature = "postgres")]
 pub use self::data_structures::EnumInformation;
+#[cfg(feature = "postgres")]
+pub use self::pg::{camel_cased, canonicalize_pg_type_name};
 
 pub fn load_table_names(database_url: &str, schema_name: Option<&str>)
     -> Result<Vec<String>, Box<Error>>

--- a/diesel_codegen_shared/src/schema_inference/mod.rs
+++ b/diesel_codegen_shared/src/schema_inference/mod.rs
@@ -80,6 +80,7 @@ pub fn get_table_data(conn: &InferConnection, table_name: &str)
 }
 
 pub fn determine_column_type(
+    extra_types_module: Option<&str>,
     attr: &ColumnInformation,
     conn: &InferConnection,
 ) -> Result<ColumnType, Box<Error>> {
@@ -87,7 +88,7 @@ pub fn determine_column_type(
         #[cfg(feature = "sqlite")]
         InferConnection::Sqlite(_) => sqlite::determine_column_type(attr),
         #[cfg(feature = "postgres")]
-        InferConnection::Pg(_) => pg::determine_column_type(attr),
+        InferConnection::Pg(_) => pg::determine_column_type(extra_types_module, attr),
     }
 }
 

--- a/diesel_codegen_shared/src/schema_inference/mod.rs
+++ b/diesel_codegen_shared/src/schema_inference/mod.rs
@@ -6,11 +6,14 @@ mod sqlite;
 
 use diesel::Connection;
 use diesel::result::Error::NotFound;
+use itertools::Itertools;
 use std::error::Error;
 
 use InferConnection;
 use database_url::extract_database_url;
 pub use self::data_structures::{ColumnInformation, ColumnType};
+#[cfg(feature = "postgres")]
+pub use self::data_structures::EnumInformation;
 
 pub fn load_table_names(database_url: &str, schema_name: Option<&str>)
     -> Result<Vec<String>, Box<Error>>
@@ -107,4 +110,32 @@ pub fn get_primary_keys(
     } else {
         Ok(primary_keys)
     }
+}
+
+#[cfg(feature = "postgres")]
+pub fn get_enum_information(conn: &InferConnection, schema_name: Option<&str>)
+                            -> Result<Vec<EnumInformation>, Box<Error>> {
+    let rows = try!(match *conn {
+        #[cfg(feature = "sqlite")]
+        InferConnection::Sqlite(_) =>
+            panic!("Diesel does not support inferring enum types from SQLite"),
+        #[cfg(feature = "postgres")]
+        InferConnection::Pg(ref c) => pg::load_enum_info(c, schema_name),
+    });
+    let mut enum_information = vec!();
+    for (oid, grouped) in rows.into_iter().group_by(|&(_, _, oid)| oid).into_iter() {
+        let mut grouped = grouped.peekable();
+        let type_name = match grouped.peek() {
+            Some(&(ref type_name, _, _)) => type_name.clone(),
+            None => panic!("enum must have at least one variant"),
+        };
+        let variants = grouped.map(|(_, ref variant_name, _)| variant_name.clone()).collect();
+        enum_information.push(EnumInformation {
+            type_name: type_name,
+            variants: variants,
+            oid: oid,
+            array_oid: oid,  // TODO: fix this.
+        });
+    }
+    Ok(enum_information)
 }

--- a/diesel_codegen_shared/src/schema_inference/sqlite.rs
+++ b/diesel_codegen_shared/src/schema_inference/sqlite.rs
@@ -100,6 +100,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
 
     Ok(ColumnType {
         path: path,
+        is_builtin: true,
         is_array: false,
         is_nullable: attr.nullable,
     })

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -118,7 +118,8 @@ fn associations_can_be_grouped_multiple_levels_deep() {
     // let posts = Post::belonging_to(&users).load::<Post>().unwrap();
     // let comments = Comment::belonging_to(&users).load::<Comment>().unwrap();
     // ```
-    let users = vec![User::new(1, "Sean"), User::new(2, "Tess")];
+    let users = vec![User::new(1, "Sean", UserType::Default),
+                     User::new(2, "Tess", UserType::Default)];
     let posts = vec![Post::new(1, 1, "Hello", None), Post::new(2, 2, "World", None), Post::new(3, 1, "Hello 2", None)];
     let comments = vec![Comment::new(1, 3, "LOL"), Comment::new(2, 1, "UR dumb"), Comment::new(3, 3, "Funny")]; // Never read the comments
 
@@ -136,7 +137,8 @@ fn associations_can_be_grouped_multiple_levels_deep() {
 
 fn conn_with_test_data() -> (TestConnection, User, User, User) {
     let connection = connection_with_sean_and_tess_in_users_table();
-    insert(&NewUser::new("Jim", None)).into(users::table).execute(&connection).unwrap();
+    insert(&NewUser::new("Jim", None, UserType::Default))
+        .into(users::table).execute(&connection).unwrap();
 
     let sean = find_user_by_name("Sean", &connection);
     let tess = find_user_by_name("Tess", &connection);

--- a/diesel_tests/tests/boxed_queries.rs
+++ b/diesel_tests/tests/boxed_queries.rs
@@ -4,7 +4,7 @@ use diesel::*;
 #[test]
 fn boxed_queries_can_be_executed() {
     let connection = connection_with_sean_and_tess_in_users_table();
-    insert(&NewUser::new("Jim", None)).into(users::table)
+    insert(&NewUser::new("Jim", None, UserType::Default)).into(users::table)
         .execute(&connection).unwrap();
     let query_which_fails_unless_all_segments_are_applied =
         users::table
@@ -23,7 +23,7 @@ fn boxed_queries_can_be_executed() {
 #[test]
 fn boxed_queries_can_differ_conditionally() {
     let connection = connection_with_sean_and_tess_in_users_table();
-    insert(&NewUser::new("Jim", None)).into(users::table)
+    insert(&NewUser::new("Jim", None, UserType::Default)).into(users::table)
         .execute(&connection).unwrap();
 
     enum Query { All, Ordered, One };
@@ -71,7 +71,7 @@ fn boxed_queries_implement_select_dsl() {
 #[test]
 fn boxed_queries_implement_filter_dsl() {
     let connection = connection_with_sean_and_tess_in_users_table();
-    insert(&NewUser::new("Shane", None)).into(users::table)
+    insert(&NewUser::new("Shane", None, UserType::Default)).into(users::table)
         .execute(&connection).unwrap();
     let data = users::table.into_boxed()
         .select(users::name)

--- a/diesel_tests/tests/enums.rs
+++ b/diesel_tests/tests/enums.rs
@@ -1,0 +1,1 @@
+infer_enums!("dotenv:DATABASE_URL");

--- a/diesel_tests/tests/errors.rs
+++ b/diesel_tests/tests/errors.rs
@@ -7,10 +7,10 @@ use schema::*;
 #[test]
 fn unique_constraints_are_detected() {
     let connection = connection();
-    diesel::insert(&User::new(1, "Sean")).into(users::table)
+    diesel::insert(&User::new(1, "Sean", UserType::Default)).into(users::table)
         .execute(&connection).unwrap();
 
-    let failure = diesel::insert(&User::new(1, "Jim")).into(users::table)
+    let failure = diesel::insert(&User::new(1, "Jim", UserType::Default)).into(users::table)
         .execute(&connection);
     assert_matches!(failure, Err(DatabaseError(UniqueViolation, _)));
 }
@@ -20,10 +20,10 @@ fn unique_constraints_are_detected() {
 fn unique_constraints_report_correct_constraint_name() {
     let connection = connection();
     connection.execute("CREATE UNIQUE INDEX users_name ON users (name)").unwrap();
-    diesel::insert(&User::new(1, "Sean")).into(users::table)
+    diesel::insert(&User::new(1, "Sean", UserType::Default)).into(users::table)
         .execute(&connection).unwrap();
 
-    let failure = diesel::insert(&User::new(2, "Sean")).into(users::table)
+    let failure = diesel::insert(&User::new(2, "Sean", UserType::Default)).into(users::table)
         .execute(&connection);
     match failure {
         Err(DatabaseError(UniqueViolation, e)) => {
@@ -47,7 +47,7 @@ macro_rules! try_no_coerce {
 #[test]
 fn cached_prepared_statements_can_be_reused_after_error() {
     let connection = connection_without_transaction();
-    let user = User::new(1, "Sean");
+    let user = User::new(1, "Sean", UserType::Default);
     let query = diesel::insert(&user).into(users::table);
 
     connection.test_transaction(|| {

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -1,7 +1,7 @@
 mod date_and_time;
 mod ops;
 
-use schema::{connection, NewUser, connection_with_sean_and_tess_in_users_table};
+use schema::{connection, NewUser, connection_with_sean_and_tess_in_users_table, UserType};
 use schema::users::dsl::*;
 use diesel::*;
 use diesel::backend::Backend;
@@ -14,7 +14,8 @@ fn test_count_counts_the_rows() {
     let source = users.select(count(id));
 
     assert_eq!(Ok(0), source.first(&connection));
-    insert(&NewUser::new("Sean", None)).into(users).execute(&connection).unwrap();
+    insert(&NewUser::new("Sean", None, UserType::Default))
+        .into(users).execute(&connection).unwrap();
     assert_eq!(Ok(1), source.first(&connection));
 }
 
@@ -24,7 +25,8 @@ fn test_count_star() {
     let source = users.count();
 
     assert_eq!(Ok(0), source.first(&connection));
-    insert(&NewUser::new("Sean", None)).into(users).execute(&connection).unwrap();
+    insert(&NewUser::new("Sean", None, UserType::Default))
+        .into(users).execute(&connection).unwrap();
     assert_eq!(Ok(1), source.first(&connection));
 
     // Ensure we're doing COUNT(*) instead of COUNT(table.*) which is going to be more efficient
@@ -75,9 +77,9 @@ fn max_returns_same_type_as_expression_being_maximized() {
     let source = users.select(max(name));
 
     let data: &[_] = &[
-        NewUser::new("B", None),
-        NewUser::new("C", None),
-        NewUser::new("A", None),
+        NewUser::new("B", None, UserType::Default),
+        NewUser::new("C", None, UserType::Default),
+        NewUser::new("A", None, UserType::Default),
     ];
     insert(data).into(users).execute(&connection).unwrap();
     assert_eq!(Ok("C".to_string()), source.first(&connection));
@@ -160,7 +162,8 @@ fn function_with_multiple_arguments() {
     use schema::users::dsl::*;
 
     let connection = connection();
-    let new_users = vec![NewUser::new("Sean", Some("black")), NewUser::new("Tess", None)];
+    let new_users = vec![NewUser::new("Sean", Some("black"), UserType::Default),
+                         NewUser::new("Tess", None, UserType::Default)];
     insert(&new_users).into(users).execute(&connection).unwrap();
 
     let expected_data = vec!["black".to_string(), "Tess".to_string()];

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -6,8 +6,8 @@ fn filter_by_inequality() {
     use schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
 
     assert_eq!(vec![tess.clone()], users.filter(name.ne("Sean")).load(&connection).unwrap());
     assert_eq!(vec![sean.clone()], users.filter(name.ne("Tess")).load(&connection).unwrap());
@@ -19,8 +19,8 @@ fn filter_by_gt() {
     use schema::users::dsl::*;
 
     let connection = connection_with_3_users();
-    let tess = User::new(2, "Tess");
-    let jim = User::new(3, "Jim");
+    let tess = User::new(2, "Tess", UserType::Default);
+    let jim = User::new(3, "Jim", UserType::Default);
 
     assert_eq!(vec![tess, jim.clone()],
         users.filter(id.gt(1)).load(&connection).unwrap());
@@ -32,8 +32,8 @@ fn filter_by_ge() {
     use schema::users::dsl::*;
 
     let connection = connection_with_3_users();
-    let tess = User::new(2, "Tess");
-    let jim = User::new(3, "Jim");
+    let tess = User::new(2, "Tess", UserType::Default);
+    let jim = User::new(3, "Jim", UserType::Default);
 
     assert_eq!(vec![tess, jim.clone()],
         users.filter(id.ge(2)).load(&connection).unwrap());
@@ -45,8 +45,8 @@ fn filter_by_lt() {
     use schema::users::dsl::*;
 
     let connection = connection_with_3_users();
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
 
     assert_eq!(vec![sean.clone(), tess],
         users.filter(id.lt(3)).load(&connection).unwrap());
@@ -58,8 +58,8 @@ fn filter_by_le() {
     use schema::users::dsl::*;
 
     let connection = connection_with_3_users();
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
 
     assert_eq!(vec![sean.clone(), tess],
         users.filter(id.le(2)).load(&connection).unwrap());
@@ -71,9 +71,9 @@ fn filter_by_between() {
     use schema::users::dsl::*;
 
     let connection = connection_with_3_users();
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
-    let jim = User::new(3, "Jim");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
+    let jim = User::new(3, "Jim", UserType::Default);
 
     assert_eq!(vec![sean, tess.clone(), jim.clone()],
         users.filter(id.between(1..3)).load(&connection).unwrap());
@@ -87,9 +87,9 @@ fn filter_by_like() {
 
     let connection = connection();
     let data = vec![
-        NewUser::new("Sean Griffin", None),
-        NewUser::new("Tess Griffin", None),
-        NewUser::new("Jim", None),
+        NewUser::new("Sean Griffin", None, UserType::Default),
+        NewUser::new("Tess Griffin", None, UserType::Default),
+        NewUser::new("Jim", None, UserType::Default),
     ];
     insert(&data).into(users).execute(&connection).unwrap();
     let data = users.load::<User>(&connection).unwrap();
@@ -110,9 +110,9 @@ fn filter_by_any() {
     use diesel::expression::dsl::any;
 
     let connection = connection_with_3_users();
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
-    let jim = User::new(3, "Jim");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
+    let jim = User::new(3, "Jim", UserType::Default);
 
     let owned_names = vec!["Sean", "Tess"];
     let borrowed_names: &[&str] = &["Sean", "Jim"];
@@ -127,9 +127,9 @@ fn filter_by_in() {
     use schema::users::dsl::*;
 
     let connection = connection_with_3_users();
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
-    let jim = User::new(3, "Jim");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
+    let jim = User::new(3, "Jim", UserType::Default);
 
     let owned_names = vec!["Sean", "Tess"];
     let borrowed_names: &[_] = &["Sean", "Jim"];

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -10,8 +10,8 @@ fn find() {
     connection.execute("INSERT INTO users (id, name) VALUES (1, 'Sean'), (2, 'Tess')")
         .unwrap();
 
-    assert_eq!(Ok(User::new(1, "Sean")), users.find(1).first(&connection));
-    assert_eq!(Ok(User::new(2, "Tess")), users.find(2).first(&connection));
+    assert_eq!(Ok(User::new(1, "Sean", UserType::Default)), users.find(1).first(&connection));
+    assert_eq!(Ok(User::new(2, "Tess", UserType::Default)), users.find(2).first(&connection));
     assert_eq!(Ok(None::<User>), users.find(3).first(&connection).optional());
 }
 

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -6,16 +6,18 @@ fn insert_records() {
     use schema::users::table as users;
     let connection = connection();
     let new_users: &[_] = &[
-        NewUser::new("Sean", Some("Black")),
-        NewUser::new("Tess", None),
+        NewUser::new("Sean", Some("Black"), UserType::Default),
+        NewUser::new("Tess", None, UserType::Default),
     ];
 
     insert(new_users).into(users).execute(&connection).unwrap();
     let actual_users = users.load::<User>(&connection).unwrap();
 
     let expected_users = vec![
-        User { id: actual_users[0].id, name: "Sean".to_string(), hair_color: Some("Black".to_string()) },
-        User { id: actual_users[1].id, name: "Tess".to_string(), hair_color: None },
+        User { id: actual_users[0].id, name: "Sean".to_string(),
+               hair_color: Some("Black".to_string()), user_class: UserType::Default },
+        User { id: actual_users[1].id, name: "Tess".to_string(),
+               hair_color: None, user_class: UserType::Default },
     ];
     assert_eq!(expected_users, actual_users);
 }
@@ -26,14 +28,16 @@ fn insert_records_using_returning_clause() {
     use schema::users::table as users;
     let connection = connection();
     let new_users: &[_] = &[
-        NewUser::new("Sean", Some("Black")),
-        NewUser::new("Tess", None),
+        NewUser::new("Sean", Some("Black"), UserType::Default),
+        NewUser::new("Tess", None, UserType::Default),
     ];
 
     let inserted_users = insert(new_users).into(users).get_results::<User>(&connection).unwrap();
     let expected_users = vec![
-        User { id: inserted_users[0].id, name: "Sean".to_string(), hair_color: Some("Black".to_string()) },
-        User { id: inserted_users[1].id, name: "Tess".to_string(), hair_color: None },
+        User { id: inserted_users[0].id, name: "Sean".to_string(),
+               hair_color: Some("Black".to_string()), user_class: UserType::Default },
+        User { id: inserted_users[1].id, name: "Tess".to_string(),
+               hair_color: None, user_class: UserType::Default },
     ];
 
     assert_eq!(expected_users, inserted_users);
@@ -46,8 +50,8 @@ fn insert_records_with_custom_returning_clause() {
 
     let connection = connection();
     let new_users: &[_] = &[
-        NewUser::new("Sean", Some("Black")),
-        NewUser::new("Tess", None),
+        NewUser::new("Sean", Some("Black"), UserType::Default),
+        NewUser::new("Tess", None, UserType::Default),
     ];
 
     let inserted_users = insert(new_users)
@@ -77,14 +81,16 @@ fn batch_insert_with_defaults() {
     )).execute(&connection).unwrap();
 
     let new_users: &[_] = &[
-        NewUser::new("Sean", Some("Black")),
-        NewUser::new("Tess", None),
+        NewUser::new("Sean", Some("Black"), UserType::Default),
+        NewUser::new("Tess", None, UserType::Default),
     ];
     insert(new_users).into(users).execute(&connection).unwrap();
 
     let expected_users = vec![
-        User { id: 1, name: "Sean".to_string(), hair_color: Some("Black".to_string()) },
-        User { id: 2, name: "Tess".to_string(), hair_color: Some("Green".to_string()) },
+        User { id: 1, name: "Sean".to_string(),
+               hair_color: Some("Black".to_string()), user_class: UserType::Default},
+        User { id: 2, name: "Tess".to_string(),
+               hair_color: Some("Green".to_string()), user_class: UserType::Default },
     ];
     let actual_users = users.load(&connection).unwrap();
 
@@ -103,10 +109,12 @@ fn insert_with_defaults() {
         string("name").not_null(),
         string("hair_color").not_null().default("'Green'"),
     )).execute(&connection).unwrap();
-    insert(&NewUser::new("Tess", None)).into(users).execute(&connection).unwrap();
+    insert(&NewUser::new("Tess", None, UserType::Default))
+        .into(users).execute(&connection).unwrap();
 
     let expected_users = vec![
-        User { id: 1, name: "Tess".to_string(), hair_color: Some("Green".to_string()) },
+        User { id: 1, name: "Tess".to_string(),
+               hair_color: Some("Green".to_string()), user_class: UserType::Default },
     ];
     let actual_users = users.load(&connection).unwrap();
 
@@ -158,8 +166,8 @@ fn insert_borrowed_content() {
 
     let actual_users = users.load::<User>(&connection).unwrap();
     let expected_users = vec![
-        User::new(actual_users[0].id, "Sean"),
-        User::new(actual_users[1].id, "Tess"),
+        User::new(actual_users[0].id, "Sean", UserType::Default),
+        User::new(actual_users[1].id, "Tess", UserType::Default),
     ];
 
     assert_eq!(expected_users, actual_users);

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -10,8 +10,8 @@ fn belongs_to() {
         (2, 2, 'World', NULL)
     ").unwrap();
 
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
     let seans_post = Post::new(1, 1, "Hello", Some("Content"));
     let tess_post = Post::new(2, 2, "World", None);
 
@@ -76,7 +76,7 @@ fn select_only_one_side_of_join() {
 
     let source = users::table.inner_join(posts::table).select(users::all_columns);
 
-    let expected_data = vec![User::new(2, "Tess")];
+    let expected_data = vec![User::new(2, "Tess", UserType::Default)];
     let actual_data: Vec<_> = source.load(&connection).unwrap();
 
     assert_eq!(expected_data, actual_data);
@@ -91,8 +91,8 @@ fn left_outer_joins() {
         (2, 1, 'World')
     ").unwrap();
 
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
     let seans_post = Post::new(1, 1, "Hello", None);
     let seans_second_post = Post::new(2, 1, "World", None);
 
@@ -157,8 +157,8 @@ fn select_complex_from_left_join() {
         (1, 'World', NULL)
     ").unwrap();
 
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
     let expected_data = vec![
         (sean.clone(), Some(("Hello".to_string(), Some("Content".to_string())))),
         (sean, Some(("World".to_string(), None))),
@@ -180,8 +180,8 @@ fn select_right_side_with_nullable_column_first() {
         (1, 'World', NULL)
     ").unwrap();
 
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
     let expected_data = vec![
         (sean.clone(), Some((Some("Content".to_string()), "Hello".to_string()))),
         (sean, Some((None, "World".to_string()))),
@@ -219,9 +219,10 @@ fn join_through_other() {
     use schema::users::dsl::*;
     let connection = connection_with_sean_and_tess_in_users_table();
 
-    insert(&NewUser::new("Jim", None)).into(users).execute(&connection).unwrap();
+    insert(&NewUser::new("Jim", None, UserType::Default)).into(users).execute(&connection).unwrap();
     insert(&vec![
-        NewPost::new(1, "Hello", None), NewPost::new(2, "World", None),
+        NewPost::new(1, "Hello", None),
+        NewPost::new(2, "World", None),
         NewPost::new(1, "Hello again!", None),
     ]).into(posts::table).execute(&connection).unwrap();
     let posts = posts::table.load::<Post>(&connection).unwrap();
@@ -234,8 +235,8 @@ fn join_through_other() {
     let data = users.inner_join(comments::table).load(&connection)
         .unwrap();
 
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
     let expected_data = vec![
         (sean.clone(), comments[0].clone()),
         (tess, comments[1].clone()),

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -14,6 +14,8 @@ mod custom_schemas;
 mod debug;
 mod delete;
 mod deserialization;
+#[cfg(feature = "postgres")]
+mod enums;
 mod errors;
 mod expressions;
 mod filter;

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -32,5 +32,6 @@ mod schema_inference;
 mod select;
 mod transactions;
 mod types;
+mod type_inference;
 mod types_roundtrip;
 mod update;

--- a/diesel_tests/tests/macros.rs
+++ b/diesel_tests/tests/macros.rs
@@ -17,8 +17,8 @@ fn test_sql_function() {
     connection.execute("CREATE FUNCTION my_lower(varchar) RETURNS varchar
         AS $$ SELECT LOWER($1) $$
         LANGUAGE SQL").unwrap();
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
+    let sean = User::new(1, "Sean", UserType::Default);
+    let tess = User::new(2, "Tess", UserType::Default);
 
     assert_eq!(vec![sean], users.filter(my_lower(name).eq("sean"))
         .load(&connection).unwrap());

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -7,9 +7,9 @@ fn order_by_column() {
 
     let conn = connection();
     let data = vec![
-        NewUser::new("Sean", None),
-        NewUser::new("Tess", None),
-        NewUser::new("Jim", None),
+        NewUser::new("Sean", None, UserType::Default),
+        NewUser::new("Tess", None, UserType::Default),
+        NewUser::new("Jim", None, UserType::Default),
     ];
     insert(&data).into(users).execute(&conn).unwrap();
     let data = users.load::<User>(&conn).unwrap();
@@ -18,21 +18,21 @@ fn order_by_column() {
     let jim = &data[2];
 
     let expected_data = vec![
-        User::new(jim.id, "Jim"),
-        User::new(sean.id, "Sean"),
-        User::new(tess.id, "Tess"),
+        User::new(jim.id, "Jim", UserType::Default),
+        User::new(sean.id, "Sean", UserType::Default),
+        User::new(tess.id, "Tess", UserType::Default),
     ];
     let data: Vec<_> = users.order(name).load(&conn).unwrap();
     assert_eq!(expected_data, data);
 
-    insert(&NewUser::new("Aaron", None)).into(users)
+    insert(&NewUser::new("Aaron", None, UserType::Default)).into(users)
         .execute(&conn).unwrap();
     let aaron = users.order(id.desc()).first::<User>(&conn).unwrap();
     let expected_data = vec![
-        User::new(aaron.id, "Aaron"),
-        User::new(jim.id, "Jim"),
-        User::new(sean.id, "Sean"),
-        User::new(tess.id, "Tess"),
+        User::new(aaron.id, "Aaron", UserType::Default),
+        User::new(jim.id, "Jim", UserType::Default),
+        User::new(sean.id, "Sean", UserType::Default),
+        User::new(tess.id, "Tess", UserType::Default),
     ];
     let data: Vec<_> = users.order(name.asc()).load(&conn).unwrap();
     assert_eq!(expected_data, data);
@@ -44,9 +44,9 @@ fn order_by_descending_column() {
 
     let conn = connection();
     let data = vec![
-        NewUser::new("Sean", None),
-        NewUser::new("Tess", None),
-        NewUser::new("Jim", None),
+        NewUser::new("Sean", None, UserType::Default),
+        NewUser::new("Tess", None, UserType::Default),
+        NewUser::new("Jim", None, UserType::Default),
     ];
     insert(&data).into(users).execute(&conn).unwrap();
     let data = users.load::<User>(&conn).unwrap();
@@ -55,21 +55,21 @@ fn order_by_descending_column() {
     let jim = &data[2];
 
     let expected_data = vec![
-        User::new(tess.id, "Tess"),
-        User::new(sean.id, "Sean"),
-        User::new(jim.id, "Jim"),
+        User::new(tess.id, "Tess", UserType::Default),
+        User::new(sean.id, "Sean", UserType::Default),
+        User::new(jim.id, "Jim", UserType::Default),
     ];
     let data: Vec<_> = users.order(name.desc()).load(&conn).unwrap();
     assert_eq!(expected_data, data);
 
-    insert(&NewUser::new("Aaron", None)).into(users)
+    insert(&NewUser::new("Aaron", None, UserType::Default)).into(users)
         .execute(&conn).unwrap();
     let aaron = users.order(id.desc()).first::<User>(&conn).unwrap();
     let expected_data = vec![
-        User::new(tess.id, "Tess"),
-        User::new(sean.id, "Sean"),
-        User::new(jim.id, "Jim"),
-        User::new(aaron.id, "Aaron"),
+        User::new(tess.id, "Tess", UserType::Default),
+        User::new(sean.id, "Sean", UserType::Default),
+        User::new(jim.id, "Jim", UserType::Default),
+        User::new(aaron.id, "Aaron", UserType::Default),
     ];
     let data: Vec<_> = users.order(name.desc()).load(&conn).unwrap();
     assert_eq!(expected_data, data);

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -2,6 +2,8 @@ use diesel::*;
 use dotenv::dotenv;
 use std::env;
 
+infer_enums!("dotenv:DATABASE_URL");
+pub use self::__diesel_infer_enums::UserType;
 infer_schema!("dotenv:DATABASE_URL");
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, Associations)]
@@ -11,18 +13,20 @@ pub struct User {
     pub id: i32,
     pub name: String,
     pub hair_color: Option<String>,
+    pub user_class: UserType,
 }
 
 impl User {
-    pub fn new(id: i32, name: &str) -> Self {
-        User { id: id, name: name.to_string(), hair_color: None }
+    pub fn new(id: i32, name: &str, user_class: UserType) -> Self {
+        User { id: id, name: name.to_string(), hair_color: None, user_class: user_class, }
     }
 
-    pub fn with_hair_color(id: i32, name: &str, hair_color: &str) -> Self {
+    pub fn with_hair_color(id: i32, name: &str, hair_color: &str, user_class: UserType) -> Self {
         User {
             id: id,
             name: name.to_string(),
             hair_color: Some(hair_color.to_string()),
+            user_class: user_class,
         }
     }
 
@@ -87,7 +91,7 @@ pub use self::backend_specifics::*;
 
 numeric_expr!(users::id);
 
-select_column_workaround!(users -> comments (id, name, hair_color));
+select_column_workaround!(users -> comments (id, name, hair_color, user_class));
 select_column_workaround!(comments -> users (id, post_id, text));
 
 join_through!(users -> posts -> comments);
@@ -97,13 +101,15 @@ join_through!(users -> posts -> comments);
 pub struct NewUser {
     pub name: String,
     pub hair_color: Option<String>,
+    pub user_class: UserType,
 }
 
 impl NewUser {
-    pub fn new(name: &str, hair_color: Option<&str>) -> Self {
+    pub fn new(name: &str, hair_color: Option<&str>, user_class: UserType) -> Self {
         NewUser {
             name: name.to_string(),
             hair_color: hair_color.map(|s| s.to_string()),
+            user_class: user_class,
         }
     }
 }

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -1,10 +1,9 @@
+pub use enums::*;
 use diesel::*;
 use dotenv::dotenv;
 use std::env;
 
-infer_enums!("dotenv:DATABASE_URL");
-pub use self::__diesel_infer_enums::UserType;
-infer_schema!("dotenv:DATABASE_URL");
+infer_schema!(extra_types_module = "::enums", "dotenv:DATABASE_URL");
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, Associations)]
 #[has_many(posts)]

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -29,11 +29,11 @@ fn selecting_a_struct() {
         .unwrap();
 
     let expected_users = vec![
-        NewUser::new("Sean", None),
-        NewUser::new("Tess", None),
+        NewUser::new("Sean", None, UserType::Default),
+        NewUser::new("Tess", None, UserType::Default),
     ];
     let actual_users: Vec<_> = users
-        .select((name, hair_color))
+        .select((name, hair_color, user_class))
         .load(&connection).unwrap();
     assert_eq!(expected_users, actual_users);
 }
@@ -136,8 +136,8 @@ fn selecting_columns_with_different_definition_order() {
         string("hair_color"),
         string("name").not_null(),
     )).execute(&connection).unwrap();
-    let expected_user = User::with_hair_color(1, "Sean", "black");
-    insert(&NewUser::new("Sean", Some("black"))).into(users::table)
+    let expected_user = User::with_hair_color(1, "Sean", "black", UserType::Default);
+    insert(&NewUser::new("Sean", Some("black"), UserType::Default)).into(users::table)
         .execute(&connection).unwrap();
     let user_from_select = users::table.first(&connection);
 

--- a/diesel_tests/tests/type_inference.rs
+++ b/diesel_tests/tests/type_inference.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "postgres")]
 mod postgres {
+    use diesel;
+    use diesel::types::HasSqlType;
+
     use std::collections::HashMap;
     use std::fmt::Write;
 
@@ -40,5 +43,10 @@ mod postgres {
         let mut h = HashMap::new();
         h.insert(UserType::Default, UserType::Guest);
         assert!(h.contains_key(&UserType::Default));
+    }
+
+    #[test]
+    fn pg_has_enum_type() {
+        let _ = <diesel::pg::Pg as HasSqlType<UserType>>::metadata();
     }
 }

--- a/diesel_tests/tests/type_inference.rs
+++ b/diesel_tests/tests/type_inference.rs
@@ -1,0 +1,44 @@
+#[cfg(feature = "postgres")]
+mod postgres {
+    use std::collections::HashMap;
+    use std::fmt::Write;
+
+    infer_enums!("dotenv:DATABASE_URL");
+
+    #[test]
+    fn inferred_existing_enums() {
+        let _something = UserType::Admin;
+        let _something = UserType::Guest;
+        let _something = UserType::GroupOwner;
+        let _something = UserType::Default;
+    }
+
+    #[test]
+    fn enum_supports_eq() {
+        assert_eq!(UserType::Admin, UserType::Admin);
+        assert!(UserType::Admin != UserType::Guest);
+    }
+
+    #[test]
+    fn enum_supports_clone_and_copy() {
+        let something = UserType::Admin.clone();
+        let something_else = UserType::Guest;
+        let closed_1 = || { something == something_else };
+        let closed_2 = || { something != something_else };
+        assert!(closed_1() != closed_2());
+    }
+
+    #[test]
+    fn enum_supports_debug() {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", UserType::Default).expect("error writing to buffer");
+        assert_eq!("Default", s);
+    }
+
+    #[test]
+    fn enum_goes_into_hash_container() {
+        let mut h = HashMap::new();
+        h.insert(UserType::Default, UserType::Guest);
+        assert!(h.contains_key(&UserType::Default));
+    }
+}

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -65,7 +65,7 @@ fn test_updating_multiple_columns() {
         hair_color.eq(Some("black")),
     )).execute(&connection).unwrap();
 
-    let expected_user = User::with_hair_color(sean.id, "Jim", "black");
+    let expected_user = User::with_hair_color(sean.id, "Jim", "black", UserType::Default);
     let user = users.find(sean.id).first(&connection);
     assert_eq!(Ok(expected_user), user);
 }
@@ -79,7 +79,7 @@ fn update_returning_struct() {
     let sean = find_user_by_name("Sean", &connection);
     let user = update(users.filter(id.eq(sean.id))).set(hair_color.eq("black"))
         .get_result(&connection);
-    let expected_user = User::with_hair_color(sean.id, "Sean", "black");
+    let expected_user = User::with_hair_color(sean.id, "Sean", "black", UserType::Default);
 
     assert_eq!(Ok(expected_user), user);
 }
@@ -106,12 +106,12 @@ fn update_with_struct_as_changes() {
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
-    let changes = NewUser::new("Jim", Some("blue"));
+    let changes = NewUser::new("Jim", Some("blue"), UserType::Default);
 
     update(users.filter(id.eq(sean.id))).set(&changes)
         .execute(&connection).unwrap();
     let user = users.find(sean.id).first(&connection);
-    let expected_user = User::with_hair_color(sean.id, "Jim", "blue");
+    let expected_user = User::with_hair_color(sean.id, "Jim", "blue", UserType::Default);
 
     assert_eq!(Ok(expected_user), user);
 }
@@ -123,12 +123,12 @@ fn update_with_struct_does_not_set_primary_key() {
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
     let other_id = sean.id + 1;
-    let changes = User::with_hair_color(other_id, "Jim", "blue");
+    let changes = User::with_hair_color(other_id, "Jim", "blue", UserType::Default);
 
     update(users.filter(id.eq(sean.id))).set(&changes)
         .execute(&connection).unwrap();
     let user = users.find(sean.id).first(&connection);
-    let expected_user = User::with_hair_color(sean.id, "Jim", "blue");
+    let expected_user = User::with_hair_color(sean.id, "Jim", "blue", UserType::Default);
 
     assert_eq!(Ok(expected_user), user);
 }
@@ -139,7 +139,8 @@ fn save_on_struct_with_primary_key_changes_that_struct() {
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
-    let user = User::with_hair_color(sean.id, "Jim", "blue").save_changes::<User>(&connection);
+    let user = User::with_hair_color(sean.id, "Jim", "blue", UserType::Default)
+        .save_changes::<User>(&connection);
 
     let user_in_db = users.find(sean.id).first(&connection);
 
@@ -155,9 +156,9 @@ fn option_fields_on_structs_are_not_assigned() {
     update(users.filter(id.eq(sean.id)))
         .set(hair_color.eq("black"))
         .execute(&connection).unwrap();
-    let user = User::new(sean.id, "Jim").save_changes(&connection);
+    let user = User::new(sean.id, "Jim", UserType::Default).save_changes(&connection);
 
-    let expected_user = User::with_hair_color(sean.id, "Jim", "black");
+    let expected_user = User::with_hair_color(sean.id, "Jim", "black", UserType::Default);
     assert_eq!(Ok(expected_user), user);
 }
 
@@ -177,7 +178,7 @@ fn sql_syntax_is_correct_when_option_field_comes_before_non_option() {
         .execute(&connection).unwrap();
     let user = users::table.find(sean.id).first(&connection);
 
-    let expected_user = User::new(sean.id, "Jim");
+    let expected_user = User::new(sean.id, "Jim", UserType::Default);
     assert_eq!(Ok(expected_user), user);
 }
 

--- a/migrations/postgresql/20161223212352_create_enums/down.sql
+++ b/migrations/postgresql/20161223212352_create_enums/down.sql
@@ -1,0 +1,2 @@
+DROP TYPE custom_schema.admin_type;
+DROP TYPE user_type;

--- a/migrations/postgresql/20161223212352_create_enums/up.sql
+++ b/migrations/postgresql/20161223212352_create_enums/up.sql
@@ -1,0 +1,2 @@
+CREATE TYPE user_type AS ENUM ('admin', 'guest', 'group_owner', 'default');
+CREATE TYPE custom_schema.admin_type AS ENUM ('super_user', 'super_duper_user', 'alright_user');

--- a/migrations/postgresql/20161224024421_add_enum_columns/down.sql
+++ b/migrations/postgresql/20161224024421_add_enum_columns/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users DROP COLUMN user_class;
+ALTER TABLE custom_schema.users DROP COLUMN admin_class;

--- a/migrations/postgresql/20161224024421_add_enum_columns/up.sql
+++ b/migrations/postgresql/20161224024421_add_enum_columns/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users ADD COLUMN user_class user_type NOT NULL
+  DEFAULT CAST('default' AS user_type);
+-- ALTER TABLE custom_schema.users ADD COLUMN admin_class custom_schema.admin_type NOT NULL
+--   DEFAULT CAST('super_duper_user' AS custom_schema.admin_type);


### PR DESCRIPTION
This PR provides the `infer_enums!` macro, which creates Rust enums for each enum discovered in a database, and extends `infer_schema!` so that you can name columns .

See #343 for discussion about how this has been developed up until now.

Items to be addressed before this is ready for merge:
- [ ] Correctly implement all necessary traits for newly declared types.
- [ ] Clean up changes to `infer_schema!` and related macros. (Argument-passing to indicate where to look up non-builtin types is rather unslightly.)
- [ ] Add more Rust documentation describing how the new features work.
- [ ] Fix migrations and tests so that tests pass on SQLite again. (SQLite does not support custom enum types the way Postgres does.)
- [ ] Get things working within custom schemas.
- [ ] Implement and test arrays of custom types.