### PR TITLE
Allow bind parameters to be supplied to raw SQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,30 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for chrono types with SQLite.
 
-* Added support for the [PostgreSQL network types][pg-network-0.13.0] `CIDR` and `INET`.
+* Bind values can now be supplied to queries constructed using raw SQL. See [the
+  docs][sql-bind-0.13.0] for more details.
+
+[sql-bind-0.13.0]: http://docs.diesel.rs/diesel/expression/sql_literal/struct.SqlLiteral.html#method.bind
+
+* Added support for the [PostgreSQL network types][pg-network-0.13.0] `CIDR` and
+  `INET`.
 
 [pg-network-0.13.0]: https://www.postgresql.org/docs/9.6/static/datatype-net-types.html
 
 * Added support for `ILIKE` in PostgreSQL.
 
-* Added the `migration list` command to Diesel CLI for listing all available migrations and marking those that have been applied.
+* Added the `migration list` command to Diesel CLI for listing all available
+  migrations and marking those that have been applied.
 
 * Added support for adding two nullable columns.
 
 * Added support for unsigned types in MySQL.
 
-* Added the `any_pending_migrations` function to determine if there are any pending migrations in the migrations directory.
+* Added the `any_pending_migrations` function to determine if there are any
+  pending migrations in the migrations directory.
 
-* Added the `migration pending` command to the Diesel CLI to run the `any_pending_migrations` function and report the output.
+* Added the `migration pending` command to the Diesel CLI to run the
+  `any_pending_migrations` function and report the output.
 
 ### Fixed
 

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -40,6 +40,7 @@ pub mod nullable;
 #[macro_use]
 pub mod predicates;
 pub mod sql_literal;
+mod unchecked_bind;
 
 /// Reexports various top level functions and core extensions that are too
 /// generic to export by default. This module exists to conveniently glob import

--- a/diesel/src/expression/unchecked_bind.rs
+++ b/diesel/src/expression/unchecked_bind.rs
@@ -1,0 +1,57 @@
+use std::marker::PhantomData;
+
+use backend::Backend;
+use query_builder::*;
+use result::QueryResult;
+use types::{ToSql, HasSqlType};
+
+#[derive(Debug, Clone, Copy)]
+#[must_use="Queries are only executed when calling `load`, `get_result` or similar."]
+pub struct UncheckedBind<Query, Value, ST> {
+    query: Query,
+    value: Value,
+    _marker: PhantomData<ST>,
+}
+
+impl<Query, Value, ST> UncheckedBind<Query, Value, ST> {
+    pub fn new(query: Query, value: Value) -> Self {
+        UncheckedBind {
+            query,
+            value,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn bind<ST2, Value2>(self, value: Value2) -> UncheckedBind<Self, Value2, ST2> {
+        UncheckedBind::new(self, value)
+    }
+}
+
+impl<Query, Value, ST> QueryId for UncheckedBind<Query, Value, ST> where
+    Query: QueryId,
+    ST: QueryId,
+{
+    type QueryId = UncheckedBind<Query::QueryId, (), ST::QueryId>;
+
+    fn has_static_query_id() -> bool {
+        Query::has_static_query_id() && ST::has_static_query_id()
+    }
+}
+
+impl<Query, Value, ST, DB> QueryFragment<DB> for UncheckedBind<Query, Value, ST> where
+    DB: Backend + HasSqlType<ST>,
+    Query: QueryFragment<DB>,
+    Value: ToSql<ST, DB>,
+{
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        self.query.walk_ast(out.reborrow())?;
+        out.push_bind_param_value_only(&self.value)?;
+        Ok(())
+    }
+}
+
+impl<Q, Value, ST> Query for UncheckedBind<Q, Value, ST> where
+    Q: Query,
+{
+    type SqlType = Q::SqlType;
+}

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -91,6 +91,16 @@ impl<'a, DB> AstPass<'a, DB> where
             None
         }
     }
+
+    pub fn push_bind_param_value_only<T, U>(&mut self, bind: &U) -> QueryResult<()> where
+        DB: HasSqlType<T>,
+        U: ToSql<T, DB>,
+    {
+        if let AstPassInternals::CollectBinds(..) = self.internals {
+            self.push_bind_param(bind)?;
+        }
+        Ok(())
+    }
 }
 
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
This is a first pass at a much requested feature. While this does not
provide the richer raw SQL story I eventually want to provide, this
should serve as a sufficient stopgap. Bind parameters are included in
the raw SQL string, and then bound after the fact by calling `.bind`
once for each parameter (supplying the SQL type of the parameter at the
call site).

It should be noted that I have explicitly *not* implemented `Expression`
for the new AST node that this added, as it seems like it'll be too easy
to mess up the parameter index when it's used as a fragment of a query
constructed using the query builder. This can be expanded in the future
(maybe only allowed on SQLite and MySQL which don't index bind params),
but I wanted to be conservative to start.