### PR TITLE
numeric/BigDecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for the [PostgreSQL network types][pg-network-0.14.0] `MACADDR`.
 
+* Added support for the Numeric datatypes, using the [BigDecimal crate][bigdecimal-0.14.0].
+
 * Added a function which maps to SQL `NOT`. See [the docs][not-0.14.0] for more
   details.
 
@@ -18,6 +20,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 [pg-network-0.14.0]: https://www.postgresql.org/docs/9.6/static/datatype-net-types.html
 [not-0.14.0]: http://docs.diesel.rs/diesel/expression/dsl/fn.not.html
 [insert-default-0.14.0]: http://docs.diesel.rs/disel/fn.insert_default_values.html
+[bigdecimal-0.14-0]: https://crates.io/crates/bigdecimal
 
 * Added `diesel_prefix_operator!` which behaves identically to
   `diesel_postfix_operator!` (previously `postfix_predicate!`), but for

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -25,6 +25,10 @@ time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
 uuid = { version = ">=0.2.0, <0.6.0", optional = true, features = ["use_std"] }
 ipnetwork = { version = "0.12.2", optional = true }
+num-bigint = { version = "0.1.37", optional = true }
+num-traits = { version = "0.1.35", optional = true }
+num-integer = { version = "0.1.32", optional = true }
+bigdecimal = { version = "0.0.7", optional = true }
 
 [dev-dependencies]
 cfg-if = "0.1.0"
@@ -35,7 +39,7 @@ tempdir = "^0.3.4"
 
 [features]
 default = ["with-deprecated"]
-extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address"]
+extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address", "numeric"]
 unstable = []
 lint = ["clippy"]
 large-tables = []
@@ -46,6 +50,7 @@ mysql = ["mysqlclient-sys", "url"]
 with-deprecated = []
 deprecated-time = ["time"]
 network-address = ["ipnetwork", "libc"]
+numeric = ["num-bigint", "bigdecimal", "num-traits", "num-integer"]
 
 [badges]
 travis-ci = { repository = "diesel-rs/diesel" }

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -4,6 +4,7 @@ pub mod floats;
 #[cfg(feature = "network-address")]
 mod network_address;
 mod integers;
