### PR TITLE
Refactor `LoadDsl` to make it easier to introduce the raw SQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `postfix_predicate!` and `postfix_expression!` have been renamed to
   `diesel_postfix_operator!`.
 
+* Trait bounds along the lines of `T: LoadDsl<Conn>, U: Queryable<T::SqlType,
+  Conn::Backend>` should be changed to `T: LoadQuery<Conn, U>`.
+
 ## [0.13.0] - 2017-05-15
 
 ### Added

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -136,18 +136,7 @@ pub trait Connection: SimpleConnection + Sized + Send {
     fn execute(&self, query: &str) -> QueryResult<usize>;
 
     #[doc(hidden)]
-    fn query_one<T, U>(&self, source: T) -> QueryResult<U> where
-        T: AsQuery,
-        T::Query: QueryFragment<Self::Backend> + QueryId,
-        Self::Backend: HasSqlType<T::SqlType>,
-        U: Queryable<T::SqlType, Self::Backend>,
-    {
-        self.query_all(source)
-            .and_then(|e: Vec<U>| e.into_iter().next().ok_or(Error::NotFound))
-    }
-
-    #[doc(hidden)]
-    fn query_all<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
+    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
         Self::Backend: HasSqlType<T::SqlType>,

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -59,7 +59,7 @@ impl Connection for MysqlConnection {
     }
 
     #[doc(hidden)]
-    fn query_all<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
+    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
         Self::Backend: HasSqlType<T::SqlType>,

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -63,7 +63,7 @@ impl Connection for PgConnection {
     }
 
     #[doc(hidden)]
-    fn query_all<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
+    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
         T: AsQuery,
         T::Query: QueryFragment<Pg> + QueryId,
         Pg: HasSqlType<T::SqlType>,

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -3,31 +3,34 @@ use connection::Connection;
 use helper_types::Limit;
 use query_builder::{QueryFragment, AsQuery, QueryId};
 use query_source::Queryable;
-use result::QueryResult;
+use result::{QueryResult, first_or_not_found};
 use super::LimitDsl;
 use types::HasSqlType;
 
+pub trait LoadQuery<Conn, U>: LoadDsl<Conn> {
+    fn internal_load(self, conn: &Conn) -> QueryResult<Vec<U>>;
+}
+
+impl<Conn, T, U> LoadQuery<Conn, U> for T where
+    Conn: Connection,
+    Conn::Backend: HasSqlType<T::SqlType>,
+    T: AsQuery,
+    T::Query: QueryFragment<Conn::Backend> + QueryId,
+    U: Queryable<T::SqlType, Conn::Backend>,
+{
+    fn internal_load(self, conn: &Conn) -> QueryResult<Vec<U>> {
+        conn.query_by_index(self)
+    }
+}
+
 /// Methods to execute a query given a connection. These are automatically implemented for the
 /// various query types.
-pub trait LoadDsl<Conn: Connection>: Sized where
-    Conn::Backend: HasSqlType<Self::SqlType>,
-{
-    type SqlType;
-
+pub trait LoadDsl<Conn>: Sized {
     /// Executes the given query, returning a `Vec` with the returned rows.
     fn load<U>(self, conn: &Conn) -> QueryResult<Vec<U>> where
-        U: Queryable<Self::SqlType, Conn::Backend>;
-
-    /// Attempts to load a single record. Returns `Ok(record)` if found, and
-    /// `Err(NotFound)` if no results are returned. If the query truly is
-    /// optional, you can call `.optional()` on the result of this to get a
-    /// `Result<Option<U>>`.
-    fn first<U>(self, conn: &Conn) -> QueryResult<U> where
-        Self: LimitDsl,
-        Limit<Self>: LoadDsl<Conn, SqlType=<Self as LoadDsl<Conn>>::SqlType>,
-        U: Queryable<<Self as LoadDsl<Conn>>::SqlType, Conn::Backend>,
+        Self: LoadQuery<Conn, U>,
     {
-        self.limit(1).get_result(conn)
+        self.internal_load(conn)
     }
 
     /// Runs the command, and returns the affected row. `Err(NotFound)` will be
@@ -35,33 +38,45 @@ pub trait LoadDsl<Conn: Connection>: Sized where
     /// result of this if the command was optional to get back a
     /// `Result<Option<U>>`
     fn get_result<U>(self, conn: &Conn) -> QueryResult<U> where
-        U: Queryable<Self::SqlType, Conn::Backend>;
+        Self: LoadQuery<Conn, U>,
+    {
+        first_or_not_found(self.load(conn))
+    }
 
     /// Runs the command, returning an `Vec` with the affected rows.
     fn get_results<U>(self, conn: &Conn) -> QueryResult<Vec<U>> where
-        U: Queryable<Self::SqlType, Conn::Backend>,
+        Self: LoadQuery<Conn, U>,
     {
         self.load(conn)
     }
 }
 
-impl<Conn: Connection, T: AsQuery> LoadDsl<Conn> for T where
-    T::Query: QueryFragment<Conn::Backend> + QueryId,
+impl<Conn, T> LoadDsl<Conn> for T where
+    // These constraints are fairly redundant with `Self: LoadQuery`,
+    // But since `LoadQuery` has a second type parameter, it can't be
+    // used to prove impls on things like `SupportsReturningClause` are disjoint.
+    // If disjointness on associated types ever lands, we can drop all of these
+    // except `T: AsQuery`
+    Conn: Connection,
     Conn::Backend: HasSqlType<T::SqlType>,
+    T: AsQuery,
+    T::Query: QueryFragment<Conn::Backend> + QueryId,
 {
-    type SqlType = <Self as AsQuery>::SqlType;
+}
 
-    fn load<U>(self, conn: &Conn) -> QueryResult<Vec<U>> where
-        U: Queryable<Self::SqlType, Conn::Backend>,
+pub trait FirstDsl<Conn>: LimitDsl + LoadDsl<Conn> {
+    /// Attempts to load a single record. Returns `Ok(record)` if found, and
+    /// `Err(NotFound)` if no results are returned. If the query truly is
+    /// optional, you can call `.optional()` on the result of this to get a
+    /// `Result<Option<U>>`.
+    fn first<U>(self, conn: &Conn) -> QueryResult<U> where
+        Limit<Self>: LoadQuery<Conn, U>,
     {
-        conn.query_all(self)
+        self.limit(1).get_result(conn)
     }
+}
 
-    fn get_result<U>(self, conn: &Conn) -> QueryResult<U> where
-        U: Queryable<Self::SqlType, Conn::Backend>,
-    {
-        conn.query_one(self)
-    }
+impl<Conn, T: LimitDsl + LoadDsl<Conn>> FirstDsl<Conn> for T {
 }
 
 pub trait ExecuteDsl<Conn: Connection<Backend=DB>, DB: Backend = <Conn as Connection>::Backend>: Sized {

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -26,7 +26,7 @@ pub use self::filter_dsl::{FilterDsl, FindDsl};
 pub use self::group_by_dsl::GroupByDsl;
 pub use self::join_dsl::{InternalJoinDsl, JoinDsl};
 pub use self::limit_dsl::LimitDsl;
-pub use self::load_dsl::{LoadDsl, ExecuteDsl};
+pub use self::load_dsl::{LoadDsl, ExecuteDsl, FirstDsl, LoadQuery};
 pub use self::offset_dsl::OffsetDsl;
 pub use self::order_dsl::OrderDsl;
 pub use self::save_changes_dsl::SaveChangesDsl;

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -180,3 +180,7 @@ fn error_impls_send() {
     let err: Error = unimplemented!();
     let x: &Send = &err;
 }
+
+pub(crate) fn first_or_not_found<T>(records: QueryResult<Vec<T>>) -> QueryResult<T> {
+    records?.into_iter().next().ok_or(Error::NotFound)
+}

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -61,7 +61,7 @@ impl Connection for SqliteConnection {
     }
 
     #[doc(hidden)]
-    fn query_all<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
+    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>> where
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
         Self::Backend: HasSqlType<T::SqlType>,

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -27,15 +27,13 @@ fn managing_updated_at_for_table() {
     connection.execute("SELECT diesel_manage_updated_at('auto_time');").unwrap();
 
     connection.execute("INSERT INTO auto_time (n) VALUES (2), (1), (5);").unwrap();
-    let result = connection.query_one::<_, i64>(
-        select(sql("COUNT(*) FROM auto_time WHERE updated_at IS NULL"))
-    );
+    let result = select(sql("COUNT(*) FROM auto_time WHERE updated_at IS NULL"))
+        .get_result::<i64>(&connection);
     assert_eq!(Ok(3), result);
 
     connection.execute("UPDATE auto_time SET n = n + 1 WHERE true;").unwrap();
-    let result = connection.query_one::<_, i64>(
-        select(sql("COUNT(*) FROM auto_time WHERE updated_at IS NULL"))
-    );
+    let result = select(sql("COUNT(*) FROM auto_time WHERE updated_at IS NULL"))
+        .get_result::<i64>(&connection);
     assert_eq!(Ok(0), result);
 
     let query = auto_time.find(2).select(updated_at);


### PR DESCRIPTION
One of the things that's going to make our upcoming raw SQL escape hatch
different from our current `sql` function is that it's not going to
require specifying the SQL type fo the query, and it's going to load
parameters by name instead of by index. This does mean that we'll need
to provide a parallel trait to `Queryable`, but I'd prefer to avoid
introducing a parallel version of `LoadDsl`.

So in order to make the type we will introduce for this compatible with
`LoadDsl`, we needed to remove all mentions of `Queryable` from the
trait itself, and move it to bounds on the impl instead. This means we
need a new trait that is generic over the type we're deserializing, and
changed `LoadDsl` to entirely base its bounds on that.

I've opted for the name `LoadQuery` instead of something like
`InternalLoadDsl`, as this trait is one that may end up in bounds for
user code, and will certainly show up in error messages.

I had to keep a bunch of redundant bounds on `LoadDsl` in order to make
the impls of `SaveChangesDsl` remain disjoint. This is because
associated types are basically ignored for purposes of disjointness.
While we know that `Update<T, T>: !LoadQuery<SqliteConnection, U>`,
since there is that second unconstrained type parameter, we cannot use
`LoadQuery` for disjointness either since someone could in theory write
a blanket impl of `impl<T, Conn> LoadQuery<Conn, MyType> for T`
(possibly slightly more specific than that).

Finally, as some bits for clarity, I've moved `Connection#query_one`
over to `LoadDsl`, since it had no real reason to exist on the
connection. I've renamed `query_all` to `query_by_index`, since that's
how it will differ from other methods starting with `query_`. Finally,
I've moved `LoadDsl#first` off to its own trait, since the bounds are
verbose to write if you wanted to call `.first` otherwise.