### PR TITLE
Add support for MySQL to Diesel CLI

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -4,6 +4,8 @@ use diesel::expression::sql;
 use diesel::pg::PgConnection;
 #[cfg(feature="sqlite")]
 use diesel::sqlite::SqliteConnection;
+#[cfg(feature="mysql")]
+use diesel::mysql::MysqlConnection;
 use diesel::types::Bool;
 use diesel::{migrations, Connection, select, LoadDsl};
 
@@ -17,6 +19,8 @@ enum Backend {
     Pg,
     #[cfg(feature="sqlite")]
     Sqlite,
+    #[cfg(feature="mysql")]
+    Mysql,
 }
 
 impl Backend {
@@ -25,12 +29,15 @@ impl Backend {
             #[cfg(feature="postgres")]
             _ if database_url.starts_with("postgres://") || database_url.starts_with("postgresql://") =>
                 Backend::Pg,
+            #[cfg(feature="mysql")]
+            _ if database_url.starts_with("mysql://") =>
+                Backend::Mysql,
             #[cfg(feature="sqlite")]
             _ => Backend::Sqlite,
-            #[cfg(all(feature="postgres", not(feature="sqlite")))]
+            #[cfg(not(feature="sqlite"))]
             _ => {
-                panic!("{:?} is not a valid PostgreSQL URL. It should start with \
-                        `postgres://` or `postgresql://`", database_url);
+                panic!("{:?} is not a valid database URL. It should start with \
+                        `postgres://` or `mysql://`", database_url);
             }
         }
     }
@@ -41,6 +48,8 @@ pub enum InferConnection {
     Pg(PgConnection),
     #[cfg(feature="sqlite")]
     Sqlite(SqliteConnection),
+    #[cfg(feature="mysql")]
+    Mysql(MysqlConnection),
 }
 
 impl InferConnection {
@@ -52,6 +61,9 @@ impl InferConnection {
             #[cfg(feature="sqlite")]
             Backend::Sqlite => SqliteConnection::establish(database_url)
                     .map(InferConnection::Sqlite),
+            #[cfg(feature="mysql")]
+            Backend::Mysql => MysqlConnection::establish(database_url)
+                    .map(InferConnection::Mysql),
         }.map_err(Into::into)
     }
 }
@@ -73,6 +85,8 @@ macro_rules! call_with_conn {
             ::database::InferConnection::Pg(ref conn) => $($func)::+ (conn, $($args),*),
             #[cfg(feature="sqlite")]
             ::database::InferConnection::Sqlite(ref conn) => $($func)::+ (conn, $($args),*),
+            #[cfg(feature="mysql")]
+            ::database::InferConnection::Mysql(ref conn) => $($func)::+ (conn, $($args),*),
         }
     };
 }
