### PR TITLE
Add comments to generated migration files

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -74,6 +74,8 @@ fn run_migration_command(matches: &ArgMatches) {
             call_with_conn!(database_url, redo_latest_migration);
         }
         ("generate", Some(args)) => {
+            use std::io::Write;
+
             let migration_name = args.value_of("MIGRATION_NAME").unwrap();
             let version = migration_version(args);
             let versioned_name = format!("{}_{}", version, migration_name);
@@ -87,10 +89,13 @@ fn run_migration_command(matches: &ArgMatches) {
 
             let up_path = migration_dir.join("up.sql");
             println!("Creating {}", migration_dir_relative.join("up.sql").display());
-            fs::File::create(up_path).unwrap();
+            let mut up = fs::File::create(up_path).unwrap();
+            up.write_all(b"-- Your SQL goes here").unwrap();
+
             let down_path = migration_dir.join("down.sql");
             println!("Creating {}", migration_dir_relative.join("down.sql").display());
-            fs::File::create(down_path).unwrap();
+            let mut down = fs::File::create(down_path).unwrap();
+            down.write_all(b"-- This file should undo anything in `up.sql`").unwrap();
         }
         _ => unreachable!("The cli parser should prevent reaching here"),
     }

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -29,6 +29,37 @@ Creating migrations.\\d{14}_hello.down.sql\
 }
 
 #[test]
+fn migration_generate_creates_a_migration_with_initital_contents() {
+    let p = project("migration_name")
+        .folder("migrations")
+        .build();
+    let result = p.command("migration")
+        .arg("generate")
+        .arg("hello")
+        .run();
+    assert!(result.is_success(), "Command failed: {:?}", result);
+
+    let migrations = p.migrations();
+    let migration = &migrations[0];
+
+    let up = file_content(&migration.path().join("up.sql"));
+    let down = file_content(&migration.path().join("down.sql"));
+
+    assert_eq!(up.trim(), "-- Your SQL goes here");
+    assert_eq!(down.trim(), "-- This file should undo anything in `up.sql`");
+
+    fn file_content<P: AsRef<::std::path::Path>>(path: P) -> String {
+        use std::io::Read;
+
+        let mut file = ::std::fs::File::open(path).unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+
+        contents
+    }
+}
+
+#[test]
 fn migration_generate_doesnt_require_database_url_to_be_set() {
     let p = project("migration_name")
         .folder("migrations")


### PR DESCRIPTION
Previously, those where empty (0 bytes) files. This adds short comments
as initial content to tell users what they are expected to put in there.

Once we have more documentation for migrations specifically, we should
add a link to that as well.