### PR TITLE
Use backend specific env vars if present for tests

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$1" = "integration" ] && [ "$2" = "sqlite" ]; then
-  (cd diesel_tests && DATABASE_URL=/tmp/test.db cargo test --features "sqlite" --no-default-features)
+  (cd diesel_tests && cargo test --features "sqlite" --no-default-features)
 elif [ "$1" = "integration" ]; then
   (cd diesel_tests && cargo test --features "postgres" --no-default-features)
 elif [ "$1" = "compile" ]; then
@@ -13,7 +13,7 @@ else
   (cd diesel_infer_schema && cargo test --features "sqlite")
   (cd diesel_codegen_shared && cargo test --features "sqlite")
   (cd diesel_codegen && cargo test --features "sqlite")
-  (cd diesel_tests && DATABASE_URL=/tmp/test.db cargo test --features "sqlite" --no-default-features)
+  (cd diesel_tests && cargo test --features "sqlite" --no-default-features)
   (cd examples && ./test_all)
   (cd diesel_infer_schema && cargo test --features "postgres")
   (cd diesel_codegen_shared && cargo test --features "postgres")

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -10,7 +10,7 @@ cfg_if! {
         type DB = diesel::pg::Pg;
 
         fn connection_no_data() -> diesel::pg::PgConnection {
-            let connection_url = database_url_from_env();
+            let connection_url = database_url_from_env("PG_DATABASE_URL");
             let connection = diesel::pg::PgConnection::establish(&connection_url).unwrap();
             connection.begin_test_transaction().unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
@@ -55,7 +55,7 @@ cfg_if! {
         type DB = diesel::mysql::Mysql;
 
         fn connection_no_data() -> diesel::mysql::MysqlConnection {
-            let connection_url = database_url_from_env();
+            let connection_url = database_url_from_env("MYSQL_DATABASE_URL");
             let connection = diesel::mysql::MysqlConnection::establish(&connection_url).unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
 
@@ -81,10 +81,13 @@ cfg_if! {
     }
 }
 
-fn database_url_from_env() -> String {
+fn database_url_from_env(bakend_specific_env_var: &str) -> String {
+    use std::env;
+
     dotenv().ok();
 
-    ::std::env::var("DATABASE_URL")
+    env::var(bakend_specific_env_var)
+        .or_else(|_| env::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests")
 }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -207,7 +207,9 @@ mod tests {
 
     fn connection() -> PgConnection {
         dotenv().ok();
-        let database_url = env::var("DATABASE_URL").unwrap();
+        let database_url = env::var("PG_DATABASE_URL")
+            .or_else(|_| env::var("DATABASE_URL"))
+            .expect("DATABASE_URL must be set in order to run tests");
         PgConnection::establish(&database_url).unwrap()
     }
 }

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -259,7 +259,8 @@ mod tests {
             fn $test_name(val: $tpe) -> bool {
                 dotenv().ok();
 
-                let connection_url = ::std::env::var("DATABASE_URL")
+                let connection_url = ::std::env::var("PG_DATABASE_URL")
+                    .or_else(|_| ::std::env::var("DATABASE_URL"))
                     .expect("DATABASE_URL must be set in order to run tests");
                 let connection = PgConnection::establish(&connection_url).unwrap();
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -158,7 +158,8 @@ mod tests {
     fn connection() -> PgConnection {
         dotenv().ok();
 
-        let connection_url = ::std::env::var("DATABASE_URL")
+        let connection_url = ::std::env::var("PG_DATABASE_URL")
+            .or_else(|_| ::std::env::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests");
         PgConnection::establish(&connection_url).unwrap()
     }

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -80,7 +80,8 @@ mod tests {
     fn connection() -> PgConnection {
         dotenv().ok();
 
-        let connection_url = ::std::env::var("DATABASE_URL")
+        let connection_url = ::std::env::var("PG_DATABASE_URL")
+            .or_else(|_| ::std::env::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests");
         PgConnection::establish(&connection_url).unwrap()
     }

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -21,8 +21,9 @@ cfg_if! {
 
         pub fn connection() -> TestConnection {
             dotenv().ok();
-            let database_url = env::var("DATABASE_URL")
-                .expect("DATABASE_URL must be set to run tests");
+            let database_url = env::var("PG_DATABASE_URL")
+                .or_else(|_| env::var("DATABASE_URL"))
+                .expect("DATABASE_URL must be set in order to run tests");
             let conn = PgConnection::establish(&database_url).unwrap();
             conn.begin_test_transaction().unwrap();
             conn
@@ -45,8 +46,9 @@ cfg_if! {
 
         pub fn connection_no_transaction() -> TestConnection {
             dotenv().ok();
-            let database_url = env::var("DATABASE_URL")
-                .expect("DATABASE_URL must be set to run tests");
+            let database_url = env::var("MYSQL_DATABASE_URL")
+                .or_else(|_| env::var("DATABASE_URL"))
+                .expect("DATABASE_URL must be set in order to run tests");
             MysqlConnection::establish(&database_url).unwrap()
         }
     } else {

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -164,14 +164,16 @@ pub fn load_table_names<Conn>(connection: &Conn, schema_name: Option<&str>)
 mod tests {
     extern crate dotenv;
 
-    use super::*;
-    use self::dotenv::dotenv;
     use diesel::pg::PgConnection;
+    use self::dotenv::dotenv;
+    use std::env;
+    use super::*;
 
     fn connection() -> PgConnection {
         let _ = dotenv();
 
-        let connection_url = ::std::env::var("DATABASE_URL")
+        let connection_url = env::var("PG_DATABASE_URL")
+            .or_else(|_| env::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests");
         let connection = PgConnection::establish(&connection_url).unwrap();
         connection.begin_test_transaction().unwrap();

--- a/diesel_tests/build.rs
+++ b/diesel_tests/build.rs
@@ -2,15 +2,13 @@ extern crate diesel;
 extern crate dotenv;
 use self::diesel::*;
 use self::dotenv::dotenv;
-use std::io;
+use std::{io, env};
 
 #[cfg(feature = "postgres")]
 use self::diesel::pg::PgConnection;
 #[cfg(feature = "postgres")]
 fn connection() -> PgConnection {
-    dotenv().ok();
-    let database_url = ::std::env::var("DATABASE_URL")
-        .expect("DATABASE_URL must be set to run tests");
+    let database_url = database_url_from_env("PG_DATABASE_URL");
     PgConnection::establish(&database_url).unwrap()
 }
 
@@ -18,9 +16,7 @@ fn connection() -> PgConnection {
 use self::diesel::sqlite::SqliteConnection;
 #[cfg(feature = "sqlite")]
 fn connection() -> SqliteConnection {
-    dotenv().ok();
-    let database_url = ::std::env::var("DATABASE_URL")
-        .expect("DATABASE_URL must be set to run tests");
+    let database_url = database_url_from_env("SQLITE_DATABASE_URL");
     SqliteConnection::establish(&database_url).unwrap()
 }
 
@@ -28,10 +24,7 @@ fn connection() -> SqliteConnection {
 use self::diesel::mysql::MysqlConnection;
 #[cfg(feature = "mysql")]
 fn connection() -> MysqlConnection {
-    dotenv().ok();
-    let database_url = ::std::env::var("MYSQL_DATABASE_URL")
-        .or_else(|_| ::std::env::var("DATABASE_URL"))
-        .expect("DATABASE_URL must be set to run tests");
+    let database_url = database_url_from_env("MYSQL_DATABASE_URL");
     MysqlConnection::establish(&database_url).unwrap()
 }
 
@@ -43,6 +36,20 @@ const MIGRATION_SUBDIR: &'static str = "sqlite";
 
 #[cfg(feature = "mysql")]
 const MIGRATION_SUBDIR: &'static str = "mysql";
+
+fn database_url_from_env(backend_specific_env_var: &str) -> String {
+    dotenv().ok();
+    match env::var(backend_specific_env_var) {
+        Ok(val) => {
+            println!(r#"cargo:rustc-cfg=feature="backend_specific_database_url""#);
+            val
+        }
+        _ => {
+            env::var("DATABASE_URL")
+                .expect("DATABASE_URL must be set in order to run tests")
+        }
+    }
+}
 
 fn main() {
     let migrations_dir = migrations::find_migrations_directory().unwrap().join(MIGRATION_SUBDIR);

--- a/diesel_tests/tests/custom_schemas.rs
+++ b/diesel_tests/tests/custom_schemas.rs
@@ -3,6 +3,9 @@ use schema::connection;
 
 mod using_infer_schema {
     use super::*;
+    #[cfg(feature="backend_specific_database_url")]
+    infer_schema!("dotenv:PG_DATABASE_URL", "custom_schema");
+    #[cfg(not(feature="backend_specific_database_url"))]
     infer_schema!("dotenv:DATABASE_URL", "custom_schema");
     use self::custom_schema::users;
 
@@ -27,6 +30,9 @@ mod using_infer_schema {
 mod using_infer_table_from_schema {
     use super::*;
     mod infer_users {
+        #[cfg(feature="backend_specific_database_url")]
+        infer_table_from_schema!("dotenv:PG_DATABASE_URL", "custom_schema.users");
+        #[cfg(not(feature="backend_specific_database_url"))]
         infer_table_from_schema!("dotenv:DATABASE_URL", "custom_schema.users");
     }
     use self::infer_users::users;

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -2,6 +2,13 @@ use diesel::*;
 use dotenv::dotenv;
 use std::env;
 
+#[cfg(all(feature="postgres", feature="backend_specific_database_url"))]
+infer_schema!("dotenv:PG_DATABASE_URL");
+#[cfg(all(feature="sqlite", feature="backend_specific_database_url"))]
+infer_schema!("dotenv:SQLITE_DATABASE_URL");
+#[cfg(all(feature="mysql", feature="backend_specific_database_url"))]
+infer_schema!("dotenv:MYSQL_DATABASE_URL");
+#[cfg(not(feature="backend_specific_database_url"))]
 infer_schema!("dotenv:DATABASE_URL");
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, Associations)]
@@ -151,7 +158,8 @@ pub fn connection() -> TestConnection {
 #[cfg(feature = "postgres")]
 pub fn connection_without_transaction() -> TestConnection {
     dotenv().ok();
-    let connection_url = env::var("DATABASE_URL")
+    let connection_url = env::var("PG_DATABASE_URL")
+        .or_else(|_| env::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     ::diesel::pg::PgConnection::establish(&connection_url).unwrap()
 }


### PR DESCRIPTION
Having a single `DATABASE_URL` is really nice in contexts where you're
likely only using one backend. It makes a lot of sense for Travis, which
runs against one backend at a time. It also makes sense for CLI to
continue to default to it by convention, as it has to look at the URL to
figure out which backend to use.

However, for development on Diesel itself, we are switching between
different backends all the time. This didn't matter as much for SQLite,
since we can just give it some random file path and have it work (and
we're usually connecting to `:memory:` anyway). For MySQL though, we
need to be more concrete. Where applicable, our test suite will now look
for `PG_DATABASE_URL`, before falling back to just `DATABASE_URL`. This
does not apply to our examples, as they assume PG and set the
`DATABASE_URL` manually in `examples/test_all`. This also doesn't apply
to CLI's test suite, which sets `DATABASE_URL` manually as needed, since
it can't run in a transaction and thus needs a different database
per-test.

So developers who frequently run our test suite against more than one
backend will likely have a `.env` file which looks like:

```
PG_DATABASE_URL=postgres://localhost/diesel_test
MYSQL_DATABASE_URL=mysql://localhost/diesel_test
SQLITE_DATABASE_URL=/tmp/test.db
```