### PR TITLE
cfg out of tests that use `get_result` for MySQL

### DIFF
--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -28,6 +28,7 @@ use schema::*;
 // }
 
 #[test]
+#[cfg(not(any(feature="sqlite", feature="mysql")))]
 fn association_where_parent_and_child_have_underscores() {
     #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
     #[has_many(special_comments)]

--- a/diesel_tests/tests/delete.rs
+++ b/diesel_tests/tests/delete.rs
@@ -29,7 +29,7 @@ fn delete_single_record() {
 }
 
 #[test]
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(any(feature="sqlite", feature="mysql")))]
 fn return_deleted_records() {
     use schema::users::dsl::*;
     let connection = connection_with_sean_and_tess_in_users_table();

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -21,7 +21,7 @@ fn insert_records() {
 }
 
 #[test]
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(any(feature="sqlite", feature="mysql")))]
 fn insert_records_using_returning_clause() {
     use schema::users::table as users;
     let connection = connection();
@@ -40,7 +40,7 @@ fn insert_records_using_returning_clause() {
 }
 
 #[test]
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(any(feature="sqlite", feature="mysql")))]
 fn insert_records_with_custom_returning_clause() {
     use schema::users::dsl::*;
 

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -71,7 +71,7 @@ fn test_updating_multiple_columns() {
 }
 
 #[test]
-#[cfg(not(feature="sqlite"))]
+#[cfg(not(any(feature="sqlite", feature="mysql")))]
 fn update_returning_struct() {
     use schema::users::dsl::*;
 
@@ -85,7 +85,7 @@ fn update_returning_struct() {
 }
 
 #[test]
-#[cfg(not(feature="sqlite"))]
+#[cfg(not(any(feature="sqlite", feature="mysql")))]
 fn update_with_custom_returning_clause() {
     use schema::users::dsl::*;
 


### PR DESCRIPTION
MySQL does not support returning clauses.