### PR TITLE
Refactor PG's schema inference code to be (almost) ANSI

### DIFF
--- a/diesel_infer_schema/src/inference.rs
+++ b/diesel_infer_schema/src/inference.rs
@@ -93,7 +93,7 @@ pub fn get_primary_keys(
     conn: &InferConnection,
     table: &TableData,
 ) -> Result<Vec<String>, Box<Error>> {
-    let primary_keys = try!(match *conn {
+    let primary_keys: Vec<String> = try!(match *conn {
         #[cfg(feature = "sqlite")]
         InferConnection::Sqlite(ref c) => ::sqlite::get_primary_keys(c, table),
         #[cfg(feature = "postgres")]


### PR DESCRIPTION
`information_schema` is in fact part of the ANSI standard, and most
backends conform to it, including MySQL. This will allow us to reuse
this code for MySQL and most likely any other future backends we add.
SQLite does not provide an equivalent of `information_schema`. The on
thing that we cannot use the standard for is column type. While there is
an `information_schema.columns.data_type` column, it doesn't provide
what we need. Both PG and MySQL provide a nonstandard column that we can
use instead.