### PR TITLE
Implement prepared statements which return data for MySQL

### DIFF
--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -56,8 +56,7 @@ cfg_if! {
 
         fn connection_no_data() -> diesel::mysql::MysqlConnection {
             let connection_url = database_url_from_env();
-            let connection = diesel::mysql::MysqlConnection::establish(connection_url).unwrap();
-            connection.begin_test_transaction().unwrap();
+            let connection = diesel::mysql::MysqlConnection::establish(&connection_url).unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
 
             connection
@@ -69,9 +68,10 @@ cfg_if! {
 
             connection.execute("CREATE TABLE users (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
-                name VARCHAR NOT NULL
-            )").unwrap();
+                name TEXT NOT NULL
+            ) CHARACTER SET utf8mb4").unwrap();
             connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").unwrap();
+            connection.begin_test_transaction().unwrap();
 
             connection
         }

--- a/diesel/src/macros/queryable.rs
+++ b/diesel/src/macros/queryable.rs
@@ -166,56 +166,65 @@ mod tests {
     use expression::dsl::sql;
     use prelude::*;
     use test_helpers::connection;
-    use types::Integer;
+
+    cfg_if! {
+        if #[cfg(feature = "mysql")] {
+            type IntLiteralSql = ::types::BigInt;
+            type IntLiteralRust = i64;
+        } else {
+            type IntLiteralSql = ::types::Integer;
+            type IntLiteralRust = i32;
+        }
+    }
 
     #[test]
     fn named_struct_definition() {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         struct MyStruct {
-            foo: i32,
-            bar: i32,
+            foo: IntLiteralRust,
+            bar: IntLiteralRust,
         }
 
         impl_Queryable! {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
             struct MyStruct {
-                foo: i32,
-                bar: i32,
+                foo: IntLiteralRust,
+                bar: IntLiteralRust,
             }
         }
 
         let conn = connection();
-        let data = ::select(sql::<(Integer, Integer)>("1, 2")).get_result(&conn);
+        let data = ::select(sql::<(IntLiteralSql, IntLiteralSql)>("1, 2")).get_result(&conn);
         assert_eq!(Ok(MyStruct { foo: 1, bar: 2 }), data);
     }
 
     #[test]
     fn tuple_struct() {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        struct MyStruct(i32, i32);
+        struct MyStruct(IntLiteralRust, IntLiteralRust);
 
         impl_Queryable! {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-            struct MyStruct(#[column_name(foo)] i32, #[column_name(bar)] i32);
+            struct MyStruct(#[column_name(foo)] IntLiteralRust, #[column_name(bar)] IntLiteralRust);
         }
 
         let conn = connection();
-        let data = ::select(sql::<(Integer, Integer)>("1, 2")).get_result(&conn);
+        let data = ::select(sql::<(IntLiteralSql, IntLiteralSql)>("1, 2")).get_result(&conn);
         assert_eq!(Ok(MyStruct(1, 2)), data);
     }
 
     #[test]
     fn tuple_struct_without_column_name_annotations() {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        struct MyStruct(i32, i32);
+        struct MyStruct(IntLiteralRust, IntLiteralRust);
 
         impl_Queryable! {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-            struct MyStruct(i32, i32);
+            struct MyStruct(IntLiteralRust, IntLiteralRust);
         }
 
         let conn = connection();
-        let data = ::select(sql::<(Integer, Integer)>("1, 2")).get_result(&conn);
+        let data = ::select(sql::<(IntLiteralSql, IntLiteralSql)>("1, 2")).get_result(&conn);
         assert_eq!(Ok(MyStruct(1, 2)), data);
     }
 }

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -64,3 +64,24 @@ impl HasSqlType<::types::Timestamp> for Mysql {
         MysqlType::Timestamp
     }
 }
+
+use types::{ToSql, IsNull, FromSql};
+use std::error::Error as StdError;
+use std::io::Write;
+
+impl ToSql<::types::Bool, Mysql> for bool {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<StdError+Send+Sync>> {
+        let int_value = if *self {
+            1
+        } else {
+            0
+        };
+        <i32 as ToSql<::types::Integer, Mysql>>::to_sql(&int_value, out)
+    }
+}
+
+impl FromSql<::types::Bool, Mysql> for bool {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError+Send+Sync>> {
+        Ok(not_none!(bytes).iter().any(|x| *x != 0))
+    }
+}

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -9,6 +9,7 @@ pub struct Binds {
     lengths: Vec<libc::c_ulong>,
     is_nulls: Vec<ffi::my_bool>,
     mysql_binds: Vec<ffi::MYSQL_BIND>,
+    errors: Option<Vec<ffi::my_bool>>,
 }
 
 impl Binds {
@@ -31,6 +32,36 @@ impl Binds {
             lengths: lengths,
             is_nulls: is_nulls,
             mysql_binds: mysql_binds,
+            errors: None,
+        };
+        unsafe { res.link_mysql_bind_pointers(); }
+        res
+    }
+
+    pub fn from_output_types<Iter>(types: Iter) -> Self where
+        Iter: IntoIterator<Item=ffi::enum_field_types>,
+    {
+        let mysql_binds = types.into_iter().map(|tpe| {
+            let mut bind: ffi::MYSQL_BIND = unsafe { mem::zeroed() };
+            bind.buffer_type = tpe;
+            bind
+        }).collect::<Vec<_>>();
+        let is_nulls = vec![0; mysql_binds.len()];
+        let errors = is_nulls.clone();
+        let data = mysql_binds.iter().map(|bind| {
+            match known_buffer_size_for_ffi_type(bind.buffer_type) {
+                Some(size) => vec![0; size as usize],
+                None => Vec::new(),
+            }
+        }).collect::<Vec<_>>();
+        let lengths = data.iter().map(|x| x.len() as libc::c_ulong).collect();
+
+        let mut res = Binds {
+            data: data,
+            lengths: lengths,
+            is_nulls: is_nulls,
+            mysql_binds: mysql_binds,
+            errors: Some(errors),
         };
         unsafe { res.link_mysql_bind_pointers(); }
         res
@@ -38,6 +69,56 @@ impl Binds {
 
     pub fn mysql_binds(&mut self) -> &mut [ffi::MYSQL_BIND] {
         &mut self.mysql_binds
+    }
+
+    /// The caller of this function must immediately check for errors
+    /// after return
+    pub fn populate_dynamic_buffers(&mut self, stmt: *mut ffi::MYSQL_STMT) {
+        use std::cmp::min;
+
+        for (i, buffer) in self.data.iter_mut().enumerate() {
+            if self.errors.as_ref().unwrap()[i] != 0 {
+                let written_bytes = buffer.len();
+                let needed_capacity = self.lengths[i] as usize;
+                buffer.reserve(needed_capacity - written_bytes);
+                self.mysql_binds[i].buffer = buffer.as_mut_ptr() as *mut libc::c_void;
+                mem::swap(&mut self.lengths[i], &mut self.mysql_binds[i].buffer_length);
+                let load_result = unsafe {
+                    ffi::mysql_stmt_fetch_column(
+                        stmt,
+                        &mut self.mysql_binds[i],
+                        i as libc::c_uint,
+                        written_bytes as libc::c_ulong,
+                    )
+                };
+                if load_result != 0 {
+                    return;
+                }
+            }
+
+            let actual_bytes_in_buffer = min(
+                self.mysql_binds[i].buffer_length,
+                self.lengths[i],
+            );
+            unsafe { buffer.set_len(actual_bytes_in_buffer as usize) }
+        }
+    }
+
+    pub fn reset_dynamic_buffers(&mut self) {
+        for (i, bind) in self.mysql_binds.iter().enumerate() {
+            if known_buffer_size_for_ffi_type(bind.buffer_type).is_none() {
+                self.lengths[i] = 0;
+                unsafe { self.data[i].set_len(0) };
+            }
+        }
+    }
+
+    pub fn field_data(&self, idx: usize) -> Option<&[u8]> {
+        if self.is_nulls[idx] == 0 {
+            Some(&*self.data[idx])
+        } else {
+            None
+        }
     }
 
     // This function relies on the invariant that no further mutations to this
@@ -48,6 +129,10 @@ impl Binds {
             self.mysql_binds[i].buffer_length = data.capacity() as libc::c_ulong;
             self.mysql_binds[i].length = &mut self.lengths[i];
             self.mysql_binds[i].is_null = &mut self.is_nulls[i];
+
+            if let Some(ref mut errors) = self.errors {
+                self.mysql_binds[i].error = &mut errors[i];
+            }
         }
     }
 }
@@ -68,5 +153,27 @@ fn mysql_type_to_ffi_type(tpe: MysqlType) -> ffi::enum_field_types {
         MysqlType::Timestamp => MYSQL_TYPE_TIMESTAMP,
         MysqlType::String => MYSQL_TYPE_STRING,
         MysqlType::Blob => MYSQL_TYPE_BLOB,
+    }
+}
+
+fn known_buffer_size_for_ffi_type(tpe: ffi::enum_field_types) -> Option<libc::c_ulong> {
+    use std::mem::size_of;
+    use self::ffi::enum_field_types as t;
+
+    match tpe {
+        t::MYSQL_TYPE_TINY => Some(1),
+        t::MYSQL_TYPE_YEAR |
+        t::MYSQL_TYPE_SHORT => Some(2),
+        t::MYSQL_TYPE_INT24 |
+        t::MYSQL_TYPE_LONG |
+        t::MYSQL_TYPE_FLOAT => Some(4),
+        t::MYSQL_TYPE_LONGLONG |
+        t::MYSQL_TYPE_DOUBLE => Some(8),
+        t::MYSQL_TYPE_TIME |
+        t::MYSQL_TYPE_DATE |
+        t::MYSQL_TYPE_DATETIME |
+        t::MYSQL_TYPE_TIMESTAMP =>
+            Some(size_of::<ffi::MYSQL_TIME>() as libc::c_ulong),
+        _ => None,
     }
 }

