### PR TITLE
Enable joining from boxed queries

### DIFF
--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -9,6 +9,7 @@ use query_builder::offset_clause::OffsetClause;
 use query_builder::order_clause::OrderClause;
 use query_dsl::*;
 use query_source::QuerySource;
+use query_source::joins::*;
 use result::QueryResult;
 use types::{HasSqlType, Bool, BigInt};
 
@@ -112,6 +113,26 @@ impl<'a, ST, QS, DB> QueryId for BoxedSelectStatement<'a, ST, QS, DB> {
     }
 }
 
+impl<'a, ST, QS, DB, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On>
+    for BoxedSelectStatement<'a, ST, QS, DB> where
+        BoxedSelectStatement<'a, ST, JoinOn<Join<QS, Rhs, Kind>, On>, DB>: AsQuery,
+{
+    type Output = BoxedSelectStatement<'a, ST, JoinOn<Join<QS, Rhs, Kind>, On>, DB>;
+
+    fn join(self, rhs: Rhs, kind: Kind, on: On) -> Self::Output {
+        BoxedSelectStatement::new(
+            self.select,
+            Join::new(self.from, rhs, kind).on(on),
+            self.distinct,
+            self.where_clause,
+            self.order,
+            self.limit,
+            self.offset,
+            self.group_by,
+        )
+    }
+}
+
 impl<'a, ST, QS, DB, Selection> SelectDsl<Selection>
     for BoxedSelectStatement<'a, ST, QS, DB> where
         DB: Backend + HasSqlType<Selection::SqlType>,
@@ -202,5 +223,20 @@ impl<'a, ST, QS, DB, Expr> GroupByDsl<Expr>
     fn group_by(mut self, group_by: Expr) -> Self::Output {
         self.group_by = Box::new(GroupByClause(group_by));
         self
+    }
+}
+
+// FIXME: Should we disable joining when `.group_by` has been called? Are there
+// any other query methods where a join no longer has the same semantics as
+// joining on just the table?
+impl<'a, ST, QS, DB, Rhs> JoinTo<Rhs>
+    for BoxedSelectStatement<'a, ST, QS, DB> where
+        QS: JoinTo<Rhs>,
+{
+    type FromClause = QS::FromClause;
+    type OnClause = QS::OnClause;
+
+    fn join_target(rhs: Rhs) -> (Self::FromClause, Self::OnClause) {
+        QS::join_target(rhs)
     }
 }

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -102,7 +102,6 @@ pub trait JoinDsl: Sized {
     {
         self.left_outer_join(rhs)
     }
-
 }
 
 impl<T: AsQuery> JoinDsl for T {

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -68,6 +68,29 @@ fn select_multiple_from_join() {
 }
 
 #[test]
+fn join_boxed_query() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    connection.execute("INSERT INTO posts (id, user_id, title) VALUES
+        (1, 1, 'Hello'),
+        (2, 2, 'World')
+    ").unwrap();
+
+    let source = posts::table
+        .into_boxed()
+        .inner_join(users::table)
+        .select((users::name, posts::title));
+
+    let expected_data = vec![
+        ("Sean".to_string(), "Hello".to_string()),
+        ("Tess".to_string(), "World".to_string()),
+    ];
+    let actual_data: Vec<_> = source.load(&connection).unwrap();
+
+    assert_eq!(expected_data, actual_data);
+}
+
+#[test]
 fn select_only_one_side_of_join() {
     let connection = connection_with_sean_and_tess_in_users_table();
 


### PR DESCRIPTION
This has pretty limited usefulness, since the return type is going to
change which mostly defeats the purpose of boxing in the first place.
However, there's been some desire for this in crates.io.