### PR TITLE
Allow lookup of OIDs at runtime

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -27,6 +27,7 @@ pub trait Backend where
 
 pub trait TypeMetadata {
     type TypeMetadata;
+    type MetadataLookup;
 }
 
 pub trait SupportsReturningClause {}
@@ -45,6 +46,7 @@ impl Backend for Debug {
 
 impl TypeMetadata for Debug {
     type TypeMetadata = ();
+    type MetadataLookup = ();
 }
 
 impl SupportsReturningClause for Debug {}

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -39,6 +39,7 @@ impl Backend for Mysql {
 
 impl TypeMetadata for Mysql {
     type TypeMetadata = MysqlType;
+    type MetadataLookup = ();
 }
 
 impl SupportsDefaultKeyword for Mysql {}

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -70,7 +70,7 @@ impl Connection for MysqlConnection {
 
         let mut stmt = try!(self.prepare_query(&source.as_query()));
         let mut metadata = Vec::new();
-        Mysql::row_metadata(&mut metadata);
+        Mysql::row_metadata(&mut metadata, &());
         let results = unsafe { stmt.results(metadata)? };
         results.map(|mut row| {
             U::Row::build_from_row(&mut row)
@@ -112,7 +112,7 @@ impl MysqlConnection {
             self.raw_connection.prepare(sql)
         })?;
         let mut bind_collector = RawBytesBindCollector::<Mysql>::new();
-        try!(source.collect_binds(&mut bind_collector));
+        try!(source.collect_binds(&mut bind_collector, &()));
         let metadata = bind_collector.metadata;
         let binds = bind_collector.binds;
         try!(stmt.bind(metadata.into_iter().zip(binds)));

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -8,12 +8,12 @@ use std::os::raw as libc;
 use std::{ptr, mem, slice};
 
 use mysql::Mysql;
-use types::{ToSql, FromSql, IsNull, Timestamp, Time, Date};
+use types::{ToSql, ToSqlOutput, FromSql, IsNull, Timestamp, Time, Date};
 
 macro_rules! mysql_time_impls {
     ($ty:ty) => {
         impl ToSql<$ty, Mysql> for ffi::MYSQL_TIME {
-            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+            fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> Result<IsNull, Box<Error+Send+Sync>> {
                 let bytes = unsafe {
                     let bytes_ptr = self as *const ffi::MYSQL_TIME as *const u8;
                     slice::from_raw_parts(bytes_ptr, mem::size_of::<ffi::MYSQL_TIME>())
@@ -46,7 +46,7 @@ mysql_time_impls!(Time);
 mysql_time_impls!(Date);
 
 impl ToSql<Timestamp, Mysql> for NaiveDateTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let mut mysql_time: ffi::MYSQL_TIME = unsafe { mem::zeroed() };
 
         mysql_time.year = self.year() as libc::c_uint;
@@ -78,7 +78,7 @@ impl FromSql<Timestamp, Mysql> for NaiveDateTime {
 }
 
 impl ToSql<Time, Mysql> for NaiveTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let mut mysql_time: ffi::MYSQL_TIME = unsafe { mem::zeroed() };
 
         mysql_time.hour = self.hour() as libc::c_uint;
@@ -101,7 +101,7 @@ impl FromSql<Time, Mysql> for NaiveTime {
 }
 
 impl ToSql<Date, Mysql> for NaiveDate {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let mut mysql_time: ffi::MYSQL_TIME = unsafe { mem::zeroed() };
 
         mysql_time.year = self.year() as libc::c_uint;

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -24,19 +24,19 @@ impl FromSql<::types::Bool, Mysql> for bool {
 }
 
 impl HasSqlType<::types::Date> for Mysql {
-    fn metadata() -> MysqlType {
+    fn metadata(_: &()) -> MysqlType {
         MysqlType::Date
     }
 }
 
 impl HasSqlType<::types::Time> for Mysql {
-    fn metadata() -> MysqlType {
+    fn metadata(_: &()) -> MysqlType {
         MysqlType::Time
     }
 }
 
 impl HasSqlType<::types::Timestamp> for Mysql {
-    fn metadata() -> MysqlType {
+    fn metadata(_: &()) -> MysqlType {
         MysqlType::Timestamp
     }
 }

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -4,10 +4,10 @@ mod date_and_time;
 use mysql::{Mysql, MysqlType};
 use std::error::Error as StdError;
 use std::io::Write;
-use types::{ToSql, IsNull, FromSql, HasSqlType};
+use types::{ToSql, ToSqlOutput, IsNull, FromSql, HasSqlType};
 
 impl ToSql<::types::Bool, Mysql> for bool {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<StdError+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> Result<IsNull, Box<StdError+Send+Sync>> {
         let int_value = if *self {
             1
         } else {

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -1,16 +1,27 @@
 use byteorder::NetworkEndian;
 
 use backend::*;
+use prelude::Queryable;
 use query_builder::bind_collector::RawBytesBindCollector;
+use super::PgMetadataLookup;
 use super::query_builder::PgQueryBuilder;
+use types::Oid;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Pg;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct PgTypeMetadata {
     pub oid: u32,
     pub array_oid: u32,
+}
+
+impl Queryable<(Oid, Oid), Pg> for PgTypeMetadata {
+    type Row = (u32, u32);
+
+    fn build((oid, array_oid): Self::Row) -> Self {
+        PgTypeMetadata { oid, array_oid }
+    }
 }
 
 impl Backend for Pg {
@@ -22,7 +33,7 @@ impl Backend for Pg {
 
 impl TypeMetadata for Pg {
     type TypeMetadata = PgTypeMetadata;
-    type MetadataLookup = ();
+    type MetadataLookup = PgMetadataLookup;
 }
 
 impl SupportsReturningClause for Pg {}

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -22,6 +22,7 @@ impl Backend for Pg {
 
 impl TypeMetadata for Pg {
     type TypeMetadata = PgTypeMetadata;
+    type MetadataLookup = ();
 }
 
 impl SupportsReturningClause for Pg {}

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -9,7 +9,7 @@ use std::ffi::{CString, CStr};
 use std::os::raw as libc;
 
 use connection::*;
-use pg::Pg;
+use pg::{Pg, PgMetadataLookup};
 use query_builder::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use query_source::Queryable;
@@ -110,7 +110,7 @@ impl PgConnection {
         -> QueryResult<(MaybeCached<Statement>, Vec<Option<Vec<u8>>>)>
     {
         let mut bind_collector = RawBytesBindCollector::<Pg>::new();
-        try!(source.collect_binds(&mut bind_collector, &()));
+        try!(source.collect_binds(&mut bind_collector, PgMetadataLookup::new(self)));
         let binds = bind_collector.binds;
         let metadata = bind_collector.metadata;
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -110,7 +110,7 @@ impl PgConnection {
         -> QueryResult<(MaybeCached<Statement>, Vec<Option<Vec<u8>>>)>
     {
         let mut bind_collector = RawBytesBindCollector::<Pg>::new();
-        try!(source.collect_binds(&mut bind_collector));
+        try!(source.collect_binds(&mut bind_collector, &()));
         let binds = bind_collector.binds;
         let metadata = bind_collector.metadata;
 

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -1,0 +1,32 @@
+use std::mem;
+
+use prelude::*;
+use super::{PgConnection, PgTypeMetadata};
+
+#[allow(missing_debug_implementations)]
+pub struct PgMetadataLookup {
+    conn: PgConnection,
+}
+
+impl PgMetadataLookup {
+    pub(crate) fn new(conn: &PgConnection) -> &Self {
+        unsafe { mem::transmute(conn) }
+    }
+
+    pub fn lookup_type(&self, type_name: &str) -> PgTypeMetadata {
+        use self::pg_type::dsl::*;
+
+        pg_type.select((oid, typarray))
+            .filter(typname.eq(type_name))
+            .first(&self.conn)
+            .unwrap_or_default()
+    }
+}
+
+table! {
+    pg_type (oid) {
+        oid -> Oid,
+        typname -> Text,
+        typarray -> Oid,
+    }
+}

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -1,6 +1,7 @@
 pub mod expression;
 
 mod backend;
+mod metadata_lookup;
 mod query_builder;
 mod connection;
 pub mod types;
@@ -8,6 +9,7 @@ pub mod upsert;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;
+pub use self::metadata_lookup::PgMetadataLookup;
 pub use self::query_builder::PgQueryBuilder;
 
 pub mod data_types {

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -122,7 +122,7 @@ impl<'a, ST, T> ToSql<Array<ST>, Pg> for &'a [T] where
     Pg: HasSqlType<ST>,
     T: ToSql<ST, Pg>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let num_dimensions = 1;
         try!(out.write_i32::<NetworkEndian>(num_dimensions));
         let flags = 0;
@@ -132,7 +132,7 @@ impl<'a, ST, T> ToSql<Array<ST>, Pg> for &'a [T] where
         let lower_bound = 1;
         try!(out.write_i32::<NetworkEndian>(lower_bound));
 
-        let mut buffer = Vec::new();
+        let mut buffer = out.with_buffer(Vec::new());
         for elem in self.iter() {
             let is_null = try!(elem.to_sql(&mut buffer));
             if let IsNull::No = is_null {
@@ -153,7 +153,7 @@ impl<'a, ST, T> ToSql<Nullable<Array<ST>>, Pg> for &'a [T] where
     Pg: HasSqlType<ST>,
     &'a [T]: ToSql<Array<ST>, Pg>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<Array<ST>, Pg>::to_sql(self, out)
     }
 }
@@ -163,7 +163,7 @@ impl<ST, T> ToSql<Array<ST>, Pg> for Vec<T> where
     for<'a> &'a [T]: ToSql<Array<ST>, Pg>,
     T: fmt::Debug,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         (self as &[T]).to_sql(out)
     }
 }
@@ -172,7 +172,7 @@ impl<ST, T> ToSql<Nullable<Array<ST>>, Pg> for Vec<T> where
     Pg: HasSqlType<ST>,
     Vec<T>: ToSql<Array<ST>, Pg>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<Array<ST>, Pg>::to_sql(self, out)
     }
 }

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -11,9 +11,9 @@ use types::*;
 impl<T> HasSqlType<Array<T>> for Pg where
     Pg: HasSqlType<T>,
 {
-    fn metadata() -> PgTypeMetadata {
+    fn metadata(lookup: &()) -> PgTypeMetadata {
         PgTypeMetadata {
-            oid: <Pg as HasSqlType<T>>::metadata().array_oid,
+            oid: <Pg as HasSqlType<T>>::metadata(lookup).array_oid,
             array_oid: 0,
         }
     }
@@ -22,7 +22,7 @@ impl<T> HasSqlType<Array<T>> for Pg where
 impl<T> HasSqlType<Array<T>> for Debug where
     Debug: HasSqlType<T>,
 {
-    fn metadata() {}
+    fn metadata(_: &()) {}
 }
 
 impl_query_id!(Array<T>);
@@ -127,7 +127,8 @@ impl<'a, ST, T> ToSql<Array<ST>, Pg> for &'a [T] where
         try!(out.write_i32::<NetworkEndian>(num_dimensions));
         let flags = 0;
         try!(out.write_i32::<NetworkEndian>(flags));
-        try!(out.write_u32::<NetworkEndian>(Pg::metadata().oid));
+        let element_oid = Pg::metadata(out.metadata_lookup()).oid;
+        try!(out.write_u32::<NetworkEndian>(element_oid));
         try!(out.write_i32::<NetworkEndian>(self.len() as i32));
         let lower_bound = 1;
         try!(out.write_i32::<NetworkEndian>(lower_bound));

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -4,14 +4,14 @@ use std::fmt;
 use std::io::Write;
 
 use backend::Debug;
-use pg::{Pg, PgTypeMetadata};
+use pg::{Pg, PgTypeMetadata, PgMetadataLookup};
 use query_source::Queryable;
 use types::*;
 
 impl<T> HasSqlType<Array<T>> for Pg where
     Pg: HasSqlType<T>,
 {
-    fn metadata(lookup: &()) -> PgTypeMetadata {
+    fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata {
             oid: <Pg as HasSqlType<T>>::metadata(lookup).array_oid,
             array_oid: 0,

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use self::time::{Timespec, Duration};
 
 use pg::Pg;
-use types::{self, ToSql, FromSql, IsNull};
+use types::{self, ToSql, ToSqlOutput, FromSql, IsNull};
 
 expression_impls! {
     Timestamp -> Timespec,
@@ -19,7 +19,7 @@ queryable_impls! {
 const TIME_SEC_CONV: i64 = 946684800;
 
 impl ToSql<types::Timestamp, Pg> for Timespec {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let pg_epoch = Timespec::new(TIME_SEC_CONV, 0);
         let duration = *self - pg_epoch;
         let t = try!(duration.num_microseconds().ok_or("Overflow error"));

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -81,7 +81,7 @@ primitive_impls!(Interval -> (PgInterval, pg: (1186, 1187)));
 use types::HasSqlType;
 
 impl HasSqlType<types::Date> for Pg {
-    fn metadata() -> PgTypeMetadata {
+    fn metadata(_: &()) -> PgTypeMetadata {
         PgTypeMetadata {
             oid: 1082,
             array_oid: 1182,
@@ -90,7 +90,7 @@ impl HasSqlType<types::Date> for Pg {
 }
 
 impl HasSqlType<types::Time> for Pg {
-    fn metadata() -> PgTypeMetadata {
+    fn metadata(_: &()) -> PgTypeMetadata {
         PgTypeMetadata {
             oid: 1083,
             array_oid: 1183,
@@ -99,7 +99,7 @@ impl HasSqlType<types::Time> for Pg {
 }
 
 impl HasSqlType<types::Timestamp> for Pg {
-    fn metadata() -> PgTypeMetadata {
+    fn metadata(_: &()) -> PgTypeMetadata {
         PgTypeMetadata {
             oid: 1114,
             array_oid: 1115,

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::ops::Add;
 
 use pg::{Pg, PgTypeMetadata};
-use types::{self, FromSql, ToSql, IsNull};
+use types::{self, FromSql, ToSql, ToSqlOutput, IsNull};
 
 primitive_impls!(Timestamptz -> (pg: (1184, 1185)));
 primitive_impls!(Timestamptz);
@@ -108,7 +108,7 @@ impl HasSqlType<types::Timestamp> for Pg {
 }
 
 impl ToSql<types::Timestamp, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::BigInt, Pg>::to_sql(&self.0, out)
     }
 }
@@ -121,7 +121,7 @@ impl FromSql<types::Timestamp, Pg> for PgTimestamp {
 }
 
 impl ToSql<types::Timestamptz, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::Timestamp, Pg>::to_sql(self, out)
     }
 }
@@ -133,7 +133,7 @@ impl FromSql<types::Timestamptz, Pg> for PgTimestamp {
 }
 
 impl ToSql<types::Date, Pg> for PgDate {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::Integer, Pg>::to_sql(&self.0, out)
     }
 }
@@ -146,7 +146,7 @@ impl FromSql<types::Date, Pg> for PgDate {
 }
 
 impl ToSql<types::Time, Pg> for PgTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::BigInt, Pg>::to_sql(&self.0, out)
     }
 }
@@ -159,7 +159,7 @@ impl FromSql<types::Time, Pg> for PgTime {
 }
 
 impl ToSql<types::Interval, Pg> for PgInterval {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         try!(ToSql::<types::BigInt, Pg>::to_sql(&self.microseconds, out));
         try!(ToSql::<types::Integer, Pg>::to_sql(&self.days, out));
         try!(ToSql::<types::Integer, Pg>::to_sql(&self.months, out));

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::Write;
 use std::ops::Add;
 
-use pg::{Pg, PgTypeMetadata};
+use pg::{Pg, PgTypeMetadata, PgMetadataLookup};
 use types::{self, FromSql, ToSql, ToSqlOutput, IsNull};
 
 primitive_impls!(Timestamptz -> (pg: (1184, 1185)));
@@ -81,7 +81,7 @@ primitive_impls!(Interval -> (PgInterval, pg: (1186, 1187)));
 use types::HasSqlType;
 
 impl HasSqlType<types::Date> for Pg {
-    fn metadata(_: &()) -> PgTypeMetadata {
+    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata {
             oid: 1082,
             array_oid: 1182,
@@ -90,7 +90,7 @@ impl HasSqlType<types::Date> for Pg {
 }
 
 impl HasSqlType<types::Time> for Pg {
-    fn metadata(_: &()) -> PgTypeMetadata {
+    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata {
             oid: 1083,
             array_oid: 1183,
@@ -99,7 +99,7 @@ impl HasSqlType<types::Time> for Pg {
 }
 
 impl HasSqlType<types::Timestamp> for Pg {
-    fn metadata(_: &()) -> PgTypeMetadata {
+    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata {
             oid: 1114,
             array_oid: 1115,

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use pg::Pg;
-use types::{self, ToSql, FromSql, IsNull};
+use types::{self, ToSql, ToSqlOutput, FromSql, IsNull};
 
 expression_impls! {
     Timestamp -> SystemTime,
@@ -19,7 +19,7 @@ fn pg_epoch() -> SystemTime {
 }
 
 impl ToSql<types::Timestamp, Pg> for SystemTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let (before_epoch, duration) = match self.duration_since(pg_epoch()) {
             Ok(duration) => (false, duration),
             Err(time_err) => (true, time_err.duration()),

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::io::prelude::*;
 
 use pg::Pg;
-use types::{self, IsNull, FromSql, ToSql};
+use types::{self, IsNull, FromSql, ToSql, ToSqlOutput};
 
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
@@ -68,7 +68,7 @@ impl FromSql<types::Numeric, Pg> for PgNumeric {
 }
 
 impl ToSql<types::Numeric, Pg> for PgNumeric {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let sign = match *self {
             PgNumeric::Positive { .. } => 0,
             PgNumeric::Negative { .. } => 0x4000,

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::io::prelude::*;
 
 use pg::Pg;
-use types::{self, ToSql, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
 
 primitive_impls!(Oid -> (u32, pg: (26, 1018)));
 
@@ -15,7 +15,7 @@ impl FromSql<types::Oid, Pg> for u32 {
 }
 
 impl ToSql<types::Oid, Pg> for u32 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_u32::<NetworkEndian>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -24,7 +24,7 @@ impl ToSql<types::Oid, Pg> for u32 {
 
 #[test]
 fn i16_to_sql() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     ToSql::<types::SmallInt, Pg>::to_sql(&1i16, &mut bytes).unwrap();
     ToSql::<types::SmallInt, Pg>::to_sql(&0i16, &mut bytes).unwrap();
     ToSql::<types::SmallInt, Pg>::to_sql(&-1i16, &mut bytes).unwrap();
@@ -33,7 +33,7 @@ fn i16_to_sql() {
 
 #[test]
 fn i32_to_sql() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     ToSql::<types::Integer, Pg>::to_sql(&1i32, &mut bytes).unwrap();
     ToSql::<types::Integer, Pg>::to_sql(&0i32, &mut bytes).unwrap();
     ToSql::<types::Integer, Pg>::to_sql(&-1i32, &mut bytes).unwrap();
@@ -42,7 +42,7 @@ fn i32_to_sql() {
 
 #[test]
 fn i64_to_sql() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     ToSql::<types::BigInt, Pg>::to_sql(&1i64, &mut bytes).unwrap();
     ToSql::<types::BigInt, Pg>::to_sql(&0i64, &mut bytes).unwrap();
     ToSql::<types::BigInt, Pg>::to_sql(&-1i64, &mut bytes).unwrap();

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -6,7 +6,7 @@ use std::io::prelude::*;
 use std::error::Error;
 
 use pg::Pg;
-use types::{self, ToSql, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
 
 // The OIDs used to identify `json` and `jsonb` are not documented anywhere
 // obvious, but they are discussed on various PostgreSQL mailing lists,
@@ -26,7 +26,7 @@ impl FromSql<types::Json, Pg> for serde_json::Value {
 }
 
 impl ToSql<types::Json, Pg> for serde_json::Value {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         serde_json::to_writer(out, self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -45,7 +45,7 @@ impl FromSql<types::Jsonb, Pg> for serde_json::Value {
 }
 
 impl ToSql<types::Jsonb, Pg> for serde_json::Value {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         try!(out.write_all(&[1]));
         serde_json::to_writer(out, self)
             .map(|_| IsNull::No)

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -55,7 +55,7 @@ impl ToSql<types::Jsonb, Pg> for serde_json::Value {
 
 #[test]
 fn json_to_sql() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     let test_json = serde_json::Value::Bool(true);
     ToSql::<types::Json, Pg>::to_sql(&test_json, &mut bytes).unwrap();
     assert_eq!(bytes, b"true");
@@ -85,7 +85,7 @@ fn no_json_from_sql() {
 
 #[test]
 fn jsonb_to_sql() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     let test_json = serde_json::Value::Bool(true);
     ToSql::<types::Jsonb, Pg>::to_sql(&test_json, &mut bytes).unwrap();
     assert_eq!(bytes, b"\x01true");

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -20,7 +20,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 pub struct PgMoney(pub i64);
 
 use pg::Pg;
-use types::{self, ToSql, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
 
 // https://github.com/postgres/postgres/blob/502a3832cc54c7115dacb8a2dae06f0620995ac6/src/include/catalog/pg_type.h#L429-L432
 primitive_impls!(Money -> (PgMoney, pg: (790, 791)));
@@ -33,7 +33,7 @@ impl FromSql<types::Money, Pg> for PgMoney {
 }
 
 impl ToSql<types::Money, Pg> for PgMoney {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error + Send + Sync>> {
         out.write_i64::<NetworkEndian>(self.0)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use pg::Pg;
-use types::{self, ToSql, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
 use self::ipnetwork::{IpNetwork,Ipv4Network,Ipv6Network};
 
 #[cfg(windows)]
@@ -51,7 +51,7 @@ impl FromSql<types::MacAddr, Pg> for [u8; 6] {
 }
 
 impl ToSql<types::MacAddr, Pg> for [u8; 6] {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error + Send + Sync>> {
         out.write_all(&self[..])
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
@@ -93,7 +93,7 @@ macro_rules! impl_Sql {
         }
 
         impl ToSql<$ty, Pg> for IpNetwork {
-            fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+            fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error + Send + Sync>> {
                 use self::ipnetwork::IpNetwork::*;
                 let net_type = $net_type;
                 match *self {

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -135,7 +135,7 @@ impl_Sql!(types::Cidr, 1);
 
 #[test]
 fn macaddr_roundtrip() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     let input_address = [0x52, 0x54,0x00, 0xfb, 0xc6, 0x16];
     ToSql::<types::MacAddr, Pg>::to_sql(&input_address, &mut bytes).unwrap();
     let output_address:[u8; 6] = FromSql::from_sql(Some(bytes.as_ref())).unwrap();
@@ -146,7 +146,7 @@ fn macaddr_roundtrip() {
 fn v4address_to_sql() {
     macro_rules! test_to_sql {
         ($ty: ty, $net_type: expr) => {
-            let mut bytes = vec![];
+            let mut bytes = ToSqlOutput::test();
             let test_address = IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 1), 32).unwrap());
             ToSql::<$ty, Pg>::to_sql(&test_address, &mut bytes).unwrap();
             assert_eq!(bytes, vec![PGSQL_AF_INET, 32, $net_type, 4, 127, 0, 0, 1]);
@@ -162,7 +162,7 @@ fn some_v4address_from_sql() {
     macro_rules! test_some_address_from_sql {
         ($ty: ty) => {
             let input_address = IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 1), 32).unwrap());
-            let mut bytes = vec![];
+            let mut bytes = ToSqlOutput::test();
             ToSql::<$ty, Pg>::to_sql(&input_address, &mut bytes).unwrap();
             let output_address = FromSql::<$ty, Pg>::from_sql(Some(bytes.as_ref())).unwrap();
             assert_eq!(input_address, output_address);
@@ -177,7 +177,7 @@ fn some_v4address_from_sql() {
 fn v6address_to_sql() {
     macro_rules! test_to_sql {
         ($ty: ty, $net_type: expr) => {
-            let mut bytes = vec![];
+            let mut bytes = ToSqlOutput::test();
             let test_address = IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 64).unwrap());
             ToSql::<$ty, Pg>::to_sql(&test_address, &mut bytes).unwrap();
             assert_eq!(bytes, vec![PGSQL_AF_INET6, 64, $net_type, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
@@ -193,7 +193,7 @@ fn some_v6address_from_sql() {
     macro_rules! test_some_address_from_sql {
         ($ty: ty) => {
             let input_address = IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 64).unwrap());
-            let mut bytes = vec![];
+            let mut bytes = ToSqlOutput::test();
             ToSql::<$ty, Pg>::to_sql(&input_address, &mut bytes).unwrap();
             let output_address = FromSql::<$ty, Pg>::from_sql(Some(bytes.as_ref())).unwrap();
             assert_eq!(input_address, output_address);

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -16,7 +16,7 @@ mod bigdecimal {
     use self::bigdecimal::BigDecimal;
 
     use pg::data_types::PgNumeric;
-    use types::{self, FromSql, ToSql, IsNull};
+    use types::{self, FromSql, ToSql, ToSqlOutput, IsNull};
 
     type Digits = Vec<i16>;
 
@@ -69,7 +69,7 @@ mod bigdecimal {
     }
 
     impl ToSql<types::Numeric, Pg> for BigDecimal {
-        fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error + Send + Sync>> {
+        fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error + Send + Sync>> {
             // The encoding of the BigDecimal type for PostgreSQL is a bit complicated:
             // PostgreSQL expects the data in base-10000 (so two bytes per 10k),
             // and the decimal point should lie on a boundary (as per definition of "base-10000").

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 use pg::Pg;
 use pg::data_types::PgNumeric;
-use types::{self, ToSql, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
 
 primitive_impls!(Numeric -> (PgNumeric, pg: (1700, 1231)));
 
@@ -17,7 +17,7 @@ impl FromSql<types::Bool, Pg> for bool {
 }
 
 impl ToSql<types::Bool, Pg> for bool {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let write_result = if *self {
             out.write_all(&[1])
         } else {

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -31,7 +31,7 @@ impl ToSql<types::Bool, Pg> for bool {
 
 #[test]
 fn bool_to_sql() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     ToSql::<types::Bool, Pg>::to_sql(&true, &mut bytes).unwrap();
     ToSql::<types::Bool, Pg>::to_sql(&false, &mut bytes).unwrap();
     assert_eq!(bytes, vec![1u8, 0u8]);

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::error::Error;
 
 use pg::Pg;
-use types::{self, ToSql, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
 
 primitive_impls!(Uuid -> (uuid::Uuid, pg: (2950, 2951)));
 
@@ -16,7 +16,7 @@ impl FromSql<types::Uuid, Pg> for uuid::Uuid {
 }
 
 impl ToSql<types::Uuid, Pg> for uuid::Uuid {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_all(self.as_bytes())
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -25,7 +25,7 @@ impl ToSql<types::Uuid, Pg> for uuid::Uuid {
 
 #[test]
 fn uuid_to_sql() {
-    let mut bytes = vec![];
+    let mut bytes = ToSqlOutput::test();
     let test_uuid = uuid::Uuid::from_fields(4_294_967_295, 65_535, 65_535, b"abcdef12").unwrap();
     ToSql::<types::Uuid, Pg>::to_sql(&test_uuid, &mut bytes).unwrap();
     assert_eq!(bytes, test_uuid.as_bytes());

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -1,7 +1,7 @@
 use backend::{Backend, TypeMetadata};
 use result::Error::SerializationError;
 use result::QueryResult;
-use types::{HasSqlType, ToSql, IsNull};
+use types::{HasSqlType, ToSql, ToSqlOutput, IsNull};
 
 pub trait BindCollector<DB: Backend> {
     fn push_bound_value<T, U>(&mut self, bind: &U) -> QueryResult<()> where
@@ -29,9 +29,9 @@ impl<DB: Backend + TypeMetadata> BindCollector<DB> for RawBytesBindCollector<DB>
         DB: HasSqlType<T>,
         U: ToSql<T, DB>,
     {
-        let mut bytes = Vec::new();
-        match bind.to_sql(&mut bytes).map_err(SerializationError)? {
-            IsNull::No => self.binds.push(Some(bytes)),
+        let mut to_sql_output = ToSqlOutput::new(Vec::new());
+        match bind.to_sql(&mut to_sql_output).map_err(SerializationError)? {
+            IsNull::No => self.binds.push(Some(to_sql_output.into_inner())),
             IsNull::Yes => self.binds.push(None),
         }
         self.metadata.push(<DB as HasSqlType<T>>::metadata());

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -4,7 +4,11 @@ use result::QueryResult;
 use types::{HasSqlType, ToSql, ToSqlOutput, IsNull};
 
 pub trait BindCollector<DB: Backend> {
-    fn push_bound_value<T, U>(&mut self, bind: &U) -> QueryResult<()> where
+    fn push_bound_value<T, U>(
+        &mut self,
+        bind: &U,
+        metadata_lookup: &DB::MetadataLookup,
+    ) -> QueryResult<()> where
         DB: HasSqlType<T>,
         U: ToSql<T, DB>;
 }
@@ -25,16 +29,20 @@ impl<DB: Backend + TypeMetadata> RawBytesBindCollector<DB> {
 }
 
 impl<DB: Backend + TypeMetadata> BindCollector<DB> for RawBytesBindCollector<DB> {
-    fn push_bound_value<T, U>(&mut self, bind: &U) -> QueryResult<()> where
+    fn push_bound_value<T, U>(
+        &mut self,
+        bind: &U,
+        metadata_lookup: &DB::MetadataLookup,
+    ) -> QueryResult<()> where
         DB: HasSqlType<T>,
         U: ToSql<T, DB>,
     {
-        let mut to_sql_output = ToSqlOutput::new(Vec::new());
+        let mut to_sql_output = ToSqlOutput::new(Vec::new(), metadata_lookup);
         match bind.to_sql(&mut to_sql_output).map_err(SerializationError)? {
             IsNull::No => self.binds.push(Some(to_sql_output.into_inner())),
             IsNull::Yes => self.binds.push(None),
         }
-        self.metadata.push(<DB as HasSqlType<T>>::metadata());
+        self.metadata.push(<DB as HasSqlType<T>>::metadata(metadata_lookup));
         Ok(())
     }
 }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -87,8 +87,12 @@ pub trait QueryFragment<DB: Backend> {
         self.walk_ast(AstPass::to_sql(out))
     }
 
-    fn collect_binds(&self, out: &mut DB::BindCollector) -> QueryResult<()> {
-        self.walk_ast(AstPass::collect_binds(out))
+    fn collect_binds(
+        &self,
+        out: &mut DB::BindCollector,
+        metadata_lookup: &DB::MetadataLookup,
+    ) -> QueryResult<()> {
+        self.walk_ast(AstPass::collect_binds(out, metadata_lookup))
     }
 
     fn is_safe_to_cache_prepared(&self) -> QueryResult<bool> {

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -29,6 +29,7 @@ impl Backend for Sqlite {
 
 impl TypeMetadata for Sqlite {
     type TypeMetadata = SqliteType;
+    type MetadataLookup = ();
 }
 
 impl UsesAnsiSavepointSyntax for Sqlite {}

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -104,7 +104,7 @@ impl SqliteConnection {
         let mut statement = try!(self.cached_prepared_statement(source));
 
         let mut bind_collector = RawBytesBindCollector::<Sqlite>::new();
-        try!(source.collect_binds(&mut bind_collector));
+        try!(source.collect_binds(&mut bind_collector, &()));
         let metadata = bind_collector.metadata;
         let binds = bind_collector.binds;
         for (tpe, value) in metadata.into_iter().zip(binds) {

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -6,7 +6,7 @@ use self::chrono::{NaiveDateTime, NaiveDate, NaiveTime, Datelike};
 
 use sqlite::Sqlite;
 use sqlite::connection::SqliteValue;
-use types::{Date, FromSql, IsNull, Time, Timestamp, ToSql, Text};
+use types::{Date, FromSql, IsNull, Time, Timestamp, ToSql, ToSqlOutput, Text};
 
 const SQLITE_TIME_FMT: &'static str = "%0H:%0M:%0S%.6f";
 
@@ -40,7 +40,7 @@ impl FromSql<Date, Sqlite> for NaiveDate {
 }
 
 impl ToSql<Date, Sqlite> for NaiveDate {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let s = dump_sqlite_date(self);
         ToSql::<Text, Sqlite>::to_sql(&s, out)
     }
@@ -55,7 +55,7 @@ impl FromSql<Time, Sqlite> for NaiveTime {
 }
 
 impl ToSql<Time, Sqlite> for NaiveTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let s = format!("{}", self.format(SQLITE_TIME_FMT));
         ToSql::<Text, Sqlite>::to_sql(&s, out)
     }
@@ -78,7 +78,7 @@ impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
 }
 
 impl ToSql<Timestamp, Sqlite> for NaiveDateTime {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<Date, Sqlite>::to_sql(&self.date(), out)?;
         write!(out, " ")?;
         ToSql::<Time, Sqlite>::to_sql(&self.time(), out)

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use sqlite::{Sqlite, SqliteType};
 use sqlite::connection::SqliteValue;
-use types::{self, FromSql, ToSql, IsNull, HasSqlType};
+use types::{self, FromSql, ToSql, ToSqlOutput, IsNull, HasSqlType};
 
 #[cfg(feature = "chrono")]
 mod chrono;
@@ -48,13 +48,13 @@ impl FromSql<types::Date, Sqlite> for String {
 }
 
 impl<'a> ToSql<types::Date, Sqlite> for &'a str {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::Text, Sqlite>::to_sql(self, out)
     }
 }
 
 impl ToSql<types::Date, Sqlite> for String {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         <&str as ToSql<types::Date, Sqlite>>::to_sql(&&**self, out)
     }
 }
@@ -66,13 +66,13 @@ impl FromSql<types::Time, Sqlite> for String {
 }
 
 impl<'a> ToSql<types::Time, Sqlite> for &'a str {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::Text, Sqlite>::to_sql(self, out)
     }
 }
 
 impl ToSql<types::Time, Sqlite> for String {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         <&str as ToSql<types::Time, Sqlite>>::to_sql(&&**self, out)
     }
 }
@@ -84,13 +84,13 @@ impl FromSql<types::Timestamp, Sqlite> for String {
 }
 
 impl<'a> ToSql<types::Timestamp, Sqlite> for &'a str {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         ToSql::<types::Text, Sqlite>::to_sql(self, out)
     }
 }
 
 impl ToSql<types::Timestamp, Sqlite> for String {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         <&str as ToSql<types::Timestamp, Sqlite>>::to_sql(&&**self, out)
     }
 }

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -9,19 +9,19 @@ use types::{self, FromSql, ToSql, ToSqlOutput, IsNull, HasSqlType};
 mod chrono;
 
 impl HasSqlType<types::Date> for Sqlite {
-    fn metadata() -> SqliteType {
+    fn metadata(_: &()) -> SqliteType {
         SqliteType::Text
     }
 }
 
 impl HasSqlType<types::Time> for Sqlite {
-    fn metadata() -> SqliteType {
+    fn metadata(_: &()) -> SqliteType {
         SqliteType::Text
     }
 }
 
 impl HasSqlType<types::Timestamp> for Sqlite {
-    fn metadata() -> SqliteType {
+    fn metadata(_: &()) -> SqliteType {
         SqliteType::Text
     }
 }

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 
 use super::Sqlite;
 use super::connection::SqliteValue;
-use types::{self, FromSql, ToSql, IsNull};
+use types::{self, FromSql, ToSql, ToSqlOutput, IsNull};
 
 impl FromSql<types::VarChar, Sqlite> for String {
     fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error+Send+Sync>> {
@@ -58,7 +58,7 @@ impl FromSql<types::Double, Sqlite> for f64 {
 }
 
 impl ToSql<types::Bool, Sqlite> for bool {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> Result<IsNull, Box<Error+Send+Sync>> {
         let int_value = if *self {
             1
         } else {

--- a/diesel/src/types/impls/debug.rs
+++ b/diesel/src/types/impls/debug.rs
@@ -8,7 +8,7 @@ use types::*;
 macro_rules! debug_to_sql {
     ($sql_type:ty, $ty:ty) => {
         impl ToSql<$sql_type, Debug> for $ty {
-            fn to_sql<W: Write>(&self, _: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+            fn to_sql<W: Write>(&self, _: &mut ToSqlOutput<W, Debug>) -> Result<IsNull, Box<Error+Send+Sync>> {
                 Ok(IsNull::No)
             }
         }
@@ -53,7 +53,7 @@ mod chrono_impls {
 
     #[cfg(feature = "postgres")]
     impl<TZ: TimeZone> ToSql<Timestamptz, Debug> for DateTime<TZ> {
-        fn to_sql<W: Write>(&self, _: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+        fn to_sql<W: Write>(&self, _: &mut ToSqlOutput<W, Debug>) -> Result<IsNull, Box<Error+Send+Sync>> {
             Ok(IsNull::No)
         }
     }

--- a/diesel/src/types/impls/floats.rs
+++ b/diesel/src/types/impls/floats.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::io::prelude::*;
 
 use backend::Backend;
-use types::{self, FromSql, ToSql, IsNull};
+use types::{self, FromSql, ToSql, ToSqlOutput, IsNull};
 
 impl<DB: Backend<RawValue=[u8]>> FromSql<types::Float, DB> for f32 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
@@ -15,7 +15,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Float, DB> for f32 {
 }
 
 impl<DB: Backend> ToSql<types::Float, DB> for f32 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_f32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -32,7 +32,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Double, DB> for f64 {
 }
 
 impl<DB: Backend> ToSql<types::Double, DB> for f64 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_f64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)

--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::io::prelude::*;
 
 use backend::Backend;
-use types::{self, FromSql, ToSql, IsNull};
+use types::{self, FromSql, ToSql, ToSqlOutput, IsNull};
 
 impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
@@ -18,7 +18,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::SmallInt, DB> for i16 {
 }
 
 impl<DB: Backend> ToSql<types::SmallInt, DB> for i16 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_i16::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -37,7 +37,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Integer, DB> for i32 {
 }
 
 impl<DB: Backend> ToSql<types::Integer, DB> for i32 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_i32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -56,7 +56,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::BigInt, DB> for i64 {
 }
 
 impl<DB: Backend> ToSql<types::BigInt, DB> for i64 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_i64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -115,7 +115,7 @@ macro_rules! primitive_impls {
     ($Source:ident -> (pg: ($oid:expr, $array_oid:expr) $($rest:tt)*)) => {
         #[cfg(feature = "postgres")]
         impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::pg::Pg {
-            fn metadata(_: &()) -> $crate::pg::PgTypeMetadata {
+            fn metadata(_: &$crate::pg::PgMetadataLookup) -> $crate::pg::PgTypeMetadata {
                 $crate::pg::PgTypeMetadata {
                     oid: $oid,
                     array_oid: $array_oid,

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -50,7 +50,7 @@ macro_rules! expression_impls {
                 DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
                 $Target: $crate::types::ToSql<$crate::types::$Source, DB>,
             {
-                fn to_sql<W: ::std::io::Write>(&self, out: &mut W) -> Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
+                fn to_sql<W: ::std::io::Write>(&self, out: &mut $crate::types::ToSqlOutput<W, DB>) -> Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
                     $crate::types::ToSql::<$crate::types::$Source, DB>::to_sql(self, out)
                 }
             }

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -104,7 +104,7 @@ macro_rules! primitive_impls {
     ($Source:ident -> (sqlite: ($tpe:ident) $($rest:tt)*)) => {
         #[cfg(feature = "sqlite")]
         impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::sqlite::Sqlite {
-            fn metadata() -> $crate::sqlite::SqliteType {
+            fn metadata(_: &()) -> $crate::sqlite::SqliteType {
                 $crate::sqlite::SqliteType::$tpe
             }
         }
@@ -115,7 +115,7 @@ macro_rules! primitive_impls {
     ($Source:ident -> (pg: ($oid:expr, $array_oid:expr) $($rest:tt)*)) => {
         #[cfg(feature = "postgres")]
         impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::pg::Pg {
-            fn metadata() -> $crate::pg::PgTypeMetadata {
+            fn metadata(_: &()) -> $crate::pg::PgTypeMetadata {
                 $crate::pg::PgTypeMetadata {
                     oid: $oid,
                     array_oid: $array_oid,
@@ -129,7 +129,7 @@ macro_rules! primitive_impls {
     ($Source:ident -> (mysql: ($tpe:ident) $($rest:tt)*)) => {
         #[cfg(feature = "mysql")]
         impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::mysql::Mysql {
-            fn metadata() -> $crate::mysql::MysqlType {
+            fn metadata(_: &()) -> $crate::mysql::MysqlType {
                 $crate::mysql::MysqlType::$tpe
             }
         }
@@ -154,7 +154,7 @@ macro_rules! primitive_impls {
 
     ($Source:ident) => {
         impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::backend::Debug {
-            fn metadata() {}
+            fn metadata(_: &()) {}
         }
 
         impl $crate::query_builder::QueryId for $crate::types::$Source {

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -116,7 +116,7 @@ use pg::Pg;
 #[cfg(feature = "postgres")]
 fn option_to_sql() {
     type Type = types::Nullable<types::VarChar>;
-    let mut bytes = Vec::<u8>::new();
+    let mut bytes = ToSqlOutput::test();
 
     let is_null = ToSql::<Type, Pg>::to_sql(&None::<String>, &mut bytes).unwrap();
     assert_eq!(IsNull::Yes, is_null);
@@ -129,5 +129,5 @@ fn option_to_sql() {
     let is_null = ToSql::<Type, Pg>::to_sql(&Some("Sean"), &mut bytes).unwrap();
     let expectd_bytes = b"Sean".to_vec();
     assert_eq!(IsNull::No, is_null);
-    assert_eq!(expectd_bytes, bytes);
+    assert_eq!(bytes, expectd_bytes);
 }

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -7,7 +7,7 @@ use expression::*;
 use expression::bound::Bound;
 use query_builder::QueryId;
 use query_source::Queryable;
-use types::{HasSqlType, FromSql, FromSqlRow, Nullable, ToSql, IsNull, NotNull};
+use types::{HasSqlType, FromSql, FromSqlRow, Nullable, ToSql, ToSqlOutput, IsNull, NotNull};
 
 impl<T, DB> HasSqlType<Nullable<T>> for DB where
     DB: Backend + HasSqlType<T>, T: NotNull,
@@ -61,7 +61,7 @@ impl<T, ST, DB> ToSql<Nullable<ST>, DB> for Option<T> where
     DB: Backend + HasSqlType<ST>,
     ST: NotNull,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         if let Some(ref value) = *self {
             value.to_sql(out)
         } else {

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -12,12 +12,12 @@ use types::{HasSqlType, FromSql, FromSqlRow, Nullable, ToSql, ToSqlOutput, IsNul
 impl<T, DB> HasSqlType<Nullable<T>> for DB where
     DB: Backend + HasSqlType<T>, T: NotNull,
 {
-    fn metadata() -> DB::TypeMetadata {
-        <DB as HasSqlType<T>>::metadata()
+    fn metadata(lookup: &DB::MetadataLookup) -> DB::TypeMetadata {
+        <DB as HasSqlType<T>>::metadata(lookup)
     }
 
-    fn row_metadata(out: &mut Vec<DB::TypeMetadata>) {
-        <DB as HasSqlType<T>>::row_metadata(out)
+    fn row_metadata(out: &mut Vec<DB::TypeMetadata>, lookup: &DB::MetadataLookup) {
+        <DB as HasSqlType<T>>::row_metadata(out, lookup)
     }
 }
 

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::io::Write;
 
 use backend::Backend;
-use types::{self, HasSqlType, FromSql, ToSql, IsNull, NotNull};
+use types::{self, HasSqlType, FromSql, ToSql, ToSqlOutput, IsNull, NotNull};
 
 primitive_impls!(Bool -> (bool, pg: (16, 1000), sqlite: (Integer), mysql: (Tiny)));
 
@@ -37,7 +37,7 @@ impl<DB: Backend<RawValue=[u8]>> FromSql<types::Text, DB> for String {
 }
 
 impl<'a, DB: Backend> ToSql<types::Text, DB> for &'a str {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_all(self.as_bytes())
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -48,7 +48,7 @@ impl<DB> ToSql<types::Text, DB> for String where
     DB: Backend,
     for<'a> &'a str: ToSql<types::Text, DB>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         (self as &str).to_sql(out)
     }
 }
@@ -63,13 +63,13 @@ impl<DB> ToSql<types::Binary, DB> for Vec<u8> where
     DB: Backend,
     for<'a> &'a [u8]: ToSql<types::Binary, DB>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         (self as &[u8]).to_sql(out)
     }
 }
 
 impl<'a, DB: Backend> ToSql<types::Binary, DB> for &'a [u8] {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         out.write_all(self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error+Send+Sync>)
@@ -82,7 +82,7 @@ impl<'a, T: ?Sized, ST, DB> ToSql<ST, DB> for Cow<'a, T> where
     DB: Backend + HasSqlType<ST>,
     T::Owned: ToSql<ST, DB>,
 {
-    fn to_sql<W: Write>(&self, out: &mut W) -> Result<IsNull, Box<Error+Send+Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error+Send+Sync>> {
         match *self {
             Cow::Borrowed(t) => t.to_sql(out),
             Cow::Owned(ref t) => t.to_sql(out),

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -22,12 +22,12 @@ macro_rules! tuple_impls {
                 $(DB: HasSqlType<$T>),+,
                 DB: Backend,
             {
-                fn metadata() -> DB::TypeMetadata {
+                fn metadata(_: &DB::MetadataLookup) -> DB::TypeMetadata {
                     unreachable!("Tuples should never implement `ToSql` directly");
                 }
 
-                fn row_metadata(out: &mut Vec<DB::TypeMetadata>) {
-                    $(<DB as HasSqlType<$T>>::row_metadata(out);)+
+                fn row_metadata(out: &mut Vec<DB::TypeMetadata>, lookup: &DB::MetadataLookup) {
+                    $(<DB as HasSqlType<$T>>::row_metadata(out, lookup);)+
                 }
             }
 

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -338,7 +338,7 @@ pub enum IsNull {
     No,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 #[doc(hidden)]
 pub struct ToSqlOutput<'a, T, DB> where
     DB: TypeMetadata,
@@ -417,6 +417,15 @@ impl<'a, T, U, DB> PartialEq<U> for ToSqlOutput<'a, T, DB> where
 {
     fn eq(&self, rhs: &U) -> bool {
         self.out == *rhs
+    }
+}
+
+impl<'a, T, DB> fmt::Debug for ToSqlOutput<'a, T, DB> where
+    T: fmt::Debug,
+    DB: TypeMetadata,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.out.fmt(f)
     }
 }
 

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -369,6 +369,16 @@ impl<'a, T, DB: TypeMetadata> ToSqlOutput<'a, T, DB> {
     }
 }
 
+#[cfg(test)]
+impl<DB: TypeMetadata> ToSqlOutput<'static, Vec<u8>, DB> {
+    /// Returns a `ToSqlOutput` suitable for testing `ToSql` implementations.
+    /// Unsafe to use for testing types which perform dynamic metadata lookup.
+    pub fn test() -> Self {
+        use std::mem;
+        Self::new(Vec::new(), unsafe { mem::uninitialized() })
+    }
+}
+
 impl<'a, T: Write, DB: TypeMetadata> Write for ToSqlOutput<'a, T, DB> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.out.write(buf)
@@ -398,6 +408,15 @@ impl<'a, T, DB: TypeMetadata> Deref for ToSqlOutput<'a, T, DB> {
 impl<'a, T, DB: TypeMetadata> DerefMut for ToSqlOutput<'a, T, DB> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.out
+    }
+}
+
+impl<'a, T, U, DB> PartialEq<U> for ToSqlOutput<'a, T, DB> where
+    DB: TypeMetadata,
+    T: PartialEq<U>,
+{
+    fn eq(&self, rhs: &U) -> bool {
+        self.out == *rhs
     }
 }
 

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -1,0 +1,96 @@
+use diesel::*;
+use diesel::connection::SimpleConnection;
+use schema::*;
+
+table! {
+    use diesel::types::*;
+    use super::MyType;
+    custom_types {
+        id -> Integer,
+        custom_enum -> MyType,
+    }
+}
+
+pub struct MyType;
+
+#[derive(Debug, PartialEq)]
+pub enum MyEnum {
+    Foo,
+    Bar,
+}
+
+mod impls_for_insert_and_query {
+    use diesel::expression::AsExpression;
+    use diesel::expression::bound::Bound;
+    use diesel::pg::Pg;
+    use diesel::row::Row;
+    use diesel::types::*;
+    use std::error::Error;
+    use std::io::Write;
+
+    use super::{MyType, MyEnum};
+
+    impl HasSqlType<MyType> for Pg {
+        fn metadata(lookup: &Self::MetadataLookup) -> Self::TypeMetadata {
+            lookup.lookup_type("my_type")
+        }
+    }
+
+    impl NotNull for MyType {}
+
+    impl<'a> AsExpression<MyType> for &'a MyEnum {
+        type Expression = Bound<MyType, &'a MyEnum>;
+
+        fn as_expression(self) -> Self::Expression {
+            Bound::new(self)
+        }
+    }
+
+    impl ToSql<MyType, Pg> for MyEnum {
+        fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {
+            match *self {
+                MyEnum::Foo => out.write_all(b"foo")?,
+                MyEnum::Bar => out.write_all(b"bar")?,
+            }
+            Ok(IsNull::No)
+        }
+    }
+
+    impl FromSqlRow<MyType, Pg> for MyEnum {
+        fn build_from_row<T: Row<Pg>>(row: &mut T) -> Result<Self, Box<Error+Send+Sync>> {
+            match row.take() {
+                Some(b"foo") => Ok(MyEnum::Foo),
+                Some(b"bar") => Ok(MyEnum::Bar),
+                Some(_) => Err("Unrecognized enum variant".into()),
+                None => Err("Unexpected null for non-null column".into()),
+            }
+        }
+    }
+}
+
+#[derive(Insertable, Queryable, Identifiable, Debug, PartialEq)]
+#[table_name="custom_types"]
+struct HasCustomTypes {
+    id: i32,
+    custom_enum: MyEnum,
+}
+
+#[test]
+fn custom_types_round_trip() {
+    let data = vec![
+        HasCustomTypes { id: 1, custom_enum: MyEnum::Foo },
+        HasCustomTypes { id: 2, custom_enum: MyEnum::Bar },
+    ];
+    let connection = connection();
+    connection.batch_execute(r#"
+        CREATE TYPE my_type AS ENUM ('foo', 'bar');
+        CREATE TABLE custom_types (
+            id SERIAL PRIMARY KEY,
+            custom_enum my_type NOT NULL
+        );
+    "#).unwrap();
+
+    let inserted = insert(&data).into(custom_types::table)
+        .get_results(&connection).unwrap();
+    assert_eq!(data, inserted);
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -11,6 +11,8 @@ mod boxed_queries;
 mod connection;
 #[cfg(feature = "postgres")]
 mod custom_schemas;
+#[cfg(feature = "postgres")]
+mod custom_types;
 mod debug;
 mod delete;
 mod deserialization;

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -638,8 +638,8 @@ fn third_party_crates_can_add_new_types() {
     struct MyInt;
 
     impl HasSqlType<MyInt> for Pg {
-        fn metadata(_: &()) -> Self::TypeMetadata {
-            <Pg as HasSqlType<Integer>>::metadata(&())
+        fn metadata(lookup: &Self::MetadataLookup) -> Self::TypeMetadata {
+            <Pg as HasSqlType<Integer>>::metadata(lookup)
         }
     }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -639,7 +639,7 @@ fn third_party_crates_can_add_new_types() {
 
     impl HasSqlType<MyInt> for Pg {
         fn metadata(_: &()) -> Self::TypeMetadata {
-            <Pg as HasSqlType<Integer>>::metadata()
+            <Pg as HasSqlType<Integer>>::metadata(&())
         }
     }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -638,7 +638,7 @@ fn third_party_crates_can_add_new_types() {
     struct MyInt;
 
     impl HasSqlType<MyInt> for Pg {
-        fn metadata() -> Self::TypeMetadata {
+        fn metadata(_: &()) -> Self::TypeMetadata {
             <Pg as HasSqlType<Integer>>::metadata()
         }
     }


### PR DESCRIPTION
This lays all the groundwork for a custom type (or type implementing an extension) to perform an OID lookup at runtime. I'm not interested in supporting any extensions or user defined types in Diesel proper, but I do want to see third party crates provide that capability. This change is required for those crates to be able to exist.

Ultimately the root issue that this PR needs to solve is that `TypeMetadata::metadata` needs to have access to the database connection for PG. Of course I don't want to expose the *actual* connection, since that function should not have the capability to execute arbitrary queries. This does mean that we have to make the wrapper struct a little funky, as putting a lifetime on it would require either adding a lifetime to `Pg` or `TypeMetadata`, neither of which are things I'd like to do. We can refactor the funky `new` signature away once ATCs land.

To keep the scope of the PR small, I have explicitly omitted error handling and caching from this implementation. They will be done in a follow-up PR.

I've tried to implement this in a way that has as little unnecessary churn as possible (e.g. wrapping the parameter of `ToSql` instead of passing a second parameter so we only have to change definitions but not call sites).