### PR TITLE
Ensure aggregate functions enforce the column is from the right table

### DIFF
--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -51,9 +51,9 @@ macro_rules! fold_function {
 
         impl_query_id!($type_name<T>);
 
-        impl<ST, T, QS> SelectableExpression<QS> for $type_name<T> where
-            ST: Foldable,
-            T: Expression<SqlType=ST>,
+        impl<T, QS> SelectableExpression<QS> for $type_name<T> where
+            $type_name<T>: Expression,
+            T: SelectableExpression<QS>,
         {
         }
     }

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -52,6 +52,7 @@ macro_rules! ord_function {
 
         impl<T, QS> SelectableExpression<QS> for $type_name<T> where
             $type_name<T>: Expression,
+            T: SelectableExpression<QS>,
         {
         }
     }

--- a/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    use diesel::expression::dsl::*;
+    let source = users::table.select(sum(posts::id));
+    //~^ ERROR E0277
+    let source = users::table.select(avg(posts::id));
+    //~^ ERROR E0277
+    let source = users::table.select(max(posts::id));
+    //~^ ERROR E0277
+    let source = users::table.select(min(posts::id));
+    //~^ ERROR E0277
+}


### PR DESCRIPTION
While working on #621, I noticed that these impls were incorrect and
could be used to compile an incorrect query. I've corrected the impls
and added the appropriate compile-fail test.

I'm not sure if this was just an oversight or if I intentionally did
this to avoid nullability somewhere. The latter is no longer relevant
since we always make these expressions nullable now.
