### PR TITLE
Don't print `Dropping database` to STDOUT when db doesn't exist

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -16,6 +16,7 @@
 
 extern crate chrono;
 extern crate clap;
+#[cfg_attr(any(feature="mysql", feature="postgres"), macro_use)]
 extern crate diesel;
 extern crate dotenv;
 extern crate diesel_infer_schema;

--- a/diesel_cli/tests/database_drop.rs
+++ b/diesel_cli/tests/database_drop.rs
@@ -16,3 +16,20 @@ fn database_drop_drops_database() {
         "Unexpected stdout {}", result.stdout());
     assert!(!db.exists());
 }
+
+#[test]
+fn database_drop_does_not_print_to_stdout_if_no_db_exists() {
+    let p = project("database_drop_no_stdout").build();
+    let db = database(&p.database_url());
+
+    assert!(!db.exists());
+
+    let result = p.command("database")
+        .arg("drop")
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(!result.stdout().contains("Dropping database:"),
+        "Unexpected stdout {}", result.stdout());
+    assert!(!db.exists());
+}

--- a/diesel_cli/tests/database_reset.rs
+++ b/diesel_cli/tests/database_reset.rs
@@ -62,4 +62,8 @@ fn reset_handles_postgres_urls_with_username_and_password() {
         .run();
 
     assert!(result.is_success(), "Result was unsuccessful {:?}", result.stdout());
+    assert!(result.stdout().contains("Dropping database:"),
+        "Unexpected stdout {}", result.stdout());
+    assert!(result.stdout().contains("Creating database:"),
+        "Unexpected stdout {}", result.stdout());
 }


### PR DESCRIPTION
There was an interesting failure when running the CLI tests for PG
locally after adding MySQL support. The failure only happened on the
second run of a test, so wouldn't have been caught by CI. The failure
occurred because the test creates a database, then creates a new role,
and runs `diesel database reset` as that role. On the second run it
would fail to drop the role because there was an existing database
depending on it.

The issue was that I had changed the name of the database created by the
project, but that test constructed its own database url and was out of
sync. The fix was [this][fix], but the fact that CI wouldn't have caught
this bothered me. There was no change I could make in just the test to
ensure all my assumptions were correct, since we would always say
"dropping database:" in the CLI.

[fix]: https://github.com/diesel-rs/diesel/commit/a56eae379c37bd9fe39f21ad7d11d2d1f9364f05#diff-6c048bb08a0433845cbca8b7536be378R58,

With this change, we now only print "Dropping database:" if the database
already exists, mimicking the behavior of `diesel database setup`. If
that same bug existed in that test today, it would be caught on the
first test run rather than the second.