### PR TITLE
Update byteorder to 1.0.

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 libc = "0.2.*"
 pq-sys = { version = "^0.2.0", optional = true }
 libsqlite3-sys = { version = "^0.4.0", optional = true }
-byteorder = "0.3.*"
+byteorder = "1.0"
 quickcheck = { version = "0.3.1", optional = true }
 chrono = { version = "^0.2.17", optional = true }
 uuid = { version = ">=0.2.0, <0.4.0", optional = true, features = ["use_std"] }


### PR DESCRIPTION
The byteorder crate is now 1.0. This bumps Diesel's version constraint on it so downstream programs can use the latest one. There are no changes that impact Diesel as far as I can tell—it seems to have just been a formality for stabilization.