### PR TITLE
Refactor join methods into a trait

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -13,8 +13,29 @@ use query_builder::{AsQuery, Query, QueryFragment, SelectStatement};
 use query_dsl::*;
 use query_dsl::boxed_dsl::InternalBoxedDsl;
 use query_source::QuerySource;
+use query_source::joins::Join;
 use super::BoxedSelectStatement;
 use types::{self, Bool};
+
+impl<F, S, D, W, O, L, Of, G, Rhs, Kind> InternalJoinDsl<Rhs, Kind>
+    for SelectStatement<F, S, D, W, O, L, Of, G> where
+        SelectStatement<Join<F, Rhs, Kind>, S, D, W, O, L, Of, G>: AsQuery,
+{
+    type Output = SelectStatement<Join<F, Rhs, Kind>, S, D, W, O, L, Of, G>;
+
+    fn join(self, rhs: Rhs, kind: Kind) -> Self::Output {
+        SelectStatement::new(
+            self.select,
+            Join::new(self.from, rhs, kind),
+            self.distinct,
+            self.where_clause,
+            self.order,
+            self.limit,
+            self.offset,
+            self.group_by,
+        )
+    }
+}
 
 impl<F, S, D, W, O, L, Of, G, Selection, Type> SelectDsl<Selection>
     for SelectStatement<F, S, D, W, O, L, Of, G> where

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -6,7 +6,6 @@ pub use self::boxed::BoxedSelectStatement;
 use backend::Backend;
 use expression::*;
 use query_source::*;
-use query_source::joins::Join;
 use result::QueryResult;
 use super::distinct_clause::NoDistinctClause;
 use super::group_by_clause::NoGroupByClause;
@@ -62,40 +61,6 @@ impl<F, S, D, W, O, L, Of, G> SelectStatement<F, S, D, W, O, L, Of, G> {
             offset: offset,
             group_by: group_by,
         }
-    }
-
-    pub fn inner_join<T>(self, other: T)
-        -> SelectStatement<Join<F, T, joins::Inner>, S, D, W, O, L, Of, G> where
-            T: Table,
-            F: Table + JoinTo<T, joins::Inner>,
-    {
-        SelectStatement::new(
-            self.select,
-            self.from.inner_join(other),
-            self.distinct,
-            self.where_clause,
-            self.order,
-            self.limit,
-            self.offset,
-            self.group_by,
-        )
-    }
-
-    pub fn left_outer_join<T>(self, other: T)
-        -> SelectStatement<Join<F, T, joins::LeftOuter>, S, D, W, O, L, Of, G> where
-            T: Table,
-            F: Table + JoinTo<T, joins::LeftOuter>,
-    {
-        SelectStatement::new(
-            self.select,
-            self.from.left_outer_join(other),
-            self.distinct,
-            self.where_clause,
-            self.order,
-            self.limit,
-            self.offset,
-            self.group_by,
-        )
     }
 }
 

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -1,0 +1,38 @@
+use query_builder::AsQuery;
+use query_source::{joins, QuerySource};
+
+#[doc(hidden)]
+/// `JoinDsl` support trait to emulate associated type constructors
+pub trait InternalJoinDsl<Rhs, Kind> {
+    type Output: AsQuery;
+
+    fn join(self, rhs: Rhs, kind: Kind) -> Self::Output;
+}
+
+impl<T, Rhs, Kind> InternalJoinDsl<Rhs, Kind> for T where
+    T: QuerySource + AsQuery,
+    T::Query: InternalJoinDsl<Rhs, Kind>,
+{
+    type Output = <T::Query as InternalJoinDsl<Rhs, Kind>>::Output;
+
+    fn join(self, rhs: Rhs, kind: Kind) -> Self::Output {
+        self.as_query().join(rhs, kind)
+    }
+}
+
+pub trait JoinDsl: Sized {
+    fn inner_join<Rhs>(self, rhs: Rhs) -> Self::Output where
+        Self: InternalJoinDsl<Rhs, joins::Inner>,
+    {
+        self.join(rhs, joins::Inner)
+    }
+
+    fn left_outer_join<Rhs>(self, rhs: Rhs) -> Self::Output where
+        Self: InternalJoinDsl<Rhs, joins::LeftOuter>,
+    {
+        self.join(rhs, joins::LeftOuter)
+    }
+}
+
+impl<T: AsQuery> JoinDsl for T {
+}

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -4,6 +4,7 @@ pub mod boxed_dsl;
 mod count_dsl;
 mod distinct_dsl;
 mod group_by_dsl;
