### PR TITLE
Update clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: nightly-2017-02-09
+  - rust: nightly-2017-03-04
     env: CLIPPY=YESPLEASE
     script:
     - (cd diesel && cargo rustc --no-default-features --features "lint unstable chrono serde_json uuid sqlite postgres mysql" -- -Zno-trans)

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 [dependencies]
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
-clippy = { optional = true, version = "=0.0.114" }
+clippy = { optional = true, version = "=0.0.118" }
 libsqlite3-sys = { version = ">=0.7.1, <0.8.0", optional = true }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -46,8 +46,8 @@ impl<T, ST> FromSql<Array<ST>, Pg> for Vec<T> where
         let num_elements = try!(bytes.read_i32::<NetworkEndian>());
         let lower_bound = try!(bytes.read_i32::<NetworkEndian>());
 
-        assert!(num_dimensions == 1, "multi-dimensional arrays are not supported");
-        assert!(lower_bound == 1, "lower bound must be 1");
+        assert_eq!(num_dimensions, 1, "multi-dimensional arrays are not supported");
+        assert_eq!(lower_bound, 1, "lower bound must be 1");
 
         (0..num_elements).map(|_| {
             let elem_size = try!(bytes.read_i32::<NetworkEndian>());

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -78,7 +78,7 @@ mod tests {
     fn queries_with_different_types_have_different_ids() {
         let id1 = query_id(users::table.select(users::name));
         let id2 = query_id(users::table.select(users::id));
-        assert!(id1 != id2);
+        assert_ne!(id1, id2);
     }
 
     #[test]

--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -10,7 +10,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 2, "Received more than 2 bytes decoding i16. \
                       Was an Integer expression accidentally identified as SmallInt?");
-        debug_assert!(bytes.len() == 2, "Received fewer than 2 bytes decoding i16. \
+        debug_assert!(bytes.len() >= 2, "Received fewer than 2 bytes decoding i16. \
                       Was an expression of a different type accidentally identified \
                       as SmallInt?");
         bytes.read_i16::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -30,7 +30,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Integer, DB> for i32 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 4, "Received more than 4 bytes decoding i32. \
                       Was a BigInteger expression accidentally identified as Integer?");
-        debug_assert!(bytes.len() == 4, "Received fewer than 4 bytes decoding i32. \
+        debug_assert!(bytes.len() >= 4, "Received fewer than 4 bytes decoding i32. \
                       Was a SmallInteger expression accidentally identified as Integer?");
         bytes.read_i32::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }
@@ -49,7 +49,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::BigInt, DB> for i64 {
         let mut bytes = not_none!(bytes);
         debug_assert!(bytes.len() <= 8, "Received more than 8 bytes decoding i64. \
                       Was an expression of a different type misidentified as BigInteger?");
-        debug_assert!(bytes.len() == 8, "Received fewer than 8 bytes decoding i64. \
+        debug_assert!(bytes.len() >= 8, "Received fewer than 8 bytes decoding i64. \
                       Was an Integer expression misidentified as BigInteger?");
         bytes.read_i64::<DB::ByteOrder>().map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
     }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ clap = "2.20.3"
 diesel = { version = "0.11.0", default-features = false }
 dotenv = "0.8.0"
 diesel_infer_schema = "0.11.0"
-clippy = { optional = true, version = "=0.0.114" }
+clippy = { optional = true, version = "=0.0.118" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -291,6 +291,7 @@ fn change_database_of_url(database_url: &str, default_database: &str) -> (String
     (database.to_owned(), new_url)
 }
 
+#[cfg_attr(feature="clippy", allow(needless_pass_by_value))]
 fn handle_error<E: Error, T>(error: E) -> T {
     println!("{}", error);
     ::std::process::exit(1);

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -200,6 +200,7 @@ fn should_redo_migration_in_transaction(_t: &Any) -> bool {
     true
 }
 
+#[cfg_attr(feature="clippy", allow(needless_pass_by_value))]
 fn handle_error<E: Error, T>(error: E) -> T {
     println!("{}", error);
     ::std::process::exit(1);

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -16,7 +16,7 @@ quote = "0.3.12"
 dotenv = { version = "0.8.0", optional = true }
 diesel = { version = "0.11.0", default-features = false }
 diesel_infer_schema = { version = "0.11.0", default-features = false, optional = true }
-clippy = { optional = true, version = "=0.0.114" }
+clippy = { optional = true, version = "=0.0.118" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(warnings, missing_copy_implementations)]
 
 // Clippy lints
-#![cfg_attr(feature = "clippy", allow(unstable_features))]
+#![cfg_attr(feature = "clippy", allow(needless_pass_by_value))]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy(conf_file="../clippy.toml")))]
 #![cfg_attr(feature = "clippy", allow(

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 diesel = { version = "0.11.0", default-features = false }
 syn = "0.11.4"
 quote = "0.3.1"
-clippy = { optional = true, version = "=0.0.114" }
+clippy = { optional = true, version = "=0.0.118" }
 
 [dev-dependencies]
 dotenv = "0.8.0"


### PR DESCRIPTION
There's a few new lints which we had to account for. One is checking for
`assert!(x == y)`. In the case of integer deserialization, I changed the
condition because I actually don't want the error message that
`assert_eq!` would give.

The other new lint is for functions which are pass by value, but only
call methods that take a reference. This was pretty much only false
positives for us. In the case of `diesel_codegen`, that lint triggered
for every `#[proc_macro_derive]` function, where we don't even control
the signature, so I've disabled it crate-wide.