### PR TITLE
Make `sum` and `avg` unconditionally nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   remove the `Nullable` portion (Unless you are using it with fields that are
   actually nullable)
 
+* The return type of `sum` and `avg` is now always considered to be `Nullable`,
+  as these functions return `NULL` when against on an empty table.
+
 ## [0.14.0] - 2017-07-04
 
 ### Added

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -66,7 +66,7 @@ Foldable.
 # fn main() {
 #     use self::animals::dsl::*;
 #     let connection = establish_connection();
-assert_eq!(Ok(12i64), animals.select(sum(legs)).first(&connection));
+assert_eq!(Ok(Some(12i64)), animals.select(sum(legs)).first(&connection));
 # }
 ");
 
@@ -91,7 +91,7 @@ Foldable.
 # fn main() {
 #     use self::animals::dsl::*;
 #     let connection = establish_connection();
-// assert_eq!(Ok(6f64), animals.select(avg(legs)).first(&connection));
+// assert_eq!(Ok(Some(6f64)), animals.select(avg(legs)).first(&connection));
 // TODO: There doesn't currently seem to be a way to use avg with integers, since
 // they return a `Numeric` which doesn't have a corresponding Rust type.
 # }

--- a/diesel/src/types/fold.rs
+++ b/diesel/src/types/fold.rs
@@ -7,19 +7,17 @@ pub trait Foldable {
 
 impl<T> Foldable for types::Nullable<T> where
     T: Foldable + NotNull,
-    T::Sum: NotNull,
-    T::Avg: NotNull,
 {
-    type Sum = types::Nullable<T::Sum>;
-    type Avg = types::Nullable<T::Avg>;
+    type Sum = T::Sum;
+    type Avg = T::Avg;
 }
 
 macro_rules! foldable_impls {
     ($($Source:ty => ($SumType:ty, $AvgType:ty)),+,) => {
         $(
             impl Foldable for $Source {
-                type Sum = $SumType;
-                type Avg = $AvgType;
+                type Sum = types::Nullable<$SumType>;
+                type Avg = types::Nullable<$AvgType>;
             }
         )+
     }

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -221,6 +221,9 @@ pub type VarChar = Text;
 /// [interval dsls]: /diesel/pg/expression/extensions/index.html
 #[derive(Debug, Clone, Copy, Default)] pub struct Interval;
 
+#[cfg(not(feature = "postgres"))]
+impl NotNull for Interval {} // FIXME: Interval should not be in this file
+
 /// The time SQL type.
 ///
 /// This type is currently only implemented for PostgreSQL and SQLite.

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -162,9 +162,11 @@ fn test_sum() {
     connection.execute("INSERT INTO numbers (n) VALUES (2), (1), (5)").unwrap();
     let source = numbers.select(sum(n));
 
-    assert_eq!(Ok(8), source.first(&connection));
+    assert_eq!(Ok(Some(8)), source.first(&connection));
     connection.execute("DELETE FROM numbers WHERE n = 2").unwrap();
-    assert_eq!(Ok(6), source.first(&connection));
+    assert_eq!(Ok(Some(6)), source.first(&connection));
+    connection.execute("DELETE FROM numbers").unwrap();
+    assert_eq!(Ok(None::<i64>), source.first(&connection));
 }
 
 table! {
@@ -182,9 +184,11 @@ fn test_sum_for_double() {
     connection.execute("INSERT INTO precision_numbers (n) VALUES (2), (1), (5.5)").unwrap();
     let source = numbers.select(sum(n));
 
-    assert_eq!(Ok(8.5f64), source.first(&connection));
+    assert_eq!(Ok(Some(8.5f64)), source.first(&connection));
     connection.execute("DELETE FROM precision_numbers WHERE n = 2").unwrap();
-    assert_eq!(Ok(6.5f64), source.first(&connection));
+    assert_eq!(Ok(Some(6.5f64)), source.first(&connection));
+    connection.execute("DELETE FROM precision_numbers").unwrap();
+    assert_eq!(Ok(None::<f64>), source.first(&connection));
 }
 
 table! {
@@ -217,11 +221,12 @@ fn test_avg() {
     connection.execute("INSERT INTO precision_numbers (n) VALUES (2), (1), (6)").unwrap();
     let source = numbers.select(avg(n));
 
-    assert_eq!(Ok(3f64), source.first(&connection));
+    assert_eq!(Ok(Some(3f64)), source.first(&connection));
     connection.execute("DELETE FROM precision_numbers WHERE n = 2").unwrap();
-    assert_eq!(Ok(3.5f64), source.first(&connection));
+    assert_eq!(Ok(Some(3.5f64)), source.first(&connection));
+    connection.execute("DELETE FROM precision_numbers").unwrap();
+    assert_eq!(Ok(None::<f64>), source.first(&connection));
 }
-
 
 #[test]
 fn test_avg_for_nullable() {
@@ -247,22 +252,22 @@ fn test_avg_for_integer() {
     connection.execute("INSERT INTO numbers (n) VALUES (2), (1), (6)").unwrap();
     let source = numbers.select(avg(n));
 
-    let result = source.first::<data_types::PgNumeric>(&connection);
+    let result = source.first(&connection);
     let expected_result = data_types::PgNumeric::Positive {
         digits: vec![3],
         weight: 0,
         scale: 16,
     };
-    assert_eq!(Ok(expected_result), result);
+    assert_eq!(Ok(Some(expected_result)), result);
 
     connection.execute("DELETE FROM numbers WHERE n = 2").unwrap();
-    let result = source.first::<data_types::PgNumeric>(&connection);
+    let result = source.first(&connection);
     let expected_result = data_types::PgNumeric::Positive {
         digits: vec![3, 5000],
         weight: 0,
         scale: 16,
     };
-    assert_eq!(Ok(expected_result), result);
+    assert_eq!(Ok(Some(expected_result)), result);
 }
 
 table! {
@@ -282,11 +287,11 @@ fn test_avg_for_numeric() {
     connection.execute("INSERT INTO numeric (n) VALUES (2), (1), (6)").unwrap();
     let source = numeric.select(avg(n));
 
-    let result = source.first::<data_types::PgNumeric>(&connection);
+    let result = source.first(&connection);
     let expected_result = data_types::PgNumeric::Positive {
         digits: vec![3],
         weight: 0,
         scale: 16,
     };
-    assert_eq!(Ok(expected_result), result);
+    assert_eq!(Ok(Some(expected_result)), result);
 }


### PR DESCRIPTION
I said I was going to do this in cf32f6f7 but I guess I forgot... Blame
Ruby. These functions return `NULL` when run on an empty table. We need
to reflect that or we'll get runtime errors. This mirrors the signature
of `Iterator#sum`.