### PR TITLE
Add support for `ON CONFLICT DO UPDATE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* Added support for the majority of PG upsert (`INSERT ON CONFLICT`). We now
+  support specifying the constraint, as well as `DO UPDATE` in addition to `DO
+  NOTHING`. See [the module docs][upsert-0.12.0] for details.
+
+[upsert-0.12.0]: http://docs.diesel.rs/diesel/pg/upsert/index.html
+
 * Added support for the SQL concatenation operator `||`. See [the docs for
   `.concat`][concat-0.12.0] for more details.
 

--- a/diesel/src/pg/upsert/mod.rs
+++ b/diesel/src/pg/upsert/mod.rs
@@ -3,6 +3,6 @@ mod on_conflict_clause;
 mod on_conflict_extension;
 mod on_conflict_target;
 
-pub use self::on_conflict_actions::do_nothing;
+pub use self::on_conflict_actions::{do_nothing, do_update, excluded};
 pub use self::on_conflict_extension::OnConflictExtension;
 pub use self::on_conflict_target::on_constraint;

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -1,3 +1,10 @@
+use backend::Backend;
+use expression::{AppearsOnTable, Expression};
+use pg::Pg;
+use query_builder::*;
+use query_source::*;
+use result::QueryResult;
+
 /// Used in conjuction with
 /// [`on_conflict`](trait.OnConflictExtension.html#method.on_conflict) to write
 /// a query in the form `ON CONFLICT (name) DO NOTHING`. If you want to do
@@ -8,6 +15,227 @@ pub fn do_nothing() -> DoNothing {
     DoNothing
 }
 
+/// Used to create a query in the form `ON CONFLICT (...) DO UPDATE ...`
+///
+/// Call `.set` on the result of this function with the changes you want to
+/// apply. The argument to `set` can be anything that implements `AsChangeset`
+/// (e.g. anything you could pass to `set` on a normal update statement).
+///
+/// Note: When inserting more than one row at a time, this query can still fail
+/// if the rows being inserted conflict with each other.
+///
+/// # Examples
+///
+/// ## Set specific value on conflict
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # #[macro_use] extern crate diesel_codegen;
+/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// use self::diesel::pg::upsert::*;
+///
+/// #     let conn = establish_connection();
+/// #     conn.execute("TRUNCATE TABLE users").unwrap();
+/// let user = User { id: 1, name: "Pascal" };
+/// let user2 = User { id: 1, name: "Sean" };
+///
+/// assert_eq!(Ok(1), diesel::insert(&user).into(users).execute(&conn));
+///
+/// let insert_count = diesel::insert(
+///     &user2.on_conflict(id, do_update().set(name.eq("I DONT KNOW ANYMORE")))
+/// ).into(users).execute(&conn);
+/// assert_eq!(Ok(1), insert_count);
+///
+/// let users_in_db = users.load(&conn);
+/// assert_eq!(Ok(vec![(1, "I DONT KNOW ANYMORE".to_string())]), users_in_db);
+/// # }
+/// ```
+///
+/// ## Set `AsChangeset` struct on conflict
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # #[macro_use] extern crate diesel_codegen;
+/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// use self::diesel::pg::upsert::*;
+///
+/// #     let conn = establish_connection();
+/// #     conn.execute("TRUNCATE TABLE users").unwrap();
+/// let user = User { id: 1, name: "Pascal" };
+/// let user2 = User { id: 1, name: "Sean" };
+///
+/// assert_eq!(Ok(1), diesel::insert(&user).into(users).execute(&conn));
+///
+/// let insert_count = diesel::insert(
+///     &user2.on_conflict(id, do_update().set(&user2))
+/// ).into(users).execute(&conn);
+/// assert_eq!(Ok(1), insert_count);
+///
+/// let users_in_db = users.load(&conn);
+/// assert_eq!(Ok(vec![(1, "Sean".to_string())]), users_in_db);
+/// # }
+/// ```
+///
+/// ## Use `excluded` to get the rejected value
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # #[macro_use] extern crate diesel_codegen;
+/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// use self::diesel::pg::upsert::*;
+///
+/// #     let conn = establish_connection();
+/// #     conn.execute("TRUNCATE TABLE users").unwrap();
+/// let user = User { id: 1, name: "Pascal" };
+/// let user2 = User { id: 1, name: "Sean" };
+/// let user3 = User { id: 2, name: "Tess" };
+///
+/// assert_eq!(Ok(1), diesel::insert(&user).into(users).execute(&conn));
+///
+/// let insert_count = diesel::insert(&vec![user2, user3]
+///     .on_conflict(id, do_update().set(name.eq(excluded(name))))
+/// ).into(users).execute(&conn);
+/// assert_eq!(Ok(2), insert_count);
+///
+/// let users_in_db = users.load(&conn);
+/// assert_eq!(Ok(vec![(1, "Sean".to_string()), (2, "Tess".to_string())]), users_in_db);
+/// # }
+pub fn do_update() -> IncompleteDoUpdate {
+    IncompleteDoUpdate
+}
+
+/// Represents `excluded.column` in an `ON CONFLICT DO UPDATE` clause.
+pub fn excluded<T>(excluded: T) -> Excluded<T> {
+    Excluded(excluded)
+}
+
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy)]
 pub struct DoNothing;
