### PR TITLE
Add rough support for chrono's Naive{DateTime,Date,Time} types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* Added support for chrono types with SQLite.
+
 * Added support for the [PostgreSQL network types][pg-network-0.13.0] `CIDR` and `INET`.
 
 [pg-network-0.13.0]: https://www.postgresql.org/docs/9.6/static/datatype-net-types.html

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -1,0 +1,263 @@
+extern crate chrono;
+
+use std::error::Error;
+use std::io::Write;
+use self::chrono::{NaiveDateTime, NaiveDate, NaiveTime, Datelike};
+
+use sqlite::Sqlite;
+use sqlite::connection::SqliteValue;
+use types::{Date, FromSql, IsNull, Time, Timestamp, ToSql, Text};
+
+const SQLITE_TIME_FMT: &'static str = "%0H:%0M:%0S%.6f";
+
+fn parse_sqlite_date(date: &str) -> Result<NaiveDate, Box<Error+Send+Sync>> {
+    let negative_year = date.starts_with('-');
+
+    let ymd: Vec<u32> = date.split('-').flat_map(str::parse).collect();
+    if ymd.len() != 3 {
+        return Err("Cannot parse date, too many parts. The date should be in the form: YYYY-MM-DD".into())
+    }
+
+    if negative_year {
+        return Ok(NaiveDate::from_ymd(-(ymd[0] as i32), ymd[1], ymd[2]))
+    }
+
+    match NaiveDate::from_ymd_opt(ymd[0] as i32, ymd[1], ymd[2]) {
+        Some(d) => Ok(d),
+        None => Err("Invalid date.".into()),
+    }
+}
+
+fn dump_sqlite_date<T: Datelike>(date: &T) -> String {
+    format!("{:0>4}-{:0>2}-{:0>2}", date.year(), date.month(), date.day())
+}
+
+impl FromSql<Date, Sqlite> for NaiveDate {
+    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error+Send+Sync>> {
+        let text = not_none!(value).read_text();
+        parse_sqlite_date(text)
+    }
+}
+
+impl ToSql<Date, Sqlite> for NaiveDate {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+        let s = dump_sqlite_date(self);
+        ToSql::<Text, Sqlite>::to_sql(&s, out)
+    }
+}
+
+impl FromSql<Time, Sqlite> for NaiveTime {
+    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error+Send+Sync>> {
+        let text = not_none!(value).read_text();
+        let time = NaiveTime::parse_from_str(text, SQLITE_TIME_FMT)?;
+        Ok(time)
+    }
+}
+
+impl ToSql<Time, Sqlite> for NaiveTime {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+        let s = format!("{}", self.format(SQLITE_TIME_FMT));
+        ToSql::<Text, Sqlite>::to_sql(&s, out)
+    }
+}
+
+impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
+    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error+Send+Sync>> {
+        let text = not_none!(value).read_text();
+        let dt: Vec<&str> = text.split(' ').collect();
+
+        if dt.len() != 2 {
+            return Err("Can't parse Datetime. Too many parts. It should be in the form: YYYY-MM-DD HH:MM:SS".into())
+        }
+
+        let time = NaiveTime::parse_from_str(dt[1], SQLITE_TIME_FMT)?;
+        let datetime = parse_sqlite_date(dt[0])?.and_time(time);
+
+        Ok(datetime)
+    }
+}
+
+impl ToSql<Timestamp, Sqlite> for NaiveDateTime {
+    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<Date, Sqlite>::to_sql(&self.date(), out)?;
+        write!(out, " ")?;
+        ToSql::<Time, Sqlite>::to_sql(&self.time(), out)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    extern crate dotenv;
+    extern crate chrono;
+
+    use self::chrono::{Duration, NaiveDate, NaiveTime, NaiveDateTime, UTC, Timelike};
+    use self::chrono::naive::date;
+    use self::dotenv::dotenv;
+
+    use ::select;
+    use expression::dsl::{sql, now};
+    use sqlite::SqliteConnection;
+    use prelude::*;
+    use types::{Date, Time, Timestamp};
+
+    fn connection() -> SqliteConnection {
+        dotenv().ok();
+
+        let connection_url = ::std::env::var("SQLITE_DATABASE_URL")
+            .or_else(|_| ::std::env::var("DATABASE_URL"))
+            .expect("DATABASE_URL must be set in order to run tests");
+        SqliteConnection::establish(&connection_url).unwrap()
+    }
+
+    #[test]
+    fn unix_epoch_encodes_correctly() {
+        let connection = connection();
+        let time = NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 0);
+        let query = select(sql::<Timestamp>("'1970-01-01 00:00:00.000000'").eq(time));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+    }
+
+
+    #[test]
+    fn unix_epoch_decodes_correctly() {
+        let connection = connection();
+        let time = NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 0);
+        let epoch_from_sql = select(sql::<Timestamp>("'1970-1-1 00:00:00'"))
+            .get_result(&connection);
+        assert_eq!(Ok(time), epoch_from_sql);
+    }
+
+    #[test]
+    fn times_relative_to_now_encode_correctly() {
+        let connection = connection();
+        let time = UTC::now().naive_utc() + Duration::seconds(60);
+        let query = select(now.lt(time));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let time = UTC::now().naive_utc() - Duration::seconds(600);
+        let query = select(now.gt(time));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+    }
+
+    #[test]
+    fn times_of_day_encode_correctly() {
+        let connection = connection();
+
+        let midnight = NaiveTime::from_hms(0, 0, 0);
+        let query = select(sql::<Time>("'00:00:00.000000'").eq(midnight));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let noon = NaiveTime::from_hms(12, 0, 0);
+        let query = select(sql::<Time>("'12:00:00.000000'").eq(noon));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let roughly_half_past_eleven = NaiveTime::from_hms_micro(23, 37, 4, 2200);
+        let query = select(sql::<Time>("'23:37:04.002200'").eq(roughly_half_past_eleven));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+    }
+
+    #[test]
+    fn times_of_day_decode_correctly() {
+        let connection = connection();
+        let midnight = NaiveTime::from_hms(0, 0, 0);
+        let query = select(sql::<Time>("'00:00:00'"));
+        assert_eq!(Ok(midnight), query.get_result::<NaiveTime>(&connection));
+
+        let noon = NaiveTime::from_hms(12, 0, 0);
+        let query = select(sql::<Time>("'12:00:00'"));
+        assert_eq!(Ok(noon), query.get_result::<NaiveTime>(&connection));
+
+        let roughly_half_past_eleven = NaiveTime::from_hms_micro(23, 37, 4, 2200);
+        let query = select(sql::<Time>("'23:37:04.002200'"));
+        assert_eq!(Ok(roughly_half_past_eleven), query.get_result::<NaiveTime>(&connection));
+    }
+
+    #[test]
+    fn dates_encode_correctly() {
+        let connection = connection();
+        let january_first_2000 = NaiveDate::from_ymd(2000, 1, 1);
+        let query = select(sql::<Date>("'2000-01-01'").eq(january_first_2000));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let distant_past = NaiveDate::from_ymd(-398, 4, 11);
+        let query = select(sql::<Date>("'-398-04-11'").eq(distant_past));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let max_date = date::MAX;
+        let query = select(sql::<Date>("'262143-12-31'").eq(max_date));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let january_first_2018 = NaiveDate::from_ymd(2018, 1, 1);
+        let query = select(sql::<Date>("'2018-01-01'").eq(january_first_2018));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let distant_future = NaiveDate::from_ymd(72400, 1, 8);
+        let query = select(sql::<Date>("'72400-01-08'").eq(distant_future));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+    }
+
+    #[test]
+    fn dates_decode_correctly() {
+        let connection = connection();
+        let january_first_2000 = NaiveDate::from_ymd(2000, 1, 1);
+        let query = select(sql::<Date>("'2000-1-1'"));
+        assert_eq!(Ok(january_first_2000), query.get_result::<NaiveDate>(&connection));
+
+        let distant_past = NaiveDate::from_ymd(-399, 4, 11);
+        let query = select(sql::<Date>("'-399-04-11'"));
+        assert_eq!(Ok(distant_past), query.get_result::<NaiveDate>(&connection));
+
+        let max_date = date::MAX;
+        let query = select(sql::<Date>("'262143-12-31'"));
+        assert_eq!(Ok(max_date), query.get_result::<NaiveDate>(&connection));
+
+        let january_first_2018 = NaiveDate::from_ymd(2018, 1, 1);
+        let query = select(sql::<Date>("'2018-01-01'"));
+        assert_eq!(Ok(january_first_2018), query.get_result::<NaiveDate>(&connection));
+
+        let distant_future = NaiveDate::from_ymd(72400, 1, 8);
+        let query = select(sql::<Date>("'72400-01-08'"));
+        assert_eq!(Ok(distant_future), query.get_result::<NaiveDate>(&connection));
+    }
+
+    #[test]
+    fn datetimes_decode_correctly() {
+        let connection = connection();
+        let january_first_2000 = NaiveDate::from_ymd(2000, 1, 1).and_hms(1, 1, 1);
+        let query = select(sql::<Timestamp>("'2000-1-1 01:01:01.000000'"));
+        assert_eq!(Ok(january_first_2000), query.get_result::<NaiveDateTime>(&connection));
+
+        let distant_past = NaiveDate::from_ymd(-399, 4, 11).and_hms(2, 2, 2);
+        let query = select(sql::<Timestamp>("'-399-04-11 02:02:02.000000'"));
+        assert_eq!(Ok(distant_past), query.get_result::<NaiveDateTime>(&connection));
+
+        let january_first_2018 = NaiveDate::from_ymd(2018, 1, 1);
+        let query = select(sql::<Date>("'2018-01-01'"));
+        assert_eq!(Ok(january_first_2018), query.get_result::<NaiveDate>(&connection));
+
+        let distant_future = NaiveDate::from_ymd(72400, 1, 8).and_hms(23, 59, 59).with_nanosecond(100000).unwrap();
+        let query = select(sql::<Timestamp>("'72400-01-08 23:59:59.000100'"));
+        assert_eq!(Ok(distant_future), query.get_result::<NaiveDateTime>(&connection));
+   }
+
+    #[test]
+    fn datetimes_encode_correctly() {
+        let connection = connection();
+        let january_first_2000 = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
+        let query = select(sql::<Timestamp>("'2000-01-01 00:00:00.000000'").eq(january_first_2000));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let distant_past = NaiveDate::from_ymd(-398, 4, 11).and_hms(20, 00, 20);
+        let query = select(sql::<Timestamp>("'-398-04-11 20:00:20.000000'").eq(distant_past));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let january_first_2018 = NaiveDate::from_ymd(2018, 1, 1).and_hms(12, 00, 00).with_nanosecond(500000).unwrap();
+        let query = select(sql::<Timestamp>("'2018-01-01 12:00:00.000500'").eq(january_first_2018));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+
+        let distant_future = NaiveDate::from_ymd(72400, 1, 8).and_hms(0, 0, 0);
+        let query = select(sql::<Timestamp>("'72400-01-08 00:00:00.000000'").eq(distant_future));
+        assert!(query.get_result::<bool>(&connection).unwrap());
+    }
+}

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -5,6 +5,9 @@ use sqlite::{Sqlite, SqliteType};
 use sqlite::connection::SqliteValue;
 use types::{self, FromSql, ToSql, IsNull, HasSqlType};
 
