### PR TITLE
Generate more human-readable migration dir names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   tables. You will need to explicitly invoke `joinable!` instead, unless you are
   using `infer_schema!`
 
+* Changed the migration directory name format to `%Y-%m-%d-%H%M%S`.
+
 ### Removed
 
 * `debug_sql!` has been deprecated in favor of `diesel::debug_sql`.

--- a/diesel/src/migrations/migration.rs
+++ b/diesel/src/migrations/migration.rs
@@ -84,7 +84,7 @@ pub fn version_from_path(path: &Path) -> Result<String, MigrationError> {
         .to_string_lossy()
         .split('_')
         .nth(0)
-        .map(|s| Ok(s.into()))
+        .map(|s| Ok(s.replace('-', "")))
         .unwrap_or_else(|| {
             Err(MigrationError::UnknownMigrationFormat(path.to_path_buf()))
         })

--- a/diesel/src/migrations/mod.rs
+++ b/diesel/src/migrations/mod.rs
@@ -84,7 +84,7 @@ use std::env;
 use std::path::{PathBuf, Path};
 
 
-pub static TIMESTAMP_FORMAT: &'static str ="%Y%m%d%H%M%S";
+pub static TIMESTAMP_FORMAT: &'static str ="%Y-%m-%d-%H%M%S";
 
 /// Runs all migrations that have not yet been run. This function will print all progress to
 /// stdout. This function will return an `Err` if some error occurs reading the migrations, or if

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -16,8 +16,8 @@ fn migration_generate_creates_a_migration_with_the_proper_name() {
 
     // check overall output
     let expected_stdout = Regex::new("\
-Creating migrations.\\d*_hello.up.sql
-Creating migrations.\\d*_hello.down.sql\
+Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}_hello.up.sql
+Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}_hello.down.sql\
         ").unwrap();
     assert!(result.is_success(), "Command failed: {:?}", result);
     assert!(expected_stdout.is_match(result.stdout()));

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -23,7 +23,7 @@ Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}_hello.down.sql\
     assert!(expected_stdout.is_match(result.stdout()));
 
     // check timestamps are properly formatted
-    let captured_timestamps = Regex::new(r"(?P<stamp>\d*)_hello").unwrap();
+    let captured_timestamps = Regex::new(r"(?P<stamp>[\d-]*)_hello").unwrap();
     let mut stamps_found = 0;
     for caps in captured_timestamps.captures_iter(result.stdout()) {
         let timestamp = Utc.datetime_from_str(&caps["stamp"], TIMESTAMP_FORMAT);


### PR DESCRIPTION
Seperate Year/Month/Day with - when generating migration directory names, results in the following: 
```
$ diesel migration generate add_table_users

Creating migrations/2017-03-24-061420_add_table_users/up.sql
Creating migrations/2017-03-24-061420_add_table_users/down.sql
```
Format I went with  `YYYY-MM-DD-HHMMSS_migration_name` ( my preferred middle ground from #358 )

I haven't created any new-tests, as I'd like to see how others feel about the `.replace('-', "")` before I do.
I did this so the resulting migrations will still generate the same 'version' slug as the old-ones would. Though im not sure if we care about that at all. 