### PR TITLE
Add support for `ON CONFLICT conflict_target DO NOTHING`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Fixed
+
+* `diesel_codegen` will provide a more useful error message when it encounters
+  an unsupported type that contains a space in MySQL.
+
 ## [0.11.4] - 2017-02-21
 
 ### Fixed

--- a/diesel/src/pg/upsert/mod.rs
+++ b/diesel/src/pg/upsert/mod.rs
@@ -1,4 +1,8 @@
+mod on_conflict_actions;
 mod on_conflict_clause;
 mod on_conflict_extension;
+mod on_conflict_target;
 
+pub use self::on_conflict_actions::do_nothing;
 pub use self::on_conflict_extension::OnConflictExtension;
+pub use self::on_conflict_target::on_constraint;

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -1,0 +1,13 @@
+/// Used in conjuction with
+/// [`on_conflict`](trait.OnConflictExtension.html#method.on_conflict) to write
+/// a query in the form `ON CONFLICT (name) DO NOTHING`. If you want to do
+/// nothing when *any* constraint conflicts, use
+/// [`on_conflict_do_nothing()`](trait.OnConflictExtension.html#method.on_conflict_do_nothing)
+/// instead.
+pub fn do_nothing() -> DoNothing {
+    DoNothing
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct DoNothing;

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -5,6 +5,8 @@ use query_builder::*;
 use query_builder::insert_statement::*;
 use query_source::Table;
 use result::QueryResult;
+use super::on_conflict_actions::*;
+use super::on_conflict_target::*;
 
 #[derive(Debug, Clone, Copy)]
 pub struct OnConflictDoNothing<T>(T);
@@ -15,7 +17,36 @@ impl<T> OnConflictDoNothing<T> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct OnConflict<Records, Target, Action> {
+    records: Records,
+    target: Target,
+    action: Action,
+}
+
+impl<Records, Target, Action> OnConflict<Records, Target, Action> {
+    pub fn new(records: Records, target: Target, action: Action) -> Self {
+        OnConflict {
+            records: records,
+            target: target,
+            action: action,
+        }
+    }
+}
+
 impl<'a, T, Tab, Op> IntoInsertStatement<Tab, Op> for &'a OnConflictDoNothing<T> {
+    type InsertStatement = InsertStatement<Tab, Self, Op>;
+
+    fn into_insert_statement(self, target: Tab, operator: Op)
+        -> Self::InsertStatement
+    {
+        InsertStatement::no_returning_clause(target, self, operator)
+    }
+}
+
+impl<'a, Recods, Target, Action, Tab, Op> IntoInsertStatement<Tab, Op>
+    for &'a OnConflict<Recods, Target, Action>
+{
     type InsertStatement = InsertStatement<Tab, Self, Op>;
 
     fn into_insert_statement(self, target: Tab, operator: Op)
@@ -30,31 +61,61 @@ impl<'a, T, Tab> Insertable<Tab, Pg> for &'a OnConflictDoNothing<T> where
     T: Insertable<Tab, Pg> + Copy,
     T: UndecoratedInsertRecord<Tab>,
 {
-    type Values = OnConflictDoNothingValues<T::Values>;
+    type Values = OnConflictValues<T::Values, NoConflictTarget, DoNothing>;
 
     fn values(self) -> Self::Values {
-        OnConflictDoNothingValues(self.0.values())
+        OnConflictValues {
+            values: self.0.values(),
+            target: NoConflictTarget,
+            action: DoNothing,
+        }
+    }
+}
+
+impl<'a, Records, Target, Action, Tab> Insertable<Tab, Pg>
+    for &'a OnConflict<Records, Target, Action> where
+        Tab: Table,
+        Records: Insertable<Tab, Pg> + Copy,
+        Records: UndecoratedInsertRecord<Tab>,
+        Target: OnConflictTarget<Tab> + Copy,
+        Action: Copy,
+{
+    type Values = OnConflictValues<Records::Values, Target, Action>;
+
+    fn values(self) -> Self::Values {
+        OnConflictValues {
+            values: self.records.values(),
+            target: self.target,
+            action: self.action,
+        }
     }
 }
 
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy)]
-pub struct OnConflictDoNothingValues<T>(pub T);
+pub struct OnConflictValues<Values, Target, Action> {
+    values: Values,
+    target: Target,
+    action: Action,
+}
 
