### PR TITLE
Allow use of uuid 0.4.0 https://github.com/diesel-rs/diesel/issues/628

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -19,7 +19,7 @@ mysqlclient-sys = { git = "https://github.com/sgrif/mysqlclient-sys.git", option
 pq-sys = { version = "^0.2.0", optional = true }
 quickcheck = { version = "0.3.1", optional = true }
 serde_json = { version = ">=0.8.0, <0.10.0", optional = true }
-uuid = { version = ">=0.2.0, <0.4.0", optional = true, features = ["use_std"] }
+uuid = { version = ">=0.2.0, <0.5.0", optional = true, features = ["use_std"] }
 url = { version = "1.4.0", optional = true }
 
 [dev-dependencies]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -16,7 +16,7 @@ diesel = { path = "../diesel", default-features = false, features = ["quickcheck
 diesel_codegen = { path = "../diesel_codegen" }
 dotenv = "0.8.0"
 quickcheck = { version = "0.3.1", features = ["unstable"] }
-uuid = { version = ">=0.2.0, <0.4.0" }
+uuid = { version = ">=0.2.0, <0.5.0" }
 serde_json = "0.9"
 
 [features]


### PR DESCRIPTION
`rocket 0.2` uses `uuid 0.4.0`