### PR TITLE
Update mysqlclient-sys and pq-sys

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["database"]
 [dependencies]
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
-libc = "0.2.*"
+libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">= 0.4.0, <0.7.0", optional = true }
-mysqlclient-sys = { git = "https://github.com/sgrif/mysqlclient-sys.git", optional = true, rev = "3b1daa0f3a8f41fd685f470a3f2db7ca57857862" }
-pq-sys = { version = "^0.2.0", optional = true }
+mysqlclient-sys = { version = "0.1.2", optional = true }
+pq-sys = { version = "0.3.1", optional = true }
 quickcheck = { version = "0.3.1", optional = true }
 serde_json = { version = ">=0.8.0, <0.10.0", optional = true }
 uuid = { version = ">=0.2.0, <0.5.0", optional = true, features = ["use_std"] }
@@ -39,6 +39,6 @@ lint = ["clippy"]
 large-tables = []
 huge-tables = ["large-tables"]
 postgres = ["pq-sys"]
-sqlite = ["libsqlite3-sys"]
+sqlite = ["libsqlite3-sys", "libc"]
 mysql = ["mysqlclient-sys", "url"]
 with-deprecated = []

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 mod cursor;
 pub mod raw;
 mod row;
@@ -8,6 +6,7 @@ pub mod result;
 mod stmt;
 
 use std::ffi::{CString, CStr};
+use std::os::raw as libc;
 
 use connection::*;
 use pg::Pg;

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(feature = "clippy", allow(too_many_arguments))]
 
 extern crate pq_sys;
-extern crate libc;
 
 use self::pq_sys::*;
 use std::ffi::{CString, CStr};
+use std::os::raw as libc;
 use std::{str, ptr};
 
 use result::*;
@@ -16,6 +16,8 @@ pub struct RawConnection {
 
 impl RawConnection {
     pub fn establish(database_url: &str) -> ConnectionResult<Self> {
+        use self::ConnStatusType::*;
+
         let connection_string = try!(CString::new(database_url));
         let connection_ptr = unsafe { PQconnectdb(connection_string.as_ptr()) };
         let connection_status = unsafe { PQstatus(connection_ptr) };

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -1,13 +1,13 @@
 extern crate pq_sys;
-extern crate libc;
+
+use self::pq_sys::*;
+use std::ffi::CStr;
+use std::os::raw as libc;
+use std::{str, slice};
 
 use result::{Error, QueryResult, DatabaseErrorInformation, DatabaseErrorKind};
 use super::row::PgRow;
 use super::raw::RawResult;
-
-use self::pq_sys::*;
-use std::ffi::CStr;
-use std::{str, slice};
 
 pub struct PgResult {
     internal_result: RawResult,
@@ -15,6 +15,8 @@ pub struct PgResult {
 
 impl PgResult {
     pub fn new(internal_result: RawResult) -> QueryResult<Self> {
+        use self::ExecStatusType::*;
+
         let result_status = unsafe { PQresultStatus(internal_result.as_ptr()) };
         match result_status {
             PGRES_COMMAND_OK | PGRES_TUPLES_OK => {

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -1,8 +1,7 @@
 extern crate pq_sys;
-extern crate libc;
-
 
 use std::ffi::CString;
+use std::os::raw as libc;
 use std::ptr;
 
 use pg::PgTypeMetadata;


### PR DESCRIPTION
I've changed mysqlclient to generate the bindings at build time, and
released it to crates.io. I've updated pq-sys to generate the bindings
at build time, use a more recent version of rust-bindgen, and dropped
the dependency on libc. We don't control libsqlite3-sys, so we can't
fully drop the libc dependency unless they accept
https://github.com/jgallagher/rusqlite/pull/237