### PR TITLE
Allow types from other crates with `table!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Diesel CLI: Added `db` as an alias for `database`, so you can now write `diesel db setup` (which is almost 40% faster!).
 
+* The `table!` macro now allows you to use types from crates outside of Diesel.
+  You can specify where types should be imported from by doing: `table! { use
+  some_modules::*; foo { columns... }`. Not specifying any any modules is
+  equivalent to `use diesel::types::*;`.
+
 ### Fixed
 
 * `diesel_codegen` will provide a more useful error message when it encounters


### PR DESCRIPTION
This doesn't affect `infer_schema!` yet (which is where this is most
important), but it lays the groundwork required. Additional modules to
import types from can be specified by writing `using types from
list::of::paths`. Due to how `use` works here, these will always need to
be relative to the crate root, and `self` or `super` will be
inconsistent.

This shouldn't matter, since the most common case is going to be to
import types from a third party crate, which means there will usually be
`extern crate whatever` at the root.

For the `table!` macro to finish, we now need to know all of the
following:

- table name
- schema name
- table body
- primary key
- type modules

Only two of those things are mandatory, so we basically have to have
`3!` branches in the `table!` macro to handle every combination of
information that could be given. I'm not sure if there's a way that we
can just have one branch per optional piece, but I don't believe we can.