### PR TITLE
Add initial structure for MySQL support

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -11,19 +11,21 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 categories = ["database"]
 
 [dependencies]
-libc = "0.2.*"
-pq-sys = { version = "^0.2.0", optional = true }
-libsqlite3-sys = { version = ">= 0.4.0, <0.7.0", optional = true }
 byteorder = "1.0"
-quickcheck = { version = "0.3.1", optional = true }
 chrono = { version = "^0.2.17", optional = true }
-uuid = { version = ">=0.2.0, <0.4.0", optional = true, features = ["use_std"] }
+libc = "0.2.*"
+libsqlite3-sys = { version = ">= 0.4.0, <0.7.0", optional = true }
+mysqlclient-sys = { git = "https://github.com/sgrif/mysqlclient-sys.git", optional = true }
+pq-sys = { version = "^0.2.0", optional = true }
+quickcheck = { version = "0.3.1", optional = true }
 serde_json = { version = ">=0.8.0, <0.10.0", optional = true }
+uuid = { version = ">=0.2.0, <0.4.0", optional = true, features = ["use_std"] }
 
 [dev-dependencies]
+cfg-if = "0.1.0"
 diesel_codegen = "0.10.0"
-quickcheck = "0.3.1"
 dotenv = "0.8.0"
+quickcheck = "0.3.1"
 tempdir = "^0.3.4"
 
 [features]
@@ -33,4 +35,5 @@ large-tables = []
 huge-tables = ["large-tables"]
 postgres = ["pq-sys"]
 sqlite = ["libsqlite3-sys"]
+mysql = ["mysqlclient-sys"]
 with-deprecated = []

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -1,60 +1,91 @@
 extern crate dotenv;
+#[macro_use] extern crate cfg_if;
 
 use diesel::prelude::*;
 use self::dotenv::dotenv;
 
-#[cfg(feature = "postgres")]
-#[allow(dead_code)]
-type DB = diesel::pg::Pg;
+cfg_if! {
+    if #[cfg(feature = "postgres")] {
+        #[allow(dead_code)]
+        type DB = diesel::pg::Pg;
 
-#[cfg(feature = "postgres")]
-fn connection_no_data() -> diesel::pg::PgConnection {
+        fn connection_no_data() -> diesel::pg::PgConnection {
+            let connection_url = database_url_from_env();
+            let connection = diesel::pg::PgConnection::establish(&connection_url).unwrap();
+            connection.begin_test_transaction().unwrap();
+            connection.execute("DROP TABLE IF EXISTS users").unwrap();
+
+            connection
+        }
+
+        #[allow(dead_code)]
+        fn establish_connection() -> diesel::pg::PgConnection {
+            let connection = connection_no_data();
+
+            connection.execute("CREATE TABLE users (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR NOT NULL
+            )").unwrap();
+            connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").unwrap();
+
+            connection
+        }
+    } else if #[cfg(feature = "sqlite")] {
+        #[allow(dead_code)]
+        type DB = diesel::sqlite::Sqlite;
+
+        fn connection_no_data() -> diesel::sqlite::SqliteConnection {
+            diesel::sqlite::SqliteConnection::establish(":memory:").unwrap()
+        }
+
+        #[allow(dead_code)]
+        fn establish_connection() -> diesel::sqlite::SqliteConnection {
+            let connection = connection_no_data();
+
+            connection.execute("CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR NOT NULL
+            )").unwrap();
+            connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").unwrap();
+
+            connection
+        }
+    } else if #[cfg(feature = "mysql")] {
+        #[allow(dead_code)]
+        type DB = diesel::mysql::Mysql;
+
+        fn connection_no_data() -> diesel::mysql::MysqlConnection {
+            let connection_url = database_url_from_env();
+            let connection = diesel::mysql::MysqlConnection::establish(connection_url).unwrap();
+            connection.begin_test_transaction().unwrap();
+            connection.execute("DROP TABLE IF EXISTS users").unwrap();
+
+            connection
+        }
+
+        #[allow(dead_code)]
+        fn establish_connection() -> diesel::mysql::MysqlConnection {
+            let connection = connection_no_data();
+
+            connection.execute("CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTO_INCREMENT,
+                name VARCHAR NOT NULL
+            )").unwrap();
+            connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").unwrap();
+
+            connection
+        }
+    } else {
+        // FIXME: https://github.com/rust-lang/rfcs/pull/1695
+        // compile_error!("At least one backend must be enabled to run tests");
+    }
+}
+
+fn database_url_from_env() -> String {
     dotenv().ok();
 
-    let connection_url = ::std::env::var("DATABASE_URL")
-        .expect("DATABASE_URL must be set in order to run tests");
-    let connection = diesel::pg::PgConnection::establish(&connection_url).unwrap();
-    connection.begin_test_transaction().unwrap();
-    connection.execute("DROP TABLE IF EXISTS users").unwrap();
-
-    connection
-}
-
-#[cfg(feature = "postgres")]
-#[allow(dead_code)]
-fn establish_connection() -> diesel::pg::PgConnection {
-    let connection = connection_no_data();
-
-    connection.execute("CREATE TABLE users (
-        id SERIAL PRIMARY KEY,
-        name VARCHAR NOT NULL
-    )").unwrap();
-    connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").unwrap();
-
-    connection
-}
-
-#[cfg(all(not(feature = "postgres"), feature = "sqlite"))]
-#[allow(dead_code)]
-type DB = diesel::sqlite::Sqlite;
-
-#[cfg(all(not(feature = "postgres"), feature = "sqlite"))]
-fn connection_no_data() -> diesel::sqlite::SqliteConnection {
-    diesel::sqlite::SqliteConnection::establish(":memory:").unwrap()
-}
-
-#[cfg(all(not(feature = "postgres"), feature = "sqlite"))]
-#[allow(dead_code)]
-fn establish_connection() -> diesel::sqlite::SqliteConnection {
-    let connection = connection_no_data();
-
-    connection.execute("CREATE TABLE users (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name VARCHAR NOT NULL
-    )").unwrap();
-    connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").unwrap();
-
-    connection
+    ::std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set in order to run tests")
 }
 
 #[derive(Clone)]

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -8,6 +8,10 @@
 mod macros;
 
 #[cfg(test)]
