### PR TITLE
Automatically generate `numeric_expr!` for known numeric types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Changed
+
+* Diesel will now automatically invoke `numeric_expr!` for your columns in the
+  common cases. You will likely need to delete any manual invocations of this
+  macro.
+
 ## [0.14.0] - 2017-07-04
 
 ### Added

--- a/diesel/src/expression/ops/mod.rs
+++ b/diesel/src/expression/ops/mod.rs
@@ -1,39 +1,3 @@
-#[macro_export]
-/// Implements the Rust operator for a given type. If you create a new SQL
-/// function, which returns a type that you'd like to use an operator on, you
-/// should invoke this macro. Unfortunately, Rust disallows us from
-/// automatically implementing `Add` and other traits from `std::ops`, under its
-/// orphan rules.
-macro_rules! operator_allowed {
-    ($tpe: ty, $op: ident, $fn_name: ident) => {
-        impl<Rhs> ::std::ops::$op<Rhs> for $tpe where
-            Rhs: $crate::expression::AsExpression<
-                <<$tpe as $crate::Expression>::SqlType as $crate::types::ops::$op>::Rhs
-            >,
-        {
-            type Output = $crate::expression::ops::$op<Self, Rhs::Expression>;
-
-            fn $fn_name(self, rhs: Rhs) -> Self::Output {
-                $crate::expression::ops::$op::new(self, rhs.as_expression())
-            }
-        }
-    }
-}
-
-#[macro_export]
-/// Indicates that an expression allows all numeric operators. If you create new
-/// SQL functions that return a numeric type, you should invoke this macro that
-/// type. Unfortunately, Rust disallows us from automatically implementing `Add`
-/// for types which implement `Expression`, under its orphan rules.
-macro_rules! numeric_expr {
-    ($tpe: ty) => {
-        operator_allowed!($tpe, Add, add);
-        operator_allowed!($tpe, Sub, sub);
-        operator_allowed!($tpe, Div, div);
-        operator_allowed!($tpe, Mul, mul);
-    }
-}
-
 macro_rules! generic_numeric_expr_inner {
     ($tpe: ident, ($($param: ident),*), $op: ident, $fn_name: ident) => {
         impl<Rhs, $($param),*> ::std::ops::$op<Rhs> for $tpe<$($param),*> where

--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -1,0 +1,65 @@
+#[macro_export]
+/// Implements the Rust operator for a given type. If you create a new SQL
+/// function, which returns a type that you'd like to use an operator on, you
+/// should invoke this macro. Unfortunately, Rust disallows us from
+/// automatically implementing `Add` and other traits from `std::ops`, under its
+/// orphan rules.
+macro_rules! operator_allowed {
+    ($tpe: ty, $op: ident, $fn_name: ident) => {
+        impl<Rhs> ::std::ops::$op<Rhs> for $tpe where
+            Rhs: $crate::expression::AsExpression<
+                <<$tpe as $crate::Expression>::SqlType as $crate::types::ops::$op>::Rhs
+            >,
+        {
+            type Output = $crate::expression::ops::$op<Self, Rhs::Expression>;
+
+            fn $fn_name(self, rhs: Rhs) -> Self::Output {
+                $crate::expression::ops::$op::new(self, rhs.as_expression())
+            }
+        }
+    }
+}
+
+#[macro_export]
+/// Indicates that an expression allows all numeric operators. If you create new
+/// SQL functions that return a numeric type, you should invoke this macro that
+/// type. Unfortunately, Rust disallows us from automatically implementing `Add`
+/// for types which implement `Expression`, under its orphan rules.
+macro_rules! numeric_expr {
+    ($tpe: ty) => {
+        operator_allowed!($tpe, Add, add);
+        operator_allowed!($tpe, Sub, sub);
+        operator_allowed!($tpe, Div, div);
+        operator_allowed!($tpe, Mul, mul);
+    }
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __diesel_generate_ops_impls_if_numeric {
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
+
+    ($column_name:ident, SmallInt) => { numeric_expr!($column_name); };
+    ($column_name:ident, Int2) => { numeric_expr!($column_name); };
+    ($column_name:ident, Smallint) => { numeric_expr!($column_name); };
+    ($column_name:ident, SmallSerial) => { numeric_expr!($column_name); };
+
+    ($column_name:ident, Integer) => { numeric_expr!($column_name); };
+    ($column_name:ident, Int4) => { numeric_expr!($column_name); };
+    ($column_name:ident, Serial) => { numeric_expr!($column_name); };
+
+    ($column_name:ident, BigInt) => { numeric_expr!($column_name); };
+    ($column_name:ident, Int8) => { numeric_expr!($column_name); };
+    ($column_name:ident, Bigint) => { numeric_expr!($column_name); };
+    ($column_name:ident, BigSerial) => { numeric_expr!($column_name); };
+
+    ($column_name:ident, Float) => { numeric_expr!($column_name); };
+    ($column_name:ident, Float4) => { numeric_expr!($column_name); };
+
+    ($column_name:ident, Double) => { numeric_expr!($column_name); };
+    ($column_name:ident, Float8) => { numeric_expr!($column_name); };
+
+    ($column_name:ident, Numeric) => { numeric_expr!($column_name); };
+
+    ($column_name:ident, $non_numeric_type:ty) => {};
+}

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -89,8 +89,6 @@ mod backend_specifics;
 
 pub use self::backend_specifics::*;
 
-numeric_expr!(users::id);
-
 #[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset)]
 #[table_name = "users"]
 pub struct NewUser {
@@ -146,8 +144,6 @@ impl FkTest {
         FkTest{ id: id, fk_id: fk_id }
     }
 }
-
-numeric_expr!(nullable_table::value);
 
 #[derive(Queryable, Insertable)]
 #[table_name="nullable_table"]


### PR DESCRIPTION
This was a much larger pain in the ass then I expected. It turns out
that capturing a token as a `ty` doesn't just prevent breaking it back
apart later, it prevents any matches against it period. So we have to
carry the ty through as a series of `tt` until the very end.

The problem is that this is impossible to do unambiguously, and we
can't even reliably get just the "common" cases since ty params use `<>`
which aren't a single token tree.

So this implementation basically does a best effort case to match the
"common" cases, and then falls back to just capturing in a `ty`
fragment afterwards. For the cases that don't match `$($x:tt)::*
$(<$($y:tt)::*>)*`, they would never be numeric anyway (we will need to
increase the nesting to 3 for the ty params once unsigned comes back
though, since `Nullable<Unsigned<Integer>>` will be a thing)

Ideally I'd like to eventually revert this, and instead be able to write
the impl with a `where Self::SqlType: types::ops::Add`, but that is
currently invalid in Rust.

Close #966.