### PR TITLE
Emit a message on stderr when infering a varchar[]

### DIFF
--- a/diesel_infer_schema/src/pg.rs
+++ b/diesel_infer_schema/src/pg.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::io::{stderr, Write};
 
 use data_structures::*;
 
@@ -9,6 +10,14 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
     } else {
         &attr.type_name
     };
+
+    let tpe_is_varchar = tpe.to_lowercase() == "varchar";
+
+    // Postgres doesn't coerce varchar[] to text[] so print out a message to inform
+    // the user.
+    if tpe_is_varchar && is_array {
+        writeln!(&mut stderr(), "The column `{}` is of type `varchar[]`. This will cause problems when using Diesel. You should consider changing the column type to `text[]`.", attr.column_name)?;
+    }
 
     Ok(ColumnType {
         path: vec!["diesel".into(), "types".into(), capitalize(tpe)],


### PR DESCRIPTION
Since postgres does not coerce varchar[] to text[] and diesel does not
make any difference between varchar and text, you cannot use array
specific operators with a varchar[].