### PR TITLE
Ensure that `MysqlConnection` is `Send`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `.on_conflict_do_nothing()` now interacts with slices properly.
 
+* `MysqlConnection` now implements `Send`, which is required for connection
+  pooling.
+
 ## [0.11.0] - 2017-02-16
 
 ### Added

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -16,7 +16,7 @@ pub trait SimpleConnection {
     fn batch_execute(&self, query: &str) -> QueryResult<()>;
 }
 
-pub trait Connection: SimpleConnection + Sized {
+pub trait Connection: SimpleConnection + Sized + Send {
     type Backend: Backend;
     #[doc(hidden)]
     type TransactionManager: TransactionManager<Self>;

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -23,6 +23,8 @@ pub struct MysqlConnection {
     statement_cache: StatementCache<Mysql, Statement>,
 }
 
+unsafe impl Send for MysqlConnection {}
+
 impl SimpleConnection for MysqlConnection {
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
         self.raw_connection.enable_multi_statements(|| {


### PR DESCRIPTION
`mysql::Statement` is not send due to the raw pointer. The `MYSQL_STMT`
type is very much unsafe to be sent across threads, since it contains a
pointer to the connection which is not thread safe. However, we never
expose statements directly, and sending the whole connection is safe.

I've also just made it a supertrait of `Connection` so I don't make this
mistake again.

Fixes #726.