### PR TITLE
Allow joins which contain more than 2 tables

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -61,6 +61,7 @@ mod query_dsl;
 pub mod query_source;
 pub mod result;
 pub mod row;
+mod util;
 
 pub mod helper_types {
     //! Provide helper types for concisely writing the return type of functions.

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -551,6 +551,12 @@ macro_rules! joinable_inner {
 /// Allow two tables which are otherwise unrelated to be used together in a
 /// multi-table join. This macro only needs to be invoked when the two tables
 /// don't have an association between them (e.g. parent to grandchild)
+///
+/// # Example
+///
+/// ```ignore
+/// enable_multi_table_joins!(users, comments);
+/// ```
 #[macro_export]
 macro_rules! enable_multi_table_joins {
     ($left_mod:ident, $right_mod:ident) => {

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -183,3 +183,27 @@ impl<F, S, D, W, O, L, Of, G> NonAggregate
         SelectStatement<F, S, D, W, O, L, Of, G>: Expression,
 {
 }
+
+// Allow `SelectStatement<From>` to act as if it were `From` as long as
+// no other query methods have been called on it
+impl<From, T> AppearsInFromClause<T> for SelectStatement<From> where
+    From: AppearsInFromClause<T>,
+{
+    type Count = From::Count;
+}
+
+impl<From> QuerySource for SelectStatement<From> where
+    From: QuerySource,
+    From::DefaultSelection: SelectableExpression<Self>,
+{
+    type FromClause = From::FromClause;
+    type DefaultSelection = From::DefaultSelection;
+
+    fn from_clause(&self) -> Self::FromClause {
+        self.from.from_clause()
+    }
+
+    fn default_selection(&self) -> Self::DefaultSelection {
+        self.from.default_selection()
+    }
+}

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -40,7 +40,7 @@ pub struct SelectStatement<
     GroupBy = NoGroupByClause,
 > {
     select: Select,
-    from: From,
+    pub(crate) from: From,
     distinct: Distinct,
     where_clause: Where,
     order: Order,

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -185,8 +185,8 @@ impl<F, S, D, W, O, L, Of, G> NonAggregate
 {
 }
 
-// Allow `SelectStatement<From>` to act as if it were `From` as long as
-// no other query methods have been called on it
+/// Allow `SelectStatement<From>` to act as if it were `From` as long as
+/// no other query methods have been called on it
 impl<From, T> AppearsInFromClause<T> for SelectStatement<From> where
     From: AppearsInFromClause<T>,
 {

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -16,6 +16,7 @@ pub use self::boxed::BoxedSelectStatement;
 use backend::Backend;
 use expression::*;
 use query_source::*;
+use query_source::joins::AppendSelection;
 use result::QueryResult;
 use super::distinct_clause::NoDistinctClause;
 use super::group_by_clause::NoGroupByClause;
@@ -40,7 +41,7 @@ pub struct SelectStatement<
     GroupBy = NoGroupByClause,
 > {
     select: Select,
-    pub(crate) from: From,
+    from: From,
     distinct: Distinct,
     where_clause: Where,
     order: Order,
@@ -205,5 +206,15 @@ impl<From> QuerySource for SelectStatement<From> where
 
     fn default_selection(&self) -> Self::DefaultSelection {
         self.from.default_selection()
+    }
+}
+
+impl<From, Selection> AppendSelection<Selection> for SelectStatement<From> where
+    From: AppendSelection<Selection>,
+{
+    type Output = From::Output;
+
+    fn append_selection(&self, selection: Selection) -> Self::Output {
+        self.from.append_selection(selection)
     }
 }

--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -1,6 +1,6 @@
 use backend::Backend;
 use query_builder::AsQuery;
-use query_source::QuerySource;
+use query_source::Table;
 
 pub trait InternalBoxedDsl<'a, DB: Backend> {
     type Output;
@@ -10,7 +10,7 @@ pub trait InternalBoxedDsl<'a, DB: Backend> {
 
 impl<'a, T, DB> InternalBoxedDsl<'a, DB> for T where
     DB: Backend,
-    T: QuerySource + AsQuery,
+    T: Table + AsQuery,
     T::Query: InternalBoxedDsl<'a, DB>,
 {
     type Output = <T::Query as InternalBoxedDsl<'a, DB>>::Output;

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -1,5 +1,5 @@
 use query_builder::AsQuery;
-use query_source::QuerySource;
+use query_source::Table;
 
 /// Adds the `DISTINCT` keyword to a query.
 ///
@@ -37,7 +37,7 @@ pub trait DistinctDsl: AsQuery {
 }
 
 impl<T, ST> DistinctDsl for T where
-    T: AsQuery<SqlType=ST> + QuerySource,
+    T: Table + AsQuery<SqlType=ST>,
     T::Query: DistinctDsl<SqlType=ST>,
 {
     type Output = <T::Query as DistinctDsl>::Output;

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -38,7 +38,7 @@ pub trait FilterDsl<Predicate>: AsQuery {
 }
 
 impl<T, U, Predicate> FilterDsl<Predicate> for T where
-    T: QuerySource + AsQuery<SqlType=<U as Query>::SqlType, Query=U>,
+    T: Table + AsQuery<SqlType=<U as Query>::SqlType, Query=U>,
     U: Query + FilterDsl<Predicate, SqlType=<U as Query>::SqlType>,
 {
     type Output = Filter<U, Predicate>;

--- a/diesel/src/query_dsl/group_by_dsl.rs
+++ b/diesel/src/query_dsl/group_by_dsl.rs
@@ -1,6 +1,6 @@
 use expression::Expression;
 use query_builder::{Query, AsQuery};
-use query_source::QuerySource;
+use query_source::Table;
 
 pub trait GroupByDsl<Expr: Expression> {
     type Output: Query;
@@ -10,7 +10,7 @@ pub trait GroupByDsl<Expr: Expression> {
 
 impl<T, Expr> GroupByDsl<Expr> for T where
     Expr: Expression,
-    T: QuerySource + AsQuery,
+    T: Table + AsQuery,
     T::Query: GroupByDsl<Expr>,
 {
     type Output = <T::Query as GroupByDsl<Expr>>::Output;

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -1,5 +1,5 @@
 use query_builder::AsQuery;
-use query_source::{joins, QuerySource, JoinTo};
+use query_source::{joins, Table, JoinTo};
 
 #[doc(hidden)]
 /// `JoinDsl` support trait to emulate associated type constructors
@@ -10,7 +10,7 @@ pub trait InternalJoinDsl<Rhs, Kind, On> {
 }
 
 impl<T, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On> for T where
-    T: QuerySource + AsQuery,
+    T: Table + AsQuery,
     T::Query: InternalJoinDsl<Rhs, Kind, On>,
 {
     type Output = <T::Query as InternalJoinDsl<Rhs, Kind, On>>::Output;

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -52,6 +52,13 @@ pub trait JoinDsl: Sized {
     {
         self.join_with_implicit_on_clause(rhs, joins::LeftOuter)
     }
+
+    fn left_join<Rhs>(self, rhs: Rhs) -> Self::Output where
+        Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    {
+        self.left_outer_join(rhs)
+    }
+
 }
 
 impl<T: AsQuery> JoinDsl for T {

--- a/diesel/src/query_dsl/limit_dsl.rs
+++ b/diesel/src/query_dsl/limit_dsl.rs
@@ -1,5 +1,5 @@
 use query_builder::AsQuery;
-use query_source::QuerySource;
+use query_source::Table;
 
 /// Sets the limit clause of a query. If there was already a limit clause, it
 /// will be overridden. This is automatically implemented for the various query
@@ -11,7 +11,7 @@ pub trait LimitDsl: AsQuery {
 }
 
 impl<T, ST> LimitDsl for T where
-    T: QuerySource + AsQuery<SqlType=ST>,
+    T: Table + AsQuery<SqlType=ST>,
     T::Query: LimitDsl<SqlType=ST>,
 {
     type Output = <T::Query as LimitDsl>::Output;

--- a/diesel/src/query_dsl/offset_dsl.rs
+++ b/diesel/src/query_dsl/offset_dsl.rs
@@ -1,5 +1,5 @@
 use query_builder::AsQuery;
-use query_source::QuerySource;
+use query_source::Table;
 
 /// Sets the offset clause of a query. If there was already a offset clause, it
 /// will be overridden. This is automatically implemented for the various query
@@ -11,7 +11,7 @@ pub trait OffsetDsl: AsQuery {
 }
 
 impl<T, ST> OffsetDsl for T where
-    T: QuerySource + AsQuery<SqlType=ST>,
+    T: Table + AsQuery<SqlType=ST>,
     T::Query: OffsetDsl<SqlType=ST>,
 {
     type Output = <T::Query as OffsetDsl>::Output;

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -1,6 +1,6 @@
 use expression::Expression;
 use query_builder::AsQuery;
-use query_source::QuerySource;
+use query_source::Table;
 
 /// Sets the order clause of a query. If there was already a order clause, it
 /// will be overridden. The expression passed to `order` must actually be valid
@@ -49,7 +49,7 @@ pub trait OrderDsl<Expr: Expression>: AsQuery {
 
 impl<T, Expr, ST> OrderDsl<Expr> for T where
     Expr: Expression,
-    T: QuerySource + AsQuery<SqlType=ST>,
+    T: Table + AsQuery<SqlType=ST>,
     T::Query: OrderDsl<Expr, SqlType=ST>,
 {
     type Output = <T::Query as OrderDsl<Expr>>::Output;

--- a/diesel/src/query_dsl/select_dsl.rs
+++ b/diesel/src/query_dsl/select_dsl.rs
@@ -1,6 +1,6 @@
 use expression::*;
 use query_builder::{Query, AsQuery};
-use query_source::QuerySource;
+use query_source::Table;
 
 /// Sets the select clause of a query. If there was already a select clause, it
 /// will be overridden. The expression passed to `select` must actually be valid
@@ -14,7 +14,7 @@ pub trait SelectDsl<Selection: Expression> {
 
 impl<T, Selection> SelectDsl<Selection> for T where
     Selection: Expression,
-    T: QuerySource + AsQuery,
+    T: Table + AsQuery,
     T::Query: SelectDsl<Selection>,
 {
     type Output = <T::Query as SelectDsl<Selection>>::Output;

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -199,16 +199,6 @@ impl<Join, On, Selection> AppendSelection<Selection> for JoinOn<Join, On> where
     }
 }
 
-impl<From, Selection> AppendSelection<Selection> for SelectStatement<From> where
-    From: AppendSelection<Selection>,
-{
-    type Output = From::Output;
-
-    fn append_selection(&self, selection: Selection) -> Self::Output {
-        self.from.append_selection(selection)
-    }
-}
-
 use backend::Backend;
 
 #[doc(hidden)]

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -214,6 +214,27 @@ impl<Left, Mid, Right, Kind> JoinTo<Join<Mid, Right, Kind>> for Left where
     }
 }
 
+impl<Left, Mid, Right, Kind> JoinTo<Right> for Join<Left, Mid, Kind> where
+    Left: JoinTo<Right>,
+{
+    type JoinOnClause = Left::JoinOnClause;
+
+    fn join_on_clause() -> Self::JoinOnClause {
+        Left::join_on_clause()
+    }
+}
+
+impl<Join, On, Right> JoinTo<Right> for JoinOn<Join, On> where
+    Join: JoinTo<Right>,
+{
+    type JoinOnClause = Join::JoinOnClause;
+
+    fn join_on_clause() -> Self::JoinOnClause {
+        Join::join_on_clause()
+    }
+}
+
+
 use super::{Succ, Never, AppearsInFromClause};
 
 impl<T, Left, Right, Kind> AppearsInFromClause<T> for Join<Left, Right, Kind> where

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -7,4 +7,10 @@ use backend::Backend;
 pub trait Row<DB: Backend> {
     fn take(&mut self) -> Option<&DB::RawValue>;
     fn next_is_null(&self, count: usize) -> bool;
+
+    fn advance(&mut self, count: usize) {
+        for _ in 0..count {
+            self.take();
+        }
+    }
 }

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -56,8 +56,9 @@ macro_rules! tuple_impls {
                 DB: HasSqlType<($($ST,)+)>,
             {
                 fn build_from_row<RowT: Row<DB>>(row: &mut RowT) -> Result<Self, Box<Error+Send+Sync>> {
-                    if row.next_is_null(Self::fields_needed()) {
-                        row.advance(Self::fields_needed());
+                    let fields_needed = <Self as FromSqlRow<Nullable<($($ST,)+)>, DB>>::fields_needed();
+                    if row.next_is_null(fields_needed) {
+                        row.advance(fields_needed);
                         Ok(None)
                     } else {
                         Ok(Some(($(try!($T::build_from_row(row)),)+)))

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use associations::BelongsTo;
 use backend::{Backend, SupportsDefaultKeyword};
 use expression::{Expression, SelectableExpression, AppearsOnTable, NonAggregate};
@@ -6,8 +8,8 @@ use query_builder::*;
 use query_source::{QuerySource, Queryable, Table, Column};
 use result::QueryResult;
 use row::Row;
-use std::error::Error;
 use types::{HasSqlType, FromSqlRow, Nullable, IntoNullable, NotNull};
+use util::TupleAppend;
 
 macro_rules! tuple_impls {
     ($(
@@ -236,6 +238,16 @@ macro_rules! tuple_impls {
 
                 fn foreign_key_column() -> Self::ForeignKeyColumn {
                     A::foreign_key_column()
+                }
+            }
+
+            impl<$($T,)+ Next> TupleAppend<Next> for ($($T,)+) {
+                type Output = ($($T,)+ Next);
+
+                #[allow(non_snake_case)]
+                fn tuple_append(self, next: Next) -> Self::Output {
+                    let ($($T,)+) = self;
+                    ($($T,)+ next)
                 }
             }
         )+

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -292,6 +292,12 @@ pub trait FromSql<A, DB: Backend + HasSqlType<A>>: Sized {
 /// implemented for tuples of various sizes.
 pub trait FromSqlRow<A, DB: Backend + HasSqlType<A>>: Sized {
     fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self, Box<Error+Send+Sync>>;
+
+    /// The number of fields that this type will consume. Should be equal to
+    /// the number of times you would call `row.take()` in `build_from_row`
+    fn fields_needed() -> usize {
+        1
+    }
 }
 
 #[cfg(feature = "unstable")]

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -1,0 +1,5 @@
+pub trait TupleAppend<T> {
+    type Output;
+
+    fn tuple_append(self, right: T) -> Self::Output;
+}

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -1,3 +1,5 @@
+/// Treats tuples as a list which can be appended to. e.g.
+/// `(a,).tuple_append(b) == (a, b)`
 pub trait TupleAppend<T> {
     type Output;
 

--- a/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
@@ -17,17 +17,26 @@ table! {
     }
 }
 
+table! {
+    comments {
+        id -> Integer,
+        post_id -> Integer,
+    }
+}
+
+joinable!(comments -> posts (post_id));
+enable_multi_table_joins!(users, posts);
+enable_multi_table_joins!(users, comments);
+
 fn main() {
     let _ = users::table.inner_join(posts::table);
-    //~^ ERROR JoinTo
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
+    //~^ ERROR users::table: diesel::JoinTo<posts::table>
     let _ = users::table.left_outer_join(posts::table);
-    //~^ ERROR JoinTo
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
+    //~^ ERROR users::table: diesel::JoinTo<posts::table>
+
+    // Sanity check to make sure the error is when users
+    // become involved
+    let join = posts::table.inner_join(comments::table);
+    let _ = users::table.inner_join(join);
+    //~^ ERROR users::table: diesel::JoinTo<posts::table>
 }

--- a/diesel_tests/tests/backend_specific_schema.rs
+++ b/diesel_tests/tests/backend_specific_schema.rs
@@ -1,8 +1,9 @@
 use diesel::*;
-use super::{User, posts, comments, users};
+use super::{User, posts, comments, users, followings};
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 #[has_many(comments)]
+#[has_many(followings)]
 #[belongs_to(User)]
 pub struct Post {
     pub id: i32,

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -358,7 +358,7 @@ fn selecting_parent_child_sibling() {
     let data = users::table.inner_join(posts::table).inner_join(likes::table)
         .load(&connection);
     let expected = vec![
-        ((tess.clone(), posts[1].clone()), likes[0].clone()),
+        (tess.clone(), posts[1].clone(), likes[0].clone()),
     ];
     assert_eq!(Ok(expected), data);
 
@@ -366,9 +366,9 @@ fn selecting_parent_child_sibling() {
         .order((users::id, posts::id))
         .load(&connection);
     let expected = vec![
-        ((sean.clone(), posts[0].clone()), None),
-        ((sean.clone(), posts[2].clone()), None),
-        ((tess.clone(), posts[1].clone()), Some(likes[0].clone())),
+        (sean.clone(), posts[0].clone(), None),
+        (sean.clone(), posts[2].clone(), None),
+        (tess.clone(), posts[1].clone(), Some(likes[0].clone())),
     ];
     assert_eq!(Ok(expected), data);
 }

--- a/diesel_tests/tests/postgres_specific_schema.rs
+++ b/diesel_tests/tests/postgres_specific_schema.rs
@@ -1,7 +1,8 @@
-use super::{User, posts, comments};
+use super::{User, posts, comments, followings};
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 #[has_many(comments)]
+#[has_many(followings)]
 #[belongs_to(User)]
 pub struct Post {
     pub id: i32,

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -12,8 +12,9 @@ infer_schema!("dotenv:MYSQL_DATABASE_URL");
 infer_schema!("dotenv:DATABASE_URL");
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, Associations)]
-#[has_many(posts)]
+#[has_many(followings)]
 #[has_many(likes)]
+#[has_many(posts)]
 #[table_name = "users"]
 pub struct User {
     pub id: i32,
@@ -58,7 +59,9 @@ impl Comment {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Associations)]
+#[belongs_to(User)]
+#[belongs_to(Post)]
 #[table_name="followings"]
 pub struct Following {
     pub user_id: i32,
@@ -254,3 +257,5 @@ pub fn find_user_by_name(name: &str, connection: &TestConnection) -> User {
 
 enable_multi_table_joins!(users, comments);
 enable_multi_table_joins!(posts, likes);
+enable_multi_table_joins!(followings, likes);
+enable_multi_table_joins!(followings, comments);

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -13,6 +13,7 @@ infer_schema!("dotenv:DATABASE_URL");
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, Associations)]
 #[has_many(posts)]
+#[has_many(likes)]
 #[table_name = "users"]
 pub struct User {
     pub id: i32,
@@ -40,6 +41,7 @@ impl User {
 
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
 #[belongs_to(Post)]
+#[has_many(likes)]
 pub struct Comment {
     id: i32,
     post_id: i32,
@@ -155,6 +157,16 @@ pub struct NullableColumn {
     value: Option<i32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Identifiable, Associations)]
+#[table_name="likes"]
+#[primary_key(user_id, comment_id)]
+#[belongs_to(User)]
+#[belongs_to(Comment)]
+pub struct Like {
+    pub user_id: i32,
+    pub comment_id: i32,
+}
+
 #[cfg(feature = "postgres")]
 pub type TestConnection = ::diesel::pg::PgConnection;
 #[cfg(feature = "sqlite")]
@@ -239,3 +251,6 @@ pub fn find_user_by_name(name: &str, connection: &TestConnection) -> User {
         .first(connection)
         .unwrap()
 }
+
+enable_multi_table_joins!(users, comments);
+enable_multi_table_joins!(posts, likes);

--- a/migrations/mysql/20170603131224_add_likes/down.sql
+++ b/migrations/mysql/20170603131224_add_likes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE likes;

--- a/migrations/mysql/20170603131224_add_likes/up.sql
+++ b/migrations/mysql/20170603131224_add_likes/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE likes (
+  comment_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  PRIMARY KEY (comment_id, user_id)
+);

--- a/migrations/postgresql/20170603131224_add_likes/down.sql
+++ b/migrations/postgresql/20170603131224_add_likes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE likes;

--- a/migrations/postgresql/20170603131224_add_likes/up.sql
+++ b/migrations/postgresql/20170603131224_add_likes/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE likes (
+  comment_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  PRIMARY KEY (comment_id, user_id)
+);

--- a/migrations/sqlite/20170603131224_add_likes/down.sql
+++ b/migrations/sqlite/20170603131224_add_likes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE likes;

--- a/migrations/sqlite/20170603131224_add_likes/up.sql
+++ b/migrations/sqlite/20170603131224_add_likes/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE likes (
+  comment_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  PRIMARY KEY (comment_id, user_id)
+);


### PR DESCRIPTION
This pull request is split into 4 commits, and I recommend reviewing each commit separately. Each message has more context about the individual changes. Beyond this PR, I still need to add some doctests for multi-table joins, and figure out the right way to document `enable_multi_table_joins!`.

Fixes #398 
Fixes #89 
Partially addresses #298 
Fixes #759 