### PR TITLE
Update clippy to 0.0.126

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: nightly-2017-04-19
+  - rust: nightly-2017-04-25
     env: CLIPPY=YESPLEASE
     script:
     - (cd diesel && cargo rustc --no-default-features --features "lint unstable chrono serde_json uuid sqlite postgres mysql" -- -Zno-trans)

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 [dependencies]
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
-clippy = { optional = true, version = "=0.0.125" }
+clippy = { optional = true, version = "=0.0.126" }
 libsqlite3-sys = { version = ">=0.8.0, <0.9.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ clap = "2.20.3"
 diesel = { version = "0.12.0", default-features = false }
 dotenv = ">=0.8, <0.10"
 diesel_infer_schema = "0.12.0"
-clippy = { optional = true, version = "=0.0.125" }
+clippy = { optional = true, version = "=0.0.126" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -16,7 +16,7 @@ quote = "0.3.12"
 dotenv = { version = ">=0.8, <0.10", optional = true }
 diesel = { version = "0.12.0", default-features = false }
 diesel_infer_schema = { version = "0.12.0", default-features = false, optional = true }
-clippy = { optional = true, version = "=0.0.125" }
+clippy = { optional = true, version = "=0.0.126" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 diesel = { version = "0.12.0", default-features = false }
 syn = "0.11.4"
 quote = "0.3.1"
-clippy = { optional = true, version = "=0.0.125" }
+clippy = { optional = true, version = "=0.0.126" }
 
 [dev-dependencies]
 dotenv = ">=0.8, <0.10"


### PR DESCRIPTION
This change updates clippy, and updates the travis nightly version to
2017-04-25.