### PR TITLE
Clean up type lookup for MySQL and PG

### DIFF
--- a/diesel_infer_schema/src/inference.rs
+++ b/diesel_infer_schema/src/inference.rs
@@ -105,9 +105,9 @@ pub fn determine_column_type(
         #[cfg(feature = "sqlite")]
         InferConnection::Sqlite(_) => ::sqlite::determine_column_type(attr),
         #[cfg(feature = "postgres")]
-        InferConnection::Pg(_) => ::information_schema::determine_column_type(attr),
+        InferConnection::Pg(_) => ::pg::determine_column_type(attr),
         #[cfg(feature = "mysql")]
-        InferConnection::Mysql(_) => ::information_schema::determine_column_type(attr),
+        InferConnection::Mysql(_) => ::mysql::determine_column_type(attr),
     }
 }
 

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -81,31 +81,6 @@ mod information_schema {
     }
 }
 
-pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
-    let is_array = attr.type_name.starts_with('_');
-    let tpe = if is_array {
-        &attr.type_name[1..]
-    } else {
-        &attr.type_name
-    };
-
-    let tpe = if let Some(idx) = tpe.find('(') {
-        &tpe[..idx]
-    } else {
-        tpe
-    };
-
-    Ok(ColumnType {
-        path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
-        is_array: is_array,
-        is_nullable: attr.nullable,
-    })
-}
-
-fn capitalize(name: &str) -> String {
-    name[..1].to_uppercase() + &name[1..]
-}
-
 pub fn get_table_data<Conn>(conn: &Conn, table: &TableData)
     -> QueryResult<Vec<ColumnInformation>> where
         Conn: Connection,

--- a/diesel_infer_schema/src/lib.rs
+++ b/diesel_infer_schema/src/lib.rs
@@ -14,6 +14,10 @@ mod table_data;
 
 #[cfg(feature="uses_information_schema")]
 mod information_schema;
+#[cfg(feature="mysql")]
+mod mysql;
+#[cfg(feature="postgres")]
+mod pg;
 #[cfg(feature="sqlite")]
 mod sqlite;
 

--- a/diesel_infer_schema/src/mysql.rs
+++ b/diesel_infer_schema/src/mysql.rs
@@ -1,0 +1,55 @@
+use std::error::Error;
+
+use data_structures::*;
+
+pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
+    let tpe = determine_type_name(&attr.type_name);
+
+    Ok(ColumnType {
+        path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
+        is_array: false,
+        is_nullable: attr.nullable,
+    })
+}
+
+fn determine_type_name(sql_type_name: &str) -> &str {
+    if sql_type_name == "tinyint(1)" {
+        "bool"
+    } else if sql_type_name.starts_with("int") {
+        "integer"
+    } else if let Some(idx) = sql_type_name.find('(') {
+        &sql_type_name[..idx]
+    } else {
+        &sql_type_name
+    }
+}
+
+fn capitalize(name: &str) -> String {
+    name[..1].to_uppercase() + &name[1..]
+}
+
+#[test]
+fn values_which_already_map_to_type_are_returned_unchanged() {
+    assert_eq!("text", determine_type_name("text"));
+    assert_eq!("integer", determine_type_name("integer"));
+    assert_eq!("biginteger", determine_type_name("biginteger"));
+}
+
+#[test]
+fn trailing_parenthesis_are_stripped() {
+    assert_eq!("varchar", determine_type_name("varchar(255)"));
+    assert_eq!("decimal", determine_type_name("decimal(10, 2)"));
+    assert_eq!("float", determine_type_name("float(1)"));
+}
+
+#[test]
+fn tinyint_is_bool_if_limit_1() {
+    assert_eq!("bool", determine_type_name("tinyint(1)"));
+    assert_eq!("tinyint", determine_type_name("tinyint(2)"));
+}
+
+#[test]
+fn int_is_treated_as_integer() {
+    assert_eq!("integer", determine_type_name("int"));
+    assert_eq!("integer", determine_type_name("int(11)"));
+}

--- a/diesel_infer_schema/src/pg.rs
+++ b/diesel_infer_schema/src/pg.rs
@@ -1,0 +1,22 @@
+use std::error::Error;
+
+use data_structures::*;
+
+pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
+    let is_array = attr.type_name.starts_with('_');
+    let tpe = if is_array {
+        &attr.type_name[1..]
+    } else {
+        &attr.type_name
+    };
+
+    Ok(ColumnType {
+        path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
+        is_array: is_array,
+        is_nullable: attr.nullable,
+    })
+}
+
+fn capitalize(name: &str) -> String {
+    name[..1].to_uppercase() + &name[1..]
+}


### PR DESCRIPTION
This moves the PG type lookup code to its own function, and removes the
mysql specific parenthesis handling.

For MySQL we have a few special cases to handle

- tinyint(1) is treated as a boolean
- integer is usually called int
- types often have limit/precision/scale specified in parenthesis after
  the name

Other than those cases, our lookup behavior is more or less the same as
PG. I added unit tests for the MySQL behavior, but not the PG -- This is
because for both of them I want to test the full output of
`determine_column_type`, but I also don't want that function to care
about paths, which is a larger refactoring I'm going to do for 0.11 to
support `infer_schema!` with application specific sql types or types
which come from a third party crate.