### PR TITLE
(Mostly) allow tests to pass locally

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,9 +54,12 @@ environment:
     PGPASSWORD: Password12!
     MYSQL_PWD: Password12!
 
+  # TODO: get rid of DATABASE_URL throughout.
   matrix:
     - target: x86_64-pc-windows-msvc
       backend: postgres
+      PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
+      PG_EXAMPLE_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_example
       DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
     # SQLite doesn't distribute a static lib
     # - target: x86_64-pc-windows-msvc
@@ -64,19 +67,25 @@ environment:
     #   DATABASE_URL: test.db
     - target: x86_64-pc-windows-msvc
       backend: mysql
-      DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
+      MYSQL_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
+      MYSQL_EXAMPLE_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_example
       MYSQL_UNIT_TEST_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_unit_test
+      DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
       # Neither mysql_config or pkg-config work for this on Windows
       MYSQLCLIENT_LIB_DIR: C:\Program Files\MySQL\MySQL Server 5.7\lib
       RUST_TEST_THREADS: 1
     - target: x86_64-pc-windows-gnu
       backend: postgres
+      PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
       DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
     - target: x86_64-pc-windows-gnu
       backend: sqlite
+      SQLITE_DATABASE_URL: test.db
       DATABASE_URL: test.db
     - target: x86_64-pc-windows-gnu
       backend: mysql
+      MYSQL_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
+      MYSQL_EXAMPLE_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_example
       DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
       MYSQL_UNIT_TEST_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_unit_test
       # Neither mysql_config or pkg-config work for this on Windows

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,39 +54,33 @@ environment:
     PGPASSWORD: Password12!
     MYSQL_PWD: Password12!
 
-  # TODO: get rid of DATABASE_URL throughout.
   matrix:
     - target: x86_64-pc-windows-msvc
       backend: postgres
       PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
       PG_EXAMPLE_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_example
-      DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
     # SQLite doesn't distribute a static lib
     # - target: x86_64-pc-windows-msvc
     #   backend: sqlite
-    #   DATABASE_URL: test.db
+    #   SQLITE_DATABASE_URL: test.db
     - target: x86_64-pc-windows-msvc
       backend: mysql
       MYSQL_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
       MYSQL_EXAMPLE_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_example
       MYSQL_UNIT_TEST_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_unit_test
-      DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
       # Neither mysql_config or pkg-config work for this on Windows
       MYSQLCLIENT_LIB_DIR: C:\Program Files\MySQL\MySQL Server 5.7\lib
       RUST_TEST_THREADS: 1
     - target: x86_64-pc-windows-gnu
       backend: postgres
       PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
-      DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
     - target: x86_64-pc-windows-gnu
       backend: sqlite
       SQLITE_DATABASE_URL: test.db
-      DATABASE_URL: test.db
     - target: x86_64-pc-windows-gnu
       backend: mysql
       MYSQL_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
       MYSQL_EXAMPLE_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_example
-      DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
       MYSQL_UNIT_TEST_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_unit_test
       # Neither mysql_config or pkg-config work for this on Windows
       MYSQLCLIENT_LIB_DIR: C:\Program Files\MySQL\MySQL Server 5.7\lib

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PG_DATABASE_URL=postgresql://postgres@localhost:5432/diesel_test
+PG_EXAMPLE_DATABASE_URL=postgresql://postgres@localhost:5432/diesel_example
+SQLITE_DATABASE_URL=/tmp/diesel_test.sqlite
+MYSQL_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_test
+MYSQL_EXAMPLE_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_example
+MYSQL_UNIT_TEST_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_test

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,15 @@
+# The database to use when testing against Postgres.
+PG_DATABASE_URL=postgresql://postgres@localhost:5432/diesel_test
+# The database to use when running the Postgres examples during testing.
+PG_EXAMPLE_DATABASE_URL=postgresql://postgres@localhost:5432/diesel_example
+
+# The database to use when testing against MySQL.
+MYSQL_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_test
+# The database to use when running the MySQL examples during testing.
+MYSQL_EXAMPLE_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_example
+# A database different from the others above used for certain unit tests.
+# TODO: this is magical, explain what it's there for.
+MYSQL_UNIT_TEST_DATABASE_URL=mysql://root@127.0.0.1:3306/diesel_unit_test
+
+# The database to use when testing against SQLite.
+SQLITE_DATABASE_URL=/tmp/diesel_test.sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,18 +52,14 @@ matrix:
     - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
     - (cd diesel_compile_tests && cargo test)
 env:
-  # TODO: get rid of DATABASE_URL throughout.
   # TODO: why is there no database specified for Postgres?
   matrix:
     - BACKEND=sqlite
