### PR TITLE
Remove the separate code path for non-cached statements on PG

### DIFF
--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -47,29 +47,6 @@ impl RawConnection {
         RawResult::new(PQexec(self.internal_connection, query), self)
     }
 
-    pub unsafe fn exec_params(
-        &self,
-        query: *const libc::c_char,
-        param_count: libc::c_int,
-        param_types: *const Oid,
-        param_values: *const *const libc::c_char,
-        param_lengths: *const libc::c_int,
-        param_formats: *const libc::c_int,
-        result_format: libc::c_int,
-    ) -> QueryResult<RawResult> {
-        let ptr = PQexecParams(
-            self.internal_connection,
-            query,
-            param_count,
-            param_types,
-            param_values,
-            param_lengths,
-            param_formats,
-            result_format,
-        );
-        RawResult::new(ptr, self)
-    }
-
     pub unsafe fn exec_prepared(
         &self,
         stmt_name: *const libc::c_char,


### PR DESCRIPTION
In the case where a statement isn't safe to cache, we go through a
separate code path to use `PQexecParams` instead of `PQprepare` and
`PQexecPrepared`. `PQexecParams` does effectively the same thing that
we're doing now (preparing the statement with no name, and immediately
executing it).

The old code was slightly more efficient since `PQexecParams` avoided
sending a `Sync` message between the `Parse` and `Bind` messages. The
new code ends up doing one extra round trip, and one extra check for
errors. However, the completely-uncached case is the least used code
path, and the performance difference is minimal even when we hit it.
For that reason, I don't think it's worth the additional code.