### PR TITLE
Don't pass pointers to freed memory to MySQL

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -27,7 +27,7 @@ impl Connection for MysqlConnection {
     fn establish(database_url: &str) -> ConnectionResult<Self> {
         let raw_connection = RawConnection::new();
         let connection_options = try!(ConnectionOptions::parse(database_url));
-        try!(raw_connection.connect(connection_options));
+        try!(raw_connection.connect(&connection_options));
         Ok(MysqlConnection {
             _raw_connection: raw_connection,
         })

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -34,11 +34,11 @@ impl RawConnection {
         result
     }
 
-    pub fn connect(&self, connection_options: ConnectionOptions) -> ConnectionResult<()> {
-        let host = try!(connection_options.host());
-        let user = try!(connection_options.user());
-        let password = try!(connection_options.password());
-        let database = try!(connection_options.database());
+    pub fn connect(&self, connection_options: &ConnectionOptions) -> ConnectionResult<()> {
+        let host = connection_options.host();
+        let user = connection_options.user();
+        let password = connection_options.password();
+        let database = connection_options.database();
         let port = connection_options.port();
 
         unsafe {


### PR DESCRIPTION
All of the options that were wrapped in an option were being freed
before going to MySQL. This is because `Option<CString>::map` takes
ownership of the value, and the raw pointer has no lifetime information.
The simplest solution is to just change the `database.map(|x|
x.as_ptr())` to be `database.as_ref().map(|x| x.as_ptr())`, but I've
gone one step futher and made the API much more difficult to misuse.