+mod numeric;
 mod primitives;
 #[cfg(feature = "uuid")]
 mod uuid;

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -22,6 +22,16 @@ mod bigdecimal {
         fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
             use std::str::FromStr;
 
+            // The encoding of the BigDecimal type for PostgreSQL is a bit complicated:
+            // PostgreSQL expects the data in base-10000 (so two bytes per 10k),
+            // and the decimal point should lie on a boundary (as per definition of "base-10000").
+
+            // BigDecimal, internally, holds an int vector (base-256, one byte per byte),
+            // and a base (u64, base-10) shift.
+
+            // Therefore, we split up the encoding in three parts:
+            // the sign, the (integer) part before the decimal, and the part after the decimal.
+
             let absolute = self.abs();
 
             let mut digits = vec![];

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -1,0 +1,102 @@
+#[cfg(feature="bigdecimal")]
+mod bigdecimal {
+    extern crate num_traits;
+    extern crate num_bigint;
+    extern crate num_integer;
+    extern crate bigdecimal;
+
+    use std::error::Error;
+    use std::io::prelude::*;
+
+    use pg::Pg;
+
+    use self::num_traits::{Signed, Zero, ToPrimitive};
+    use self::num_bigint::{Sign, BigInt, BigUint, ToBigInt};
+    use self::num_integer::Integer;
+    use self::bigdecimal::BigDecimal;
+
+    use pg::data_types::PgNumeric;
+    use types::{self, FromSql, ToSql, IsNull};
+
+    impl ToSql<types::Numeric, Pg> for BigDecimal {
+        fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+            use std::str::FromStr;
+
+            let absolute = self.abs();
+
+            let mut digits = vec![];
+            let ten_k = BigInt::from(10000);
+            let mut integer_part = absolute.to_bigint().expect("Can always take integer part of BigDecimal");
+            let decimal_part = &absolute;
+            let mut decimal_part = decimal_part - absolute.with_scale(0);
+            // scale is the amount of digits to print. to_string() includes a "0.",
+            // that's why the -2 is there.
+            let scale = if decimal_part == Zero::zero() {
+                0
+            } else {
+                decimal_part.to_string().len() as u16 - 2
+            };
+            let mut weight = 0;
+
+            // Encode the integer part
+            while ten_k < integer_part {
+                weight += 1;
+                // digit is integer_part REM 10_000
+                let (div, digit) = integer_part.div_rem(&ten_k);
+                digits.push(digit.to_u16().expect("digit < 10000, but cannot fit in i16") as i16);
+                integer_part = div;
+            }
+            digits.push(integer_part.to_string().parse::<i16>().expect("digit < 10000, but cannot fit in i16"));
+
+            digits.reverse();
+
+            // Encode the decimal part
+            let ten_k = BigDecimal::from_str("10000").expect("Could not parse into BigDecimal");
+            while decimal_part != BigDecimal::zero() {
+                decimal_part *= &ten_k;
+                let digit = decimal_part.to_bigint().expect("Can always take integer part of BigDecimal");
+                // This can be simplified when github.com/akubera/bigdecimal-rs/issues/13 gets
+                // solved; decimal_part -= &digit; should suffice by then.
+                decimal_part -= BigDecimal::new(digit.clone(), 0);
+                digits.push(digit.to_u16().expect("digit < 10000, but cannot fit in i16") as i16);
+            }
+
+            let numeric = match self.sign() {
+                Sign::Plus => PgNumeric::Positive {
+                    digits, scale, weight
+                },
+                Sign::Minus => PgNumeric::Negative {
+                    digits, scale, weight
+                },
+                Sign::NoSign => PgNumeric::Positive {
+                    digits: vec![0],
+                    scale: 0,
+                    weight: 0,
+                },
+            };
+            ToSql::<types::Numeric, Pg>::to_sql(&numeric, out)
+        }
+    }
+
+    impl FromSql<types::Numeric, Pg> for BigDecimal {
+        fn from_sql(numeric: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
+            let (sign, weight, _, digits) = match PgNumeric::from_sql(numeric)? {
+                PgNumeric::Positive { weight, scale, digits } => (Sign::Plus, weight, scale, digits),
+                PgNumeric::Negative { weight, scale, digits } => (Sign::Minus, weight, scale, digits),
+                PgNumeric::NaN => return Err(Box::from("NaN is not (yet) supported in BigDecimal")),
+            };
+            let mut result = BigUint::default();
+            let count = digits.len() as i64;
+            for digit in digits {
+                result = result * BigUint::from(10_000u64);
+                result = result + BigUint::from(digit as u64);
+            }
+            // First digit got factor 10_000^(digits.len() - 1), but should get 10_000^weight
+            let correction_exp = 4 * ( (weight as i64) - count + 1);
+            // FIXME: `scale` allows to drop some insignificant figures, which is currently unimplemented.
+            // This means that e.g. PostgreSQL 0.01 will be interpreted as 0.0100
+            let result = BigDecimal::new(BigInt::from_biguint(sign, result), -correction_exp);
+            Ok(result)
+        }
+    }
+}

--- a/diesel/src/types/impls/decimal.rs
+++ b/diesel/src/types/impls/decimal.rs
@@ -1,0 +1,11 @@
+#[cfg(feature="bigdecimal")]
+mod bigdecimal {
+    extern crate bigdecimal;
+    expression_impls! {
+        Numeric -> bigdecimal::BigDecimal,
+    }
+
+    queryable_impls! {
+        Numeric -> bigdecimal::BigDecimal,
+    }
+}

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -177,3 +177,4 @@ mod integers;
 pub mod option;
 mod primitives;
 mod tuples;
