### PR TITLE
Add DateTime<Local> support for FromSql traits of postgresql

### DIFF
--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -21,6 +21,7 @@ expression_impls! {
 queryable_impls! {
     Timestamptz -> NaiveDateTime,
     Timestamptz -> DateTime<UTC>,
+    Timestamptz -> DateTime<Local>,
 }
 
 // Postgres timestamps start from January 1st 2000.
@@ -70,6 +71,15 @@ impl FromSql<Timestamptz, Pg> for DateTime<UTC> {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let naive_date_time = try!(<NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes));
         Ok(DateTime::from_utc(naive_date_time, UTC))
+    }
+}
+
+impl FromSql<Timestamptz, Pg> for DateTime<Local> {
+    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
+        let naive_date_time = try!(<NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes));
+        let local_offset = Local.offset_from_utc_datetime(&naive_date_time);
+
+        Ok(DateTime::from_utc(naive_date_time, local_offset))
     }
 }
 


### PR DESCRIPTION
Added `DateTime<Local>` support for `FromSql` traits of postgresql.
This PR enables the code like below:

```rust
#[derive(Queryable)]
pub struct Hoge {
    pub id: i32,
    pub start_at: DateTime<Local>,
    pub end_at: DateTime<Local>,
}
```

```rust
fn main() {
    use self::schema::hoges::dsl::*;

    let connection = establish_connection();
    let results = hoges.limit(5)
        .load::<Hoge>(&connection)
        .expect("Error loading hoges");
}
```