+#[macro_use]
+extern crate cfg_if;
+
+#[cfg(test)]
 pub mod test_helpers;
 
 pub mod associations;
@@ -25,6 +29,8 @@ pub mod types;
 #[cfg(feature = "with-deprecated")]
 pub use self::insertable as persistable;
 
+#[cfg(feature = "mysql")]
+pub mod mysql;
 #[cfg(feature = "postgres")]
 pub mod pg;
 #[cfg(feature = "sqlite")]

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -1,0 +1,62 @@
+use backend::*;
+use query_builder::bind_collector::RawBytesBindCollector;
+use super::query_builder::MysqlQueryBuilder;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Mysql;
+
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+/// Represents the possible forms a bind parameter can be transmitted as.
+/// Each variant represents one of the forms documented at
+/// https://dev.mysql.com/doc/refman/5.7/en/c-api-prepared-statement-type-codes.html
+///
+/// The null variant is omitted, as we will never prepare a statement in which
+/// one of the bind parameters can always be NULL
+pub enum MysqlType {
+    Tiny,
+    Short,
+    Long,
+    LongLong,
+    Float,
+    Double,
+    Time,
+    Date,
+    DateTime,
+    Timestamp,
+    String,
+    Blob,
+}
+
+impl Backend for Mysql {
+    type QueryBuilder = MysqlQueryBuilder;
+    type BindCollector = RawBytesBindCollector<Mysql>;
+    type RawValue = [u8];
+}
+
+impl TypeMetadata for Mysql {
+    type TypeMetadata = MysqlType;
+}
+
+impl SupportsReturningClause for Mysql {}
+impl SupportsDefaultKeyword for Mysql {}
+
+// FIXME: Move this out of this module
+use types::HasSqlType;
+
+impl HasSqlType<::types::Date> for Mysql {
+    fn metadata() -> MysqlType {
+        MysqlType::Date
+    }
+}
+
+impl HasSqlType<::types::Time> for Mysql {
+    fn metadata() -> MysqlType {
+        MysqlType::Time
+    }
+}
+
+impl HasSqlType<::types::Timestamp> for Mysql {
+    fn metadata() -> MysqlType {
+        MysqlType::Timestamp
+    }
+}

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -1,0 +1,66 @@
+extern crate mysqlclient_sys as ffi;
+
+use connection::{Connection, SimpleConnection};
+use query_builder::*;
+use query_source::Queryable;
+use result::*;
+use super::backend::Mysql;
+use types::HasSqlType;
+
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct MysqlConnection;
+
+impl SimpleConnection for MysqlConnection {
+    fn batch_execute(&self, _query: &str) -> QueryResult<()> {
+        unimplemented!()
+    }
+}
+
+impl Connection for MysqlConnection {
+    type Backend = Mysql;
+
+    fn establish(_database_url: &str) -> ConnectionResult<Self> {
+        unimplemented!()
+    }
+
+    fn execute(&self, _query: &str) -> QueryResult<usize> {
+        unimplemented!()
+    }
+
+    fn query_all<T, U>(&self, _source: T) -> QueryResult<Vec<U>> where
+        T: AsQuery,
+        T::Query: QueryFragment<Self::Backend> + QueryId,
+        Self::Backend: HasSqlType<T::SqlType>,
+        U: Queryable<T::SqlType, Self::Backend>,
+    {
+        unimplemented!()
+    }
+
+    fn silence_notices<F: FnOnce() -> T, T>(&self, _f: F) -> T {
+        unimplemented!()
+    }
+
+    fn execute_returning_count<T>(&self, _source: &T) -> QueryResult<usize> {
+        unimplemented!()
+    }
+
+    fn begin_transaction(&self) -> QueryResult<()> {
+        unimplemented!()
+    }
+
+    fn rollback_transaction(&self) -> QueryResult<()> {
+        unimplemented!()
+    }
+
+    fn commit_transaction(&self) -> QueryResult<()> {
+        unimplemented!()
+    }
+
+    fn get_transaction_depth(&self) -> i32 {
+        unimplemented!()
+    }
+
+    fn setup_helper_functions(&self) {
+        unimplemented!()
+    }
+}

