### PR TITLE
Split `SelectableExpression` into two traits

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -52,22 +52,6 @@ impl<T, U> Expression for NotIn<T, U> where
     type SqlType = Bool;
 }
 
-impl<T, U, QS> SelectableExpression<QS> for In<T, U> where
-    In<T, U>: Expression,
-    T: SelectableExpression<QS>,
-    U: SelectableExpression<QS>,
-{
-    type SqlTypeForSelect = Self::SqlType;
-}
-
-impl<T, U, QS> SelectableExpression<QS> for NotIn<T, U> where
-    NotIn<T, U>: Expression,
-    T: SelectableExpression<QS>,
-    U: SelectableExpression<QS>,
-{
-    type SqlTypeForSelect = Self::SqlType;
-}
-
 impl<T, U> NonAggregate for In<T, U> where
     In<T, U>: Expression,
 {
@@ -138,6 +122,8 @@ impl<T, U, DB> QueryFragment<DB> for NotIn<T, U> where
 
 impl_query_id!(In<T, U>);
 impl_query_id!(NotIn<T, U>);
+impl_selectable_expression!(In<T, U>);
+impl_selectable_expression!(NotIn<T, U>);
 
 use std::marker::PhantomData;
 use query_builder::{SelectStatement, BoxedSelectStatement};
@@ -202,10 +188,16 @@ impl<T> MaybeEmpty for Many<T> {
 }
 
 impl<T, QS> SelectableExpression<QS> for Many<T> where
-    Many<T>: Expression,
+    Many<T>: AppearsOnTable<QS>,
     T: SelectableExpression<QS>,
 {
     type SqlTypeForSelect = T::SqlTypeForSelect;
+}
+
+impl<T, QS> AppearsOnTable<QS> for Many<T> where
+    Many<T>: Expression,
+    T: AppearsOnTable<QS>,
+{
 }
 
 impl<T, DB> QueryFragment<DB> for Many<T> where
@@ -252,10 +244,16 @@ impl<T, ST> MaybeEmpty for Subselect<T, ST> {
 }
 
 impl<T, ST, QS> SelectableExpression<QS> for Subselect<T, ST> where
-    Subselect<T, ST>: Expression,
+    Subselect<T, ST>: AppearsOnTable<QS>,
     T: Query,
 {
     type SqlTypeForSelect = ST;
+}
+
+impl<T, ST, QS> AppearsOnTable<QS> for Subselect<T, ST> where
+    Subselect<T, ST>: Expression,
+    T: Query,
+{
 }
 
 impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST> where

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -4,7 +4,7 @@ use backend::Backend;
 use query_builder::*;
 use result::Error::SerializationError;
 use result::QueryResult;
-use super::{Expression, SelectableExpression, NonAggregate};
+use super::*;
 use types::{HasSqlType, ToSql, IsNull};
 
 #[derive(Debug, Clone, Copy)]
@@ -64,9 +64,14 @@ impl<T: QueryId, U> QueryId for Bound<T, U> {
 }
 
 impl<T, U, QS> SelectableExpression<QS> for Bound<T, U> where
-    Bound<T, U>: Expression,
+    Bound<T, U>: AppearsOnTable<QS>,
 {
     type SqlTypeForSelect = T;
+}
+
+impl<T, U, QS> AppearsOnTable<QS> for Bound<T, U> where
+    Bound<T, U>: Expression,
+{
 }
 
 impl<T, U> NonAggregate for Bound<T, U> where

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use backend::Backend;
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::*;
 use query_builder::*;
 use result::QueryResult;
 
@@ -42,6 +42,11 @@ impl<T, ST, QS> SelectableExpression<QS> for Coerce<T, ST> where
     T: SelectableExpression<QS>,
 {
     type SqlTypeForSelect = Self::SqlType;
+}
+
+impl<T, ST, QS> AppearsOnTable<QS> for Coerce<T, ST> where
+    T: AppearsOnTable<QS>,
+{
 }
 
 impl<T, ST, DB> QueryFragment<DB> for Coerce<T, ST> where

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,7 +1,7 @@
 use backend::Backend;
 use query_builder::*;
 use result::QueryResult;
-use super::{Expression, SelectableExpression};
+use super::Expression;
 use types::BigInt;
 
 /// Creates a SQL `COUNT` expression
@@ -78,10 +78,7 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
 }
 
 impl_query_id!(Count<T>);
