### PR TITLE
Document the common abbreviations in `select_statement`

### DIFF
--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -1,3 +1,13 @@
+//! Within this module, types commonly use the following abbreviations:
+//!
+//! F: From Clause
+//! S: Select Clause
+//! D: Distinct Clause
+//! W: Where Clause
+//! O: Order By Clause
+//! L: Limit Clause
+//! Of: Offset Clause
+//! G: Group By Clause
 mod dsl_impls;
 mod boxed;
 


### PR DESCRIPTION
I should do this for `DB`, `ST`, and `QS` as well, but it's less clear
where to put those. These docs are not rendered on the site, and are
purely to help ease in new contributors.