-impl<T> InsertValues<Pg> for OnConflictDoNothingValues<T> where
-    T: InsertValues<Pg>,
+impl<Values, Target, Action> InsertValues<Pg> for OnConflictValues<Values, Target, Action> where
+    Values: InsertValues<Pg>,
+    Target: QueryFragment<Pg>,
 {
     fn column_names(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
-        self.0.column_names(out)
+        self.values.column_names(out)
     }
 
     fn values_clause(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
-        try!(self.0.values_clause(out));
-        out.push_sql(" ON CONFLICT DO NOTHING");
+        try!(self.values.values_clause(out));
+        out.push_sql(" ON CONFLICT");
+        try!(self.target.to_sql(out));
+        out.push_sql(" DO NOTHING");
         Ok(())
     }
 
     fn values_bind_params(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
-        self.0.values_bind_params(out)
+        self.values.values_bind_params(out)
     }
 }

--- a/diesel/src/pg/upsert/on_conflict_docs_setup.rs
+++ b/diesel/src/pg/upsert/on_conflict_docs_setup.rs
@@ -1,0 +1,15 @@
+include!("src/doctest_setup.rs");
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+#[derive(Clone, Copy, Insertable)]
+#[table_name="users"]
+struct User<'a> {
+    id: i32,
+    name: &'a str,
+}

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -1,4 +1,5 @@
 pub use super::on_conflict_clause::*;
