### PR TITLE
Pass `AstPass` by value, not by reference

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -79,9 +79,9 @@ impl<T, U, DB> QueryFragment<DB> for In<T, U> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.left.walk_ast(pass)?;
-        self.values.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.left.walk_ast(pass.reborrow())?;
+        self.values.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -103,9 +103,9 @@ impl<T, U, DB> QueryFragment<DB> for NotIn<T, U> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.left.walk_ast(pass)?;
-        self.values.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.left.walk_ast(pass.reborrow())?;
+        self.values.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -202,12 +202,12 @@ impl<T, DB> QueryFragment<DB> for Many<T> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             for value in &self.0 {
-                value.walk_ast(pass)?;
+                value.walk_ast(pass.reborrow())?;
             }
         }
         Ok(())
@@ -252,7 +252,7 @@ impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST> where
         self.values.to_sql(out)
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.values.walk_ast(pass)
     }
 }

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -34,8 +34,8 @@ impl<T, U, DB> QueryFragment<DB> for Bound<T, U> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::CollectBinds(ref mut out) = *pass {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::CollectBinds(out) = pass {
             out.push_bound_value(&self.item)?;
         }
         Ok(())

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -56,7 +56,7 @@ impl<T, ST, DB> QueryFragment<DB> for Coerce<T, ST> where
         self.expr.to_sql(out)
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.expr.walk_ast(pass)
     }
 }

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -88,7 +88,7 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.target.walk_ast(pass)
     }
 }
@@ -110,7 +110,7 @@ impl<DB: Backend> QueryFragment<DB> for CountStar {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -63,7 +63,7 @@ impl<T, DB> QueryFragment<DB> for Exists<T> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)?;
         Ok(())
     }

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -39,7 +39,7 @@ macro_rules! fold_function {
                 Ok(())
             }
 
-            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+            fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
                 self.target.walk_ast(pass)?;
                 Ok(())
             }

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -38,7 +38,7 @@ macro_rules! ord_function {
                 Ok(())
             }
 
-            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+            fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
                 self.target.walk_ast(pass)?;
                 Ok(())
             }

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -23,7 +23,7 @@ impl<DB: Backend> QueryFragment<DB> for now {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -47,7 +47,7 @@ macro_rules! sql_function_body {
                 Ok(())
             }
 
-            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
+            fn walk_ast(&self, pass: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
                 try!($crate::query_builder::QueryFragment::walk_ast(
                         &($(&self.$arg_name),*), pass));
                 Ok(())
@@ -180,7 +180,7 @@ macro_rules! no_arg_sql_function_body {
                 Ok(())
             }
 
-            fn walk_ast(&self, _: &mut $crate::query_builder::AstPass<DB>) -> QueryResult<()> {
+            fn walk_ast(&self, _: $crate::query_builder::AstPass<DB>) -> QueryResult<()> {
                 Ok(())
             }
         }

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -18,7 +18,7 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)?;
         Ok(())
     }

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -28,7 +28,7 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
         self.0.to_sql(out)
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }
 }

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -41,9 +41,9 @@ macro_rules! numeric_operation {
             }
 
 
-            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-                self.lhs.walk_ast(pass)?;
-                self.rhs.walk_ast(pass)?;
+            fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+                self.lhs.walk_ast(pass.reborrow())?;
+                self.rhs.walk_ast(pass.reborrow())?;
                 Ok(())
             }
         }

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -50,9 +50,9 @@ macro_rules! global_infix_predicate_to_sql {
                 self.right.to_sql(out)
             }
 
-            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
-                self.left.walk_ast(pass)?;
-                self.right.walk_ast(pass)?;
+            fn walk_ast(&self, mut pass: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
+                self.left.walk_ast(pass.reborrow())?;
+                self.right.walk_ast(pass.reborrow())?;
                 Ok(())
             }
         }
@@ -76,9 +76,9 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 self.right.to_sql(out)
             }
 
