### PR TITLE
Add MySQL to the local test script

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -17,17 +17,23 @@ elif [ "$1" = "compile" ]; then
   shift
   (cd diesel_compile_tests && cargo test $*)
 else
-  (cd diesel && cargo test --no-default-features --features "chrono sqlite postgres" $*)
+  (cd diesel && cargo test --no-default-features --features "all sqlite postgres mysql" $*)
+  (cd diesel && cargo test --features "all sqlite" $*)
   (cd diesel_cli && cargo test --features "sqlite" --no-default-features $*)
   (cd diesel_infer_schema && cargo test --features "sqlite" $*)
-  (cd diesel_codegen_shared && cargo test --features "sqlite" $*)
   (cd diesel_codegen && cargo test --features "sqlite" $*)
   (cd diesel_tests && cargo test --features "sqlite" --no-default-features $*)
   (cd examples && ./test_all $*)
+  (cd diesel && cargo test --features "all postgres" $*)
   (cd diesel_infer_schema && cargo test --features "postgres" $*)
-  (cd diesel_codegen_shared && cargo test --features "postgres" $*)
   (cd diesel_codegen && cargo test --features "postgres" $*)
   (cd diesel_cli && cargo test --features "postgres" --no-default-features $*)
   (cd diesel_tests && cargo test --features "postgres" --no-default-features $*)
+  export RUST_TEST_THREADS=1
+  (cd diesel && cargo test --features "all mysql" $*)
+  (cd diesel_infer_schema && cargo test --features "mysql" $*)
+  (cd diesel_codegen && cargo test --features "mysql" $*)
+  (cd diesel_cli && cargo test --features "mysql" --no-default-features $*)
+  (cd diesel_tests && cargo test --features "mysql" --no-default-features $*)
   (cd diesel_compile_tests && cargo test $*)
 fi;

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -31,6 +31,7 @@ tempdir = "^0.3.4"
 
 [features]
 default = ["with-deprecated"]
+extras = ["chrono", "serde_json", "uuid"]
 unstable = []
 large-tables = []
 huge-tables = ["large-tables"]

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -55,7 +55,7 @@ cfg_if! {
         type DB = diesel::mysql::Mysql;
 
         fn connection_no_data() -> diesel::mysql::MysqlConnection {
-            let connection_url = database_url_from_env("MYSQL_DATABASE_URL");
+            let connection_url = database_url_from_env("MYSQL_UNIT_TEST_DATABASE_URL");
             let connection = diesel::mysql::MysqlConnection::establish(&connection_url).unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
 

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -46,7 +46,7 @@ cfg_if! {
 
         pub fn connection_no_transaction() -> TestConnection {
             dotenv().ok();
-            let database_url = env::var("MYSQL_DATABASE_URL")
+            let database_url = env::var("MYSQL_UNIT_TEST_DATABASE_URL")
                 .or_else(|_| env::var("DATABASE_URL"))
                 .expect("DATABASE_URL must be set in order to run tests");
             MysqlConnection::establish(&database_url).unwrap()

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -6,10 +6,11 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [workspace]
 
 [dependencies]
-diesel = { version = "0.10.0", features = ["sqlite", "postgres"] }
+diesel = { version = "0.10.0", features = ["all", "sqlite", "postgres", "mysql"] }
 diesel_codegen = { version = "0.10.0" }
 compiletest_rs = "0.2.3"
 
 [replace]
-"diesel:0.10.0" = { path = "../diesel" }
-"diesel_codegen:0.10.0" = { path = "../diesel_codegen" }
+"diesel:0.10.1" = { path = "../diesel" }
+"diesel_codegen:0.10.1" = { path = "../diesel_codegen" }
+"diesel_infer_schema:0.10.1" = { path = "../diesel_infer_schema" }


### PR DESCRIPTION
The best I could come up with for enabling the unit test suite is to
make sure that it's using a different database than the integration test
suite. I'm only looking for the `UNIT_TEST` env var and not falling back
to `MYSQL_DATABASE_URL` because running it against the same database as
the integration tests will mess things up (less of a problem for CI
since it runs unit, then integration, then throws everything away)

I'm holding off on adding it to CI until I tweak a few more things.