### PR TITLE
implement macaddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* Added support for the [PostgreSQL network types][pg-network-0.13.1] `MACADDR`.
+
 * Added a function which maps to SQL `NOT`. See [the docs][not-0.14.0] for more
   details.
 
+[pg-network-0.13.1]: https://www.postgresql.org/docs/9.6/static/datatype-net-types.html
 [not-0.14.0]: http://docs.diesel.rs/diesel/expression/dsl/fn.not.html
 
 ## [0.13.0] - 2017-05-15

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -280,6 +280,72 @@ pub mod sql_types {
     /// ```
     #[derive(Debug, Clone, Copy, Default)] pub struct Money;
 
+    #[cfg(feature = "network-address")]
+    /// The [`MACADDR`](https://www.postgresql.org/docs/9.6/static/datatype-net-types.html) SQL type. This type can only be used with `feature = "network-address"`
+    ///
+    /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+    ///
+    /// - `[u8; 6]`
+    ///
+    /// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+    ///
+    /// - `[u8; 6]`
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #![allow(dead_code)]
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Serial,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # use diesel::types::MacAddr;
+    ///
+    /// #[derive(Queryable)]
+    /// struct Device {
+    ///     id: i32,
+    ///     macaddr: [u8; 6],
+    /// }
+    ///
+    /// #[derive(Insertable)]
+    /// #[table_name="devices"]
+    /// struct NewDevice {
+    ///     macaddr: [u8;6],
+    /// }
+    ///
+    /// table! {
+    ///     devices {
+    ///         id -> Integer,
+    ///         macaddr -> MacAddr,
+    ///     }
+    /// }
+    ///
+    /// # fn main() {
+    /// #     use self::diesel::insert;
+    /// #     use self::devices::dsl::*;
+    /// #     let connection = connection_no_data();
+    /// #     connection.execute("CREATE TABLE devices (
+    /// #         id SERIAL PRIMARY KEY,
+    /// #         macaddr MACADDR NOT NULL
+    /// #     )").unwrap();
+    /// let new_device = NewDevice {
+    ///     macaddr: [0x08, 0x00, 0x2b, 0x01, 0x02, 0x03],
+    /// };
+    /// let inserted_device = insert(&new_device).into(devices)
+    ///     .get_result::<Device>(&connection).unwrap();
+    /// assert_eq!([0x08, 0x00, 0x2b, 0x01, 0x02, 0x03], inserted_device.macaddr);
+    /// # }
+    /// ```
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct MacAddr;
+
     /// The [`CIDR`](https://www.postgresql.org/docs/9.6/static/datatype-net-types.html) SQL type. This type can only be used with `feature = "network-address"`
     ///
     /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -455,6 +455,24 @@ fn pg_uuid_to_sql_uuid() {
 
 #[test]
 #[cfg(feature = "postgres")]
+fn pg_macaddress_from_sql() {
+    let query = "'08:00:2b:01:02:03'::macaddr";
+    let expected_value = [0x08, 0x00, 0x2b, 0x01, 0x02, 0x03];
+    assert_eq!(expected_value,
+               query_single_value::<MacAddr, [u8; 6]>(query));
+}
+
+#[test]
+#[cfg(feature = "postgres")]
+fn pg_macaddress_to_sql_macaddress() {
+    let expected_value = "'08:00:2b:01:02:03'::macaddr";
+    let value = [0x08, 0x00, 0x2b, 0x01, 0x02, 0x03];
+    assert!(query_to_sql_equality::<MacAddr, [u8; 6]>(expected_value, value));
+}
+
+
+#[test]
+#[cfg(feature = "postgres")]
 fn pg_v4address_from_sql() {
     extern crate ipnetwork;
     use std::str::FromStr;

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -107,12 +107,18 @@ mod pg_types {
     test_round_trip!(array_of_bigint_roundtrips, Array<BigInt>, Vec<i64>);
     test_round_trip!(array_of_dynamic_size_roundtrips, Array<Text>, Vec<String>);
     test_round_trip!(array_of_nullable_roundtrips, Array<Nullable<Text>>, Vec<Option<String>>);
+    test_round_trip!(macaddr_roundtrips, MacAddr, (u8, u8, u8, u8, u8, u8), mk_macaddr);
 
     fn mk_uuid(data: (u32, u16, u16, (u8, u8, u8, u8, u8, u8, u8, u8))) -> self::uuid::Uuid {
         let a = data.3;
         let b = [a.0, a.1, a.2, a.3, a.4, a.5, a.6, a.7];
         uuid::Uuid::from_fields(data.0, data.1, data.2, &b).unwrap()
     }
+
+    fn mk_macaddr(data: (u8, u8, u8, u8, u8, u8)) -> [u8; 6] {
+        [data.0, data.1, data.2, data.3, data.4, data.5]
+    }
+
 }
 
 #[cfg(feature = "mysql")]


### PR DESCRIPTION
implement macaddr type of [network address types](https://www.postgresql.org/docs/9.6/static/datatype-net-types.html) for PostgreSQL. This patch finishes #719 .

Currently, I'm using [hwaddr - Cargo: packages for Rust](https://crates.io/crates/hwaddr) to represent MAC addresses but because it's just six octets, `[u8; 6]` <-> `MacAddr` is possible. Which is convenient?