### PR TITLE
Remove `join_through!`

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -578,29 +578,6 @@ macro_rules! joinable_inner {
     }
 }
 
-#[macro_export]
-#[doc(hidden)]
-macro_rules! join_through {
-    ($parent:ident -> $through:ident -> $child:ident) => {
-        impl<JoinType: Copy> $crate::JoinTo<$child::table, JoinType> for $parent::table {
-            type JoinClause = <
-                <$parent::table as $crate::JoinTo<$through::table, JoinType>>::JoinClause
-                as $crate::query_builder::nodes::CombinedJoin<
-                    <$through::table as $crate::JoinTo<$child::table, JoinType>>::JoinClause,
-                >>::Output;
-
-            fn join_clause(&self, join_type: JoinType) -> Self::JoinClause {
-                use $crate::query_builder::nodes::CombinedJoin;
-                let parent_to_through = $crate::JoinTo::<$through::table, JoinType>
-                    ::join_clause(&$parent::table, join_type);
-                let through_to_child = $crate::JoinTo::<$child::table, JoinType>
-                    ::join_clause(&$through::table, join_type);
-                parent_to_through.combine_with(through_to_child)
-            }
-        }
-    }
-}
-
 /// Takes a query `QueryFragment` expression as an argument and returns a string
 /// of SQL with placeholders for the dynamic values.
 ///

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -38,25 +38,6 @@ impl<T, U, V, W> Join<T, U, V, W> {
     }
 }
 
-pub trait CombinedJoin<Other> {
-    type Output;
-
-    fn combine_with(self, other: Other) -> Self::Output;
-}
-
-impl<T, U, UU, V, VV, W, WW> CombinedJoin<Join<U, UU, VV, WW>> for Join<T, U, V, W> {
-    type Output = Join<
-        Self,
-        UU,
-        VV,
-        WW,
-    >;
-
-    fn combine_with(self, other: Join<U, UU, VV, WW>) -> Self::Output {
-        Join::new(self, other.rhs, other.predicate, other.join_type)
-    }
-}
-
 impl<T, U, V, W, DB> QueryFragment<DB> for Join<T, U, V, W> where
     DB: Backend,
     T: QueryFragment<DB>,

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -274,33 +274,3 @@ fn selecting_complex_expression_from_both_sides_of_outer_join() {
     ];
     assert_eq!(Ok(expected_data), titles);
 }
-
-#[test]
-fn join_through_other() {
-    use schema::users::dsl::*;
-    let connection = connection_with_sean_and_tess_in_users_table();
-
-    insert(&NewUser::new("Jim", None)).into(users).execute(&connection).unwrap();
-    insert(&vec![
-        NewPost::new(1, "Hello", None), NewPost::new(2, "World", None),
-        NewPost::new(1, "Hello again!", None),
-    ]).into(posts::table).execute(&connection).unwrap();
-    let posts = posts::table.load::<Post>(&connection).unwrap();
-    insert(&vec![
-        NewComment(posts[0].id, "OMG"), NewComment(posts[1].id, "WTF"),
-        NewComment(posts[2].id, "Best post ever!!!")
-    ]).into(comments::table).execute(&connection).unwrap();
-    let comments = comments::table.load::<Comment>(&connection).unwrap();
-
-    let data = users.inner_join(comments::table).load(&connection)
-        .unwrap();
-
-    let sean = User::new(1, "Sean");
-    let tess = User::new(2, "Tess");
-    let expected_data = vec![
-        (sean.clone(), comments[0].clone()),
-        (tess, comments[1].clone()),
-        (sean, comments[2].clone()),
-    ];
-    assert_eq!(expected_data, data);
-}

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -90,8 +90,6 @@ pub use self::backend_specifics::*;
 
 numeric_expr!(users::id);
 
-join_through!(users -> posts -> comments);
-
 #[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset)]
 #[table_name = "users"]
 pub struct NewUser {


### PR DESCRIPTION
This was a small helper I added back before associations had actually
been implemented. It was never made part of the public API, and we're at
the point where its existence is making other refactorings more
difficult. I do want this feature to come back eventually, but it will
likely be as `#[has_many(comments, through="posts")]` or
`users.inner_join(comments.through(posts))`