### PR TITLE
Loosen the serde dependency to allow using serde 1.0 with diesel.

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -19,7 +19,7 @@ libsqlite3-sys = { version = ">=0.8.0, <0.9.0", optional = true, features = ["mi
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
 quickcheck = { version = "0.3.1", optional = true }
-serde_json = { version = ">=0.8.0, <0.10.0", optional = true }
+serde_json = { version = ">=0.8.0, <2.0", optional = true }
 time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
 uuid = { version = ">=0.2.0, <0.5.0", optional = true, features = ["use_std"] }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -17,7 +17,7 @@ diesel_codegen = { path = "../diesel_codegen" }
 dotenv = ">=0.8, <0.10"
 quickcheck = { version = "0.3.1", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.5.0" }
-serde_json = "0.9"
+serde_json = { version=">=0.9, <2.0" }
 
 [features]
 default = []


### PR DESCRIPTION
I'm not sure this is the right way to do this ?

Maybe it should be `>=0.8.0, < 1.1` but minor versions shouldn't be breaking changes so...
