### PR TITLE
Add support for `IS DISTINCT FROM`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* Added support for the PG `IS DISTINCT FROM` operator
+
 ### Changed
 
 * Diesel will now automatically invoke `numeric_expr!` for your columns in the

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -23,14 +23,50 @@ pub trait PgExpressionMethods: Expression + Sized {
     /// # fn main() {
     /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// let data = users.select(id).filter(name.is_not_distinct_from("Sean"));
-    /// assert_eq!(Ok(1), data.first(&connection));
+    /// let distinct = users.select(id).filter(name.is_distinct_from("Sean"));
+    /// let not_distinct = users.select(id).filter(name.is_not_distinct_from("Sean"));
+    /// assert_eq!(Ok(2), distinct.first(&connection));
+    /// assert_eq!(Ok(1), not_distinct.first(&connection));
     /// # }
+    /// ```
     fn is_not_distinct_from<T>(self, other: T)
         -> IsNotDistinctFrom<Self, T::Expression> where
             T: AsExpression<Self::SqlType>,
     {
         IsNotDistinctFrom::new(self, other.as_expression())
+    }
+
+    /// Creates a PostgreSQL `IS DISTINCT FROM` expression. This behaves
+    /// identically to the `!=` operator, except that `NULL` is treated as a
+    /// normal value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// let distinct = users.select(id).filter(name.is_distinct_from("Sean"));
+    /// let not_distinct = users.select(id).filter(name.is_not_distinct_from("Sean"));
+    /// assert_eq!(Ok(2), distinct.first(&connection));
+    /// assert_eq!(Ok(1), not_distinct.first(&connection));
+    /// # }
+    /// ```
+    fn is_distinct_from<T>(self, other: T)
+        -> IsDistinctFrom<Self, T::Expression> where
+            T: AsExpression<Self::SqlType>,
+    {
+        IsDistinctFrom::new(self, other.as_expression())
     }
 }
 

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,5 +1,6 @@
 use pg::Pg;
 
+diesel_infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
 diesel_infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
 diesel_infix_operator!(OverlapsWith, " && ", backend: Pg);
 diesel_infix_operator!(Contains, " @> ", backend: Pg);


### PR DESCRIPTION
We support `IS NOT DISTINCT FROM`, not sure why I didn't add this one at
the same time. `IS DISTINCT FROM` is roughly the same as `(lhs != rhs OR
rhs IS NULL != lhs IS NULL)`