### PR TITLE
Remove the final type parameter from `IntoInsertStatement`

### DIFF
--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -193,17 +193,16 @@ macro_rules! impl_Insertable {
         }
 
     } __diesel_parse_as_item! {
-        impl<$($lifetime: 'insert,)* 'insert, Op, Ret> $crate::query_builder::insert_statement::IntoInsertStatement<$table_name::table, Op, Ret>
+        impl<$($lifetime: 'insert,)* 'insert, Op> $crate::query_builder::insert_statement::IntoInsertStatement<$table_name::table, Op>
             for &'insert $struct_ty
         {
-            type InsertStatement = $crate::query_builder::insert_statement::InsertStatement<$table_name::table, Self, Op, Ret>;
+            type InsertStatement = $crate::query_builder::insert_statement::InsertStatement<$table_name::table, Self, Op>;
 
-            fn into_insert_statement(self, target: $table_name::table, operator: Op, returning: Ret) -> Self::InsertStatement {
-                $crate::query_builder::insert_statement::InsertStatement::new(
+            fn into_insert_statement(self, target: $table_name::table, operator: Op) -> Self::InsertStatement {
+                $crate::query_builder::insert_statement::InsertStatement::no_returning_clause(
                     target,
                     self,
                     operator,
-                    returning,
                 )
             }
         }

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -15,13 +15,13 @@ impl<T> OnConflictDoNothing<T> {
     }
 }
 
-impl<'a, T, Tab, Op, Ret> IntoInsertStatement<Tab, Op, Ret> for &'a OnConflictDoNothing<T> {
-    type InsertStatement = InsertStatement<Tab, Self, Op, Ret>;
+impl<'a, T, Tab, Op> IntoInsertStatement<Tab, Op> for &'a OnConflictDoNothing<T> {
+    type InsertStatement = InsertStatement<Tab, Self, Op>;
 
-    fn into_insert_statement(self, target: Tab, operator: Op, returning: Ret)
+    fn into_insert_statement(self, target: Tab, operator: Op)
         -> Self::InsertStatement
     {
-        InsertStatement::new(target, self, operator, returning)
+        InsertStatement::no_returning_clause(target, self, operator)
     }
 }
 


### PR DESCRIPTION
The type `NoReturningClause` is actually a voldemort type outside of our
crate. We could fix this by adding the default back to the type
parameter, but the parameter is never really used so we can just remove
it.

Fixes #590.