### PR TITLE
Use associated types for `SelectableExpression`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [transaction-0.11.0]: http://docs.diesel.rs/diesel/connection/trait.Connection.html#method.transaction
 
+* The way tuples of columns from the right side of left outer joins interact
+  with `.select` has changed. If you are deserializing into an option of a tuple
+  (instead of a tuple of options), you will need to explicitly call
+  `.nullable()`. (e.g. `.select(users::name, (posts::title,
+  posts::body).nullable())`)
+
 ### Removed
 
 * `result::TransactionError`

--- a/diesel/src/expression/aliased.rs
+++ b/diesel/src/expression/aliased.rs
@@ -20,9 +20,6 @@ impl<'a, Expr> Aliased<'a, Expr> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct FromEverywhere;
-
 impl<'a, T> Expression for Aliased<'a, T> where
     T: Expression,
 {
@@ -57,7 +54,9 @@ impl<'a, T> QueryId for Aliased<'a, T> {
 // FIXME This is incorrect, should only be selectable from WithQuerySource
 impl<'a, T, QS> SelectableExpression<QS> for Aliased<'a, T> where
     Aliased<'a, T>: Expression,
+    T: SelectableExpression<QS>,
 {
+    type SqlTypeForSelect = T::SqlTypeForSelect;
 }
 
 impl<'a, T: Expression + Copy> QuerySource for Aliased<'a, T> {

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -57,6 +57,7 @@ impl<T, U, QS> SelectableExpression<QS> for In<T, U> where
     T: SelectableExpression<QS>,
     U: SelectableExpression<QS>,
 {
+    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<T, U, QS> SelectableExpression<QS> for NotIn<T, U> where
@@ -64,6 +65,7 @@ impl<T, U, QS> SelectableExpression<QS> for NotIn<T, U> where
     T: SelectableExpression<QS>,
     U: SelectableExpression<QS>,
 {
+    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<T, U> NonAggregate for In<T, U> where
@@ -163,9 +165,10 @@ pub trait MaybeEmpty {
     fn is_empty(&self) -> bool;
 }
 
-impl<ST, S, F, W, O, L, Of> AsInExpression<ST>
-    for SelectStatement<ST, S, F, W, O, L, Of> where
-        Subselect<SelectStatement<ST, S, F, W, O, L, Of>, ST>: Expression<SqlType=ST>,
+impl<ST, S, F, W, O, L, Of, G> AsInExpression<ST>
+    for SelectStatement<S, F, W, O, L, Of, G> where
+        SelectStatement<S, F, W, O, L, Of, G>: Query<SqlType=ST>,
+        Subselect<SelectStatement<S, F, W, O, L, Of>, ST>: Expression,
 {
     type InExpression = Subselect<Self, ST>;
 
@@ -202,6 +205,7 @@ impl<T, QS> SelectableExpression<QS> for Many<T> where
     Many<T>: Expression,
     T: SelectableExpression<QS>,
 {
+    type SqlTypeForSelect = T::SqlTypeForSelect;
 }
 
 impl<T, DB> QueryFragment<DB> for Many<T> where
@@ -251,6 +255,7 @@ impl<T, ST, QS> SelectableExpression<QS> for Subselect<T, ST> where
     Subselect<T, ST>: Expression,
     T: Query,
 {
+    type SqlTypeForSelect = ST;
 }
 
 impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST> where

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -66,6 +66,7 @@ impl<T: QueryId, U> QueryId for Bound<T, U> {
 impl<T, U, QS> SelectableExpression<QS> for Bound<T, U> where
     Bound<T, U>: Expression,
 {
+    type SqlTypeForSelect = T;
 }
 
 impl<T, U> NonAggregate for Bound<T, U> where

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -41,6 +41,7 @@ impl<T, ST> Expression for Coerce<T, ST> where
 impl<T, ST, QS> SelectableExpression<QS> for Coerce<T, ST> where
     T: SelectableExpression<QS>,
 {
+    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<T, ST, DB> QueryFragment<DB> for Coerce<T, ST> where

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -80,6 +80,7 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
 impl_query_id!(Count<T>);
 
 impl<T: Expression, QS> SelectableExpression<QS> for Count<T> {
+    type SqlTypeForSelect = BigInt;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -106,6 +107,7 @@ impl<DB: Backend> QueryFragment<DB> for CountStar {
 }
 
 impl<QS> SelectableExpression<QS> for CountStar {
+    type SqlTypeForSelect = BigInt;
 }
 
 impl_query_id!(CountStar);

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -52,6 +52,7 @@ impl<T> Expression for Exists<T> where
 impl<T, QS> SelectableExpression<QS> for Exists<T> where
     Exists<T>: Expression,
 {
+    type SqlTypeForSelect = Bool;
 }
 
 impl<T> NonAggregate for Exists<T> {

--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -307,7 +307,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # fn main() {
     /// #     use self::users::dsl::*;
     /// #     let order = "name";
-    /// let ordering: Box<BoxableExpression<users, (), DB, SqlType=()>> =
+    /// let ordering: Box<BoxableExpression<users, DB, SqlType=(), SqlTypeForSelect=()>> =
     ///     if order == "name" {
     ///         Box::new(name.desc())
     ///     } else {

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -55,6 +55,7 @@ macro_rules! fold_function {
             $type_name<T>: Expression,
             T: SelectableExpression<QS>,
         {
+            type SqlTypeForSelect = Self::SqlType;
         }
     }
 }

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -51,9 +51,9 @@ macro_rules! fold_function {
 
         impl_query_id!($type_name<T>);
 
-        impl<ST, T, QS> SelectableExpression<QS> for $type_name<T> where
-            ST: Foldable,
-            T: Expression<SqlType=ST>,
+        impl<T, QS> SelectableExpression<QS> for $type_name<T> where
+            $type_name<T>: Expression,
+            T: SelectableExpression<QS>,
         {
         }
     }

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -54,6 +54,7 @@ macro_rules! ord_function {
             $type_name<T>: Expression,
             T: SelectableExpression<QS>,
         {
+            type SqlTypeForSelect = Self::SqlType;
         }
     }
 }

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -52,6 +52,7 @@ macro_rules! ord_function {
 
         impl<T, QS> SelectableExpression<QS> for $type_name<T> where
             $type_name<T>: Expression,
+            T: SelectableExpression<QS>,
         {
         }
     }

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -15,6 +15,7 @@ impl Expression for now {
 }
 
 impl<QS> SelectableExpression<QS> for now {
+    type SqlTypeForSelect = Timestamp;
 }
 
 impl NonAggregate for now {

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -65,6 +65,7 @@ macro_rules! sql_function_body {
             $($arg_name: $crate::expression::SelectableExpression<QS>,)*
             $struct_name<$($arg_name),*>: $crate::expression::Expression,
         {
+            type SqlTypeForSelect = Self::SqlType;
         }
 
         #[allow(non_camel_case_types)]
@@ -132,6 +133,7 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
         }
 
         impl<QS> $crate::expression::SelectableExpression<QS> for $type_name {
+            type SqlTypeForSelect = $return_type;
         }
 
         impl $crate::expression::NonAggregate for $type_name {

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -34,6 +34,7 @@ impl<T, QS> SelectableExpression<QS> for Grouped<T> where
     T: SelectableExpression<QS>,
     Grouped<T>: Expression,
 {
+    type SqlTypeForSelect = T::SqlTypeForSelect;
 }
 
 impl<T: NonAggregate> NonAggregate for Grouped<T> where

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -37,10 +37,14 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
     }
 }
 
+/// This impl relies on the fact that the only time `T::SqlType` will differ
+/// from `T::SqlTypeForSelect` is to make the right side of a left join become
+/// nullable.
 impl<T, QS> SelectableExpression<QS> for Nullable<T> where
     T: SelectableExpression<QS>,
     Nullable<T>: Expression,
 {
+    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<T: QueryId> QueryId for Nullable<T> {

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -59,6 +59,7 @@ macro_rules! numeric_operation {
             Rhs: SelectableExpression<QS>,
             $name<Lhs, Rhs>: Expression,
         {
+            type SqlTypeForSelect = Self::SqlType;
         }
 
         impl<Lhs, Rhs> NonAggregate for $name<Lhs, Rhs> where

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -30,6 +30,7 @@ macro_rules! infix_predicate_body {
             T: $crate::expression::SelectableExpression<QS>,
             U: $crate::expression::SelectableExpression<QS>,
         {
+            type SqlTypeForSelect = Self::SqlType;
         }
 
         impl<T, U> $crate::expression::NonAggregate for $name<T, U> where
@@ -219,6 +220,7 @@ macro_rules! postfix_predicate_body {
         impl<T, QS> $crate::expression::SelectableExpression<QS> for $name<T> where
             T: $crate::expression::SelectableExpression<QS>,
         {
+            type SqlTypeForSelect = Self::SqlType;
         }
 
         impl<T> $crate::expression::NonAggregate for $name<T> where

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -51,6 +51,7 @@ impl<ST> Query for SqlLiteral<ST> {
 }
 
 impl<QS, ST> SelectableExpression<QS> for SqlLiteral<ST> {
+    type SqlTypeForSelect = ST;
 }
 
 impl<ST> NonAggregate for SqlLiteral<ST> {

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -143,6 +143,7 @@ impl<Expr, QS> SelectableExpression<QS> for Any<Expr> where
     Any<Expr>: Expression,
     Expr: SelectableExpression<QS>,
 {
+    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<Expr> NonAggregate for Any<Expr> where
@@ -216,6 +217,7 @@ impl<Expr, QS> SelectableExpression<QS> for All<Expr> where
     All<Expr>: Expression,
     Expr: SelectableExpression<QS>,
 {
+    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<Expr> NonAggregate for All<Expr> where

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -1,12 +1,10 @@
-use std::marker::PhantomData;
-
 use backend::*;
 use expression::{AsExpression, Expression, SelectableExpression, NonAggregate};
 use pg::{Pg, PgQueryBuilder};
 use query_builder::*;
 use query_builder::debug::DebugQueryBuilder;
 use result::QueryResult;
-use types::{Array, HasSqlType};
+use types::Array;
 
 /// Creates a PostgreSQL `ANY` expression.
 ///
@@ -38,8 +36,7 @@ use types::{Array, HasSqlType};
 /// assert_eq!(Ok(vec![sean, jim]), data.load(&connection));
 /// # }
 /// ```
-pub fn any<ST, T>(vals: T) -> Any<T::Expression, ST> where
-    Pg: HasSqlType<ST>,
+pub fn any<ST, T>(vals: T) -> Any<T::Expression> where
     T: AsExpression<Array<ST>>,
 {
     Any::new(vals.as_expression())
@@ -74,8 +71,7 @@ pub fn any<ST, T>(vals: T) -> Any<T::Expression, ST> where
 /// assert_eq!(Ok(vec![tess]), data.load(&connection));
 /// # }
 /// ```
-pub fn all<ST, T>(vals: T) -> All<T::Expression, ST> where
-    Pg: HasSqlType<ST>,
+pub fn all<ST, T>(vals: T) -> All<T::Expression> where
     T: AsExpression<Array<ST>>,
 {
     All::new(vals.as_expression())
@@ -83,28 +79,25 @@ pub fn all<ST, T>(vals: T) -> All<T::Expression, ST> where
 
 #[doc(hidden)]
 #[derive(Debug, Copy, Clone)]
-pub struct Any<Expr, ST> {
+pub struct Any<Expr> {
     expr: Expr,
-    _marker: PhantomData<ST>,
 }
 
-impl<Expr, ST> Any<Expr, ST> {
+impl<Expr> Any<Expr> {
     fn new(expr: Expr) -> Self {
         Any {
             expr: expr,
-            _marker: PhantomData,
         }
     }
 }
 
-impl<Expr, ST> Expression for Any<Expr, ST> where
-    Pg: HasSqlType<ST>,
+impl<Expr, ST> Expression for Any<Expr> where
     Expr: Expression<SqlType=Array<ST>>,
 {
     type SqlType = ST;
 }
 
-impl<Expr, ST> QueryFragment<Pg> for Any<Expr, ST> where
+impl<Expr> QueryFragment<Pg> for Any<Expr> where
     Expr: QueryFragment<Pg>,
 {
     fn to_sql(&self, out: &mut PgQueryBuilder) -> BuildQueryResult {
@@ -124,7 +117,7 @@ impl<Expr, ST> QueryFragment<Pg> for Any<Expr, ST> where
     }
 }
 
-impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
+impl<Expr> QueryFragment<Debug> for Any<Expr> where
     Expr: QueryFragment<Debug>,
 {
     fn to_sql(&self, out: &mut DebugQueryBuilder) -> BuildQueryResult {
@@ -144,45 +137,40 @@ impl<Expr, ST> QueryFragment<Debug> for Any<Expr, ST> where
     }
 }
 
-impl_query_id!(Any<Expr, ST>);
+impl_query_id!(Any<Expr>);
 
-impl<Expr, ST, QS> SelectableExpression<QS> for Any<Expr, ST> where
-    Pg: HasSqlType<ST>,
-    Any<Expr, ST>: Expression,
+impl<Expr, QS> SelectableExpression<QS> for Any<Expr> where
+    Any<Expr>: Expression,
     Expr: SelectableExpression<QS>,
 {
 }
 
-impl<Expr, ST> NonAggregate for Any<Expr, ST> where
+impl<Expr> NonAggregate for Any<Expr> where
     Expr: NonAggregate,
-    Any<Expr, ST>: Expression,
 {
 }
 
 #[doc(hidden)]
 #[derive(Debug, Copy, Clone)]
-pub struct All<Expr, ST> {
+pub struct All<Expr> {
     expr: Expr,
-    _marker: PhantomData<ST>,
 }
 
-impl<Expr, ST> All<Expr, ST> {
+impl<Expr> All<Expr> {
     fn new(expr: Expr) -> Self {
         All {
             expr: expr,
-            _marker: PhantomData,
         }
     }
 }
 
-impl<Expr, ST> Expression for All<Expr, ST> where
-    Pg: HasSqlType<ST>,
+impl<Expr, ST> Expression for All<Expr> where
     Expr: Expression<SqlType=Array<ST>>,
 {
     type SqlType = ST;
 }
 
-impl<Expr, ST> QueryFragment<Pg> for All<Expr, ST> where
+impl<Expr> QueryFragment<Pg> for All<Expr> where
     Expr: QueryFragment<Pg>,
 {
     fn to_sql(&self, out: &mut PgQueryBuilder) -> BuildQueryResult {
@@ -202,7 +190,7 @@ impl<Expr, ST> QueryFragment<Pg> for All<Expr, ST> where
     }
 }
 
-impl<Expr, ST> QueryFragment<Debug> for All<Expr, ST> where
+impl<Expr> QueryFragment<Debug> for All<Expr> where
     Expr: QueryFragment<Debug>,
 {
     fn to_sql(&self, out: &mut DebugQueryBuilder) -> BuildQueryResult {
@@ -222,17 +210,15 @@ impl<Expr, ST> QueryFragment<Debug> for All<Expr, ST> where
     }
 }
 
-impl_query_id!(All<Expr, ST>);
+impl_query_id!(All<Expr>);
 
-impl<Expr, ST, QS> SelectableExpression<QS> for All<Expr, ST> where
-    Pg: HasSqlType<ST>,
-    All<Expr, ST>: Expression,
+impl<Expr, QS> SelectableExpression<QS> for All<Expr> where
+    All<Expr>: Expression,
     Expr: SelectableExpression<QS>,
 {
 }
 
-impl<Expr, ST> NonAggregate for All<Expr, ST> where
+impl<Expr> NonAggregate for All<Expr> where
     Expr: NonAggregate,
-    All<Expr, ST>: Expression,
 {
 }

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -88,5 +88,7 @@ impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
 impl<Ts, Tz, Qs> SelectableExpression<Qs> for AtTimeZone<Ts, Tz> where
     AtTimeZone<Ts, Tz>: Expression,
     Ts: SelectableExpression<Qs>,
-    Tz: SelectableExpression<Tz>,
-{}
+    Tz: SelectableExpression<Qs>,
+{
+    type SqlTypeForSelect = Self::SqlType;
+}

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -115,7 +115,7 @@ pub fn insert<T: ?Sized>(records: &T) -> IncompleteInsertStatement<&T, Insert> {
 /// Creates a bare select statement, with no from clause. Primarily used for
 /// testing diesel itself, but likely useful for third party crates as well. The
 /// given expressions must be selectable from anywhere.
-pub fn select<T>(expression: T) -> SelectStatement<T::SqlType, T, ()> where
+pub fn select<T>(expression: T) -> SelectStatement<T, ()> where
     T: Expression,
 {
     SelectStatement::simple(expression, ())

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -20,7 +20,7 @@ pub struct BoxedSelectStatement<'a, ST, QS, DB> {
     order: Box<QueryFragment<DB> + 'a>,
     limit: Box<QueryFragment<DB> + 'a>,
     offset: Box<QueryFragment<DB> + 'a>,
-    _marker: PhantomData<(ST, DB)>,
+    _marker: PhantomData<ST>,
 }
 
 impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
@@ -153,12 +153,12 @@ impl<'a, ST, QS, DB> QueryId for BoxedSelectStatement<'a, ST, QS, DB> {
     }
 }
 
-impl<'a, ST, QS, DB, Type, Selection> SelectDsl<Selection, Type>
+impl<'a, ST, QS, DB, Selection> SelectDsl<Selection, Selection::SqlTypeForSelect>
     for BoxedSelectStatement<'a, ST, QS, DB> where
-        DB: Backend + HasSqlType<Type>,
-        Selection: SelectableExpression<QS, Type> + QueryFragment<DB> + 'a,
+        DB: Backend + HasSqlType<Selection::SqlTypeForSelect>,
+        Selection: SelectableExpression<QS> + QueryFragment<DB> + 'a,
 {
-    type Output = BoxedSelectStatement<'a, Type, QS, DB>;
+    type Output = BoxedSelectStatement<'a, Selection::SqlTypeForSelect, QS, DB>;
 
     fn select(self, selection: Selection) -> Self::Output {
         BoxedSelectStatement::new(

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -13,12 +13,12 @@ use query_dsl::boxed_dsl::InternalBoxedDsl;
 use super::BoxedSelectStatement;
 use types::{self, Bool};
 
-impl<ST, S, F, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection, Type>
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+impl<S, F, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection, Type>
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
         Selection: Expression,
-        SelectStatement<Type, Selection, F, D, W, O, L, Of, G>: Query<SqlType=Type>,
+        SelectStatement<Selection, F, D, W, O, L, Of, G>: Query<SqlType=Type>,
 {
-    type Output = SelectStatement<Type, Selection, F, D, W, O, L, Of, G>;
+    type Output = SelectStatement<Selection, F, D, W, O, L, Of, G>;
 
     fn select(self, selection: Selection) -> Self::Output {
         SelectStatement::new(
@@ -35,11 +35,11 @@ impl<ST, S, F, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection, Type>
 }
 
 impl<ST, S, F, D, W, O, L, Of, G> DistinctDsl
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
-        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
-        SelectStatement<ST, S, F, DistinctClause, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
+        SelectStatement<S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<S, F, DistinctClause, W, O, L, Of, G>: AsQuery<SqlType=ST>,
 {
-    type Output = SelectStatement<ST, S, F, DistinctClause, W, O, L, Of, G>;
+    type Output = SelectStatement<S, F, DistinctClause, W, O, L, Of, G>;
 
     fn distinct(self) -> Self::Output {
         SelectStatement::new(
@@ -56,13 +56,13 @@ impl<ST, S, F, D, W, O, L, Of, G> DistinctDsl
 }
 
 impl<ST, S, F, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
-        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
-        SelectStatement<ST, S, F, D, W::Output, O, L, Of, G>: Query<SqlType=ST>,
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
+        SelectStatement<S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<S, F, D, W::Output, O, L, Of, G>: Query<SqlType=ST>,
         Predicate: SelectableExpression<F, SqlType=Bool> + NonAggregate,
         W: WhereAnd<Predicate>,
 {
-    type Output = SelectStatement<ST, S, F, D, W::Output, O, L, Of, G>;
+    type Output = SelectStatement<S, F, D, W::Output, O, L, Of, G>;
 
     fn filter(self, predicate: Predicate) -> Self::Output {
         SelectStatement::new(
@@ -79,12 +79,12 @@ impl<ST, S, F, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
 }
 
 impl<ST, S, F, D, W, O, L, Of, G, Expr> OrderDsl<Expr>
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
         Expr: SelectableExpression<F>,
-        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
-        SelectStatement<ST, S, F, D, W, OrderClause<Expr>, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<S, F, D, W, OrderClause<Expr>, L, Of, G>: AsQuery<SqlType=ST>,
 {
-    type Output = SelectStatement<ST, S, F, D, W, OrderClause<Expr>, L, Of, G>;
+    type Output = SelectStatement<S, F, D, W, OrderClause<Expr>, L, Of, G>;
 
     fn order(self, expr: Expr) -> Self::Output {
         let order = OrderClause(expr);
@@ -105,11 +105,11 @@ impl<ST, S, F, D, W, O, L, Of, G, Expr> OrderDsl<Expr>
 pub type Limit = <i64 as AsExpression<types::BigInt>>::Expression;
 
 impl<ST, S, F, D, W, O, L, Of, G> LimitDsl
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
-        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
-        SelectStatement<ST, S, F, D, W, O, LimitClause<Limit>, Of, G>: Query<SqlType=ST>,
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
+        SelectStatement<S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<S, F, D, W, O, LimitClause<Limit>, Of, G>: Query<SqlType=ST>,
 {
-    type Output = SelectStatement<ST, S, F, D, W, O, LimitClause<Limit>, Of, G>;
+    type Output = SelectStatement<S, F, D, W, O, LimitClause<Limit>, Of, G>;
 
     fn limit(self, limit: i64) -> Self::Output {
         let limit_clause = LimitClause(AsExpression::<types::BigInt>::as_expression(limit));
@@ -130,11 +130,11 @@ impl<ST, S, F, D, W, O, L, Of, G> LimitDsl
 pub type Offset = Limit;
 
 impl<ST, S, F, D, W, O, L, Of, G> OffsetDsl
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
-        SelectStatement<ST, S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
-        SelectStatement<ST, S, F, D, W, O, L, OffsetClause<Offset>, G>: AsQuery<SqlType=ST>,
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
+        SelectStatement<S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
+        SelectStatement<S, F, D, W, O, L, OffsetClause<Offset>, G>: AsQuery<SqlType=ST>,
 {
-    type Output = SelectStatement<ST, S, F, D, W, O, L, OffsetClause<Offset>, G>;
+    type Output = SelectStatement<S, F, D, W, O, L, OffsetClause<Offset>, G>;
 
     fn offset(self, offset: i64) -> Self::Output {
         let offset_clause = OffsetClause(AsExpression::<types::BigInt>::as_expression(offset));
@@ -151,11 +151,11 @@ impl<ST, S, F, D, W, O, L, Of, G> OffsetDsl
     }
 }
 
-impl<'a, ST, S, F, D, W, O, L, Of, G, Expr> WithDsl<'a, Expr>
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
-        SelectStatement<ST, S, WithQuerySource<'a, F, Expr>, D, W, O, L, Of, G>: Query,
+impl<'a, S, F, D, W, O, L, Of, G, Expr> WithDsl<'a, Expr>
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
+        SelectStatement<S, WithQuerySource<'a, F, Expr>, D, W, O, L, Of, G>: Query,
 {
-    type Output = SelectStatement<ST, S, WithQuerySource<'a, F, Expr>, D, W, O, L, Of, G>;
+    type Output = SelectStatement<S, WithQuerySource<'a, F, Expr>, D, W, O, L, Of, G>;
 
     fn with(self, expr: Aliased<'a, Expr>) -> Self::Output {
         let source = WithQuerySource::new(self.from, expr);
@@ -172,12 +172,12 @@ impl<'a, ST, S, F, D, W, O, L, Of, G, Expr> WithDsl<'a, Expr>
     }
 }
 
-impl<ST, S, F, D, W, O, L, Of, G, Expr> GroupByDsl<Expr>
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
-        SelectStatement<ST, S, F, D, W, O, L, Of, GroupByClause<Expr>>: Query,
+impl<S, F, D, W, O, L, Of, G, Expr> GroupByDsl<Expr>
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
+        SelectStatement<S, F, D, W, O, L, Of, GroupByClause<Expr>>: Query,
         Expr: Expression,
 {
-    type Output = SelectStatement<ST, S, F, D, W, O, L, Of, GroupByClause<Expr>>;
+    type Output = SelectStatement<S, F, D, W, O, L, Of, GroupByClause<Expr>>;
 
     fn group_by(self, expr: Expr) -> Self::Output {
         let group_by = GroupByClause(expr);
@@ -194,17 +194,17 @@ impl<ST, S, F, D, W, O, L, Of, G, Expr> GroupByDsl<Expr>
     }
 }
 
-impl<'a, ST, S, F, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
-    for SelectStatement<ST, S, F, D, W, O, L, Of, G> where
+impl<'a, S, F, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
         DB: Backend,
-        S: QueryFragment<DB> + 'a,
+        S: QueryFragment<DB> + SelectableExpression<F> + 'a,
         D: QueryFragment<DB> + 'a,
         W: Into<Option<Box<QueryFragment<DB> + 'a>>>,
         O: QueryFragment<DB> + 'a,
         L: QueryFragment<DB> + 'a,
         Of: QueryFragment<DB> + 'a,
 {
-    type Output = BoxedSelectStatement<'a, ST, F, DB>;
+    type Output = BoxedSelectStatement<'a, S::SqlTypeForSelect, F, DB>;
 
     fn internal_into_boxed(self) -> Self::Output {
         BoxedSelectStatement::new(

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -210,21 +210,11 @@ macro_rules! tuple_impls {
                 }
             }
 
-            impl<$($T),+, $($ST),+, QS>
-                SelectableExpression<QS, ($($ST,)+)>
-                for ($($T,)+) where
-                $($T: SelectableExpression<QS, $ST>),+,
+            impl<$($T,)+ QS> SelectableExpression<QS> for ($($T,)+) where
+                $($T: SelectableExpression<QS>,)+
                 ($($T,)+): Expression,
             {
-            }
-
-            impl<$($T),+, $($ST),+, QS>
-                SelectableExpression<QS, Nullable<($($ST,)+)>>
-                for ($($T,)+) where
-                $($ST: IntoNullable,)+
-                $($T: SelectableExpression<QS, $ST::Nullable, SqlType=$ST>),+,
-                ($($T,)+): Expression,
-            {
+                type SqlTypeForSelect = ($($T::SqlTypeForSelect,)+);
             }
 
             impl<Target, $($T,)+> AsChangeset for ($($T,)+) where

--- a/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    use diesel::expression::dsl::*;
+    let source = users::table.select(sum(posts::id));
+    //~^ ERROR E0277
+    let source = users::table.select(avg(posts::id));
+    //~^ ERROR E0277
+    let source = users::table.select(max(posts::id));
+    //~^ ERROR E0277
+    let source = users::table.select(min(posts::id));
+    //~^ ERROR E0277
+}

--- a/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
@@ -15,11 +15,4 @@ fn main() {
 
     let source = users.select((id, count(users.star())));
     //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -28,5 +28,4 @@ fn main() {
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/select_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_requires_column_from_same_table.rs
@@ -20,10 +20,4 @@ table! {
 fn main() {
     let select_id = users::table.select(posts::id);
     //~^ ERROR SelectableExpression
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -22,17 +22,6 @@ fn main() {
     let stuff = users::table.select((posts::id, posts::user_id));
     //~^ ERROR Selectable
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     let stuff = users::table.select((posts::id, users::name));
     //~^ ERROR Selectable
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -16,7 +16,7 @@ use super::data_structures::*;
 pub trait UsesInformationSchema: Backend {
     type TypeColumn: SelectableExpression<
         self::information_schema::columns::table,
-        types::Text,
+        SqlTypeForSelect=types::Text,
     > + NonAggregate + QueryId + QueryFragment<Self>;
 
     fn type_column() -> Self::TypeColumn;

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -114,7 +114,9 @@ impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
     }
 }
 
-impl<T, QS> SelectableExpression<QS> for Arbitrary<T> {}
+impl<T, QS> SelectableExpression<QS> for Arbitrary<T> {
+    type SqlTypeForSelect = T;
+}
 
 fn arbitrary<T>() -> Arbitrary<T> {
     Arbitrary { _marker: PhantomData }

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -260,7 +260,7 @@ sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 
 #[test]
 fn filter_by_boxed_predicate() {
-    fn by_name(name: &str) -> Box<BoxableExpression<users::table, types::Bool, TestBackend, SqlType=types::Bool>> {
+    fn by_name(name: &str) -> Box<BoxableExpression<users::table, TestBackend, SqlType=types::Bool, SqlTypeForSelect=types::Bool>> {
         Box::new(lower(users::name).eq(name.to_string()))
     }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -491,7 +491,7 @@ use diesel::query_builder::{QueryFragment, QueryId};
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
     TestBackend: HasSqlType<T>,
     U: AsExpression<T> + Debug + Clone,
-    U::Expression: SelectableExpression<(), T> + QueryFragment<TestBackend> + QueryId,
+    U::Expression: SelectableExpression<()> + QueryFragment<TestBackend> + QueryId,
     T: QueryId,
 {
     use diesel::expression::dsl::sql;

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -17,7 +17,7 @@ pub fn test_type_round_trips<ST, T>(value: T) -> bool where
     ST: QueryId,
     <TestConnection as Connection>::Backend: HasSqlType<ST>,
     T: AsExpression<ST> + Queryable<ST, <TestConnection as Connection>::Backend> + PartialEq + Clone + ::std::fmt::Debug,
-    <T as AsExpression<ST>>::Expression: SelectableExpression<()> + QueryFragment<<TestConnection as Connection>::Backend> + QueryId,
+    <T as AsExpression<ST>>::Expression: SelectableExpression<(), SqlTypeForSelect=ST> + QueryFragment<<TestConnection as Connection>::Backend> + QueryId,
 {
     let connection = connection();
     let query = select(AsExpression::<ST>::as_expression(value.clone()));


### PR DESCRIPTION
Note: This PR rolls up commits from a few others. Review might be easier if it's done one commit at a time.

The `SelectableExpression` trait serves two purposes for us. The first and most important role it fills is to ensure that columns from tables that aren't in the from clause cannot be used. The second way that we use it to make columns which are on the right side of a left outer join be nullable.

There were two reasons that we used a type parameter instead of an associated type. The first was to make it so that `(Nullable<X>, Nullable<Y>)` could be treated as `Nullable<(X, Y)>`. We did this because the return type of `users.left_outer_join(posts)` should be `(User, Option<Post>)`, not `(User, Post)` where every field of `Post` is an `Option`.

Since we now provide a `.nullable()` method in the core DSL, I think we can simply require calling that method explicitly if you want that tuple conversion to occur. I think that the most common time that conversion will even be used is when the default select clause is used, where we can just handle it for our users automatically.

The other reason that we went with a type parameter originally was that it was easier, since we can provide a default value for a type parameter but not an associated type. This turned out to actually be a drawback, as it led to #104. This PR actually brings back aspects of that issue, which I'll get to in a moment.

It's expected that any expression which implements `SelectableExpression<QS>` have a `T: SelectableExpression<QS>` bound for each of its parts. The problem is, the missing second parameter is defaulting to `T::SqlType`, which means we are implicitly saying that this bound only applies for `QS` which does not change the SQL type (anything except a left outer join). This ultimately led to #621.

However, with our current structure, it is impossible to fix #621 without re-introducing at least some aspects of #104. In https://github.com/diesel-rs/diesel/issues/104#issuecomment-172281522 I said that we didn't need to worry about `1 + NULL`, because we didn't implement add for any nullable types. However, I'm not sure I considered joins when I made that statement. The statement applied to joins previously because of that implicit "sql type doesn't change" constraint. This commit removes that constraint, meaning #104 will be back at least when the nullability comes from being on the right side of a left join.

I don't think this is a serious enough issue that we need to immediately address it, as the types of queries which would cause the issue still just don't happen in practice. We should come up with a long term plan for it, though. Ultimately the nullability of a field really only matters in the select clause. Since any operation on null returns null, and you basically want null to act as false in the where clasue, it doesn't matter there.

So one partial step we could take is to break this out into two separate traits. One for the "make sure this is valid given the from clause", and one for the "make this nullable sometimes" case and only constrain on the first one in the where clause. We could then re-add the "sql type doesn't change" constraint on the problem cases, which will bring back aspects of #621, but only for select clauses which is a smaller problem.

I'm not sure if I ultimately want to go the two traits route or not. If nothing else, the problem cases are much more obvious with this commit.  Anywhere that has `type SqlTypeForSelect = Self::SqlType` is likely a problem case when joins are involved. This will make it easier to find all the places to apply a solution when I come up with one that I'm happy with.

One last note about this is that it makes `BoxableExpression` that much less ergonomic to use, since now two associated types have to be specified instead of one. There's not much we can do about that (it might be helped by the two trait path), and I'm really not sure if that type is even useful since we now have the boxed queries DSL.

Fixes #621.