+mod join_dsl;
 #[doc(hidden)]
 pub mod limit_dsl;
 #[doc(hidden)]
@@ -23,6 +24,7 @@ pub use self::distinct_dsl::DistinctDsl;
 pub use self::filter_dsl::{FilterDsl, FindDsl};
 #[doc(hidden)]
 pub use self::group_by_dsl::GroupByDsl;
+pub use self::join_dsl::{InternalJoinDsl, JoinDsl};
 pub use self::limit_dsl::LimitDsl;
 pub use self::load_dsl::{LoadDsl, ExecuteDsl};
 pub use self::offset_dsl::OffsetDsl;

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -14,25 +14,12 @@ pub struct Join<Left, Right, Kind> {
 }
 
 impl<Left, Right, Kind> Join<Left, Right, Kind> {
-    pub fn new(left: Left, right: Right) -> Self where
-        Kind: Default,
-    {
+    pub fn new(left: Left, right: Right, kind: Kind) -> Self {
         Join {
             left: left,
             right: right,
-            kind: Kind::default(),
+            kind: kind,
         }
-    }
-}
-
-impl<Left, Right, Kind> AsQuery for Join<Left, Right, Kind> where
-    SelectStatement<Join<Left, Right, Kind>>: Query,
-{
-    type SqlType = <SelectStatement<Self> as Query>::SqlType;
-    type Query = SelectStatement<Self>;
-
-    fn as_query(self) -> Self::Query {
-        SelectStatement::simple(self)
     }
 }
 

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -10,7 +10,6 @@ use query_builder::*;
 use types::{FromSqlRow, HasSqlType};
 
 pub use self::joins::JoinTo;
-use self::joins::*;
 
 /// Trait indicating that a record can be queried from the database. This trait
 /// can be derived automatically using `diesel_codegen`. This trait can only be derived for
@@ -48,18 +47,4 @@ pub trait Table: QuerySource + AsQuery + Sized {
 
     fn primary_key(&self) -> Self::PrimaryKey;
     fn all_columns() -> Self::AllColumns;
-
-    fn inner_join<T>(self, other: T) -> Join<Self, T, Inner> where
-        T: Table,
-        Self: JoinTo<T, Inner>,
-    {
-        Join::new(self, other)
-    }
-
-    fn left_outer_join<T>(self, other: T) -> Join<Self, T, LeftOuter> where
-        T: Table,
-        Self: JoinTo<T, LeftOuter>,
-    {
-        Join::new(self, other)
-    }
 }

--- a/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> VarChar,
+    }
+}
+
+fn main() {
+    let _ = users::table.inner_join(posts::table);
+    //~^ ERROR E0277
+    //~| ERROR E0277
+    let _ = users::table.left_outer_join(posts::table);
+    //~^ ERROR E0277
+    //~| ERROR E0277
+}


### PR DESCRIPTION
This change is part of an ongoing refactoring to enable multi-table
joins, explicit on clauses, and other improvements. Unfortunately, this
completely ruins the error message when attempting to join between two
tables that know nothing about each other. The reason is that the
missing link is `Join<Left, Right, Kind>: QuerySource`, which is missing
*both* `Left: JoinTo<Right>` and `(Left::AllColumns, Right::AllColumns):
SelectableExpression<Self>`. Ironically, this missing link in the second
case is actually `Left: JoinTo<Right>`, but that has to go through so
many different impls I wouldn't expect Rust to be able to unify them.

Anyway, I'm planning on eventually applying the `on` segment earlier,
which should result in a missing `Left: JoinTo<Right>` constraint much
sooner and will hopefully bring back that error message. Honestly, I may
even be over thinking the error message here since in reality a missing
`JoinTo` constraint isn't conveying more information than
`InternalJoinDsl` since neither mention the associations API

I want to keep `Join<Left, Right, Kind>` in the public API for
`SelectableExpression` constraints, but it no longer needs to implement
`AsQuery` since you can no longer obtain an instance of it.