### PR TITLE
Don't treat all fields as nullable for insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* Added support for the PG `IS DISTINCT FROM` operator
+
 ### Changed
 
 * Diesel will now automatically invoke `numeric_expr!` for your columns in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   common cases. You will likely need to delete any manual invocations of this
   macro.
 
+* `Insertable` no longer treats all fields as nullable for type checking. What
+  this means for you is that if you had an impl like `impl
+  AsExpression<Nullable<SqlType>, DB> for CustomType` in your code base, you can
+  remove the `Nullable` portion (Unless you are using it with fields that are
+  actually nullable)
+
 ## [0.14.0] - 2017-07-04
 
 ### Added

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -43,7 +43,3 @@ pub type Not<Expr> = super::operators::Not<Grouped<AsExprOf<Expr, types::Bool>>>
 pub use super::operators::{IsNull, IsNotNull, Asc, Desc};
 #[doc(inline)]
 pub use super::array_comparison::EqAny;
-
-#[doc(hidden)]
-pub type AsNullableExpr<Item, TargetExpr> = AsExprOf<Item,
-    <SqlTypeOf<TargetExpr> as types::IntoNullable>::Nullable>;

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -1,11 +1,9 @@
 use std::iter;
 
 use backend::{Backend, SupportsDefaultKeyword};
-use expression::Expression;
 use result::QueryResult;
 use query_builder::AstPass;
-use query_source::{Table, Column};
-use types::IntoNullable;
+use query_source::Table;
 
 /// Represents that a structure can be used to to insert a new row into the
 /// database. This is automatically implemented for `&[T]` and `&Vec<T>` for
@@ -30,11 +28,7 @@ pub trait InsertValues<DB: Backend> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub enum ColumnInsertValue<Col, Expr> where
-    Col: Column,
-    Col::SqlType: IntoNullable,
-    Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-{
+pub enum ColumnInsertValue<Col, Expr> {
     Expression(Col, Expr),
     Default(Col),
 }

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -23,14 +23,50 @@ pub trait PgExpressionMethods: Expression + Sized {
     /// # fn main() {
     /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// let data = users.select(id).filter(name.is_not_distinct_from("Sean"));
-    /// assert_eq!(Ok(1), data.first(&connection));
+    /// let distinct = users.select(id).filter(name.is_distinct_from("Sean"));
+    /// let not_distinct = users.select(id).filter(name.is_not_distinct_from("Sean"));
+    /// assert_eq!(Ok(2), distinct.first(&connection));
+    /// assert_eq!(Ok(1), not_distinct.first(&connection));
     /// # }
+    /// ```
     fn is_not_distinct_from<T>(self, other: T)
         -> IsNotDistinctFrom<Self, T::Expression> where
             T: AsExpression<Self::SqlType>,
     {
         IsNotDistinctFrom::new(self, other.as_expression())
+    }
+
+    /// Creates a PostgreSQL `IS DISTINCT FROM` expression. This behaves
+    /// identically to the `!=` operator, except that `NULL` is treated as a
+    /// normal value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use self::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// let distinct = users.select(id).filter(name.is_distinct_from("Sean"));
+    /// let not_distinct = users.select(id).filter(name.is_not_distinct_from("Sean"));
+    /// assert_eq!(Ok(2), distinct.first(&connection));
+    /// assert_eq!(Ok(1), not_distinct.first(&connection));
+    /// # }
+    /// ```
+    fn is_distinct_from<T>(self, other: T)
+        -> IsDistinctFrom<Self, T::Expression> where
+            T: AsExpression<Self::SqlType>,
+    {
+        IsDistinctFrom::new(self, other.as_expression())
     }
 }
 

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,5 +1,6 @@
 use pg::Pg;
 
+diesel_infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
 diesel_infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
 diesel_infix_operator!(OverlapsWith, " && ", backend: Pg);
 diesel_infix_operator!(Contains, " @> ", backend: Pg);

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -8,7 +8,7 @@ use query_builder::*;
 use query_source::{QuerySource, Queryable, Table, Column};
 use result::QueryResult;
 use row::Row;
-use types::{HasSqlType, FromSqlRow, Nullable, IntoNullable, NotNull};
+use types::{HasSqlType, FromSqlRow, Nullable, NotNull};
 use util::TupleAppend;
 
 macro_rules! tuple_impls {
@@ -116,8 +116,7 @@ macro_rules! tuple_impls {
                     DB: Backend + SupportsDefaultKeyword,
                     Tab: Table,
                     $($T: Column<Table=Tab>,)+
-                    $($T::SqlType: IntoNullable,)+
-                    $($ST: Expression<SqlType=<$T::SqlType as IntoNullable>::Nullable> + QueryFragment<DB>,)+
+                    $($ST: Expression<SqlType=$T::SqlType> + QueryFragment<DB>,)+
             {
                 fn column_names(&self, out: &mut DB::QueryBuilder) -> QueryResult<()> {
                     $(
@@ -151,8 +150,7 @@ macro_rules! tuple_impls {
                 for ($(ColumnInsertValue<$T, $ST>,)+) where
                     Tab: Table,
                     $($T: Column<Table=Tab>,)+
-                    $($T::SqlType: IntoNullable,)+
-                    $($ST: Expression<SqlType=<$T::SqlType as IntoNullable>::Nullable> + QueryFragment<::sqlite::Sqlite>,)+
+                    $($ST: Expression<SqlType=$T::SqlType> + QueryFragment<::sqlite::Sqlite>,)+
             {
                 #[allow(unused_assignments)]
                 fn column_names(&self, out: &mut ::sqlite::SqliteQueryBuilder) -> QueryResult<()> {


### PR DESCRIPTION
This issue was introduced in f4511c6bdebe5937a17e4009f10296716ea4e2ca,
and I'm really not sure what I was thinking there. We've always treated
`None` values as `DEFAULT`, so there was no reason not to be extracting
the inner values when I wrote that.

This will allow enhancements to inserts like using expressions other
than bind params, and using tuples for one-off inserts similar to how
updates work.

Fixes #921.