### PR TITLE
implement network address (only cidr and inet)

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["database"]
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
 clippy = { optional = true, version = "=0.0.126" }
+libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.9.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
@@ -23,6 +24,7 @@ serde_json = { version = ">=0.8.0, <2.0", optional = true }
 time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
 uuid = { version = ">=0.2.0, <0.6.0", optional = true, features = ["use_std"] }
+ipnetwork = { version = "0.12.2", optional = true }
 
 [dev-dependencies]
 cfg-if = "0.1.0"
@@ -33,7 +35,7 @@ tempdir = "^0.3.4"
 
 [features]
 default = ["with-deprecated"]
-extras = ["chrono", "serde_json", "uuid", "deprecated-time"]
+extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address"]
 unstable = []
 lint = ["clippy"]
 large-tables = []
@@ -43,6 +45,7 @@ sqlite = ["libsqlite3-sys"]
 mysql = ["mysqlclient-sys", "url"]
 with-deprecated = []
 deprecated-time = ["time"]
+network-address = ["ipnetwork", "libc"]
 
 [badges]
 travis-ci = { repository = "diesel-rs/diesel" }

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -1,6 +1,8 @@
 mod array;
 pub mod date_and_time;
 pub mod floats;
+#[cfg(feature = "network-address")]
+mod network_address;
 mod integers;
 mod primitives;
 #[cfg(feature = "uuid")]
