### PR TITLE
Allow `now` to be used as a timestamptz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 [max-0.11.0]: http://docs.diesel.rs/diesel/expression/dsl/fn.max.html
 [min-0.11.0]: http://docs.diesel.rs/diesel/expression/dsl/fn.min.html
 
+* [`now`][now-0.11.0] can now be used as an expression of type `Timestamptz`.
+
+[now-0.11.0]: http://docs.diesel.rs/diesel/expression/dsl/struct.now.html
+
 ## [0.10.1] - 2017-02-08
 
 ### Fixed

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -1,0 +1,75 @@
+use std::marker::PhantomData;
+
+use backend::Backend;
+use expression::{Expression, SelectableExpression, NonAggregate};
+use query_builder::*;
+use result::QueryResult;
+
+#[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
+/// Coerces an expression to be another type. No checks are performed to ensure
+/// that the new type is valid in all positions that the previous type was.
+/// This does not perform an actual cast, it just lies to our type system.
+///
+/// This is used for a few expressions where we know that the types are actually
+/// always interchangeable. (Examples of this include `Timestamp` vs
+/// `Timestamptz`, `VarChar` vs `Text`, and `Json` vs `Jsonb`).
+///
+/// This struct should not be considered a general solution to equivalent types.
+/// It is a short term workaround for expressions which are known to be commonly
+/// used.
+pub struct Coerce<T, ST> {
+    expr: T,
+    _marker: PhantomData<ST>,
+}
+
+impl<T, ST> Coerce<T, ST> {
+    pub fn new(expr: T) -> Self {
+        Coerce {
+            expr: expr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, ST> Expression for Coerce<T, ST> where
+    T: Expression,
+{
+    type SqlType = ST;
+}
+
+impl<T, ST, QS> SelectableExpression<QS> for Coerce<T, ST> where
+    T: SelectableExpression<QS>,
+{
+}
+
+impl<T, ST, DB> QueryFragment<DB> for Coerce<T, ST> where
+    T: QueryFragment<DB>,
+    DB: Backend,
+{
+    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+        self.expr.to_sql(out)
+    }
+
+    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+        self.expr.collect_binds(out)
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        self.expr.is_safe_to_cache_prepared()
+    }
+}
+
+impl<T: QueryId, ST: 'static> QueryId for Coerce<T, ST> {
+    type QueryId = Coerce<T::QueryId, ST>;
+
+    fn has_static_query_id() -> bool {
+        true
+    }
+}
+
+impl<T, ST> NonAggregate for Coerce<T, ST> where
+    T: NonAggregate,
+    Coerce<T, ST>: Expression,
+{
+}

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -42,3 +42,19 @@ operator_allowed!(now, Sub, sub);
 sql_function!(date, date_t, (x: Timestamp) -> Date,
 "Represents the SQL DATE() function. The argument should be a Timestamp
 expression, and the return value will be an expression of type Date");
+
+#[cfg(feature="postgres")]
+use expression::AsExpression;
+#[cfg(feature="postgres")]
+use expression::coerce::Coerce;
+#[cfg(feature="postgres")]
+use types::Timestamptz;
+
+#[cfg(feature="postgres")]
+impl AsExpression<Timestamptz> for now {
+    type Expression = Coerce<now, Timestamptz>;
+
+    fn as_expression(self) -> Self::Expression {
+        Coerce::new(self)
+    }
+}

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -24,6 +24,8 @@ pub mod array_comparison;
 #[doc(hidden)]
 pub mod bound;
 #[doc(hidden)]
+pub mod coerce;
+#[doc(hidden)]
 pub mod count;
 #[doc(hidden)]
 pub mod exists;


### PR DESCRIPTION
There are two things wrong with this PR, but I still think this is the
best short term solution.

The first and most glaringly obviously wrong thing about it is that the
type of `NOW()` **IS** `timestamptz`. However, since we currently have
that defined as a PG specific type, we can't set the type of the
expression properly. Timestamp with/without timezone is a thing in the
SQL standard, (it's just ignored by SQLite). I need to examine how MySQL
handles it and figure out how to promote it to a more general type.
However, I don't want to deal with that right now (and probably not
before 0.11). I do still want to fix this issue, so here we are.

We also have a more general problem of type equivalence that we need to
address. `Json` expressions can always be used where a `Jsonb` is
expected. `Text` with `VarChar` (though we've skirted that one by making
them type aliases). Again, this is a deeper problem that I don't
currently have a solution in mind for.

So in the short term, this gives us a way to punt on the problem for a
while. For the most common cases that crop up, we can write
`AsExpression` impls for those cases when we notice them.

Fixes #685.