### PR TITLE
Refactor the query builder to make it easier to add new AST passes

### DIFF
--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -137,7 +137,7 @@ impl<DB, Statement> StatementCache<DB, Statement> where
 
         let cache_key = try!(StatementCacheKey::for_source(source, bind_types));
 
-        if !source.is_safe_to_cache_prepared() {
+        if !source.is_safe_to_cache_prepared()? {
             let sql = try!(cache_key.sql(source));
             return prepare_fn(&sql).map(MaybeCached::CannotCache)
         }

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -34,12 +34,11 @@ impl<T, U, DB> QueryFragment<DB> for Bound<T, U> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        out.push_bound_value(&self.item)
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::CollectBinds(ref mut out) = *pass {
+            out.push_bound_value(&self.item)?;
+        }
+        Ok(())
     }
 }
 

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -56,12 +56,8 @@ impl<T, ST, DB> QueryFragment<DB> for Coerce<T, ST> where
         self.expr.to_sql(out)
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        self.expr.collect_binds(out)
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.expr.is_safe_to_cache_prepared()
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.expr.walk_ast(pass)
     }
 }
 

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -88,13 +88,8 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.target.collect_binds(out));
-        Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.target.is_safe_to_cache_prepared()
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.target.walk_ast(pass)
     }
 }
 
@@ -115,12 +110,8 @@ impl<DB: Backend> QueryFragment<DB> for CountStar {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -63,13 +63,9 @@ impl<T, DB> QueryFragment<DB> for Exists<T> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.0.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.0.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.0.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -39,13 +39,9 @@ macro_rules! fold_function {
                 Ok(())
             }
 
-            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-                try!(self.target.collect_binds(out));
+            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+                self.target.walk_ast(pass)?;
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.target.is_safe_to_cache_prepared()
             }
         }
 

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -38,13 +38,9 @@ macro_rules! ord_function {
                 Ok(())
             }
 
-            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-                try!(self.target.collect_binds(out));
+            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+                self.target.walk_ast(pass)?;
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.target.is_safe_to_cache_prepared()
             }
         }
 

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -23,12 +23,8 @@ impl<DB: Backend> QueryFragment<DB> for now {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -47,14 +47,10 @@ macro_rules! sql_function_body {
                 Ok(())
             }
 
-            fn collect_binds(&self, out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
-                try!($crate::query_builder::QueryFragment::collect_binds(
-                        &($(&self.$arg_name),*), out));
+            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
+                try!($crate::query_builder::QueryFragment::walk_ast(
+                        &($(&self.$arg_name),*), pass));
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                ($(&self.$arg_name),*).is_safe_to_cache_prepared()
             }
         }
 
@@ -166,12 +162,8 @@ macro_rules! no_arg_sql_function_body {
                 Ok(())
             }
 
-            fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
+            fn walk_ast(&self, _: &mut $crate::query_builder::AstPass<DB>) -> QueryResult<()> {
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                true
             }
         }
     };
@@ -188,12 +180,8 @@ macro_rules! no_arg_sql_function_body {
                 Ok(())
             }
 
-            fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
+            fn walk_ast(&self, _: &mut $crate::query_builder::AstPass<DB>) -> QueryResult<()> {
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                true
             }
         }
     };

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -18,13 +18,9 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.0.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.0.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.0.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -28,12 +28,8 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
         self.0.to_sql(out)
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        self.0.collect_binds(out)
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.0.is_safe_to_cache_prepared()
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.0.walk_ast(pass)
     }
 }
 

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -40,15 +40,11 @@ macro_rules! numeric_operation {
                 self.rhs.to_sql(out)
             }
 
-            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-                try!(self.lhs.collect_binds(out));
-                try!(self.rhs.collect_binds(out));
-                Ok(())
-            }
 
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.lhs.is_safe_to_cache_prepared() &&
-                    self.rhs.is_safe_to_cache_prepared()
+            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+                self.lhs.walk_ast(pass)?;
+                self.rhs.walk_ast(pass)?;
+                Ok(())
             }
         }
 

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -50,15 +50,10 @@ macro_rules! global_infix_predicate_to_sql {
                 self.right.to_sql(out)
             }
 
-            fn collect_binds(&self, out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
-                try!(self.left.collect_binds(out));
-                try!(self.right.collect_binds(out));
+            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
+                self.left.walk_ast(pass)?;
+                self.right.walk_ast(pass)?;
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.left.is_safe_to_cache_prepared() &&
-                    self.right.is_safe_to_cache_prepared()
             }
         }
     }