-            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<$backend>) -> $crate::result::QueryResult<()> {
-                self.left.walk_ast(pass)?;
-                self.right.walk_ast(pass)?;
+            fn walk_ast(&self, mut pass: $crate::query_builder::AstPass<$backend>) -> $crate::result::QueryResult<()> {
+                self.left.walk_ast(pass.reborrow())?;
+                self.right.walk_ast(pass.reborrow())?;
                 Ok(())
             }
         }
@@ -98,9 +98,9 @@ macro_rules! backend_specific_infix_predicate_to_sql {
                 self.right.to_sql(out)
             }
 
-            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<$crate::backend::Debug>) -> $crate::result::QueryResult<()> {
-                self.left.walk_ast(pass)?;
-                self.right.walk_ast(pass)?;
+            fn walk_ast(&self, mut pass: $crate::query_builder::AstPass<$crate::backend::Debug>) -> $crate::result::QueryResult<()> {
+                self.left.walk_ast(pass.reborrow())?;
+                self.right.walk_ast(pass.reborrow())?;
                 Ok(())
             }
         }
@@ -182,7 +182,7 @@ macro_rules! postfix_predicate_body {
                 Ok(())
             }
 
-            fn walk_ast(&self, pass: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
+            fn walk_ast(&self, pass: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
                 self.expr.walk_ast(pass)?;
                 Ok(())
             }

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -40,9 +40,9 @@ impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         }
         Ok(())
     }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -20,7 +20,7 @@ macro_rules! __diesel_column {
                 out.push_identifier(stringify!($column_name))
             }
 
-            fn walk_ast(&self, _: &mut $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
+            fn walk_ast(&self, _: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
                 Ok(())
             }
         }
@@ -470,7 +470,7 @@ macro_rules! table_body {
                         Ok(())
                     }
 
-                    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+                    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
                         Ok(())
                     }
                 }

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -107,7 +107,7 @@ impl<Expr> QueryFragment<Pg> for Any<Expr> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
         self.expr.walk_ast(pass)?;
         Ok(())
     }
@@ -123,7 +123,7 @@ impl<Expr> QueryFragment<Debug> for Any<Expr> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Debug>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<Debug>) -> QueryResult<()> {
         self.expr.walk_ast(pass)?;
         Ok(())
     }
@@ -167,7 +167,7 @@ impl<Expr> QueryFragment<Pg> for All<Expr> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
         self.expr.walk_ast(pass)?;
         Ok(())
     }
