### PR TITLE
Provide a more helpful error message when to few bytes were received

### DIFF
--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -10,6 +10,9 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 2, "Received more than 2 bytes decoding i16. \
                       Was an Integer expression accidentally identified as SmallInt?");
+        debug_assert!(bytes.len() == 2, "Received fewer than 2 bytes decoding i16. \
+                      Was an expression of a different type accidentally identified \
+                      as SmallInt?");
         bytes.read_i16::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
@@ -27,6 +30,8 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Integer, DB> for i32 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 4, "Received more than 4 bytes decoding i32. \
                       Was a BigInteger expression accidentally identified as Integer?");
+        debug_assert!(bytes.len() == 4, "Received fewer than 4 bytes decoding i32. \
+                      Was a SmallInteger expression accidentally identified as Integer?");
         bytes.read_i32::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }
@@ -44,6 +49,8 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::BigInt, DB> for i64 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 8, "Received more than 8 bytes decoding i64. \
                       Was an expression of a different type misidentified as BigInteger?");
+        debug_assert!(bytes.len() == 8, "Received fewer than 8 bytes decoding i64. \
+                      Was an Integer expression misidentified as BigInteger?");
         bytes.read_i64::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
 }


### PR DESCRIPTION
We have a debug check for the semi-common error of mislabeling a
field/expression to a type which is too small. We originally added these
because the value would actually deserialize successfully, but to the
wrong value. We didn't add checks for the "too few bytes" case, as it
would have errored anyway and seemed less common.

However, the error message received when one does make this mistake is
not terribly helpful. We can add an additional check in debug mode to
give a bit more information when someone does make this mistake.

We should see if we can provide some more general improvements to an
error generated by `DeserializationError` in the future. Including the
column name would go a long way, but is a bit larger in scope.

Fixes #696.