### PR TITLE
add Add/Sub impls for PgMoney

### DIFF
--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -40,35 +40,39 @@ impl ToSql<types::Money, Pg> for PgMoney {
     }
 }
 
-/// # Panics
-/// will `panic!` on overflow
 impl Add for PgMoney {
     type Output = Self;
+    /// # Panics
+    ///
+    /// Performs a checked addition, and will `panic!` on overflow in both `debug` and `release`.
     fn add(self, rhs: PgMoney) -> Self::Output {
         self.0.checked_add(rhs.0).map(PgMoney).expect("overflow adding money amounts")
     }
 }
 
-/// # Panics
-/// will `panic!` on overflow
 impl AddAssign for PgMoney {
+    /// # Panics
+    ///
+    /// Performs a checked addition, and will `panic!` on overflow in both `debug` and `release`.
     fn add_assign(&mut self, rhs: PgMoney) {
         self.0 = self.0.checked_add(rhs.0).expect("overflow adding money amounts")
     }
 }
 
-/// # Panics
-/// will `panic!` on underflow
 impl Sub for PgMoney {
     type Output = Self;
+    /// # Panics
+    ///
+    /// Performs a checked subtraction, and will `panic!` on underflow in both `debug` and `release`.
     fn sub(self, rhs: PgMoney) -> Self::Output {
         self.0.checked_sub(rhs.0).map(PgMoney).expect("underflow subtracting money amounts")
     }
 }
 
-/// # Panics
-/// will `panic!` on underflow
 impl SubAssign for PgMoney {
+    /// # Panics
+    ///
+    /// Performs a checked subtraction, and will `panic!` on underflow in both `debug` and `release`.
     fn sub_assign(&mut self, rhs: PgMoney) {
         self.0 = self.0.checked_sub(rhs.0).expect("underflow subtracting money amounts")
     }

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -96,11 +96,25 @@ fn add_money() {
 }
 
 #[test]
-#[should_panic]
+fn add_assign_money() {
+    let mut c1 = PgMoney(123);
+    c1 += PgMoney(456);
+    assert_eq!(PgMoney(579), c1);
+}
+
+#[test]
+#[should_panic(expected = "overflow adding money amounts")]
 fn add_money_overflow() {
     let c1 = PgMoney(::std::i64::MAX);
     let c2 = PgMoney(1);
     let _overflow = c1 + c2;
+}
+
+#[test]
+#[should_panic(expected = "overflow adding money amounts")]
+fn add_assign_money_overflow() {
+    let mut c1 = PgMoney(::std::i64::MAX);
+    c1 += PgMoney(1);
 }
 
 #[test]
@@ -111,9 +125,23 @@ fn sub_money() {
 }
 
 #[test]
-#[should_panic]
+fn sub_assign_money() {
+    let mut c1 = PgMoney(123);
+    c1 -= PgMoney(456);
+    assert_eq!(PgMoney(-333), c1);
+}
+
+#[test]
+#[should_panic(expected = "underflow subtracting money amounts")]
 fn sub_money_underflow() {
     let c1 = PgMoney(::std::i64::MIN);
     let c2 = PgMoney(1);
     let _underflow = c1 - c2;
+}
+
+#[test]
+#[should_panic(expected = "underflow subtracting money amounts")]
+fn sub_assign_money_underflow() {
+    let mut c1 = PgMoney(::std::i64::MIN);
+    c1 -= PgMoney(1);
 }

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -53,7 +53,7 @@ impl Add for PgMoney {
 /// will `panic!` on overflow
 impl AddAssign for PgMoney {
     fn add_assign(&mut self, rhs: PgMoney) {
-        self.0 += rhs.0
+        self.0 = self.0.checked_add(rhs.0).expect("overflow adding money amounts")
     }
 }
 
@@ -70,7 +70,7 @@ impl Sub for PgMoney {
 /// will `panic!` on underflow
 impl SubAssign for PgMoney {
     fn sub_assign(&mut self, rhs: PgMoney) {
-        self.0 -= rhs.0
+        self.0 = self.0.checked_sub(rhs.0).expect("underflow subtracting money amounts")
     }
 }
 

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -1,5 +1,6 @@
 //! Support for Money values under PostgreSQL.
 use std::error::Error;
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::io::prelude::*;
 
 use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
@@ -39,6 +40,32 @@ impl ToSql<types::Money, Pg> for PgMoney {
     }
 }
 
+impl Add for PgMoney {
+    type Output = Self;
+    fn add(self, rhs: PgMoney) -> Self::Output {
+        PgMoney(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for PgMoney {
+    fn add_assign(&mut self, rhs: PgMoney) {
+        self.0 += rhs.0;
+    }
+}
+
+impl Sub for PgMoney {
+    type Output = Self;
+    fn sub(self, rhs: PgMoney) -> Self::Output {
+        PgMoney(self.0 - rhs.0)
+    }
+}
+
+impl SubAssign for PgMoney {
+    fn sub_assign(&mut self, rhs: PgMoney) {
+        self.0 -= rhs.0;
+    }
+}
+
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls {
     extern crate quickcheck;
@@ -51,4 +78,18 @@ mod quickcheck_impls {
             PgMoney(i64::arbitrary(g))
         }
     }
+}
+
+#[test]
+fn add_money() {
+    let c1 = PgMoney(123);
+    let c2 = PgMoney(456);
+    assert_eq!(PgMoney(579), c1 + c2);
+}
+
+#[test]
+fn sub_money() {
+    let c1 = PgMoney(123);
+    let c2 = PgMoney(456);
+    assert_eq!(PgMoney(-333), c1 - c2);
 }


### PR DESCRIPTION
Implements `ops::{Add, AddAssign, Sub, SubAssign}` for `PgMoney`. I have explicitly opted not to implement `Mul` and `Div`, as I think end users should deal with rounding/truncation issues.