### PR TITLE
[WIP] Feature/infer enums

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -25,6 +25,7 @@ time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
 uuid = { version = ">=0.2.0, <0.6.0", optional = true, features = ["use_std"] }
 ipnetwork = { version = "0.12.2", optional = true }
+chashmap = "2.2"
 
 [dev-dependencies]
 cfg-if = "0.1.0"

--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -122,3 +122,24 @@ macro_rules! embed_migrations {
         }
     }
 }
+
+#[macro_export]
+macro_rules! infer_enum {
+    ($database_url: expr) => {
+        mod __diesel_infer_enum {
+            #[derive(InferEnum)]
+            #[infer_enum_options(database_url=$database_url)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_enum::*;
+    };
+
+    ($database_url: expr, $schema_name: expr) => {
+        mod __diesel_infer_enum {
+            #[derive(InferEnum)]
+            #[infer_enum_options(database_url=$database_url, schema_name=$schema_name)]
+            struct _Dummy;
+        }
+        pub use self::__diesel_infer_enum::*;
+    };
+}

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -35,6 +35,15 @@ impl Backend for Mysql {
     type BindCollector = RawBytesBindCollector<Mysql>;
     type RawValue = [u8];
     type ByteOrder = NativeEndian;
+    type MetadataLookup = ();
+}
+
+impl MetadataLookup<MysqlType> for () {
+    type MetadataIdentifier = ();
+
+    fn lookup(&self, _t: &MysqlType) -> ::result::QueryResult<()> {
+        Ok(())
+    }
 }
 
 impl TypeMetadata for Mysql {

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -112,7 +112,7 @@ impl MysqlConnection {
             self.raw_connection.prepare(sql)
         })?;
         let mut bind_collector = RawBytesBindCollector::<Mysql>::new();
-        try!(source.collect_binds(&mut bind_collector));
+        try!(source.collect_binds(&mut bind_collector, &()));
         let metadata = bind_collector.metadata;
         let binds = bind_collector.binds;
         try!(stmt.bind(metadata.into_iter().zip(binds)));

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -7,13 +7,13 @@ use std::io::Write;
 use types::{ToSql, IsNull, FromSql, HasSqlType};
 
 impl ToSql<::types::Bool, Mysql> for bool {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<StdError+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<StdError+Send+Sync>> {
         let int_value = if *self {
             1
         } else {
             0
         };
-        <i32 as ToSql<::types::Integer, Mysql>>::to_sql(&int_value, out)
+        <i32 as ToSql<::types::Integer, Mysql>>::to_sql(&int_value, out, lookup)
     }
 }
 

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -8,9 +8,22 @@ use super::query_builder::PgQueryBuilder;
 pub struct Pg;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub struct PgTypeMetadata {
-    pub oid: u32,
-    pub array_oid: u32,
+pub enum IsArray {
+    Yes,
+    No,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum PgTypeMetadata {
+    Static {
+        oid: u32,
+        array_oid: u32,
+    },
+    Dynamic {
+        schema: &'static str,
+        typename: &'static str,
+        as_array: IsArray,
+    },
 }
 
 impl Backend for Pg {

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -31,6 +31,7 @@ impl Backend for Pg {
     type BindCollector = RawBytesBindCollector<Pg>;
     type RawValue = [u8];
     type ByteOrder = NetworkEndian;
+    type MetadataLookup = super::connection::PgConnection;
 }
 
 impl TypeMetadata for Pg {

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -26,12 +26,31 @@ pub enum PgTypeMetadata {
     },
 }
 
+#[allow(missing_debug_implementations)]
+pub struct PgMetadataLookup {
+    c: super::connection::PgConnection,
+}
+
+impl PgMetadataLookup {
+    pub(super) fn new(conn: &super::connection::PgConnection) -> &Self {
+        unsafe{ ::std::mem::transmute(conn) }
+    }
+}
+
+impl MetadataLookup<PgTypeMetadata> for PgMetadataLookup {
+    type MetadataIdentifier = u32;
+
+    fn lookup(&self, t: &PgTypeMetadata) -> ::result::QueryResult<u32> {
+        self.c.lookup(t)
+    }
+}
+
 impl Backend for Pg {
     type QueryBuilder = PgQueryBuilder;
     type BindCollector = RawBytesBindCollector<Pg>;
     type RawValue = [u8];
     type ByteOrder = NetworkEndian;
-    type MetadataLookup = super::connection::PgConnection;
+    type MetadataLookup = PgMetadataLookup;
 }
 
 impl TypeMetadata for Pg {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -1,3 +1,4 @@
+extern crate chashmap;
 mod cursor;
 pub mod raw;
 mod row;
@@ -7,9 +8,15 @@ mod stmt;
 
 use std::ffi::{CString, CStr};
 use std::os::raw as libc;
+use std::ops::Deref;
 
+use expression_methods::global_expression_methods::ExpressionMethods;
+use expression_methods::bool_expression_methods::BoolExpressionMethods;
+use query_dsl::select_dsl::SelectDsl;
+use query_dsl::filter_dsl::FilterDsl;
+use query_dsl::load_dsl::LoadDsl;
 use connection::*;
-use pg::Pg;
+use pg::{Pg, PgTypeMetadata, IsArray};
 use query_builder::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use query_source::Queryable;
@@ -19,6 +26,24 @@ use self::raw::RawConnection;
 use self::result::PgResult;
 use self::stmt::Statement;
 use types::HasSqlType;
+use self::chashmap::CHashMap;
+
+table! {
+    pg_type(oid) {
+        typname -> Text,
+        oid -> Oid,
+        typarray -> Oid,
+        typnamespace -> Oid,
+        typtype -> Text,
+    }
+}
+
+table! {
+    pg_catalog.pg_namespace(oid) {
+        oid -> Oid,
+        nspname -> Text,
+    }
+}
 
 /// The connection string expected by `PgConnection::establish`
 /// should be a PostgreSQL connection string, as documented at
@@ -28,6 +53,7 @@ pub struct PgConnection {
     raw_connection: RawConnection,
     transaction_manager: AnsiTransactionManager,
     statement_cache: StatementCache<Pg, Statement>,
+    type_cache: CHashMap<(&'static str, &'static str, IsArray), u32>,
 }
 
 unsafe impl Send for PgConnection {}
@@ -53,6 +79,7 @@ impl Connection for PgConnection {
                 raw_connection: raw_conn,
                 transaction_manager: AnsiTransactionManager::new(),
                 statement_cache: StatementCache::new(),
+                type_cache: Default::default(),
             }
         })
     }
@@ -122,7 +149,7 @@ impl PgConnection {
                 None
             };
             Statement::prepare(
-                &self.raw_connection,
+                self,
                 sql,
                 query_name.as_ref().map(|s| &**s),
                 &metadata,
@@ -133,8 +160,50 @@ impl PgConnection {
     }
 
     fn execute_inner(&self, query: &str) -> QueryResult<PgResult> {
-        let query = try!(Statement::prepare(&self.raw_connection, query, None, &[]));
+        let query = try!(Statement::prepare(self, query, None, &[]));
         query.execute(&self.raw_connection, &Vec::new())
+    }
+
+    pub fn lookup(&self, t: &PgTypeMetadata) -> QueryResult<u32> {
+        use self::pg_type::dsl::{pg_type, typname, typtype, typnamespace,
+                                 oid as pg_type_oid, typarray};
+        use self::pg_namespace::dsl::{pg_namespace, oid as pg_namespace_oid, nspname};
+        match *t {
+            PgTypeMetadata::Static { oid, .. } => return Ok(oid),
+            PgTypeMetadata::Dynamic { schema, typename, as_array } => {
+                if let Some(ref oid) =
+                    self.type_cache.get(&(schema, typename, as_array)) {
+                    return Ok(*(oid.deref()));
+                    }
+                let q: Option<u32> = if IsArray::No == as_array {
+                    pg_type.filter(typtype.eq("e")
+                                   .and(typname.eq(typename))
+                                   .and(typnamespace.eq_any(
+                                       pg_namespace.select(pg_namespace_oid)
+                                           .filter(nspname.eq(schema))
+                                   )))
+                        .select(pg_type_oid)
+                        .first(self)
+                        .optional()?
+                } else {
+                    pg_type.filter(typtype.eq("e")
+                                   .and(typname.eq(typename))
+                                   .and(typnamespace.eq_any(
+                                       pg_namespace.select(pg_namespace_oid)
+                                           .filter(nspname.eq(schema))
+                                   )))
+                        .select(typarray)
+                        .first(self)
+                        .optional()?
+                };
+                if let Some(res) = q{
+                    self.type_cache.insert((schema, typename, as_array),
+                                           res);
+                    return Ok(res);
+                }
+                panic!()
+            }
+        }
     }
 }
 

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -5,6 +5,7 @@ use std::os::raw as libc;
 use std::ptr;
 
 use pg::PgTypeMetadata;
+use backend::MetadataLookup;
 use super::result::PgResult;
 use super::PgConnection;
 use result::QueryResult;

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -5,7 +5,6 @@ use std::os::raw as libc;
 use std::ptr;
 
 use pg::PgTypeMetadata;
-use backend::MetadataLookup;
 use super::result::PgResult;
 use super::PgConnection;
 use result::QueryResult;

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -6,7 +6,7 @@ mod connection;
 pub mod types;
 pub mod upsert;
 
-pub use self::backend::{Pg, PgTypeMetadata, IsArray};
+pub use self::backend::{Pg, PgTypeMetadata, IsArray, PgMetadataLookup};
 pub use self::connection::PgConnection;
 pub use self::query_builder::PgQueryBuilder;
 

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -6,7 +6,7 @@ mod connection;
 pub mod types;
 pub mod upsert;
 
-pub use self::backend::{Pg, PgTypeMetadata};
+pub use self::backend::{Pg, PgTypeMetadata, IsArray};
 pub use self::connection::PgConnection;
 pub use self::query_builder::PgQueryBuilder;
 

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::io::Write;
 
 use backend::{Debug, MetadataLookup};
-use pg::{Pg, PgTypeMetadata, IsArray, PgConnection};
+use pg::{Pg, PgTypeMetadata, IsArray, PgMetadataLookup};
 use query_source::Queryable;
 use types::*;
 
@@ -134,7 +134,7 @@ impl<'a, ST, T> ToSql<Array<ST>, Pg> for &'a [T] where
     Pg: HasSqlType<ST>,
     T: ToSql<ST, Pg>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         let oid = try!(lookup.lookup(&Pg::metadata()));
         let num_dimensions = 1;
         try!(out.write_i32::<NetworkEndian>(num_dimensions));
@@ -166,7 +166,7 @@ impl<'a, ST, T> ToSql<Nullable<Array<ST>>, Pg> for &'a [T] where
     Pg: HasSqlType<ST>,
     &'a [T]: ToSql<Array<ST>, Pg>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<Array<ST>, Pg>::to_sql(self, out, lookup)
     }
 }
