### PR TITLE
Index columns used in migrations

### DIFF
--- a/migrations/mysql/20170211150830_index_columns_used_in_benchmarks/down.sql
+++ b/migrations/mysql/20170211150830_index_columns_used_in_benchmarks/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX users_hair_color;
+DROP INDEX posts_user_id;

--- a/migrations/mysql/20170211150830_index_columns_used_in_benchmarks/up.sql
+++ b/migrations/mysql/20170211150830_index_columns_used_in_benchmarks/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX users_hair_color ON users (hair_color(255));
+CREATE INDEX posts_user_id ON posts (user_id);

--- a/migrations/postgresql/20170211150830_index_columns_used_in_benchmarks/down.sql
+++ b/migrations/postgresql/20170211150830_index_columns_used_in_benchmarks/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX users_hair_color;
+DROP INDEX posts_user_id;

--- a/migrations/postgresql/20170211150830_index_columns_used_in_benchmarks/up.sql
+++ b/migrations/postgresql/20170211150830_index_columns_used_in_benchmarks/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX users_hair_color ON users (hair_color);
+CREATE INDEX posts_user_id ON posts (user_id);

--- a/migrations/sqlite/20170211150830_index_columns_used_in_benchmarks/down.sql
+++ b/migrations/sqlite/20170211150830_index_columns_used_in_benchmarks/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX users_hair_color;
+DROP INDEX posts_user_id;

--- a/migrations/sqlite/20170211150830_index_columns_used_in_benchmarks/up.sql
+++ b/migrations/sqlite/20170211150830_index_columns_used_in_benchmarks/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX users_hair_color ON users (hair_color);
+CREATE INDEX posts_user_id ON posts (user_id);


### PR DESCRIPTION
We were benchmarking queries without sufficient indices, causing
inconsistent performance characteristics. For example, changing
`hair_color.eq("black")` to
`hair_color.eq("black").or(hair_color.eq("blue"))` would cause SQLite to
perform between 2-10 times better depending on the number of rows. By
adding these indexes, we ensure that our benchmarks perform more
consistently