### PR TITLE
Fix buffer overrun issue with MySQL

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -155,6 +155,7 @@ impl BindData {
 
             debug_assert!(truncated_amount > 0, "output buffers were invalidated \
                 without calling `mysql_stmt_bind_result`");
+            self.bytes.set_len(offset);
             self.bytes.reserve(truncated_amount);
             self.bytes.set_len(self.length as usize);
 


### PR DESCRIPTION
`Vec::reserve` ensures that `self.capacity() >= self.len() +
additional`, not `self.capacity() >= original_capacity + additional`. If
we don't set the length before this call, we aren't necessarily actually
allocating to be the size we want to be, and risk a buffer overrun.