### PR TITLE
Not for merge - test of PRs to pq-sys and mysqlclient-sys

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -116,3 +116,4 @@ environment:
       VCPKG_DEFAULT_TRIPLET: x64-windows-static
       VCPKG_PKGS: libmysql
       RUSTFLAGS: -Ctarget-feature=+crt-static
+

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,15 +14,17 @@ cache:
 
 install:
   - curl -fsS --retry 3 --retry-connrefused -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init -yv --default-toolchain stable --default-host %target%
+  # nightly is required for -Ctarget-feature=+crt-static until Rust 1.19
+  - if not defined RUSTFLAGS rustup-init -yv --default-toolchain stable --default-host %target%
+  - if defined RUSTFLAGS rustup-init -yv --default-toolchain nightly --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV
-  - curl -fsS --retry 3 --retry-connrefused -o sqlite3.zip https://sqlite.org/2017/sqlite-dll-win64-x64-3160200.zip
-  - 7z e sqlite3.zip -y
-  - set SQLITE3_LIB_DIR=%APPVEYOR_BUILD_FOLDER%
-  - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
-  - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\lib.exe" /def:sqlite3.def /OUT:sqlite3.lib /machine:x64'
+  - if not defined VCPKG_DEFAULT_TRIPLET curl -fsS --retry 3 --retry-connrefused -o sqlite3.zip https://sqlite.org/2017/sqlite-dll-win64-x64-3160200.zip
+  - if not defined VCPKG_DEFAULT_TRIPLET 7z e sqlite3.zip -y
+  - if not defined VCPKG_DEFAULT_TRIPLET set SQLITE3_LIB_DIR=%APPVEYOR_BUILD_FOLDER%
+  - if not defined VCPKG_DEFAULT_TRIPLET set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
+  - if not defined VCPKG_DEFAULT_TRIPLET "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\lib.exe" /def:sqlite3.def /OUT:sqlite3.lib /machine:x64
 
 build: false
 
@@ -36,6 +38,11 @@ before_test:
   # setup mysql databases
   - SET PATH=C:\Program Files\MySQL\MySQL Server 5.7\bin;C:\Program Files\MySQL\MySQL Server 5.7\lib;%PATH%
   - mysql -e "create database diesel_test; create database diesel_unit_test;" -uroot
+  # install vcpkg if required
+  - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
+  - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install %VCPKG_PKGS%
 
 test_script:
   - cd diesel
@@ -84,3 +91,28 @@ environment:
       # Neither mysql_config or pkg-config work for this on Windows
       MYSQLCLIENT_LIB_DIR: C:\Program Files\MySQL\MySQL Server 5.7\lib
       RUST_TEST_THREADS: 1
+      #
+      # builds from vcpkg
+      #
+    - target: x86_64-pc-windows-msvc
+      backend: postgres
+      PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test
+      PG_EXAMPLE_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_example
+      VCPKG_DEFAULT_TRIPLET: x64-windows-static
+      VCPKG_PKGS: libpq
+      RUSTFLAGS: -Ctarget-feature=+crt-static
+    - target: x86_64-pc-windows-msvc
+      backend: sqlite
+      SQLITE_DATABASE_URL: test.db
+      VCPKG_DEFAULT_TRIPLET: x64-windows-static
+      VCPKG_PKGS: sqlite3
+      RUSTFLAGS: -Ctarget-feature=+crt-static
+    - target: x86_64-pc-windows-msvc
+      backend: mysql
+      MYSQL_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_test
+      MYSQL_EXAMPLE_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_example
+      MYSQL_UNIT_TEST_DATABASE_URL: mysql://root:Password12!@localhost:3306/diesel_unit_test
+      RUST_TEST_THREADS: 1
+      VCPKG_DEFAULT_TRIPLET: x64-windows-static
+      VCPKG_PKGS: libmysql
+      RUSTFLAGS: -Ctarget-feature=+crt-static

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,5 @@
 version: 1.0.{build}
 
-# MySQL fails to link on 2015
-image: Visual Studio 2013
-
 branches:
   only:
     - master
@@ -72,6 +69,7 @@ environment:
       # Neither mysql_config or pkg-config work for this on Windows
       MYSQLCLIENT_LIB_DIR: C:\Program Files\MySQL\MySQL Server 5.7\lib
       RUST_TEST_THREADS: 1
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
     - target: x86_64-pc-windows-gnu
       backend: postgres
       PG_DATABASE_URL: postgres://postgres:Password12!@localhost/diesel_test

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,8 +17,8 @@ chrono = { version = "0.3", optional = true }
 clippy = { optional = true, version = "=0.0.126" }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.9.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
-mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
-pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
+mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true, git = "https://github.com/mcgoo/mysqlclient-sys", branch = "vcpkg" }
+pq-sys = { version = ">=0.3.0, <0.5.0", optional = true, git = "https://github.com/mcgoo/pq-sys", branch = "vcpkg" }
 quickcheck = { version = "0.3.1", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }
 time = { version = "0.1", optional = true }


### PR DESCRIPTION
This PR is to cause a run of the Diesel tests as requested by @sgrif [here](https://github.com/sgrif/pq-sys/pull/13#issuecomment-305991886)

It should test the two unmerged PRs below, which allow msvc abi builds to pick up libs from a vcpkg installation. This allows more easy building of a static binary on Windows to allow installation with `cargo install` (or `copy`.) [Demo.](https://github.com/mcgoo/vcpkg_diesel_build/blob/master/build_diesel_static.cmd)

https://github.com/sgrif/mysqlclient-sys/pull/4
https://github.com/sgrif/pq-sys/pull/13

