### PR TITLE
Turn `to_sql` into a standard AST pass

### DIFF
--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -225,10 +225,8 @@ impl<DB> StatementCacheKey<DB> where
     }
 
     fn construct_sql<T: QueryFragment<DB>>(source: &T) -> QueryResult<String> {
-        use result::Error::QueryBuilderError;
-
         let mut query_builder = DB::QueryBuilder::default();
-        try!(source.to_sql(&mut query_builder).map_err(QueryBuilderError));
+        try!(source.to_sql(&mut query_builder));
         Ok(query_builder.finish())
     }
 }

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -29,11 +29,6 @@ impl<T, U, DB> QueryFragment<DB> for Bound<T, U> where
     DB: Backend + HasSqlType<T>,
     U: ToSql<T, DB>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        out.push_bind_param();
-        Ok(())
-    }
-
     fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
         pass.push_bind_param(&self.item)?;
         Ok(())

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -52,10 +52,6 @@ impl<T, ST, DB> QueryFragment<DB> for Coerce<T, ST> where
     T: QueryFragment<DB>,
     DB: Backend,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        self.expr.to_sql(out)
-    }
-
     fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.expr.walk_ast(pass)
     }

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -81,15 +81,11 @@ impl<T: Expression> Expression for Count<T> {
 }
 
 impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Count<T> {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("COUNT(");
-        try!(self.target.to_sql(out));
+        self.target.walk_ast(out.reborrow())?;
         out.push_sql(")");
         Ok(())
-    }
-
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        self.target.walk_ast(pass)
     }
 }
 
@@ -105,12 +101,8 @@ impl Expression for CountStar {
 }
 
 impl<DB: Backend> QueryFragment<DB> for CountStar {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("COUNT(*)");
-        Ok(())
-    }
-
-    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -56,15 +56,10 @@ impl<T, DB> QueryFragment<DB> for Exists<T> where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("EXISTS (");
-        try!(self.0.to_sql(out));
+        self.0.walk_ast(out.reborrow())?;
         out.push_sql(")");
-        Ok(())
-    }
-
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        self.0.walk_ast(pass)?;
         Ok(())
     }
 }

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -32,15 +32,10 @@ macro_rules! fold_function {
             T: Expression + QueryFragment<DB>,
             DB: Backend + HasSqlType<T::SqlType>,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+            fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                 out.push_sql(concat!($operator, "("));
-                try!(self.target.to_sql(out));
+                self.target.walk_ast(out.reborrow())?;
                 out.push_sql(")");
-                Ok(())
-            }
-
-            fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-                self.target.walk_ast(pass)?;
                 Ok(())
             }
         }

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -31,15 +31,10 @@ macro_rules! ord_function {
             T: Expression + QueryFragment<DB>,
             DB: Backend + HasSqlType<T::SqlType>,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+            fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                 out.push_sql(concat!($operator, "("));
-                try!(self.target.to_sql(out));
+                self.target.walk_ast(out.reborrow())?;
                 out.push_sql(")");
-                Ok(())
-            }
-
-            fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-                self.target.walk_ast(pass)?;
                 Ok(())
             }
         }

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -18,12 +18,8 @@ impl NonAggregate for now {
 }
 
 impl<DB: Backend> QueryFragment<DB> for now {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("CURRENT_TIMESTAMP");
-        Ok(())
-    }
-
-    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -38,18 +38,11 @@ macro_rules! sql_function_body {
             DB: $crate::backend::Backend,
             for <'a> ($(&'a $arg_name),*): $crate::query_builder::QueryFragment<DB>,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder) -> $crate::query_builder::BuildQueryResult {
-                use $crate::query_builder::QueryBuilder;
+            fn walk_ast(&self, mut out: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
                 out.push_sql(concat!(stringify!($fn_name), "("));
-                try!($crate::query_builder::QueryFragment::to_sql(
-                        &($(&self.$arg_name),*), out));
+                $crate::query_builder::QueryFragment::walk_ast(
+                    &($(&self.$arg_name),*), out.reborrow())?;
                 out.push_sql(")");
-                Ok(())
-            }
-
-            fn walk_ast(&self, pass: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
-                try!($crate::query_builder::QueryFragment::walk_ast(
-                        &($(&self.$arg_name),*), pass));
                 Ok(())
             }
         }