@@ -183,7 +183,7 @@ impl<Expr> QueryFragment<Debug> for All<Expr> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Debug>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<Debug>) -> QueryResult<()> {
         self.expr.walk_ast(pass)?;
         Ok(())
     }

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -49,9 +49,9 @@ impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz> where
         self.timezone.to_sql(out)
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
-        self.timestamp.walk_ast(pass)?;
-        self.timezone.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<Pg>) -> QueryResult<()> {
+        self.timestamp.walk_ast(pass.reborrow())?;
+        self.timezone.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -69,9 +69,9 @@ impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
         self.timezone.to_sql(out)
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Debug>) -> QueryResult<()> {
-        self.timestamp.walk_ast(pass)?;
-        self.timezone.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<Debug>) -> QueryResult<()> {
+        self.timestamp.walk_ast(pass.reborrow())?;
+        self.timezone.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -128,7 +128,7 @@ impl QueryFragment<Pg> for DoNothing {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<Pg>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -163,10 +163,10 @@ impl<T> QueryFragment<Pg> for DoUpdate<T> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
-        match *pass {
-            AstPass::CollectBinds(ref mut out) => self.changeset.collect_binds(out)?,
-            AstPass::IsSafeToCachePrepared(ref mut result) => **result = false,
+    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
+        match pass {
+            AstPass::CollectBinds(out) => self.changeset.collect_binds(out)?,
+            AstPass::IsSafeToCachePrepared(result) => *result = false,
         }
         Ok(())
     }
@@ -185,7 +185,7 @@ impl<T> QueryFragment<Pg> for Excluded<T> where
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<Pg>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -64,7 +64,7 @@ impl QueryFragment<Pg> for NoConflictTarget {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<Pg>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -84,7 +84,7 @@ impl<T: Column> QueryFragment<Pg> for ConflictTarget<T> {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<Pg>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -101,7 +101,7 @@ impl<ST> QueryFragment<Pg> for ConflictTarget<SqlLiteral<ST>> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
         self.0.walk_ast(pass)?;
         Ok(())
     }
@@ -119,7 +119,7 @@ impl<'a> QueryFragment<Pg> for ConflictTarget<OnConstraint<'a>> {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<Pg>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -144,7 +144,7 @@ macro_rules! on_conflict_tuples {
                 Ok(())
             }
 
-            fn walk_ast(&self, _: &mut AstPass<Pg>) -> QueryResult<()> {
+            fn walk_ast(&self, _: AstPass<Pg>) -> QueryResult<()> {
                 Ok(())
             }
         }

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -16,7 +16,7 @@ macro_rules! simple_clause {
                 Ok(())
             }
 
-            fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+            fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
                 Ok(())
             }
         }
@@ -35,7 +35,7 @@ macro_rules! simple_clause {
                 self.0.to_sql(out)
             }
 
-            fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+            fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
                 self.0.walk_ast(pass)
             }
         }

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -38,10 +38,10 @@ impl<T, U, Ret, DB> QueryFragment<DB> for DeleteStatement<T, U, Ret> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.table.from_clause().walk_ast(pass)?;
-        self.where_clause.walk_ast(pass)?;
-        self.returning.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.table.from_clause().walk_ast(pass.reborrow())?;
+        self.where_clause.walk_ast(pass.reborrow())?;
+        self.returning.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -12,7 +12,7 @@ impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -25,7 +25,7 @@ impl<DB: Backend> QueryFragment<DB> for DistinctClause {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -116,17 +116,17 @@ impl<T, U, Op, Ret, DB> QueryFragment<DB> for InsertStatement<T, U, Op, Ret> whe
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             let values = self.records.values();
-            self.operator.walk_ast(pass)?;
-            self.target.from_clause().walk_ast(pass)?;
-            if let AstPass::CollectBinds(ref mut out) = *pass {
+            self.operator.walk_ast(pass.reborrow())?;
+            self.target.from_clause().walk_ast(pass.reborrow())?;
+            if let AstPass::CollectBinds(ref mut out) = pass {
                 values.values_bind_params(out)?;
             }
-            self.returning.walk_ast(pass)?;
+            self.returning.walk_ast(pass.reborrow())?;
         }
         Ok(())
     }
@@ -344,7 +344,7 @@ impl<DB: Backend> QueryFragment<DB> for Insert {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -10,7 +10,7 @@ impl<'a, DB: Backend> QueryFragment<DB> for Identifier<'a> {
         out.push_identifier(self.0)
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -44,9 +44,9 @@ impl<'a, T, U, DB> QueryFragment<DB> for InfixNode<'a, T, U> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.lhs.walk_ast(pass)?;
-        self.rhs.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.lhs.walk_ast(pass.reborrow())?;
+        self.rhs.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -29,7 +29,7 @@ impl<QS> SelectClauseExpression<QS> for DefaultSelectClause where
 
 pub trait SelectClauseQueryFragment<QS, DB: Backend> {
     fn to_sql(&self, source: &QS, out: &mut DB::QueryBuilder) -> BuildQueryResult;
-    fn walk_ast(&self, source: &QS, pass: &mut AstPass<DB>) -> QueryResult<()>;
+    fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()>;
 }
 
 impl<T, QS, DB> SelectClauseQueryFragment<QS, DB> for SelectClause<T> where
@@ -40,7 +40,7 @@ impl<T, QS, DB> SelectClauseQueryFragment<QS, DB> for SelectClause<T> where
         self.0.to_sql(out)
     }
 
-    fn walk_ast(&self, _: &QS, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: &QS, pass: AstPass<DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }
 }
