### PR TITLE
Add support for the SQL concat operator `||`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* Added support for the SQL concatenation operator `||`. See [the docs for
+  `.concat`][concat-0.12.0] for more details
+
+[concat-0.12.0]: http://docs.diesel.rs/diesel/expression/expression_methods/text_expression_methods/trait.TextExpressionMethods.html#method.concat
+
 ### Fixed
 
 * `diesel_codegen` will provide a more useful error message when it encounters

--- a/diesel/src/expression/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/text_expression_methods.rs
@@ -1,8 +1,39 @@
 use expression::{Expression, AsExpression};
-use expression::predicates::{Like, NotLike};
+use expression::predicates::{Concat, Like, NotLike};
 use types::Text;
 
 pub trait TextExpressionMethods: Expression<SqlType=Text> + Sized {
+    /// Concatenates two strings using the `||` operator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let names = users.select(name.concat(" the Greatest")).load(&connection);
+    /// let expected_names = vec![
+    ///     "Sean the Greatest".to_string(),
+    ///     "Tess the Greatest".to_string(),
+    /// ];
+    /// assert_eq!(Ok(expected_names), names);
+    /// # }
+    /// ```
+    fn concat<T: AsExpression<Text>>(self, other: T) -> Concat<Self, T::Expression> {
+        Concat::new(self, other.as_expression())
+    }
+
     /// Returns a SQL `LIKE` expression
     fn like<T: AsExpression<Text>>(self, other: T) -> Like<Self, T::Expression> {
         Like::new(self.as_expression(), other.as_expression())

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -235,6 +235,7 @@ macro_rules! postfix_expression {
     }
 }
 
+infix_expression!(Concat, " || ", ::types::Text);
 infix_predicate!(And, " AND ");
 infix_predicate!(Between, " BETWEEN ");
 infix_predicate!(Escape, " ESCAPE ");

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -70,6 +70,11 @@ pub enum ConnectionError {
     InvalidCString(NulError),
     BadConnection(String),
     InvalidConnectionUrl(String),
+    /// Diesel may try to automatically set session specific configuration
+    /// values, such as UTF8 encoding, or enabling the `||` operator on MySQL.
+    /// This variant is returned if an error occurred executing the query to set
+    /// those options. Diesel will never affect global configuration.
+    CouldntSetupConfiguration(Error),
     #[doc(hidden)]
     __Nonexhaustive, // Match against _ instead, more variants may be added in the future
 }
@@ -139,6 +144,7 @@ impl Display for ConnectionError {
             ConnectionError::InvalidCString(ref nul_err) => nul_err.fmt(f),
             ConnectionError::BadConnection(ref s) => write!(f, "{}", s),
             ConnectionError::InvalidConnectionUrl(ref s) => write!(f, "{}", s),
+            ConnectionError::CouldntSetupConfiguration(ref e) => e.fmt(f),
             ConnectionError::__Nonexhaustive => unreachable!(),
         }
     }
@@ -150,6 +156,7 @@ impl StdError for ConnectionError {
             ConnectionError::InvalidCString(ref nul_err) => nul_err.description(),
             ConnectionError::BadConnection(ref s) => s,
             ConnectionError::InvalidConnectionUrl(ref s) => s,
+            ConnectionError::CouldntSetupConfiguration(ref e) => e.description(),
             ConnectionError::__Nonexhaustive => unreachable!(),
         }
     }

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -237,7 +237,7 @@ fn select_then_join() {
 // FIXME: This is fixed by the new join design which removes the associated type
 // form `SelectableExpression`
 // #[test]
-// fn selecting_complex_expression_from_right_side_of_join() {
+// fn selecting_complex_expression_from_right_side_of_left_join() {
 //     use diesel::types::Text;
 
 //     let connection = connection_with_sean_and_tess_in_users_table();
@@ -253,6 +253,31 @@ fn select_then_join() {
 //         .order((users::id, posts::id))
 //         .load(&connection);
 //     let expected_data = vec![Some("post one".to_string()), Some("post two".to_string()), None];
+//     assert_eq!(Ok(expected_data), titles);
+// }
+
+// FIXME: This is fixed by the new join design which removes the associated type
+// form `SelectableExpression`
+// #[test]
+// fn selecting_complex_expression_from_both_sides_of_outer_join() {
+//     use diesel::types::Text;
+
+//     let connection = connection_with_sean_and_tess_in_users_table();
+//     let new_posts = vec![
+//         NewPost::new(1, "Post One", None),
+//         NewPost::new(1, "Post Two", None),
+//     ];
+//     insert(&new_posts).into(posts::table).execute(&connection).unwrap();
+
+//     let titles = users::table.left_outer_join(posts::table)
+//         .select(users::name.concat(" wrote ").concat(posts::title).nullable())
+//         .order((users::id, posts::id))
+//         .load(&connection);
+//     let expected_data = vec![
+//         Some("Sean wrote Post One".to_string()),
+//         Some("Sean wrote Post Two".to_string()),
+//         None,
+//     ];
 //     assert_eq!(Ok(expected_data), titles);
 // }
 


### PR DESCRIPTION
The integration test was actually the main reason I wanted this. I was
originally going to do `sql_function!(concat)`, but on PG that function
ignores null arguments rather than returning null, and SQLite doesn't
even have it. The pipe operator is ANSI standard SQL, but it's behind a
configuration option for MySQL. I set up a bit of groundwork for more
"always set configuration settings", since I think we will probably want
to at minimum ensure client encoding is UTF-8 and that the timezone is
UTC for all backends eventually.

This operator is notably not supported by MS SQL Server, but I don't
plan on supporting that backend in tree, and a single hypothetical third
party backend isn't enough to warrant adding a `SupportsPipeOperator`
marker.