### PR TITLE
[bugfix][diesel_cli] parse dbname from connection string in a way that still leaves bugs

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -20,6 +20,7 @@ diesel = { version = "0.12.0", default-features = false }
 dotenv = "0.8.0"
 diesel_infer_schema = "0.12.0"
 clippy = { optional = true, version = "=0.0.118" }
+url = "1.4"
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -1,4 +1,5 @@
 use clap::ArgMatches;
+#[cfg(any(feature="postgres", feature="mysql"))]
 use url::Url;
 use diesel::expression::sql;
 #[cfg(feature="postgres")]

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -303,7 +303,7 @@ fn change_database_of_url(database_url: &str, default_database: &str) -> (String
         (database.to_owned(), new_url)
     } else {
         let new_url = format!("{}/{}", split.join("/"), default_database);
-        ("".to_string(), new_url)
+        ("".to_owned(), new_url)
     }
 
 }

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -287,8 +287,10 @@ pub fn database_url(matches: &ArgMatches) -> String {
 fn change_database_of_url(database_url: &str, default_database: &str) -> (String, String) {
     // This method accepts a valid MySQL or Postgres connection string returns the
     // name of the database and a new connection string to the database specified
-    // by the default_database argument. If the database name is not specified
-    // in the connection string, then we return an empty string.
+    // by the default_database argument. If the database name is not specified in
+    // the connection string then we default to an empty string. NOTE: This function
+    // does not validate connection strings (look at the signature, no Option or
+    // Result is there).
     //
     // Connection string formats
     //         mysql://[user[:password]@]host/database_name

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -20,6 +20,7 @@ extern crate clap;
 extern crate diesel;
 extern crate dotenv;
 extern crate diesel_infer_schema;
+extern crate url;
 
 mod database_error;
 #[macro_use]


### PR DESCRIPTION
I corrected to the parsing logic for database name in the connection string

When connecting to a new server, the database specified by the user
in the connection string may not exist. We instead make the first connection
to the default database which will always exist. We accomplish this by
editing the provided connection string to replace the database name with the
default database for the specific database backend.

MySQL and Postgres both have the same connection string format where the database
name appears after the third '/' character. In Postgres the database names continues
until a '?' or until the end of string. In MySQL the database name continues until
the end of the string. As a dirty hack, we parse all connection strings as if they
were Postgres connections, treating the dbname as any characters that occur between
the third '?' and the next '?'. This prevents us from using the '?' character
in the name of MySQL databases.