+
+impl QueryFragment<Pg> for DoNothing {
+    fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        out.push_sql(" DO NOTHING");
+        Ok(())
+    }
+
+    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct IncompleteDoUpdate;
+
+impl IncompleteDoUpdate {
+    pub fn set<T: AsChangeset>(self, changeset: T) -> DoUpdate<T> {
+        DoUpdate {
+            changeset: changeset,
+        }
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct DoUpdate<T> {
+    changeset: T,
+}
+
+impl<T> QueryFragment<Pg> for DoUpdate<T> where
+    T: Changeset<Pg>,
+{
+    fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        if self.changeset.is_noop() {
+            out.push_sql(" DO NOTHING");
+        } else {
+            out.push_sql(" DO UPDATE SET ");
+            try!(self.changeset.to_sql(out));
+        }
+        Ok(())
+    }
+
+    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        try!(self.changeset.collect_binds(out));
+        Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        false
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct Excluded<T>(T);
+
+impl<T> QueryFragment<Pg> for Excluded<T> where
+    T: Column,
+{
+    fn to_sql(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+        out.push_sql("excluded.");
+        try!(out.push_identifier(T::name()));
+        Ok(())
+    }
+
+    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+        Ok(())
+    }
+
+    fn is_safe_to_cache_prepared(&self) -> bool {
+        true
+    }
+}
+
+impl<T> Expression for Excluded<T> where
+    T: Expression,
+{
+    type SqlType = T::SqlType;
+}
+
+impl<T> AppearsOnTable<T::Table> for Excluded<T> where
+    T: Column,
+    Excluded<T>: Expression,
+{
+}
+
+#[doc(hidden)]
+pub trait IntoConflictAction<T> {
+    type Action: QueryFragment<Pg>;
+
+    fn into_conflict_action(self) -> Self::Action;
+}
+
+impl<T> IntoConflictAction<T> for DoNothing {
+    type Action = Self;
+
+    fn into_conflict_action(self) -> Self::Action {
+        self
+    }
+}
+
+impl<Table, Changes> IntoConflictAction<Table> for DoUpdate<Changes> where
+    Table: QuerySource,
+    Changes: AsChangeset<Target=Table>,
+    DoUpdate<Changes::Changeset>: QueryFragment<Pg>,
+{
+    type Action = DoUpdate<Changes::Changeset>;
+
+    fn into_conflict_action(self) -> Self::Action {
+        DoUpdate {
+            changeset: self.changeset.as_changeset()
+        }
+    }
+}

--- a/diesel/src/pg/upsert/on_conflict_docs_setup.rs
+++ b/diesel/src/pg/upsert/on_conflict_docs_setup.rs
@@ -7,7 +7,7 @@ table! {
     }
 }
 