@@ -100,7 +114,7 @@ fn create_database_if_needed(database_url: &str) -> DatabaseResult<()> {
         #[cfg(feature="postgres")]
         Backend::Pg => {
             if PgConnection::establish(database_url).is_err() {
-                let (database, postgres_url) = split_pg_connection_string(database_url);
+                let (database, postgres_url) = change_database_of_url(database_url, "postgres");
                 println!("Creating database: {}", database);
                 let conn = try!(PgConnection::establish(&postgres_url));
                 try!(conn.execute(&format!("CREATE DATABASE {}", database)));
@@ -111,6 +125,15 @@ fn create_database_if_needed(database_url: &str) -> DatabaseResult<()> {
             if !::std::path::Path::new(database_url).exists() {
                 println!("Creating database: {}", database_url);
                 try!(SqliteConnection::establish(database_url));
+            }
+        },
+        #[cfg(feature="mysql")]
+        Backend::Mysql => {
+            if MysqlConnection::establish(database_url).is_err() {
+                let (database, mysql_url) = change_database_of_url(database_url, "information_schema");
+                println!("Creating database: {}", database);
+                let conn = try!(MysqlConnection::establish(&mysql_url));
+                try!(conn.execute(&format!("CREATE DATABASE {}", database)));
             }
         },
     }
@@ -138,8 +161,7 @@ fn drop_database(database_url: &str) -> DatabaseResult<()> {
     match Backend::for_url(database_url) {
         #[cfg(feature="postgres")]
         Backend::Pg => {
-            let (database, postgres_url) = split_pg_connection_string(database_url);
-            println!("Dropping database: {}", database);
+            let (database, postgres_url) = change_database_of_url(database_url, "postgres");
             let conn = try!(PgConnection::establish(&postgres_url));
             try!(conn.silence_notices(|| {
                 conn.execute(&format!("DROP DATABASE IF EXISTS {}", database))
@@ -149,6 +171,13 @@ fn drop_database(database_url: &str) -> DatabaseResult<()> {
         Backend::Sqlite => {
             println!("Dropping database: {}", database_url);
             try!(::std::fs::remove_file(&database_url));
+        },
+        #[cfg(feature="mysql")]
+        Backend::Mysql => {
+            let (database, mysql_url) = change_database_of_url(database_url, "information_schema");
+            println!("Dropping database: {}", database);
+            let conn = try!(MysqlConnection::establish(&mysql_url));
+            try!(conn.execute(&format!("DROP DATABASE IF EXISTS {}", database)));
         },
     }
     Ok(())
@@ -175,6 +204,15 @@ pub fn schema_table_exists(database_url: &str) -> DatabaseResult<bool> {
                      AND name = '__diesel_schema_migrations')"))
                 .get_result(&conn)
         },
+        #[cfg(feature="mysql")]
+        InferConnection::Mysql(conn) => {
+            select(sql::<Bool>("EXISTS \
+                    (SELECT 1 \
+                     FROM information_schema.tables \
+                     WHERE table_name = '__diesel_schema_migrations'
+                     AND table_schema = DATABASE())"))
+                .get_result(&conn)
+        },
     }.map_err(Into::into)
 }
 
@@ -187,12 +225,12 @@ pub fn database_url(matches: &ArgMatches) -> String {
         })
 }
 
-#[cfg(feature="postgres")]
-fn split_pg_connection_string(database_url: &str) -> (String, String) {
+#[cfg(any(feature="postgres", feature="mysql"))]
+fn change_database_of_url(database_url: &str, default_database: &str) -> (String, String) {
     let mut split: Vec<&str> = database_url.split("/").collect();
     let database = split.pop().unwrap();
-    let postgres_url = format!("{}/{}", split.join("/"), "postgres");
-    (database.to_owned(), postgres_url)
+    let new_url = format!("{}/{}", split.join("/"), default_database);
+    (database.to_owned(), new_url)
 }
 
 fn handle_error<E: Error, T>(error: E) -> T {
@@ -200,9 +238,9 @@ fn handle_error<E: Error, T>(error: E) -> T {
     ::std::process::exit(1);
 }
 
-#[cfg(all(test, feature="postgres"))]
+#[cfg(all(test, any(feature="postgres", feature="mysql")))]
 mod tests {
-    use super::split_pg_connection_string;
+    use super::change_database_of_url;
 
     #[test]
     fn split_pg_connection_string_returns_postgres_url_and_database() {
@@ -210,7 +248,7 @@ mod tests {
         let base_url = "postgresql://localhost:5432".to_owned();
         let database_url = format!("{}/{}", base_url, database);
         let postgres_url = format!("{}/{}", base_url, "postgres");
-        assert_eq!((database, postgres_url), split_pg_connection_string(&database_url));
+        assert_eq!((database, postgres_url), change_database_of_url(&database_url, "postgres"));
     }
 
     #[test]
@@ -219,6 +257,6 @@ mod tests {
         let base_url = "postgresql://user:password@localhost:5432".to_owned();
         let database_url = format!("{}/{}", base_url, database);
         let postgres_url = format!("{}/{}", base_url, "postgres");
-        assert_eq!((database, postgres_url), split_pg_connection_string(&database_url));
+        assert_eq!((database, postgres_url), change_database_of_url(&database_url, "postgres"));
     }
 }

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -162,6 +162,7 @@ fn drop_database(database_url: &str) -> DatabaseResult<()> {
         #[cfg(feature="postgres")]
         Backend::Pg => {
             let (database, postgres_url) = change_database_of_url(database_url, "postgres");
+            println!("Dropping database: {}", database);
             let conn = try!(PgConnection::establish(&postgres_url));
             try!(conn.silence_notices(|| {
                 conn.execute(&format!("DROP DATABASE IF EXISTS {}", database))

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -176,7 +176,7 @@ fn should_redo_migration_in_transaction(t: &Any) -> bool {
 }
 
 #[cfg(not(feature="mysql"))]
-fn should_redo_migration_in_transaction(t: &Any) -> bool {
+fn should_redo_migration_in_transaction(_t: &Any) -> bool {
     true
 }
 

--- a/diesel_cli/tests/database_reset.rs
+++ b/diesel_cli/tests/database_reset.rs
@@ -55,9 +55,10 @@ fn reset_handles_postgres_urls_with_username_and_password() {
     db.execute("DROP ROLE IF EXISTS foo");
     db.execute("CREATE ROLE foo WITH LOGIN SUPERUSER PASSWORD 'password'");
 
+    let database_url = format!("postgres://foo:password@localhost/diesel_{}", p.name);
     let result = p.command("database")
         .arg("reset")
-        .env("DATABASE_URL", &format!("postgres://foo:password@localhost/{}", p.name))
+        .env("DATABASE_URL", &database_url)
         .run();
 
     assert!(result.is_success(), "Result was unsuccessful {:?}", result.stdout());

--- a/diesel_cli/tests/migration_redo.rs
+++ b/diesel_cli/tests/migration_redo.rs
@@ -6,8 +6,8 @@ fn migration_redo_runs_the_last_migration_down_and_up() {
         .folder("migrations")
         .build();
     p.create_migration("12345_create_users_table",
-                       "CREATE TABLE users ( id INTEGER )",
-                       "DROP TABLE users");
+                       "CREATE TABLE users (id INTEGER);",
+                       "DROP TABLE users;");
 
     // Make sure the project is setup
     p.command("setup").run();

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -75,6 +75,14 @@ fn migration_run_inserts_run_on_timestamps() {
             .unwrap()
     }
 
+    #[cfg(feature="mysql")]
+    fn valid_run_on_timestamp(db: &database::Database) -> bool {
+        select(sql::<Bool>("EXISTS (SELECT 1 FROM __diesel_schema_migrations \
+                WHERE run_on < NOW() + INTERVAL 1 HOUR)"))
+            .get_result(&db.conn())
+            .unwrap()
+    }
+
     assert!(valid_run_on_timestamp(&db),
             "Running a migration did not insert an updated run_on value");
 }

--- a/diesel_cli/tests/support/mod.rs
+++ b/diesel_cli/tests/support/mod.rs
@@ -18,6 +18,7 @@ mod project_builder;
 
 #[cfg_attr(feature="sqlite", path="sqlite_database.rs")]
 #[cfg_attr(feature="postgres", path="postgres_database.rs")]
+#[cfg_attr(feature="mysql", path="mysql_database.rs")]
 pub mod database;
 
 pub use self::project_builder::project;

--- a/diesel_cli/tests/support/mysql_database.rs
+++ b/diesel_cli/tests/support/mysql_database.rs
@@ -1,0 +1,61 @@
+use diesel::expression::sql;
+use diesel::mysql::MysqlConnection;
+use diesel::types::Bool;
+use diesel::*;
+
+pub struct Database {
+    url: String
+}
+
+impl Database {
+    pub fn new(url: &str) -> Self {
+        Database {
+            url: url.into()
+        }
+    }
+
+    pub fn create(self) -> Self {
+        let (database, mysql_url) = self.split_url();
+        let conn = MysqlConnection::establish(&mysql_url).unwrap();
+        conn.execute(&format!("CREATE DATABASE {}", database)).unwrap();
+        self
+    }
+
+    pub fn exists(&self) -> bool {
+        MysqlConnection::establish(&self.url).is_ok()
+    }
+
+    pub fn table_exists(&self, table: &str) -> bool {
+        select(sql::<Bool>(&format!("EXISTS \
+                (SELECT 1 \
+                 FROM information_schema.tables \
+                 WHERE table_name = '{}'
+                 AND table_schema = DATABASE())", table)))
+            .get_result(&self.conn()).unwrap()
+    }
+
+    pub fn conn(&self) -> MysqlConnection {
+        MysqlConnection::establish(&self.url)
+            .expect(&format!("Failed to open connection to {}", &self.url))
+    }
+
+    pub fn execute(&self, command: &str) {
+        self.conn().execute(command)
+            .expect(&format!("Error executing command {}", command));
+    }
+
+    fn split_url(&self) -> (String, String) {
+        let mut split: Vec<&str> = self.url.split("/").collect();
+        let database = split.pop().unwrap();
+        let mysql_url = format!("{}/{}", split.join("/"), "information_schema");
+        (database.into(), mysql_url)
+    }
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        let (database, mysql_url) = self.split_url();
+        let conn = try_drop!(MysqlConnection::establish(&mysql_url), "Couldn't connect to database");
+        try_drop!(conn.execute(&format!("DROP DATABASE IF EXISTS {}", database)), "Couldn't drop database");
+    }
+}

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -69,7 +69,12 @@ impl Project {
 
     #[cfg(feature="postgres")]
     pub fn database_url(&self) -> String {
-        format!("postgres://localhost/{}", self.name)
+        format!("postgres://localhost/diesel_{}", self.name)
+    }
+
+    #[cfg(feature="mysql")]
+    pub fn database_url(&self) -> String {
+        format!("mysql://localhost/diesel_{}", self.name)
     }
 
     #[cfg(feature="sqlite")]


### PR DESCRIPTION
MySQL is relatively similar to PG for CLI's purposes. The main
differences are:

- `information_schema.tables` aren't scoped to the current database
- The default databases that are present are `mysql`,
  `information_schema`, and sometimes `test`. I chcose the second
  because it seemed most likely to have permissions granted
- `migration redo` can't run inside of a transaction because the
  transaction is implicitly committed when the schema is modified.
  `COMMIT` when not inside of a transaction is not an error, but
  wrapping the outer calls in a transaction cause us to use savepoints
  which error when we try to release them.

Running the tests for CLI requires GRANT ALL ON `diesel_%`.* TO
''@'localhost'. I need to see if I can make the URLs we use more
configurable.

The way we check to run a transaction in `migration_redo` is a little
hacky, but was overall less code than restructuring it to pass the enum
through further.