### PR TITLE
Execute queries in `execute` and `batch_execute`

### DIFF
--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -493,9 +493,10 @@ mod tests {
             }
         } else if #[cfg(feature = "mysql")] {
             fn connection() -> ::test_helpers::TestConnection {
-                let conn = ::test_helpers::connection();
+                let conn = ::test_helpers::connection_no_transaction();
                 conn.execute("DROP TABLE IF EXISTS users").unwrap();
-                conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTO_INCREMENT, name VARCHAR NOT NULL, hair_color VARCHAR DEFAULT 'Green')").unwrap();
+                conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTO_INCREMENT, name TEXT NOT NULL, hair_color VARCHAR(255) DEFAULT 'Green')").unwrap();
+                conn.begin_test_transaction().unwrap();
                 conn
             }
         } else {

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -38,12 +38,16 @@ cfg_if! {
         pub type TestConnection = MysqlConnection;
 
         pub fn connection() -> TestConnection {
+            let conn = connection_no_transaction();
+            conn.begin_test_transaction().unwrap();
+            conn
+        }
+
+        pub fn connection_no_transaction() -> TestConnection {
             dotenv().ok();
             let database_url = env::var("DATABASE_URL")
                 .expect("DATABASE_URL must be set to run tests");
-            let conn = MysqlConnection::establish(&database_url).unwrap();
-            conn.begin_test_transaction().unwrap();
-            conn
+            MysqlConnection::establish(&database_url).unwrap()
         }
     } else {
         // FIXME: https://github.com/rust-lang/rfcs/pull/1695


### PR DESCRIPTION
Neither of these methods are public API. `batch_execute` is used by
migrations, and `execute`.... Actually can probably be deleted at this
point. They are both methods that are intended to run raw SQL queries
(batch runs more than one, execute returns affected rows) which do not
involve prepared statements or any results, so they make good low
targets for this piece of the implementation.

Setting `MYSQL_OPTION_MULTI_STATEMENTS_ON` appears to have all kinds of
nasty side effects that may blow everything up. However, our test suite
does not appear to be blowing up yet. I suspect that a migration which
contains an insert/update statement with a returning clause or a select
statement (which there's no reason to do, but let's check anyway) will
blow up.

Things that are terrible about MySQL that I had forgotten about before
today:

- Columns of type `BLOB`, `TEXT`, `GEOMETRY`, and `JSON` cannot have
  default values. Because reasons I guess.
- `VARCHAR` is not valid syntax, even though the documentation claims
  that you can have a varchar column of unspecified length.
- Any modifications of schema will implicitly commit the current
  transaction, meaning our test suite will need major modifications to
  support MySQL.
- Nobody is fucking consistent in how the declare auto incrementing
  columns.