### PR TITLE
Remove useless internal API

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -28,4 +28,4 @@ pub use self::load_dsl::{LoadDsl, ExecuteDsl};
 pub use self::offset_dsl::OffsetDsl;
 pub use self::order_dsl::OrderDsl;
 pub use self::save_changes_dsl::SaveChangesDsl;
-pub use self::select_dsl::{SelectDsl, SelectSqlDsl};
+pub use self::select_dsl::SelectDsl;

--- a/diesel/src/query_dsl/select_dsl.rs
+++ b/diesel/src/query_dsl/select_dsl.rs
@@ -26,23 +26,3 @@ impl<T, Selection, Type> SelectDsl<Selection, Type> for T where
         self.as_query().select(selection)
     }
 }
-
-#[doc(hidden)]
-pub trait SelectSqlDsl: Sized {
-    fn select_sql<A>(self, columns: &str)
-        -> <Self as SelectDsl<SqlLiteral<A>>>::Output where
-        Self: SelectDsl<SqlLiteral<A>>,
-    {
-        self.select_sql_inner(columns)
-    }
-
-    fn select_sql_inner<A, S>(self, columns: S)
-        -> <Self as SelectDsl<SqlLiteral<A>>>::Output where
-        S: Into<String>,
-        Self: SelectDsl<SqlLiteral<A>>,
-    {
-        self.select(SqlLiteral::new(columns.into()))
-    }
-}
-
-impl<T> SelectSqlDsl for T {}

--- a/diesel_compile_tests/tests/compile-fail/select_sql_still_ensures_result_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_sql_still_ensures_result_type.rs
@@ -2,6 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
+use diesel::expression::dsl::sql;
 use diesel::pg::PgConnection;
 
 table! {
@@ -13,7 +14,7 @@ table! {
 
 fn main() {
     let connection = PgConnection::establish("").unwrap();
-    let select_count = users::table.select_sql::<types::BigInt>("COUNT(*)");
+    let select_count = users::table.select(sql::<types::BigInt>("COUNT(*)"));
     let count = select_count.get_result::<String>(&connection).unwrap();
     //~^ ERROR E0277
 }

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -54,11 +54,13 @@ fn with_safe_select() {
 
 #[test]
 fn with_select_sql() {
+    use diesel::expression::dsl::sql;
+
     let connection = connection();
     connection.execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
         .unwrap();
 
-    let select_count = users::table.select_sql::<types::BigInt>("COUNT(*)");
+    let select_count = users::table.select(sql::<types::BigInt>("COUNT(*)"));
     let get_count = || select_count.clone().first::<i64>(&connection);
 
     assert_eq!(Ok(2), get_count());


### PR DESCRIPTION
I spotted this while working on #774. This method is not part of the
public API, and is useless now that `sql` exists. I've skipped adding a
changelog entry since this doesn't affect public API.