@@ -81,17 +76,10 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 self.right.to_sql(out)
             }
 
-            fn collect_binds(&self, out: &mut <$backend as $crate::backend::Backend>::BindCollector)
-                -> $crate::result::QueryResult<()>
-            {
-                try!(self.left.collect_binds(out));
-                try!(self.right.collect_binds(out));
+            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<$backend>) -> $crate::result::QueryResult<()> {
+                self.left.walk_ast(pass)?;
+                self.right.walk_ast(pass)?;
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.left.is_safe_to_cache_prepared() &&
-                    self.right.is_safe_to_cache_prepared()
             }
         }
 
@@ -110,18 +98,10 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 self.right.to_sql(out)
             }
 
-            fn collect_binds(
-                &self,
-                out: &mut <$crate::backend::Debug as $crate::backend::Backend>::BindCollector,
-            ) -> $crate::result::QueryResult<()> {
-                try!(self.left.collect_binds(out));
-                try!(self.right.collect_binds(out));
+            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<$crate::backend::Debug>) -> $crate::result::QueryResult<()> {
+                self.left.walk_ast(pass)?;
+                self.right.walk_ast(pass)?;
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.left.is_safe_to_cache_prepared() &&
-                    self.right.is_safe_to_cache_prepared()
             }
         }
     }
@@ -202,13 +182,9 @@ macro_rules! postfix_predicate_body {
                 Ok(())
             }
 
-            fn collect_binds(&self, out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
-                try!(self.expr.collect_binds(out));
+            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
+                self.expr.walk_ast(pass)?;
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.expr.is_safe_to_cache_prepared()
             }
         }
 

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -40,12 +40,11 @@ impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST> where
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -20,12 +20,8 @@ macro_rules! __diesel_column {
                 out.push_identifier(stringify!($column_name))
             }
 
-            fn collect_binds(&self, _out: &mut DB::BindCollector) -> $crate::result::QueryResult<()> {
+            fn walk_ast(&self, _: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                true
             }
         }
 
@@ -436,7 +432,7 @@ macro_rules! table_body {
                 use super::table;
                 use $crate::{Table, Expression, SelectableExpression, AppearsOnTable, QuerySource};
                 use $crate::backend::Backend;
-                use $crate::query_builder::{QueryBuilder, BuildQueryResult, QueryFragment};
+                use $crate::query_builder::{QueryBuilder, BuildQueryResult, QueryFragment, AstPass};
                 use $crate::query_source::joins::{Join, Inner, LeftOuter};
                 use $crate::result::QueryResult;
                 $(use $($import)::+;)+
@@ -462,12 +458,8 @@ macro_rules! table_body {
                         Ok(())
                     }
 
-                    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+                    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
                         Ok(())
-                    }
-
-                    fn is_safe_to_cache_prepared(&self) -> bool {
-                        true
                     }
                 }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -116,7 +116,7 @@ impl PgConnection {
 
         let cache_len = self.statement_cache.len();
         let query = self.statement_cache.cached_statement(source, &metadata, |sql| {
-            let query_name = if source.is_safe_to_cache_prepared() {
+            let query_name = if source.is_safe_to_cache_prepared()? {
                 Some(format!("__diesel_stmt_{}", cache_len))
             } else {
                 None

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -107,13 +107,9 @@ impl<Expr> QueryFragment<Pg> for Any<Expr> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.expr.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+        self.expr.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.expr.is_safe_to_cache_prepared()
     }
 }
 
@@ -127,13 +123,9 @@ impl<Expr> QueryFragment<Debug> for Any<Expr> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.expr.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Debug>) -> QueryResult<()> {
+        self.expr.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.expr.is_safe_to_cache_prepared()
     }
 }
 
@@ -175,13 +167,9 @@ impl<Expr> QueryFragment<Pg> for All<Expr> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.expr.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+        self.expr.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.expr.is_safe_to_cache_prepared()
     }
 }
 
@@ -195,13 +183,9 @@ impl<Expr> QueryFragment<Debug> for All<Expr> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.expr.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Debug>) -> QueryResult<()> {
+        self.expr.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.expr.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -49,15 +49,10 @@ impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz> where
         self.timezone.to_sql(out)
     }
 
-    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.timestamp.collect_binds(out));
-        try!(self.timezone.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+        self.timestamp.walk_ast(pass)?;
+        self.timezone.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.timestamp.is_safe_to_cache_prepared() &&
-            self.timezone.is_safe_to_cache_prepared()
     }
 }
 