@@ -176,7 +176,7 @@ impl<ST, T> ToSql<Array<ST>, Pg> for Vec<T> where
     for<'a> &'a [T]: ToSql<Array<ST>, Pg>,
     T: fmt::Debug,
 {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         (self as &[T]).to_sql(out, lookup)
     }
 }
@@ -185,7 +185,7 @@ impl<ST, T> ToSql<Nullable<Array<ST>>, Pg> for Vec<T> where
     Pg: HasSqlType<ST>,
     Vec<T>: ToSql<Array<ST>, Pg>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<Array<ST>, Pg>::to_sql(self, out, lookup)
     }
 }

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -82,7 +82,7 @@ use types::HasSqlType;
 
 impl HasSqlType<types::Date> for Pg {
     fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata {
+        PgTypeMetadata::Static {
             oid: 1082,
             array_oid: 1182,
         }
@@ -91,7 +91,7 @@ impl HasSqlType<types::Date> for Pg {
 
 impl HasSqlType<types::Time> for Pg {
     fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata {
+        PgTypeMetadata::Static {
             oid: 1083,
             array_oid: 1183,
         }
@@ -100,7 +100,7 @@ impl HasSqlType<types::Time> for Pg {
 
 impl HasSqlType<types::Timestamp> for Pg {
     fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata {
+        PgTypeMetadata::Static {
             oid: 1114,
             array_oid: 1115,
         }

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::Write;
 use std::ops::Add;
 
-use pg::{Pg, PgTypeMetadata, PgConnection};
+use pg::{Pg, PgTypeMetadata, PgMetadataLookup};
 use types::{self, FromSql, ToSql, IsNull};
 
 primitive_impls!(Timestamptz -> (pg: (1184, 1185)));
@@ -108,7 +108,7 @@ impl HasSqlType<types::Timestamp> for Pg {
 }
 
 impl ToSql<types::Timestamp, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::BigInt, Pg>::to_sql(&self.0, out, lookup)
     }
 }
@@ -121,7 +121,7 @@ impl FromSql<types::Timestamp, Pg> for PgTimestamp {
 }
 
 impl ToSql<types::Timestamptz, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::Timestamp, Pg>::to_sql(self, out, lookup)
     }
 }
@@ -133,7 +133,7 @@ impl FromSql<types::Timestamptz, Pg> for PgTimestamp {
 }
 
 impl ToSql<types::Date, Pg> for PgDate {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::Integer, Pg>::to_sql(&self.0, out, lookup)
     }
 }
@@ -146,7 +146,7 @@ impl FromSql<types::Date, Pg> for PgDate {
 }
 
 impl ToSql<types::Time, Pg> for PgTime {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::BigInt, Pg>::to_sql(&self.0, out, lookup)
     }
 }
@@ -159,7 +159,7 @@ impl FromSql<types::Time, Pg> for PgTime {
 }
 
 impl ToSql<types::Interval, Pg> for PgInterval {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         try!(ToSql::<types::BigInt, Pg>::to_sql(&self.microseconds, out, lookup));
         try!(ToSql::<types::Integer, Pg>::to_sql(&self.days, out, lookup));
         try!(ToSql::<types::Integer, Pg>::to_sql(&self.months, out, lookup));

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::Write;
 use std::ops::Add;
 
-use pg::{Pg, PgTypeMetadata};
+use pg::{Pg, PgTypeMetadata, PgConnection};
 use types::{self, FromSql, ToSql, IsNull};
 
 primitive_impls!(Timestamptz -> (pg: (1184, 1185)));
@@ -108,8 +108,8 @@ impl HasSqlType<types::Timestamp> for Pg {
 }
 
 impl ToSql<types::Timestamp, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        ToSql::<types::BigInt, Pg>::to_sql(&self.0, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::BigInt, Pg>::to_sql(&self.0, out, lookup)
     }
 }
 
@@ -121,8 +121,8 @@ impl FromSql<types::Timestamp, Pg> for PgTimestamp {
 }
 
 impl ToSql<types::Timestamptz, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        ToSql::<types::Timestamp, Pg>::to_sql(self, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::Timestamp, Pg>::to_sql(self, out, lookup)
     }
 }
 
@@ -133,8 +133,8 @@ impl FromSql<types::Timestamptz, Pg> for PgTimestamp {
 }
 
 impl ToSql<types::Date, Pg> for PgDate {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        ToSql::<types::Integer, Pg>::to_sql(&self.0, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::Integer, Pg>::to_sql(&self.0, out, lookup)
     }
 }
 
@@ -146,8 +146,8 @@ impl FromSql<types::Date, Pg> for PgDate {
 }
 
 impl ToSql<types::Time, Pg> for PgTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        ToSql::<types::BigInt, Pg>::to_sql(&self.0, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::BigInt, Pg>::to_sql(&self.0, out, lookup)
     }
 }
 