@@ -54,7 +54,7 @@ impl<QS, DB> SelectClauseQueryFragment<QS, DB> for DefaultSelectClause where
         source.default_selection().to_sql(out)
     }
 
-    fn walk_ast(&self, source: &QS, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()> {
         source.default_selection().walk_ast(pass)
     }
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -76,18 +76,18 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.distinct.walk_ast(pass)?;
-        self.select.walk_ast(pass)?;
-        self.from.from_clause().walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.distinct.walk_ast(pass.reborrow())?;
+        self.select.walk_ast(pass.reborrow())?;
+        self.from.from_clause().walk_ast(pass.reborrow())?;
 
         if let Some(ref where_clause) = self.where_clause {
-            where_clause.walk_ast(pass)?;
+            where_clause.walk_ast(pass.reborrow())?;
         }
 
-        self.order.walk_ast(pass)?;
-        self.limit.walk_ast(pass)?;
-        self.offset.walk_ast(pass)?;
+        self.order.walk_ast(pass.reborrow())?;
+        self.limit.walk_ast(pass.reborrow())?;
+        self.offset.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -111,17 +111,17 @@ impl<'a, ST, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, (), DB> wher
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.distinct.walk_ast(pass)?;
-        self.select.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.distinct.walk_ast(pass.reborrow())?;
+        self.select.walk_ast(pass.reborrow())?;
 
         if let Some(ref where_clause) = self.where_clause {
-            where_clause.walk_ast(pass)?;
+            where_clause.walk_ast(pass.reborrow())?;
         }
 
-        self.order.walk_ast(pass)?;
-        self.limit.walk_ast(pass)?;
-        self.offset.walk_ast(pass)?;
+        self.order.walk_ast(pass.reborrow())?;
+        self.limit.walk_ast(pass.reborrow())?;
+        self.offset.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -139,15 +139,15 @@ impl<F, S, D, W, O, L, Of, G, DB> QueryFragment<DB>
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.distinct.walk_ast(pass)?;
-        self.select.walk_ast(&self.from, pass)?;
-        self.from.from_clause().walk_ast(pass)?;
-        self.where_clause.walk_ast(pass)?;
-        self.group_by.walk_ast(pass)?;
-        self.order.walk_ast(pass)?;
-        self.limit.walk_ast(pass)?;
-        self.offset.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.distinct.walk_ast(pass.reborrow())?;
+        self.select.walk_ast(&self.from, pass.reborrow())?;
+        self.from.from_clause().walk_ast(pass.reborrow())?;
+        self.where_clause.walk_ast(pass.reborrow())?;
+        self.group_by.walk_ast(pass.reborrow())?;
+        self.order.walk_ast(pass.reborrow())?;
+        self.limit.walk_ast(pass.reborrow())?;
+        self.offset.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -175,14 +175,14 @@ impl<S, D, W, O, L, Of, G, DB> QueryFragment<DB>
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        self.distinct.walk_ast(pass)?;
-        self.select.walk_ast(&(), pass)?;
-        self.where_clause.walk_ast(pass)?;
-        self.group_by.walk_ast(pass)?;
-        self.order.walk_ast(pass)?;
-        self.limit.walk_ast(pass)?;
-        self.offset.walk_ast(pass)?;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        self.distinct.walk_ast(pass.reborrow())?;
+        self.select.walk_ast(&(), pass.reborrow())?;
+        self.where_clause.walk_ast(pass.reborrow())?;
+        self.group_by.walk_ast(pass.reborrow())?;
+        self.order.walk_ast(pass.reborrow())?;
+        self.limit.walk_ast(pass.reborrow())?;
+        self.offset.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -69,18 +69,18 @@ impl<T, U, V, Ret, DB> QueryFragment<DB> for UpdateStatement<T, U, V, Ret> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
-            self.table.from_clause().walk_ast(pass)?;
+            self.table.from_clause().walk_ast(pass.reborrow())?;
             // FIXME: Let's see if we can move `Changeset` into AST passes
             // on `QueryFragment`
-            if let AstPass::CollectBinds(ref mut out) = *pass {
+            if let AstPass::CollectBinds(ref mut out) = pass {
                 self.values.collect_binds(out)?;
             }
-            self.where_clause.walk_ast(pass)?;
-            self.returning.walk_ast(pass)?;
+            self.where_clause.walk_ast(pass.reborrow())?;
+            self.returning.walk_ast(pass.reborrow())?;
         }
         Ok(())
     }

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -22,7 +22,7 @@ impl<DB: Backend> QueryFragment<DB> for NoWhereClause {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -55,7 +55,7 @@ impl<DB, Expr> QueryFragment<DB> for WhereClause<Expr> where
         self.0.to_sql(out)
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }
 }

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -117,10 +117,10 @@ impl<Left, Right, Kind, DB> QueryFragment<DB> for Join<Left, Right, Kind> where
         Ok(())
     }
 
