### PR TITLE
Add some missing tests for PG prepared statement caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* Queries constructed using [`diesel::select`][select-0.11.0] now work properly
+  when [boxed][boxed-0.11.0].
+
+[select-0.11.0]: http://docs.diesel.rs/diesel/fn.select.html
+[boxed-0.11.0]: http://docs.diesel.rs/diesel/prelude/trait.BoxedDsl.html
+
 ### Changed
 
 * It is no longer possible to exhaustively match against

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -29,6 +29,7 @@ pub mod count;
 pub mod exists;
 pub mod expression_methods;
 #[doc(hidden)]
+#[macro_use]
 pub mod functions;
 #[doc(hidden)]
 pub mod grouped;


### PR DESCRIPTION
I'm looking into extracting the prepared statement caching for SQLite
and PG into a shared module (so I don't have to re-implement it *again*
for MySQL). While I was making sure I understood the requirements of the
existing implementations, I noticed that we had no tests for PG where
the statement is cached, but not on the type id.

The only cases where `QueryFragment::is_safe_to_cache_prepared` returns
`true`, but `QueryId::has_static_query_id` returns `false` is using
`Aliased`/`with` on PG, and boxed queries. Since these tests run with no
schema, boxing is easier to test.

When I wrote these tests, I noticed that attempting to run a boxed query
with no query source failed to compile. I've added the missing impl
required for it. It's copypasta from the other impl, with the from lines
deleted, but I liked this code better than with `to_sql_before_from`,
`to_sql_after_from`, `collect_binds_before_from`, etc pulled out. We can
always refactor if these impls end up having to change a lot.