### PR TITLE
rm TransactionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [now-0.11.0]: http://docs.diesel.rs/diesel/expression/dsl/struct.now.html
 
+* [`Connection::transaction`][transaction-0.11.0] now returns your error
+  directly instead of wrapping it in `TransactionError`. It requires that the
+  error implement `From<diesel::result::Error>`
+
+[transaction-0.11.0]: http://docs.diesel.rs/diesel/connection/trait.Connection.html#method.transaction
+
+### Removed
+
+* `result::TransactionError`
+* `result::TransactionResult`
+
 ## [0.10.1] - 2017-02-08
 
 ### Fixed

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -123,7 +123,7 @@ pub mod prelude {
     pub use insertable::Insertable;
     pub use query_dsl::*;
     pub use query_source::{QuerySource, Queryable, Table, Column, JoinTo};
-    pub use result::{QueryResult, TransactionError, TransactionResult, ConnectionError, ConnectionResult, OptionalExtension};
+    pub use result::{QueryResult, ConnectionError, ConnectionResult, OptionalExtension};
 }
 
 pub use prelude::*;

--- a/diesel/src/migrations/migration_error.rs
+++ b/diesel/src/migrations/migration_error.rs
@@ -1,4 +1,4 @@
-use result::{self, TransactionError};
+use result;
 
 use std::convert::From;
 use std::{fmt, io};
@@ -97,15 +97,5 @@ impl From<result::Error> for RunMigrationsError {
 impl From<io::Error> for RunMigrationsError {
     fn from(e: io::Error) -> Self {
         RunMigrationsError::MigrationError(e.into())
-    }
-}
-
-impl From<TransactionError<RunMigrationsError>> for RunMigrationsError {
-    fn from(e: TransactionError<RunMigrationsError>) -> Self {
-        use result::TransactionError::*;
-        match e {
-            CouldntCreateTransaction(e) => RunMigrationsError::from(e),
-            UserReturnedError(e) => e,
-        }
     }
 }

--- a/diesel/src/migrations/mod.rs
+++ b/diesel/src/migrations/mod.rs
@@ -227,20 +227,19 @@ fn run_migration<Conn>(conn: &Conn, migration: &Migration, output: &mut Write)
         try!(migration.run(conn));
         try!(conn.insert_new_migration(migration.version()));
         Ok(())
-    }).map_err(|e| e.into())
+    })
 }
 
 fn revert_migration<Conn: Connection>(conn: &Conn, migration: Box<Migration>, output: &mut Write)
     -> Result<(), RunMigrationsError>
 {
-    try!(conn.transaction(|| {
+    conn.transaction(|| {
         try!(writeln!(output, "Rolling back migration {}", migration.version()));
         try!(migration.revert(conn));
         let target = __diesel_schema_migrations.filter(version.eq(migration.version()));
         try!(::delete(target).execute(conn));
         Ok(())
-    }));
-    Ok(())
+    })
 }
 
 /// Returns the directory containing migrations. Will look at for


### PR DESCRIPTION
This was always a fairly clunky API. Its main upside was that type
inference was able to figure out the error type in more cases than the
current implementation does. It has much larger downsides though. The
most common case is that you're just returning `diesel::result::Error`
anyway, so this enum was just an annoyance. If you weren't returning
that, you were probably returning an application specific error which
has a variant for `diesel::result::Error`, and now also had to handle
this additional type. It also turns out that
[`TransactionError<Box<::std::error::Error>>` doesn't implement
`::std::error::Error`](https://github.com/rust-lang/rust/pull/39792).

The new API might require explicitly stating the error type in a few
more places (in particular `try!(conn.transaction(|| try!(query);
Ok(()))); Ok(...)` stopped inferring), but I think that this will end up
being more ergonomic for most uses.