### PR TITLE
Scope type `types` module to the diesel crate in macros.

### DIFF
--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -9,7 +9,7 @@ use self::chrono::naive::date;
 
 use pg::Pg;
 use super::{PgDate, PgTime, PgTimestamp};
-use types::{self, Date, FromSql, IsNull, Time, Timestamp, Timestamptz, ToSql};
+use types::{Date, FromSql, IsNull, Time, Timestamp, Timestamptz, ToSql};
 
 expression_impls! {
     Date -> NaiveDate,

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -14,44 +14,44 @@ macro_rules! not_none {
 macro_rules! expression_impls {
     ($($Source:ident -> $Target:ty),+,) => {
         $(
-            impl<'a> $crate::expression::AsExpression<types::$Source> for $Target {
-                type Expression = $crate::expression::bound::Bound<types::$Source, Self>;
+            impl<'a> $crate::expression::AsExpression<$crate::types::$Source> for $Target {
+                type Expression = $crate::expression::bound::Bound<$crate::types::$Source, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a, 'expr> $crate::expression::AsExpression<types::$Source> for &'expr $Target {
-                type Expression = $crate::expression::bound::Bound<types::$Source, Self>;
+            impl<'a, 'expr> $crate::expression::AsExpression<$crate::types::$Source> for &'expr $Target {
+                type Expression = $crate::expression::bound::Bound<$crate::types::$Source, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a> $crate::expression::AsExpression<$crate::types::Nullable<types::$Source>> for $Target {
-                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<types::$Source>, Self>;
+            impl<'a> $crate::expression::AsExpression<$crate::types::Nullable<$crate::types::$Source>> for $Target {
+                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$crate::types::$Source>, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a, 'expr> $crate::expression::AsExpression<$crate::types::Nullable<types::$Source>> for &'expr $Target {
-                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<types::$Source>, Self>;
+            impl<'a, 'expr> $crate::expression::AsExpression<$crate::types::Nullable<$crate::types::$Source>> for &'expr $Target {
+                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$crate::types::$Source>, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a, DB> $crate::types::ToSql<$crate::types::Nullable<types::$Source>, DB> for $Target where
-                DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
-                $Target: $crate::types::ToSql<types::$Source, DB>,
+            impl<'a, DB> $crate::types::ToSql<$crate::types::Nullable<$crate::types::$Source>, DB> for $Target where
+                DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
+                $Target: $crate::types::ToSql<$crate::types::$Source, DB>,
             {
                 fn to_sql<W: ::std::io::Write>(&self, out: &mut W) -> Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
-                    $crate::types::ToSql::<types::$Source, DB>::to_sql(self, out)
+                    $crate::types::ToSql::<$crate::types::$Source, DB>::to_sql(self, out)
                 }
             }
         )+
@@ -62,28 +62,28 @@ macro_rules! expression_impls {
 #[macro_export]
 macro_rules! queryable_impls {
     ($($Source:ident -> $Target:ty),+,) => {$(
-        impl<DB> $crate::types::FromSqlRow<types::$Source, DB> for $Target where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
-            $Target: $crate::types::FromSql<types::$Source, DB>,
+        impl<DB> $crate::types::FromSqlRow<$crate::types::$Source, DB> for $Target where
+            DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
+            $Target: $crate::types::FromSql<$crate::types::$Source, DB>,
         {
             fn build_from_row<R: $crate::row::Row<DB>>(row: &mut R) -> Result<Self, Box<::std::error::Error+Send+Sync>> {
-                $crate::types::FromSql::<types::$Source, DB>::from_sql(row.take())
+                $crate::types::FromSql::<$crate::types::$Source, DB>::from_sql(row.take())
             }
         }
 
         #[cfg(not(feature = "unstable"))]
-        impl<DB> $crate::types::FromSqlRow<$crate::types::Nullable<types::$Source>, DB> for Option<$Target> where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
-            Option<$Target>: $crate::types::FromSql<$crate::types::Nullable<types::$Source>, DB>,
+        impl<DB> $crate::types::FromSqlRow<$crate::types::Nullable<$crate::types::$Source>, DB> for Option<$Target> where
+            DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
+            Option<$Target>: $crate::types::FromSql<$crate::types::Nullable<$crate::types::$Source>, DB>,
         {
             fn build_from_row<R: $crate::row::Row<DB>>(row: &mut R) -> Result<Self, Box<::std::error::Error+Send+Sync>> {
-                $crate::types::FromSql::<$crate::types::Nullable<types::$Source>, DB>::from_sql(row.take())
+                $crate::types::FromSql::<$crate::types::Nullable<$crate::types::$Source>, DB>::from_sql(row.take())
             }
         }
 
-        impl<DB> $crate::query_source::Queryable<types::$Source, DB> for $Target where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<types::$Source>,
-            $Target: $crate::types::FromSqlRow<types::$Source, DB>,
+        impl<DB> $crate::query_source::Queryable<$crate::types::$Source, DB> for $Target where
+            DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
+            $Target: $crate::types::FromSqlRow<$crate::types::$Source, DB>,
         {
             type Row = Self;
 
@@ -103,7 +103,7 @@ macro_rules! primitive_impls {
 
     ($Source:ident -> (sqlite: ($tpe:ident) $($rest:tt)*)) => {
         #[cfg(feature = "sqlite")]
-        impl types::HasSqlType<types::$Source> for $crate::sqlite::Sqlite {
+        impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::sqlite::Sqlite {
             fn metadata() -> $crate::sqlite::SqliteType {
                 $crate::sqlite::SqliteType::$tpe
             }
@@ -114,7 +114,7 @@ macro_rules! primitive_impls {
 
     ($Source:ident -> (pg: ($oid:expr, $array_oid:expr) $($rest:tt)*)) => {
         #[cfg(feature = "postgres")]
-        impl types::HasSqlType<types::$Source> for $crate::pg::Pg {
+        impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::pg::Pg {
             fn metadata() -> $crate::pg::PgTypeMetadata {
                 $crate::pg::PgTypeMetadata {
                     oid: $oid,
@@ -128,7 +128,7 @@ macro_rules! primitive_impls {
 
     ($Source:ident -> (mysql: ($tpe:ident) $($rest:tt)*)) => {
         #[cfg(feature = "mysql")]
-        impl types::HasSqlType<types::$Source> for $crate::mysql::Mysql {
+        impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::mysql::Mysql {
             fn metadata() -> $crate::mysql::MysqlType {
                 $crate::mysql::MysqlType::$tpe
             }
@@ -153,11 +153,11 @@ macro_rules! primitive_impls {
     };
 
     ($Source:ident) => {
-        impl types::HasSqlType<types::$Source> for $crate::backend::Debug {
+        impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::backend::Debug {
             fn metadata() {}
         }
 
-        impl $crate::query_builder::QueryId for types::$Source {
+        impl $crate::query_builder::QueryId for $crate::types::$Source {
             type QueryId = Self;
 
             fn has_static_query_id() -> bool {
@@ -165,7 +165,7 @@ macro_rules! primitive_impls {
             }
         }
 
-        impl types::NotNull for types::$Source {
+        impl $crate::types::NotNull for $crate::types::$Source {
         }
     }
 }


### PR DESCRIPTION
Several `$crate::` qualifiers were missing in the `expression_impls!`, `queryable_impls!`, and `primitive_impls!` macros, so the user would have to import `diesel::types` into the scope where the macros were used.