### PR TITLE
Remove the `Clone` requirement from `StatementCache`

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -9,7 +9,7 @@ use types::HasSqlType;
 
 pub use self::transaction_manager::{TransactionManager, AnsiTransactionManager};
 #[doc(hidden)]
-pub use self::statement_cache::{StatementCache, StatementCacheKey};
+pub use self::statement_cache::{StatementCache, StatementCacheKey, MaybeCached};
 
 pub trait SimpleConnection {
     #[doc(hidden)]

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -1,8 +1,9 @@
 use std::any::TypeId;
 use std::borrow::Cow;
-use std::cell::RefCell;
+use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::ops::{Deref, DerefMut};
 
 use backend::Backend;
 use query_builder::*;
@@ -36,30 +37,58 @@ impl<DB, Statement> StatementCache<DB, Statement> where
         source: &T,
         bind_types: &[DB::TypeMetadata],
         prepare_fn: F,
-    ) -> QueryResult<Statement> where
+    ) -> QueryResult<MaybeCached<Statement>> where
         T: QueryFragment<DB> + QueryId,
         F: FnOnce(&str) -> QueryResult<Statement>,
-        Statement: Clone,
     {
         use std::collections::hash_map::Entry::{Occupied, Vacant};
 
         let cache_key = try!(StatementCacheKey::for_source(source, bind_types));
-        let mut cache = self.cache.borrow_mut();
 
-        match cache.entry(cache_key) {
-            Occupied(entry) => Ok(entry.get().clone()),
-            Vacant(entry) => {
-                let statement = {
-                    let sql = try!(entry.key().sql(source));
-                    prepare_fn(&sql)
-                };
+        if !source.is_safe_to_cache_prepared() {
+            let sql = try!(cache_key.sql(source));
+            return prepare_fn(&sql).map(MaybeCached::CannotCache)
+        }
 
-                if !source.is_safe_to_cache_prepared() {
-                    return statement;
+        refmut_map_result(self.cache.borrow_mut(), |cache| {
+            match cache.entry(cache_key) {
+                Occupied(entry) => Ok(entry.into_mut()),
+                Vacant(entry) => {
+                    let statement = {
+                        let sql = try!(entry.key().sql(source));
+                        prepare_fn(&sql)
+                    };
+
+                    Ok(entry.insert(try!(statement)))
                 }
-
-                Ok(entry.insert(try!(statement)).clone())
             }
+        }).map(MaybeCached::Cached)
+    }
+}
+
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub enum MaybeCached<'a, T: 'a> {
+    CannotCache(T),
+    Cached(RefMut<'a, T>),
+}
+
+impl<'a, T> Deref for MaybeCached<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match *self {
+            MaybeCached::CannotCache(ref x) => x,
+            MaybeCached::Cached(ref x) => &**x,
+        }
+    }
+}
+
+impl<'a, T> DerefMut for MaybeCached<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match *self {
+            MaybeCached::CannotCache(ref mut x) => x,
+            MaybeCached::Cached(ref mut x) => &mut **x,
         }
     }
 }
@@ -109,5 +138,25 @@ impl<DB> StatementCacheKey<DB> where
         let mut query_builder = DB::QueryBuilder::default();
         try!(source.to_sql(&mut query_builder).map_err(QueryBuilderError));
         Ok(query_builder.finish())
+    }
+}
+
+fn refmut_map_result<T, U, F>(refmut: RefMut<T>, mapper: F)
+    -> QueryResult<RefMut<U>> where
+        F: FnOnce(&mut T) -> QueryResult<&mut U>,
+{
+    use std::mem;
+
+    let mut error = None;
+    let result = RefMut::map(refmut, |mutref| match mapper(mutref) {
+        Ok(x) => x,
+        Err(e) => {
+            error = Some(e);
+            unsafe { mem::uninitialized() }
+        }
+    });
+    match error {
+        Some(e) => Err(e),
+        None => Ok(result),
     }
 }

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -4,16 +4,17 @@ use backend::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use super::query_builder::MysqlQueryBuilder;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Mysql;
 
-#[allow(missing_debug_implementations, missing_copy_implementations)]
+#[allow(missing_debug_implementations)]
 /// Represents the possible forms a bind parameter can be transmitted as.
 /// Each variant represents one of the forms documented at
 /// https://dev.mysql.com/doc/refman/5.7/en/c-api-prepared-statement-type-codes.html
 ///
 /// The null variant is omitted, as we will never prepare a statement in which
 /// one of the bind parameters can always be NULL
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub enum MysqlType {
     Tiny,
     Short,

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -4,16 +4,16 @@ use query_source::Queryable;
 use result::Error::DeserializationError;
 use result::QueryResult;
 use sqlite::Sqlite;
-use super::stmt::Statement;
+use super::stmt::StatementUse;
 use types::{HasSqlType, FromSqlRow};
 
 pub struct StatementIterator<'a, ST, T> {
-    stmt: &'a mut Statement,
+    stmt: StatementUse<'a>,
     _marker: PhantomData<(ST, T)>,
 }
 
 impl<'a, ST, T> StatementIterator<'a, ST, T> {
-    pub fn new(stmt: &'a mut Statement) -> Self {
+    pub fn new(stmt: StatementUse<'a>) -> Self {
         StatementIterator {
             stmt: stmt,
             _marker: PhantomData,


### PR DESCRIPTION
While there wasn't any performance concern from the reference counting,
SQLite and MySQL both use a struct that gets mutated as part of
execution. We want to ensure only one execution is occurring at a time,
and representing that with a unique reference better reflects (and
better enforces) that invariant.