+pub use super::on_conflict_target::*;
 
 /// Adds extension methods related to PG upsert
 pub trait OnConflictExtension {
@@ -12,21 +13,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
-    /// #
-    /// # table! {
-    /// #     users {
-    /// #         id -> Integer,
-    /// #         name -> VarChar,
-    /// #     }
-    /// # }
-    /// #
-    /// # #[derive(Clone, Copy, Insertable)]
-    /// # #[table_name="users"]
-    /// # struct User<'a> {
-    /// #     id: i32,
-    /// #     name: &'a str,
-    /// # }
+    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
@@ -51,21 +38,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
-    /// #
-    /// # table! {
-    /// #     users {
-    /// #         id -> Integer,
-    /// #         name -> VarChar,
-    /// #     }
-    /// # }
-    /// #
-    /// # #[derive(Clone, Copy, Insertable)]
-    /// # #[table_name="users"]
-    /// # struct User<'a> {
-    /// #     id: i32,
-    /// #     name: &'a str,
-    /// # }
+    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
@@ -86,21 +59,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
-    /// #
-    /// # table! {
-    /// #     users {
-    /// #         id -> Integer,
-    /// #         name -> VarChar,
-    /// #     }
-    /// # }
-    /// #
-    /// # #[derive(Clone, Copy, Insertable)]
-    /// # #[table_name="users"]
-    /// # struct User<'a> {
-    /// #     id: i32,
-    /// #     name: &'a str,
-    /// # }
+    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
@@ -118,6 +77,111 @@ pub trait OnConflictExtension {
     /// ```
     fn on_conflict_do_nothing(&self) -> OnConflictDoNothing<&Self> {
         OnConflictDoNothing::new(self)
+    }
+
+    /// Adds an `ON CONFLICT` to the insert statement, performing the action
+    /// specified by `Action` if a conflict occurs for `Target`.
+    ///
+    /// `Target` can be one of:
+    ///
+    /// - A column
+    /// - A tuple of columns
+    /// - [`on_constraint("constraint_name")`](fn.on_constraint.html)
+    ///
+    /// `Action` can be one of:
+    ///
+    /// - [`do_nothing()`](fn.do_nothing.html)
+    /// - [`do_update()`]
+    ///
+    /// # Examples
+    ///
+    /// ### Specifying a column as the target
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// use self::diesel::pg::upsert::*;
+    ///
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// conn.execute("CREATE UNIQUE INDEX users_name ON users (name)").unwrap();
+    /// let user = User { id: 1, name: "Sean", };
+    /// let same_name_different_id = User { id: 2, name: "Sean" };
+    /// let same_id_different_name = User { id: 1, name: "Pascal" };
+    ///
+    /// assert_eq!(Ok(1), diesel::insert(&user).into(users).execute(&conn));
+    ///
+    /// let inserted_row_count = diesel::insert(
+    ///     &same_name_different_id.on_conflict(name, do_nothing())
+    /// ).into(users).execute(&conn);
+    /// assert_eq!(Ok(0), inserted_row_count);
+    ///
+    /// let pk_conflict_result = diesel::insert(
+    ///     &same_id_different_name.on_conflict(name, do_nothing())
+    /// ).into(users).execute(&conn);
+    /// assert!(pk_conflict_result.is_err());
+    /// # }
+    /// ```
+    ///
+    /// ### Specifying multiple columns as the target
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #         hair_color -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Clone, Copy, Insertable)]
+    /// # #[table_name="users"]
+    /// # struct User<'a> {
+    /// #     id: i32,
+    /// #     name: &'a str,
+    /// #     hair_color: &'a str,
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// use self::diesel::pg::upsert::*;
+    ///
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE users").unwrap();
+    /// #     conn.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT, hair_color TEXT)").unwrap();
+    /// conn.execute("CREATE UNIQUE INDEX users_name_hair_color ON users (name, hair_color)").unwrap();
+    /// let user = User { id: 1, name: "Sean", hair_color: "black" };
+    /// let same_name_different_hair_color = User { id: 2, name: "Sean", hair_color: "brown" };
+    /// let same_same_name_same_hair_color = User { id: 3, name: "Sean", hair_color: "black" };
+    ///
+    /// assert_eq!(Ok(1), diesel::insert(&user).into(users).execute(&conn));
+    ///
+    /// let inserted_row_count = diesel::insert(
+    ///     &same_name_different_hair_color.on_conflict((name, hair_color), do_nothing())
+    /// ).into(users).execute(&conn);
+    /// assert_eq!(Ok(1), inserted_row_count);
+    ///
+    /// let inserted_row_count = diesel::insert(
+    ///     &same_same_name_same_hair_color.on_conflict((name, hair_color), do_nothing())
+    /// ).into(users).execute(&conn);
+    /// assert_eq!(Ok(0), inserted_row_count);
+    /// # }
+    /// ```
+    ///
+    /// See the documentation for [`on_constraint`](fn.on_constraint.html) and [`do_update`] for
+    /// more examples.
+    fn on_conflict<Target, Action>(&self, target: Target, action: Action)
+        -> OnConflict<&Self, ConflictTarget<Target>, Action>
+    {
+        OnConflict::new(self, ConflictTarget(target), action)
     }
 }
 

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -1,0 +1,160 @@
+use backend::Backend;
+use pg::Pg;
+use query_builder::*;
+use query_source::Column;
+use result::QueryResult;
+
+/// Used to specify the constraint name for an upsert statement in the form `ON
+/// CONFLICT ON CONSTRAINT`. Note that `constraint_name` must be the name of a
+/// unique constraint, not the name of an index.
+///
+/// # Example
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # #[macro_use] extern crate diesel_codegen;
+/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// use self::diesel::pg::upsert::*;
+///
+/// #     let conn = establish_connection();
+/// #     conn.execute("TRUNCATE TABLE users").unwrap();
+/// conn.execute("ALTER TABLE users ADD CONSTRAINT users_name UNIQUE (name)").unwrap();
+/// let user = User { id: 1, name: "Sean", };
+/// let same_name_different_id = User { id: 2, name: "Sean" };
+/// let same_id_different_name = User { id: 1, name: "Pascal" };
+///
+/// assert_eq!(Ok(1), diesel::insert(&user).into(users).execute(&conn));
+///
+/// let inserted_row_count = diesel::insert(
+///     &same_name_different_id.on_conflict(on_constraint("users_name"), do_nothing())
+/// ).into(users).execute(&conn);
+/// assert_eq!(Ok(0), inserted_row_count);
+///
+/// let pk_conflict_result = diesel::insert(
+///     &same_id_different_name.on_conflict(on_constraint("users_name"), do_nothing())
+/// ).into(users).execute(&conn);
+/// assert!(pk_conflict_result.is_err());
+/// # }
+/// ```
+pub fn on_constraint(constraint_name: &str) -> OnConstraint {
+    OnConstraint {
+        constraint_name: constraint_name,
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct OnConstraint<'a> {
+    constraint_name: &'a str,
+}
+
+pub trait OnConflictTarget<Table>: QueryFragment<Pg> {
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct NoConflictTarget;
+
+impl QueryFragment<Pg> for NoConflictTarget {
+    fn to_sql(&self, _: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        Ok(())
+    }
+
+    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
+}
+
+impl<Table> OnConflictTarget<Table> for NoConflictTarget {
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct ConflictTarget<T>(pub T);
+
+impl<T: Column> QueryFragment<Pg> for ConflictTarget<T> {
+    fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        out.push_sql(" (");
+        try!(out.push_identifier(T::name()));
+        out.push_sql(")");
+        Ok(())
+    }
+
+    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
+}
+
+impl<T: Column> OnConflictTarget<T::Table> for ConflictTarget<T> {
+}
+
+impl<'a> QueryFragment<Pg> for ConflictTarget<OnConstraint<'a>> {
+    fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        out.push_sql(" ON CONSTRAINT ");
+        try!(out.push_identifier(self.0.constraint_name));
+        Ok(())
+    }
+
+    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
+}
+
+impl<'a, Table> OnConflictTarget<Table> for ConflictTarget<OnConstraint<'a>> {
+}
+
+macro_rules! on_conflict_tuples {
+    ($($col:ident),+) => {
+        impl<T, $($col),+> QueryFragment<Pg> for ConflictTarget<(T, $($col),+)> where
+            T: Column,
+            $($col: Column<Table=T::Table>,)+
+        {
+            fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+                out.push_sql(" (");
+                try!(out.push_identifier(T::name()));
+                $(
+                    out.push_sql(", ");
+                    try!(out.push_identifier($col::name()));
+                )+
+                out.push_sql(")");
+                Ok(())
+            }
+
+            fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+                Ok(())
+            }
+
+            fn is_safe_to_cache_prepared(&self) -> bool {
+                true
+            }
+        }
+
+        impl<T, $($col),+> OnConflictTarget<T::Table> for ConflictTarget<(T, $($col),+)> where
+            T: Column,
+            $($col: Column<Table=T::Table>,)+
+        {
+        }
+    }
+}
+
+on_conflict_tuples!(U);
+on_conflict_tuples!(U, V);
+on_conflict_tuples!(U, V, W);
+on_conflict_tuples!(U, V, W, X);
+on_conflict_tuples!(U, V, W, X, Y);
+on_conflict_tuples!(U, V, W, X, Y, Z);