+#[cfg(feature = "chrono")]
+mod chrono;
+
 impl HasSqlType<types::Date> for Sqlite {
     fn metadata() -> SqliteType {
         SqliteType::Text

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -176,7 +176,7 @@ pub type VarChar = Text;
 
 /// The date SQL type.
 ///
-/// This type is currently only implemented for PostgreSQL.
+/// This type is currently only implemented for PostgreSQL and SQLite.
 ///
 /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
 ///
@@ -209,7 +209,7 @@ pub type VarChar = Text;
 
 /// The time SQL type.
 ///
-/// This type is currently only implemented for PostgreSQL.
+/// This type is currently only implemented for PostgreSQL and SQLite.
 ///
 /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
 ///
@@ -224,7 +224,7 @@ pub type VarChar = Text;
 
 /// The timestamp/datetime SQL type.
 ///
-/// This type is currently only implemented for PostgreSQL.
+/// This type is currently only implemented for PostgreSQL and SQLite.
 ///
 /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
 ///

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -81,6 +81,9 @@ mod sqlite_types {
     test_round_trip!(date_roundtrips, Date, String);
     test_round_trip!(time_roundtrips, Time, String);
     test_round_trip!(timestamp_roundtrips, Timestamp, String);
+    test_round_trip!(naive_time_roundtrips, Time, (u32, u32), mk_naive_time);
+    test_round_trip!(naive_date_roundtrips, Date, u32, mk_naive_date);
+    test_round_trip!(naive_datetime_roundtrips, Timestamp, (i64, u32), mk_naive_datetime);
 }
 
 #[cfg(feature = "postgres")]
@@ -147,6 +150,14 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
     let latest_mysql_date = NaiveDate::from_ymd(9999, 12, 31);
     let num_days_representable = latest_mysql_date.signed_duration_since(earliest_mysql_date).num_days();
     earliest_mysql_date + Duration::days(days as i64 % num_days_representable)
+}
+
+#[cfg(feature = "sqlite")]
+pub fn mk_naive_date(days: u32) -> NaiveDate {
+    let earliest_sqlite_date = date::MIN;
+    let latest_sqlite_date = date::MAX;
+    let num_days_representable = latest_sqlite_date.signed_duration_since(earliest_sqlite_date).num_days();
+    earliest_sqlite_date + Duration::days(days as i64 % num_days_representable)
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
This is #344 with tests and fixed date parsing

I took the liberty to finish that since nothing happened in the PR for more than a year.

I had to parse dates without chrono since %Y doesn't support years > 9999