### PR TITLE
Refactor join construction to be much more composeable

### DIFF
--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -16,51 +16,6 @@ impl<'a, DB: Backend> QueryFragment<DB> for Identifier<'a> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct Join<T, U, V, W> {
-    lhs: T,
-    rhs: U,
-    predicate: V,
-    join_type: W,
-}
-
-impl<T, U, V, W> Join<T, U, V, W> {
-    pub fn new(lhs: T, rhs: U, predicate: V, join_type: W) -> Self {
-        Join {
-            lhs: lhs,
-            rhs: rhs,
-            predicate: predicate,
-            join_type: join_type,
-        }
-    }
-}
-
-impl<T, U, V, W, DB> QueryFragment<DB> for Join<T, U, V, W> where
-    DB: Backend,
-    T: QueryFragment<DB>,
-    U: QueryFragment<DB>,
-    V: QueryFragment<DB>,
-    W: QueryFragment<DB>,
-{
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        try!(self.lhs.to_sql(out));
-        try!(self.join_type.to_sql(out));
-        out.push_sql(" JOIN ");
-        try!(self.rhs.to_sql(out));
-        out.push_sql(" ON ");
-        try!(self.predicate.to_sql(out));
-        Ok(())
-    }
-
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.lhs.walk_ast(pass)?;
-        self.join_type.walk_ast(pass)?;
-        self.rhs.walk_ast(pass)?;
-        self.predicate.walk_ast(pass)?;
-        Ok(())
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
 pub struct InfixNode<'a, T, U> {
     lhs: T,
     rhs: U,

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -1,36 +1,56 @@
 use query_builder::AsQuery;
-use query_source::{joins, QuerySource};
+use query_source::{joins, QuerySource, JoinTo};
 
 #[doc(hidden)]
 /// `JoinDsl` support trait to emulate associated type constructors
-pub trait InternalJoinDsl<Rhs, Kind> {
+pub trait InternalJoinDsl<Rhs, Kind, On> {
     type Output: AsQuery;
 
-    fn join(self, rhs: Rhs, kind: Kind) -> Self::Output;
+    fn join(self, rhs: Rhs, kind: Kind, on: On) -> Self::Output;
 }
 
-impl<T, Rhs, Kind> InternalJoinDsl<Rhs, Kind> for T where
+impl<T, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On> for T where
     T: QuerySource + AsQuery,
-    T::Query: InternalJoinDsl<Rhs, Kind>,
+    T::Query: InternalJoinDsl<Rhs, Kind, On>,
 {
-    type Output = <T::Query as InternalJoinDsl<Rhs, Kind>>::Output;
+    type Output = <T::Query as InternalJoinDsl<Rhs, Kind, On>>::Output;
 
-    fn join(self, rhs: Rhs, kind: Kind) -> Self::Output {
-        self.as_query().join(rhs, kind)
+    fn join(self, rhs: Rhs, kind: Kind, on: On) -> Self::Output {
+        self.as_query().join(rhs, kind, on)
+    }
+}
+
+#[doc(hidden)]
+/// `JoinDsl` support trait to emulate associated type constructors and grab
+/// the known on clause from the associations API
+pub trait JoinWithImplicitOnClause<Rhs, Kind> {
+    type Output: AsQuery;
+
+    fn join_with_implicit_on_clause(self, rhs: Rhs, kind: Kind) -> Self::Output;
+}
+
+impl<Lhs, Rhs, Kind> JoinWithImplicitOnClause<Rhs, Kind> for Lhs where
+    Lhs: JoinTo<Rhs>,
+    Lhs: InternalJoinDsl<Rhs, Kind, <Lhs as JoinTo<Rhs>>::JoinOnClause>,
+{
+    type Output = <Lhs as InternalJoinDsl<Rhs, Kind, Lhs::JoinOnClause>>::Output;
+
+    fn join_with_implicit_on_clause(self, rhs: Rhs, kind: Kind) -> Self::Output {
+        self.join(rhs, kind, Lhs::join_on_clause())
     }
 }
 
 pub trait JoinDsl: Sized {
     fn inner_join<Rhs>(self, rhs: Rhs) -> Self::Output where
-        Self: InternalJoinDsl<Rhs, joins::Inner>,
+        Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
     {
-        self.join(rhs, joins::Inner)
+        self.join_with_implicit_on_clause(rhs, joins::Inner)
     }
 
     fn left_outer_join<Rhs>(self, rhs: Rhs) -> Self::Output where
-        Self: InternalJoinDsl<Rhs, joins::LeftOuter>,
+        Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
     {
-        self.join(rhs, joins::LeftOuter)
+        self.join_with_implicit_on_clause(rhs, joins::LeftOuter)
     }
 }
 

--- a/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
@@ -19,9 +19,15 @@ table! {
 
 fn main() {
     let _ = users::table.inner_join(posts::table);
-    //~^ ERROR E0277
+    //~^ ERROR JoinTo
+    //~| ERROR E0277
+    //~| ERROR E0277
+    //~| ERROR E0277
     //~| ERROR E0277
     let _ = users::table.left_outer_join(posts::table);
-    //~^ ERROR E0277
+    //~^ ERROR JoinTo
+    //~| ERROR E0277
+    //~| ERROR E0277
+    //~| ERROR E0277
     //~| ERROR E0277
 }


### PR DESCRIPTION
This moves most of the knowledge of join construction out of `JoinTo`
and into the join methods themselves. Aside from exposing less of our
internals, this is useful to us because it's much easier to implement
`JoinTo` on joins themselves than it is to implement the specific join
methods.

The downside to this approach is that it gives us less specific control
over certain types, and means that
`users.inner_join(posts).inner_join(settings)` will likely have the type
`(User, (Post, Setting))` instead of `(User, Post, Setting)` which will
make it unfortunately difficult to differentiate
`user.inner_join(posts).inner_join(comments)` from
`user.inner_join(posts.inner_join(comments))`.

Still, I think this is the path that will get us to *some* form of
multi-table joins, and we can always refine later. This structure should
make it fairly simple to add all of:

- Joining to subselects
- Cross joins
- Join with explicit on-clauses
- Self-referential joins (though not through the associations API)

Additionally, the only real blocker remaining for multi-table joins is
implementing `SelectableExpression` which should hopefully be unblocked
by Rust soon.