### PR TITLE
Properly drop databases in CLI's tests

### DIFF
--- a/diesel_cli/tests/support/postgres_database.rs
+++ b/diesel_cli/tests/support/postgres_database.rs
@@ -46,7 +46,7 @@ impl Database {
     fn split_url(&self) -> (String, String) {
         let mut split: Vec<&str> = self.url.split("/").collect();
         let database = split.pop().unwrap();
-        let postgres_url = split.join("/");
+        let postgres_url = format!("{}/{}", split.join("/"), "postgres");
         (database.into(), postgres_url)
     }
 }


### PR DESCRIPTION
The behavior of `diesel cli drop` is to connect to the `postgres`
database, which is known to exist. The test suite for `diesel database
setup` is not specifying a database, which connects to a database with
the same name as the PG user (which deafults to the local username).
This brings the behavior of the two back in line. In theory these two
should be code between them at least for the database URL munging, but
the tests live in a separate crate out of necessity and I don't want to
deal with exposing CLI as a library crate to fix this minor test issue.