### PR TITLE
Implement `MysqlConnection::execute_returning_count`

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -1,0 +1,72 @@
+extern crate mysqlclient_sys as ffi;
+
+use mysql::MysqlType;
+use std::mem;
+use std::os::{raw as libc};
+
+pub struct Binds {
+    data: Vec<Vec<u8>>,
+    lengths: Vec<libc::c_ulong>,
+    is_nulls: Vec<ffi::my_bool>,
+    mysql_binds: Vec<ffi::MYSQL_BIND>,
+}
+
+impl Binds {
+    pub fn from_input_data(input: Vec<(MysqlType, Option<Vec<u8>>)>) -> Self {
+        let is_nulls = input.iter()
+            .map(|&(_, ref data)| if data.is_none() { 1 } else { 0 })
+            .collect();
+        let (types, data): (Vec<_>, Vec<_>) = input.into_iter()
+            .map(|(t, data)| (t, data.unwrap_or(Vec::new()))).unzip();
+        let lengths = data.iter().map(|x| x.len() as libc::c_ulong).collect();
+
+        let mysql_binds = types.into_iter().map(|tpe| {
+            let mut bind: ffi::MYSQL_BIND = unsafe { mem::zeroed() };
+            bind.buffer_type = mysql_type_to_ffi_type(tpe);
+            bind
+        }).collect();
+
+        let mut res = Binds {
+            data: data,
+            lengths: lengths,
+            is_nulls: is_nulls,
+            mysql_binds: mysql_binds,
+        };
+        unsafe { res.link_mysql_bind_pointers(); }
+        res
+    }
+
+    pub fn mysql_binds(&mut self) -> &mut [ffi::MYSQL_BIND] {
+        &mut self.mysql_binds
+    }
+
+    // This function relies on the invariant that no further mutations to this
+    // struct will occur after this function has been called.
+    unsafe fn link_mysql_bind_pointers(&mut self) {
+        for (i, data) in self.data.iter_mut().enumerate() {
+            self.mysql_binds[i].buffer = data.as_mut_ptr() as *mut libc::c_void;
+            self.mysql_binds[i].buffer_length = data.capacity() as libc::c_ulong;
+            self.mysql_binds[i].length = &mut self.lengths[i];
+            self.mysql_binds[i].is_null = &mut self.is_nulls[i];
+        }
+    }
+}
+
+fn mysql_type_to_ffi_type(tpe: MysqlType) -> ffi::enum_field_types {
+    use self::ffi::enum_field_types::*;
+
+    match tpe {
+        MysqlType::Tiny => MYSQL_TYPE_TINY,
+        MysqlType::Short => MYSQL_TYPE_SHORT,
+        MysqlType::Long => MYSQL_TYPE_LONG,
+        MysqlType::LongLong => MYSQL_TYPE_LONGLONG,
+        MysqlType::Float => MYSQL_TYPE_FLOAT,
+        MysqlType::Double => MYSQL_TYPE_DOUBLE,
+        MysqlType::Time => MYSQL_TYPE_TIME,
+        MysqlType::Date => MYSQL_TYPE_DATE,
+        MysqlType::DateTime => MYSQL_TYPE_DATETIME,
+        MysqlType::Timestamp => MYSQL_TYPE_TIMESTAMP,
+        MysqlType::String => MYSQL_TYPE_STRING,
+        MysqlType::Blob => MYSQL_TYPE_BLOB,
+    }
+}

--- a/diesel/src/mysql/connection/stmt.rs
+++ b/diesel/src/mysql/connection/stmt.rs
@@ -1,0 +1,87 @@
+extern crate mysqlclient_sys as ffi;
+
+use std::os::{raw as libc};
+use std::ffi::CStr;
+
+use result::QueryResult;
+use super::bind::Binds;
+use mysql::MysqlType;
+
+pub struct Statement {
+    stmt: *mut ffi::MYSQL_STMT,
+    input_binds: Option<Binds>,
+}
+
+impl Statement {
+    pub fn new(stmt: *mut ffi::MYSQL_STMT) -> Self {
+        Statement {
+            stmt: stmt,
+            input_binds: None,
+        }
+    }
+
+    pub fn prepare(&self, query: &str) -> QueryResult<()> {
+        unsafe {
+            ffi::mysql_stmt_prepare(
+                self.stmt,
+                query.as_ptr() as *const libc::c_char,
+                query.len() as libc::c_ulong,
+            );
+        }
+        self.did_an_error_occur()
+    }
+
+    pub fn bind(&mut self, binds: Vec<(MysqlType, Option<Vec<u8>>)>) -> QueryResult<()> {
+        let mut input_binds = Binds::from_input_data(binds);
+        let bind_ptr = input_binds.mysql_binds().as_mut_ptr();
+        self.input_binds = Some(input_binds);
+        // This relies on the invariant that the current value of `self.input_binds`
+        // will not change without this function being called
+        unsafe { ffi::mysql_stmt_bind_param(self.stmt, bind_ptr); }
+        self.did_an_error_occur()
+    }
+
+    pub fn execute(&self) -> QueryResult<()> {
+        unsafe { ffi::mysql_stmt_execute(self.stmt); }
+        self.did_an_error_occur()
+    }
+
+    pub fn affected_rows(&self) -> usize {
+        let affected_rows = unsafe { ffi::mysql_stmt_affected_rows(self.stmt) };
+        affected_rows as usize
+    }
+
+    fn last_error_message(&self) -> String {
+        unsafe { CStr::from_ptr(ffi::mysql_stmt_error(self.stmt)) }
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn did_an_error_occur(&self) -> QueryResult<()> {
+        use result::DatabaseErrorKind;
+        use result::Error::DatabaseError;
+
+        let error_message = self.last_error_message();
+        if error_message.is_empty() {
+            Ok(())
+        } else {
+            Err(DatabaseError(
+                DatabaseErrorKind::__Unknown,
+                Box::new(error_message),
+            ))
+        }
+    }
+}
+
+impl Drop for Statement {
+    fn drop(&mut self) {
+        let drop_result = unsafe { ffi::mysql_stmt_close(self.stmt) };
+        // FIXME: Remove this before we ship this feature. We don't really care
+        // about any of the error cases that can occur, but I suspect we'll need
+        // to stick an `Rc<RawConnection>` on this struct to ensure the right
+        // drop order once prepared statement caching is added. This is mostly
+        // here so I don't forget.
+        assert_eq!(0, drop_result, "@sgrif forgot to delete this assertion. Please open a github issue");
+    }
+}
+


### PR DESCRIPTION
This adds the initial implementation of prepared statement support for
MySQL. This does not handle prepared statements which return values, nor
does it implement any form of prepared statement caching.

Prepared statements in MySQL operate on a structure called `MYSQL_BIND`
both for input and output. This thing is a fucking nightmare to work
with. We need to give it the structs in an array, which is behind a
pointer. We are responsible for allocating, managing, keeping alive, and
cleaning up the `MYSQL_BIND` structures. Additionally, it has several
fields which are also behind pointers, and we are also responsible for
keeping those values alive. Looking through their API docs, I see no
reasonable cause to have any of the fields except the buffer behind a
pointer. Still, that's the API we have to work with, so we have a bunch
of random vecs on the struct that only really exist so that we keep
these pointers alive.