### PR TITLE
cli db alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [pg-money-0.12.0]: https://www.postgresql.org/docs/9.6/static/datatype-money.html
 
+* Diesel CLI: Added `db` as an alias for `database`, so you can now write `diesel db setup` (which is almost 40% faster!).
+
 ### Fixed
 
 * `diesel_codegen` will provide a more useful error message when it encounters

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -46,6 +46,7 @@ pub fn build_cli() -> App<'static, 'static> {
                 specified in your DATABASE_URL, and runs existing migrations.");
 
     let database_subcommand = SubCommand::with_name("database")
+        .alias("db")
         .about("A group of commands for setting up and resetting your database.")
         .setting(AppSettings::VersionlessSubcommands)
         .subcommand(SubCommand::with_name("setup")

--- a/diesel_cli/tests/database_setup.rs
+++ b/diesel_cli/tests/database_setup.rs
@@ -63,3 +63,18 @@ fn database_setup_runs_migrations_if_no_schema_table() {
         "Unexpected stdout {}", result.stdout());
     assert!(db.table_exists("users"));
 }
+
+#[test]
+fn database_abbreviated_as_db() {
+    let p = project("database_abbreviated_as_db").folder("migrations").build();
+    let db = database(&p.database_url());
+
+    let result = p.command("db")
+        .arg("setup")
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(result.stdout().contains("Creating database:"),
+        "Unexpected stdout {}", result.stdout());
+    assert!(db.exists());
+}


### PR DESCRIPTION
Contains #742

- Add "db" as alias for "database" subcommand
- Add changelog and test for `db` abbr