### PR TITLE
 Add ilike method for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* Added support for `ILIKE` in PostgreSQL.
+
 * Added the `migration list` command to Diesel CLI for listing all available migrations and marking those that have been applied.
 
 * Added support for adding two nullable columns.

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -33,6 +33,7 @@ pub mod expression_methods;
 pub mod functions;
 #[doc(hidden)]
 pub mod grouped;
+#[macro_use]
 pub mod helper_types;
 #[doc(hidden)]
 pub mod nullable;

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -1,6 +1,6 @@
 use expression::{Expression, AsExpression};
 use super::predicates::*;
-use types::Array;
+use types::{Array, Text};
 
 pub trait PgExpressionMethods: Expression + Sized {
     /// Creates a PostgreSQL `IS NOT DISTINCT FROM` expression. This behaves
@@ -313,3 +313,17 @@ pub trait SortExpressionMethods : Sized {
 impl<T> SortExpressionMethods for Asc<T> {}
 
 impl<T> SortExpressionMethods for Desc<T> {}
+
+pub trait PgTextExpressionMethods: Expression<SqlType=Text> + Sized {
+    /// Returns a SQL `ILIKE` expression
+    fn ilike<T: AsExpression<Text>>(self, other: T) -> ILike<Self, T::Expression> {
+        ILike::new(self.as_expression(), other.as_expression())
+    }
+
+    /// Returns a SQL `NOT ILIKE` expression
+    fn not_ilike<T: AsExpression<Text>>(self, other: T) -> NotILike<Self, T::Expression> {
+        NotILike::new(self.as_expression(), other.as_expression())
+    }
+}
+
+impl<T: Expression<SqlType=Text>> PgTextExpressionMethods for T {}

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,0 +1,6 @@
+use ::expression::AsExpression;
+use types;
+
+gen_helper_type!(ILike, VarChar);
+gen_helper_type!(NotILike, VarChar);
+

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -4,6 +4,8 @@ pub mod expression_methods;
 pub mod extensions;
 #[doc(hidden)]
 pub mod predicates;
+#[doc(hidden)]
+pub mod helper_types;
 
 mod date_and_time;
 

--- a/diesel/src/pg/expression/predicates.rs
+++ b/diesel/src/pg/expression/predicates.rs
@@ -5,5 +5,7 @@ infix_predicate!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
 infix_predicate!(OverlapsWith, " && ", backend: Pg);
 infix_predicate!(Contains, " @> ", backend: Pg);
 infix_predicate!(IsContainedBy, " <@ ", backend: Pg);
+infix_predicate!(ILike, " ILIKE ", backend: Pg);
+infix_predicate!(NotILike, " NOT ILIKE ", backend: Pg);
 postfix_expression!(NullsFirst, " NULLS FIRST", ());
 postfix_expression!(NullsLast, " NULLS LAST", ());

--- a/diesel_compile_tests/tests/compile-fail/ilike_only_compiles_for_pg.rs
+++ b/diesel_compile_tests/tests/compile-fail/ilike_only_compiles_for_pg.rs
@@ -1,0 +1,32 @@
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_codegen;
+
+use diesel::*;
+use diesel::sqlite::SqliteConnection;
+use diesel::mysql::MysqlConnection;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+#[derive(Insertable)]
+#[table_name="users"]
+struct User {
+    id: i32,
+    name: String,
+}
+
+fn main() {
+    let connection = SqliteConnection::establish("").unwrap();
+    users::table.filter(users::name.ilike("%hey%")).execute(&connection);
+    //~^ ERROR E0277
+
+    let connection = MysqlConnection::establish("").unwrap();
+    users::table.filter(users::name.ilike("%hey%")).execute(&connection);
+    //~^ ERROR E0277
+}

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -105,6 +105,29 @@ fn filter_by_like() {
 
 #[test]
 #[cfg(feature = "postgres")]
+fn filter_by_ilike() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    let data = vec![
+        NewUser::new("Sean Griffin", None),
+        NewUser::new("Tess Griffin", None),
+        NewUser::new("Jim", None),
+    ];
+    insert(&data).into(users).execute(&connection).unwrap();
+    let data = users.load::<User>(&connection).unwrap();
+    let sean = data[0].clone();
+    let tess = data[1].clone();
+    let jim = data[2].clone();
+
+    assert_eq!(vec![sean, tess],
+        users.filter(name.ilike("%grifFin")).order(id.asc()).load(&connection).unwrap());
+    assert_eq!(vec![jim],
+        users.filter(name.not_ilike("%grifFin")).order(id.asc()).load(&connection).unwrap());
+}
+
+#[test]
+#[cfg(feature = "postgres")]
 fn filter_by_any() {
     use schema::users::dsl::*;
     use diesel::expression::dsl::any;


### PR DESCRIPTION
It's mostly a copy/paste job from like and not_like.
I just had to export the gen_helper_type! macro to use it in the pg
module.

Fixes #784