### PR TITLE
Place `Identifiable` in prelude

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -112,7 +112,7 @@ pub mod helper_types {
 
 pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using Diesel.
-    pub use associations::GroupedBy;
+    pub use associations::{GroupedBy, Identifiable};
     pub use connection::Connection;
     pub use expression::{Expression, SelectableExpression, AppearsOnTable, BoxableExpression};
     pub use expression::expression_methods::*;


### PR DESCRIPTION
I've been wanting to call `.id()` for `.find` with composite PKs a lot
lately. This shouldn't be something that needs manual importing.