### PR TITLE
Unsigned types support for mysql.

### DIFF
--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -1,10 +1,12 @@
 #[cfg(feature = "chrono")]
 mod date_and_time;
 
-use mysql::{Mysql, MysqlType};
+use byteorder::{WriteBytesExt};
+use mysql::{Mysql, MysqlType, backend};
 use std::error::Error as StdError;
 use std::io::Write;
-use types::{ToSql, IsNull, FromSql, HasSqlType};
+use types::{ToSql, IsNull, FromSql, HasSqlType, Unsigned};
+use backend::Backend;
 
 impl ToSql<::types::Bool, Mysql> for bool {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<StdError+Send+Sync>> {
@@ -40,3 +42,49 @@ impl HasSqlType<::types::Timestamp> for Mysql {
         MysqlType::Timestamp
     }
 }
+
+impl FromSql<Unsigned<::types::SmallInt>, Mysql> for u16 {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError+Send+Sync>> {
+        let value: i16 = FromSql::<::types::SmallInt, Mysql>::from_sql(bytes)?;
+        Ok(value as u16)
+    }
+}
+
+impl ToSql<Unsigned<::types::SmallInt>, Mysql> for u16 {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<StdError+Send+Sync>> {
+        out.write_u16::<<backend::Mysql as Backend>::ByteOrder>(*self)
+            .map(|_| IsNull::No)
+            .map_err(|e| Box::new(e) as Box<StdError+Send+Sync>)
+    }
+}
+
+impl FromSql<Unsigned<::types::Integer>, Mysql> for u32 {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError+Send+Sync>> {
+        let value: i32 = FromSql::<::types::Integer, Mysql>::from_sql(bytes)?;
+        Ok(value as u32)
+    }
+}
+
+impl ToSql<Unsigned<::types::Integer>, Mysql> for u32 {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<StdError+Send+Sync>> {
+        out.write_u32::<<backend::Mysql as Backend>::ByteOrder>(*self)
+            .map(|_| IsNull::No)
+            .map_err(|e| Box::new(e) as Box<StdError+Send+Sync>)
+    }
+}
+
+impl FromSql<Unsigned<::types::BigInt>, Mysql> for u64 {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError+Send+Sync>> {
+        let value: i64 = FromSql::<::types::BigInt, Mysql>::from_sql(bytes)?;
+        Ok(value as u64)
+    }
+}
+
+impl ToSql<Unsigned<::types::BigInt>, Mysql> for u64 {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<StdError+Send+Sync>> {
+        out.write_u64::<<backend::Mysql as Backend>::ByteOrder>(*self)
+            .map(|_| IsNull::No)
+            .map_err(|e| Box::new(e) as Box<StdError+Send+Sync>)
+    }
+}
+

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -9,6 +9,9 @@ primitive_impls!(Bool -> (bool, pg: (16, 1000), sqlite: (Integer), mysql: (Tiny)
 primitive_impls!(SmallInt -> (i16, pg: (21, 1005), sqlite: (SmallInt), mysql: (Short)));
 primitive_impls!(Integer -> (i32, pg: (23, 1007), sqlite: (Integer), mysql: (Long)));
 primitive_impls!(BigInt -> (i64, pg: (20, 1016), sqlite: (Long), mysql: (LongLong)));
+primitive_impls!(UInt2 -> (u16, mysql: (Short)));
+primitive_impls!(UInt4 -> (u32, mysql: (Long)));
+primitive_impls!(UInt8 -> (u64, mysql: (LongLong)));
 
 primitive_impls!(Float -> (f32, pg: (700, 1021), sqlite: (Float), mysql: (Float)));
 primitive_impls!(Double -> (f64, pg: (701, 1022), sqlite: (Double), mysql: (Double)));

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -249,6 +249,12 @@ pub type VarChar = Text;
 /// - `Option<T>` for any `T` which implements `FromSql<ST>`
 #[derive(Debug, Clone, Copy, Default)] pub struct Nullable<ST: NotNull>(ST);
 
+#[derive(Debug, Clone, Copy, Default)] pub struct Unsigned<ST>(ST);
+
+#[doc(hidden)] pub type UInt2 = Unsigned<SmallInt>;
+#[doc(hidden)] pub type UInt4 = Unsigned<Integer>;
+#[doc(hidden)] pub type UInt8 = Unsigned<BigInt>;
+
 #[cfg(feature = "postgres")]
 pub use pg::types::sql_types::*;
 

--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -84,6 +84,9 @@ fn column_def_tokens(
     };
     let mut tpe = quote!(#tpe);
 
+    if column_type.is_unsigned {
+        tpe = quote!(Unsigned<#tpe>);
+    }
     if column_type.is_array {
         tpe = quote!(Array<#tpe>);
     }

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -19,6 +19,7 @@ pub struct ColumnType {
     pub path: Vec<String>,
     pub is_array: bool,
     pub is_nullable: bool,
+    pub is_unsigned: bool,
 }
 
 impl ColumnInformation {

--- a/diesel_infer_schema/src/mysql.rs
+++ b/diesel_infer_schema/src/mysql.rs
@@ -4,15 +4,17 @@ use data_structures::*;
 
 pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
     let tpe = determine_type_name(&attr.type_name)?;
+    let unsigned = determine_unsigned(&attr.type_name);
 
     Ok(ColumnType {
-        path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
+        path: vec!["diesel".into(), "types".into(), capitalize(tpe.trim())],
         is_array: false,
         is_nullable: attr.nullable,
+        is_unsigned: unsigned,
     })
 }
 
-fn determine_type_name(sql_type_name: &str) -> Result<&str, Box<Error>> {
+fn determine_type_name(sql_type_name: &str) -> Result<String, Box<Error>> {
     let result = if sql_type_name == "tinyint(1)" {
         "bool"
     } else if sql_type_name.starts_with("int") {
@@ -24,12 +26,17 @@ fn determine_type_name(sql_type_name: &str) -> Result<&str, Box<Error>> {
     };
 
     if result.to_lowercase().contains("unsigned") {
-        Err("unsigned types are not yet supported".into())
+        let result = result.to_lowercase().replace("unsigned", "").trim().to_owned();
+        Ok(result)
     } else if result.contains(' ') {
         Err(format!("unrecognized type {:?}", result).into())
     } else {
-        Ok(result)
+        Ok(result.to_owned())
     }
+}
+
+fn determine_unsigned(sql_type_name: &str) -> bool {
+    sql_type_name.to_lowercase().contains("unsigned")
 }
 
 fn capitalize(name: &str) -> String {
@@ -63,10 +70,15 @@ fn int_is_treated_as_integer() {
 }
 
 #[test]
-fn unsigned_types_are_not_supported() {
-    assert!(determine_type_name("float unsigned").is_err());
-    assert!(determine_type_name("UNSIGNED INT").is_err());
-    assert!(determine_type_name("unsigned bigint").is_err())
+fn unsigned_types_are_supported() {
+    assert!(determine_unsigned("float unsigned"));
+    assert!(determine_unsigned("UNSIGNED INT"));
+    assert!(determine_unsigned("unsigned bigint"));
+    assert!(!determine_unsigned("bigint"));
+    assert!(!determine_unsigned("FLOAT"));
+    assert_eq!("float", determine_type_name("float unsigned").unwrap());
+    assert_eq!("int", determine_type_name("UNSIGNED INT").unwrap());
+    assert_eq!("bigint", determine_type_name("unsigned bigint").unwrap());
 }
 
 #[test]

--- a/diesel_infer_schema/src/pg.rs
+++ b/diesel_infer_schema/src/pg.rs
@@ -14,6 +14,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
         path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
         is_array: is_array,
         is_nullable: attr.nullable,
+        is_unsigned: false,
     })
 }
 

--- a/diesel_infer_schema/src/sqlite.rs
+++ b/diesel_infer_schema/src/sqlite.rs
@@ -111,6 +111,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
         path: path,
         is_array: false,
         is_nullable: attr.nullable,
+        is_unsigned: false,
     })
 }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -97,6 +97,27 @@ fn i32_to_sql_integer() {
 }
 
 #[test]
+#[cfg(feature = "mysql")]
+fn u32_to_sql_interger(){
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("-1", 4294967295));
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("0", 0));
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("1", 1));
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("70000", 70000));
+    assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>("0", 1));
+    assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>("70000", 69999));
+    assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>("-1", 4294967294));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn u32_from_sql() {
+    assert_eq!(0, query_single_value::<Unsigned<Integer>, u32>("0"));
+    assert_eq!(4294967295, query_single_value::<Unsigned<Integer>, u32>("-1"));
+    assert_ne!(4294967294, query_single_value::<Unsigned<Integer>, u32>("-1"));
+    assert_eq!(70000, query_single_value::<Unsigned<Integer>, u32>("70000"));
+}
+
+#[test]
 #[cfg(feature = "postgres")]
 fn i64_from_sql() {
     assert_eq!(0, query_single_value::<BigInt, i64>("0::int8"));


### PR DESCRIPTION
It needs more tests, some documentation, support for floats (yay, mysql, unsigned floats \o/) but I just pushed to get some feedback.

I'm not convinced by the codegen changes, the only alternative I see is `determine_type_name`  returning `(String, bool)` to indicate if the type is unsigned or not, but then the name isn't right anymore + you've got a bool returned that doesn't really mean anything...