### PR TITLE
Clean up the backend inference for Diesel CLI

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -1,8 +1,8 @@
 use clap::ArgMatches;
 use diesel::expression::sql;
-#[cfg(feature = "postgres")]
+#[cfg(feature="postgres")]
 use diesel::pg::PgConnection;
-#[cfg(feature = "sqlite")]
+#[cfg(feature="sqlite")]
 use diesel::sqlite::SqliteConnection;
 use diesel::types::Bool;
 use diesel::{migrations, Connection, select, LoadDsl};
@@ -12,32 +12,69 @@ use database_error::{DatabaseError, DatabaseResult};
 use std::error::Error;
 use std::env;
 
+enum Backend {
+    #[cfg(feature="postgres")]
+    Pg,
+    #[cfg(feature="sqlite")]
+    Sqlite,
+}
+
+impl Backend {
+    fn for_url(database_url: &str) -> Self {
+        match database_url {
+            #[cfg(feature="postgres")]
+            _ if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") =>
+                Backend::Pg,
+            #[cfg(feature="sqlite")]
+            _ => Backend::Sqlite,
+            #[cfg(all(feature="postgres", not(feature="sqlite")))]
+            _ => {
+                panic!("{:?} is not a valid PostgreSQL URL. It should start with \
+                        `postgres://` or `postgresql://`", database_url);
+            }
+        }
+    }
+}
+
+pub enum InferConnection {
+    #[cfg(feature="postgres")]
+    Pg(PgConnection),
+    #[cfg(feature="sqlite")]
+    Sqlite(SqliteConnection),
+}
+
+impl InferConnection {
+    pub fn establish(database_url: &str) -> DatabaseResult<Self> {
+        match Backend::for_url(database_url) {
+            #[cfg(feature="postgres")]
+            Backend::Pg => PgConnection::establish(database_url)
+                .map(InferConnection::Pg),
+            #[cfg(feature="sqlite")]
+            Backend::Sqlite => SqliteConnection::establish(database_url)
+                    .map(InferConnection::Sqlite),
+        }.map_err(Into::into)
+    }
+}
+
 macro_rules! call_with_conn {
     (
-        $database_url:ident,
+        $database_url:expr,
         $($func:ident)::+
-    ) => {{
+    ) => {
         call_with_conn!($database_url, $($func)::+ ())
-    }};
+    };
 
     (
-        $database_url:ident,
+        $database_url:expr,
         $($func:ident)::+ ($($args:expr),*)
-    ) => {{
-        match ::database::backend(&$database_url) {
-            #[cfg(feature = "postgres")]
-            "postgres" => {
-                let conn = PgConnection::establish(&$database_url).unwrap();
-                $($func)::+(&conn, $($args),*)
-            },
-            #[cfg(feature = "sqlite")]
-            "sqlite" => {
-                let conn = SqliteConnection::establish(&$database_url).unwrap();
-                $($func)::+(&conn, $($args),*)
-            },
-            _ => unreachable!("The backend function should ensure we never get here."),
+    ) => {
+        match ::database::InferConnection::establish(&$database_url).unwrap() {
+            #[cfg(feature="postgres")]
+            ::database::InferConnection::Pg(ref conn) => $($func)::+ (conn, $($args),*),
+            #[cfg(feature="sqlite")]
+            ::database::InferConnection::Sqlite(ref conn) => $($func)::+ (conn, $($args),*),
         }
-    }};
+    };
 }
 
 pub fn reset_database(args: &ArgMatches) -> DatabaseResult<()> {
@@ -58,10 +95,10 @@ pub fn drop_database_command(args: &ArgMatches) -> DatabaseResult<()> {
 
 /// Creates the database specified in the connection url. It returns an error
 /// it it was unable to create the database.
-fn create_database_if_needed(database_url: &String) -> DatabaseResult<()> {
-    match backend(database_url) {
-        #[cfg(feature = "postgres")]
-        "postgres" => {
+fn create_database_if_needed(database_url: &str) -> DatabaseResult<()> {
+    match Backend::for_url(database_url) {
+        #[cfg(feature="postgres")]
+        Backend::Pg => {
             if PgConnection::establish(database_url).is_err() {
                 let (database, postgres_url) = split_pg_connection_string(database_url);
                 println!("Creating database: {}", database);
@@ -69,14 +106,13 @@ fn create_database_if_needed(database_url: &String) -> DatabaseResult<()> {
                 try!(conn.execute(&format!("CREATE DATABASE {}", database)));
             }
         },
-        #[cfg(feature = "sqlite")]
-        "sqlite" => {
+        #[cfg(feature="sqlite")]
+        Backend::Sqlite => {
             if !::std::path::Path::new(database_url).exists() {
                 println!("Creating database: {}", database_url);
                 try!(SqliteConnection::establish(database_url));
             }
         },
-        _ => unreachable!("The backend function should ensure we never get here."),
     }
 
     Ok(())
@@ -86,7 +122,7 @@ fn create_database_if_needed(database_url: &String) -> DatabaseResult<()> {
 /// table didn't exist, it also runs any pending migrations. Returns a
 /// `DatabaseError::ConnectionError` if it can't create the table, and exits
 /// with a migration error if it can't run migrations.
-fn create_schema_table_and_run_migrations_if_needed(database_url: &String)
+fn create_schema_table_and_run_migrations_if_needed(database_url: &str)
     -> DatabaseResult<()>
 {
     if !schema_table_exists(database_url).unwrap_or_else(handle_error) {
@@ -98,10 +134,10 @@ fn create_schema_table_and_run_migrations_if_needed(database_url: &String)
 
 /// Drops the database specified in the connection url. It returns an error
 /// if it was unable to drop the database.
-fn drop_database(database_url: &String) -> DatabaseResult<()> {
-    match backend(database_url) {
-        #[cfg(feature = "postgres")]
-        "postgres" => {
+fn drop_database(database_url: &str) -> DatabaseResult<()> {
+    match Backend::for_url(database_url) {
+        #[cfg(feature="postgres")]
+        Backend::Pg => {
             let (database, postgres_url) = split_pg_connection_string(database_url);
             println!("Dropping database: {}", database);
             let conn = try!(PgConnection::establish(&postgres_url));
@@ -109,42 +145,37 @@ fn drop_database(database_url: &String) -> DatabaseResult<()> {
                 conn.execute(&format!("DROP DATABASE IF EXISTS {}", database))
             }));
         },
-        #[cfg(feature = "sqlite")]
-        "sqlite" => {
+        #[cfg(feature="sqlite")]
+        Backend::Sqlite => {
             println!("Dropping database: {}", database_url);
             try!(::std::fs::remove_file(&database_url));
         },
-        _ => unreachable!("The backend function should ensure we never get here."),
     }
     Ok(())
 }
 
 /// Returns true if the '__diesel_schema_migrations' table exists in the
 /// database we connect to, returns false if it does not.
-pub fn schema_table_exists(database_url: &String) -> DatabaseResult<bool> {
-    let result = match backend(database_url) {
-        #[cfg(feature = "postgres")]
-        "postgres" => {
-            let conn = PgConnection::establish(database_url).unwrap();
-            try!(select(sql::<Bool>("EXISTS \
+pub fn schema_table_exists(database_url: &str) -> DatabaseResult<bool> {
+    match InferConnection::establish(database_url).unwrap() {
+        #[cfg(feature="postgres")]
+        InferConnection::Pg(conn) => {
+            select(sql::<Bool>("EXISTS \
                     (SELECT 1 \
                      FROM information_schema.tables \
                      WHERE table_name = '__diesel_schema_migrations')"))
-                .get_result(&conn))
+                .get_result(&conn)
         },
-        #[cfg(feature = "sqlite")]
-        "sqlite" => {
-            let conn = SqliteConnection::establish(database_url).unwrap();
-            try!(select(sql::<Bool>("EXISTS \
+        #[cfg(feature="sqlite")]
+        InferConnection::Sqlite(conn) => {
+            select(sql::<Bool>("EXISTS \
                     (SELECT 1 \
                      FROM sqlite_master \
                      WHERE type = 'table' \
                      AND name = '__diesel_schema_migrations')"))
-                .get_result(&conn))
+                .get_result(&conn)
         },
-        _ => unreachable!("The backend function should ensure we never get here."),
-    };
-    Ok(result)
+    }.map_err(Into::into)
 }
 
 pub fn database_url(matches: &ArgMatches) -> String {
@@ -156,21 +187,8 @@ pub fn database_url(matches: &ArgMatches) -> String {
         })
 }
 
-/// Returns a &str representing the type of backend being used, determined
-/// by the format of the database url.
-pub fn backend(database_url: &String) -> &str {
-    if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") && cfg!(feature = "postgres") {
-        "postgres"
-    } else if cfg!(feature = "sqlite") {
-        "sqlite"
-    } else {
-        panic!("{:?} is not a valid PostgreSQL URL. It should start with\
-                `postgres://` or `postgresql://`", database_url);
-    }
-}
-
-#[cfg(feature = "postgres")]
-fn split_pg_connection_string(database_url: &String) -> (String, String) {
+#[cfg(feature="postgres")]
+fn split_pg_connection_string(database_url: &str) -> (String, String) {
     let mut split: Vec<&str> = database_url.split("/").collect();
     let database = split.pop().unwrap();
     let postgres_url = format!("{}/{}", split.join("/"), "postgres");
@@ -182,7 +200,7 @@ fn handle_error<E: Error, T>(error: E) -> T {
     ::std::process::exit(1);
 }
 
-#[cfg(all(test, feature = "postgres"))]
+#[cfg(all(test, feature="postgres"))]
 mod tests {
     use super::split_pg_connection_string;
 

--- a/diesel_cli/src/database_error.rs
+++ b/diesel_cli/src/database_error.rs
@@ -10,7 +10,6 @@ pub type DatabaseResult<T> = Result<T, DatabaseError>;
 
 #[derive(Debug)]
 pub enum DatabaseError {
-    #[allow(dead_code)]
     CargoTomlNotFound,
     DatabaseUrlMissing,
     IoError(io::Error),

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -14,10 +14,6 @@ mod pretty_printing;
 
 use chrono::*;
 use clap::{ArgMatches,Shell};
-#[cfg(feature = "postgres")]
-use diesel::pg::PgConnection;
-#[cfg(feature = "sqlite")]
-use diesel::sqlite::SqliteConnection;
 use diesel::migrations::schema::*;
 use diesel::types::{FromSql, VarChar};
 use diesel::{migrations, Connection, Insertable};

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -59,20 +59,18 @@ fn migration_run_inserts_run_on_timestamps() {
     // By running a query that compares timestamps, we are also checking
     // that the auto-inserted values for the "run_on" column are valid.
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(feature="sqlite")]
     fn valid_run_on_timestamp(db: &database::Database) -> bool {
-        select(sql::<Bool>("EXISTS (SELECT run_on < DATETIME('now', '-1 hour') \
-                                    FROM __diesel_schema_migrations)"))
+        select(sql::<Bool>("EXISTS (SELECT 1 FROM __diesel_schema_migrations \
+                WHERE run_on < DATETIME('now', '+1 hour'))"))
             .get_result(&db.conn())
             .unwrap()
     }
 
-    #[cfg(feature = "postgres")]
+    #[cfg(feature="postgres")]
     fn valid_run_on_timestamp(db: &database::Database) -> bool {
-        select(sql::<Bool>("EXISTS (SELECT \
-                              run_on < (CAST('now' AS TIMESTAMP) - \
-                                        CAST('1 hour' AS INTERVAL)) \
-                              FROM __diesel_schema_migrations)"))
+        select(sql::<Bool>("EXISTS (SELECT 1 FROM __diesel_schema_migrations \
+                WHERE run_on < NOW() + INTERVAL '1 hour')"))
             .get_result(&db.conn())
             .unwrap()
     }

--- a/diesel_cli/tests/support/mod.rs
+++ b/diesel_cli/tests/support/mod.rs
@@ -16,12 +16,8 @@ macro_rules! try_drop {
 mod command;
 mod project_builder;
 
-#[cfg(feature = "sqlite")]
-#[path="sqlite_database.rs"]
-pub mod database;
-
-#[cfg(feature = "postgres")]
-#[path="postgres_database.rs"]
+#[cfg_attr(feature="sqlite", path="sqlite_database.rs")]
+#[cfg_attr(feature="postgres", path="postgres_database.rs")]
 pub mod database;
 
 pub use self::project_builder::project;

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -67,12 +67,12 @@ impl Project {
             .collect()
     }
 
-    #[cfg(feature = "postgres")]
+    #[cfg(feature="postgres")]
     pub fn database_url(&self) -> String {
         format!("postgres://localhost/{}", self.name)
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(feature="sqlite")]
     pub fn database_url(&self) -> String {
         self.directory.path().join(&self.name)
             .into_os_string()
@@ -96,7 +96,7 @@ impl Project {
     }
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(not(feature="sqlite"))]
 impl Drop for Project {
     fn drop(&mut self) {
         try_drop!(self.command("database").arg("drop").run().result(), "Couldn't drop database");


### PR DESCRIPTION
The old code was stringly typed, and fairly spaghetti-ish. I've applied
the pattern that we're using in codegen/infer_schema, using an enum for
each enabled backend. The resulting code should require fewer changes to
support additional backends, and will fail to compile when those
backends aren't enabled rather than panicking.