### PR TITLE
Ensure schema inference loads tables in a deterministic order

### DIFF
--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -156,6 +156,7 @@ pub fn load_table_names<Conn>(connection: &Conn, schema_name: Option<&str>)
         .filter(table_schema.eq(schema_name))
         .filter(table_name.not_like("\\_\\_%"))
         .filter(table_type.like("BASE TABLE"))
+        .order(table_name)
         .load(connection)
         .map_err(Into::into)
 }


### PR DESCRIPTION
We have a test that is failing intermittently because the order is
switching around. There's no ordinal position column or anything like
that so we'll just sort them alphabetically.