-    fn walk_ast(&self, out: &mut AstPass<DB>) -> QueryResult<()> {
-        self.left.from_clause().walk_ast(out)?;
-        self.kind.walk_ast(out)?;
-        self.right.from_clause().walk_ast(out)?;
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        self.left.from_clause().walk_ast(out.reborrow())?;
+        self.kind.walk_ast(out.reborrow())?;
+        self.right.from_clause().walk_ast(out.reborrow())?;
         Ok(())
     }
 }
@@ -175,7 +175,7 @@ impl<DB: Backend> QueryFragment<DB> for Inner {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -191,7 +191,7 @@ impl<DB: Backend> QueryFragment<DB> for LeftOuter {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/sqlite/query_builder/nodes.rs
+++ b/diesel/src/sqlite/query_builder/nodes.rs
@@ -12,7 +12,7 @@ impl QueryFragment<Sqlite> for Replace {
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<Sqlite>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<Sqlite>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -86,8 +86,8 @@ macro_rules! tuple_impls {
                     Ok(())
                 }
 
-                fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-                    $(self.$idx.walk_ast(pass)?;)+
+                fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+                    $(self.$idx.walk_ast(pass.reborrow())?;)+
                     Ok(())
                 }
             }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -88,7 +88,7 @@ impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
         Ok(())
     }
 
-    fn walk_ast(&self, _: &mut AstPass<DB>) -> QueryResult<()> {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -86,9 +86,9 @@ impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             self.columns.walk_ast(pass)?;
         }
@@ -114,9 +114,9 @@ impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         }
         Ok(())
     }
@@ -140,9 +140,9 @@ impl<DB, Col> QueryFragment<DB> for PrimaryKey<Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             self.0.walk_ast(pass)?;
         }
@@ -162,9 +162,9 @@ impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Sqlite>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<Sqlite>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             self.0.walk_ast(pass)?;
         }
@@ -182,9 +182,9 @@ impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<Pg>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             self.0.walk_ast(pass)?;
         }
@@ -202,9 +202,9 @@ impl<DB, Col> QueryFragment<DB> for NotNull<Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             self.0.walk_ast(pass)?;
         }
@@ -225,9 +225,9 @@ impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: &mut AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(ref mut result) = *pass {
-            **result = false;
+    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
+        if let AstPass::IsSafeToCachePrepared(result) = pass {
+            *result = false;
         } else {
             self.column.walk_ast(pass)?;
         }


### PR DESCRIPTION
The reason for passing `&mut AstPass` in the first place was to get
around the fact that Rust doesn't expose the concept of reborrowing in a
way that it can be implemented for structs. However, when `&mut AstPass`
is passed around, that means that a child node could randomly decide to
change the variant on the parent. This feels extremely wrong, and while
this is a bit more code to emulate reborrowing, I think it's worth it to
properly express the semantics we need.