@@ -159,10 +159,10 @@ impl FromSql<types::Time, Pg> for PgTime {
 }
 
 impl ToSql<types::Interval, Pg> for PgInterval {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        try!(ToSql::<types::BigInt, Pg>::to_sql(&self.microseconds, out));
-        try!(ToSql::<types::Integer, Pg>::to_sql(&self.days, out));
-        try!(ToSql::<types::Integer, Pg>::to_sql(&self.months, out));
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+        try!(ToSql::<types::BigInt, Pg>::to_sql(&self.microseconds, out, lookup));
+        try!(ToSql::<types::Integer, Pg>::to_sql(&self.days, out, lookup));
+        try!(ToSql::<types::Integer, Pg>::to_sql(&self.months, out, lookup));
         Ok(IsNull::No)
     }
 }

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use pg::Pg;
+use pg::{Pg, PgConnection};
 use types::{self, ToSql, FromSql, IsNull};
 
 expression_impls! {
@@ -19,7 +19,7 @@ fn pg_epoch() -> SystemTime {
 }
 
 impl ToSql<types::Timestamp, Pg> for SystemTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
         let (before_epoch, duration) = match self.duration_since(pg_epoch()) {
             Ok(duration) => (false, duration),
             Err(time_err) => (true, time_err.duration()),
@@ -29,7 +29,7 @@ impl ToSql<types::Timestamp, Pg> for SystemTime {
         } else {
             duration_to_usecs(duration) as i64
         };
-        ToSql::<types::BigInt, Pg>::to_sql(&time_since_epoch, out)
+        ToSql::<types::BigInt, Pg>::to_sql(&time_since_epoch, out, lookup)
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use pg::{Pg, PgConnection};
+use pg::{Pg, PgMetadataLookup};
 use types::{self, ToSql, FromSql, IsNull};
 
 expression_impls! {
@@ -19,7 +19,7 @@ fn pg_epoch() -> SystemTime {
 }
 
 impl ToSql<types::Timestamp, Pg> for SystemTime {
-    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         let (before_epoch, duration) = match self.duration_since(pg_epoch()) {
             Ok(duration) => (false, duration),
             Err(time_err) => (true, time_err.duration()),

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -2,7 +2,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 use std::error::Error;
 use std::io::prelude::*;
 
-use pg::{Pg, PgConnection};
+use pg::{Pg, PgMetadataLookup};
 use types::{self, IsNull, FromSql, ToSql};
 
 #[cfg(feature = "quickcheck")]
@@ -68,7 +68,7 @@ impl FromSql<types::Numeric, Pg> for PgNumeric {
 }
 
 impl ToSql<types::Numeric, Pg> for PgNumeric {
-    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         let sign = match *self {
             PgNumeric::Positive { .. } => 0,
             PgNumeric::Negative { .. } => 0x4000,

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -2,7 +2,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 use std::error::Error;
 use std::io::prelude::*;
 
-use pg::Pg;
+use pg::{Pg, PgConnection};
 use types::{self, IsNull, FromSql, ToSql};
 
 #[cfg(feature = "quickcheck")]
@@ -68,7 +68,7 @@ impl FromSql<types::Numeric, Pg> for PgNumeric {
 }
 
 impl ToSql<types::Numeric, Pg> for PgNumeric {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
         let sign = match *self {
             PgNumeric::Positive { .. } => 0,
             PgNumeric::Negative { .. } => 0x4000,

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -2,7 +2,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 use std::error::Error;
 use std::io::prelude::*;
 
-use pg::Pg;
+use pg::{Pg, PgConnection};
 use types::{self, ToSql, IsNull, FromSql};
 
 primitive_impls!(Oid -> (u32, pg: (26, 1018)));
@@ -15,7 +15,7 @@ impl FromSql<types::Oid, Pg> for u32 {
 }
 
 impl ToSql<types::Oid, Pg> for u32 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_u32::<NetworkEndian>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -2,7 +2,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 use std::error::Error;
 use std::io::prelude::*;
 
-use pg::{Pg, PgConnection};
+use pg::{Pg, PgMetadataLookup};
 use types::{self, ToSql, IsNull, FromSql};
 
 primitive_impls!(Oid -> (u32, pg: (26, 1018)));
@@ -15,7 +15,7 @@ impl FromSql<types::Oid, Pg> for u32 {
 }
 
 impl ToSql<types::Oid, Pg> for u32 {
-    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_u32::<NetworkEndian>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -19,7 +19,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PgMoney(pub i64);
 
-use pg::{Pg, PgConnection};
+use pg::{Pg, PgMetadataLookup};
 use types::{self, ToSql, IsNull, FromSql};
 
 // https://github.com/postgres/postgres/blob/502a3832cc54c7115dacb8a2dae06f0620995ac6/src/include/catalog/pg_type.h#L429-L432
@@ -33,7 +33,7 @@ impl FromSql<types::Money, Pg> for PgMoney {
 }
 
 impl ToSql<types::Money, Pg> for PgMoney {
-    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgMetadataLookup) -> Result<IsNull, Box<Error + Send + Sync>> {
         out.write_i64::<NetworkEndian>(self.0)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -19,7 +19,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PgMoney(pub i64);
 
-use pg::Pg;
+use pg::{Pg, PgConnection};
 use types::{self, ToSql, IsNull, FromSql};
 
 // https://github.com/postgres/postgres/blob/502a3832cc54c7115dacb8a2dae06f0620995ac6/src/include/catalog/pg_type.h#L429-L432
@@ -33,7 +33,7 @@ impl FromSql<types::Money, Pg> for PgMoney {
 }
 
 impl ToSql<types::Money, Pg> for PgMoney {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error + Send + Sync>> {
         out.write_i64::<NetworkEndian>(self.0)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -1,7 +1,7 @@
 use std::io::prelude::*;
 use std::error::Error;
 
-use pg::{Pg, PgConnection};
+use pg::{Pg, PgMetadataLookup};
 use pg::data_types::PgNumeric;
 use types::{self, ToSql, IsNull, FromSql};
 
@@ -17,7 +17,7 @@ impl FromSql<types::Bool, Pg> for bool {
 }
 
 impl ToSql<types::Bool, Pg> for bool {
-    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         let write_result = if *self {
             out.write_all(&[1])
         } else {

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -1,7 +1,7 @@
 use std::io::prelude::*;
 use std::error::Error;
 
-use pg::Pg;
+use pg::{Pg, PgConnection};
 use pg::data_types::PgNumeric;
 use types::{self, ToSql, IsNull, FromSql};
 
@@ -17,7 +17,7 @@ impl FromSql<types::Bool, Pg> for bool {
 }
 
 impl ToSql<types::Bool, Pg> for bool {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
         let write_result = if *self {
             out.write_all(&[1])
         } else {

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -87,8 +87,8 @@ pub trait QueryFragment<DB: Backend> {
         self.walk_ast(AstPass::to_sql(out))
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        self.walk_ast(AstPass::collect_binds(out))
+    fn collect_binds(&self, out: &mut DB::BindCollector, lookup: &DB::MetadataLookup) -> QueryResult<()> {
+        self.walk_ast(AstPass::collect_binds(out, lookup))
     }
 
     fn is_safe_to_cache_prepared(&self) -> QueryResult<bool> {

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -25,6 +25,15 @@ impl Backend for Sqlite {
     type BindCollector = RawBytesBindCollector<Sqlite>;
     type RawValue = SqliteValue;
     type ByteOrder = NativeEndian;
+    type MetadataLookup = ();
+}
+
+impl MetadataLookup<SqliteType> for () {
+    type MetadataIdentifier = ();
+
+    fn lookup(&self, _t: &SqliteType) -> ::result::QueryResult<()> {
+        Ok(())
+    }
 }
 
 impl TypeMetadata for Sqlite {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -104,7 +104,7 @@ impl SqliteConnection {
         let mut statement = try!(self.cached_prepared_statement(source));
 
         let mut bind_collector = RawBytesBindCollector::<Sqlite>::new();
-        try!(source.collect_binds(&mut bind_collector));
+        try!(source.collect_binds(&mut bind_collector, &()));
         let metadata = bind_collector.metadata;
         let binds = bind_collector.binds;
         for (tpe, value) in metadata.into_iter().zip(binds) {

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -48,14 +48,14 @@ impl FromSql<types::Date, Sqlite> for String {
 }
 
 impl<'a> ToSql<types::Date, Sqlite> for &'a str {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        ToSql::<types::Text, Sqlite>::to_sql(self, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::Text, Sqlite>::to_sql(self, out, lookup)
     }
 }
 
 impl ToSql<types::Date, Sqlite> for String {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        <&str as ToSql<types::Date, Sqlite>>::to_sql(&&**self, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
+        <&str as ToSql<types::Date, Sqlite>>::to_sql(&&**self, out, lookup)
     }
 }
 
@@ -66,14 +66,14 @@ impl FromSql<types::Time, Sqlite> for String {
 }
 
 impl<'a> ToSql<types::Time, Sqlite> for &'a str {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        ToSql::<types::Text, Sqlite>::to_sql(self, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::Text, Sqlite>::to_sql(self, out, lookup)
     }
 }
 
 impl ToSql<types::Time, Sqlite> for String {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        <&str as ToSql<types::Time, Sqlite>>::to_sql(&&**self, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
+        <&str as ToSql<types::Time, Sqlite>>::to_sql(&&**self, out, lookup)
     }
 }
 
@@ -84,13 +84,13 @@ impl FromSql<types::Timestamp, Sqlite> for String {
 }
 
 impl<'a> ToSql<types::Timestamp, Sqlite> for &'a str {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        ToSql::<types::Text, Sqlite>::to_sql(self, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
+        ToSql::<types::Text, Sqlite>::to_sql(self, out, lookup)
     }
 }
 
 impl ToSql<types::Timestamp, Sqlite> for String {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        <&str as ToSql<types::Timestamp, Sqlite>>::to_sql(&&**self, out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
+        <&str as ToSql<types::Timestamp, Sqlite>>::to_sql(&&**self, out, lookup)
     }
 }

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -58,12 +58,12 @@ impl FromSql<types::Double, Sqlite> for f64 {
 }
 
 impl ToSql<types::Bool, Sqlite> for bool {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
         let int_value = if *self {
             1
         } else {
             0
         };
-        <i32 as ToSql<types::Integer, Sqlite>>::to_sql(&int_value, out)
+        <i32 as ToSql<types::Integer, Sqlite>>::to_sql(&int_value, out, lookup)
     }
 }

--- a/diesel/src/types/impls/debug.rs
+++ b/diesel/src/types/impls/debug.rs
@@ -8,7 +8,7 @@ use types::*;
 macro_rules! debug_to_sql {
     ($sql_type:ty, $ty:ty) => {
         impl ToSql<$sql_type, Debug> for $ty {
-            fn to_sql<W: Write>(&self, _: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+            fn to_sql<W: Write>(&self, _: &mut W, _: &()) -> Result<IsNull, Box<Error+Send+Sync>> {
                 Ok(IsNull::No)
             }
         }

--- a/diesel/src/types/impls/floats.rs
+++ b/diesel/src/types/impls/floats.rs
@@ -15,7 +15,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Float, DB> for f32 {
 }
 
 impl<DB: Backend> ToSql<types::Float, DB> for f32 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_f32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -32,7 +32,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Double, DB> for f64 {
 }
 
 impl<DB: Backend> ToSql<types::Double, DB> for f64 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_f64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)

--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -18,7 +18,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
 }
 
 impl<DB: Backend> ToSql<types::SmallInt, DB> for i16 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_i16::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -37,7 +37,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Integer, DB> for i32 {
 }
 
 impl<DB: Backend> ToSql<types::Integer, DB> for i32 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_i32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -56,7 +56,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::BigInt, DB> for i64 {
 }
 
 impl<DB: Backend> ToSql<types::BigInt, DB> for i64 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, _: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_i64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -116,7 +116,7 @@ macro_rules! primitive_impls {
         #[cfg(feature = "postgres")]
         impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::pg::Pg {
             fn metadata() -> $crate::pg::PgTypeMetadata {
-                $crate::pg::PgTypeMetadata {
+                $crate::pg::PgTypeMetadata::Static {
                     oid: $oid,
                     array_oid: $array_oid,
                 }

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -50,8 +50,8 @@ macro_rules! expression_impls {
                 DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
                 $Target: $crate::types::ToSql<$crate::types::$Source, DB>,
             {
-                fn to_sql<W: ::std::io::Write>(&self, out: &mut W) -> Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
-                    $crate::types::ToSql::<$crate::types::$Source, DB>::to_sql(self, out)
+                fn to_sql<W: ::std::io::Write>(&self, out: &mut W, lookup: &DB::MetadataLookup) -> Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
+                    $crate::types::ToSql::<$crate::types::$Source, DB>::to_sql(self, out, lookup)
                 }
             }
         )+

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -61,9 +61,9 @@ impl<T, ST, DB> ToSql<Nullable<ST>, DB> for Option<T> where
     DB: Backend + HasSqlType<ST>,
     ST: NotNull,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
         if let Some(ref value) = *self {
-            value.to_sql(out)
+            value.to_sql(out, lookup)
         } else {
             Ok(IsNull::Yes)
         }

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -321,14 +321,14 @@ pub enum IsNull {
 /// included as a bind parameter, and is expected to be the binary format, not
 /// text.
 pub trait ToSql<A, DB: Backend + HasSqlType<A>>: fmt::Debug {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>>;
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>>;
 }
 
 impl<'a, A, T, DB> ToSql<A, DB> for &'a T where
     DB: Backend + HasSqlType<A>,
     T: ToSql<A, DB>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-        (*self).to_sql(out)
+    fn to_sql<W: Write>(&self, out: &mut W, lookup: &DB::MetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
+        (*self).to_sql(out, lookup)
     }
 }

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -90,7 +90,16 @@ pub fn build_cli() -> App<'static, 'static> {
              .help("Use table list as blacklist")
              .conflicts_with("whitelist"));
 
-    App::new("diesel")
+    let infer_enums = SubCommand::with_name("print-enums")
+        .setting(AppSettings::VersionlessSubcommands)
+        .about("Print enum definitions for database enum.")
+        .arg(Arg::with_name("schema")
+             .long("schema")
+             .short("s")
+             .takes_value(true)
+             .help("The name of the schema."));
+
+    let mut diesel = App::new("diesel")
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::VersionlessSubcommands)
         .after_help("You can also run `diesel SUBCOMMAND -h` to get more information about that subcommand.")
@@ -100,7 +109,11 @@ pub fn build_cli() -> App<'static, 'static> {
         .subcommand(database_subcommand)
         .subcommand(generate_bash_completion_subcommand)
         .subcommand(infer_schema_subcommand)
-        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .setting(AppSettings::SubcommandRequiredElseHelp);
+    if cfg!(feature="postgres"){
+        diesel = diesel.subcommand(infer_enums);
+    }
+    diesel
 }
 
 fn migration_dir_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -88,6 +88,12 @@ pub fn derive_infer_table_from_schema(input: TokenStream) -> TokenStream {
     expand_derive(input, schema_inference::derive_infer_table_from_schema)
 }
 
+#[proc_macro_derive(InferEnum, attributes(infer_enum_options))]
+#[cfg(all(feature = "diesel_infer_schema", feature = "postgres"))]
+pub fn derive_infer_enum(input: TokenStream) -> TokenStream {
+    expand_derive(input, schema_inference::derive_infer_enum)
+}
+
 #[proc_macro_derive(EmbedMigrations, attributes(embed_migrations_options))]
 pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
     expand_derive(input, embed_migrations::derive_embed_migrations)

--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -160,14 +160,17 @@ pub fn expand_enum(enum_info: EnumInformation, mode: ExpandEnumMode) -> quote::T
 
     let to_sql = quote!{
         impl ToSql<Nullable<#sql_type_name>, Pg> for #type_name {
-            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
-                ToSql::<MoodSql, Pg>::to_sql(self, out)
+            fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+                ToSql::<MoodSql, Pg>::to_sql(self, out, lookup)
             }
         }
+    };
+    let to_sql = quote!{
+        #to_sql
 
         impl ToSql<#sql_type_name, Pg> for #type_name {
-            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
-                ToSql::<Text, Pg>::to_sql(&String::from(self), out)
+            fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error + Send + Sync>> {
+                ToSql::<Text, Pg>::to_sql(&String::from(self), out, lookup)
             }
 }
     };
@@ -218,7 +221,7 @@ pub fn expand_enum(enum_info: EnumInformation, mode: ExpandEnumMode) -> quote::T
         #map_names
     };
     let diesel_imports = quote!{
-        use diesel::pg::{PgTypeMetadata, Pg, IsArray};
+        use diesel::pg::{PgTypeMetadata, Pg, IsArray, PgConnection};
         use diesel::types::{HasSqlType, NotNull, IsNull};
         use diesel::types::{FromSql, FromSqlRow, ToSql};
         use diesel::types::{Nullable, Text};

--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -4,9 +4,253 @@ use quote;
 use syn;
 
 use table_data::TableData;
-use data_structures::ColumnInformation;
+use data_structures::{ColumnInformation, EnumInformation};
 use inference::{establish_connection, get_table_data, determine_column_type, get_primary_keys,
                 InferConnection};
+
+pub fn wrap_item_in_const(const_name: syn::Ident, item: quote::Tokens) -> quote::Tokens {
+    quote! {
+        #[allow(dead_code)]
+        const #const_name: () = {
+            extern crate diesel;
+            #item
+        };
+    }
+}
+
+fn to_uppercase(ty: String) -> String {
+    let mut ret = String::with_capacity(ty.len());
+    let mut next_uppercase = true;
+    for c in ty.chars() {
+        if c == '_' {
+            next_uppercase = true;
+            continue;
+        }
+        if next_uppercase {
+            ret += &c.to_uppercase().to_string();
+        } else {
+            ret.push(c);
+        }
+        next_uppercase = false;
+    }
+    ret
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ExpandEnumMode {
+    PrettyPrint,
+    Codegen,
+}
+
+pub fn expand_enum(enum_info: EnumInformation, mode: ExpandEnumMode) -> quote::Tokens {
+    let EnumInformation{type_name, fields, oid, array_oid} = enum_info;
+    let sql_mod = syn::Ident::new(format!("sql_{}", type_name));
+    let sql_type_name = syn::Ident::new(to_uppercase(format!("{}Sql", type_name)));
+    let type_name = syn::Ident::new(to_uppercase(type_name));
+
+    let field_mapping = fields.clone().into_iter().map(|field| {
+        let ident = syn::Ident::new(to_uppercase(field.clone()));
+        quote!(#field => #type_name::#ident)
+    }).collect::<Vec<_>>();
+    let reverse_mapping = fields.clone().into_iter().map(|field| {
+        let ident = syn::Ident::new(to_uppercase(field.clone()));
+        quote!(#type_name::#ident => #field)
+    }).collect::<Vec<_>>();
+
+    let fields = fields.into_iter().map(|field|{
+        syn::Ident::new(to_uppercase(field))
+    });
+
+        let map_names = {
+        let from_1 = {
+            let field_mapping = field_mapping.clone();
+            quote! {
+                impl<'a> From<&'a str> for #type_name {
+                    fn from(s: &'a str) -> Self {
+                        match s {
+                            #(#field_mapping,)*
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+        };
+        quote!{
+            #from_1
+            impl From<String> for #type_name {
+                fn from(s: String) -> Self {
+                    match s.as_str() {
+                        #(#field_mapping,)*
+                        _ => unreachable!(),
+                    }
+                }
+            }
+            impl<'a> From<&'a #type_name> for String {
+                fn from(t: &'a #type_name) -> Self {
+                    match *t {
+                        #(#reverse_mapping,)*
+                    }.into()
+                }
+            }
+        }
+    };
+
+    let metadata = quote!{
+        impl HasSqlType<#sql_type_name> for Debug {
+            fn metadata() {}
+        }
+
+        impl HasSqlType<#sql_type_name> for Pg {
+            fn metadata() -> PgTypeMetadata {
+                PgTypeMetadata {
+                    oid: #oid,
+                    array_oid: #array_oid,
+                }
+            }
+        }
+        impl NotNull for #sql_type_name {}
+
+        impl QueryId for #sql_type_name {
+            type QueryId = Self;
+
+            fn has_static_query_id() -> bool {
+                true
+            }
+        }
+    };
+
+    let expressions = quote!{
+        impl<'a> AsExpression<#sql_type_name> for #type_name {
+            type Expression = Bound<#sql_type_name, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl<'a, 'expr> AsExpression<#sql_type_name> for &'expr #type_name {
+            type Expression = Bound<#sql_type_name, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+    };
+
+    let expressions = quote!{
+        #expressions
+
+        impl<'a> AsExpression<Nullable<#sql_type_name>> for #type_name {
+            type Expression = Bound<Nullable<#sql_type_name>, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl<'a, 'expr> AsExpression<Nullable<#sql_type_name>> for &'expr #type_name {
+            type Expression = Bound<Nullable<#sql_type_name>, Self>;
+
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+    };
+
+    let to_sql = quote!{
+        impl ToSql<Nullable<#sql_type_name>, Pg> for #type_name {
+            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+                ToSql::<MoodSql, Pg>::to_sql(self, out)
+            }
+        }
+
+        impl ToSql<#sql_type_name, Pg> for #type_name {
+            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+                ToSql::<Text, Pg>::to_sql(&String::from(self), out)
+            }
+}
+    };
+
+    let from_sql = quote! {
+        impl FromSql<#sql_type_name, Pg> for #type_name {
+            fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>>{
+                <String as FromSql<Text, Pg>>::from_sql(bytes).map(Into::into)
+            }
+        }
+        impl FromSqlRow<#sql_type_name, Pg> for #type_name {
+            fn build_from_row<R: Row<Pg>>(row: &mut R) -> Result<Self, Box<Error + Send + Sync>> {
+                FromSql::<#sql_type_name, Pg>::from_sql(row.take())
+            }
+        }
+    };
+
+    let queryable = quote!{
+        impl Queryable<#sql_type_name, Pg> for #type_name {
+            type Row = Self;
+
+            fn build(row: Self::Row) -> Self {
+                row
+            }
+        }
+    };
+    let enum_def =     quote!{
+        #[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
+        pub enum #type_name {
+            #(#fields,)*
+        }
+        #map_names
+    };
+    let diesel_imports = quote!{
+        use diesel::pg::{PgTypeMetadata, Pg};
+        use diesel::types::{HasSqlType, NotNull, IsNull};
+        use diesel::types::{FromSql, FromSqlRow, ToSql};
+        use diesel::types::{Nullable, Text};
+        use diesel::expression::AsExpression;
+    };
+    let diesel_imports = quote!{
+        #diesel_imports
+        use diesel::row::Row;
+        use diesel::query_builder::QueryId;
+        use diesel::expression::bound::Bound;
+        use diesel::Queryable;
+        use diesel::backend::Debug;
+    };
+    let sql_mod_inner = quote!(
+        #diesel_imports
+        use super::#type_name;
+        use std::error::Error;
+        use std::io::Write;
+        #metadata
+        #expressions
+        #to_sql
+        #from_sql
+        #queryable
+    );
+
+    if mode == ExpandEnumMode::PrettyPrint {
+        quote!{
+            #enum_def
+            pub mod #sql_mod {
+                pub struct #sql_type_name;
+                #sql_mod_inner
+            }
+        }
+    } else {
+        let name = syn::Ident::new(
+            format!("IMPL_ENUM_FOR_{}",
+                    type_name.as_ref().to_uppercase()));
+        let sql_mod_inner = wrap_item_in_const(name, quote!{
+            #sql_mod_inner
+        });
+        quote!{
+            #enum_def
+            pub mod #sql_mod {
+                pub struct #sql_type_name;
+                #sql_mod_inner
+            }
+        }
+    }
+}
 
 pub fn expand_infer_table_from_schema(database_url: &str, table: &TableData)
     -> Result<quote::Tokens, Box<Error>>

--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -160,7 +160,7 @@ pub fn expand_enum(enum_info: EnumInformation, mode: ExpandEnumMode) -> quote::T
 
     let to_sql = quote!{
         impl ToSql<Nullable<#sql_type_name>, Pg> for #type_name {
-            fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error+Send+Sync>> {
+            fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error+Send+Sync>> {
                 ToSql::<MoodSql, Pg>::to_sql(self, out, lookup)
             }
         }
@@ -169,7 +169,7 @@ pub fn expand_enum(enum_info: EnumInformation, mode: ExpandEnumMode) -> quote::T
         #to_sql
 
         impl ToSql<#sql_type_name, Pg> for #type_name {
-            fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgConnection) -> Result<IsNull, Box<Error + Send + Sync>> {
+            fn to_sql<W: Write>(&self, out: &mut W, lookup: &PgMetadataLookup) -> Result<IsNull, Box<Error + Send + Sync>> {
                 ToSql::<Text, Pg>::to_sql(&String::from(self), out, lookup)
             }
 }
@@ -221,7 +221,7 @@ pub fn expand_enum(enum_info: EnumInformation, mode: ExpandEnumMode) -> quote::T
         #map_names
     };
     let diesel_imports = quote!{
-        use diesel::pg::{PgTypeMetadata, Pg, IsArray, PgConnection};
+        use diesel::pg::{PgTypeMetadata, Pg, IsArray, PgMetadataLookup};
         use diesel::types::{HasSqlType, NotNull, IsNull};
         use diesel::types::{FromSql, FromSqlRow, ToSql};
         use diesel::types::{Nullable, Text};

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -11,9 +11,8 @@ use super::information_schema::UsesInformationSchema;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumInformation {
     pub type_name: String,
+    pub schema: String,
     pub fields: Vec<String>,
-    pub oid: u32,
-    pub array_oid: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -9,6 +9,14 @@ use diesel::types::{HasSqlType, FromSqlRow};
 use super::information_schema::UsesInformationSchema;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumInformation {
+    pub type_name: String,
+    pub fields: Vec<String>,
+    pub oid: u32,
+    pub array_oid: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnInformation {
     pub column_name: String,
     pub type_name: String,

--- a/diesel_infer_schema/src/lib.rs
+++ b/diesel_infer_schema/src/lib.rs
@@ -40,3 +40,6 @@ mod sqlite;
 pub use codegen::*;
 pub use inference::load_table_names;
 pub use table_data::TableData;
+
+#[cfg(feature="postgres")]
+pub use pg::load_enums;


### PR DESCRIPTION
follow up for #940 

* This will only work with postgres in the current version

This is a first draft version to get some feedback on this. 
Things to fix before merging:
- [ ] Formating
- [ ] Documentation
- [ ] Tests
- [x] Fix compiling other backends

Using an implementation similar to the shown, will restrict the produced binary to exactly the same database that was used to compile the code because the type oid's of the enums are hardcoded in `HasSqlType::metadata`. As far as I understand those oid's could/will change if you run your migrations on a other database instance, so the provided mapping will be invalid.

As far as I see there are two possible solutions:
- Document and accept the behavior 
- Add some way to query the database on startup/connect for the actual oid's and store them in some kind of static map. Then use this map to generate the metadata 

Fixes #343