-#[derive(Clone, Copy, Insertable)]
+#[derive(Clone, Copy, Insertable, AsChangeset)]
 #[table_name="users"]
 struct User<'a> {
     id: i32,

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -91,7 +91,7 @@ pub trait OnConflictExtension {
     /// `Action` can be one of:
     ///
     /// - [`do_nothing()`](fn.do_nothing.html)
-    /// - [`do_update()`]
+    /// - [`do_update()`](fn.do_update.html)
     ///
     /// # Examples
     ///

--- a/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
@@ -1,0 +1,58 @@
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+use diesel::pg::upsert::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> VarChar,
+    }
+}
+
+#[derive(Insertable)]
+#[table_name="users"]
+struct NewUser(#[column_name(name)] &'static str);
+
+fn main() {
+    use self::users::dsl::*;
+    let connection = PgConnection::establish("postgres://localhost").unwrap();
+
+    // Valid update as sanity check
+    insert(&NewUser("Sean").on_conflict(id, do_update().set(name.eq("Sean")))).into(users).execute(&connection);
+
+    // No set clause
+    insert(&NewUser("Sean").on_conflict(id, do_update())).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
+
+    // Update column from other table
+    insert(&NewUser("Sean").on_conflict(id, do_update().set(posts::title.eq("Sean")))).into(users).execute(&connection);
+    //~^ ERROR no method named `execute`
+
+    // Update column with value that is not selectable
+    insert(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(posts::title)))).into(users).execute(&connection);
+    //~^ ERROR E0277
+    //~| ERROR no method named `execute`
+
+    // Update column with excluded value that is not selectable
+    insert(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(excluded(posts::title))))).into(users).execute(&connection);
+    //~^ ERROR E0271
+    //~| ERROR no method named `execute`
+
+    // Update column with excluded value of wrong type
+    insert(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(excluded(id))))).into(users).execute(&connection);
+    //~^ ERROR E0271
+
+    // Excluded is only valid in upsert
+    // FIXME: This should not compile
+    update(users).set(name.eq(excluded(name))).execute(&connection);
+}

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -272,3 +272,22 @@ fn update_with_no_changes() {
     let changes = Changes { name: None, hair_color: None, };
     update(users::table).set(&changes).execute(&connection).unwrap();
 }
+
+#[test]
+#[cfg(feature="postgres")]
+fn upsert_with_no_changes_executes_do_nothing() {
+    use diesel::pg::upsert::*;
+
+    #[derive(AsChangeset)]
+    #[table_name="users"]
+    struct Changes {
+        hair_color: Option<String>,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let result = insert(&User::new(1, "Sean")
+       .on_conflict(users::id, do_update().set(&Changes { hair_color: None }))
+    ).into(users::table).execute(&connection);
+
+    assert_eq!(Ok(0), result);
+}


### PR DESCRIPTION
With this commit, we support the majority of PG's upsert. The things
that are still missing are things I want to support at some point, but
they're lower priority. The things that are known to be missing are:

- Support for expression indexes
    - We need a way for the entire ast to know not to qualify column
      names in that one position
- Where clauses on the `DO UPDATE` clause
    - Should actually be easy to do, just not high priority
- Support for using `excluded.column` in arbitrary expressions
    - This probably already works, just needs tests. Additional work is
      needed to make things like the `+` operator work though.

`ON CONFLICT (target) DO UPDATE SET changes` is done as:
`insert(&record.on_conflict(target, do_update().set(changes)))`. Changes
can be anything that works with normal update statements. You can
reference the value that was proposed for insertion as
`excluded(column)` (this is important for multi-row insertions).

There's one notable type safety hole which is that `excluded` can be
passed to normal update statements and compile successfully. We should
fix this at some point, but it's not worth blocking this feature for,
as you'd only ever really run into it by explicitly trying to break
things.

Fixes #196.