### PR TITLE
Allow `Cow` to be used as an expression

### DIFF
--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -109,3 +109,27 @@ impl <'a, T: ?Sized, ST, DB> ::types::FromSqlRow<ST, DB> for Cow<'a, T> where
         FromSql::<ST, DB>::from_sql(row.take())
     }
 }
+
+use expression::bound::Bound;
+use expression::{AsExpression, Expression};
+impl <'a, T: ?Sized, ST> ::expression::AsExpression<ST> for Cow<'a, T> where
+    T: 'a + ToOwned,
+    Bound<ST, Self>: Expression<SqlType=ST>,
+{
+    type Expression = Bound<ST, Self>;
+
+    fn as_expression(self) -> Self::Expression {
+        Bound::new(self)
+    }
+}
+
+impl <'a, 'b, T: ?Sized, ST> ::expression::AsExpression<ST> for &'b Cow<'a, T> where
+    T: 'a + ToOwned,
+    &'b T: AsExpression<ST>,
+{
+    type Expression = <&'b T as AsExpression<ST>>::Expression;
+
+    fn as_expression(self) -> Self::Expression {
+        (&**self).as_expression()
+    }
+}

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -114,7 +114,7 @@ use expression::bound::Bound;
 use expression::{AsExpression, Expression};
 impl <'a, T: ?Sized, ST> ::expression::AsExpression<ST> for Cow<'a, T> where
     T: 'a + ToOwned,
-    Bound<ST, Self>: Expression<SqlType=ST>,
+    Bound<ST, Cow<'a, T>>: Expression<SqlType=ST>,
 {
     type Expression = Bound<ST, Self>;
 

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -148,6 +148,20 @@ mod lifetimes_with_names_other_than_a {
     }
 }
 
+mod insertable_with_cow {
+    #![allow(dead_code)]
+    use schema::posts;
+    use std::borrow::Cow;
+
+    #[derive(Insertable)]
+    #[table_name="posts"]
+    pub struct MyPost<'a> {
+        id: i32,
+        title: Cow<'a, str>,
+        body: Cow<'a, str>,
+    }
+}
+
 mod custom_foreign_keys_are_respected_on_belongs_to {
     #![allow(dead_code)]
 


### PR DESCRIPTION
I tried to use `Cow<'a, str>` in a stuct which had
`#[derive(Insertable)]` expecting it to work and it didn't.