### PR TITLE
Change the return type of `max` and `min` to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Updated chrono to version 0.3.
 
+* [`max`][max-0.11.0] and [`min`][min-0.11.0] are now always nullable. The database will
+  return `NULL` when the table is empty.
+
+[max-0.11.0]: http://docs.diesel.rs/diesel/expression/dsl/fn.max.html
+[min-0.11.0]: http://docs.diesel.rs/diesel/expression/dsl/fn.min.html
+
 ## [0.10.1] - 2017-02-08
 
 ### Fixed

--- a/diesel/src/migrations/connection.rs
+++ b/diesel/src/migrations/connection.rs
@@ -12,7 +12,7 @@ use types::{FromSql, VarChar};
 /// should be useable where this trait is required.
 pub trait MigrationConnection: Connection {
     fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>>;
-    fn latest_run_migration_version(&self) -> QueryResult<String>;
+    fn latest_run_migration_version(&self) -> QueryResult<Option<String>>;
     fn insert_new_migration(&self, version: &str) -> QueryResult<()>;
 }
 
@@ -27,7 +27,7 @@ impl<T> MigrationConnection for T where
             .map(FromIterator::from_iter)
     }
 
-    fn latest_run_migration_version(&self) -> QueryResult<String> {
+    fn latest_run_migration_version(&self) -> QueryResult<Option<String>> {
         use ::expression::dsl::max;
         __diesel_schema_migrations.select(max(version))
             .first(self)

--- a/diesel/src/migrations/migration_error.rs
+++ b/diesel/src/migrations/migration_error.rs
@@ -11,6 +11,7 @@ pub enum MigrationError {
     UnknownMigrationFormat(PathBuf),
     IoError(io::Error),
     UnknownMigrationVersion(String),
+    NoMigrationRun,
 }
 
 impl Error for MigrationError {
@@ -25,6 +26,8 @@ impl Error for MigrationError {
                 error.description(),
             MigrationError::UnknownMigrationVersion(_) =>
                 "Unable to find migration version to revert in the migrations directory.",
+            MigrationError::NoMigrationRun =>
+                "No migrations have been run. Did you forget `diesel migration run`?",
         }
     }
 }

--- a/diesel/src/migrations/mod.rs
+++ b/diesel/src/migrations/mod.rs
@@ -117,7 +117,8 @@ pub fn revert_latest_migration<Conn>(conn: &Conn) -> Result<String, RunMigration
     Conn: MigrationConnection,
 {
     try!(setup_database(conn));
-    let latest_migration_version = try!(conn.latest_run_migration_version());
+    let latest_migration_version = conn.latest_run_migration_version()?
+        .ok_or_else(|| RunMigrationsError::MigrationError(MigrationError::NoMigrationRun))?;
     revert_migration_with_version(conn, &latest_migration_version, &mut stdout())
         .map(|_| latest_migration_version)
 }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -63,9 +63,11 @@ fn test_count_max() {
     connection.execute("INSERT INTO numbers (n) VALUES (2), (1), (5)").unwrap();
     let source = numbers.select(max(n));
 
-    assert_eq!(Ok(5), source.first(&connection));
+    assert_eq!(Ok(Some(5)), source.first(&connection));
     connection.execute("DELETE FROM numbers WHERE n = 5").unwrap();
-    assert_eq!(Ok(2), source.first(&connection));
+    assert_eq!(Ok(Some(2)), source.first(&connection));
+    connection.execute("DELETE FROM numbers").unwrap();
+    assert_eq!(Ok(None::<i32>), source.first(&connection));
 }
 
 #[test]
@@ -79,9 +81,11 @@ fn max_returns_same_type_as_expression_being_maximized() {
         NewUser::new("A", None),
     ];
     insert(data).into(users).execute(&connection).unwrap();
-    assert_eq!(Ok("C".to_string()), source.first(&connection));
+    assert_eq!(Ok(Some("C".to_string())), source.first(&connection));
     connection.execute("DELETE FROM users WHERE name = 'C'").unwrap();
-    assert_eq!(Ok("B".to_string()), source.first(&connection));
+    assert_eq!(Ok(Some("B".to_string())), source.first(&connection));
+    connection.execute("DELETE FROM users").unwrap();
+    assert_eq!(Ok(None::<String>), source.first(&connection));
 }
 
 use std::marker::PhantomData;
@@ -146,9 +150,11 @@ fn test_min() {
     connection.execute("INSERT INTO numbers (n) VALUES (2), (1), (5)").unwrap();
     let source = numbers.select(min(n));
 
-    assert_eq!(Ok(1), source.first(&connection));
+    assert_eq!(Ok(Some(1)), source.first(&connection));
     connection.execute("DELETE FROM numbers WHERE n = 1").unwrap();
-    assert_eq!(Ok(2), source.first(&connection));
+    assert_eq!(Ok(Some(2)), source.first(&connection));
+    connection.execute("DELETE FROM numbers").unwrap();
+    assert_eq!(Ok(None::<i32>), source.first(&connection));
 }
 
 sql_function!(coalesce, coalesce_t, (x: types::Nullable<types::VarChar>, y: types::VarChar) -> types::VarChar);


### PR DESCRIPTION
Regardless of the input type, these functions return `NULL` on an empty
table. This both makes the behavior of these functions correctly mirror
the underlying database semantics, and also mirror the behavior of the
equivalent methods on `Iterator`. We need to make the same change for
`avg` and `sum`, but they're structured differently and will be a
separate PR.

Fixes #671.