-
-impl<T: Expression, QS> SelectableExpression<QS> for Count<T> {
-    type SqlTypeForSelect = BigInt;
-}
+impl_selectable_expression!(Count<T>);
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -106,8 +103,5 @@ impl<DB: Backend> QueryFragment<DB> for CountStar {
     }
 }
 
-impl<QS> SelectableExpression<QS> for CountStar {
-    type SqlTypeForSelect = BigInt;
-}
-
 impl_query_id!(CountStar);
+impl_selectable_expression!(CountStar);

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::{Expression, NonAggregate};
 use query_builder::*;
 use result::QueryResult;
 use types::Bool;
@@ -49,12 +49,6 @@ impl<T> Expression for Exists<T> where
     type SqlType = Bool;
 }
 
-impl<T, QS> SelectableExpression<QS> for Exists<T> where
-    Exists<T>: Expression,
-{
-    type SqlTypeForSelect = Bool;
-}
-
 impl<T> NonAggregate for Exists<T> {
 }
 
@@ -80,3 +74,4 @@ impl<T, DB> QueryFragment<DB> for Exists<T> where
 }
 
 impl_query_id!(Exists<T>);
+impl_selectable_expression!(Exists<T>);

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{Expression, SelectableExpression};
+use expression::Expression;
 use query_builder::*;
 use result::QueryResult;
 use types::{Foldable, HasSqlType};
@@ -50,13 +50,7 @@ macro_rules! fold_function {
         }
 
         impl_query_id!($type_name<T>);
-
-        impl<T, QS> SelectableExpression<QS> for $type_name<T> where
-            $type_name<T>: Expression,
-            T: SelectableExpression<QS>,
-        {
-            type SqlTypeForSelect = Self::SqlType;
-        }
+        impl_selectable_expression!($type_name<T>);
     }
 }
 

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{Expression, SelectableExpression};
+use expression::Expression;
 use query_builder::*;
 use result::QueryResult;
 use types::{SqlOrd, HasSqlType, IntoNullable};
@@ -49,13 +49,7 @@ macro_rules! ord_function {
         }
 
         impl_query_id!($type_name<T>);
-
-        impl<T, QS> SelectableExpression<QS> for $type_name<T> where
-            $type_name<T>: Expression,
-            T: SelectableExpression<QS>,
-        {
-            type SqlTypeForSelect = Self::SqlType;
-        }
+        impl_selectable_expression!($type_name<T>);
     }
 }
 

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::{Expression, NonAggregate};
 use query_builder::*;
 use result::QueryResult;
 use types::*;
