### PR TITLE
Don't include the default schema name on MySQL

### DIFF
--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -23,8 +23,9 @@ pub fn expand_infer_table_from_schema(database_url: &str, table: &TableData)
     for a in data {
         tokens.push(column_def_tokens(&a, &connection)?);
     }
-    if let Some(ref schema) = table.schema {
-        if cfg!(not(feature = "postgres")) || schema != "public" {
+    let default_schema = default_schema(&connection);
+    if table.schema != default_schema {
+        if let Some(ref schema) = table.schema {
             let schema_name = syn::Ident::new(&schema[..]);
             return Ok(quote!(table! {
                 #schema_name.#table_name (#(#primary_keys),*) {
@@ -81,4 +82,20 @@ fn column_def_tokens(
         tpe = quote!(Nullable<#tpe>);
     }
     Ok(quote!(#column_name -> #tpe))
+}
+
+fn default_schema(conn: &InferConnection) -> Option<String> {
+    #[cfg(feature="mysql")]
+    use information_schema::UsesInformationSchema;
+    #[cfg(feature="mysql")]
+    use diesel::mysql::Mysql;
+
+    match *conn {
+        #[cfg(feature="sqlite")]
+        InferConnection::Sqlite(_) => None,
+        #[cfg(feature="postgres")]
+        InferConnection::Pg(_) => Some("public".into()),
+        #[cfg(feature="mysql")]
+        InferConnection::Mysql(ref c) => Mysql::default_schema(c).ok(),
+    }
 }


### PR DESCRIPTION
Right now for any schema name other than `public`, codegen generates
`table! { schema_name.table_name` instead of just `table_name`. This
doesn't break anything technically, but it does mean that the output of
`print-schema` isn't what you'd expect. It also means all of our
integration tests that assert the actual generated SQL fail since they
don't expect `users` to be schema qualified.