### PR TITLE
`impl FromSqlRow<Nullable<Array<ST>>, Pg> for Option<Vec<T>>`

### DIFF
--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -71,6 +71,16 @@ impl<T, ST> FromSqlRow<Array<ST>, Pg> for Vec<T> where
     }
 }
 
+#[cfg(not(feature="unstable"))]
+impl<T, ST> FromSqlRow<Nullable<Array<ST>>, Pg> for Option<Vec<T>> where
+    Pg: HasSqlType<ST>,
+    Option<Vec<T>>: FromSql<Nullable<Array<ST>>, Pg>,
+{
+    fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error+Send+Sync>> {
+        FromSql::<Nullable<Array<ST>>, Pg>::from_sql(row.take())
+    }
+}
+
 impl<T, ST> Queryable<Array<ST>, Pg> for Vec<T> where
     T: FromSql<ST, Pg> + Queryable<ST, Pg>,
     Pg: HasSqlType<ST>,


### PR DESCRIPTION
Normally this impl gets generated by the macros invoked for various
types. However, since array is generic, we don't use that macro. I had
missed this impl, and attempting to have a nullable array would fail to
compile. As part of testing this I've removed the "test array for
literally every type" test, and just tested a few concrete types. I
don't think this severely hurts coverage.