### PR TITLE
Fix use-after-free with MySQL

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -65,10 +65,10 @@ impl Connection for MysqlConnection {
         use types::FromSqlRow;
 
         let mut stmt = try!(self.prepare_query(&source.as_query()));
-        stmt.execute()?;
         let mut metadata = Vec::new();
         Mysql::row_metadata(&mut metadata);
-        stmt.results(metadata)?.map(|mut row| {
+        let results = unsafe { stmt.results(metadata)? };
+        results.map(|mut row| {
             U::Row::build_from_row(&mut row)
                 .map(U::build)
                 .map_err(DeserializationError)
@@ -85,7 +85,7 @@ impl Connection for MysqlConnection {
         T: QueryFragment<Self::Backend> + QueryId,
     {
         let stmt = try!(self.prepare_query(source));
-        try!(stmt.execute());
+        unsafe { try!(stmt.execute()); }
         Ok(stmt.affected_rows())
     }
 

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -14,7 +14,8 @@ impl<'a> StatementIterator<'a> {
         let mut output_binds = Binds::from_output_types(types);
 
         unsafe {
-            output_binds.with_mysql_binds(|bind_ptr| stmt.bind_result(bind_ptr))?
+            output_binds.with_mysql_binds(|bind_ptr| stmt.bind_result(bind_ptr))?;
+            stmt.execute()?;
         }
 
         Ok(StatementIterator {

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -47,8 +47,11 @@ impl Statement {
         self.did_an_error_occur()
     }
 
-    pub fn execute(&self) -> QueryResult<()> {
-        unsafe { ffi::mysql_stmt_execute(self.stmt); }
+    /// This function should be called instead of `results` on queries which
+    /// have no return value. It should never be called on a statement on
+    /// which `results` has previously been called?
+    pub unsafe fn execute(&self) -> QueryResult<()> {
+        ffi::mysql_stmt_execute(self.stmt);
         self.did_an_error_occur()
     }
 
@@ -57,7 +60,10 @@ impl Statement {
         affected_rows as usize
     }
 
-    pub fn results(&mut self, types: Vec<MysqlType>) -> QueryResult<StatementIterator> {
+    /// This function should be called instead of `execute` for queries which
+    /// have a return value. After calling this function, `execute` can never
+    /// be called on this statement.
+    pub unsafe fn results(&mut self, types: Vec<MysqlType>) -> QueryResult<StatementIterator> {
         StatementIterator::new(self, types)
     }
 


### PR DESCRIPTION
The function `mysql_stmt_execute` does some really dumb shit. When you
call `mysql_stmt_bind_result`, it sets a flag on the statement called
`bind_result_done`. If that flag is set when you call `mysql_execute`,
it goes and tries to write some values to the bind parameters.

The thing is, `mysql_execute` is completely separate from the functions
related to getting the results from queries. And there's absolutely no
reason that it should be assuming that the binds it has still point to
valid memory. At the very least it should be mentioned in the
documentation.

So the problem here occured with a test which looked like the following:

prepare a
execute a
prepare b
execute b
execute a

On the second execution of a, it would try to write these fields, which
was pointed at freed memory. One portion of that memory was now used as
a pointer on the prepared statement for b, and so it tried to write `4`
to a pointer value which was later dereferenced.

To fix this, we diverge from the *documented* flow of

execute
bind_result
loop:
  fetch results

And instead always bind before executing.

Now here's the kicker -- The code which caused all of this problems? It
was a switch statement over the buffer type, and writing to the buffer
length field......... Which is a field that is either ignored (fixed
sized types), or completely irrelevant until we've tried to load data
into it.

Thanks, MySQL. You're *just great*.