### PR TITLE
Fix sqlite appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,7 @@ install:
   - curl -fsS --retry 3 --retry-connrefused -o sqlite3.zip https://sqlite.org/2017/sqlite-dll-win64-x64-3160200.zip
   - 7z e sqlite3.zip -y
   - set SQLITE3_LIB_DIR=%APPVEYOR_BUILD_FOLDER%
+  - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
 
 build: false
 
@@ -74,10 +75,9 @@ environment:
     - target: x86_64-pc-windows-gnu
       backend: postgres
       PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
-    # These tests are failing with an obscure error
-    # - target: x86_64-pc-windows-gnu
-    #   backend: sqlite
-    #   SQLITE_DATABASE_URL: test.db
+    - target: x86_64-pc-windows-gnu
+      backend: sqlite
+      SQLITE_DATABASE_URL: test.db
     - target: x86_64-pc-windows-gnu
       backend: mysql
       MYSQL_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,7 @@ install:
   - 7z e sqlite3.zip -y
   - set SQLITE3_LIB_DIR=%APPVEYOR_BUILD_FOLDER%
   - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
+  - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\lib.exe" /def:sqlite3.def /OUT:sqlite3.lib /machine:x64'
 
 build: false
 
@@ -60,10 +61,9 @@ environment:
       backend: postgres
       PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
       PG_EXAMPLE_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_example
-    # SQLite doesn't distribute a static lib
-    # - target: x86_64-pc-windows-msvc
-    #   backend: sqlite
-    #   SQLITE_DATABASE_URL: test.db
+    - target: x86_64-pc-windows-msvc
+      backend: sqlite
+      SQLITE_DATABASE_URL: test.db
     - target: x86_64-pc-windows-msvc
       backend: mysql
       MYSQL_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test

--- a/diesel_cli/tests/support/mod.rs
+++ b/diesel_cli/tests/support/mod.rs
@@ -1,3 +1,4 @@
+#[allow(unused)]
 macro_rules! try_drop {
     ($e:expr, $msg:expr) => { match $e {
         Ok(x) => x,


### PR DESCRIPTION
Recent changes to cargo mean that `cargo test` won't look for dlls in paths outside of the target dir even if a build script tries to add them - the path/dylib path must be manually updated outside of cargo.