### PR TITLE
Add error message for derive(Insertable) on empty struct

### DIFF
--- a/diesel_codegen/src/insertable.rs
+++ b/diesel_codegen/src/insertable.rs
@@ -21,6 +21,11 @@ pub fn derive_insertable(item: syn::MacroInput) -> quote::Tokens {
     let lifetimes = model.generics.lifetimes;
     let fields = model.attrs.as_slice();
 
+    if fields.is_empty() {
+        panic!("Failed to derive `Insertable` for `{}`: `Insertable` \
+           cannot be used on structs with empty fields", struct_name);
+    }
+
     quote!(impl_Insertable! {
         (
             struct_name = #struct_name,

--- a/diesel_compile_tests/tests/compile-fail/empty_insertable_struct.rs
+++ b/diesel_compile_tests/tests/compile-fail/empty_insertable_struct.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_codegen;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+#[derive(Insertable)]
+//~^ ERROR proc-macro derive panicked
+//~| HELP Failed to derive `Insertable` for `NewUser`: `Insertable` cannot be used on structs with empty fields
+#[table_name="users"]
+pub struct NewUser {}
+
+fn main() {
+}


### PR DESCRIPTION
This change adds a new error message when attempting to derive
Insertable on a struct with no fields, and a compile-fail test to
ensure it is displayed appropriately.

See #920