### PR TITLE
Fix warnings in examples/**/test_all

### DIFF
--- a/examples/mysql/test_all
+++ b/examples/mysql/test_all
@@ -3,7 +3,7 @@ set -e
 
 export DATABASE_URL="mysql://localhost/diesel_example"
 
-for dir in $(find . -type d -maxdepth 1 -mindepth 1); do
+for dir in $(find . -maxdepth 1 -mindepth 1 -type d); do
   cd $dir
   ../../../bin/diesel database reset
   cargo build

--- a/examples/postgres/test_all
+++ b/examples/postgres/test_all
@@ -3,7 +3,7 @@ set -e
 
 export DATABASE_URL="postgres://localhost/diesel_examples"
 
-for dir in $(find . -type d -maxdepth 1 -mindepth 1); do
+for dir in $(find . -maxdepth 1 -mindepth 1 -type d); do
   cd $dir
   ../../../bin/diesel database reset
   cargo build

--- a/examples/test_all
+++ b/examples/test_all
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-for dir in $(find . -type d -maxdepth 1 -mindepth 1); do
+for dir in $(find . -maxdepth 1 -mindepth 1 -type d); do
   (cd $dir && ./test_all)
 done


### PR DESCRIPTION
find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.

Just move the `-type d` argument at the end of the command.