### PR TITLE
Implement a shared `StatementCacheKey`

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -1,3 +1,4 @@
+mod statement_cache;
 mod transaction_manager;
 
 use backend::Backend;
@@ -7,6 +8,8 @@ use result::*;
 use types::HasSqlType;
 
 pub use self::transaction_manager::{TransactionManager, AnsiTransactionManager};
+#[doc(hidden)]
+pub use self::statement_cache::StatementCacheKey;
 
 pub trait SimpleConnection {
     #[doc(hidden)]

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -1,0 +1,54 @@
+use std::any::TypeId;
+use std::borrow::Cow;
+
+use backend::Backend;
+use query_builder::*;
+use result::QueryResult;
+
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+#[derive(Hash, PartialEq, Eq)]
+pub enum StatementCacheKey<DB: Backend> {
+    Type(TypeId),
+    Sql {
+        sql: String,
+        bind_types: Vec<DB::TypeMetadata>,
+    }
+}
+
+impl<DB> StatementCacheKey<DB> where
+    DB: Backend,
+    DB::QueryBuilder: Default,
+    DB::TypeMetadata: Clone,
+{
+    pub fn for_source<T>(source: &T, bind_types: &[DB::TypeMetadata])
+        -> QueryResult<Self> where
+            T: QueryFragment<DB> + QueryId,
+    {
+        match T::query_id() {
+            Some(id) => Ok(StatementCacheKey::Type(id)),
+            None => {
+                let sql = try!(Self::construct_sql(source));
+                Ok(StatementCacheKey::Sql {
+                    sql: sql,
+                    bind_types: bind_types.into(),
+                })
+            }
+        }
+    }
+
+    pub fn sql<T: QueryFragment<DB>>(&self, source: &T) -> QueryResult<Cow<str>> {
+        match *self {
+            StatementCacheKey::Type(_) => Self::construct_sql(source).map(Cow::Owned),
+            StatementCacheKey::Sql { ref sql, .. } => Ok(Cow::Borrowed(sql)),
+        }
+    }
+
+    fn construct_sql<T: QueryFragment<DB>>(source: &T) -> QueryResult<String> {
+        use result::Error::QueryBuilderError;
+
+        let mut query_builder = DB::QueryBuilder::default();
+        try!(source.to_sql(&mut query_builder).map_err(QueryBuilderError));
+        Ok(query_builder.finish())
+    }
+}

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -559,11 +559,11 @@ macro_rules! join_through {
 #[macro_export]
 macro_rules! debug_sql {
     ($query:expr) => {{
-        use $crate::query_builder::QueryFragment;
+        use $crate::query_builder::{QueryFragment, QueryBuilder};
         use $crate::query_builder::debug::DebugQueryBuilder;
         let mut query_builder = DebugQueryBuilder::new();
         QueryFragment::<$crate::backend::Debug>::to_sql(&$query, &mut query_builder).unwrap();
-        query_builder.sql
+        query_builder.finish()
     }};
 }
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -12,7 +12,9 @@ pub struct Binds {
 }
 
 impl Binds {
-    pub fn from_input_data(input: Vec<(MysqlType, Option<Vec<u8>>)>) -> Self {
+    pub fn from_input_data<Iter>(input: Iter) -> Self where
+        Iter: IntoIterator<Item=(MysqlType, Option<Vec<u8>>)>,
+    {
         let data = input.into_iter().map(|(tpe, bytes)| {
             BindData::for_input(tpe, bytes)
         }).collect();

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -103,8 +103,10 @@ impl MysqlConnection {
         try!(source.to_sql(&mut query_builder).map_err(Error::QueryBuilderError));
         let mut bind_collector = RawBytesBindCollector::<Mysql>::new();
         try!(source.collect_binds(&mut bind_collector));
-        let mut stmt = try!(self.raw_connection.prepare(&query_builder.sql));
-        try!(stmt.bind(bind_collector.binds));
+        let mut stmt = try!(self.raw_connection.prepare(&query_builder.finish()));
+        let metadata = bind_collector.metadata;
+        let binds = bind_collector.binds;
+        try!(stmt.bind(metadata.into_iter().zip(binds)));
         Ok(stmt)
     }
 }

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -34,7 +34,9 @@ impl Statement {
         self.did_an_error_occur()
     }
 
-    pub fn bind(&mut self, binds: Vec<(MysqlType, Option<Vec<u8>>)>) -> QueryResult<()> {
+    pub fn bind<Iter>(&mut self, binds: Iter) -> QueryResult<()> where
+        Iter: IntoIterator<Item=(MysqlType, Option<Vec<u8>>)>,
+    {
         let mut input_binds = Binds::from_input_data(binds);
         input_binds.with_mysql_binds(|bind_ptr| {
             // This relies on the invariant that the current value of `self.input_binds`

--- a/diesel/src/mysql/query_builder.rs
+++ b/diesel/src/mysql/query_builder.rs
@@ -4,7 +4,7 @@ use query_builder::{QueryBuilder, BuildQueryResult};
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct MysqlQueryBuilder {
-    pub sql: String,
+    sql: String,
 }
 
 impl MysqlQueryBuilder {
@@ -27,5 +27,9 @@ impl QueryBuilder<Mysql> for MysqlQueryBuilder {
 
     fn push_bind_param(&mut self) {
         self.push_sql("?");
+    }
+
+    fn finish(self) -> String {
+        self.sql
     }
 }

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -4,10 +4,10 @@ use backend::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use super::query_builder::PgQueryBuilder;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Pg;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct PgTypeMetadata {
     pub oid: u32,
     pub array_oid: u32,

--- a/diesel/src/pg/connection/stmt/cache.rs
+++ b/diesel/src/pg/connection/stmt/cache.rs
@@ -1,43 +1,17 @@
-use std::any::TypeId;
 use std::cell::RefCell;
 use std::collections::HashMap;
 #[cfg(test)]
 use std::ffi::CString;
 use std::rc::Rc;
 
-use pg::{Pg, PgQueryBuilder};
+use connection::StatementCacheKey;
+use pg::{Pg, PgTypeMetadata};
 use query_builder::{QueryFragment, QueryId};
 use result::QueryResult;
-use result::Error::QueryBuilderError;
 use super::{Query, RawConnection};
 
 pub struct StatementCache {
-    cache: RefCell<HashMap<StatementCacheKey, Rc<Query>>>,
-}
-
-#[derive(Hash, PartialEq, Eq)]
-enum StatementCacheKey {
-    Type(TypeId),
-    Query {
-        sql: String,
-        bind_types: Vec<u32>,
-    }
-}
-
-impl StatementCacheKey {
-    fn sql(&self) -> Option<&str> {
-        match *self {
-            StatementCacheKey::Query { ref sql, .. } => Some(&*sql),
-            _ => None
-        }
-    }
-
-    fn bind_types(&self) -> Option<&Vec<u32>> {
-        match *self {
-            StatementCacheKey::Query { ref bind_types, .. } => Some(bind_types),
-            _ => None
-        }
-    }
+    cache: RefCell<HashMap<StatementCacheKey<Pg>, Rc<Query>>>,
 }
 
 impl StatementCache {
@@ -51,36 +25,26 @@ impl StatementCache {
         &self,
         conn: &RawConnection,
         source: &T,
-        bind_types: Vec<u32>,
+        bind_types: &[PgTypeMetadata],
     ) -> QueryResult<Rc<Query>> {
-        use std::borrow::Cow;
         use std::collections::hash_map::Entry::{Occupied, Vacant};
 
         let cache_suffix = self.cache.borrow().len() + 1;
         let mut cache = self.cache.borrow_mut();
-        let (cache_key, maybe_binds) = try!(cache_key(source, bind_types));
+        let cache_key = try!(StatementCacheKey::for_source(source, bind_types));
 
         match cache.entry(cache_key) {
             Occupied(entry) => Ok(entry.get().clone()),
             Vacant(entry) => {
                 let statement = {
-                    let sql = match entry.key().sql() {
-                        Some(sql) => Cow::Borrowed(sql),
-                        None => Cow::Owned(try!(to_sql(source))),
-                    };
-
+                    let sql = try!(entry.key().sql(source));
                     let name = format!("__diesel_stmt_{}", cache_suffix);
-
-                    let bind_types = entry.key()
-                        .bind_types()
-                        .or_else(|| maybe_binds.as_ref())
-                        .expect("Missing bind types");
 
                     Rc::new(try!(Query::prepare(
                         conn,
                         &sql,
                         &name,
-                        &bind_types,
+                        bind_types,
                     )))
                 };
 
@@ -103,29 +67,5 @@ impl StatementCache {
             }).collect::<Vec<_>>();
         statement_names.dedup();
         statement_names
-    }
-}
-
-fn to_sql<T: QueryFragment<Pg>>(source: &T)
-    -> QueryResult<String>
-{
-    let mut query_builder = PgQueryBuilder::new();
-    try!(source.to_sql(&mut query_builder).map_err(QueryBuilderError));
-    Ok(query_builder.sql)
-}
-
-fn cache_key<T: QueryFragment<Pg> + QueryId>(
-    source: &T,
-    bind_types: Vec<u32>,
-) -> QueryResult<(StatementCacheKey, Option<Vec<u32>>)> {
-    match T::query_id() {
-        Some(id) => Ok((StatementCacheKey::Type(id), Some(bind_types))),
-        None => Ok((
-            StatementCacheKey::Query {
-                sql: try!(to_sql(source)),
-                bind_types: bind_types
-            },
-            None,
-        )),
     }
 }

--- a/diesel/src/pg/query_builder.rs
+++ b/diesel/src/pg/query_builder.rs
@@ -4,7 +4,7 @@ use query_builder::{QueryBuilder, BuildQueryResult};
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct PgQueryBuilder {
-    pub sql: String,
+    sql: String,
     bind_idx: u32,
 }
 
@@ -30,5 +30,9 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
         self.bind_idx += 1;
         let sql = format!("${}", self.bind_idx);
         self.push_sql(&sql);
+    }
+
+    fn finish(self) -> String {
+        self.sql
     }
 }

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -7,12 +7,14 @@ pub trait BindCollector<DB: Backend> {
 
 #[derive(Debug)]
 pub struct RawBytesBindCollector<DB: Backend + TypeMetadata> {
-    pub binds: Vec<(DB::TypeMetadata, Option<Vec<u8>>)>,
+    pub metadata: Vec<DB::TypeMetadata>,
+    pub binds: Vec<Option<Vec<u8>>>,
 }
 
 impl<DB: Backend + TypeMetadata> RawBytesBindCollector<DB> {
     pub fn new() -> Self {
         RawBytesBindCollector {
+            metadata: Vec::new(),
             binds: Vec::new(),
         }
     }
@@ -20,7 +22,7 @@ impl<DB: Backend + TypeMetadata> RawBytesBindCollector<DB> {
 
 impl<DB: Backend + TypeMetadata> BindCollector<DB> for RawBytesBindCollector<DB> {
     fn push_bound_value<T>(&mut self, bind: Option<Vec<u8>>) where DB: HasSqlType<T> {
-        let metadata = <DB as HasSqlType<T>>::metadata();
-        self.binds.push((metadata, bind));
+        self.metadata.push(<DB as HasSqlType<T>>::metadata());
+        self.binds.push(bind);
     }
 }

--- a/diesel/src/query_builder/debug.rs
+++ b/diesel/src/query_builder/debug.rs
@@ -4,8 +4,7 @@ use super::{QueryBuilder, BuildQueryResult};
 #[doc(hidden)]
 #[derive(Debug, Default)]
 pub struct DebugQueryBuilder {
-    pub sql: String,
-    pub bind_types: Vec<u32>,
+    sql: String,
 }
 
 impl DebugQueryBuilder {
@@ -28,5 +27,9 @@ impl QueryBuilder<Debug> for DebugQueryBuilder {
 
     fn push_bind_param(&mut self) {
         self.push_sql("?");
+    }
+
+    fn finish(self) -> String {
+        self.sql
     }
 }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -57,6 +57,7 @@ pub trait QueryBuilder<DB: Backend> {
     fn push_sql(&mut self, sql: &str);
     fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult;
     fn push_bind_param(&mut self);
+    fn finish(self) -> String;
 }
 
 /// A complete SQL query with a return type. This can be a select statement, or

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -5,10 +5,11 @@ use query_builder::bind_collector::RawBytesBindCollector;
 use super::connection::SqliteValue;
 use super::query_builder::SqliteQueryBuilder;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Sqlite;
 
-#[allow(missing_debug_implementations, missing_copy_implementations)]
+#[allow(missing_debug_implementations)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub enum SqliteType {
     Binary,
     Text,

--- a/diesel/src/sqlite/query_builder/mod.rs
+++ b/diesel/src/sqlite/query_builder/mod.rs
@@ -8,7 +8,7 @@ pub mod nodes;
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct SqliteQueryBuilder {
-    pub sql: String,
+    sql: String,
 }
 
 impl SqliteQueryBuilder {
@@ -31,5 +31,9 @@ impl QueryBuilder<Sqlite> for SqliteQueryBuilder {
 
     fn push_bind_param(&mut self) {
         self.push_sql("?");
+    }
+
+    fn finish(self) -> String {
+        self.sql
     }
 }


### PR DESCRIPTION
This is part of a refactoring to have a shared `StatementCache` between
all three backends because I don't want to write this code a third time
for MySQL.

A refresher on the situation with prepared statements. For a given
query, it will fall into one of three categories:

- Unsafe to cache. This means that the query could potentially generate
  an unbounded number of prepared statements. Only insert queries
  (SQL varies based on number of records inserted), queries containing
  `IN`/`NOT IN` (SQL varies based on number of items on the right side),
  and queries containing `SqlLiteral` (SQL varies based on who the fuck
  knows because we didn't generate) fall into this category.
- Safe to cache, but can't be identified by type. These are queries
  where the SQL can change without the Rust type changing, but there is
  an upper bound on the number of queries it could generate. Generally
  only boxed select statements fall into this category.
- Safe to cache, uniquely identified by type. The majority of queries
  will fall into this category. These are also the happy path, as we can
  skip the query builder entirely for subsequent executions.

The PG code also goes through a completely separate code path for
queries which aren't safe to cache. It doesn't need to do this though,
and I'm going to refactor it to not do it in the future.

For queries which are cached by SQL instead of type, the types of the
bind parameters also matter for PG. They don't matter for SQLite or
MySQL, but we could potentially save some allocations by holding onto
that vector anyway. The wins from doing this would be questionable at
best.

A few notes on things that might be funky in the implementation:

I opted for a `where DB::QueryBuilder: Default` bound instead of adding
a `query_buidler()` function to `Backend` because I do not want to rule
out future backends requiring additional constructor parameters to their
query builders (those backends just won't be able to use this prepared
statement cache).

I had to derive `Hash`, `PartialEq`, and `Eq` on the structs themselves
because `#[derive]` generates unnecessary bounds. This felt less bad
than writing manual impls.

There's a handful of additional optimizations I could do here (not allocating on the "cache on SQL" case, implementing `PgTypeMetadata` to only hash on oid instead of all fields, etc) but I don't think any of them will result in meaningful performance wins.