-      DATABASE_URL=/tmp/test.db
       SQLITE_DATABASE_URL=/tmp/test.db
     - BACKEND=postgres
-      DATABASE_URL=postgres://postgres@localhost/
       PG_DATABASE_URL=postgres://postgres@localhost/
       PG_EXAMPLE_DATABASE_URL=postgres://postgres@localhost/diesel_example
     - BACKEND=mysql
-      DATABASE_URL=mysql://travis@localhost/diesel_test
       MYSQL_DATABASE_URL=mysql://travis@localhost/diesel_test
       MYSQL_EXAMPLE_DATABASE_URL=mysql://travis@localhost/diesel_example
       MYSQL_UNIT_TEST_DATABASE_URL=mysql://travis@localhost/diesel_unit_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,20 @@ matrix:
     - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
     - (cd diesel_compile_tests && cargo test)
 env:
+  # TODO: get rid of DATABASE_URL throughout.
+  # TODO: why is there no database specified for Postgres?
   matrix:
     - BACKEND=sqlite
       DATABASE_URL=/tmp/test.db
+      SQLITE_DATABASE_URL=/tmp/test.db
     - BACKEND=postgres
       DATABASE_URL=postgres://postgres@localhost/
+      PG_DATABASE_URL=postgres://postgres@localhost/
+      PG_EXAMPLE_DATABASE_URL=postgres://postgres@localhost/diesel_example
     - BACKEND=mysql
       DATABASE_URL=mysql://travis@localhost/diesel_test
+      MYSQL_DATABASE_URL=mysql://travis@localhost/diesel_test
+      MYSQL_EXAMPLE_DATABASE_URL=mysql://travis@localhost/diesel_example
       MYSQL_UNIT_TEST_DATABASE_URL=mysql://travis@localhost/diesel_unit_test
       RUST_TEST_THREADS=1
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,30 +57,30 @@ Thank you! We'll try to get back to you as soon as possible.
 2. Install the system libraries needed to interface with the database systems
    you which to use.
 
-    These are the same as when compiling diesel. In general, it is a good idea
-    to have _all_ drivers installed so you can run all tests locally.
+   These are the same as when compiling diesel. In general, it is a good idea
+   to have _all_ drivers installed so you can run all tests locally.
 
-    *Shortcut:* On macOS, you don't need to install anything to work with SQLite
-    and for PostgreSQL you'll only need the server (`libpq` is installed by
-    default). So, to get started, `brew install postgresql mysql` and follow the
-    instructions shown to set up the database servers.
+   *Shortcut:* On macOS, you don't need to install anything to work with SQLite
+   and for PostgreSQL you'll only need the server (`libpq` is installed by
+   default). So, to get started, `brew install postgresql mysql` and follow the
+   instructions shown to set up the database servers.
 3. Clone this repository and open it in your favorite editor.
 4. Create a `.env` file in the `diesel/` directory, and add the connection
    details for your databases.
 
-    For example:
+   For example:
 
-    ```
-    PG_DATABASE_URL=postgresql://localhost/diesel_test
-    SQLITE_DATABASE_URL=/tmp/diesel_test.sqlite
-    MYSQL_DATABASE_URL=mysql://localhost/diesel_test
-    MYSQL_UNIT_TEST_DATABASE_URL=mysql://localhost/diesel_unit_tests
-    ```
+   ```
+   PG_DATABASE_URL=postgresql://localhost/diesel_test
+   SQLITE_DATABASE_URL=/tmp/diesel_test.sqlite
+   MYSQL_DATABASE_URL=mysql://localhost/diesel_test
+   MYSQL_UNIT_TEST_DATABASE_URL=mysql://localhost/diesel_unit_tests
+   ```
 
-    *Note:* If you didn't specify the MySQL user to be one with elevated
-    permissions, you'll want to a command like ```mysql -c "GRANT ALL ON
-    `diesel_%`.* TO ''@'localhost';" -uroot```, or something similar for the
-    user that you've specified.
+   *Note:* If you didn't specify the MySQL user to be one with elevated
+   permissions, you'll want to a command like ```mysql -c "GRANT ALL ON
+   `diesel_%`.* TO ''@'localhost';" -uroot```, or something similar for the
+   user that you've specified.
 5. Now, try running the test suite to confirm everything works for you locally
    by executing `bin/test`. (Initially, this will take a while to compile
    everything.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,22 +65,35 @@ Thank you! We'll try to get back to you as soon as possible.
    default). So, to get started, `brew install postgresql mysql` and follow the
    instructions shown to set up the database servers.
 3. Clone this repository and open it in your favorite editor.
