### PR TITLE
Don't assume that integers are always transmitted as network-endian

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -1,3 +1,5 @@
+use byteorder::{ByteOrder, NativeEndian};
+
 use query_builder::{QueryBuilder, BindCollector};
 use query_builder::debug::DebugQueryBuilder;
 use types::{self, HasSqlType};
@@ -19,6 +21,7 @@ pub trait Backend where
     type QueryBuilder: QueryBuilder<Self>;
     type BindCollector: BindCollector<Self>;
     type RawValue: ?Sized;
+    type ByteOrder: ByteOrder;
 }
 
 pub trait TypeMetadata {
@@ -36,6 +39,7 @@ impl Backend for Debug {
     type QueryBuilder = DebugQueryBuilder;
     type BindCollector = ();
     type RawValue = ();
+    type ByteOrder = NativeEndian;
 }
 
 impl BindCollector<Debug> for () {

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -4,6 +4,8 @@
 #![deny(warnings, missing_debug_implementations, missing_copy_implementations)]
 #![cfg_attr(feature = "unstable", feature(specialization))]
 
+extern crate byteorder;
+
 #[macro_use]
 mod macros;
 

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -1,3 +1,5 @@
+use byteorder::NativeEndian;
+
 use backend::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use super::query_builder::MysqlQueryBuilder;
@@ -31,6 +33,7 @@ impl Backend for Mysql {
     type QueryBuilder = MysqlQueryBuilder;
     type BindCollector = RawBytesBindCollector<Mysql>;
     type RawValue = [u8];
+    type ByteOrder = NativeEndian;
 }
 
 impl TypeMetadata for Mysql {

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -1,3 +1,5 @@
+use byteorder::NetworkEndian;
+
 use backend::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use super::query_builder::PgQueryBuilder;
@@ -15,6 +17,7 @@ impl Backend for Pg {
     type QueryBuilder = PgQueryBuilder;
     type BindCollector = RawBytesBindCollector<Pg>;
     type RawValue = [u8];
+    type ByteOrder = NetworkEndian;
 }
 
 impl TypeMetadata for Pg {

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -1,6 +1,4 @@
-extern crate byteorder;
-
-use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
+use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 use std::error::Error;
 use std::io::prelude::*;
 
@@ -43,13 +41,13 @@ impl Error for InvalidNumericSign {
 impl FromSql<types::Numeric, Pg> for PgNumeric {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let mut bytes = not_none!(bytes);
-        let ndigits = try!(bytes.read_u16::<BigEndian>());
+        let ndigits = try!(bytes.read_u16::<NetworkEndian>());
         let mut digits = Vec::with_capacity(ndigits as usize);
-        let weight = try!(bytes.read_i16::<BigEndian>());
-        let sign = try!(bytes.read_u16::<BigEndian>());
-        let scale = try!(bytes.read_u16::<BigEndian>());
+        let weight = try!(bytes.read_i16::<NetworkEndian>());
+        let sign = try!(bytes.read_u16::<NetworkEndian>());
+        let scale = try!(bytes.read_u16::<NetworkEndian>());
         for _ in 0..ndigits {
-            digits.push(try!(bytes.read_i16::<BigEndian>()));
+            digits.push(try!(bytes.read_i16::<NetworkEndian>()));
         }
 
         match sign {
@@ -92,12 +90,12 @@ impl ToSql<types::Numeric, Pg> for PgNumeric {
             &PgNumeric::Negative { scale, .. } => scale,
             &PgNumeric::NaN => 0,
         };
-        try!(out.write_u16::<BigEndian>(digits.len() as u16));
-        try!(out.write_i16::<BigEndian>(weight));
-        try!(out.write_u16::<BigEndian>(sign));
-        try!(out.write_u16::<BigEndian>(scale));
+        try!(out.write_u16::<NetworkEndian>(digits.len() as u16));
+        try!(out.write_i16::<NetworkEndian>(weight));
+        try!(out.write_u16::<NetworkEndian>(sign));
+        try!(out.write_u16::<NetworkEndian>(scale));
         for digit in digits.iter() {
-            try!(out.write_i16::<BigEndian>(*digit));
+            try!(out.write_i16::<NetworkEndian>(*digit));
         }
 
         Ok(IsNull::No)

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -1,6 +1,4 @@
-extern crate byteorder;
-
-use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
+use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 use std::error::Error;
 use std::io::prelude::*;
 
@@ -12,13 +10,13 @@ primitive_impls!(Oid -> (u32, pg: (26, 1018)));
 impl FromSql<types::Oid, Pg> for u32 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let mut bytes = not_none!(bytes);
-        bytes.read_u32::<BigEndian>().map_err(|e| e.into())
+        bytes.read_u32::<NetworkEndian>().map_err(|e| e.into())
     }
 }
 
 impl ToSql<types::Oid, Pg> for u32 {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        out.write_u32::<BigEndian>(*self)
+        out.write_u32::<NetworkEndian>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())
     }

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -1,3 +1,5 @@
+use byteorder::NativeEndian;
+
 use backend::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use super::connection::SqliteValue;
@@ -21,6 +23,7 @@ impl Backend for Sqlite {
     type QueryBuilder = SqliteQueryBuilder;
     type BindCollector = RawBytesBindCollector<Sqlite>;
     type RawValue = SqliteValue;
+    type ByteOrder = NativeEndian;
 }
 
 impl TypeMetadata for Sqlite {

--- a/diesel/src/types/impls/floats.rs
+++ b/diesel/src/types/impls/floats.rs
@@ -1,10 +1,8 @@
-extern crate byteorder;
-
+use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
 use backend::Backend;
-use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
 use types::{self, FromSql, ToSql, IsNull};
 
 impl<DB: Backend<RawValue=[u8]>> FromSql<types::Float, DB> for f32 {
@@ -12,13 +10,13 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Float, DB> for f32 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 4, "Received more than 4 bytes while decoding \
                       an f32. Was a double accidentally marked as float?");
-        bytes.read_f32::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
+        bytes.read_f32::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
 
 impl<DB: Backend> ToSql<types::Float, DB> for f32 {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        out.write_f32::<BigEndian>(*self)
+        out.write_f32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
@@ -29,13 +27,13 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Double, DB> for f64 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 8, "Received more than 8 bytes while decoding \
                       an f64. Was a numeric accidentally marked as dobule?");
-        bytes.read_f64::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
+        bytes.read_f64::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
 
 impl<DB: Backend> ToSql<types::Double, DB> for f64 {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        out.write_f64::<BigEndian>(*self)
+        out.write_f64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }

--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -1,8 +1,6 @@
-extern crate byteorder;
-
+use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
-use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
 
 use backend::Backend;
 use types::{self, FromSql, ToSql, IsNull};
@@ -12,13 +10,13 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 2, "Received more than 2 bytes decoding i16. \
                       Was an Integer expression accidentally identified as SmallInt?");
-        bytes.read_i16::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
+        bytes.read_i16::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
 
 impl<DB: Backend> ToSql<types::SmallInt, DB> for i16 {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        out.write_i16::<BigEndian>(*self)
+        out.write_i16::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
@@ -29,13 +27,13 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Integer, DB> for i32 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 4, "Received more than 4 bytes decoding i32. \
                       Was a BigInteger expression accidentally identified as Integer?");
-        bytes.read_i32::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
+        bytes.read_i32::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
 
 impl<DB: Backend> ToSql<types::Integer, DB> for i32 {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        out.write_i32::<BigEndian>(*self)
+        out.write_i32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
@@ -46,13 +44,13 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::BigInt, DB> for i64 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 8, "Received more than 8 bytes decoding i64. \
                       Was an expression of a different type misidentified as BigInteger?");
-        bytes.read_i64::<BigEndian>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
+        bytes.read_i64::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
 
 impl<DB: Backend> ToSql<types::BigInt, DB> for i64 {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        out.write_i64::<BigEndian>(*self)
+        out.write_i64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }


### PR DESCRIPTION
This is not the long term solution to this problem. I need to
fundamentall rethink how `ToSql` works. I think the biggest indicator
that this is the wrong approach is that we had to stick `type ByteOrder
= NativeEndian` on the `Debug` backend. (Ultimately I'd like to find an
approach that actually shows the output of `std::fmt::Debug::fmt` in
`debug_sql!`).

While I think this will need more work in the future, for now this is
the path of least resistance to continue with the MVP implementation for
MySQL support. MySQL is LittleEndian in its wire protocol, and
NativeEndian in its C API. Since we're just wrapping the C API right
now, I've marked it as `NativeEndian`. Really the fact that we're
wrapping the C API is a detail of the connection, not the backend, but
again I don't think this is a great API long term.

Since SQLite isn't really any endian since it's just calling C
functions, I've moved it to native-endian to do a little bit less work.
Since its bind param handling function is now a bit more unsafe, I've
gone ahead and documented its invariants (these are the requirements for
memory safety, not for the function to be correct)