### PR TITLE
Bump pq-sys and mysqlclient-sys

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -16,9 +16,9 @@ byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
 clippy = { optional = true, version = "=0.0.114" }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">= 0.4.0, <0.7.0", optional = true }
-mysqlclient-sys = { version = "0.1.2", optional = true }
-pq-sys = { version = "0.3.1", optional = true }
+libsqlite3-sys = { version = ">=0.4.0, <0.7.0", optional = true }
+mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
+pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
 quickcheck = { version = "0.3.1", optional = true }
 serde_json = { version = ">=0.8.0, <0.10.0", optional = true }
 time = { version = "0.1", optional = true }


### PR DESCRIPTION
I've released new versions of these libraries that have pre-generated
bindings rather than generating them at build time. Requiring a bleeding
edge libclang caused far too many issues.