### PR TITLE
Don't panic while panicking in CLI's tests

### DIFF
--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -66,6 +66,15 @@ impl CommandResult {
     pub fn code(&self) -> i32 {
         self.output.status.code().unwrap()
     }
+
+    #[allow(dead_code)]
+    pub fn result(self) -> Result<Self, Self> {
+        if self.is_success() {
+            Ok(self)
+        } else {
+            Err(self)
+        }
+    }
 }
 
 fn path_to_diesel_cli() -> PathBuf {

--- a/diesel_cli/tests/support/mod.rs
+++ b/diesel_cli/tests/support/mod.rs
@@ -1,3 +1,18 @@
+macro_rules! try_drop {
+    ($e:expr, $msg:expr) => { match $e {
+        Ok(x) => x,
+        Err(e) => {
+            use ::std::io::{Write, stderr};
+            if ::std::thread::panicking() {
+                write!(stderr(), "{}: {:?}", $msg, e);
+                return;
+            } else {
+                panic!("{}: {:?}", $msg, e);
+            }
+        }
+    }}
+}
+
 mod command;
 mod project_builder;
 

--- a/diesel_cli/tests/support/postgres_database.rs
+++ b/diesel_cli/tests/support/postgres_database.rs
@@ -54,9 +54,9 @@ impl Database {
 impl Drop for Database {
     fn drop(&mut self) {
         let (database, postgres_url) = self.split_url();
-        let conn = PgConnection::establish(&postgres_url).unwrap();
+        let conn = try_drop!(PgConnection::establish(&postgres_url), "Couldn't connect to database");
         conn.silence_notices(|| {
-            conn.execute(&format!("DROP DATABASE IF EXISTS {}", database)).unwrap();
+            try_drop!(conn.execute(&format!("DROP DATABASE IF EXISTS {}", database)), "Couldn't drop database");
         });
     }
 }

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -99,17 +99,7 @@ impl Project {
 #[cfg(feature = "postgres")]
 impl Drop for Project {
     fn drop(&mut self) {
-        use std::io::{self, Write};
-        use std::thread;
-
-        let result = self.command("database").arg("drop").run();
-        if !result.is_success() {
-            if thread::panicking() {
-                writeln!(io::stderr(), "Couldn't drop database: {:?}", result).unwrap();
-            } else {
-                panic!("Couldn't drop database: {:?}", result);
-            }
-        }
+        try_drop!(self.command("database").arg("drop").run().result(), "Couldn't drop database");
     }
 }
 


### PR DESCRIPTION
Diesel CLI's tests will abort with no output if the tests for `diesel
database create` fail to drop the database. (This is actually failing
for many people because the code to drop it has diverged from CLI's
behavior, which will be fixed separately).

This change ensures that none of the `Drop` impls in our test suite will
abort the process.