@@ -277,4 +279,30 @@ pub mod sql_types {
     /// # }
     /// ```
     #[derive(Debug, Clone, Copy, Default)] pub struct Money;
+
+    /// The [`CIDR`](https://www.postgresql.org/docs/9.6/static/datatype-net-types.html) SQL type. This type can only be used with `feature = "network-address"`
+    ///
+    /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+    ///
+    /// - [`ipnetwork::IpNetwork`][IpNetwork]
+    ///
+    /// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+    ///
+    /// - [`ipnetwork::IpNetwork`][IpNetwork]
+    ///
+    /// [IpNetwork]: https://docs.rs/ipnetwork/0.12.2/ipnetwork/enum.IpNetwork.html
+    #[derive(Debug, Clone, Copy, Default)] pub struct Cidr;
+
+    /// The [`INET`](https://www.postgresql.org/docs/9.6/static/datatype-net-types.html) SQL type. This type can only be used with `feature = "network-address"`
+    ///
+    /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+    ///
+    /// - [`ipnetwork::IpNetwork`][IpNetwork]
+    ///
+    /// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+    ///
+    /// - [`ipnetwork::IpNetwork`][IpNetwork]
+    ///
+    /// [IpNetwork]: https://docs.rs/ipnetwork/0.12.2/ipnetwork/enum.IpNetwork.html
+    #[derive(Debug, Clone, Copy, Default)] pub struct Inet;
 }

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -1,0 +1,208 @@
+extern crate ipnetwork;
+extern crate libc;
+
+use std::io::prelude::*;
+use std::error::Error;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use pg::Pg;
+use types::{self, ToSql, IsNull, FromSql};
+use self::ipnetwork::{IpNetwork,Ipv4Network,Ipv6Network};
+
+#[cfg(windows)]
+const AF_INET: u8 = 2;
+// Maybe not used, but defining to follow Rust's libstd/net/sys
+#[cfg(redox)]
+const AF_INET: u8 = 1;
+#[cfg(not(any(windows, redox)))]
+const AF_INET: u8 = libc::AF_INET as u8;
+
+
+const PGSQL_AF_INET: u8 = AF_INET + 0;
+const PGSQL_AF_INET6: u8 = AF_INET + 1;
+
+primitive_impls!(Cidr -> (IpNetwork, pg: (650, 651)));
+primitive_impls!(Inet -> (IpNetwork, pg: (869, 1041)));
+
+macro_rules! err {
+    () => (return Err("invalid network address format".into()));
+    ($msg: expr) => (return Err(format!("invalid network address format. {}", $msg).into()));
+}
+
+macro_rules! assert_or_error {
+    ($cond: expr) => {
+        if ! $cond { err!() }
+    };
+
+    ($cond: expr, $msg: expr) => {
+        if ! $cond { err!($msg) }
+    };
+}
+
+macro_rules! impl_Sql {
+    ($ty: ty, $net_type: expr) => {
+        impl FromSql<$ty, Pg> for IpNetwork {
+            fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+                // https://github.com/postgres/postgres/blob/55c3391d1e6a201b5b891781d21fe682a8c64fe6/src/include/utils/inet.h#L23-L28
+                let bytes = not_none!(bytes);
+                assert_or_error!(4 <= bytes.len(), "input is too short.");
+                let af = bytes[0];
+                let prefix = bytes[1];
+                let net_type = bytes[2];
+                let len = bytes[3];
+                assert_or_error!(net_type == $net_type, format!("returned type isn't a {}", stringify!($ty)));
+                if af == PGSQL_AF_INET {
+                    assert_or_error!(bytes.len() == 8);
+                    assert_or_error!(len == 4, "the data isn't the size of ipv4");
+                    let b = &bytes[4..];
+                    let addr = Ipv4Addr::new(b[0], b[1], b[2], b[3]);
+                    let inet = Ipv4Network::new(addr, prefix)?;
+                    Ok(IpNetwork::V4(inet))
+                } else if af == PGSQL_AF_INET6 {
+                    assert_or_error!(bytes.len() == 20);
+                    assert_or_error!(len == 16, "the data isn't the size of ipv6");
+                    let b = &bytes[4..];
+                    let addr = Ipv6Addr::from([b[0],  b[1],  b[2],  b[3],
+                                               b[4],  b[5],  b[6],  b[7],
+                                               b[8],  b[9],  b[10], b[11],
+                                               b[12], b[13], b[14], b[15]]);
+                    let inet = Ipv6Network::new(addr, prefix)?;
+                    Ok(IpNetwork::V6(inet))
+                } else {
+                    err!()
+                }
+            }
+        }
+
+        impl ToSql<$ty, Pg> for IpNetwork {
+            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+                use self::ipnetwork::IpNetwork::*;
+                let net_type = $net_type;
+                match *self {
+                    V4(ref net) => {
+                        let mut data = [0u8;8];
+                        let af = PGSQL_AF_INET;
+                        let prefix = net.prefix();
+                        let len: u8 = 4;
+                        let addr = net.ip().octets();
+                        data[0] = af; data[1] = prefix; data[2] = net_type; data[3] = len;
+                        data[4..].copy_from_slice(&addr);
+                        out.write_all(&data)
+                            .map(|_| IsNull::No)
+                            .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
+                    },
+                    V6(ref net) => {
+                        let mut data = [0u8;20];
+                        let af = PGSQL_AF_INET6;
+                        let prefix = net.prefix();
+                        let len: u8 = 16;
+                        let addr = net.ip().octets();
+                        data[0] = af; data[1] = prefix; data[2] = net_type; data[3] = len;
+                        data[4..].copy_from_slice(&addr);
+                        out.write_all(&data)
+                            .map(|_| IsNull::No)
+                            .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
+
+                    },
+                }
+            }
+        }
+
+    }
+}
+
+impl_Sql!(types::Inet, 0);
+impl_Sql!(types::Cidr, 1);
+
+
+#[test]
+fn v4address_to_sql() {
+    macro_rules! test_to_sql {
+        ($ty: ty, $net_type: expr) => {
+            let mut bytes = vec![];
+            let test_address = IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 1), 32).unwrap());
+            ToSql::<$ty, Pg>::to_sql(&test_address, &mut bytes).unwrap();
+            assert_eq!(bytes, vec![PGSQL_AF_INET, 32, $net_type, 4, 127, 0, 0, 1]);
+        }
+    }
+
+    test_to_sql!(types::Inet, 0);
+    test_to_sql!(types::Cidr, 1);
+}
+
+#[test]
+fn some_v4address_from_sql() {
+    macro_rules! test_some_address_from_sql {
+        ($ty: ty) => {
+            let input_address = IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 1), 32).unwrap());
+            let mut bytes = vec![];
+            ToSql::<$ty, Pg>::to_sql(&input_address, &mut bytes).unwrap();
+            let output_address = FromSql::<$ty, Pg>::from_sql(Some(bytes.as_ref())).unwrap();
+            assert_eq!(input_address, output_address);
+        }
+    }
+
+    test_some_address_from_sql!(types::Cidr);
+    test_some_address_from_sql!(types::Inet);
+}
+
+#[test]
+fn v6address_to_sql() {
+    macro_rules! test_to_sql {
+        ($ty: ty, $net_type: expr) => {
+            let mut bytes = vec![];
+            let test_address = IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 64).unwrap());
+            ToSql::<$ty, Pg>::to_sql(&test_address, &mut bytes).unwrap();
+            assert_eq!(bytes, vec![PGSQL_AF_INET6, 64, $net_type, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        }
+    }
+
+    test_to_sql!(types::Inet, 0);
+    test_to_sql!(types::Cidr, 1);
+}
+
+#[test]
+fn some_v6address_from_sql() {
+    macro_rules! test_some_address_from_sql {
+        ($ty: ty) => {
+            let input_address = IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 64).unwrap());
+            let mut bytes = vec![];
+            ToSql::<$ty, Pg>::to_sql(&input_address, &mut bytes).unwrap();
+            let output_address = FromSql::<$ty, Pg>::from_sql(Some(bytes.as_ref())).unwrap();
+            assert_eq!(input_address, output_address);
+        }
+    }
+
+    test_some_address_from_sql!(types::Inet);
+    test_some_address_from_sql!(types::Cidr);
+}
+
+#[test]
+fn bad_address_from_sql() {
+    macro_rules! bad_address_from_sql {
+        ($ty: ty) => {
+            let address: Result<IpNetwork, Box<Error + Send + Sync>> =
+                FromSql::<$ty, Pg>::from_sql(Some(&[7, PGSQL_AF_INET, 0]));
+            assert_eq!(address.unwrap_err().description(), "invalid network address format. input is too short.");
+        }
+    }
+
+    bad_address_from_sql!(types::Inet);
+    bad_address_from_sql!(types::Cidr);
+}
+
+#[test]
+fn no_address_from_sql() {
+    macro_rules! test_no_address_from_sql {
+        ($ty: ty) => {
+            let address: Result<IpNetwork, Box<Error + Send + Sync>> =
+                FromSql::<$ty, Pg>::from_sql(None);
+            assert_eq!(address.unwrap_err().description(),
+                       "Unexpected null for non-null column");
+
+        }
+    }
+
+    test_no_address_from_sql!(types::Inet);
+    test_no_address_from_sql!(types::Cidr);
+}

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -12,12 +12,13 @@ dotenv = ">=0.8, <0.10"
 [dependencies]
 assert_matches = "1.0.1"
 chrono = { version = "0.3" }
-diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json"] }
+diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address"] }
 diesel_codegen = { path = "../diesel_codegen" }
 dotenv = ">=0.8, <0.10"
 quickcheck = { version = "0.3.1", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.6.0" }
 serde_json = { version=">=0.9, <2.0" }
+ipnetwork = "0.12.2"
 
 [features]
 default = []

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -408,6 +408,78 @@ fn pg_uuid_to_sql_uuid() {
 
 #[test]
 #[cfg(feature = "postgres")]
+fn pg_v4address_from_sql() {
+    extern crate ipnetwork;
+    use std::str::FromStr;
+
+    let query = "'192.168.1.0/24'::cidr";
+    let expected_value = ipnetwork::IpNetwork::V4(ipnetwork::Ipv4Network::from_str("192.168.1.0/24")
+                                                      .unwrap());
+    assert_eq!(expected_value,
+               query_single_value::<Cidr, ipnetwork::IpNetwork>(query));
+    let query = "'192.168.1.0/24'::inet";
+    let expected_value = ipnetwork::IpNetwork::V4(ipnetwork::Ipv4Network::from_str("192.168.1.0/24")
+                                                      .unwrap());
+    assert_eq!(expected_value,
+               query_single_value::<Inet, ipnetwork::IpNetwork>(query));
+}
+#[test]
+#[cfg(feature = "postgres")]
+fn pg_v6address_from_sql() {
+    extern crate ipnetwork;
+    use std::str::FromStr;
+
+    let query = "'2001:4f8:3:ba::/64'::cidr";
+    let expected_value =
+        ipnetwork::IpNetwork::V6(ipnetwork::Ipv6Network::from_str("2001:4f8:3:ba::/64").unwrap());
+    assert_eq!(expected_value,
+               query_single_value::<Cidr, ipnetwork::IpNetwork>(query));
+    let query = "'2001:4f8:3:ba::/64'::inet";
+    let expected_value =
+        ipnetwork::IpNetwork::V6(ipnetwork::Ipv6Network::from_str("2001:4f8:3:ba::/64").unwrap());
+    assert_eq!(expected_value,
+               query_single_value::<Inet, ipnetwork::IpNetwork>(query));
+}
+
+#[test]
+#[cfg(feature = "postgres")]
+fn pg_v4address_to_sql_v4address() {
+    extern crate ipnetwork;
+    use std::str::FromStr;
+
+    let expected_value = "'192.168.1'::cidr";
+    let value = ipnetwork::IpNetwork::V4(ipnetwork::Ipv4Network::from_str("192.168.1.0/24")
+                                             .unwrap());
+    assert!(query_to_sql_equality::<Cidr, ipnetwork::IpNetwork>(expected_value, value));
+    let expected_value = "'192.168.1.0/24'::inet";
+    let value = ipnetwork::IpNetwork::V4(ipnetwork::Ipv4Network::from_str("192.168.1.0/24")
+                                             .unwrap());
+    assert!(query_to_sql_equality::<Inet, ipnetwork::IpNetwork>(expected_value, value));
+    let expected_non_equal_value = "'192.168.1.0/23'::inet";
+    assert!(!query_to_sql_equality::<Inet, ipnetwork::IpNetwork>(expected_non_equal_value, value));
+}
+
+#[test]
+#[cfg(feature = "postgres")]
+fn pg_v6address_to_sql_v6address() {
+    extern crate ipnetwork;
+    use std::str::FromStr;
+
+    let expected_value = "'2001:4f8:3:ba::/64'::cidr";
+    let value = ipnetwork::IpNetwork::V6(ipnetwork::Ipv6Network::from_str("2001:4f8:3:ba::/64")
+                                             .unwrap());
+    assert!(query_to_sql_equality::<Cidr, ipnetwork::IpNetwork>(expected_value, value));
+    let expected_value = "'2001:4f8:3:ba::/64'::cidr";
+    let value = ipnetwork::IpNetwork::V6(ipnetwork::Ipv6Network::from_str("2001:4f8:3:ba::/64")
+                                             .unwrap());
+    assert!(query_to_sql_equality::<Inet, ipnetwork::IpNetwork>(expected_value, value));
+    let expected_non_equal_value = "'2001:4f8:3:ba::/63'::cidr";
+    assert!(!query_to_sql_equality::<Inet, ipnetwork::IpNetwork>(expected_non_equal_value, value));
+}
+
+
+#[test]
+#[cfg(feature = "postgres")]
 fn pg_json_from_sql() {
     extern crate serde_json;
 


### PR DESCRIPTION
partially implementing #719 . I looked at uuid for reference implementation.
Are there anything left to do? I'm not confident this is all.

My `rustfmt` touched some code. Must I fix them? (I hope there are a rustfmt.toml to avoid creating meaningless diffs)