@@ -156,13 +149,8 @@ macro_rules! no_arg_sql_function_body {
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend + $($constraint)::+,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder) -> $crate::query_builder::BuildQueryResult {
-                use $crate::query_builder::QueryBuilder;
+            fn walk_ast(&self, mut out: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
                 out.push_sql(concat!(stringify!($type_name), "()"));
-                Ok(())
-            }
-
-            fn walk_ast(&self, _: &mut $crate::query_builder::AstPass<DB>) -> QueryResult<()> {
                 Ok(())
             }
         }
@@ -174,13 +162,8 @@ macro_rules! no_arg_sql_function_body {
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder) -> $crate::query_builder::BuildQueryResult {
-                use $crate::query_builder::QueryBuilder;
+            fn walk_ast(&self, mut out: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
                 out.push_sql(concat!(stringify!($type_name), "()"));
-                Ok(())
-            }
-
-            fn walk_ast(&self, _: $crate::query_builder::AstPass<DB>) -> QueryResult<()> {
                 Ok(())
             }
         }

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -11,15 +11,10 @@ impl<T: Expression> Expression for Grouped<T> {
 }
 
 impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("(");
-        try!(self.0.to_sql(out));
+        self.0.walk_ast(out.reborrow())?;
         out.push_sql(")");
-        Ok(())
-    }
-
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        self.0.walk_ast(pass)?;
         Ok(())
     }
 }

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -24,10 +24,6 @@ impl<T, DB> QueryFragment<DB> for Nullable<T> where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        self.0.to_sql(out)
-    }
-
     fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -34,16 +34,10 @@ macro_rules! numeric_operation {
             Lhs: QueryFragment<DB>,
             Rhs: QueryFragment<DB>,
         {
-            fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-                try!(self.lhs.to_sql(out));
+            fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+                self.lhs.walk_ast(out.reborrow())?;
                 out.push_sql($op);
-                self.rhs.to_sql(out)
-            }
-
-
-            fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
-                self.lhs.walk_ast(pass.reborrow())?;
-                self.rhs.walk_ast(pass.reborrow())?;
+                self.rhs.walk_ast(out.reborrow())?;
                 Ok(())
             }
         }

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -35,13 +35,9 @@ impl<ST> Expression for SqlLiteral<ST> {
 impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST> where
     DB: Backend + HasSqlType<ST>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
         out.push_sql(&self.sql);
-        Ok(())
-    }
-
-    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
-        pass.unsafe_to_cache_prepared();
         Ok(())
     }
 }

--- a/diesel/src/mysql/query_builder.rs
+++ b/diesel/src/mysql/query_builder.rs
@@ -1,5 +1,6 @@
 use super::backend::Mysql;
-use query_builder::{QueryBuilder, BuildQueryResult};
+use query_builder::QueryBuilder;
+use result::QueryResult;
 
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
@@ -18,7 +19,7 @@ impl QueryBuilder<Mysql> for MysqlQueryBuilder {
         self.sql.push_str(sql);
     }
 
-    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
+    fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
         self.push_sql("`");
         self.push_sql(&identifier.replace("`", "``"));
         self.push_sql("`");

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -1,8 +1,7 @@
 use backend::*;
 use expression::{AsExpression, Expression, NonAggregate};
-use pg::{Pg, PgQueryBuilder};
+use pg::Pg;
 use query_builder::*;
-use query_builder::debug::DebugQueryBuilder;
 use result::QueryResult;
 use types::Array;
 
@@ -100,15 +99,10 @@ impl<Expr, ST> Expression for Any<Expr> where
 impl<Expr> QueryFragment<Pg> for Any<Expr> where
     Expr: QueryFragment<Pg>,
 {
-    fn to_sql(&self, out: &mut PgQueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.push_sql("ANY(");
-        try!(self.expr.to_sql(out));
+        self.expr.walk_ast(out.reborrow())?;
         out.push_sql(")");
-        Ok(())
-    }
-
-    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
-        self.expr.walk_ast(pass)?;
         Ok(())
     }
 }
