### PR TITLE
Update to libsqlite3-sys 0.8.0.

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["database"]
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
 clippy = { optional = true, version = "=0.0.121" }
-libsqlite3-sys = { version = ">=0.7.1, <0.8.0", optional = true }
+libsqlite3-sys = { version = ">=0.8.0, <0.9.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
 quickcheck = { version = "0.3.1", optional = true }


### PR DESCRIPTION
Specifies feature to use SQLite 3.7.16+ bindings. Closes #844.

See [my comment on #844](https://github.com/diesel-rs/diesel/issues/844#issuecomment-292253945) for more background on this.