--- a/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -1,0 +1,54 @@
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+use diesel::pg::upsert::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> VarChar,
+    }
+}
+
+#[derive(Insertable)]
+#[table_name="users"]
+struct NewUser(#[column_name(name)] &'static str);
+
+sql_function!(lower, lower_t, (x: diesel::types::Text) -> diesel::types::Text);
+
+fn main() {
+    use self::users::dsl::*;
+    let connection = PgConnection::establish("postgres://localhost").unwrap();
+
+    let valid_insert = insert(&NewUser("Sean").on_conflict(id, do_nothing())).into(users).execute(&connection);
+    // Sanity check, no error
+
+    // Using UFCS to get a more specific error message
+    let column_from_other_table = <_ as ExecuteDsl<_>>::execute(
+        //~^ ERROR E0277
+        // FIXME: I'd like that message to mention `OnConflictTarget<users::table>`
+        insert(&NewUser("Sean").on_conflict(posts::id, do_nothing())).into(users),
+        &connection,
+    );
+
+    let expression_using_column_from_other_table = <_ as ExecuteDsl<_>>::execute(
+        //~^ ERROR E0277
+        insert(&NewUser("Sean").on_conflict(lower(posts::title), do_nothing())).into(users),
+        &connection,
+    );
+
+    let random_non_expression = <_ as ExecuteDsl<_>>::execute(
+        //~^ ERROR E0277
+        insert(&NewUser("Sean").on_conflict("id", do_nothing())).into(users),
+        &connection,
+    );
+}

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -22,11 +22,22 @@ fn main() {
 
     insert(&NewUser("Sean").on_conflict_do_nothing().on_conflict_do_nothing()).into(users).execute(&connection);
     //~^ ERROR no method named `execute`
+    insert(&NewUser("Sean").on_conflict(id, do_nothing()).on_conflict_do_nothing()).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
+    insert(&NewUser("Sean").on_conflict_do_nothing().on_conflict(id, do_nothing())).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
+    insert(&NewUser("Sean").on_conflict(id, do_nothing()).on_conflict(id, do_nothing())).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
     insert(&vec![NewUser("Sean").on_conflict_do_nothing()]).into(users).execute(&connection);
     //~^ ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
     insert(&vec![&NewUser("Sean").on_conflict_do_nothing()]).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
+    //~| ERROR E0277
+    //~| ERROR E0277
+    //~| ERROR E0277
+    insert(&vec![&NewUser("Sean").on_conflict(id, do_nothing())]).into(users).execute(&connection);
     //~^ ERROR no method named `execute`
     //~| ERROR E0277
     //~| ERROR E0277

--- a/diesel_infer_schema/src/mysql.rs
+++ b/diesel_infer_schema/src/mysql.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use data_structures::*;
 
 pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
-    let tpe = determine_type_name(&attr.type_name);
+    let tpe = determine_type_name(&attr.type_name)?;
 
     Ok(ColumnType {
         path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
@@ -12,8 +12,8 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
     })
 }
 
-fn determine_type_name(sql_type_name: &str) -> &str {
-    if sql_type_name == "tinyint(1)" {
+fn determine_type_name(sql_type_name: &str) -> Result<&str, Box<Error>> {
+    let result = if sql_type_name == "tinyint(1)" {
         "bool"
     } else if sql_type_name.starts_with("int") {
         "integer"
@@ -21,6 +21,14 @@ fn determine_type_name(sql_type_name: &str) -> &str {
         &sql_type_name[..idx]
     } else {
         sql_type_name
+    };
+
+    if result.to_lowercase().contains("unsigned") {
+        Err("unsigned types are not yet supported".into())
+    } else if result.contains(' ') {
+        Err(format!("unrecognized type {:?}", result).into())
+    } else {
+        Ok(result)
     }
 }
 
@@ -30,26 +38,38 @@ fn capitalize(name: &str) -> String {
 
 #[test]
 fn values_which_already_map_to_type_are_returned_unchanged() {
-    assert_eq!("text", determine_type_name("text"));
-    assert_eq!("integer", determine_type_name("integer"));
-    assert_eq!("biginteger", determine_type_name("biginteger"));
+    assert_eq!("text", determine_type_name("text").unwrap());
+    assert_eq!("integer", determine_type_name("integer").unwrap());
+    assert_eq!("biginteger", determine_type_name("biginteger").unwrap());
 }
 
 #[test]
 fn trailing_parenthesis_are_stripped() {
-    assert_eq!("varchar", determine_type_name("varchar(255)"));
-    assert_eq!("decimal", determine_type_name("decimal(10, 2)"));
-    assert_eq!("float", determine_type_name("float(1)"));
+    assert_eq!("varchar", determine_type_name("varchar(255)").unwrap());
+    assert_eq!("decimal", determine_type_name("decimal(10, 2)").unwrap());
+    assert_eq!("float", determine_type_name("float(1)").unwrap());
 }
 
 #[test]
 fn tinyint_is_bool_if_limit_1() {
-    assert_eq!("bool", determine_type_name("tinyint(1)"));
-    assert_eq!("tinyint", determine_type_name("tinyint(2)"));
+    assert_eq!("bool", determine_type_name("tinyint(1)").unwrap());
+    assert_eq!("tinyint", determine_type_name("tinyint(2)").unwrap());
 }
 
 #[test]
 fn int_is_treated_as_integer() {
-    assert_eq!("integer", determine_type_name("int"));
-    assert_eq!("integer", determine_type_name("int(11)"));
+    assert_eq!("integer", determine_type_name("int").unwrap());
+    assert_eq!("integer", determine_type_name("int(11)").unwrap());
+}
+
+#[test]
+fn unsigned_types_are_not_supported() {
+    assert!(determine_type_name("float unsigned").is_err());
+    assert!(determine_type_name("UNSIGNED INT").is_err());
+    assert!(determine_type_name("unsigned bigint").is_err())
+}
+
+#[test]
+fn types_with_space_are_not_supported() {
+    assert!(determine_type_name("lol wat").is_err());
 }


### PR DESCRIPTION
This adds support for the next third of #196, adding the ability to
specify the conflict target. This does not yet add support for `DO
UPDATE`, that will come in a later PR. This does not support all
possible conflict targets. They're described in the pg syntax as

```
one of:
    ( { index_column_name | ( index_expression ) } [ COLLATE collation ] [ opclass ] [, ...] ) [ WHERE index_predicate ]
    ON CONSTRAINT constraint_name
```

The grammar supported by this PR is:

```
one of:
    ( index_column_name [, ...] )
    ON CONSTRAINT constraint_name
```

Supporting expression indexes is a bit more work, since column names
have to appear without the table name here. We'd either need to add a
new trait which is implemented for everything in the query builder, or
modify `QueryFragment#to_sql` to have an additional parameter of whether
to include the table name or not.

It's something I want to support eventually, but it's low priority (and
may even have to wait until 2.0). I also need to verify whether bind
parameters can appear in expression position here or not. If the answer
is no, we'll just need to provide a raw SQL API for expression indexes
no matter what.