### PR TITLE
Don't panic when running empty migrations.

### DIFF
--- a/diesel/src/migrations/migration.rs
+++ b/diesel/src/migrations/migration.rs
@@ -104,6 +104,11 @@ fn run_sql_from_file(conn: &SimpleConnection, path: &Path) -> Result<(), RunMigr
     let mut sql = String::new();
     let mut file = try!(File::open(path));
     try!(file.read_to_string(&mut sql));
+
+    if sql.is_empty() {
+        return Err(RunMigrationsError::EmptyMigration);
+    }
+
     try!(conn.batch_execute(&sql));
     Ok(())
 }

--- a/diesel/src/migrations/migration_error.rs
+++ b/diesel/src/migrations/migration_error.rs
@@ -65,6 +65,7 @@ impl From<io::Error> for MigrationError {
 pub enum RunMigrationsError {
     MigrationError(MigrationError),
     QueryError(result::Error),
+    EmptyMigration,
 }
 
 impl Error for RunMigrationsError {
@@ -72,6 +73,7 @@ impl Error for RunMigrationsError {
         match *self {
             RunMigrationsError::MigrationError(ref error) => error.description(),
             RunMigrationsError::QueryError(ref error) => error.description(),
+            RunMigrationsError::EmptyMigration => "Attempted to run an empty migration.",
         }
     }
 }

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -24,6 +24,10 @@ impl PgResult {
                     internal_result: internal_result,
                 })
             },
+            PGRES_EMPTY_QUERY => {
+                let error_message = "Received an empty query".to_string();
+                Err(Error::DatabaseError(DatabaseErrorKind::__Unknown, Box::new(error_message)))
+            },
             _ => {
                 let error_kind = match get_result_field(internal_result.as_ptr(), ResultField::SqlState) {
                     Some(error_codes::UNIQUE_VIOLATION) => DatabaseErrorKind::UniqueViolation,

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -86,3 +86,25 @@ fn migration_run_inserts_run_on_timestamps() {
     assert!(valid_run_on_timestamp(&db),
             "Running a migration did not insert an updated run_on value");
 }
+
+#[test]
+fn empty_migrations_are_not_valid() {
+    let p = project("migration_run_empty")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    p.create_migration(
+        "12345_empty_migration",
+        "",
+        ""
+    );
+
+    let result = p.command("migration")
+        .arg("run")
+        .run();
+
+    assert!(!result.is_success());
+    assert!(result.stdout().contains("empty migration"));
+}

--- a/diesel_tests/tests/internal_details.rs
+++ b/diesel_tests/tests/internal_details.rs
@@ -32,3 +32,20 @@ fn query_which_cannot_be_transmitted_gives_proper_error_message() {
         Err(_) => panic!("We got back the wrong kind of error. This test is invalid."),
     }
 }
+
+#[test]
+#[cfg(feature="postgres")]
+fn empty_query_gives_proper_error_instead_of_panicking() {
+    use diesel::result::Error::DatabaseError;
+    use diesel::result::DatabaseErrorKind::__Unknown;
+    use diesel::expression::dsl::sql;
+
+    let connection = connection();
+    let query = sql::<Integer>("");
+
+    match query.execute(&connection) {
+        Ok(_) => panic!("We successfully executed an empty query"),
+        Err(DatabaseError(__Unknown, info)) => assert_ne!("", info.message()),
+        Err(_) => panic!("We got back the wrong kind of error. This test is invalid."),
+    }
+}


### PR DESCRIPTION
PGRES_EMPTY_QUERY is not an error case.

https://github.com/postgres/postgres/blob/93e6e40574bccf9c6f33c520a4189d3e98e2fd1f/src/interfaces/libpq/fe-exec.c#L177

I'm not sure if we should add all the non error cases here (I have no idea how to test the others)