@@ -74,14 +69,9 @@ impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
         self.timezone.to_sql(out)
     }
 
-    fn collect_binds(&self, out: &mut <Debug as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.timestamp.collect_binds(out));
-        try!(self.timezone.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Debug>) -> QueryResult<()> {
+        self.timestamp.walk_ast(pass)?;
+        self.timezone.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.timestamp.is_safe_to_cache_prepared() &&
-            self.timezone.is_safe_to_cache_prepared()
     }
 }

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -128,12 +128,8 @@ impl QueryFragment<Pg> for DoNothing {
         Ok(())
     }
 
-    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 
@@ -167,13 +163,12 @@ impl<T> QueryFragment<Pg> for DoUpdate<T> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.changeset.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+        match *pass {
+            AstPass::CollectBinds(ref mut out) => self.changeset.collect_binds(out)?,
+            AstPass::IsSafeToCachePrepared(ref mut result) => **result = false,
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 
@@ -190,12 +185,8 @@ impl<T> QueryFragment<Pg> for Excluded<T> where
         Ok(())
     }
 
-    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -64,12 +64,8 @@ impl QueryFragment<Pg> for NoConflictTarget {
         Ok(())
     }
 
-    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 
@@ -88,12 +84,8 @@ impl<T: Column> QueryFragment<Pg> for ConflictTarget<T> {
         Ok(())
     }
 
-    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 
@@ -109,13 +101,9 @@ impl<ST> QueryFragment<Pg> for ConflictTarget<SqlLiteral<ST>> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.0.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+        self.0.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.0.is_safe_to_cache_prepared()
     }
 }
 
@@ -131,12 +119,8 @@ impl<'a> QueryFragment<Pg> for ConflictTarget<OnConstraint<'a>> {
         Ok(())
     }
 
-    fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 
@@ -160,12 +144,8 @@ macro_rules! on_conflict_tuples {
                 Ok(())
             }
 
-            fn collect_binds(&self, _: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+            fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                true
             }
         }
 

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -6,7 +6,7 @@ macro_rules! simple_clause {
     ($no_clause:ident, $clause:ident, $sql:expr, backend_bounds = $($backend_bounds:ident),*) => {
         use backend::Backend;
         use result::QueryResult;
-        use super::{QueryFragment, QueryBuilder, BuildQueryResult};
+        use super::{QueryFragment, QueryBuilder, BuildQueryResult, AstPass};
 
         #[derive(Debug, Clone, Copy)]
         pub struct $no_clause;
@@ -16,12 +16,8 @@ macro_rules! simple_clause {
                 Ok(())
             }
 
-            fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+            fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
                 Ok(())
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                true
             }
         }
 
@@ -39,12 +35,8 @@ macro_rules! simple_clause {
                 self.0.to_sql(out)
             }
 
-            fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-                self.0.collect_binds(out)
-            }
-
-            fn is_safe_to_cache_prepared(&self) -> bool {
-                self.0.is_safe_to_cache_prepared()
+            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+                self.0.walk_ast(pass)
             }
         }
 

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -38,17 +38,11 @@ impl<T, U, Ret, DB> QueryFragment<DB> for DeleteStatement<T, U, Ret> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.table.from_clause().collect_binds(out));
-        try!(self.where_clause.collect_binds(out));
-        try!(self.returning.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.table.from_clause().walk_ast(pass)?;
+        self.where_clause.walk_ast(pass)?;
+        self.returning.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.table.from_clause().is_safe_to_cache_prepared() &&
-            self.where_clause.is_safe_to_cache_prepared() &&
-            self.returning.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -12,12 +12,8 @@ impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 
@@ -29,12 +25,8 @@ impl<DB: Backend> QueryFragment<DB> for DistinctClause {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -29,8 +29,7 @@ impl<QS> SelectClauseExpression<QS> for DefaultSelectClause where
 
 pub trait SelectClauseQueryFragment<QS, DB: Backend> {
     fn to_sql(&self, source: &QS, out: &mut DB::QueryBuilder) -> BuildQueryResult;
-    fn collect_binds(&self, source: &QS, out: &mut DB::BindCollector) -> QueryResult<()>;
-    fn is_safe_to_cache_prepared(&self, source: &QS) -> bool;
+    fn walk_ast(&self, source: &QS, pass: &mut AstPass<DB>) -> QueryResult<()>;
 }
 
 impl<T, QS, DB> SelectClauseQueryFragment<QS, DB> for SelectClause<T> where
@@ -41,12 +40,8 @@ impl<T, QS, DB> SelectClauseQueryFragment<QS, DB> for SelectClause<T> where
         self.0.to_sql(out)
     }
 
-    fn collect_binds(&self, _: &QS, out: &mut DB::BindCollector) -> QueryResult<()> {
-        self.0.collect_binds(out)
-    }
-
-    fn is_safe_to_cache_prepared(&self, _: &QS) -> bool {
-        self.0.is_safe_to_cache_prepared()
+    fn walk_ast(&self, _: &QS, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.0.walk_ast(pass)
     }
 }
 
@@ -59,11 +54,7 @@ impl<QS, DB> SelectClauseQueryFragment<QS, DB> for DefaultSelectClause where
         source.default_selection().to_sql(out)
     }
 
