### PR TITLE
Remove libc crate dependency by upgrading libsqlite3-sys

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -15,8 +15,7 @@ categories = ["database"]
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
 clippy = { optional = true, version = "=0.0.114" }
-libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.4.0, <0.7.0", optional = true }
+libsqlite3-sys = { version = ">=0.7.1, <0.8.0", optional = true }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
 quickcheck = { version = "0.3.1", optional = true }
@@ -40,7 +39,7 @@ lint = ["clippy"]
 large-tables = []
 huge-tables = ["large-tables"]
 postgres = ["pq-sys"]
-sqlite = ["libsqlite3-sys", "libc"]
+sqlite = ["libsqlite3-sys"]
 mysql = ["mysqlclient-sys", "url"]
 with-deprecated = []
 deprecated-time = ["time"]

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1,5 +1,4 @@
 extern crate libsqlite3_sys as ffi;
-extern crate libc;
 
 #[doc(hidden)]
 pub mod raw;
@@ -9,6 +8,7 @@ mod sqlite_value;
 
 pub use self::sqlite_value::SqliteValue;
 
+use std::os::raw as libc;
 use std::rc::Rc;
 
 use connection::*;

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -1,8 +1,8 @@
 extern crate libsqlite3_sys as ffi;
-extern crate libc;
 
 use std::ffi::{CString, CStr};
 use std::io::{stderr, Write};
+use std::os::raw as libc;
 use std::{ptr, str};
 
 use result::*;

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -1,6 +1,6 @@
 extern crate libsqlite3_sys as ffi;
-extern crate libc;
 
+use std::os::raw as libc;
 use std::{slice, str};
 
 use sqlite::Sqlite;

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -1,8 +1,8 @@
 extern crate libsqlite3_sys as ffi;
-extern crate libc;
 
 use std::ffi::CString;
 use std::io::{stderr, Write};
+use std::os::raw as libc;
 use std::ptr;
 use std::rc::Rc;
 


### PR DESCRIPTION
This is followup from jgallagher/rusqlite#237 and #715.

I haven't really looked into what it would entail, but is there any interest in using `rusqlite` for diesel's SQLite backend instead of `libsqlite3-sys` directly?