### PR TITLE
Fix `infer_table_from_schema!` when no schema name is given

### DIFF
--- a/diesel_tests/tests/custom_schemas.rs
+++ b/diesel_tests/tests/custom_schemas.rs
@@ -54,3 +54,32 @@ mod using_infer_table_from_schema {
         assert_eq!(Ok(vec![1]), users);
     }
 }
+
+mod using_infer_table_from_schema_with_default_schema {
+    use super::*;
+    mod infer_users {
+        #[cfg(feature="backend_specific_database_url")]
+        infer_table_from_schema!("dotenv:PG_DATABASE_URL", "users");
+        #[cfg(not(feature="backend_specific_database_url"))]
+        infer_table_from_schema!("dotenv:DATABASE_URL", "users");
+    }
+    use self::infer_users::users;
+
+    #[derive(Insertable)]
+    #[table_name="users"]
+    struct NewUser<'a> {
+        id: i32,
+        name: &'a str,
+    }
+
+    #[test]
+    fn custom_schemas_are_loaded_by_infer_table_from_schema() {
+        let conn = connection();
+        insert(&NewUser { id: 1, name: "Sean" }).into(users::table)
+            .execute(&conn).unwrap();
+        let users = users::table.select(users::id)
+            .load(&conn);
+
+        assert_eq!(Ok(vec![1]), users);
+    }
+}


### PR DESCRIPTION
When no schema is given, we are incorrectly querying `WHERE schema_name
= NULL`, which is nonsense and not what we want to write. It appears
this went uncaught because `infer_schema!` always gives a schema name to
`infer_table_from_schema!`

Fixes #704