-4. Create a `.env` file in the `diesel/` directory, and add the connection
-   details for your databases.
+4. Create a `.env` file in this directory, and add the connection details for
+   your databases.
 
-   For example:
-
-   ```
-   PG_DATABASE_URL=postgresql://localhost/diesel_test
-   SQLITE_DATABASE_URL=/tmp/diesel_test.sqlite
-   MYSQL_DATABASE_URL=mysql://localhost/diesel_test
-   MYSQL_UNIT_TEST_DATABASE_URL=mysql://localhost/diesel_unit_tests
-   ```
+   See [.env.example](.env.example) for an example that should work with a trivial
+   local setup.
 
    *Note:* If you didn't specify the MySQL user to be one with elevated
    permissions, you'll want to a command like ```mysql -c "GRANT ALL ON
    `diesel_%`.* TO ''@'localhost';" -uroot```, or something similar for the
    user that you've specified.
+
+   If you have [Docker](https://docker.io), the following snippet might be
+   useful to get Postgres and MySQL running (with the above `.env` file):
+
+   ```bash
+   #!/usr/bin/env sh
+   set -e
+   docker run -d --name diesel.mysql -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql
+   while
+     sleep 1;
+     ! echo 'CREATE DATABASE diesel_test;' | docker exec -i diesel.mysql mysql
+   do sleep 1; done
+
+   docker run -d --name diesel.postgres -p 5432:5432 postgres
+   while
+     sleep 1;
+     ! echo 'CREATE DATABASE diesel_test;' | docker exec -i diesel.postgres psql -U postgres
+   do :; done
+   ```
 5. Now, try running the test suite to confirm everything works for you locally
    by executing `bin/test`. (Initially, this will take a while to compile
    everything.)

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 CLIPPY="lint"

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -81,12 +81,12 @@ cfg_if! {
     }
 }
 
-fn database_url_from_env(bakend_specific_env_var: &str) -> String {
+fn database_url_from_env(backend_specific_env_var: &str) -> String {
     use std::env;
 
     dotenv().ok();
 
-    env::var(bakend_specific_env_var)
+    env::var(backend_specific_env_var)
         .or_else(|_| env::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests")
 }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -24,6 +24,7 @@ clippy = { optional = true, version = "=0.0.118" }
 [dev-dependencies]
 tempdir = "0.3.4"
 regex = "0.1.48"
+url = { version = "1.4.0" }
 
 [features]
 default = ["postgres", "sqlite", "mysql"]

--- a/examples/mysql/test_all
+++ b/examples/mysql/test_all
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -e
 
-export DATABASE_URL="mysql://localhost/diesel_example"
+set -a
+if [ -f ../../.env ]; then . ../../.env; fi
+DATABASE_URL=${MYSQL_EXAMPLE_DATABASE_URL}
+set +a
 
 for dir in $(find . -maxdepth 1 -mindepth 1 -type d); do
   cd $dir

--- a/examples/postgres/test_all
+++ b/examples/postgres/test_all
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -e
 
-export DATABASE_URL="postgres://localhost/diesel_examples"
+set -a
+if [ -f ../../.env ]; then . ../../.env; fi
+DATABASE_URL=${PG_EXAMPLE_DATABASE_URL}
+set +a
 
 for dir in $(find . -maxdepth 1 -mindepth 1 -type d); do
   cd $dir


### PR DESCRIPTION
Tried to run the local tests as indicated in `CONTRIBUTING.md` but ran into one
problem after another. Most of the trouble came from ad-hoc database URLs that
were used in various locations; those have been replaced and a repo-root `.env`
file should now be used correctly for all databases.

Added a docker-incantation to spin up throwaway Postgres and MySQL compatible
with the default `.env` file.

Some unintended cross-pollination caused further problems: The examples left
state behind that causes the `diesel_tests` to fail as it tried to migrate the
overlapping but incompatible schema. As a workaround, let the example tests
clean up after themselves.

There are still issues left; sometimes I can get a clear pass, but mostly
`diesel_tests` fail with a message such as (this one being from the `sqlite`
invocation):

```
error[E0432]: unresolved import `schema::users::dsl::*`
[hundreds more elided]
```

I suspect that this has something to do with a stale schema somewhere because
it goes away as soon as I touch `build.rs` (after which I suspect it re-ingests
the schema and then everything works).

It's been a bit frustrating getting set up and hopefully this PR can make it
a bit easier for future contributors. Very likely I didn't solve all these
problems satisfactorily, but I'm happy to take feedback to get there.