### PR TITLE
add #[allow(unused)] for a macro that is not used in sqlite build

### DIFF
--- a/diesel_cli/tests/support/mod.rs
+++ b/diesel_cli/tests/support/mod.rs
@@ -1,3 +1,4 @@
+#[allow(unused)]
 macro_rules! try_drop {
     ($e:expr, $msg:expr) => { match $e {
         Ok(x) => x,


### PR DESCRIPTION
fixes 

```
cd diesel_cli
cargo test --no-default-features --features sqlite

   Compiling diesel_cli v0.13.0 (file:///C:/Users/jim/src/rust/diesel/diesel_cli)
error: unused macro definition
  --> tests\support\mod.rs:1:1
   |
1  | / macro_rules! try_drop {
2  | |     ($e:expr, $msg:expr) => { match $e {
3  | |         Ok(x) => x,
4  | |         Err(e) => {
...  |
13 | |     }}
14 | | }
   | |_^
```