### PR TITLE
Add a link to the bind method on the sql() function page

### DIFF
--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -139,6 +139,12 @@ impl<ST> NonAggregate for SqlLiteral<ST> {
 /// DSL. You will need to provide the SQL type of the expression, in addition to
 /// the SQL.
 ///
+/// # Bound parameters
+///
+/// If you need to pass arguments to your query, you should use [`.bind()`].
+///
+/// [`.bind()`]: ../sql_literal/struct.SqlLiteral.html#method.bind
+///
 /// # Safety
 ///
 /// The compiler will be unable to verify the correctness of the annotated type.


### PR DESCRIPTION
This improves discoverability of bound values.

[ci skip]