@@ -116,15 +110,10 @@ impl<Expr> QueryFragment<Pg> for Any<Expr> where
 impl<Expr> QueryFragment<Debug> for Any<Expr> where
     Expr: QueryFragment<Debug>,
 {
-    fn to_sql(&self, out: &mut DebugQueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<Debug>) -> QueryResult<()> {
         out.push_sql("ANY(");
-        try!(self.expr.to_sql(out));
+        self.expr.walk_ast(out.reborrow())?;
         out.push_sql(")");
-        Ok(())
-    }
-
-    fn walk_ast(&self, pass: AstPass<Debug>) -> QueryResult<()> {
-        self.expr.walk_ast(pass)?;
         Ok(())
     }
 }
@@ -160,15 +149,10 @@ impl<Expr, ST> Expression for All<Expr> where
 impl<Expr> QueryFragment<Pg> for All<Expr> where
     Expr: QueryFragment<Pg>,
 {
-    fn to_sql(&self, out: &mut PgQueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.push_sql("ALL(");
-        try!(self.expr.to_sql(out));
+        self.expr.walk_ast(out.reborrow())?;
         out.push_sql(")");
-        Ok(())
-    }
-
-    fn walk_ast(&self, pass: AstPass<Pg>) -> QueryResult<()> {
-        self.expr.walk_ast(pass)?;
         Ok(())
     }
 }
@@ -176,15 +160,10 @@ impl<Expr> QueryFragment<Pg> for All<Expr> where
 impl<Expr> QueryFragment<Debug> for All<Expr> where
     Expr: QueryFragment<Debug>,
 {
-    fn to_sql(&self, out: &mut DebugQueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<Debug>) -> QueryResult<()> {
         out.push_sql("ALL(");
-        try!(self.expr.to_sql(out));
+        self.expr.walk_ast(out.reborrow())?;
         out.push_sql(")");
-        Ok(())
-    }
-
-    fn walk_ast(&self, pass: AstPass<Debug>) -> QueryResult<()> {
-        self.expr.walk_ast(pass)?;
         Ok(())
     }
 }

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -1,6 +1,6 @@
 use backend::*;
 use expression::{Expression, NonAggregate};
-use pg::{Pg, PgQueryBuilder};
+use pg::Pg;
 use query_builder::*;
 use result::QueryResult;
 use types::{Timestamp, Timestamptz, Date, VarChar};
@@ -43,15 +43,10 @@ impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz> where
     Ts: QueryFragment<Pg>,
     Tz: QueryFragment<Pg>,
 {
-    fn to_sql(&self, out: &mut PgQueryBuilder) -> BuildQueryResult {
-        try!(self.timestamp.to_sql(out));
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        self.timestamp.walk_ast(out.reborrow())?;
         out.push_sql(" AT TIME ZONE ");
-        self.timezone.to_sql(out)
-    }
-
-    fn walk_ast(&self, mut pass: AstPass<Pg>) -> QueryResult<()> {
-        self.timestamp.walk_ast(pass.reborrow())?;
-        self.timezone.walk_ast(pass.reborrow())?;
+        self.timezone.walk_ast(out.reborrow())?;
         Ok(())
     }
 }
