### PR TITLE
Allow use of uuid 0.5.0

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -22,7 +22,7 @@ quickcheck = { version = "0.3.1", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }
 time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
-uuid = { version = ">=0.2.0, <0.5.0", optional = true, features = ["use_std"] }
+uuid = { version = ">=0.2.0, <0.6.0", optional = true, features = ["use_std"] }
 
 [dev-dependencies]
 cfg-if = "0.1.0"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -16,7 +16,7 @@ diesel = { path = "../diesel", default-features = false, features = ["quickcheck
 diesel_codegen = { path = "../diesel_codegen" }
 dotenv = ">=0.8, <0.10"
 quickcheck = { version = "0.3.1", features = ["unstable"] }
-uuid = { version = ">=0.2.0, <0.5.0" }
+uuid = { version = ">=0.2.0, <0.6.0" }
 serde_json = { version=">=0.9, <2.0" }
 
 [features]


### PR DESCRIPTION
This is related to #628; there's a new version of uuid so we need to increase the version range. Fixes #877.