### PR TITLE
Clean up output of `diesel print-schema`

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -226,9 +226,8 @@ fn run_infer_schema(matches: &ArgMatches) {
             if is_blacklist && filtering_tables.contains(&table_name[..]) {
                 return None;
             }
-            Some(diesel_infer_schema::infer_schema_for_schema_name(table, &database_url)
-                .expect(&format!("Could not load table `{}`", table.to_string()))
-                .tokens())
+            Some(diesel_infer_schema::expand_infer_table_from_schema(&database_url, &table)
+                .expect(&format!("Could not load table `{}`", table.to_string())))
         });
 
     let schema = diesel_infer_schema::handle_schema(tables, schema_name);

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -19,43 +19,31 @@ fn run_infer_schema() {
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
     if cfg!(feature = "sqlite") {
         assert_eq!(result.stdout(),
-r"mod infer_users1 {
-    table! {
-        users1 (id) {
-            id -> Nullable<Integer>,
-        }
+r"table! {
+    users1 (id) {
+        id -> Nullable<Integer>,
     }
 }
-pub use self::infer_users1::*;
-mod infer_users2 {
-    table! {
-        users2 (id) {
-            id -> Nullable<Integer>,
-        }
-    }
-}
-pub use self::infer_users2::*;
 
+table! {
+    users2 (id) {
+        id -> Nullable<Integer>,
+    }
+}
 ");
     } else if cfg!(feature = "postgres") {
                 assert_eq!(result.stdout(),
-r"mod infer_users1 {
-    table! {
-        users1 (id) {
-            id -> Int4,
-        }
+r"table! {
+    users1 (id) {
+        id -> Int4,
     }
 }
-pub use self::infer_users1::*;
-mod infer_users2 {
-    table! {
-        users2 (id) {
-            id -> Int4,
-        }
-    }
-}
-pub use self::infer_users2::*;
 
+table! {
+    users2 (id) {
+        id -> Int4,
+    }
+}
 ");
     }
 }
@@ -79,27 +67,19 @@ fn run_infer_schema_whitelist() {
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
     if cfg!(feature = "sqlite") {
         assert_eq!(result.stdout(),
-r"mod infer_users1 {
-    table! {
-        users1 (id) {
-            id -> Nullable<Integer>,
-        }
+r"table! {
+    users1 (id) {
+        id -> Nullable<Integer>,
     }
 }
-pub use self::infer_users1::*;
-
 ");
     } else if cfg!(feature = "postgres") {
         assert_eq!(result.stdout(),
-r"mod infer_users1 {
-    table! {
-        users1 (id) {
-            id -> Int4,
-        }
+r"table! {
+    users1 (id) {
+        id -> Int4,
     }
 }
-pub use self::infer_users1::*;
-
 ");
     }
 }
@@ -123,27 +103,19 @@ fn run_infer_schema_blacklist() {
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
     if cfg!(feature = "sqlite") {
         assert_eq!(result.stdout(),
-r"mod infer_users2 {
-    table! {
-        users2 (id) {
-            id -> Nullable<Integer>,
-        }
+r"table! {
+    users2 (id) {
+        id -> Nullable<Integer>,
     }
 }
-pub use self::infer_users2::*;
-
 ");
     } else if cfg!(feature = "postgres") {
         assert_eq!(result.stdout(),
-r"mod infer_users2 {
-    table! {
-        users2 (id) {
-            id -> Int4,
-        }
+r"table! {
+    users2 (id) {
+        id -> Int4,
     }
 }
-pub use self::infer_users2::*;
-
 ");
     }
 }

--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -3,12 +3,12 @@ use std::error::Error;
 use quote;
 use syn;
 
-use table_data::{TableData, TableDataWithTokens};
+use table_data::TableData;
 use data_structures::ColumnInformation;
 use inference::{establish_connection, get_table_data, determine_column_type, get_primary_keys,
                 InferConnection};
 
-pub fn derive_infer_table_from_schema(database_url: &str, table: &TableData)
+pub fn expand_infer_table_from_schema(database_url: &str, table: &TableData)
     -> Result<quote::Tokens, Box<Error>>
 {
     let connection = establish_connection(database_url)?;
@@ -38,21 +38,6 @@ pub fn derive_infer_table_from_schema(database_url: &str, table: &TableData)
             #(#tokens),*,
         }
     }))
-}
-
-pub fn infer_schema_for_schema_name(table: &TableData, database_url: &str)
-     -> Result<TableDataWithTokens, Box<Error>>
-{
-    let mod_ident = syn::Ident::new(format!("infer_{}", table.name()));
-    let table_macro = derive_infer_table_from_schema(database_url, table)?;
-    let tokens = quote! {
-        mod #mod_ident {
-            #table_macro
-        }
-        pub use self::#mod_ident::*;
-    };
-
-    Ok(table.set_tokens(tokens))
 }
 
 pub fn handle_schema<I>(tables: I, schema_name: Option<&str>) -> quote::Tokens

--- a/diesel_infer_schema/src/lib.rs
+++ b/diesel_infer_schema/src/lib.rs
@@ -8,7 +8,7 @@ extern crate diesel;
 mod codegen;
 mod data_structures;
 mod inference;
-pub mod table_data;
+mod table_data;
 
 #[cfg(feature = "postgres")]
 mod pg;
@@ -17,3 +17,4 @@ mod sqlite;
 
 pub use codegen::*;
 pub use inference::load_table_names;
+pub use table_data::TableData;

--- a/diesel_infer_schema/src/table_data.rs
+++ b/diesel_infer_schema/src/table_data.rs
@@ -1,6 +1,4 @@
-use std::ops::Deref;
-
-use quote;
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TableData {
@@ -25,42 +23,13 @@ impl TableData {
     pub fn schema(&self) -> &Option<String> {
         &self.schema
     }
-
-    pub fn set_tokens(&self, tokens: quote::Tokens) -> TableDataWithTokens {
-        TableDataWithTokens {
-          table: self.clone(),
-          tokens: tokens,
-        }
-    }
 }
 
-impl ToString for TableData {
-    fn to_string(&self) -> String {
+impl fmt::Display for TableData {
+    fn fmt(&self, out: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self.schema {
-            Some(ref schema_name) => format!("{}.{}", schema_name, self.name),
-            None => self.name.clone(),
+            Some(ref schema_name) => write!(out, "{}.{}", schema_name, self.name),
+            None => write!(out, "{}", self.name)
         }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct TableDataWithTokens {
-    /// Table data with name and schema
-    table: TableData,
-    /// Table represented as tokens of `table!` macro
-    tokens: quote::Tokens,
-}
-
-impl TableDataWithTokens {
-    pub fn tokens(&self) -> quote::Tokens {
-        self.tokens.clone()
-    }
-}
-
-impl Deref for TableDataWithTokens {
-    type Target = TableData;
-
-    fn deref(&self) -> &TableData {
-        &self.table
     }
 }


### PR DESCRIPTION
Prior to this commit, the output would include the `mod infer_table {
table! { ... }; pub use self::infer_table::*;` wrapper that we generate.
This is only needed due to how the macros work with Macros 1.1. When
calling the various functions directly, we should generate code that is
closer to what the user would write themselves.

In addition to not including that wrapper code, I've also inserted a
newline between each table! macro, and trimmed all trailing whitespace,
making it nearly exactly what the user would write themselves.