-    fn collect_binds(&self, source: &QS, out: &mut DB::BindCollector) -> QueryResult<()> {
-        source.default_selection().collect_binds(out)
-    }
-
-    fn is_safe_to_cache_prepared(&self, source: &QS) -> bool {
-        source.default_selection().is_safe_to_cache_prepared()
+    fn walk_ast(&self, source: &QS, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        source.default_selection().walk_ast(pass)
     }
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -76,29 +76,19 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.distinct.collect_binds(out));
-        try!(self.select.collect_binds(out));
-        try!(self.from.from_clause().collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.distinct.walk_ast(pass)?;
+        self.select.walk_ast(pass)?;
+        self.from.from_clause().walk_ast(pass)?;
 
         if let Some(ref where_clause) = self.where_clause {
-            try!(where_clause.collect_binds(out));
+            where_clause.walk_ast(pass)?;
         }
 
-        try!(self.order.collect_binds(out));
-        try!(self.limit.collect_binds(out));
-        try!(self.offset.collect_binds(out));
+        self.order.walk_ast(pass)?;
+        self.limit.walk_ast(pass)?;
+        self.offset.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.distinct.is_safe_to_cache_prepared() &&
-            self.select.is_safe_to_cache_prepared() &&
-            self.from.from_clause().is_safe_to_cache_prepared() &&
-            self.where_clause.as_ref().map(|w| w.is_safe_to_cache_prepared()).unwrap_or(true) &&
-            self.order.is_safe_to_cache_prepared() &&
-            self.limit.is_safe_to_cache_prepared() &&
-            self.offset.is_safe_to_cache_prepared()
     }
 }
 
@@ -121,27 +111,18 @@ impl<'a, ST, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, (), DB> wher
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.distinct.collect_binds(out));
-        try!(self.select.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.distinct.walk_ast(pass)?;
+        self.select.walk_ast(pass)?;
 
         if let Some(ref where_clause) = self.where_clause {
-            try!(where_clause.collect_binds(out));
+            where_clause.walk_ast(pass)?;
         }
 
-        try!(self.order.collect_binds(out));
-        try!(self.limit.collect_binds(out));
-        try!(self.offset.collect_binds(out));
+        self.order.walk_ast(pass)?;
+        self.limit.walk_ast(pass)?;
+        self.offset.walk_ast(pass)?;
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.distinct.is_safe_to_cache_prepared() &&
-            self.select.is_safe_to_cache_prepared() &&
-            self.where_clause.as_ref().map(|w| w.is_safe_to_cache_prepared()).unwrap_or(true) &&
-            self.order.is_safe_to_cache_prepared() &&
-            self.limit.is_safe_to_cache_prepared() &&
-            self.offset.is_safe_to_cache_prepared()
     }
 }
 

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -3,7 +3,7 @@ use expression::*;
 use expression::expression_methods::*;
 use expression::predicates::And;
 use result::QueryResult;