@@ -12,10 +12,6 @@ pub struct now;
 
 impl Expression for now {
     type SqlType = Timestamp;
-}
-
-impl<QS> SelectableExpression<QS> for now {
-    type SqlTypeForSelect = Timestamp;
 }
 
 impl NonAggregate for now {
@@ -37,6 +33,7 @@ impl<DB: Backend> QueryFragment<DB> for now {
 }
 
 impl_query_id!(now);
+impl_selectable_expression!(now);
 
 operator_allowed!(now, Add, add);
 operator_allowed!(now, Sub, sub);

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -62,10 +62,20 @@ macro_rules! sql_function_body {
 
         #[allow(non_camel_case_types)]
         impl<$($arg_name),*, QS> $crate::expression::SelectableExpression<QS> for $struct_name<$($arg_name),*> where
-            $($arg_name: $crate::expression::SelectableExpression<QS>,)*
-            $struct_name<$($arg_name),*>: $crate::expression::Expression,
+            $($arg_name: $crate::expression::SelectableExpression<
+              QS,
+              SqlTypeForSelect = <$arg_name as $crate::expression::Expression>::SqlType,
+            >,)*
+            $struct_name<$($arg_name),*>: $crate::expression::AppearsOnTable<QS>,
         {
             type SqlTypeForSelect = Self::SqlType;
+        }
+
+        #[allow(non_camel_case_types)]
+        impl<$($arg_name),*, QS> $crate::expression::AppearsOnTable<QS> for $struct_name<$($arg_name),*> where
+            $($arg_name: $crate::expression::AppearsOnTable<QS>,)*
+            $struct_name<$($arg_name),*>: $crate::expression::Expression,
+        {
         }
 
         #[allow(non_camel_case_types)]
@@ -134,6 +144,9 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
 
         impl<QS> $crate::expression::SelectableExpression<QS> for $type_name {
             type SqlTypeForSelect = $return_type;
+        }
+
+        impl<QS> $crate::expression::AppearsOnTable<QS> for $type_name {
         }
 
         impl $crate::expression::NonAggregate for $type_name {

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::{Expression, NonAggregate};
 use query_builder::*;
 use result::QueryResult;
 
@@ -29,13 +29,7 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
 }
 
 impl_query_id!(Grouped<T>);
-
-impl<T, QS> SelectableExpression<QS> for Grouped<T> where
-    T: SelectableExpression<QS>,
-    Grouped<T>: Expression,
-{
-    type SqlTypeForSelect = T::SqlTypeForSelect;
-}
+impl_selectable_expression!(Grouped<T>);
 
 impl<T: NonAggregate> NonAggregate for Grouped<T> where
     Grouped<T>: Expression,

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::*;
 use query_builder::*;
 use result::QueryResult;
 use types::IntoNullable;
@@ -42,9 +42,15 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
 /// nullable.
 impl<T, QS> SelectableExpression<QS> for Nullable<T> where
     T: SelectableExpression<QS>,
-    Nullable<T>: Expression,
+    Nullable<T>: AppearsOnTable<QS>,
 {
     type SqlTypeForSelect = Self::SqlType;
+}
+
+impl<T, QS> AppearsOnTable<QS> for Nullable<T> where
+    T: AppearsOnTable<QS>,
+    Nullable<T>: Expression,
+{
 }
 
 impl<T: QueryId> QueryId for Nullable<T> {

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::{Expression, NonAggregate};
 use query_builder::*;
 use result::QueryResult;
 use types;
@@ -53,14 +53,7 @@ macro_rules! numeric_operation {
         }
 
         impl_query_id!($name<Lhs, Rhs>);
-
-        impl<Lhs, Rhs, QS> SelectableExpression<QS> for $name<Lhs, Rhs> where
-            Lhs: SelectableExpression<QS>,
-            Rhs: SelectableExpression<QS>,
-            $name<Lhs, Rhs>: Expression,
-        {
-            type SqlTypeForSelect = Self::SqlType;
-        }
+        impl_selectable_expression!($name<Lhs, Rhs>);
 
         impl<Lhs, Rhs> NonAggregate for $name<Lhs, Rhs> where
             Lhs: NonAggregate,

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -18,19 +18,13 @@ macro_rules! infix_predicate_body {
         }
 
         impl_query_id!($name<T, U>);
+        impl_selectable_expression!($name<T, U>);
 
         impl<T, U> $crate::expression::Expression for $name<T, U> where
             T: $crate::expression::Expression,
             U: $crate::expression::Expression,
         {
             type SqlType = $return_type;
-        }
-
-        impl<T, U, QS> $crate::expression::SelectableExpression<QS> for $name<T, U> where
-            T: $crate::expression::SelectableExpression<QS>,
-            U: $crate::expression::SelectableExpression<QS>,
-        {
-            type SqlTypeForSelect = Self::SqlType;
         }
 
         impl<T, U> $crate::expression::NonAggregate for $name<T, U> where
@@ -190,6 +184,7 @@ macro_rules! postfix_predicate_body {
         }
 
         impl_query_id!($name<T>);
+        impl_selectable_expression!($name<T>);
 
         impl<T> $crate::expression::Expression for $name<T> where
             T: $crate::expression::Expression,
@@ -215,12 +210,6 @@ macro_rules! postfix_predicate_body {
             fn is_safe_to_cache_prepared(&self) -> bool {
                 self.expr.is_safe_to_cache_prepared()
             }
-        }
-
-        impl<T, QS> $crate::expression::SelectableExpression<QS> for $name<T> where
-            T: $crate::expression::SelectableExpression<QS>,
-        {
-            type SqlTypeForSelect = Self::SqlType;
         }
 
         impl<T> $crate::expression::NonAggregate for $name<T> where
@@ -269,12 +258,12 @@ use backend::Backend;
 use query_source::Column;
 use query_builder::*;
 use result::QueryResult;
-use super::SelectableExpression;
+use super::AppearsOnTable;
 
 impl<T, U, DB> Changeset<DB> for Eq<T, U> where
     DB: Backend,
     T: Column,
-    U: SelectableExpression<T::Table> + QueryFragment<DB>,
+    U: AppearsOnTable<T::Table> + QueryFragment<DB>,
 {
     fn is_noop(&self) -> bool {
         false
@@ -293,7 +282,7 @@ impl<T, U, DB> Changeset<DB> for Eq<T, U> where
 
 impl<T, U> AsChangeset for Eq<T, U> where
     T: Column,
-    U: SelectableExpression<T::Table>,
+    U: AppearsOnTable<T::Table>,
 {
     type Target = T::Table;
     type Changeset = Self;

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -1,8 +1,9 @@
+use std::marker::PhantomData;
+
 use backend::Backend;
+use expression::*;
 use query_builder::*;
 use result::QueryResult;
-use std::marker::PhantomData;
-use super::{Expression, SelectableExpression, NonAggregate};
 use types::HasSqlType;
 
 #[derive(Debug, Clone)]
@@ -52,6 +53,9 @@ impl<ST> Query for SqlLiteral<ST> {
 
 impl<QS, ST> SelectableExpression<QS> for SqlLiteral<ST> {
     type SqlTypeForSelect = ST;
+}
+
+impl<QS, ST> AppearsOnTable<QS> for SqlLiteral<ST> {
 }
 
 impl<ST> NonAggregate for SqlLiteral<ST> {

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -100,7 +100,6 @@ pub mod helper_types {
     /// Represents the return type of `.offset()`
     pub type Offset<Source> = <Source as OffsetDsl>::Output;
 
-
     use super::associations::HasTable;
     use super::query_builder::{UpdateStatement, IntoUpdateTarget, AsChangeset};
     /// Represents the return type of `update(lhs).set(rhs)`
@@ -115,7 +114,7 @@ pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using Diesel.
     pub use associations::GroupedBy;
     pub use connection::Connection;
-    pub use expression::{Expression, SelectableExpression, BoxableExpression};
+    pub use expression::{Expression, SelectableExpression, AppearsOnTable, BoxableExpression};
     pub use expression::expression_methods::*;
     #[doc(inline)]
     pub use insertable::Insertable;

--- a/diesel/src/macros/internal.rs
+++ b/diesel/src/macros/internal.rs
@@ -1,0 +1,40 @@
+/// This will implement `SelectableExpression` and `AppearsOnTable` for "simple"
+/// composite nodes where the where clause is roughly `AllTyParams:
+/// SelectableExpression<QS>, Self: Expression`.
+///
+/// This macro is exported because we want to be able to call it from other
+/// macros that are exported, but it is not part of our public API.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_selectable_expression {
+    ($struct_name:ident) => {
+        impl_selectable_expression!(ty_params = (), struct_ty = $struct_name,);
+    };
+
+    ($struct_name:ident<$($ty_params:ident),+>) => {
+        impl_selectable_expression!(
+            ty_params = ($($ty_params),+),
+            struct_ty = $struct_name<$($ty_params),+>,
+        );
+    };
+
+    (ty_params = ($($ty_params:ident),*), struct_ty = $struct_ty:ty,) => {
+        impl<$($ty_params,)* QS> $crate::expression::SelectableExpression<QS>
+            for $struct_ty where
+                $struct_ty: $crate::expression::AppearsOnTable<QS>,
+                $($ty_params: $crate::expression::SelectableExpression<
+                  QS,
+                  SqlTypeForSelect = <$ty_params as $crate::expression::Expression>::SqlType,
+                >,)*
+        {
+            type SqlTypeForSelect = <$struct_ty as $crate::expression::Expression>::SqlType;
+        }
+
+        impl<$($ty_params,)* QS> $crate::expression::AppearsOnTable<QS>
+            for $struct_ty where
+                $struct_ty: $crate::expression::Expression,
+                $($ty_params: $crate::expression::AppearsOnTable<QS>,)*
+        {
+        }
+    };
+}

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -1,5 +1,5 @@
 use backend::*;
-use expression::{AsExpression, Expression, SelectableExpression, NonAggregate};
+use expression::{AsExpression, Expression, NonAggregate};
 use pg::{Pg, PgQueryBuilder};
 use query_builder::*;
 use query_builder::debug::DebugQueryBuilder;
@@ -138,13 +138,7 @@ impl<Expr> QueryFragment<Debug> for Any<Expr> where
 }
 
 impl_query_id!(Any<Expr>);
-
-impl<Expr, QS> SelectableExpression<QS> for Any<Expr> where
-    Any<Expr>: Expression,
-    Expr: SelectableExpression<QS>,
-{
-    type SqlTypeForSelect = Self::SqlType;
-}
+impl_selectable_expression!(Any<Expr>);
 
 impl<Expr> NonAggregate for Any<Expr> where
     Expr: NonAggregate,
@@ -212,13 +206,7 @@ impl<Expr> QueryFragment<Debug> for All<Expr> where
 }
 
 impl_query_id!(All<Expr>);
-
-impl<Expr, QS> SelectableExpression<QS> for All<Expr> where
-    All<Expr>: Expression,
-    Expr: SelectableExpression<QS>,
-{
-    type SqlTypeForSelect = Self::SqlType;
-}
+impl_selectable_expression!(All<Expr>);
 
 impl<Expr> NonAggregate for All<Expr> where
     Expr: NonAggregate,

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -1,5 +1,5 @@
 use backend::*;
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::{Expression, NonAggregate};
 use pg::{Pg, PgQueryBuilder};
 use query_builder::*;
 use result::QueryResult;
@@ -62,6 +62,7 @@ impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz> where
 }
 
 impl_query_id!(AtTimeZone<Ts, Tz>);
+impl_selectable_expression!(AtTimeZone<Ts, Tz>);
 
 impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
     Ts: QueryFragment<Debug>,
@@ -83,12 +84,4 @@ impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
         self.timestamp.is_safe_to_cache_prepared() &&
             self.timezone.is_safe_to_cache_prepared()
     }
-}
-
-impl<Ts, Tz, Qs> SelectableExpression<Qs> for AtTimeZone<Ts, Tz> where
-    AtTimeZone<Ts, Tz>: Expression,
-    Ts: SelectableExpression<Qs>,
-    Tz: SelectableExpression<Qs>,
-{
-    type SqlTypeForSelect = Self::SqlType;
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use backend::Backend;
-use expression::{SelectableExpression, NonAggregate, AsExpression};
+use expression::*;
 use query_builder::*;
 use query_builder::limit_clause::LimitClause;
 use query_builder::offset_clause::OffsetClause;
@@ -176,7 +176,7 @@ impl<'a, ST, QS, DB, Selection> SelectDsl<Selection, Selection::SqlTypeForSelect
 impl<'a, ST, QS, DB, Predicate> FilterDsl<Predicate>
     for BoxedSelectStatement<'a, ST, QS, DB> where
         DB: Backend + HasSqlType<ST> + 'a,
-        Predicate: SelectableExpression<QS, SqlType=Bool> + NonAggregate,
+        Predicate: AppearsOnTable<QS, SqlType=Bool> + NonAggregate,
         Predicate: QueryFragment<DB> + 'a,
 {
     type Output = Self;
@@ -220,7 +220,7 @@ impl<'a, ST, QS, DB> OffsetDsl for BoxedSelectStatement<'a, ST, QS, DB> where
 impl<'a, ST, QS, DB, Order> OrderDsl<Order>
     for BoxedSelectStatement<'a, ST, QS, DB> where
         DB: Backend,
-        Order: QueryFragment<DB> + SelectableExpression<QS> + 'a,
+        Order: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
         BoxedSelectStatement<'a, ST, QS, DB>: Query,
 {
     type Output = Self;

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -58,7 +58,7 @@ impl<ST, S, F, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
     for SelectStatement<S, F, D, W, O, L, Of, G> where
         SelectStatement<S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
         SelectStatement<S, F, D, W::Output, O, L, Of, G>: Query<SqlType=ST>,
-        Predicate: SelectableExpression<F, SqlType=Bool> + NonAggregate,
+        Predicate: AppearsOnTable<F, SqlType=Bool> + NonAggregate,
         W: WhereAnd<Predicate>,
 {
     type Output = SelectStatement<S, F, D, W::Output, O, L, Of, G>;
@@ -79,7 +79,7 @@ impl<ST, S, F, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
 
 impl<ST, S, F, D, W, O, L, Of, G, Expr> OrderDsl<Expr>
     for SelectStatement<S, F, D, W, O, L, Of, G> where
-        Expr: SelectableExpression<F>,
+        Expr: AppearsOnTable<F>,
         SelectStatement<S, F, D, W, O, L, Of, G>: AsQuery<SqlType=ST>,
         SelectStatement<S, F, D, W, OrderClause<Expr>, L, Of, G>: AsQuery<SqlType=ST>,
 {

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -235,9 +235,15 @@ impl_query_id!(SelectStatement<S, F, D, W, O, L, Of, G>);
 
 impl<S, F, D, W, O, L, Of, G, QS> SelectableExpression<QS>
     for SelectStatement<S, F, D, W, O, L, Of, G> where
-        SelectStatement<S, F, D, W, O, L, Of, G>: Expression,
+        SelectStatement<S, F, D, W, O, L, Of, G>: AppearsOnTable<QS>,
 {
     type SqlTypeForSelect = Self::SqlType;
+}
+
+impl<S, F, D, W, O, L, Of, G, QS> AppearsOnTable<QS>
+    for SelectStatement<S, F, D, W, O, L, Of, G> where
+        SelectStatement<S, F, D, W, O, L, Of, G>: Expression,
+{
 }
 
 impl<S, F, D, W, O, L, Of, G> NonAggregate

--- a/diesel/src/query_source/filter.rs
+++ b/diesel/src/query_source/filter.rs
@@ -1,5 +1,5 @@
 use associations::HasTable;
-use expression::{SelectableExpression, NonAggregate};
+use expression::{AppearsOnTable, NonAggregate};
 use expression::expression_methods::*;
 use expression::predicates::And;
 use helper_types::Filter;
@@ -25,7 +25,7 @@ impl<Source, Predicate> FilteredQuerySource<Source, Predicate> {
 }
 
 impl<Source, Predicate> AsQuery for FilteredQuerySource<Source, Predicate> where
-    Predicate: SelectableExpression<Source, SqlType=Bool> + NonAggregate,
+    Predicate: AppearsOnTable<Source, SqlType=Bool> + NonAggregate,
     Source: QuerySource + AsQuery,
     Source::Query: FilterDsl<Predicate>,
 {
@@ -42,8 +42,8 @@ impl<Source, Predicate, NewPredicate, ST> FilterDsl<NewPredicate>
     for FilteredQuerySource<Source, Predicate> where
         FilteredQuerySource<Source, Predicate>: AsQuery<SqlType=ST>,
         FilteredQuerySource<Source, And<Predicate, NewPredicate>>: AsQuery<SqlType=ST>,
-        Predicate: SelectableExpression<Source, SqlType=Bool>,
-        NewPredicate: SelectableExpression<Source, SqlType=Bool> + NonAggregate,
+        Predicate: AppearsOnTable<Source, SqlType=Bool>,
+        NewPredicate: AppearsOnTable<Source, SqlType=Bool> + NonAggregate,
 {
     type Output = FilteredQuerySource<Source, And<Predicate, NewPredicate>>;
 
@@ -76,7 +76,7 @@ impl<Source, Predicate> HasTable for FilteredQuerySource<Source, Predicate> wher
 
 impl<Source, Predicate> IntoUpdateTarget for FilteredQuerySource<Source, Predicate> where
     FilteredQuerySource<Source, Predicate>: HasTable,
-    Predicate: SelectableExpression<Source, SqlType=Bool>,
+    Predicate: AppearsOnTable<Source, SqlType=Bool>,
 {
     type WhereClause = Predicate;
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -1,6 +1,6 @@
 use associations::BelongsTo;
 use backend::{Backend, SupportsDefaultKeyword};
-use expression::{Expression, SelectableExpression, NonAggregate};
+use expression::{Expression, SelectableExpression, AppearsOnTable, NonAggregate};
 use insertable::{ColumnInsertValue, InsertValues};
 use query_builder::*;
 use query_source::{QuerySource, Queryable, Table, Column};
@@ -212,9 +212,15 @@ macro_rules! tuple_impls {
 
             impl<$($T,)+ QS> SelectableExpression<QS> for ($($T,)+) where
                 $($T: SelectableExpression<QS>,)+
-                ($($T,)+): Expression,
+                ($($T,)+): AppearsOnTable<QS>,
             {
                 type SqlTypeForSelect = ($($T::SqlTypeForSelect,)+);
+            }
+
+            impl<$($T,)+ QS> AppearsOnTable<QS> for ($($T,)+) where
+                $($T: AppearsOnTable<QS>,)+
+                ($($T,)+): Expression,
+            {
             }
 
             impl<Target, $($T,)+> AsChangeset for ($($T,)+) where

--- a/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
@@ -19,10 +19,14 @@ fn main() {
     use diesel::expression::dsl::*;
     let source = users::table.select(sum(posts::id));
     //~^ ERROR E0277
+    //~| ERROR AppearsOnTable
     let source = users::table.select(avg(posts::id));
     //~^ ERROR E0277
+    //~| ERROR AppearsOnTable
     let source = users::table.select(max(posts::id));
     //~^ ERROR E0277
+    //~| ERROR AppearsOnTable
     let source = users::table.select(min(posts::id));
     //~^ ERROR E0277
+    //~| ERROR AppearsOnTable
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
@@ -20,5 +20,5 @@ table! {
 
 fn main() {
     users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
-    //~^ ERROR SelectableExpression
+    //~^ ERROR AppearsOnTable
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
@@ -20,5 +20,5 @@ table! {
 
 fn main() {
     users::table.into_boxed::<Pg>().order(posts::title.desc());
-    //~^ ERROR SelectableExpression
+    //~^ ERROR AppearsOnTable
 }

--- a/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
@@ -36,4 +36,5 @@ fn main() {
     };
     let stmt = insert(&new_user).into(users).returning((name, bad::age));
     //~^ ERROR SelectableExpression
+    //~| ERROR AppearsOnTable
 }

--- a/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -19,7 +19,7 @@ table! {
 
 fn main() {
     let _ = users::table.filter(posts::id.eq(1));
-    //~^ ERROR SelectableExpression
+    //~^ ERROR AppearsOnTable
     let _ = users::table.filter(users::name.eq(posts::title));
-    //~^ ERROR SelectableExpression
+    //~^ ERROR AppearsOnTable
 }

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -30,11 +30,11 @@ fn main() {
 
     // Valid
     let _ = join.select(posts::title.nullable());
+    // FIXME: This doesn't compile but we want it to
     // Valid -- NULL to a function will return null
-    let _ = join.select(lower(posts::title).nullable());
-    // FIXME: This compiles and is unsound
+    let _ = join.select(lower(posts::title).nullable()); //~ ERROR E0271
     // Invalid, only Nullable<title> is selectable
-    let _ = join.select(lower(posts::title));
+    let _ = join.select(lower(posts::title)); //~ ERROR E0271
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable())); //~ ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -22,6 +22,9 @@ fn main() {
     let stuff = users::table.select((posts::id, posts::user_id));
     //~^ ERROR Selectable
     //~| ERROR E0277
+    //~| ERROR E0277
+    //~| ERROR E0277
     let stuff = users::table.select((posts::id, users::name));
     //~^ ERROR Selectable
+    //~| ERROR E0277
 }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -101,6 +101,9 @@ impl<T, QS> SelectableExpression<QS> for Arbitrary<T> {
     type SqlTypeForSelect = T;
 }
 
+impl<T, QS> AppearsOnTable<QS> for Arbitrary<T> {
+}
+
 fn arbitrary<T>() -> Arbitrary<T> {
     Arbitrary { _marker: PhantomData }
 }

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -234,25 +234,27 @@ fn select_then_join() {
     assert_eq!(expected_data, data);
 }
 
-#[test]
-fn selecting_complex_expression_from_right_side_of_join() {
-    use diesel::types::Text;
+// FIXME: This is fixed by the new join design which removes the associated type
+// form `SelectableExpression`
+// #[test]
+// fn selecting_complex_expression_from_right_side_of_join() {
+//     use diesel::types::Text;
 
-    let connection = connection_with_sean_and_tess_in_users_table();
-    let new_posts = vec![
-        NewPost::new(1, "Post One", None),
-        NewPost::new(1, "Post Two", None),
-    ];
-    insert(&new_posts).into(posts::table).execute(&connection).unwrap();
-    sql_function!(lower, lower_t, (x: Text) -> Text);
+//     let connection = connection_with_sean_and_tess_in_users_table();
+//     let new_posts = vec![
+//         NewPost::new(1, "Post One", None),
+//         NewPost::new(1, "Post Two", None),
+//     ];
+//     insert(&new_posts).into(posts::table).execute(&connection).unwrap();
+//     sql_function!(lower, lower_t, (x: Text) -> Text);
 
-    let titles = users::table.left_outer_join(posts::table)
-        .select(lower(posts::title).nullable())
-        .order((users::id, posts::id))
-        .load(&connection);
-    let expected_data = vec![Some("post one".to_string()), Some("post two".to_string()), None];
-    assert_eq!(Ok(expected_data), titles);
-}
+//     let titles = users::table.left_outer_join(posts::table)
+//         .select(lower(posts::title).nullable())
+//         .order((users::id, posts::id))
+//         .load(&connection);
+//     let expected_data = vec![Some("post one".to_string()), Some("post two".to_string()), None];
+//     assert_eq!(Ok(expected_data), titles);
+// }
 
 #[test]
 fn join_through_other() {

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -491,7 +491,8 @@ use diesel::query_builder::{QueryFragment, QueryId};
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
     TestBackend: HasSqlType<T>,
     U: AsExpression<T> + Debug + Clone,
-    U::Expression: SelectableExpression<()> + QueryFragment<TestBackend> + QueryId,
+    U::Expression: SelectableExpression<(), SqlType=T, SqlTypeForSelect=T>,
+    U::Expression: QueryFragment<TestBackend> + QueryId,
     T: QueryId,
 {
     use diesel::expression::dsl::sql;


### PR DESCRIPTION
The change in #709 had the side effect of re-introducing #104.
With the design that we have right now, nullability isn't propagating
upwards. This puts the issue of "expressions aren't validating that the
type of its arguments haven't become nullable, and thus nulls are
slipping in where they shouldn't be" at odds with "we can't use complex
expressions in filters for joins because the SQL type changed".

This semi-resolves the issue by restricting when we care about
nullability. Ultimately the only time it really matters is when we're
selecting data, as we need to enforce that the result goes into an
`Option`. For places where we don't see the bytes in Rust (filter,
order, etc), `NULL` is effectively `false`.

This change goes back to fully fixing #104, but brings back a small
piece of #621. I've changed everything that is a composite expression to
only be selectable if the SQL type hasn't changed. This means that you
won't be able to do things like
`users.left_outer_join(posts).select(posts::id + 1)`, but you will be
able to use whatever you want in `filter`.

This change is also to support what I think will fix the root of all
these issues. The design of "Here's the SQL type on this query source"
is just fundamentally not what we need. There is only one case where the
type changes, and that is to become null when it is on the right side of
a left join, the left side of a right join, or either side of a full
join.

One of the changes that #709 made was to require that you explicitly
call `.nullable()` on a tuple if you wanted to get `Option<(i32,
String)>` instead of `(Option<i32>, Option<String>)`. This has worked
out fine, and isn't a major ergonomic pain. The common case is just to
use the default select clause anyway. So I want to go further down this
path.

The longer term plan is to remove `SqlTypeForSelect` entirely, and *not*
implement `SelectableExpression` for columns on the nullable side of a
join. We will then provide these two blanket impls:

```rust
impl<Left, Right, T> SelectableExpression<LeftOuterJoin<Left, Right>>
    for Nullable<T> where T: SelectableExpression<Right>,
{}

impl<Left, Right, Head, Tail> SelectableExpression<LeftOuterJoin<Left, Right>>
    for Nullable<Cons<Head, Tail>> where
        Nullable<Head>: SelectableExpression<LeftOuterJoin<Left, Right>>,
        Nullable<Tail>: SelectableExpression<LeftOuterJoin<Left, Right>>,
{}
```

(Note: Those impls overlap. Providing them as blanket impls would
require https://github.com/rust-lang/rust/pull/40097. Providing them as
non-blanket impls would require us to mark `Nullable` and possibly
`Cons` as `#[fundamental]`)

The end result will be that nullability naturally propagates as we want
it to. Given `sql_function!(lower, lower_t, (x: Text) -> Text)`, doing
`select(lower(posts::name).nullable())` will work. `lower(posts::name)`
will fail because `posts::name` doesn't impl `SelectableExpression`.
`lower(posts::name.nullable())` will fail because while
`SelectableExpression` will be met, the SQL type of the argument isn't
what's expected. Putting `.nullable` at the very top level naturally
follows SQL's semantics here.