### PR TITLE
Allow `SqlLiteral` to be used as an on conflict target

### DIFF
--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -77,7 +77,7 @@ impl<'a, Records, Target, Action, Tab> Insertable<Tab, Pg>
         Tab: Table,
         Records: Insertable<Tab, Pg> + Copy,
         Records: UndecoratedInsertRecord<Tab>,
-        Target: OnConflictTarget<Tab> + Copy,
+        Target: OnConflictTarget<Tab> + Clone,
         Action: IntoConflictAction<Tab> + Copy,
 {
     type Values = OnConflictValues<Records::Values, Target, Action::Action>;
@@ -85,7 +85,7 @@ impl<'a, Records, Target, Action, Tab> Insertable<Tab, Pg>
     fn values(self) -> Self::Values {
         OnConflictValues {
             values: self.records.values(),
-            target: self.target,
+            target: self.target.clone(),
             action: self.action.into_conflict_action(),
         }
     }


### PR DESCRIPTION
We won't have first class support for expression indexes or indexes with
where clauses in 0.12. We will add support eventually, but it's fairly
low priority. Generally speaking, you can just do two queries using
`.on_conflict_do_nothing` and then an update if no rows were returned,
and have the same semantics.

However, in the rare case that you really really do need to specifically
only handle conflicts for one unique index, and error on others, there's
no workaround. So for those cases, we can allow arbitrary SQL until we
have proper support for them (if we allow expression indexes, we'll end
up allowing arbitrary SQL anyway since arbitrary SQL is an expression).