### PR TITLE
Add an `use schema::{users, posts}` statement on the associations example

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -15,7 +15,14 @@
 //! relationship. You can declare an association between two records with `#[has_many]` and
 //! `#[belongs_to]`.
 //!
-//! ```ignore
+//! ```rust
+//! // You need to have the table definitions from `infer_schema!` or `table!` in scope to
+//! // derive Identifiable.
+//! # #[macro_use] extern crate diesel;
+//! # #[macro_use] extern crate diesel_codegen;
+//! # include!("src/doctest_setup.rs");
+//! use schema::{posts, users};
+//!
 //! #[derive(Identifiable, Queryable, Associations)]
 //! #[has_many(posts)]
 //! pub struct User {
@@ -23,6 +30,7 @@
 //!     name: String,
 //! }
 //!
+//! # #[derive(Debug, PartialEq)]
 //! #[derive(Identifiable, Queryable, Associations)]
 //! #[belongs_to(User)]
 //! pub struct Post {
@@ -30,6 +38,13 @@
 //!     user_id: i32,
 //!     title: String,
 //! }
+//!
+//! # fn main() {
+//! # let connection = establish_connection();
+//! # let user = users::table.find(2).get_result::<User>(&connection).unwrap();
+//! # let posts = Post::belonging_to(&user).load::<Post>(&connection);
+//! # assert_eq!(posts, Ok(vec![Post { id: 3, user_id: 2, title: "My first post too".to_owned() }]));
+//! # }
 //! ```
 //!
 //! Note that in addition to the `#[has_many]` and `#[belongs_to]` annotations, we also need to

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -15,6 +15,7 @@ cfg_if! {
             connection.begin_test_transaction().unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
             connection.execute("DROP TABLE IF EXISTS animals").unwrap();
+            connection.execute("DROP TABLE IF EXISTS posts").unwrap();
 
             connection
         }
@@ -38,6 +39,16 @@ cfg_if! {
             connection.execute("INSERT INTO animals (species, legs, name) VALUES
                                ('dog', 4, 'Jack'),
                                ('spider', 8, null)").unwrap();
+
+            connection.execute("CREATE TABLE posts (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                title VARCHAR NOT NULL
+            )").unwrap();
+            connection.execute("INSERT INTO posts (user_id, title) VALUES
+                (1, 'My first post'),
+                (1, 'About Rust'),
+                (2, 'My first post too')").unwrap();
 
             connection
         }
@@ -69,6 +80,16 @@ cfg_if! {
                                ('dog', 4, 'Jack'),
                                ('spider', 8, null)").unwrap();
 
+            connection.execute("CREATE TABLE posts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                title VARCHAR NOT NULL
+            )").unwrap();
+            connection.execute("INSERT INTO posts (user_id, title) VALUES
+                (1, 'My first post'),
+                (1, 'About Rust'),
+                (2, 'My first post too')").unwrap();
+
             connection
         }
     } else if #[cfg(feature = "mysql")] {
@@ -80,6 +101,7 @@ cfg_if! {
             let connection = diesel::mysql::MysqlConnection::establish(&connection_url).unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
             connection.execute("DROP TABLE IF EXISTS animals").unwrap();
+            connection.execute("DROP TABLE IF EXISTS posts").unwrap();
 
             connection
         }
@@ -103,6 +125,16 @@ cfg_if! {
             connection.execute("INSERT INTO animals (species, legs, name) VALUES
                                ('dog', 4, 'Jack'),
                                ('spider', 8, null)").unwrap();
+
+            connection.execute("CREATE TABLE posts (
+                id INTEGER PRIMARY KEY AUTO_INCREMENT,
+                user_id INTEGER NOT NULL,
+                title TEXT NOT NULL
+            ) CHARACTER SET utf8mb4").unwrap();
+            connection.execute("INSERT INTO posts (user_id, title) VALUES
+                (1, 'My first post'),
+                (1, 'About Rust'),
+                (2, 'My first post too')").unwrap();
 
             connection.begin_test_transaction().unwrap();
             connection
@@ -177,5 +209,21 @@ impl_Insertable! {
         species: String,
         legs: i32,
         name: Option<String>,
+    }
+}
+
+mod schema {
+    table! {
+        posts {
+            id -> Integer,
+            user_id -> Integer,
+            title -> VarChar,
+        }
+    }
+    table! {
+        users {
+            id -> Integer,
+            name -> VarChar,
+        }
     }
 }


### PR DESCRIPTION
This example seems to be confusing regarding this use statement since
it's missing and a lot of people come on gitter with an error due to the
tables not being in scope.

[ci skip]