### PR TITLE
Unify `InnerJoinSource` and `LeftOuterJoinSource` to a single struct

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -37,56 +37,47 @@ macro_rules! __diesel_column {
         impl AppearsOnTable<$($table)::*> for $column_name {
         }
 
-        impl<Right> SelectableExpression<
-            $crate::query_source::joins::InnerJoinSource<$($table)::*, Right>,
+        impl<Right, Kind> SelectableExpression<
+            Join<$($table)::*, Right, Kind>,
         > for $column_name where
-            Right: Table,
-            $($table)::*: $crate::JoinTo<Right, $crate::query_source::joins::Inner>
+            $column_name: AppearsOnTable<Join<$($table)::*, Right, Kind>>,
         {
         }
 
         impl<Left> SelectableExpression<
-            $crate::query_source::joins::InnerJoinSource<Left, $($table)::*>,
+            Join<Left, $($table)::*, Inner>,
         > for $column_name where
-            Left: $crate::JoinTo<$($table)::*, $crate::query_source::joins::Inner>
-        {
-        }
-
-        impl<Right> SelectableExpression<
-            $crate::query_source::joins::LeftOuterJoinSource<$($table)::*, Right>,
-        > for $column_name where
-            Right: Table,
-            $($table)::*: $crate::JoinTo<Right, $crate::query_source::joins::LeftOuter>
+            Left: $crate::JoinTo<$($table)::*, Inner>
         {
         }
 
         impl<Right> AppearsOnTable<
-            $crate::query_source::joins::InnerJoinSource<$($table)::*, Right>,
+            Join<$($table)::*, Right, Inner>,
         > for $column_name where
             Right: Table,
-            $($table)::*: $crate::JoinTo<Right, $crate::query_source::joins::Inner>
+            $($table)::*: $crate::JoinTo<Right, Inner>
         {
         }
 
         impl<Left> AppearsOnTable<
-            $crate::query_source::joins::InnerJoinSource<Left, $($table)::*>,
+            Join<Left, $($table)::*, Inner>,
         > for $column_name where
-            Left: $crate::JoinTo<$($table)::*, $crate::query_source::joins::Inner>
+            Left: $crate::JoinTo<$($table)::*, Inner>
         {
         }
 
         impl<Right> AppearsOnTable<
-            $crate::query_source::joins::LeftOuterJoinSource<$($table)::*, Right>,
+            Join<$($table)::*, Right, LeftOuter>,
         > for $column_name where
             Right: Table,
-            $($table)::*: $crate::JoinTo<Right, $crate::query_source::joins::LeftOuter>
+            $($table)::*: $crate::JoinTo<Right, LeftOuter>
         {
         }
 
         impl<Left> AppearsOnTable<
-            $crate::query_source::joins::LeftOuterJoinSource<Left, $($table)::*>,
+            Join<Left, $($table)::*, LeftOuter>,
         > for $column_name where
-            Left: $crate::JoinTo<$($table)::*, $crate::query_source::joins::LeftOuter>
+            Left: $crate::JoinTo<$($table)::*, LeftOuter>
         {
         }
 
@@ -446,6 +437,7 @@ macro_rules! table_body {
                 use $crate::{Table, Expression, SelectableExpression, AppearsOnTable, QuerySource};
                 use $crate::backend::Backend;
                 use $crate::query_builder::{QueryBuilder, BuildQueryResult, QueryFragment};
+                use $crate::query_source::joins::{Join, Inner, LeftOuter};
                 use $crate::result::QueryResult;
                 $(use $($import)::+;)+
 

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -6,13 +6,14 @@ pub use self::boxed::BoxedSelectStatement;
 use backend::Backend;
 use expression::*;
 use query_source::*;
+use query_source::joins::Join;
 use result::QueryResult;
 use super::distinct_clause::NoDistinctClause;
 use super::group_by_clause::NoGroupByClause;
 use super::limit_clause::NoLimitClause;
-use super::select_clause::*;
 use super::offset_clause::NoOffsetClause;
 use super::order_clause::NoOrderClause;
+use super::select_clause::*;
 use super::where_clause::NoWhereClause;
 use super::{Query, QueryBuilder, QueryFragment, BuildQueryResult};
 
@@ -64,7 +65,7 @@ impl<F, S, D, W, O, L, Of, G> SelectStatement<F, S, D, W, O, L, Of, G> {
     }
 
     pub fn inner_join<T>(self, other: T)
-        -> SelectStatement<InnerJoinSource<F, T>, S, D, W, O, L, Of, G> where
+        -> SelectStatement<Join<F, T, joins::Inner>, S, D, W, O, L, Of, G> where
             T: Table,
             F: Table + JoinTo<T, joins::Inner>,
     {
@@ -81,7 +82,7 @@ impl<F, S, D, W, O, L, Of, G> SelectStatement<F, S, D, W, O, L, Of, G> {
     }
 
     pub fn left_outer_join<T>(self, other: T)
-        -> SelectStatement<LeftOuterJoinSource<F, T>, S, D, W, O, L, Of, G> where
+        -> SelectStatement<Join<F, T, joins::LeftOuter>, S, D, W, O, L, Of, G> where
             T: Table,
             F: Table + JoinTo<T, joins::LeftOuter>,
     {

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -7,11 +7,10 @@ pub mod joins;
 use backend::Backend;
 use expression::{Expression, SelectableExpression, NonAggregate};
 use query_builder::*;
-#[doc(hidden)]
-pub use self::joins::{InnerJoinSource, LeftOuterJoinSource};
 use types::{FromSqlRow, HasSqlType};
 
 pub use self::joins::JoinTo;
+use self::joins::*;
 
 /// Trait indicating that a record can be queried from the database. This trait
 /// can be derived automatically using `diesel_codegen`. This trait can only be derived for
@@ -50,17 +49,17 @@ pub trait Table: QuerySource + AsQuery + Sized {
     fn primary_key(&self) -> Self::PrimaryKey;
     fn all_columns() -> Self::AllColumns;
 
-    fn inner_join<T>(self, other: T) -> InnerJoinSource<Self, T> where
+    fn inner_join<T>(self, other: T) -> Join<Self, T, Inner> where
         T: Table,
-        Self: JoinTo<T, joins::Inner>,
+        Self: JoinTo<T, Inner>,
     {
-        InnerJoinSource::new(self, other)
+        Join::new(self, other)
     }
 
-    fn left_outer_join<T>(self, other: T) -> LeftOuterJoinSource<Self, T> where
+    fn left_outer_join<T>(self, other: T) -> Join<Self, T, LeftOuter> where
         T: Table,
-        Self: JoinTo<T, joins::LeftOuter>,
+        Self: JoinTo<T, LeftOuter>,
     {
-        LeftOuterJoinSource::new(self, other)
+        Join::new(self, other)
     }
 }


### PR DESCRIPTION
Eventually I'd like to separate out an additional `JoinOn` struct which
represents a join and the `ON` portion, which will let me factor this to
make a little more sense than it does right now. `Join` will actually be
the thing that is visible in the public API, and eventually I want to
have the `Kind` parameter default to `Cross`, and use it to represent
two arbitrary tables for things like determining whether a subselect is
valid