### PR TITLE
Make `fmt::Debug` a supertrait of `ToSql`

### DIFF
--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -1,5 +1,6 @@
 use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 use std::error::Error;
+use std::fmt;
 use std::io::Write;
 
 use backend::Debug;
@@ -160,6 +161,7 @@ impl<'a, ST, T> ToSql<Nullable<Array<ST>>, Pg> for &'a [T] where
 impl<ST, T> ToSql<Array<ST>, Pg> for Vec<T> where
     Pg: HasSqlType<ST>,
     for<'a> &'a [T]: ToSql<Array<ST>, Pg>,
+    T: fmt::Debug,
 {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
         (self as &[T]).to_sql(out)

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -19,6 +19,8 @@ mod ord;
 pub mod impls;
 mod fold;
 
+use std::fmt;
+
 #[doc(hidden)]
 pub mod structs {
     pub mod data_types {
@@ -318,7 +320,7 @@ pub enum IsNull {
 /// Serializes a single value to be sent to the database. The output will be
 /// included as a bind parameter, and is expected to be the binary format, not
 /// text.
-pub trait ToSql<A, DB: Backend + HasSqlType<A>> {
+pub trait ToSql<A, DB: Backend + HasSqlType<A>>: fmt::Debug {
     fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>>;
 }
 


### PR DESCRIPTION
Ultimately I'd like `debug_sql!` (and our final logging solution) to
include the values of bind parameters. We'll need this bound in order
for that to happen