### PR TITLE
Implement `FindDsl` for `SelectStatement`

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -102,6 +102,24 @@ impl<ST, F, S, D, W, O, L, Of, G, Predicate> FilterDsl<Predicate>
     }
 }
 
+use expression_methods::EqAll;
+use helper_types::Filter;
+use query_source::Table;
+
+impl<F, S, D, W, O, L, Of, G, PK> FindDsl<PK>
+    for SelectStatement<F, S, D, W, O, L, Of, G> where
+        F: Table,
+        F::PrimaryKey: EqAll<PK>,
+        Self: FilterDsl<<F::PrimaryKey as EqAll<PK>>::Output>
+{
+    type Output = Filter<Self, <F::PrimaryKey as EqAll<PK>>::Output>;
+
+    fn find(self, id: PK) -> Self::Output {
+        let primary_key = self.from.primary_key();
+        self.filter(primary_key.eq_all(id))
+    }
+}
+
 impl<ST, F, S, D, W, O, L, Of, G, Expr> OrderDsl<Expr>
     for SelectStatement<F, S, D, W, O, L, Of, G> where
         Expr: AppearsOnTable<F>,

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -53,3 +53,15 @@ fn find_with_composite_pk() {
     assert_eq!(Ok(third_following), followings.find((2, 1)).first(&connection));
     assert_eq!(Ok(None::<Following>), followings.find((2, 2)).first(&connection).optional());
 }
+
+#[test]
+fn select_then_find() {
+    use schema::users::dsl::*;
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let sean = users.select(name).find(1).first(&connection);
+    let tess = users.select(name).find(2).first(&connection);
+
+    assert_eq!(Ok(String::from("Sean")), sean);
+    assert_eq!(Ok(String::from("Tess")), tess);
+}


### PR DESCRIPTION
I wanted to call `find` on a select statement. I was surprised that I
couldn't. That made me sad. This makes me not sad.