### PR TITLE
[WIP] Prototype of infering enums from the database schema

### DIFF
--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -122,3 +122,24 @@ macro_rules! embed_migrations {
         }
     }
 }
+
+#[macro_export]
+macro_rules! infer_enum {
+    ($database_url: expr) => {
+        mod __diesel_infer_enum {
+            #[derive(InferEnum)]
+            #[infer_enum_options(database_url=$database_url)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_enum::*;
+    };
+
+    ($database_url: expr, $schema_name: expr) => {
+        mod __diesel_infer_enum {
+            #[derive(InferEnum)]
+            #[infer_enum_options(database_url=$database_url, schema_name=$schema_name)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_enum::*;
+    };
+}

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -90,7 +90,16 @@ pub fn build_cli() -> App<'static, 'static> {
              .help("Use table list as blacklist")
              .conflicts_with("whitelist"));
 
-    App::new("diesel")
+    let infer_enums = SubCommand::with_name("print-enums")
+        .setting(AppSettings::VersionlessSubcommands)
+        .about("Print enum definitions for database enum.")
+        .arg(Arg::with_name("schema")
+             .long("schema")
+             .short("s")
+             .takes_value(true)
+             .help("The name of the schema."));
+
+    let mut diesel = App::new("diesel")
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::VersionlessSubcommands)
         .after_help("You can also run `diesel SUBCOMMAND -h` to get more information about that subcommand.")
@@ -100,7 +109,11 @@ pub fn build_cli() -> App<'static, 'static> {
         .subcommand(database_subcommand)
         .subcommand(generate_bash_completion_subcommand)
         .subcommand(infer_schema_subcommand)
-        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .setting(AppSettings::SubcommandRequiredElseHelp);
+    if cfg!(feature="postgres"){
+        diesel = diesel.subcommand(infer_enums);
+    }
+    diesel
 }
 
 fn migration_dir_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -88,6 +88,12 @@ pub fn derive_infer_table_from_schema(input: TokenStream) -> TokenStream {
     expand_derive(input, schema_inference::derive_infer_table_from_schema)
 }
 
+#[proc_macro_derive(InferEnum, attributes(infer_enum_options))]
+#[cfg(all(feature = "diesel_infer_schema", feature = "postgres"))]
+pub fn derive_infer_enum(input: TokenStream) -> TokenStream {
+    expand_derive(input, schema_inference::derive_infer_enum)
+}
+
 #[proc_macro_derive(EmbedMigrations, attributes(embed_migrations_options))]
 pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
     expand_derive(input, embed_migrations::derive_embed_migrations)

--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -4,9 +4,253 @@ use quote;
 use syn;
 
 use table_data::TableData;
-use data_structures::ColumnInformation;
+use data_structures::{ColumnInformation, EnumInformation};
 use inference::{establish_connection, get_table_data, determine_column_type, get_primary_keys,
                 InferConnection};
+
+pub fn wrap_item_in_const(const_name: syn::Ident, item: quote::Tokens) -> quote::Tokens {
+    quote! {
+        #[allow(dead_code)]
+        const #const_name: () = {
+            extern crate diesel;
+            #item
+        };
+    }
+}
+
+fn to_uppercase(ty: String) -> String {
+    let mut ret = String::with_capacity(ty.len());
+    let mut next_uppercase = true;
+    for c in ty.chars() {
+        if c == '_' {
+            next_uppercase = true;
+            continue;
+        }
+        if next_uppercase {
+            ret += &c.to_uppercase().to_string();
+        } else {
+            ret.push(c);
+        }
+        next_uppercase = false;
+    }
+    ret
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ExpandEnumMode {
+    PrettyPrint,
+    Codegen,
+}
+
+pub fn expand_enum(enum_info: EnumInformation, mode: ExpandEnumMode) -> quote::Tokens {
+    let EnumInformation{type_name, fields, oid, array_oid} = enum_info;
+    let sql_mod = syn::Ident::new(format!("sql_{}", type_name));
+    let sql_type_name = syn::Ident::new(to_uppercase(format!("{}Sql", type_name)));
+    let type_name = syn::Ident::new(to_uppercase(type_name));
+
+    let field_mapping = fields.clone().into_iter().map(|field| {
+        let ident = syn::Ident::new(to_uppercase(field.clone()));
+        quote!(#field => #type_name::#ident)
+    }).collect::<Vec<_>>();
+    let reverse_mapping = fields.clone().into_iter().map(|field| {
+        let ident = syn::Ident::new(to_uppercase(field.clone()));
+        quote!(#type_name::#ident => #field)
+    }).collect::<Vec<_>>();
+
+    let fields = fields.into_iter().map(|field|{
+        syn::Ident::new(to_uppercase(field))
+    });
+
+        let map_names = {
+        let from_1 = {
+            let field_mapping = field_mapping.clone();
+            quote! {
+                impl<'a> From<&'a str> for #type_name {
+                    fn from(s: &'a str) -> Self {
+                        match s {
+                            #(#field_mapping,)*
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+        };
+        quote!{
+            #from_1
+            impl From<String> for #type_name {
+                fn from(s: String) -> Self {
+                    match s.as_str() {
+                        #(#field_mapping,)*
+                        _ => unreachable!(),
+                    }
+                }
+            }
+            impl<'a> From<&'a #type_name> for String {
+                fn from(t: &'a #type_name) -> Self {
+                    match *t {
+                        #(#reverse_mapping,)*
+                    }.into()
+                }
+            }
+        }
+    };
+
+    let metadata = quote!{
+        impl HasSqlType<#sql_type_name> for Debug {
+            fn metadata() {}
+        }
+
+        impl HasSqlType<#sql_type_name> for Pg {
+            fn metadata() -> PgTypeMetadata {
+                PgTypeMetadata {
+                    oid: #oid,
+                    array_oid: #array_oid,
+                }
+            }
+        }
+        impl NotNull for #sql_type_name {}
+
+        impl QueryId for #sql_type_name {
+            type QueryId = Self;
+
+            fn has_static_query_id() -> bool {
+                true
+            }
+        }
+    };
+
+    let expressions = quote!{
+        impl<'a> AsExpression<#sql_type_name> for #type_name {
+            type Expression = Bound<#sql_type_name, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl<'a, 'expr> AsExpression<#sql_type_name> for &'expr #type_name {
+            type Expression = Bound<#sql_type_name, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+    };
+
+    let expressions = quote!{
+        #expressions
+
+        impl<'a> AsExpression<Nullable<#sql_type_name>> for #type_name {
+            type Expression = Bound<Nullable<#sql_type_name>, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl<'a, 'expr> AsExpression<Nullable<#sql_type_name>> for &'expr #type_name {
+            type Expression = Bound<Nullable<#sql_type_name>, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+    };
+
+    let to_sql = quote!{
+        impl ToSql<Nullable<#sql_type_name>, Pg> for #type_name {
+            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+                ToSql::<MoodSql, Pg>::to_sql(self, out)
+            }
+        }
+
+        impl ToSql<#sql_type_name, Pg> for #type_name {
+            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+                ToSql::<Text, Pg>::to_sql(&String::from(self), out)
+            }
+}
+    };
+
+    let from_sql = quote! {
+        impl FromSql<#sql_type_name, Pg> for #type_name {
+            fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>>{
+                <String as FromSql<Text, Pg>>::from_sql(bytes).map(Into::into)
+            }
+        }
+        impl FromSqlRow<#sql_type_name, Pg> for #type_name {
+            fn build_from_row<R: Row<Pg>>(row: &mut R) -> Result<Self, Box<Error + Send + Sync>> {
+                FromSql::<#sql_type_name, Pg>::from_sql(row.take())
+            }
+        }
+    };
+
+    let queryable = quote!{
+        impl Queryable<#sql_type_name, Pg> for #type_name {
+            type Row = Self;
+
+            fn build(row: Self::Row) -> Self {
+                row
+            }
+        }
+    };
+    let enum_def =     quote!{
+        #[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
+        pub enum #type_name {
+            #(#fields,)*
+        }
+        #map_names
+    };
+    let diesel_imports = quote!{
+        use diesel::pg::{PgTypeMetadata, Pg};
+        use diesel::types::{HasSqlType, NotNull, IsNull};
+        use diesel::types::{FromSql, FromSqlRow, ToSql};
+        use diesel::types::{Nullable, Text};
+        use diesel::expression::AsExpression;
+    };
+    let diesel_imports = quote!{
+        #diesel_imports
+        use diesel::row::Row;
+        use diesel::query_builder::QueryId;
+        use diesel::expression::bound::Bound;
+        use diesel::Queryable;
+        use diesel::backend::Debug;
+    };
+    let sql_mod_inner = quote!(
+        #diesel_imports
+        use super::#type_name;
+        use std::error::Error;
+        use std::io::Write;
+        #metadata
+        #expressions
+        #to_sql
+        #from_sql
+        #queryable
+    );
+
+    if mode == ExpandEnumMode::PrettyPrint {
+        quote!{
+            #enum_def
+            pub mod #sql_mod {
+                pub struct #sql_type_name;
+                #sql_mod_inner
+            }
+        }
+    } else {
+        let name = syn::Ident::new(
+            format!("IMPL_ENUM_FOR_{}",
+                    type_name.as_ref().to_uppercase()));
+        let sql_mod_inner = wrap_item_in_const(name, quote!{
+            #sql_mod_inner
+        });
+        quote!{
+            #enum_def
+            pub mod #sql_mod {
+                pub struct #sql_type_name;
+                #sql_mod_inner
+            }
+        }
+    }
+}
 
 pub fn expand_infer_table_from_schema(database_url: &str, table: &TableData)
     -> Result<quote::Tokens, Box<Error>>

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -9,6 +9,14 @@ use diesel::types::{HasSqlType, FromSqlRow};
 use super::information_schema::UsesInformationSchema;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumInformation {
+    pub type_name: String,
+    pub fields: Vec<String>,
+    pub oid: u32,
+    pub array_oid: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnInformation {
     pub column_name: String,
     pub type_name: String,

--- a/diesel_infer_schema/src/lib.rs
+++ b/diesel_infer_schema/src/lib.rs
@@ -40,3 +40,6 @@ mod sqlite;
 pub use codegen::*;
 pub use inference::load_table_names;
 pub use table_data::TableData;
+
+#[cfg(feature="postgres")]
+pub use pg::load_enums;


### PR DESCRIPTION
* This will only work with postgres in the current version

This is a first draft version to get some feedback on this. 
Things to fix before merging:
- [ ] Formating
- [ ] Documentation
- [ ] Tests
- [ ] Fix compiling other backends

Using an implementation similar to the shown, will restrict the produced binary to exactly the same database that was used to compile the code because the type oid's of the enums are hardcoded in `HasSqlType::metadata`. As far as I understand those oid's could/will change if you run your migrations on a other database instance, so the provided mapping will be invalid.

As far as I see there are two possible solutions:
- Document and accept the behavior 
- Add some way to query the database on startup/connect for the actual oid's and store them in some kind of static map. Then use this map to generate the metadata 

