### PR TITLE
Activate Chrono's serde feature in extras

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -35,7 +35,7 @@ tempdir = "^0.3.4"
 
 [features]
 default = ["with-deprecated"]
-extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address"]
+extras = ["chrono/serde", "serde_json", "uuid", "deprecated-time", "network-address"]
 unstable = []
 lint = ["clippy"]
 large-tables = []


### PR DESCRIPTION
AFAICT #rust-lang/cargo/633 doesn't allow _only_ activating a feature.
Activating a downstream feature means that you unconditionally pull it into the
crate.

That means we can't do:

```
[features]
serde_json = ["chrono/serde"]
```

because it would always pull chrono in even if it's unused.

This was spurred by #960 