@@ -63,15 +58,10 @@ impl<Ts, Tz> QueryFragment<Debug> for AtTimeZone<Ts, Tz> where
     Ts: QueryFragment<Debug>,
     Tz: QueryFragment<Debug>,
 {
-    fn to_sql(&self, out: &mut <Debug as Backend>::QueryBuilder) -> BuildQueryResult {
-        try!(self.timestamp.to_sql(out));
+    fn walk_ast(&self, mut out: AstPass<Debug>) -> QueryResult<()> {
+        self.timestamp.walk_ast(out.reborrow())?;
         out.push_sql(" AT TIME ZONE ");
-        self.timezone.to_sql(out)
-    }
-
-    fn walk_ast(&self, mut pass: AstPass<Debug>) -> QueryResult<()> {
-        self.timestamp.walk_ast(pass.reborrow())?;
-        self.timezone.walk_ast(pass.reborrow())?;
+        self.timezone.walk_ast(out.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/pg/expression/predicates.rs
+++ b/diesel/src/pg/expression/predicates.rs
@@ -1,5 +1,4 @@
 use pg::Pg;
-use query_builder::QueryBuilder;
 
 infix_predicate!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
 infix_predicate!(OverlapsWith, " && ", backend: Pg);

--- a/diesel/src/pg/query_builder.rs
+++ b/diesel/src/pg/query_builder.rs
@@ -1,5 +1,6 @@
 use super::backend::Pg;
-use query_builder::{QueryBuilder, BuildQueryResult};
+use query_builder::QueryBuilder;
+use result::QueryResult;
 
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
@@ -19,7 +20,7 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
         self.sql.push_str(sql);
     }
 
-    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
+    fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
         self.push_sql("\"");
         self.push_sql(&identifier.replace('"', "\"\""));
         self.push_sql("\"");

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -104,20 +104,13 @@ impl<Values, Target, Action> InsertValues<Pg> for OnConflictValues<Values, Targe
     Target: QueryFragment<Pg>,
     Action: QueryFragment<Pg>,
 {
-    fn column_names(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
+    fn column_names(&self, out: &mut <Pg as Backend>::QueryBuilder) -> QueryResult<()> {
         self.values.column_names(out)
-    }
-
-    fn values_clause(&self, out: &mut <Pg as Backend>::QueryBuilder) -> BuildQueryResult {
-        try!(self.values.values_clause(out));
-        out.push_sql(" ON CONFLICT");
-        try!(self.target.to_sql(out));
-        try!(self.action.to_sql(out));
-        Ok(())
     }
 
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         self.values.walk_ast(out.reborrow())?;
+        out.push_sql(" ON CONFLICT");
         self.target.walk_ast(out.reborrow())?;
         self.action.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use query_builder::BindCollector;
+use query_builder::{BindCollector, QueryBuilder};
 use result::QueryResult;
 use types::{ToSql, HasSqlType};
 
@@ -7,6 +7,7 @@ use types::{ToSql, HasSqlType};
 #[allow(missing_debug_implementations)]
 pub struct AstPass<'a, DB> where
     DB: Backend,
+    DB::QueryBuilder: 'a,
     DB::BindCollector: 'a,
 {
     internals: AstPassInternals<'a, DB>,
@@ -14,8 +15,16 @@ pub struct AstPass<'a, DB> where
 
 impl<'a, DB> AstPass<'a, DB> where
     DB: Backend,
+    DB::QueryBuilder: 'a,
     DB::BindCollector: 'a,
 {
+    #[cfg_attr(feature="clippy", allow(wrong_self_convention))]
+    pub fn to_sql(query_builder: &'a mut DB::QueryBuilder) -> Self {
+        AstPass {
+            internals: AstPassInternals::ToSql(query_builder),
+        }
+    }
+
     pub fn collect_binds(collector: &'a mut DB::BindCollector) -> Self {
         AstPass {
             internals: AstPassInternals::CollectBinds(collector),
@@ -34,6 +43,7 @@ impl<'a, DB> AstPass<'a, DB> where
     pub fn reborrow(&mut self) -> AstPass<DB> {
         use self::AstPassInternals::*;
         let internals = match self.internals {
+            ToSql(ref mut builder) => ToSql(&mut **builder),
             CollectBinds(ref mut collector) => CollectBinds(&mut **collector),
             IsSafeToCachePrepared(ref mut result) => IsSafeToCachePrepared(&mut **result),
         };
@@ -46,14 +56,40 @@ impl<'a, DB> AstPass<'a, DB> where
         }
     }
 
+    pub fn push_sql(&mut self, sql: &str) {
+        if let AstPassInternals::ToSql(ref mut builder) = self.internals {
+            builder.push_sql(sql);
+        }
+    }
+
+    pub fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
+        if let AstPassInternals::ToSql(ref mut builder) = self.internals {
+            builder.push_identifier(identifier)?;
+        }
+        Ok(())
+    }
+
     pub fn push_bind_param<T, U>(&mut self, bind: &U) -> QueryResult<()> where
         DB: HasSqlType<T>,
         U: ToSql<T, DB>,
     {
-        if let AstPassInternals::CollectBinds(ref mut out) = self.internals {
-            out.push_bound_value(bind)?;
+        use self::AstPassInternals::*;
+        match self.internals {
+            ToSql(ref mut out) => out.push_bind_param(),
+            CollectBinds(ref mut out) => out.push_bound_value(bind)?,
+            _ => {}, // noop
         }
         Ok(())
+    }
+
+    /// FIXME: This method is a temporary shim, and should be removed when
+    /// we are able to merge `InsertValues` into `QueryFragment`
+    pub fn query_builder(self) -> Option<&'a mut DB::QueryBuilder> {
+        if let AstPassInternals::ToSql(out) = self.internals {
+            Some(out)
+        } else {
+            None
+        }
     }
 }
 
@@ -64,8 +100,10 @@ impl<'a, DB> AstPass<'a, DB> where
 /// `AstPass` were a trait.
 enum AstPassInternals<'a, DB> where
     DB: Backend,
+    DB::QueryBuilder: 'a,
     DB::BindCollector: 'a,
 {
+    ToSql(&'a mut DB::QueryBuilder),
     CollectBinds(&'a mut DB::BindCollector),
     IsSafeToCachePrepared(&'a mut bool),
 }

--- a/diesel/src/query_builder/debug.rs
+++ b/diesel/src/query_builder/debug.rs
@@ -1,5 +1,6 @@
 use backend::Debug;
-use super::{QueryBuilder, BuildQueryResult};
+use query_builder::QueryBuilder;
+use result::QueryResult;
 
 #[doc(hidden)]
 #[derive(Debug, Default)]
@@ -18,7 +19,7 @@ impl QueryBuilder<Debug> for DebugQueryBuilder {
         self.sql.push_str(sql);
     }
 
-    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
+    fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
         self.push_sql("`");
         self.push_sql(identifier);
         self.push_sql("`");

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -30,18 +30,11 @@ impl<T, U, Ret, DB> QueryFragment<DB> for DeleteStatement<T, U, Ret> where
     U: QueryFragment<DB>,
     Ret: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("DELETE FROM ");
-        try!(self.table.from_clause().to_sql(out));
-        try!(self.where_clause.to_sql(out));
-        try!(self.returning.to_sql(out));
-        Ok(())
-    }
-
-    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
-        self.table.from_clause().walk_ast(pass.reborrow())?;
-        self.where_clause.walk_ast(pass.reborrow())?;
-        self.returning.walk_ast(pass.reborrow())?;
+        self.table.from_clause().walk_ast(out.reborrow())?;
+        self.where_clause.walk_ast(out.reborrow())?;
+        self.returning.walk_ast(out.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -8,10 +8,6 @@ pub struct NoDistinctClause;
 pub struct DistinctClause;
 
 impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
-    fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        Ok(())
-    }
-
     fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
@@ -20,12 +16,8 @@ impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
 impl_query_id!(NoDistinctClause);
 
 impl<DB: Backend> QueryFragment<DB> for DistinctClause {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("DISTINCT ");
-        Ok(())
-    }
-
-    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -28,7 +28,6 @@ impl<QS> SelectClauseExpression<QS> for DefaultSelectClause where
 }
 
 pub trait SelectClauseQueryFragment<QS, DB: Backend> {
-    fn to_sql(&self, source: &QS, out: &mut DB::QueryBuilder) -> BuildQueryResult;
     fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()>;
 }
 
@@ -36,10 +35,6 @@ impl<T, QS, DB> SelectClauseQueryFragment<QS, DB> for SelectClause<T> where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn to_sql(&self, _: &QS, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        self.0.to_sql(out)
-    }
-
     fn walk_ast(&self, _: &QS, pass: AstPass<DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }
@@ -50,10 +45,6 @@ impl<QS, DB> SelectClauseQueryFragment<QS, DB> for DefaultSelectClause where
     QS: QuerySource,
     QS::DefaultSelection: QueryFragment<DB>,
 {
-    fn to_sql(&self, source: &QS, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        source.default_selection().to_sql(out)
-    }
-
     fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()> {
         source.default_selection().walk_ast(pass)
     }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -58,36 +58,21 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
     QS: QuerySource,
     QS::FromClause: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("SELECT ");
-        try!(self.distinct.to_sql(out));
-        try!(self.select.to_sql(out));
+        self.distinct.walk_ast(out.reborrow())?;
+        self.select.walk_ast(out.reborrow())?;
         out.push_sql(" FROM ");
-        try!(self.from.from_clause().to_sql(out));
+        self.from.from_clause().walk_ast(out.reborrow())?;
 
         if let Some(ref where_clause) = self.where_clause {
             out.push_sql(" WHERE ");
-            try!(where_clause.to_sql(out));
+            where_clause.walk_ast(out.reborrow())?;
         }
 
-        try!(self.order.to_sql(out));
-        try!(self.limit.to_sql(out));
-        try!(self.offset.to_sql(out));
-        Ok(())
-    }
-
-    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
-        self.distinct.walk_ast(pass.reborrow())?;
-        self.select.walk_ast(pass.reborrow())?;
-        self.from.from_clause().walk_ast(pass.reborrow())?;
-
-        if let Some(ref where_clause) = self.where_clause {
-            where_clause.walk_ast(pass.reborrow())?;
-        }
-
-        self.order.walk_ast(pass.reborrow())?;
-        self.limit.walk_ast(pass.reborrow())?;
-        self.offset.walk_ast(pass.reborrow())?;
+        self.order.walk_ast(out.reborrow())?;
+        self.limit.walk_ast(out.reborrow())?;
+        self.offset.walk_ast(out.reborrow())?;
         Ok(())
     }
 }
@@ -95,33 +80,19 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
 impl<'a, ST, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, (), DB> where
     DB: Backend,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("SELECT ");
-        try!(self.distinct.to_sql(out));
-        try!(self.select.to_sql(out));
+        self.distinct.walk_ast(out.reborrow())?;
+        self.select.walk_ast(out.reborrow())?;
 
         if let Some(ref where_clause) = self.where_clause {
             out.push_sql(" WHERE ");
-            try!(where_clause.to_sql(out));
+            where_clause.walk_ast(out.reborrow())?;
         }
 
-        try!(self.order.to_sql(out));
-        try!(self.limit.to_sql(out));
-        try!(self.offset.to_sql(out));
-        Ok(())
-    }
-
-    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
-        self.distinct.walk_ast(pass.reborrow())?;
-        self.select.walk_ast(pass.reborrow())?;
-
-        if let Some(ref where_clause) = self.where_clause {
-            where_clause.walk_ast(pass.reborrow())?;
-        }
-
-        self.order.walk_ast(pass.reborrow())?;
-        self.limit.walk_ast(pass.reborrow())?;
-        self.offset.walk_ast(pass.reborrow())?;
+        self.order.walk_ast(out.reborrow())?;
+        self.limit.walk_ast(out.reborrow())?;
+        self.offset.walk_ast(out.reborrow())?;
         Ok(())
     }
 }

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use query_builder::{BuildQueryResult, AstPass};
+use query_builder::AstPass;
 use query_source::QuerySource;
 use result::QueryResult;
 
@@ -28,7 +28,6 @@ pub trait AsChangeset {
 /// Apps should not need to concern themselves with this trait.
 pub trait Changeset<DB: Backend> {
     fn is_noop(&self) -> bool;
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult;
     fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()>;
 }
 
@@ -44,13 +43,6 @@ impl<T: AsChangeset> AsChangeset for Option<T> {
 impl<T: Changeset<DB>, DB: Backend> Changeset<DB> for Option<T> {
     fn is_noop(&self) -> bool {
         self.is_none()
-    }
-
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        match *self {
-            Some(ref c) => c.to_sql(out),
-            None => Ok(()),
-        }
     }
 
     fn walk_ast(&self, out: AstPass<DB>) -> QueryResult<()> {

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -18,10 +18,6 @@ pub struct NoWhereClause;
 impl_query_id!(NoWhereClause);
 
 impl<DB: Backend> QueryFragment<DB> for NoWhereClause {
-    fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        Ok(())
-    }
-
     fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
@@ -50,13 +46,10 @@ impl<DB, Expr> QueryFragment<DB> for WhereClause<Expr> where
     DB: Backend,
     Expr: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql(" WHERE ");
-        self.0.to_sql(out)
-    }
-
-    fn walk_ast(&self, pass: AstPass<DB>) -> QueryResult<()> {
-        self.0.walk_ast(pass)
+        self.0.walk_ast(out.reborrow())?;
+        Ok(())
     }
 }
 

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -109,17 +109,10 @@ impl<Left, Right, Kind, DB> QueryFragment<DB> for Join<Left, Right, Kind> where
     Right::FromClause: QueryFragment<DB>,
     Kind: QueryFragment<DB>,
 {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        self.left.from_clause().to_sql(out)?;
-        self.kind.to_sql(out)?;
-        out.push_sql(" JOIN ");
-        self.right.from_clause().to_sql(out)?;
-        Ok(())
-    }
-
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         self.left.from_clause().walk_ast(out.reborrow())?;
         self.kind.walk_ast(out.reborrow())?;
+        out.push_sql(" JOIN ");
         self.right.from_clause().walk_ast(out.reborrow())?;
         Ok(())
     }
@@ -170,12 +163,8 @@ pub struct Inner;
 impl_query_id!(Inner);
 
 impl<DB: Backend> QueryFragment<DB> for Inner {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql(" INNER");
-        Ok(())
-    }
-
-    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -186,12 +175,8 @@ pub struct LeftOuter;
 impl_query_id!(LeftOuter);
 
 impl<DB: Backend> QueryFragment<DB> for LeftOuter {
-    fn to_sql(&self, out: &mut DB::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql(" LEFT OUTER");
-        Ok(())
-    }
-
-    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel/src/sqlite/query_builder/mod.rs
+++ b/diesel/src/sqlite/query_builder/mod.rs
@@ -1,5 +1,6 @@
 use super::backend::Sqlite;
-use query_builder::{QueryBuilder, BuildQueryResult};
+use query_builder::QueryBuilder;
+use result::QueryResult;
 
 pub mod functions;
 #[doc(hidden)]
@@ -22,7 +23,7 @@ impl QueryBuilder<Sqlite> for SqliteQueryBuilder {
         self.sql.push_str(sql);
     }
 
-    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
+    fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
         self.push_sql("`");
         self.push_sql(&identifier.replace("`", "``"));
         self.push_sql("`");

--- a/diesel/src/sqlite/query_builder/nodes.rs
+++ b/diesel/src/sqlite/query_builder/nodes.rs
@@ -1,4 +1,3 @@
-use backend::Backend;
 use query_builder::*;
 use result::QueryResult;
 use sqlite::Sqlite;
@@ -7,12 +6,8 @@ use sqlite::Sqlite;
 pub struct Replace;
 
 impl QueryFragment<Sqlite> for Replace {
-    fn to_sql(&self, out: &mut <Sqlite as Backend>::QueryBuilder) -> BuildQueryResult {
+    fn walk_ast(&self, mut out: AstPass<Sqlite>) -> QueryResult<()> {
         out.push_sql("REPLACE");
-        Ok(())
-    }
-
-    fn walk_ast(&self, _: AstPass<Sqlite>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -84,10 +84,6 @@ impl<T> Expression for Arbitrary<T> {
 impl<T, DB> QueryFragment<DB> for Arbitrary<T> where
     DB: Backend,
 {
-    fn to_sql(&self, _out: &mut DB::QueryBuilder) -> BuildQueryResult {
-        Ok(())
-    }
-
     fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }


### PR DESCRIPTION
We're not quite to the point where we have a single uniform function, as
we still need to eliminate some of the branches that come from the
existence of `Changeset` and `InsertValues`.

I've been wanting to introduce a `context` parameter that gets passed
around to enable things like expression index support in PG upsert, and
I suspect that this will fix the problem.

I suspect this will alter our performance characteristics in a few cases
(particularly when the query is boxed). I don't expect any major
regressions from this, but I do want to see if it's worth sticking
`#[inline]` in a few places (or even `#[inline(always)]` in some
particularly hot paths like `SelectStatement` and tuples)