### PR TITLE
Remove the implicit `'static` bound from `run_migrations`

### DIFF
--- a/diesel/src/migrations/migration.rs
+++ b/diesel/src/migrations/migration.rs
@@ -18,6 +18,34 @@ pub fn migration_from(path: PathBuf) -> Result<Box<Migration>, MigrationError> {
     }
 }
 
+impl Migration for Box<Migration> {
+    fn version(&self) -> &str {
+        (&**self).version()
+    }
+
+    fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).run(conn)
+    }
+
+    fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).revert(conn)
+    }
+}
+
+impl<'a> Migration for &'a Migration {
+    fn version(&self) -> &str {
+        (&**self).version()
+    }
+
+    fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).run(conn)
+    }
+
+    fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).revert(conn)
+    }
+}
+
 fn valid_sql_migration_directory(path: &Path) -> bool {
     file_names(path).map(|files| {
         files.contains(&"down.sql".into()) && files.contains(&"up.sql".into())

--- a/diesel/src/migrations/mod.rs
+++ b/diesel/src/migrations/mod.rs
@@ -195,14 +195,14 @@ fn migrations_in_directory(path: &Path) -> Result<Vec<Box<Migration>>, Migration
 
 /// Run all pending migrations in the given list. Apps should likely be calling
 /// `run_pending_migrations` or `run_pending_migrations_in_directory` instead.
-pub fn run_migrations<Conn, List, M>(
+pub fn run_migrations<Conn, List>(
     conn: &Conn,
     migrations: List,
     output: &mut Write,
 ) -> Result<(), RunMigrationsError> where
     Conn: MigrationConnection,
-    List: IntoIterator<Item=M>,
-    M: ::std::ops::Deref<Target=Migration>,
+    List: IntoIterator,
+    List::Item: Migration,
 {
     try!(setup_database(conn));
     let already_run = try!(conn.previously_run_migration_versions());
@@ -213,7 +213,7 @@ pub fn run_migrations<Conn, List, M>(
 
     pending_migrations.sort_by(|a, b| a.version().cmp(b.version()));
     for migration in pending_migrations {
-        try!(run_migration(conn, &*migration, output));
+        try!(run_migration(conn, &migration, output));
     }
     Ok(())
 }


### PR DESCRIPTION
Rust has the undocumented behavior of implying `+ 'static` any time you
reference a trait object directly. Normally this isn't a problem since
the only time you'd usually do that is as `Box<Trait>`, where you can
just write `Box<Trait + 'a>` instead. We can't do that here, however,
sicne `Deref<Target=Trait + 'a>` is not valid syntax. I'm not sure if
there's a workaround to keep the old code that I'm missing, or if this
is legitimately a problem in the language.

Either way it doesn't matter, we can just implement the trait on box and
ref and everything is fine.

I did not include a changelog entry, as all previous callers of this
function should continue to work, and this is a function that is
documented as "you probably should be using something else"

Fixes #593.