### PR TITLE
Don't generate join impls on self referencing associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   array that contains null, but a `table!` definition which specifies a type of
   `Array<Nullable<X>>` can now be deserialized to `Vec<Option<T>>`
 
+* [`#[belongs_to]`][belongs-to-0.11.0] associations can now be self referential.
+  This will generate the code required for
+  [`belonging_to`][belonging-to-0.11.0], without generating code for performing
+  a join.
+
 ### Changed
 
 * It is no longer possible to exhaustively match against

--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -226,25 +226,27 @@ macro_rules! BelongsTo {
             $($rest:tt)*
         })+],
     ) => {
-        joinable_inner!(
-            left_table_ty = $child_table_name::table,
-            right_table_ty = <$parent_struct as $crate::associations::HasTable>::Table,
-            right_table_expr = <$parent_struct as $crate::associations::HasTable>::table(),
-            foreign_key = $child_table_name::$foreign_key_name,
-            primary_key_ty = <<$parent_struct as $crate::associations::HasTable>::Table as $crate::Table>::PrimaryKey,
-            primary_key_expr = $crate::Table::primary_key(&<$parent_struct as $crate::associations::HasTable>::table()),
-        );
+        static_cond!(if $struct_name != $parent_struct {
+            joinable_inner!(
+                left_table_ty = $child_table_name::table,
+                right_table_ty = <$parent_struct as $crate::associations::HasTable>::Table,
+                right_table_expr = <$parent_struct as $crate::associations::HasTable>::table(),
+                foreign_key = $child_table_name::$foreign_key_name,
+                primary_key_ty = <<$parent_struct as $crate::associations::HasTable>::Table as $crate::Table>::PrimaryKey,
+                primary_key_expr = $crate::Table::primary_key(&<$parent_struct as $crate::associations::HasTable>::table()),
+            );
 
-        $(select_column_inner!(
-            $child_table_name::table,
-            <$parent_struct as $crate::associations::HasTable>::Table,
-            $child_table_name::$column_name,
-        );)+
-        select_column_inner!(
-            $child_table_name::table,
-            <$parent_struct as $crate::associations::HasTable>::Table,
-            $child_table_name::star,
-        );
+            $(select_column_inner!(
+                $child_table_name::table,
+                <$parent_struct as $crate::associations::HasTable>::Table,
+                $child_table_name::$column_name,
+            );)+
+            select_column_inner!(
+                $child_table_name::table,
+                <$parent_struct as $crate::associations::HasTable>::Table,
+                $child_table_name::star,
+            );
+        });
     };
 
     // Handle struct with no generics

--- a/migrations/mysql/20170215170122_create_trees/down.sql
+++ b/migrations/mysql/20170215170122_create_trees/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE trees;

--- a/migrations/mysql/20170215170122_create_trees/up.sql
+++ b/migrations/mysql/20170215170122_create_trees/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE trees (
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER
+);

--- a/migrations/postgresql/20170215170122_create_trees/down.sql
+++ b/migrations/postgresql/20170215170122_create_trees/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE trees;

--- a/migrations/postgresql/20170215170122_create_trees/up.sql
+++ b/migrations/postgresql/20170215170122_create_trees/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE trees (
+  id SERIAL PRIMARY KEY,
+  parent_id INTEGER
+);

--- a/migrations/sqlite/20170215170122_create_trees/down.sql
+++ b/migrations/sqlite/20170215170122_create_trees/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE trees;

--- a/migrations/sqlite/20170215170122_create_trees/up.sql
+++ b/migrations/sqlite/20170215170122_create_trees/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE trees (
+  id INTEGER PRIMARY KEY NOT NULL,
+  parent_id INTEGER
+);


### PR DESCRIPTION
We don't support self-referencing joins right now, but that doesn't
mean that we can't support the rest of the associations API.

Fixes #616.