--- a/diesel/src/mysql/connection/result.rs
+++ b/diesel/src/mysql/connection/result.rs
@@ -1,0 +1,37 @@
+extern crate mysqlclient_sys as ffi;
+
+pub struct RawResult(*mut ffi::MYSQL_RES);
+
+impl RawResult {
+    pub unsafe fn from_raw(raw: *mut ffi::MYSQL_RES) -> Option<Self> {
+        if raw.is_null() {
+            None
+        } else {
+            Some(RawResult(raw))
+        }
+    }
+
+    pub fn fields(&mut self) -> ResultFields {
+        unsafe { ffi::mysql_field_seek(self.0, 0); }
+        ResultFields(self)
+    }
+}
+
+impl Drop for RawResult {
+    fn drop(&mut self) {
+        unsafe { ffi::mysql_free_result(self.0); }
+    }
+}
+
+pub struct ResultFields<'a>(&'a mut RawResult);
+
+impl<'a> Iterator for ResultFields<'a> {
+    type Item = &'a ffi::MYSQL_FIELD;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            ffi::mysql_fetch_field((self.0).0)
+                .as_ref()
+        }
+    }
+}

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,0 +1,82 @@
+use super::{Statement, Binds, ffi, libc};
+use result::QueryResult;
+use row::Row;
+use mysql::Mysql;
+
+pub struct StatementIterator<'a> {
+    stmt: &'a mut Statement,
+    output_binds: Binds,
+}
+
+impl<'a> StatementIterator<'a> {
+    pub fn new(stmt: &'a mut Statement) -> QueryResult<Self> {
+        use result::Error::QueryBuilderError;
+
+        let mut result_metadata = match try!(stmt.result_metadata()) {
+            Some(result) => result,
+            None => return Err(QueryBuilderError("Attempted to get results \
+                on a query with no results".into())),
+        };
+        let result_types = result_metadata.fields().map(|f| f.type_);
+        let mut output_binds = Binds::from_output_types(result_types);
+
+        unsafe {
+            ffi::mysql_stmt_bind_result(
+                stmt.stmt,
+                output_binds.mysql_binds().as_mut_ptr(),
+            );
+        }
+        stmt.did_an_error_occur()?;
+
+        Ok(StatementIterator {
+            stmt: stmt,
+            output_binds: output_binds,
+        })
+    }
+
+    pub fn map<F, T>(mut self, mut f: F) -> QueryResult<Vec<T>> where
+        F: FnMut(MysqlRow) -> QueryResult<T>,
+    {
+        let mut results = Vec::new();
+        while let Some(row) = self.next() {
+            results.push(f(row?)?);
+        }
+        Ok(results)
+    }
+
+    fn next(&mut self) -> Option<QueryResult<MysqlRow>> {
+        self.output_binds.reset_dynamic_buffers();
+        let next_row_result = unsafe { ffi::mysql_stmt_fetch(self.stmt.stmt) };
+        match next_row_result as libc::c_uint {
+            ffi::MYSQL_NO_DATA => return None,
+            ffi::MYSQL_DATA_TRUNCATED => self.output_binds.populate_dynamic_buffers(self.stmt.stmt),
+            _ => {} // Either success or error which we check on the next line
+        }
+        match self.stmt.did_an_error_occur() {
+            Err(e) => return Some(Err(e)),
+            Ok(_) => {} // continue
+        }
+
+        Some(Ok(MysqlRow {
+            col_idx: 0,
+            binds: &mut self.output_binds,
+        }))
+    }
+}
+
+pub struct MysqlRow<'a> {
+    col_idx: usize,
+    binds: &'a Binds,
+}
+
+impl<'a> Row<Mysql> for MysqlRow<'a> {
+    fn take(&mut self) -> Option<&[u8]> {
+        let current_idx = self.col_idx;
+        self.col_idx += 1;
+        self.binds.field_data(current_idx)
+    }
+
+    fn next_is_null(&self, count: usize) -> bool {
+        (0..count).all(|i| self.binds.field_data(self.col_idx + i).is_none())
+    }
+}