-use super::{QueryFragment, QueryBuilder, BuildQueryResult};
+use super::*;
 use types::Bool;
 
 pub trait WhereAnd<Predicate> {
@@ -22,12 +22,8 @@ impl<DB: Backend> QueryFragment<DB> for NoWhereClause {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 
@@ -59,12 +55,8 @@ impl<DB, Expr> QueryFragment<DB> for WhereClause<Expr> where
         self.0.to_sql(out)
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        self.0.collect_binds(out)
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        self.0.is_safe_to_cache_prepared()
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        self.0.walk_ast(pass)
     }
 }
 

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -93,12 +93,8 @@ impl<DB: Backend> QueryFragment<DB> for Inner {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 
@@ -113,11 +109,7 @@ impl<DB: Backend> QueryFragment<DB> for LeftOuter {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }

--- a/diesel/src/sqlite/query_builder/nodes.rs
+++ b/diesel/src/sqlite/query_builder/nodes.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use query_builder::{QueryFragment, QueryBuilder, BuildQueryResult};
+use query_builder::*;
 use result::QueryResult;
 use sqlite::Sqlite;
 
@@ -12,12 +12,8 @@ impl QueryFragment<Sqlite> for Replace {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut <Sqlite as Backend>::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<Sqlite>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -75,10 +75,8 @@ macro_rules! tuple_impls {
                 type SqlType = ($(<$T as Expression>::SqlType,)+);
             }
 
-            #[cfg_attr(feature = "clippy", allow(eq_op))] // Clippy doesn't like the trivial case for 1-tuples
             impl<$($T: QueryFragment<DB>),+, DB: Backend> QueryFragment<DB> for ($($T,)+) {
-                fn to_sql(&self, out: &mut DB::QueryBuilder)
-                -> BuildQueryResult {
+                fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
                     $(
                         if $idx != 0 {
                             out.push_sql(", ");
@@ -88,15 +86,9 @@ macro_rules! tuple_impls {
                     Ok(())
                 }
 
-                fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-                    $(
-                        try!(self.$idx.collect_binds(out));
-                    )+
+                fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+                    $(self.$idx.walk_ast(pass)?;)+
                     Ok(())
-                }
-
-                fn is_safe_to_cache_prepared(&self) -> bool {
-                    $(self.$idx.is_safe_to_cache_prepared() &&)+ true
                 }
             }
 

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -88,12 +88,8 @@ impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        true
     }
 }
 

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -86,13 +86,13 @@ impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.columns.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        } else {
+            self.columns.walk_ast(pass)?;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 
@@ -114,12 +114,11 @@ impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut DB::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 
@@ -141,13 +140,13 @@ impl<DB, Col> QueryFragment<DB> for PrimaryKey<Col> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.0.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        } else {
+            self.0.walk_ast(pass)?;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 
@@ -163,13 +162,13 @@ impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut <Sqlite as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.0.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<Sqlite>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        } else {
+            self.0.walk_ast(pass)?;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 
@@ -183,12 +182,13 @@ impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
         Ok(())
     }
 
-    fn collect_binds(&self, _out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
+    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        } else {
+            self.0.walk_ast(pass)?;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 
@@ -202,13 +202,13 @@ impl<DB, Col> QueryFragment<DB> for NotNull<Col> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.0.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        } else {
+            self.0.walk_ast(pass)?;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 
@@ -225,13 +225,13 @@ impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
         Ok(())
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        try!(self.column.collect_binds(out));
+    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
+            **result = false;
+        } else {
+            self.column.walk_ast(pass)?;
+        }
         Ok(())
-    }
-
-    fn is_safe_to_cache_prepared(&self) -> bool {
-        false
     }
 }
 


### PR DESCRIPTION
I had initially wanted to move us towards a more of a visitor pattern,
where the `AstVisitor` trait would have most of the methods from
`QueryBuilder`, with `BindCollector` and `fn
unsafe_to_cache_prepared(&mut self)` tacked on. However, I quickly hit a
wall there when I realized that `BindCollector` cannot be made object
safe, which would prevent me from making `QueryFragment` object safe, so
that won't work.

The benefit of using the visitor pattern here would have been that it
would be easier for code *outside* of Diesel to add new AST passes if it
wanted to (within limits, I don't want to go so far as to have
`visit_specific_type` as that would be even more painful than what we
have now). This form doesn't bring that benefit.

However, using an enum instead does make it easier for us to add new
passes within Diesel itself, since we now have a single function which
will apply to all future AST passes for the majority of nodes (most
nodes don't care about any pass other than `to_sql`, they just call
their children).

The plan is to follow this up by moving `to_sql` into the `walk_ast`
method as well, and eliminate `Changeset`, and `InsertValues` since
it'll now be easier to add the new "this is like that other pass, but
slightly different for this one case" type passes.

The signature is a little funky here, since we're passing a mutable
reference to an enum which just wraps a mutable reference. I really only
want the inner `&mut`, since I want implementors to be able to mutate
the `QueryBuilder` or `BindCollector`, but not change the variant. The
reason for the outer `&mut` is because reborrowing doesn't apply to
structs. We can't pass `AstPass<'a>` multiple times, as it's not `Copy`.
When we pass a mutable reference directly, Rust creates a new reference
with a narrowed lifetime. We can't do that here. The reason I kept the
inner `&mut` instead of just having `AstPass` own the value is that we'd
have no way to cleanly get the value being mutated back out of it when
we were done.