### PR TITLE
Add function to check for pending migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for adding two nullable columns.
 
-* Addded support for unsigned types in MySQL.
+* Added support for unsigned types in MySQL.
+
+* Added the `any_pending_migrations` function to determine if there are any pending migrations in the migrations directory.
+
+* Added the `migration pending` command to the Diesel CLI to run the `any_pending_migrations` function and report the output.
 
 
 ## [0.12.0] - 2017-03-16

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -28,6 +28,8 @@ pub fn build_cli() -> App<'static, 'static> {
                     for testing that a migration can in fact be reverted.")
         ).subcommand(SubCommand::with_name("list")
             .about("Lists all available migrations, marking those that have been applied.")
+        ).subcommand(SubCommand::with_name("pending")
+             .about("Returns true if there are any pending migrations.")
         ).subcommand(SubCommand::with_name("generate")
             .about("Generate a new migration with the given name, and \
                     the current timestamp as the version"

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -119,6 +119,11 @@ fn run_migration_command(matches: &ArgMatches) {
                 println!("  [{}] {}", x, name);
             }
         }
+        ("pending", Some(_)) => {
+            let database_url = database::database_url(matches);
+            let result = call_with_conn!(database_url, migrations::any_pending_migrations);
+            println!("{:?}", result.unwrap());
+        }
         ("generate", Some(args)) => {
             use std::io::Write;
 

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -108,3 +108,72 @@ fn empty_migrations_are_not_valid() {
     assert!(!result.is_success());
     assert!(result.stdout().contains("empty migration"));
 }
+
+#[test]
+fn any_pending_migrations_works() {
+    let p = project("any_pending_migrations_one")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    p.create_migration("12345_create_users_table",
+                       "CREATE TABLE users ( id INTEGER )",
+                       "DROP TABLE users");
+
+    let result = p.command("migration")
+        .arg("pending")
+        .run();
+
+    assert!(result.stdout().contains("true\n"));
+}
+
+#[test]
+fn any_pending_migrations_after_running() {
+    let p = project("any_pending_migrations")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    p.create_migration("12345_create_users_table",
+                       "CREATE TABLE users ( id INTEGER )",
+                       "DROP TABLE users");
+
+    p.command("migration")
+        .arg("run")
+        .run();
+
+    let result = p.command("migration")
+        .arg("pending")
+        .run();
+
+    assert!(result.stdout().contains("false\n"));
+}
+
+#[test]
+fn any_pending_migrations_after_running_and_creating() {
+    let p = project("any_pending_migrations_run_then_create")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    p.create_migration("12345_create_users_table",
+                       "CREATE TABLE users ( id INTEGER )",
+                       "DROP TABLE users");
+
+    p.command("migration")
+        .arg("run")
+        .run();
+
+    p.create_migration("123456_create_posts_table",
+                       "CREATE TABLE posts ( id INTEGER )",
+                       "DROP TABLE posts");
+
+    let result = p.command("migration")
+        .arg("pending")
+        .run();
+
+    assert!(result.stdout().contains("true\n"));
+}


### PR DESCRIPTION
This change introduces the function any_pending_migrations, which
returns a `Result` wrapping a `bool`, which will be true if there are
any pending migrations, and false if there are none. `Err` states
indicate problems with the migration setup.

Currently, it introduces some moderate code duplication in
migrations/mod.rs, as it shares logic with the code to actually run the
migrations, but the APIs don't match nicely, and I don't know enough
about the system to make changes to exisiting public API.

Fixes #811 

This code compiles, but currently clippy-lints [doesn't](https://github.com/Manishearth/rust-clippy/issues/1633), so I haven't been able to run the bin/test script.
