### PR TITLE
Ensure `on_conflict_do_nothing` works with slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Fixed
+
+* `.on_conflict_do_nothing()` now interacts with slices properly.
+
 ## [0.11.0] - 2017-02-16
 
 ### Added

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -7,6 +7,8 @@ pub trait OnConflictExtension {
     ///
     /// # Examples
     ///
+    /// ### Single Record
+    ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
@@ -44,6 +46,8 @@ pub trait OnConflictExtension {
     /// # }
     /// ```
     ///
+    /// ### Vec of Records
+    ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
@@ -76,10 +80,46 @@ pub trait OnConflictExtension {
     /// assert_eq!(Ok(1), inserted_row_count);
     /// # }
     /// ```
+    ///
+    /// ### Slice of records
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Clone, Copy, Insertable)]
+    /// # #[table_name="users"]
+    /// # struct User<'a> {
+    /// #     id: i32,
+    /// #     name: &'a str,
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// use self::diesel::pg::upsert::*;
+    ///
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// let user = User { id: 1, name: "Sean", };
+    ///
+    /// let new_users: &[User] = &[user, user];
+    /// let inserted_row_count = diesel::insert(&new_users.on_conflict_do_nothing())
+    ///     .into(users).execute(&conn);
+    /// assert_eq!(Ok(1), inserted_row_count);
+    /// # }
+    /// ```
     fn on_conflict_do_nothing(&self) -> OnConflictDoNothing<&Self> {
         OnConflictDoNothing::new(self)
     }
 }
 
-impl<T> OnConflictExtension for T {
+impl<T: ?Sized> OnConflictExtension for T {
 }


### PR DESCRIPTION
Due to the various signatures, the end result of
`slice.on_conflict_do_nothing()` was `&OnConflictDoNothing<&&[T]>`,
which doesn't implement the various traits. The solution is to remove
the sized contraint from the extension method so that `[T]` implements
it instead of `&[T]`.