### PR TITLE
Fix building examples without migrations on CI

### DIFF
--- a/examples/postgres/test_all
+++ b/examples/postgres/test_all
@@ -8,7 +8,11 @@ set +a
 
 for dir in $(find . -maxdepth 1 -mindepth 1 -type d); do
   cd $dir
-  ../../../bin/diesel database reset
+
+  if [ -d "migrations" ]; then
+    ../../../bin/diesel database reset
+  fi
+
   cargo build
   cd ..
 done


### PR DESCRIPTION
#783 added an example with no migrations and CI didn't like it.

Will merge when CI is green.