### PR TITLE
Add cli option `migration list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Added
+
+* Added the `migration list` command to Diesel CLI for listing all available migrations and marking those that have been applied.
+
 ## [0.12.0] - 2016-03-16
 
 ### Added

--- a/diesel/src/migrations/migration.rs
+++ b/diesel/src/migrations/migration.rs
@@ -7,6 +7,9 @@ pub trait Migration {
     fn version(&self) -> &str;
     fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError>;
     fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError>;
+    fn file_path(&self) -> Option<&Path> {
+        None
+    }
 }
 
 pub fn migration_from(path: PathBuf) -> Result<Box<Migration>, MigrationError> {
@@ -30,6 +33,9 @@ impl Migration for Box<Migration> {
     fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
         (&**self).revert(conn)
     }
+    fn file_path(&self) -> Option<&Path> {
+        (&**self).file_path()
+    }
 }
 
 impl<'a> Migration for &'a Migration {
@@ -43,6 +49,9 @@ impl<'a> Migration for &'a Migration {
 
     fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
         (&**self).revert(conn)
+    }
+    fn file_path(&self) -> Option<&Path> {
+        (&**self).file_path()
     }
 }
 
@@ -87,6 +96,10 @@ use std::io::Read;
 struct SqlFileMigration(PathBuf, String);
 
 impl Migration for SqlFileMigration {
+    fn file_path(&self) -> Option<&Path> {
+        Some(self.0.as_path())
+    }
+
     fn version(&self) -> &str {
         &self.1
     }

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -26,6 +26,8 @@ pub fn build_cli() -> App<'static, 'static> {
         ).subcommand(SubCommand::with_name("redo")
             .about("Reverts and re-runs the latest migration. Useful \
                     for testing that a migration can in fact be reverted.")
+        ).subcommand(SubCommand::with_name("list")
+            .about("Lists all available migrations, marking those that have been applied.")
         ).subcommand(SubCommand::with_name("generate")
             .about("Generate a new migration with the given name, and \
                     the current timestamp as the version"

--- a/diesel_cli/tests/migration_list.rs
+++ b/diesel_cli/tests/migration_list.rs
@@ -1,0 +1,152 @@
+
+use chrono::UTC;
+use std::thread::sleep;
+use std::time::Duration;
+
+use support::{database, project};
+use diesel::migrations::TIMESTAMP_FORMAT;
+
+#[test]
+fn migration_list_lists_pending_applied_migrations() {
+    let p = project("migration_list_pending_applied")
+        .folder("migrations")
+        .build();
+    let db = database(&p.database_url());
+
+    p.command("setup").run();
+
+    p.create_migration("12345_create_users_table",
+                       "CREATE TABLE users ( id INTEGER )",
+                       "DROP TABLE users");
+
+    assert!(!db.table_exists("users"));
+
+    // finds unapplied migration
+    let result = p.command("migration")
+        .arg("list")
+        .run();
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(result.stdout().contains("[ ] 12345_create_users_table"));
+
+    let result = p.command("migration")
+        .arg("run")
+        .run();
+    assert!(result.is_success());
+    assert!(db.table_exists("users"));
+
+    // finds applied migration
+    let result = p.command("migration")
+        .arg("list")
+        .run();
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(result.stdout().contains("[X] 12345_create_users_table"));
+}
+
+fn assert_tags_in_order(output: &str, tags: &[&str]) {
+    let matches: Vec<_> = tags.iter().map(|s| {
+        let index = output.find(s).expect(&format!("tag {:?} not found in output: {:?}", s, output));
+        (index, s)
+    }).collect();
+    for window in matches.as_slice().windows(2) {
+        assert!(window[0].0 < window[1].0, "expected {:?} before {:?}", window[0].1, window[1].1);
+    }
+}
+
+#[test]
+fn migration_list_lists_migrations_ordered_by_timestamp() {
+    let p = project("migration_list_ordered")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    let tag1 = format!("{}_initial", UTC::now().format(TIMESTAMP_FORMAT));
+    p.create_migration(&tag1, "", "");
+
+    let result = p.command("migration")
+        .arg("list")
+        .run();
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(result.stdout().contains(&format!("[ ] {}", &tag1)));
+
+    sleep(Duration::from_millis(1100));
+
+    let tag2 = format!("{}_alter", UTC::now().format(TIMESTAMP_FORMAT));
+    p.create_migration(&tag2, "", "");
+
+    let result = p.command("migration")
+        .arg("list")
+        .run();
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    let output = result.stdout();
+    assert_tags_in_order(output, &[&tag1, &tag2]);
+}
+
+#[test]
+fn migration_list_orders_unknown_timestamps_last() {
+    let p = project("migration_list_custom")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    let tag1 = format!("{}_migration1", UTC::now().format(TIMESTAMP_FORMAT));
+    p.create_migration(&tag1, "", "");
+
+    let tag4 = "abc_migration4";
+    p.create_migration(&tag4, "", "");
+
+    let tag5 = "zzz_migration5";
+    p.create_migration(&tag5, "", "");
+
+    sleep(Duration::from_millis(1100));
+
+    let tag2 = format!("{}_migration2", UTC::now().format(TIMESTAMP_FORMAT));
+    p.create_migration(&tag2, "", "");
+
+    sleep(Duration::from_millis(1100));
+
+    let tag3 = format!("{}_migration3", UTC::now().format(TIMESTAMP_FORMAT));
+    p.create_migration(&tag3, "", "");
+
+    let result = p.command("migration")
+        .arg("list")
+        .run();
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    let output = result.stdout();
+    assert_tags_in_order(output, &[&tag1, &tag2, &tag3, &tag4, &tag5]);
+}
+
+#[test]
+fn migration_list_orders_nontimestamp_versions_lexicographically() {
+    let p = project("migration_list_nontimestamp_versions")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    let tag4 = "a_migration";
+    p.create_migration(&tag4, "", "");
+
+    let tag6 = "bc_migration";
+    p.create_migration(&tag6, "", "");
+
+    let tag5 = "aa_migration";
+    p.create_migration(&tag5, "", "");
+
+    let tag2 = "!wow_migration";
+    p.create_migration(&tag2, "", "");
+
+    let tag3 = "7letters";
+    p.create_migration(&tag3, "", "");
+
+    let tag1 = format!("{}_stamped_migration", UTC::now().format(TIMESTAMP_FORMAT));
+    p.create_migration(&tag1, "", "");
+
+    let result = p.command("migration")
+        .arg("list")
+        .run();
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    let output = result.stdout();
+    assert_tags_in_order(output, &[&tag1, &tag2, &tag3, &tag4, &tag5, &tag6]);
+}

--- a/diesel_cli/tests/tests.rs
+++ b/diesel_cli/tests/tests.rs
@@ -3,6 +3,7 @@
 extern crate diesel;
 extern crate regex;
 extern crate tempdir;
+extern crate chrono;
 
 mod setup;
 mod support;
@@ -10,6 +11,7 @@ mod migration_generate;
 mod migration_redo;
 mod migration_revert;
 mod migration_run;
+mod migration_list;
 mod database_drop;
 mod database_setup;
 mod database_reset;


### PR DESCRIPTION
- Move migration-version timestamp format to a global static
  `TIMESTAMP_FORMAT`
  (^^ may need to take this into account for  #827 )
- Added function `mark_migrations_in_directory` that compares available
  & applied migrations and returns a `Vec` of `(Option<PathBuf>, bool)`
  where `true` indicates the migration has been applied.
- Added cli arg `migration list` to invoke `mark_migrations_in_directory`
  and display the status of each migration found in `migrations_dir` in
  chronological order.
  e.g.
```
    Migrations:
      [X] longtimestamp_initial
      [ ] longtimestamp_alter-something
```