### PR DESCRIPTION
After this change, the core crate's unit test suite is 100% green for
MySQL (`cd diesel && cargo test --features mysql`)

So here's how loading data works. Output values use the same data
structure as input values. For types with a fixed size, we can allocate
the small buffer needed, and everything will just work. For things that
we don't know the size of until we fetch the row, we set the buffer to
size 0.

When mysql hits a field where the buffer isn't large enough, the return
value of `mysql_stmt_fetch` will be `MYSQL_DATA_TRUNCATED`. For each
field that was truncated, the value of `*error` will be set to non-zero
(it's a `my_bool`, so presumably that value is 1. This appears to be the
only error. I do not know why they didn't call it `is_truncated`). It
will also set `*length` to the number of bytes required to hold the
value. At this point we can reallocate the buffer, and try to load that
column directly.

Aside from the general horribleness of this API that I've ranted about
elsewhere, two things in particular greatly bother me here:

- `MYSQL_DATA_TRUNCATED` and all other values mentioned as return values
  for `mysql_stmt_fetch` are `unsigned int`. `mysql_stmt_fetch` returns
  `int`.
- The MySQL client C API is clearly buffering this value on its own. Why
  the fuck can it not just give me that pointer, a byte count, and tell
  me to `memcpy` it before calling `mysql_stmt_fetch` again if I need
  it?!

Probably the worst part of this code is the implementation of
`StatementIterator::next`. Since we're actually just mutating the same
buffers over and over, I need to yield the same value each time. Of
course I can't just return `Self`, so I need to return a reference to
the appropriate value. There's not really any way to do this without
unsafe code. In particular what I need is a way to guarantee that the
value is unused by the next call to `next`, but I have no way to express
that. So I'm transmuting the reference to `'static`, and never exposing
this API. I know it is safe in the place this is currently used. In
theory we could at least ensure no use after free by implementing
iterator on a reference instead of the struct, so we have a smaller
lifetime. Even if we did that though, we're still mutating immutable
data, which is UB. So given that any code which holds onto that
reference past the next call to `next` is invoking UB no matter what, I
went with the smallest possible solution. I am open to recommendations
here.