### PR TITLE
Upgrade Clippy to 0.121

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: nightly-2017-03-04
+  - rust: nightly-2017-03-20
     env: CLIPPY=YESPLEASE
     script:
     - (cd diesel && cargo rustc --no-default-features --features "lint unstable chrono serde_json uuid sqlite postgres mysql" -- -Zno-trans)

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 [dependencies]
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
-clippy = { optional = true, version = "=0.0.118" }
+clippy = { optional = true, version = "=0.0.121" }
 libsqlite3-sys = { version = ">=0.7.1, <0.8.0", optional = true }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -25,7 +25,7 @@
 /// ```
 ///
 /// To avoid copying your struct definition, you can use the
-/// [custom_derive crate][custom_derive].
+/// [`custom_derive` crate][custom_derive].
 ///
 /// [custom_derive]: https://crates.io/crates/custom_derive
 ///

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -204,7 +204,7 @@ macro_rules! __diesel_column {
 /// primarily with one table, to allow writing `users.filter(name.eq("Sean"))`
 /// instead of `users::table.filter(users::name.eq("Sean"))`.
 ///
-/// all_columns
+/// `all_columns`
 /// -----------
 ///
 /// A constant will be assigned called `all_columns`. This is what will be
@@ -222,7 +222,7 @@ macro_rules! __diesel_column {
 /// count statements however. It can also be accessed through the `Table.star()`
 /// method.
 ///
-/// SqlType
+/// `SqlType`
 /// -------
 ///
 /// A type alias called `SqlType` will be created. It will be the SQL type of
@@ -231,7 +231,7 @@ macro_rules! __diesel_column {
 ///
 /// [boxed_queries]: prelude/trait.BoxedDsl.html#example-1
 ///
-/// BoxedQuery
+/// `BoxedQuery`
 /// ----------
 ///
 /// ```ignore
@@ -601,7 +601,7 @@ macro_rules! join_through {
     }
 }
 
-/// Takes a query QueryFragment expression as an argument and returns a string
+/// Takes a query `QueryFragment` expression as an argument and returns a string
 /// of SQL with placeholders for the dynamic values.
 ///
 /// # Example
@@ -636,7 +636,7 @@ macro_rules! debug_sql {
     }};
 }
 
-/// Takes takes a query QueryFragment expression as an argument and prints out
+/// Takes takes a query `QueryFragment` expression as an argument and prints out
 /// the SQL with placeholders for the dynamic values.
 ///
 /// # Example

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ clap = "2.20.3"
 diesel = { version = "0.12.0", default-features = false }
 dotenv = "0.8.0"
 diesel_infer_schema = "0.12.0"
-clippy = { optional = true, version = "=0.0.118" }
+clippy = { optional = true, version = "=0.0.121" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -16,7 +16,7 @@ quote = "0.3.12"
 dotenv = { version = "0.8.0", optional = true }
 diesel = { version = "0.12.0", default-features = false }
 diesel_infer_schema = { version = "0.12.0", default-features = false, optional = true }
-clippy = { optional = true, version = "=0.0.118" }
+clippy = { optional = true, version = "=0.0.121" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 diesel = { version = "0.12.0", default-features = false }
 syn = "0.11.4"
 quote = "0.3.1"
-clippy = { optional = true, version = "=0.0.118" }
+clippy = { optional = true, version = "=0.0.121" }
 
 [dev-dependencies]
 dotenv = "0.8.0"


### PR DESCRIPTION
Previous versions of clippy no longer compile with nightly rust after 2017-03-17.
See rust-clippy#1633