### PR TITLE
Make `AstPass` an opaque struct

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -203,12 +203,9 @@ impl<T, DB> QueryFragment<DB> for Many<T> where
     }
 
     fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        } else {
-            for value in &self.0 {
-                value.walk_ast(pass.reborrow())?;
-            }
+        pass.unsafe_to_cache_prepared();
+        for value in &self.0 {
+            value.walk_ast(pass.reborrow())?;
         }
         Ok(())
     }

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -34,10 +34,8 @@ impl<T, U, DB> QueryFragment<DB> for Bound<T, U> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::CollectBinds(out) = pass {
-            out.push_bound_value(&self.item)?;
-        }
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        pass.push_bind_param(&self.item)?;
         Ok(())
     }
 }

--- a/diesel/src/expression/predicates.rs
+++ b/diesel/src/expression/predicates.rs
@@ -252,8 +252,8 @@ impl<T, U, DB> Changeset<DB> for Eq<T, U> where
         QueryFragment::to_sql(&self.right, out)
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        QueryFragment::collect_binds(&self.right, out)
+    fn walk_ast(&self, out: AstPass<DB>) -> QueryResult<()> {
+        QueryFragment::walk_ast(&self.right, out)
     }
 }
 

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -40,10 +40,8 @@ impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        }
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
         Ok(())
     }
 }

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -163,11 +163,9 @@ impl<T> QueryFragment<Pg> for DoUpdate<T> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
-        match pass {
-            AstPass::CollectBinds(out) => self.changeset.collect_binds(out)?,
-            AstPass::IsSafeToCachePrepared(result) => *result = false,
-        }
+    fn walk_ast(&self, mut pass: AstPass<Pg>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
+        self.changeset.walk_ast(pass)?;
         Ok(())
     }
 }

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -116,10 +116,10 @@ impl<Values, Target, Action> InsertValues<Pg> for OnConflictValues<Values, Targe
         Ok(())
     }
 
