### PR TITLE
Fix PgInterval docs

### DIFF
--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -35,7 +35,7 @@ pub struct PgDate(pub i32);
 pub struct PgTime(pub i64);
 
 /// Intervals in Postgres are separated into 3 parts. A 64 bit integer representing time in
-/// microseconds, a 32 bit integer representing number of minutes, and a 32 bit integer
+/// microseconds, a 32 bit integer representing number of days, and a 32 bit integer
 /// representing number of months. This struct is a dumb wrapper type, meant only to indicate the
 /// meaning of these parts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Please see the [offical docs](https://www.postgresql.org/docs/8.2/static/datatype-datetime.html):
> Internally interval values are stored as months, days, and seconds.