### PR TITLE
Give a more specific error message for unsigned types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Fixed
+
+* `diesel_codegen` will provide a more useful error message when it encounters
+  an unsupported type that contains a space in MySQL.
+
 ## [0.11.4] - 2017-02-21
 
 ### Fixed

--- a/diesel_infer_schema/src/mysql.rs
+++ b/diesel_infer_schema/src/mysql.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use data_structures::*;
 
 pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
-    let tpe = determine_type_name(&attr.type_name);
+    let tpe = determine_type_name(&attr.type_name)?;
 
     Ok(ColumnType {
         path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
@@ -12,8 +12,8 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
     })
 }
 
-fn determine_type_name(sql_type_name: &str) -> &str {
-    if sql_type_name == "tinyint(1)" {
+fn determine_type_name(sql_type_name: &str) -> Result<&str, Box<Error>> {
+    let result = if sql_type_name == "tinyint(1)" {
         "bool"
     } else if sql_type_name.starts_with("int") {
         "integer"
@@ -21,6 +21,14 @@ fn determine_type_name(sql_type_name: &str) -> &str {
         &sql_type_name[..idx]
     } else {
         sql_type_name
+    };
+
+    if result.to_lowercase().contains("unsigned") {
+        Err("unsigned types are not yet supported".into())
+    } else if result.contains(' ') {
+        Err(format!("unrecognized type {:?}", result).into())
+    } else {
+        Ok(result)
     }
 }
 
@@ -30,26 +38,38 @@ fn capitalize(name: &str) -> String {
 
 #[test]
 fn values_which_already_map_to_type_are_returned_unchanged() {
-    assert_eq!("text", determine_type_name("text"));
-    assert_eq!("integer", determine_type_name("integer"));
-    assert_eq!("biginteger", determine_type_name("biginteger"));
+    assert_eq!("text", determine_type_name("text").unwrap());
+    assert_eq!("integer", determine_type_name("integer").unwrap());
+    assert_eq!("biginteger", determine_type_name("biginteger").unwrap());
 }
 
 #[test]
 fn trailing_parenthesis_are_stripped() {
-    assert_eq!("varchar", determine_type_name("varchar(255)"));
-    assert_eq!("decimal", determine_type_name("decimal(10, 2)"));
-    assert_eq!("float", determine_type_name("float(1)"));
+    assert_eq!("varchar", determine_type_name("varchar(255)").unwrap());
+    assert_eq!("decimal", determine_type_name("decimal(10, 2)").unwrap());
+    assert_eq!("float", determine_type_name("float(1)").unwrap());
 }
 
 #[test]
 fn tinyint_is_bool_if_limit_1() {
-    assert_eq!("bool", determine_type_name("tinyint(1)"));
-    assert_eq!("tinyint", determine_type_name("tinyint(2)"));
+    assert_eq!("bool", determine_type_name("tinyint(1)").unwrap());
+    assert_eq!("tinyint", determine_type_name("tinyint(2)").unwrap());
 }
 
 #[test]
 fn int_is_treated_as_integer() {
-    assert_eq!("integer", determine_type_name("int"));
-    assert_eq!("integer", determine_type_name("int(11)"));
+    assert_eq!("integer", determine_type_name("int").unwrap());
+    assert_eq!("integer", determine_type_name("int(11)").unwrap());
+}
+
+#[test]
+fn unsigned_types_are_not_supported() {
+    assert!(determine_type_name("float unsigned").is_err());
+    assert!(determine_type_name("UNSIGNED INT").is_err());
+    assert!(determine_type_name("unsigned bigint").is_err())
+}
+
+#[test]
+fn types_with_space_are_not_supported() {
+    assert!(determine_type_name("lol wat").is_err());
 }


### PR DESCRIPTION
We don't yet support these types in MySQL, but the error a user will
recieve is not terribly helpful, since the type will contain a space so
the `table!` macro invocation will just have bad tokens.

This gives a more specific error message for unsigned types, as well as
ensuring that we get a reasonable error for other types would result in
a bad macro invocation. (I'm not actually aware of any other types which
have a space, but I'd rather not dig through the entire manual right
now)

In theory we could exclude unsigned floats from this, since unsigned
floats aren't actually a thing and that "type" in MySQL is basically
just a check constraint, but I'd rather hold off and actually represent
in Diesel that the type is different when we add support for unsigned
integer types.

Fixes #754.