### PR TITLE
Set up the groundwork for multi-table joins

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -26,47 +26,31 @@ macro_rules! __diesel_column {
         impl SelectableExpression<$($table)::*> for $column_name {
         }
 
-        impl AppearsOnTable<$($table)::*> for $column_name {
-        }
-
-        impl<Right, Kind> SelectableExpression<
-            Join<$($table)::*, Right, Kind>,
-        > for $column_name where
-            $column_name: AppearsOnTable<Join<$($table)::*, Right, Kind>>,
+        impl<QS> AppearsOnTable<QS> for $column_name where
+            QS: ContainsTable<$($table)::*, Count=Once>,
         {
         }
 
-        impl<Left> SelectableExpression<
-            Join<Left, $($table)::*, Inner>,
+        impl<Left, Right> SelectableExpression<
+            Join<Left, Right, LeftOuter>,
         > for $column_name where
-            Left: $crate::JoinTo<$($table)::*>
+            $column_name: AppearsOnTable<Join<Left, Right, LeftOuter>>,
+            Left: ContainsTable<$($table)::*, Count=Once>,
+            Right: ContainsTable<$($table)::*, Count=Never>,
         {
         }
 
-        impl<Right, Kind> AppearsOnTable<
-            Join<$($table)::*, Right, Kind>,
+        impl<Left, Right> SelectableExpression<
+            Join<Left, Right, Inner>,
         > for $column_name where
-            Right: QuerySource,
-            $($table)::*: $crate::JoinTo<Right>
-        {
-        }
-
-        impl<Left, Kind> AppearsOnTable<
-            Join<Left, $($table)::*, Kind>,
-        > for $column_name where
-            Left: $crate::JoinTo<$($table)::*>
-        {
-        }
-
-        // FIXME: Remove this when overlapping marker traits are stable
-        impl<Join, On> AppearsOnTable<JoinOn<Join, On>> for $column_name where
-            $column_name: AppearsOnTable<Join>,
+            $column_name: AppearsOnTable<Join<Left, Right, Inner>>,
+            Join<Left, Right, Inner>: ContainsTable<$($table)::*, Count=Once>,
         {
         }
 
         // FIXME: Remove this when overlapping marker traits are stable
         impl<Join, On> SelectableExpression<JoinOn<Join, On>> for $column_name where
-            $column_name: SelectableExpression<Join>,
+            $column_name: SelectableExpression<Join> + AppearsOnTable<JoinOn<Join, On>>,
         {
         }
 
@@ -339,6 +323,7 @@ macro_rules! table_body {
             use $crate::associations::HasTable;
             use $crate::query_builder::*;
             use $crate::query_builder::nodes::Identifier;
+            use $crate::query_source::{ContainsTable, Once};
             $(use $($import)::+;)+
             pub use self::columns::*;
 
@@ -418,6 +403,10 @@ macro_rules! table_body {
                 }
             }
 
+            impl ContainsTable<table> for table {
+                type Count = Once;
+            }
+
             impl_query_id!(table);
 
             /// Contains all of the columns of this table
@@ -426,7 +415,8 @@ macro_rules! table_body {
                 use $crate::{Expression, SelectableExpression, AppearsOnTable, QuerySource};
                 use $crate::backend::Backend;
                 use $crate::query_builder::{QueryFragment, AstPass};
-                use $crate::query_source::joins::{Join, JoinOn, Inner};
+                use $crate::query_source::joins::{Join, JoinOn, Inner, LeftOuter};
+                use $crate::query_source::{ContainsTable, Once, Never};
                 use $crate::result::QueryResult;
                 $(use $($import)::+;)+
 
@@ -534,6 +524,9 @@ macro_rules! joinable_inner {
         primary_key_ty = $primary_key_ty:ty,
         primary_key_expr = $primary_key_expr:expr,
     ) => {
+        impl $crate::query_source::ContainsTable<$right_table_ty> for $left_table_ty {
+            type Count = $crate::query_source::Never;
+        }
         impl $crate::JoinTo<$right_table_ty> for $left_table_ty {
             type JoinOnClause = $crate::expression::helper_types::Eq<
                 $crate::expression::nullable::Nullable<$foreign_key>,

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -27,7 +27,7 @@ macro_rules! __diesel_column {
         }
 
         impl<QS> AppearsOnTable<QS> for $column_name where
-            QS: ContainsTable<$($table)::*, Count=Once>,
+            QS: AppearsInFromClause<$($table)::*, Count=Once>,
         {
         }
 
@@ -35,8 +35,8 @@ macro_rules! __diesel_column {
             Join<Left, Right, LeftOuter>,
         > for $column_name where
             $column_name: AppearsOnTable<Join<Left, Right, LeftOuter>>,
-            Left: ContainsTable<$($table)::*, Count=Once>,
-            Right: ContainsTable<$($table)::*, Count=Never>,
+            Left: AppearsInFromClause<$($table)::*, Count=Once>,
+            Right: AppearsInFromClause<$($table)::*, Count=Never>,
         {
         }
 
@@ -44,7 +44,7 @@ macro_rules! __diesel_column {
             Join<Left, Right, Inner>,
         > for $column_name where
             $column_name: AppearsOnTable<Join<Left, Right, Inner>>,
-            Join<Left, Right, Inner>: ContainsTable<$($table)::*, Count=Once>,
+            Join<Left, Right, Inner>: AppearsInFromClause<$($table)::*, Count=Once>,
         {
         }
 
@@ -323,7 +323,7 @@ macro_rules! table_body {
             use $crate::associations::HasTable;
             use $crate::query_builder::*;
             use $crate::query_builder::nodes::Identifier;
-            use $crate::query_source::{ContainsTable, Once};
+            use $crate::query_source::{AppearsInFromClause, Once};
             $(use $($import)::+;)+
             pub use self::columns::*;
 
@@ -403,7 +403,7 @@ macro_rules! table_body {
                 }
             }
 
-            impl ContainsTable<table> for table {
+            impl AppearsInFromClause<table> for table {
                 type Count = Once;
             }
 
@@ -416,7 +416,7 @@ macro_rules! table_body {
                 use $crate::backend::Backend;
                 use $crate::query_builder::{QueryFragment, AstPass};
                 use $crate::query_source::joins::{Join, JoinOn, Inner, LeftOuter};
-                use $crate::query_source::{ContainsTable, Once, Never};
+                use $crate::query_source::{AppearsInFromClause, Once, Never};
                 use $crate::result::QueryResult;
                 $(use $($import)::+;)+
 
@@ -524,7 +524,7 @@ macro_rules! joinable_inner {
         primary_key_ty = $primary_key_ty:ty,
         primary_key_expr = $primary_key_expr:expr,
     ) => {
-        impl $crate::query_source::ContainsTable<$right_table_ty> for $left_table_ty {
+        impl $crate::query_source::AppearsInFromClause<$right_table_ty> for $left_table_ty {
             type Count = $crate::query_source::Never;
         }
         impl $crate::JoinTo<$right_table_ty> for $left_table_ty {

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -175,18 +175,18 @@ impl<DB: Backend> QueryFragment<DB> for LeftOuter {
     }
 }
 
-use super::{Succ, Never, ContainsTable};
+use super::{Succ, Never, AppearsInFromClause};
 
-impl<T, Left, Right, Kind> ContainsTable<T> for Join<Left, Right, Kind> where
-    Left: ContainsTable<T>,
-    Right: ContainsTable<T>,
+impl<T, Left, Right, Kind> AppearsInFromClause<T> for Join<Left, Right, Kind> where
+    Left: AppearsInFromClause<T>,
+    Right: AppearsInFromClause<T>,
     Left::Count: Plus<Right::Count>,
 {
     type Count = <Left::Count as Plus<Right::Count>>::Output;
 }
 
-impl<T, Join, On> ContainsTable<T> for JoinOn<Join, On> where
-    Join: ContainsTable<T>,
+impl<T, Join, On> AppearsInFromClause<T> for JoinOn<Join, On> where
+    Join: AppearsInFromClause<T>,
 {
     type Count = Join::Count;
 }

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -49,7 +49,7 @@ pub trait Table: QuerySource + AsQuery + Sized {
     fn all_columns() -> Self::AllColumns;
 }
 
-pub trait ContainsTable<QS> {
+pub trait AppearsInFromClause<QS> {
     type Count;
 }
 

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -48,3 +48,13 @@ pub trait Table: QuerySource + AsQuery + Sized {
     fn primary_key(&self) -> Self::PrimaryKey;
     fn all_columns() -> Self::AllColumns;
 }
+
+pub trait ContainsTable<QS> {
+    type Count;
+}
+
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Never;
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Succ<T>(T);
+pub type Once = Succ<Never>;

--- a/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
@@ -19,14 +19,14 @@ fn main() {
     use diesel::expression::dsl::*;
     let source = users::table.select(sum(posts::id));
     //~^ ERROR E0277
-    //~| ERROR AppearsOnTable
+    //~| ERROR AppearsInFromClause
     let source = users::table.select(avg(posts::id));
     //~^ ERROR E0277
-    //~| ERROR AppearsOnTable
+    //~| ERROR AppearsInFromClause
     let source = users::table.select(max(posts::id));
     //~^ ERROR E0277
-    //~| ERROR AppearsOnTable
+    //~| ERROR AppearsInFromClause
     let source = users::table.select(min(posts::id));
     //~^ ERROR E0277
-    //~| ERROR AppearsOnTable
+    //~| ERROR AppearsInFromClause
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
@@ -20,5 +20,5 @@ table! {
 
 fn main() {
     users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
-    //~^ ERROR AppearsOnTable
+    //~^ ERROR AppearsInFromClause
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
@@ -20,5 +20,5 @@ table! {
 
 fn main() {
     users::table.into_boxed::<Pg>().order(posts::title.desc());
-    //~^ ERROR AppearsOnTable
+    //~^ ERROR AppearsInFromClause
 }

--- a/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
@@ -36,5 +36,5 @@ fn main() {
     };
     let stmt = insert(&new_user).into(users).returning((name, bad::age));
     //~^ ERROR SelectableExpression
-    //~| ERROR AppearsOnTable
+    //~| ERROR AppearsInFromClause
 }

--- a/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -19,7 +19,7 @@ table! {
 
 fn main() {
     let _ = users::table.filter(posts::id.eq(1));
-    //~^ ERROR AppearsOnTable
+    //~^ ERROR AppearsInFromClause
     let _ = users::table.filter(users::name.eq(posts::title));
-    //~^ ERROR AppearsOnTable
+    //~^ ERROR AppearsInFromClause
 }

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -27,13 +27,17 @@ fn main() {
     let join = users::table.left_outer_join(posts::table);
 
     // Invalid, only Nullable<title> is selectable
-    let _ = join.select(posts::title); //~ ERROR E0277
+    let _ = join.select(posts::title);
+    //~^ ERROR E0271
+    //~| ERROR E0271
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
     let _ = join.select(lower(posts::title).nullable());
     // Invalid, only Nullable<title> is selectable
-    let _ = join.select(lower(posts::title)); //~ ERROR E0277
+    let _ = join.select(lower(posts::title));
+    //~^ ERROR E0271
+    //~| ERROR E0271
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable())); //~ ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -23,7 +23,6 @@ fn main() {
     //~^ ERROR Selectable
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
     let stuff = users::table.select((posts::id, users::name));
     //~^ ERROR Selectable
     //~| ERROR E0277


### PR DESCRIPTION
This solves the fundamental problem of needing
`SelectableExpression<Join<Left, Right>> for column` to work when we
don't know where the table concretely appears, just that it appears
somewhere. With this commit, the logic is now that a column can be
selected from any join where its table appears within the join exactly
once. This disallows `users.inner_join(posts.inner_join(users))`, which
we don't want to allow as it would require the second instance of
`users` to be aliased.

This does require that there is an `impl ContainsTable<left> for right`
for every two tables that would appear. Right now I'm just brute-forcing
these when the association between the two tables is defined. For
multi-table joins to work when two of the tables in the join do not have
an association, this will require a manual impl. We'll probably provide
something like `enable_multi_table_joins!(users, comments)` or similar.
This *may* go away eventually with specialization, if projections on
default associated types are eventually allowed in the fully monomorphic
case.

It should be noted that this commit does not enable multi-table joins on
itself. `Join` still does not implement `JoinDsl`, and tables do not
implement `JoinTo<Join<Mid, Right>>`. The code required to enable that
is pretty minimal, but I don't want to flip the switch just yet, as
we're actually generating invalid SQL at the moment and that needs to be
resolved.

However, with this change, all of the limitations that prevent
multi-table joins at the type level are eliminated.