### PR TITLE
Respect custom primary keys in `#[derive(AsChangeset)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `diesel_codegen` will provide a more useful error message when it encounters
   an unsupported type that contains a space in MySQL.
 
+* `#[derive(AsChangeset)]` will now respect custom `#[primary_key]` annotations,
+  and avoid setting those columns.
+
 ### Removed
 
 * `WithDsl` and `Aliased` have been removed. They were a feature that was

--- a/diesel_codegen/src/as_changeset.rs
+++ b/diesel_codegen/src/as_changeset.rs
@@ -13,7 +13,10 @@ pub fn derive_as_changeset(item: syn::MacroInput) -> quote::Tokens {
     let struct_ty = &model.ty;
     let mut lifetimes = item.generics.lifetimes;
     let attrs = model.attrs.as_slice().iter()
-        .filter(|a| a.column_name != Some(syn::Ident::new("id")))
+        .filter(|a| match a.column_name {
+            Some(ref name) => !model.primary_key_names.contains(name),
+            None => true,
+        })
         .collect::<Vec<_>>();
 
     if lifetimes.is_empty() {

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -66,7 +66,7 @@ pub fn derive_insertable(input: TokenStream) -> TokenStream {
     expand_derive(input, insertable::derive_insertable)
 }
 
-#[proc_macro_derive(AsChangeset, attributes(table_name, column_name, changeset_options))]
+#[proc_macro_derive(AsChangeset, attributes(table_name, primary_key, column_name, changeset_options))]
 pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
     expand_derive(input, as_changeset::derive_as_changeset)
 }

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -324,3 +324,46 @@ fn upsert_with_sql_literal_for_target() {
     ];
     assert_eq!(Ok(expected_data), data);
 }
+
+#[test]
+fn update_with_custom_pk() {
+    #[derive(AsChangeset)]
+    #[table_name="users"]
+    #[primary_key(name)]
+    #[allow(dead_code)]
+    struct Changes<'a> {
+        name: &'a str,
+        hair_color: Option<&'a str>,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+    update(users::table.find(1))
+        .set(&Changes { name: "Jim", hair_color: Some("Black") })
+        .execute(&connection)
+        .unwrap();
+    let user = users::table.find(1).first(&connection);
+    let expected_user = User::with_hair_color(1, "Sean", "Black");
+    assert_eq!(Ok(expected_user), user);
+}
+
+#[test]
+fn update_with_custom_composite_pk() {
+    #[derive(AsChangeset)]
+    #[table_name="users"]
+    #[primary_key(id, hair_color)]
+    #[allow(dead_code)]
+    struct Changes<'a> {
+        id: i32,
+        name: &'a str,
+        hair_color: Option<&'a str>,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+    update(users::table.find(1))
+        .set(&Changes { id: 2, name: "Jim", hair_color: Some("Blue") })
+        .execute(&connection)
+        .unwrap();
+    let user = users::table.find(1).first(&connection);
+    let expected_user = User::new(1, "Jim");
+    assert_eq!(Ok(expected_user), user);
+}


### PR DESCRIPTION
AsChangeset is supposed to skip assigning the primary key, but right now
we're assuming it's a single column called id. This corrects the
behavior when the annotation is present.

Fixes #802.