--- a/diesel/src/mysql/mod.rs
+++ b/diesel/src/mysql/mod.rs
@@ -1,0 +1,9 @@
+mod backend;
+mod connection;
+// mod types;
+
+pub mod query_builder;
+
+pub use self::backend::{Mysql, MysqlType};
+pub use self::connection::MysqlConnection;
+pub use self::query_builder::MysqlQueryBuilder;

--- a/diesel/src/mysql/query_builder.rs
+++ b/diesel/src/mysql/query_builder.rs
@@ -1,0 +1,32 @@
+use super::backend::Mysql;
+use query_builder::{QueryBuilder, BuildQueryResult};
+
+#[allow(missing_debug_implementations)]
+pub struct MysqlQueryBuilder {
+    pub sql: String,
+}
+
+impl MysqlQueryBuilder {
+    pub fn new() -> Self {
+        MysqlQueryBuilder {
+            sql: String::new(),
+        }
+    }
+}
+
+impl QueryBuilder<Mysql> for MysqlQueryBuilder {
+    fn push_sql(&mut self, sql: &str) {
+        self.sql.push_str(sql);
+    }
+
+    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
+        self.push_sql("`");
+        self.push_sql(&identifier.replace("`", "``"));
+        self.push_sql("`");
+        Ok(())
+    }
+
+    fn push_bind_param(&mut self) {
+        self.push_sql("?");
+    }
+}

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -4,18 +4,18 @@ use std::io::Write;
 use backend::Backend;
 use types::{self, HasSqlType, FromSql, ToSql, IsNull, NotNull};
 
-primitive_impls!(Bool -> (bool, pg: (16, 1000), sqlite: (Integer)));
+primitive_impls!(Bool -> (bool, pg: (16, 1000), sqlite: (Integer), mysql: (Tiny)));
 
-primitive_impls!(SmallInt -> (i16, pg: (21, 1005), sqlite: (SmallInt)));
-primitive_impls!(Integer -> (i32, pg: (23, 1007), sqlite: (Integer)));
-primitive_impls!(BigInt -> (i64, pg: (20, 1016), sqlite: (Long)));
+primitive_impls!(SmallInt -> (i16, pg: (21, 1005), sqlite: (SmallInt), mysql: (Short)));
+primitive_impls!(Integer -> (i32, pg: (23, 1007), sqlite: (Integer), mysql: (Long)));
+primitive_impls!(BigInt -> (i64, pg: (20, 1016), sqlite: (Long), mysql: (LongLong)));
 
-primitive_impls!(Float -> (f32, pg: (700, 1021), sqlite: (Float)));
-primitive_impls!(Double -> (f64, pg: (701, 1022), sqlite: (Double)));
+primitive_impls!(Float -> (f32, pg: (700, 1021), sqlite: (Float), mysql: (Float)));
+primitive_impls!(Double -> (f64, pg: (701, 1022), sqlite: (Double), mysql: (Double)));
 
-primitive_impls!(Text -> (String, pg: (25, 1009), sqlite: (Text)));
+primitive_impls!(Text -> (String, pg: (25, 1009), sqlite: (Text), mysql: (String)));
 
-primitive_impls!(Binary -> (Vec<u8>, pg: (17, 1001), sqlite: (Binary)));
+primitive_impls!(Binary -> (Vec<u8>, pg: (17, 1001), sqlite: (Binary), mysql: (Blob)));
 
 primitive_impls!(Date);
 primitive_impls!(Time);


### PR DESCRIPTION
This represents the bare minimum required to define all the basic
structures MySQL will be needing, and have the tests compile. I've opted
not to include this as a travis allowed failure or in `bin/test` until
at least the core crate is mostly complete.

A few things that stood out to me while going through all of this:

It's called `Mysql` and not `MySql` because the module and feature are
called `mysql` not `my_sql`. The struct would never be called `MySQL` in
ideomatic Rust.

I'm not sure I generated bindings correctly since there's a lot of
different header files, so I haven't published yet. I was rather
surprised nobody has written a wrapper around their C API yet. Just the
pure Rust client (which mirrors rust-postgres's API so will be
impossible to use for all the same reasons)

The C API has global initialization. I believe that wrapping it in a
`std::sync::Once` and calling that from `MysqlConnection::establish`.

Lol if your enum variant for a 32 bit integer is called `Long`

The bind type variants for input vs output are asymmentrical. We are
mirroring the input, as we would only ever care about the output for
debug purposes. There are a lot of types missing from the input list.
Notably, decimal is missing. Unsure how we transmit in that case
(granted, it's not like we have any Rust type to work with anyway)

SqliteQueryBuilder, DebugQueryBuilder, and MysqlQueryBuilder are all
currently identical. I'm not sure that I ever expect them to diverge,
and will consider unifying them.