### PR TITLE
Don't implement expression methods on tuples

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -47,6 +47,7 @@ impl<'a, Parent, Child> BelongingToDsl<&'a Parent> for Child where
     Child: HasTable + BelongsTo<Parent>,
     Id<&'a Parent>: AsExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
     <Child as HasTable>::Table: FilterDsl<Eq<Child::ForeignKeyColumn, Id<&'a Parent>>>,
+    Child::ForeignKeyColumn: ExpressionMethods,
 {
     type Output = FindBy<
         Child::Table,
@@ -64,6 +65,7 @@ impl<'a, Parent, Child> BelongingToDsl<&'a [Parent]> for Child where
     Child: HasTable + BelongsTo<Parent>,
     Vec<Id<&'a Parent>>: AsInExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
     <Child as HasTable>::Table: FilterDsl<EqAny<Child::ForeignKeyColumn, Vec<Id<&'a Parent>>>>,
+    Child::ForeignKeyColumn: ExpressionMethods,
 {
     type Output = Filter<
         Child::Table,

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -1,6 +1,7 @@
 use expression::{Expression, AsExpression, nullable};
 use expression::array_comparison::{In, NotIn, AsInExpression};
 use expression::operators::*;
+use types::SingleValue;
 
 pub trait ExpressionMethods: Expression + Sized {
     /// Creates a SQL `=` expression.
@@ -297,7 +298,16 @@ pub trait ExpressionMethods: Expression + Sized {
     fn asc(self) -> Asc<Self> {
         Asc::new(self)
     }
+}
 
+impl<T> ExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: SingleValue,
+{
+}
+
+pub trait NullableExpressionMethods: Expression + Sized {
     /// Converts this potentially non-null expression into one which is treated
     /// as nullable. This method has no impact on the generated SQL, and is only
     /// used to allow certain comparisons that would otherwise fail to compile.
@@ -353,4 +363,4 @@ pub trait ExpressionMethods: Expression + Sized {
     }
 }
 
-impl<T: Expression> ExpressionMethods for T {}
+impl<T: Expression> NullableExpressionMethods for T {}

--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -16,7 +16,7 @@ pub use self::bool_expression_methods::BoolExpressionMethods;
 #[doc(inline)]
 pub use self::escape_expression_methods::EscapeExpressionMethods;
 #[doc(inline)]
-pub use self::global_expression_methods::ExpressionMethods;
+pub use self::global_expression_methods::{ExpressionMethods, NullableExpressionMethods};
 #[doc(inline)]
 pub use self::text_expression_methods::TextExpressionMethods;
 #[doc(hidden)]

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -80,7 +80,7 @@ macro_rules! __diesel_column {
             type Output = $crate::expression::helper_types::Eq<Self, T>;
 
             fn eq_all(self, rhs: T) -> Self::Output {
-                $crate::ExpressionMethods::eq(self, rhs)
+                $crate::expression::operators::Eq::new(self, rhs.as_expression())
             }
         }
 
@@ -809,7 +809,7 @@ macro_rules! joinable_inner {
             >;
 
             fn join_on_clause() -> Self::JoinOnClause {
-                use $crate::ExpressionMethods;
+                use $crate::{ExpressionMethods, NullableExpressionMethods};
 
                 $foreign_key.nullable().eq($primary_key_expr.nullable())
             }

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -30,6 +30,9 @@ impl_query_id!(Array<T>);
 impl<T> NotNull for Array<T> {
 }
 
+impl<T> SingleValue for Array<T> {
+}
+
 impl<T, ST> FromSql<Array<ST>, Pg> for Vec<T> where
     T: FromSql<ST, Pg>,
     Pg: HasSqlType<ST>,

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -167,6 +167,9 @@ macro_rules! primitive_impls {
 
         impl $crate::types::NotNull for $crate::types::$Source {
         }
+
+        impl $crate::types::SingleValue for $crate::types::$Source {
+        }
     }
 }
 

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -153,6 +153,9 @@ use std::io::Write;
 #[cfg(not(feature="postgres"))]
 impl NotNull for Numeric {}
 
+#[cfg(not(feature="postgres"))]
+impl SingleValue for Numeric {}
+
 /// The text SQL type.
 ///
 /// On all backends strings must be valid UTF-8.
@@ -294,6 +297,12 @@ impl<T: NotNull> IntoNullable for T {
 
 impl<T: NotNull> IntoNullable for Nullable<T> {
     type Nullable = Nullable<T>;
+}
+
+pub trait SingleValue {
+}
+
+impl<T: NotNull + SingleValue> SingleValue for Nullable<T> {
 }
 
 /// How to deserialize a single field of a given type. The input will always be

--- a/diesel_compile_tests/tests/compile-fail/cannot_use_expression_methods_on_tuples.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_use_expression_methods_on_tuples.rs
@@ -1,0 +1,22 @@
+#[macro_use] extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+     users {
+         id -> Integer,
+         name -> Text,
+     }
+}
+
+fn main() {
+    use self::users::dsl::*;
+    // Sanity check that expression methods are in scope
+    users.filter(id.is_not_null());
+    users.filter(id.eq_any(users.select(id)));
+
+    users.filter((id, name).is_not_null());
+    //~^ ERROR no method named `is_not_null` found
+    users.filter((id, name).eq_any(users.find(1)));
+    //~^ ERROR no method named `eq_any` found
+}

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -637,6 +637,8 @@ fn third_party_crates_can_add_new_types() {
 
     struct MyInt;
 
+    impl SingleValue for MyInt {}
+
     impl HasSqlType<MyInt> for Pg {
         fn metadata() -> Self::TypeMetadata {
             <Pg as HasSqlType<Integer>>::metadata()
@@ -672,7 +674,7 @@ fn third_party_crates_can_add_new_types() {
 
 fn query_single_value<T, U: Queryable<T, TestBackend>>(sql_str: &str) -> U where
     TestBackend: HasSqlType<T>,
-    T: QueryId,
+    T: QueryId + SingleValue,
 {
     use diesel::expression::dsl::sql;
     let connection = connection();
@@ -688,7 +690,7 @@ fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool where
     U: AsExpression<T> + Debug + Clone,
     U::Expression: SelectableExpression<(), SqlType=T>,
     U::Expression: QueryFragment<TestBackend> + QueryId,
-    T: QueryId,
+    T: QueryId + SingleValue,
 {
     use diesel::expression::dsl::sql;
     let connection = connection();


### PR DESCRIPTION
With the exception of `.nullable`, all of these methods would generate
invalid SQL if used. Some people mistakenly think that we map rust
tuples to a PG tuple. We don't actually support PG tuples, and if we did
we'd need to have it be a separate type to differentiate `SELECT id,
name` from `SELECT (id, name)`.

This is not a full solution to the problem. Ideally we would actually
properly represent in the type system that a tuple is a list, which is
only valid in a few contexts. Instead, this solution simply prevents
their construction. I don't think this mistake is common enough to
warrant more time being spent on it.

My hope is that if/when variadic generics happen, they are not built
around tuples, which would allow us to better separate this case from
normal values. Until that time, this should suffice.

I'm not 100% sold on the name `SingleValue`, as it seems odd that
`Array<T>` implements it. However, the only other name I could think of
was `NotTuple`, which will feel odd if we ever do support PG tuples.
Something like `NotColumnList` could work, but that name feels odd to
me. I think I want to stick with a name that says what the type is, not
what it isn't.

Fixes #998.