+mod decimal;

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -132,8 +132,22 @@ use std::io::Write;
 
 /// The numeric SQL type.
 ///
-/// This type does not currently have any corresponding Rust types. On SQLite,
-/// [`Double`](struct.Double.html) should be used instead.
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`bigdecimal::BigDecimal`][bigdecimal] (currenty PostgreSQL only, requires the `numeric`
+/// feature, which depends on the
+/// [`bigdecimal`][bigdecimal] crate)
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`bigdecimal::BigDecimal`][BigDecimal] (currenty PostgreSQL only, requires the `numeric`
+/// feature, which depends on the
+/// [`bigdecimal`][bigdecimal] crate)
+///
+/// On SQLite, [`Double`](struct.Double.html) should be used instead.
+///
+/// [BigDecimal]: /bigdecimal/struct.BigDecimal.html
+/// [bigdecimal]: /bigdecimal/index.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Numeric;
 
 #[cfg(not(feature="postgres"))]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -12,13 +12,14 @@ dotenv = ">=0.8, <0.11"
 [dependencies]
 assert_matches = "1.0.1"
 chrono = { version = "0.4" }
-diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address"] }
+diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric"] }
 diesel_codegen = { path = "../diesel_codegen" }
 dotenv = ">=0.8, <0.11"
 quickcheck = { version = "0.3.1", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.6.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = "0.12.2"
+bigdecimal = "0.0.7"
 
 [features]
 default = []

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -90,6 +90,8 @@ mod sqlite_types {
 mod pg_types {
     extern crate uuid;
     extern crate ipnetwork;
+    extern crate bigdecimal;
+
     use super::*;
 
     test_round_trip!(date_roundtrips, Date, PgDate);
@@ -113,6 +115,12 @@ mod pg_types {
     test_round_trip!(cidr_v6_roundtrips, Cidr, (u16, u16, u16, u16, u16, u16, u16, u16), mk_ipv6);
     test_round_trip!(inet_v4_roundtrips, Inet, (u8, u8, u8, u8), mk_ipv4);
     test_round_trip!(inet_v6_roundtrips, Inet, (u16, u16, u16, u16, u16, u16, u16, u16), mk_ipv6);
+
+    test_round_trip!(bigdecimal_roundtrips, Numeric, (i64, u64), mk_bigdecimal);
+
+    fn mk_bigdecimal(data: (i64, u64)) -> self::bigdecimal::BigDecimal {
+        format!("{}.{}", data.0, data.1).parse().expect("Could not interpret as bigdecimal")
+    }
 
     fn mk_uuid(data: (u32, u16, u16, (u8, u8, u8, u8, u8, u8, u8, u8))) -> self::uuid::Uuid {
         let a = data.3;


### PR DESCRIPTION
WIP that implements arbitrary precision support using `num` upcoming `BigDecimal` type.

- [x] ~~`num` crate released their [BigDecimal](https://github.com/rust-num/num/pull/224) support.~~ `num` decided to split off BigDecimal to [a separate project](https://github.com/akubera/bigdecimal-rs), while it's stabilising. A preliminary version has been published. I am working on that.
- [x] PostgreSQL: I use PostgreSQL for my own needs, and I'll build that support.
  - [x] `impl FromSql` support
  - [x] `impl ToSql` support
- [ ] Other databases; if someone wants to help here, feel free to file pull requests to my `bigdecimal` branch on my repo.
- [x] The `num` dependency should be optional/a feature

Questions to be solved:

- [x] ~~Should the `num` dependency be optional/a feature? *yes*~~
- [ ] Do we want `FromSql<>`/`ToSql<> for f64/f32`?

Bugs/issues:

- [x] BigDecimal should have a new release soon, containing all the stuff we need
- [ ] Initialize the damn `digits` vector to something senseful.