### PR TITLE
Add support for PG `ON CONFLICT DO NOTHING`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
 cache: cargo
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -207,6 +207,11 @@ macro_rules! impl_Insertable {
                 )
             }
         }
+    } __diesel_parse_as_item! {
+        impl<$($lifetime: 'insert,)* 'insert> $crate::query_builder::insert_statement::UndecoratedInsertRecord<$table_name::table>
+            for &'insert $struct_ty
+        {
+        }
     }};
 }
 

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -4,6 +4,7 @@ mod backend;
 mod query_builder;
 mod connection;
 pub mod types;
+pub mod upsert;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;

--- a/diesel/src/pg/upsert/mod.rs
+++ b/diesel/src/pg/upsert/mod.rs
@@ -1,0 +1,4 @@
+mod on_conflict_clause;
+mod on_conflict_extension;
+
+pub use self::on_conflict_extension::OnConflictExtension;

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -1,0 +1,60 @@
+use backend::Backend;
+use insertable::*;
+use pg::Pg;
+use query_builder::*;
+use query_builder::insert_statement::*;
+use query_source::Table;
+use result::QueryResult;
+
+#[derive(Debug, Clone, Copy)]
+pub struct OnConflictDoNothing<T>(T);
+
+impl<T> OnConflictDoNothing<T> {
+    pub fn new(records: T) -> Self {
+        OnConflictDoNothing(records)
+    }
+}
+
+impl<'a, T, Tab, Op, Ret> IntoInsertStatement<Tab, Op, Ret> for &'a OnConflictDoNothing<T> {
+    type InsertStatement = InsertStatement<Tab, Self, Op, Ret>;
+
+    fn into_insert_statement(self, target: Tab, operator: Op, returning: Ret)
+        -> Self::InsertStatement
+    {
+        InsertStatement::new(target, self, operator, returning)
+    }
+}
+
+impl<'a, T, Tab> Insertable<Tab, Pg> for &'a OnConflictDoNothing<T> where
+    Tab: Table,
+    T: Insertable<Tab, Pg> + Copy,
+    T: UndecoratedInsertRecord<Tab>,
+{
+    type Values = OnConflictDoNothingValues<T::Values>;
+
+    fn values(self) -> Self::Values {
+        OnConflictDoNothingValues(self.0.values())
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct OnConflictDoNothingValues<T>(pub T);
+
+impl<T> InsertValues<Pg> for OnConflictDoNothingValues<T> where
+    T: InsertValues<Pg>,
+{
+    fn column_names(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        self.0.column_names(out)
+    }
+
+    fn values_clause(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        try!(self.0.values_clause(out));
+        out.push_sql(" ON CONFLICT DO NOTHING");
+        Ok(())
+    }
+
+    fn values_bind_params(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        self.0.values_bind_params(out)
+    }
+}

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -1,0 +1,85 @@
+pub use super::on_conflict_clause::*;
+
+/// Adds extension methods related to PG upsert
+pub trait OnConflictExtension {
+    /// Adds `ON CONFLICT DO NOTHING` to the insert statement, without
+    /// specifying any columns or constraints to restrict the conflict to.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Clone, Copy, Insertable)]
+    /// # #[table_name="users"]
+    /// # struct User<'a> {
+    /// #     id: i32,
+    /// #     name: &'a str,
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// use self::diesel::pg::upsert::*;
+    ///
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// let user = User { id: 1, name: "Sean", };
+    ///
+    /// let inserted_row_count = diesel::insert(&user.on_conflict_do_nothing())
+    ///     .into(users).execute(&conn);
+    /// assert_eq!(Ok(1), inserted_row_count);
+    ///
+    /// let inserted_row_count = diesel::insert(&user.on_conflict_do_nothing())
+    ///     .into(users).execute(&conn);
+    /// assert_eq!(Ok(0), inserted_row_count);
+    /// # }
+    /// ```
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Clone, Copy, Insertable)]
+    /// # #[table_name="users"]
+    /// # struct User<'a> {
+    /// #     id: i32,
+    /// #     name: &'a str,
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// use self::diesel::pg::upsert::*;
+    ///
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// let user = User { id: 1, name: "Sean", };
+    ///
+    /// let inserted_row_count = diesel::insert(&vec![user, user].on_conflict_do_nothing())
+    ///     .into(users).execute(&conn);
+    /// assert_eq!(Ok(1), inserted_row_count);
+    /// # }
+    /// ```
+    fn on_conflict_do_nothing(&self) -> OnConflictDoNothing<&Self> {
+        OnConflictDoNothing::new(self)
+    }
+}
+
+impl<T> OnConflictExtension for T {
+}

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -1,0 +1,34 @@
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+use diesel::pg::upsert::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+#[derive(Insertable)]
+#[table_name="users"]
+struct NewUser(#[column_name(name)] &'static str);
+
+fn main() {
+    use self::users::dsl::*;
+    let connection = PgConnection::establish("postgres://localhost").unwrap();
+
+    insert(&NewUser("Sean").on_conflict_do_nothing().on_conflict_do_nothing()).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
+    insert(&vec![NewUser("Sean").on_conflict_do_nothing()]).into(users).execute(&connection);
+    //~^ ERROR E0277
+    //~| ERROR E0277
+    //~| ERROR E0277
+    insert(&vec![&NewUser("Sean").on_conflict_do_nothing()]).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
+    //~| ERROR E0277
+    //~| ERROR E0277
+    //~| ERROR E0277
+}


### PR DESCRIPTION
This is the first piece of #196, and somewhat lays the groundwork for
how the rest will be implemented. Getting the examples to compile and
pass was actually quite easy. The hard part was figuring out how to get
the nested cases to fail to compile.

Rather than completely upend our `InsertStatement` structure, I've
instead opted to add a marker trait which we implement in
`#[derive(Insertable)]`. It's a bit of a kludge, but it gets the job
done.