-    fn values_bind_params(&self, out: &mut <Pg as Backend>::BindCollector) -> QueryResult<()> {
-        try!(self.values.values_bind_params(out));
-        try!(self.target.collect_binds(out));
-        try!(self.action.collect_binds(out));
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        self.values.walk_ast(out.reborrow())?;
+        self.target.walk_ast(out.reborrow())?;
+        self.action.walk_ast(out.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -1,0 +1,72 @@
+use backend::Backend;
+use query_builder::BindCollector;
+use result::QueryResult;
+use types::{ToSql, HasSqlType};
+
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub struct AstPass<'a, DB> where
+    DB: Backend,
+    DB::BindCollector: 'a,
+{
+    internals: AstPassInternals<'a, DB>,
+}
+
+impl<'a, DB> AstPass<'a, DB> where
+    DB: Backend,
+    DB::BindCollector: 'a,
+{
+    pub fn collect_binds(collector: &'a mut DB::BindCollector) -> Self {
+        AstPass {
+            internals: AstPassInternals::CollectBinds(collector),
+        }
+    }
+
+    pub fn is_safe_to_cache_prepared(result: &'a mut bool) -> Self {
+        AstPass {
+            internals: AstPassInternals::IsSafeToCachePrepared(result),
+        }
+    }
+
+    /// Effectively copies `self`, with a narrower lifetime. This method
+    /// matches the semantics of the implicit reborrow that occurs when passing
+    /// a reference by value in Rust.
+    pub fn reborrow(&mut self) -> AstPass<DB> {
+        use self::AstPassInternals::*;
+        let internals = match self.internals {
+            CollectBinds(ref mut collector) => CollectBinds(&mut **collector),
+            IsSafeToCachePrepared(ref mut result) => IsSafeToCachePrepared(&mut **result),
+        };
+        AstPass { internals }
+    }
+
+    pub fn unsafe_to_cache_prepared(&mut self) {
+        if let AstPassInternals::IsSafeToCachePrepared(ref mut result) = self.internals {
+            **result = false
+        }
+    }
+
+    pub fn push_bind_param<T, U>(&mut self, bind: &U) -> QueryResult<()> where
+        DB: HasSqlType<T>,
+        U: ToSql<T, DB>,
+    {
+        if let AstPassInternals::CollectBinds(ref mut out) = self.internals {
+            out.push_bound_value(bind)?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(missing_debug_implementations)]
+/// This is separate from the struct to cause the enum to be opaque, forcing
+/// usage of the methods provided rather than matching on the enum directly.
+/// This essentially mimics the capabilities that would be available if
+/// `AstPass` were a trait.
+enum AstPassInternals<'a, DB> where
+    DB: Backend,
+    DB::BindCollector: 'a,
+{
+    CollectBinds(&'a mut DB::BindCollector),
+    IsSafeToCachePrepared(&'a mut bool),
+}
+

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -139,10 +139,10 @@ macro_rules! tuple_impls {
                     Ok(())
                 }
 
-                fn values_bind_params(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
+                fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                     $(
                         if let ColumnInsertValue::Expression(_, ref value) = self.$idx {
-                            try!(value.collect_binds(out));
+                            value.walk_ast(out.reborrow())?;
                         }
                     )+
                     Ok(())
@@ -189,13 +189,10 @@ macro_rules! tuple_impls {
                     Ok(())
                 }
 
-                fn values_bind_params(
-                    &self,
-                    out: &mut <::sqlite::Sqlite as Backend>::BindCollector
-                ) -> QueryResult<()> {
+                fn walk_ast(&self, mut out: AstPass<::sqlite::Sqlite>) -> QueryResult<()> {
                     $(
                         if let ColumnInsertValue::Expression(_, ref value) = self.$idx {
-                            try!(value.collect_binds(out));
+                            value.walk_ast(out.reborrow())?;
                         }
                     )+
                     Ok(())
@@ -250,10 +247,8 @@ macro_rules! tuple_impls {
                     Ok(())
                 }
 
-                fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-                    $(
-                        try!(self.$idx.collect_binds(out));
-                    )+
+                fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+                    $(self.$idx.walk_ast(out.reborrow())?;)+
                     Ok(())
                 }
             }

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -86,12 +86,9 @@ impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        } else {
-            self.columns.walk_ast(pass)?;
-        }
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
+        self.columns.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -114,10 +111,8 @@ impl<'a, DB, T> QueryFragment<DB> for Column<'a, T> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        }
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
         Ok(())
     }
 }
@@ -140,12 +135,9 @@ impl<DB, Col> QueryFragment<DB> for PrimaryKey<Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        } else {
-            self.0.walk_ast(pass)?;
-        }
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
+        self.0.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -162,12 +154,9 @@ impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<Sqlite>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        } else {
-            self.0.walk_ast(pass)?;
-        }
+    fn walk_ast(&self, mut pass: AstPass<Sqlite>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
+        self.0.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -182,12 +171,9 @@ impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        } else {
-            self.0.walk_ast(pass)?;
-        }
+    fn walk_ast(&self, mut pass: AstPass<Pg>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
+        self.0.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -202,12 +188,9 @@ impl<DB, Col> QueryFragment<DB> for NotNull<Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        } else {
-            self.0.walk_ast(pass)?;
-        }
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
+        self.0.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }
@@ -225,12 +208,9 @@ impl<'a, DB, Col> QueryFragment<DB> for Default<'a, Col> where
         Ok(())
     }
 
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        if let AstPass::IsSafeToCachePrepared(result) = pass {
-            *result = false;
-        } else {
-            self.column.walk_ast(pass)?;
-        }
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        pass.unsafe_to_cache_prepared();
+        self.column.walk_ast(pass.reborrow())?;
         Ok(())
     }
 }


### PR DESCRIPTION
I'm moving towards merging `to_sql` with `walk_ast`. The code will look
*really* bad if there's a ton of conditionals on which pass it is.
Instead I'd like to have the code look the same as it would if I were
able to make `AstPass` a trait (see 97e5cba6fd5c20045a645bef3ed5d73 for
context on why we can't do that)

In order to enforce that only the methods are used, and nothing is
actually destructuring, I've had to do a bit of funky indirection.