### PR TITLE
Allow numeric operations on nullable columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+* Added support for adding two nullable columns.
+
 ## [0.12.0] - 2016-03-16
 
 ### Added

--- a/diesel/src/types/ops.rs
+++ b/diesel/src/types/ops.rs
@@ -30,9 +30,19 @@ macro_rules! numeric_type {
             type Output = super::$tpe;
         }
 
+        impl Add for super::Nullable<super::$tpe> {
+            type Rhs = super::Nullable<super::$tpe>;
+            type Output = super::Nullable<super::$tpe>;
+        }
+
         impl Sub for super::$tpe {
             type Rhs = super::$tpe;
             type Output = super::$tpe;
+        }
+
+        impl Sub for super::Nullable<super::$tpe> {
+            type Rhs = super::Nullable<super::$tpe>;
+            type Output = super::Nullable<super::$tpe>;
         }
 
         impl Mul for super::$tpe {
@@ -40,9 +50,19 @@ macro_rules! numeric_type {
             type Output = super::$tpe;
         }
 
+        impl Mul for super::Nullable<super::$tpe> {
+            type Rhs = super::Nullable<super::$tpe>;
+            type Output = super::Nullable<super::$tpe>;
+        }
+
         impl Div for super::$tpe {
             type Rhs = super::$tpe;
             type Output = super::$tpe;
+        }
+
+        impl Div for super::Nullable<super::$tpe> {
+            type Rhs = super::Nullable<super::$tpe>;
+            type Output = super::Nullable<super::$tpe>;
         }
         )*
     }

--- a/diesel_tests/tests/expressions/ops.rs
+++ b/diesel_tests/tests/expressions/ops.rs
@@ -93,6 +93,77 @@ fn dividing_column() {
 }
 
 #[test]
+fn test_adding_nullables() {
+    use schema::nullable_table::dsl::*;
+    let connection = connection_with_nullable_table_data();
+
+    let expected_data = vec![None, None, Some(2), Some(3), Some(2)];
+    let data = nullable_table.select(value + Some(1)).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data: Vec<Option<i32>> = vec![None; 5];
+    let data = nullable_table.select(value + None as Option<i32>).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data = vec![None, None, Some(2), Some(4), Some(2)];
+    let data = nullable_table.select(value + value).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[test]
+fn test_substracting_nullables() {
+    use schema::nullable_table::dsl::*;
+    let connection = connection_with_nullable_table_data();
+
+    let expected_data = vec![None, None, Some(0), Some(1), Some(0)];
+    let data = nullable_table.select(value - Some(1)).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data: Vec<Option<i32>> = vec![None; 5];
+    let data = nullable_table.select(value - None as Option<i32>).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data = vec![None, None, Some(0), Some(0), Some(0)];
+    let data = nullable_table.select(value - value).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[test]
+fn test_multiplying_nullables() {
+    use schema::nullable_table::dsl::*;
+    let connection = connection_with_nullable_table_data();
+
+    let expected_data = vec![None, None, Some(3), Some(6), Some(3)];
+    let data = nullable_table.select(value * Some(3)).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data: Vec<Option<i32>> = vec![None; 5];
+    let data = nullable_table.select(value * None as Option<i32>).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data = vec![None, None, Some(1), Some(4), Some(1)];
+    let data = nullable_table.select(value * value).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[test]
+fn test_dividing_nullables() {
+    use schema::nullable_table::dsl::*;
+    let connection = connection_with_nullable_table_data();
+
+    let expected_data = vec![None, None, Some(0), Some(1), Some(0)];
+    let data = nullable_table.select(value / Some(2)).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data: Vec<Option<i32>> = vec![None; 5];
+    let data = nullable_table.select(value / None as Option<i32>).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+
+    let expected_data = vec![None, None, Some(1), Some(1), Some(1)];
+    let data = nullable_table.select(value / value).load(&connection);
+    assert_eq!(Ok(expected_data), data);
+}
+#[test]
 fn mix_and_match_all_numeric_ops() {
     use schema::users::dsl::*;
 

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -148,6 +148,15 @@ impl FkTest {
     }
 }
 
+numeric_expr!(nullable_table::value);
+
+#[derive(Queryable, Insertable)]
+#[table_name="nullable_table"]
+pub struct NullableColumn {
+    id: i32,
+    value: Option<i32>,
+}
+
 #[cfg(feature = "postgres")]
 pub type TestConnection = ::diesel::pg::PgConnection;
 #[cfg(feature = "sqlite")]
@@ -200,6 +209,22 @@ pub fn connection_with_sean_and_tess_in_users_table() -> TestConnection {
     connection.execute("INSERT INTO users (id, name) VALUES (1, 'Sean'), (2, 'Tess')")
         .unwrap();
     ensure_primary_key_seq_greater_than(2, &connection);
+    connection
+}
+
+pub fn connection_with_nullable_table_data() -> TestConnection {
+    let connection = connection();
+
+    let test_data = vec![
+        NullableColumn { id: 1, value: None },
+        NullableColumn { id: 2, value: None },
+        NullableColumn { id: 3, value: Some(1) },
+        NullableColumn { id: 4, value: Some(2) },
+        NullableColumn { id: 5, value: Some(1) },
+    ];
+    insert(&test_data).into(nullable_table::table)
+        .execute(&connection).unwrap();
+
     connection
 }
 

--- a/migrations/mysql/20170407152306_add_nullable_table/down.sql
+++ b/migrations/mysql/20170407152306_add_nullable_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE nullable_table;

--- a/migrations/mysql/20170407152306_add_nullable_table/up.sql
+++ b/migrations/mysql/20170407152306_add_nullable_table/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE nullable_table (
+    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    value INTEGER
+) CHARACTER SET utf8mb4;

--- a/migrations/postgresql/20170407152306_add_nullable_table/down.sql
+++ b/migrations/postgresql/20170407152306_add_nullable_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE nullable_table;

--- a/migrations/postgresql/20170407152306_add_nullable_table/up.sql
+++ b/migrations/postgresql/20170407152306_add_nullable_table/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE nullable_table (
+    id SERIAL PRIMARY KEY,
+    value INTEGER
+);

--- a/migrations/sqlite/20170407152306_add_nullable_table/down.sql
+++ b/migrations/sqlite/20170407152306_add_nullable_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE nullable_table;

--- a/migrations/sqlite/20170407152306_add_nullable_table/up.sql
+++ b/migrations/sqlite/20170407152306_add_nullable_table/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE nullable_table (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    value INTEGER
+);


### PR DESCRIPTION
For now you can only do operations between two nullable columns as rust
doesn't allow us to implement a trait twice for the same type without
specialization.