### PR TITLE
Remove the associated type from `SelectableExpression`

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -191,7 +191,6 @@ impl<T, QS> SelectableExpression<QS> for Many<T> where
     Many<T>: AppearsOnTable<QS>,
     T: SelectableExpression<QS>,
 {
-    type SqlTypeForSelect = T::SqlTypeForSelect;
 }
 
 impl<T, QS> AppearsOnTable<QS> for Many<T> where
@@ -247,7 +246,6 @@ impl<T, ST, QS> SelectableExpression<QS> for Subselect<T, ST> where
     Subselect<T, ST>: AppearsOnTable<QS>,
     T: Query,
 {
-    type SqlTypeForSelect = ST;
 }
 
 impl<T, ST, QS> AppearsOnTable<QS> for Subselect<T, ST> where

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -66,7 +66,6 @@ impl<T: QueryId, U> QueryId for Bound<T, U> {
 impl<T, U, QS> SelectableExpression<QS> for Bound<T, U> where
     Bound<T, U>: AppearsOnTable<QS>,
 {
-    type SqlTypeForSelect = T;
 }
 
 impl<T, U, QS> AppearsOnTable<QS> for Bound<T, U> where

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -41,7 +41,6 @@ impl<T, ST> Expression for Coerce<T, ST> where
 impl<T, ST, QS> SelectableExpression<QS> for Coerce<T, ST> where
     T: SelectableExpression<QS>,
 {
-    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<T, ST, QS> AppearsOnTable<QS> for Coerce<T, ST> where

--- a/diesel/src/expression/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression/expression_methods/global_expression_methods.rs
@@ -286,7 +286,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # fn main() {
     /// #     use self::users::dsl::*;
     /// #     let order = "name";
-    /// let ordering: Box<BoxableExpression<users, DB, SqlType=(), SqlTypeForSelect=()>> =
+    /// let ordering: Box<BoxableExpression<users, DB, SqlType=()>> =
     ///     if order == "name" {
     ///         Box::new(name.desc())
     ///     } else {

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -62,13 +62,9 @@ macro_rules! sql_function_body {
 
         #[allow(non_camel_case_types)]
         impl<$($arg_name),*, QS> $crate::expression::SelectableExpression<QS> for $struct_name<$($arg_name),*> where
-            $($arg_name: $crate::expression::SelectableExpression<
-              QS,
-              SqlTypeForSelect = <$arg_name as $crate::expression::Expression>::SqlType,
-            >,)*
+            $($arg_name: $crate::expression::SelectableExpression<QS>,)*
             $struct_name<$($arg_name),*>: $crate::expression::AppearsOnTable<QS>,
         {
-            type SqlTypeForSelect = Self::SqlType;
         }
 
         #[allow(non_camel_case_types)]
@@ -143,7 +139,6 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
         }
 
         impl<QS> $crate::expression::SelectableExpression<QS> for $type_name {
-            type SqlTypeForSelect = $return_type;
         }
 
         impl<QS> $crate::expression::AppearsOnTable<QS> for $type_name {

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -37,16 +37,8 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
     }
 }
 
-/// This impl relies on the fact that the only time `T::SqlType` will differ
-/// from `T::SqlTypeForSelect` is to make the right side of a left join become
-/// nullable.
-impl<T, QS> SelectableExpression<QS> for Nullable<T> where
-    T: SelectableExpression<QS>,
-    Nullable<T>: AppearsOnTable<QS>,
-{
-    type SqlTypeForSelect = Self::SqlType;
-}
-
+/// Nullable can be used in where clauses everywhere, but can only be used in
+/// select clauses for outer joins.
 impl<T, QS> AppearsOnTable<QS> for Nullable<T> where
     T: AppearsOnTable<QS>,
     Nullable<T>: Expression,

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -52,7 +52,6 @@ impl<ST> Query for SqlLiteral<ST> {
 }
 
 impl<QS, ST> SelectableExpression<QS> for SqlLiteral<ST> {
-    type SqlTypeForSelect = ST;
 }
 
 impl<QS, ST> AppearsOnTable<QS> for SqlLiteral<ST> {

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -76,8 +76,8 @@ pub mod helper_types {
     use super::expression::helper_types::Eq;
 
     /// Represents the return type of `.select(selection)`
-    pub type Select<Source, Selection, Type = <Selection as super::Expression>::SqlType> =
-        <Source as SelectDsl<Selection, Type>>::Output;
+    pub type Select<Source, Selection> =
+        <Source as SelectDsl<Selection>>::Output;
 
     /// Represents the return type of `.filter(predicate)`
     pub type Filter<Source, Predicate> =

--- a/diesel/src/macros/internal.rs
+++ b/diesel/src/macros/internal.rs
@@ -22,12 +22,8 @@ macro_rules! impl_selectable_expression {
         impl<$($ty_params,)* QS> $crate::expression::SelectableExpression<QS>
             for $struct_ty where
                 $struct_ty: $crate::expression::AppearsOnTable<QS>,
-                $($ty_params: $crate::expression::SelectableExpression<
-                  QS,
-                  SqlTypeForSelect = <$ty_params as $crate::expression::Expression>::SqlType,
-                >,)*
+                $($ty_params: $crate::expression::SelectableExpression<QS>,)*
         {
-            type SqlTypeForSelect = <$struct_ty as $crate::expression::Expression>::SqlType;
         }
 
         impl<$($ty_params,)* QS> $crate::expression::AppearsOnTable<QS>

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -32,7 +32,6 @@ macro_rules! __diesel_column {
         impl_query_id!($column_name);
 
         impl SelectableExpression<$($table)::*> for $column_name {
-            type SqlTypeForSelect = $Type;
         }
 
         impl AppearsOnTable<$($table)::*> for $column_name {
@@ -44,7 +43,6 @@ macro_rules! __diesel_column {
             Right: Table,
             $($table)::*: $crate::JoinTo<Right, $crate::query_source::joins::Inner>
         {
-            type SqlTypeForSelect = $Type;
         }
 
         impl<Left> SelectableExpression<
@@ -52,7 +50,6 @@ macro_rules! __diesel_column {
         > for $column_name where
             Left: $crate::JoinTo<$($table)::*, $crate::query_source::joins::Inner>
         {
-            type SqlTypeForSelect = $Type;
         }
 
         impl<Right> SelectableExpression<
@@ -61,15 +58,6 @@ macro_rules! __diesel_column {
             Right: Table,
             $($table)::*: $crate::JoinTo<Right, $crate::query_source::joins::LeftOuter>
         {
-            type SqlTypeForSelect = $Type;
-        }
-
-        impl<Left> SelectableExpression<
-            $crate::query_source::joins::LeftOuterJoinSource<Left, $($table)::*>,
-        > for $column_name where
-            Left: $crate::JoinTo<$($table)::*, $crate::query_source::joins::LeftOuter>
-        {
-            type SqlTypeForSelect = <$Type as IntoNullable>::Nullable;
         }
 
         impl<Right> AppearsOnTable<
@@ -430,7 +418,6 @@ macro_rules! table_body {
                 }
 
                 impl SelectableExpression<table> for star {
-                    type SqlTypeForSelect = Self::SqlType;
                 }
 
                 impl AppearsOnTable<table> for star {

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::SelectableExpression;
+use expression::{Expression, SelectableExpression};
 use query_builder::*;
 use query_source::QuerySource;
 
@@ -18,13 +18,13 @@ pub trait SelectClauseExpression<QS> {
 impl<T, QS> SelectClauseExpression<QS> for SelectClause<T> where
     T: SelectableExpression<QS>,
 {
-    type SelectClauseSqlType = T::SqlTypeForSelect;
+    type SelectClauseSqlType = T::SqlType;
 }
 
 impl<QS> SelectClauseExpression<QS> for DefaultSelectClause where
     QS: QuerySource,
 {
-    type SelectClauseSqlType = <QS::DefaultSelection as SelectableExpression<QS>>::SqlTypeForSelect;
+    type SelectClauseSqlType = <QS::DefaultSelection as Expression>::SqlType;
 }
 
 pub trait SelectClauseQueryFragment<QS, DB: Backend> {

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -153,12 +153,12 @@ impl<'a, ST, QS, DB> QueryId for BoxedSelectStatement<'a, ST, QS, DB> {
     }
 }
 
-impl<'a, ST, QS, DB, Selection> SelectDsl<Selection, Selection::SqlTypeForSelect>
+impl<'a, ST, QS, DB, Selection> SelectDsl<Selection>
     for BoxedSelectStatement<'a, ST, QS, DB> where
-        DB: Backend + HasSqlType<Selection::SqlTypeForSelect>,
+        DB: Backend + HasSqlType<Selection::SqlType>,
         Selection: SelectableExpression<QS> + QueryFragment<DB> + 'a,
 {
-    type Output = BoxedSelectStatement<'a, Selection::SqlTypeForSelect, QS, DB>;
+    type Output = BoxedSelectStatement<'a, Selection::SqlType, QS, DB>;
 
     fn select(self, selection: Selection) -> Self::Output {
         BoxedSelectStatement::new(

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -16,9 +16,9 @@ use query_source::QuerySource;
 use super::BoxedSelectStatement;
 use types::{self, Bool};
 
-impl<F, S, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection, Type>
+impl<F, S, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection>
     for SelectStatement<F, S, D, W, O, L, Of, G> where
-        Selection: Expression,
+        Selection: Expression<SqlType=Type>,
         SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G>: Query<SqlType=Type>,
 {
     type Output = SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G>;
@@ -186,7 +186,7 @@ impl<'a, F, S, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
         L: QueryFragment<DB> + 'a,
         Of: QueryFragment<DB> + 'a,
 {
-    type Output = BoxedSelectStatement<'a, S::SqlTypeForSelect, F, DB>;
+    type Output = BoxedSelectStatement<'a, S::SqlType, F, DB>;
 
     fn internal_into_boxed(self) -> Self::Output {
         BoxedSelectStatement::new(
@@ -214,7 +214,7 @@ impl<'a, F, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
 {
     type Output = BoxedSelectStatement<
         'a,
-        <F::DefaultSelection as SelectableExpression<F>>::SqlTypeForSelect,
+        <F::DefaultSelection as Expression>::SqlType,
         F,
         DB,
     >;

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -238,7 +238,6 @@ impl<F, S, D, W, O, L, Of, G, QS> SelectableExpression<QS>
     for SelectStatement<F, S, D, W, O, L, Of, G> where
         SelectStatement<F, S, D, W, O, L, Of, G>: AppearsOnTable<QS>,
 {
-    type SqlTypeForSelect = Self::SqlType;
 }
 
 impl<S, F, D, W, O, L, Of, G, QS> AppearsOnTable<QS>

--- a/diesel/src/query_dsl/select_dsl.rs
+++ b/diesel/src/query_dsl/select_dsl.rs
@@ -6,21 +6,18 @@ use query_source::QuerySource;
 /// will be overridden. The expression passed to `select` must actually be valid
 /// for the query (only contains columns from the target table, doesn't mix
 /// aggregate + non-aggregate expressions, etc).
-pub trait SelectDsl<
-    Selection: Expression,
-    Type = <Selection as Expression>::SqlType,
-> {
-    type Output: Query<SqlType=Type>;
+pub trait SelectDsl<Selection: Expression> {
+    type Output: Query<SqlType=<Selection as Expression>::SqlType>;
 
     fn select(self, selection: Selection) -> Self::Output;
 }
 
-impl<T, Selection, Type> SelectDsl<Selection, Type> for T where
+impl<T, Selection> SelectDsl<Selection> for T where
     Selection: Expression,
     T: QuerySource + AsQuery,
-    T::Query: SelectDsl<Selection, Type>,
+    T::Query: SelectDsl<Selection>,
 {
-    type Output = <T::Query as SelectDsl<Selection, Type>>::Output;
+    type Output = <T::Query as SelectDsl<Selection>>::Output;
 
     fn select(self, selection: Selection) -> Self::Output {
         self.as_query().select(selection)

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -101,6 +101,13 @@ impl<Left, Right> AsQuery for LeftOuterJoinSource<Left, Right> where
 
 impl_query_id!(LeftOuterJoinSource<Left, Right>);
 
+impl<Left, Right, T> SelectableExpression<LeftOuterJoinSource<Left, Right>>
+    for Nullable<T> where
+        T: SelectableExpression<InnerJoinSource<Left, Right>>,
+        Nullable<T>: AppearsOnTable<LeftOuterJoinSource<Left, Right>>,
+{
+}
+
 /// Indicates that two tables can be used together in a JOIN clause.
 /// Implementations of this trait will be generated for you automatically by
 /// the [association annotations](FIXME: Add link) from codegen.

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -214,7 +214,6 @@ macro_rules! tuple_impls {
                 $($T: SelectableExpression<QS>,)+
                 ($($T,)+): AppearsOnTable<QS>,
             {
-                type SqlTypeForSelect = ($($T::SqlTypeForSelect,)+);
             }
 
             impl<$($T,)+ QS> AppearsOnTable<QS> for ($($T,)+) where

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -26,13 +26,14 @@ fn main() {
     let conn = PgConnection::establish("some url").unwrap();
     let join = users::table.left_outer_join(posts::table);
 
+    // Invalid, only Nullable<title> is selectable
+    let _ = join.select(posts::title); //~ ERROR E0277
     // Valid
     let _ = join.select(posts::title.nullable());
-    // FIXME: This doesn't compile but we want it to
     // Valid -- NULL to a function will return null
-    let _ = join.select(lower(posts::title).nullable()); //~ ERROR E0271
+    let _ = join.select(lower(posts::title).nullable());
     // Invalid, only Nullable<title> is selectable
-    let _ = join.select(lower(posts::title)); //~ ERROR E0271
+    let _ = join.select(lower(posts::title)); //~ ERROR E0277
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable())); //~ ERROR E0271
 }

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -16,7 +16,7 @@ use super::data_structures::*;
 pub trait UsesInformationSchema: Backend {
     type TypeColumn: SelectableExpression<
         self::information_schema::columns::table,
-        SqlTypeForSelect=types::Text,
+        SqlType=types::Text,
     > + NonAggregate + QueryId + QueryFragment<Self>;
 
     fn type_column() -> Self::TypeColumn;

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -1,7 +1,7 @@
 mod date_and_time;
 mod ops;
 
-use schema::{connection, NewUser, connection_with_sean_and_tess_in_users_table};
+use schema::{connection, NewUser};
 use schema::users::dsl::*;
 use diesel::*;
 use diesel::backend::Backend;
@@ -98,7 +98,6 @@ impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
 }
 
 impl<T, QS> SelectableExpression<QS> for Arbitrary<T> {
-    type SqlTypeForSelect = T;
 }
 
 impl<T, QS> AppearsOnTable<QS> for Arbitrary<T> {

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -260,7 +260,7 @@ sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 
 #[test]
 fn filter_by_boxed_predicate() {
-    fn by_name(name: &str) -> Box<BoxableExpression<users::table, TestBackend, SqlType=types::Bool, SqlTypeForSelect=types::Bool>> {
+    fn by_name(name: &str) -> Box<BoxableExpression<users::table, TestBackend, SqlType=types::Bool>> {
         Box::new(lower(users::name).eq(name.to_string()))
     }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -491,7 +491,7 @@ use diesel::query_builder::{QueryFragment, QueryId};
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
     TestBackend: HasSqlType<T>,
     U: AsExpression<T> + Debug + Clone,
-    U::Expression: SelectableExpression<(), SqlType=T, SqlTypeForSelect=T>,
+    U::Expression: SelectableExpression<(), SqlType=T>,
     U::Expression: QueryFragment<TestBackend> + QueryId,
     T: QueryId,
 {

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -17,7 +17,7 @@ pub fn test_type_round_trips<ST, T>(value: T) -> bool where
     ST: QueryId,
     <TestConnection as Connection>::Backend: HasSqlType<ST>,
     T: AsExpression<ST> + Queryable<ST, <TestConnection as Connection>::Backend> + PartialEq + Clone + ::std::fmt::Debug,
-    <T as AsExpression<ST>>::Expression: SelectableExpression<(), SqlTypeForSelect=ST> + QueryFragment<<TestConnection as Connection>::Backend> + QueryId,
+    <T as AsExpression<ST>>::Expression: SelectableExpression<(), SqlType=ST> + QueryFragment<<TestConnection as Connection>::Backend> + QueryId,
 {
     let connection = connection();
     let query = select(AsExpression::<ST>::as_expression(value.clone()));


### PR DESCRIPTION
This removes the flawed "SQL type varies based on the query source"
design in favor of "things become nullable if they're on the wrong side
of an outer join". This means that columns from the right side of a left
join can no longer directly be selected. `.nullable` must be manually
called. This sounds like a huge deal, but that's already the case today
with tuples (which is a more common case), and it hasn't caused a huge
ergonomics issue. Ultimately most queries just use the default select
clause.

This also causes the nullability to bubble up. If you're building a
compound expression that involves a column from the right side of a left
join, you don't have to worry about that in the compound expression. You
just have to make the whole thing nullable at the top level. This
mirrors SQL's semantics quite nicely.

One downside of this is that `.nullable` can no longer be used in
arbitrary select clauses. Doing so is questionably useful at best, but
I'd still like to bring back that support in the future. Ultimately
doing so more requires https://github.com/rust-lang/rust/pull/40097 or
similar.