### PR TITLE
impl Sync for diesel::result::Error

### DIFF
--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -9,7 +9,7 @@ use std::ffi::NulError;
 /// future without a major version bump.
 pub enum Error {
     InvalidCString(NulError),
-    DatabaseError(DatabaseErrorKind, Box<DatabaseErrorInformation+Send>),
+    DatabaseError(DatabaseErrorKind, Box<DatabaseErrorInformation+Send+Sync>),
     NotFound,
     QueryBuilderError(Box<StdError+Send+Sync>),
     DeserializationError(Box<StdError+Send+Sync>),
@@ -40,7 +40,7 @@ pub trait DatabaseErrorInformation {
     fn constraint_name(&self) -> Option<&str>;
 }
 
-impl fmt::Debug for DatabaseErrorInformation+Send {
+impl fmt::Debug for DatabaseErrorInformation+Send+Sync {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.message(), f)
     }


### PR DESCRIPTION
This adds a Sync bound for the DatabaseErrorInformation trait object in Error.
Which seems fine since right now DEI is only implemented for String, but I
suppose I could imagine it being intended to hold a reference to some sort of
thread-local thing?

Looking at blame it seems like the lack of Sync was just an oversigh, but if
Sync isn't something you want to commit to and you have other ideas for how to
make result::Error more compatible with error-chain I'm happy to put in some
work to make it so.

Also, I can't make the tests compile locally for me either with or without this change, so I'm not super confident that I didn't miss anything.