### PR TITLE
on appveyor, ignore the rust-toolchain file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ cache:
 install:
   - curl -fsS --retry 3 --retry-connrefused -o rustup-init.exe https://win.rustup.rs/
   - rustup-init -yv --default-toolchain stable --default-host %target%
+  - del rust-toolchain
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV


### PR DESCRIPTION
This should allow the appveyor builds to build using stable Rust. (It deletes the rust-toolchain file before calling anything that runs via rustup.)  

Replaces https://github.com/diesel-rs/diesel/pull/985