### PR TITLE
Remove `Table` constraints from `query_source::joins`

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -43,31 +43,16 @@ macro_rules! __diesel_column {
         {
         }
 
-        impl<Right> AppearsOnTable<
-            Join<$($table)::*, Right, Inner>,
+        impl<Right, Kind> AppearsOnTable<
+            Join<$($table)::*, Right, Kind>,
         > for $column_name where
-            Right: Table,
+            Right: QuerySource,
             $($table)::*: $crate::JoinTo<Right>
         {
         }
 
-        impl<Left> AppearsOnTable<
-            Join<Left, $($table)::*, Inner>,
-        > for $column_name where
-            Left: $crate::JoinTo<$($table)::*>
-        {
-        }
-
-        impl<Right> AppearsOnTable<
-            Join<$($table)::*, Right, LeftOuter>,
-        > for $column_name where
-            Right: Table,
-            $($table)::*: $crate::JoinTo<Right>
-        {
-        }
-
-        impl<Left> AppearsOnTable<
-            Join<Left, $($table)::*, LeftOuter>,
+        impl<Left, Kind> AppearsOnTable<
+            Join<Left, $($table)::*, Kind>,
         > for $column_name where
             Left: $crate::JoinTo<$($table)::*>
         {
@@ -438,10 +423,10 @@ macro_rules! table_body {
             /// Contains all of the columns of this table
             pub mod columns {
                 use super::table;
-                use $crate::{Table, Expression, SelectableExpression, AppearsOnTable, QuerySource};
+                use $crate::{Expression, SelectableExpression, AppearsOnTable, QuerySource};
                 use $crate::backend::Backend;
                 use $crate::query_builder::{QueryFragment, AstPass};
-                use $crate::query_source::joins::{Join, JoinOn, Inner, LeftOuter};
+                use $crate::query_source::joins::{Join, JoinOn, Inner};
                 use $crate::result::QueryResult;
                 $(use $($import)::+;)+
 

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -3,7 +3,7 @@ use expression::SelectableExpression;
 use expression::nullable::Nullable;
 use query_builder::*;
 use result::QueryResult;
-use super::{QuerySource, Table};
+use super::QuerySource;
 
 #[derive(Debug, Clone, Copy)]
 /// A query source representing the join between two tables
@@ -45,38 +45,38 @@ impl_query_id!(Join<Left, Right, Kind>);
 impl_query_id!(JoinOn<Join, On>);
 
 impl<Left, Right> QuerySource for Join<Left, Right, Inner> where
-    Left: Table + JoinTo<Right>,
-    Right: Table,
-    (Left::AllColumns, Right::AllColumns): SelectableExpression<Self>,
+    Left: QuerySource + JoinTo<Right>,
+    Right: QuerySource,
+    (Left::DefaultSelection, Right::DefaultSelection): SelectableExpression<Self>,
     Self: Clone,
 {
     type FromClause = Self;
-    type DefaultSelection = (Left::AllColumns, Right::AllColumns);
+    type DefaultSelection = (Left::DefaultSelection, Right::DefaultSelection);
 
     fn from_clause(&self) -> Self::FromClause {
         self.clone()
     }
 
     fn default_selection(&self) -> Self::DefaultSelection {
-        (Left::all_columns(), Right::all_columns())
+        (self.left.default_selection(), self.right.default_selection())
     }
 }
 
 impl<Left, Right> QuerySource for Join<Left, Right, LeftOuter> where
-    Left: Table + JoinTo<Right>,
-    Right: Table,
-    (Left::AllColumns, Nullable<Right::AllColumns>): SelectableExpression<Self>,
+    Left: QuerySource + JoinTo<Right>,
+    Right: QuerySource,
+    (Left::DefaultSelection, Nullable<Right::DefaultSelection>): SelectableExpression<Self>,
     Self: Clone,
 {
     type FromClause = Self;
-    type DefaultSelection = (Left::AllColumns, Nullable<Right::AllColumns>);
+    type DefaultSelection = (Left::DefaultSelection, Nullable<Right::DefaultSelection>);
 
     fn from_clause(&self) -> Self::FromClause {
         self.clone()
     }
 
     fn default_selection(&self) -> Self::DefaultSelection {
-        (Left::all_columns(), Right::all_columns().nullable())
+        (self.left.default_selection(), self.right.default_selection().nullable())
     }
 }
 


### PR DESCRIPTION
In order to deal with multitable joins, we'll need to support cases
where both `Lhs` and `Rhs` are not tables. `Lhs` will not be a table in
the case like `users.inner_joins(posts).inner_joins(comments)`, which
should return `(User, Post, Comment)` and represent the user, all their
posts, and all comments that they've left (not necessarily on their own
posts). `Rhs` will not be a table in the case like
`users.inner_joins(posts.inner_joins(comments))`, which should return
`(User, (Post, Comment))` and represents the user, all their posts, and
all comments left on those posts (not necessarily by that user).

Having this distinction (or multi-table joins at all, really) will
enable the much trickier case of
`users.inner_joins(posts.inner_joins(comments)).inner_joins(comments)`,
which requires table aliases to work properly... I'm not entirely sure
what I want to do for the design there, but I'm not sure I can fail that
case at compile time just yet