### PR TITLE
Add `group_by` to boxed queries

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -224,6 +224,7 @@ impl<'a, F, S, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
         O: QueryFragment<DB> + 'a,
         L: QueryFragment<DB> + 'a,
         Of: QueryFragment<DB> + 'a,
+        G: QueryFragment<DB> + 'a,
 {
     type Output = BoxedSelectStatement<'a, S::SqlType, F, DB>;
 
@@ -236,6 +237,7 @@ impl<'a, F, S, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
             Box::new(self.order),
             Box::new(self.limit),
             Box::new(self.offset),
+            Box::new(self.group_by),
         )
     }
 }
@@ -250,6 +252,7 @@ impl<'a, F, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
         O: QueryFragment<DB> + 'a,
         L: QueryFragment<DB> + 'a,
         Of: QueryFragment<DB> + 'a,
+        G: QueryFragment<DB> + 'a,
 {
     type Output = BoxedSelectStatement<
         'a,
@@ -267,6 +270,7 @@ impl<'a, F, D, W, O, L, Of, G, DB> InternalBoxedDsl<'a, DB>
             Box::new(self.order),
             Box::new(self.limit),
             Box::new(self.offset),
+            Box::new(self.group_by),
         )
     }
 }

--- a/diesel_tests/tests/group_by.rs
+++ b/diesel_tests/tests/group_by.rs
@@ -1,5 +1,6 @@
 use schema::*;
 use diesel::*;
+use diesel::backend::Debug;
 
 #[test]
 // This test is a shim for a feature which is not sufficiently implemented. It
@@ -7,6 +8,22 @@ use diesel::*;
 // functionality will change and this test is allowed to change post-1.0
 fn group_by_generates_group_by_sql() {
     let source = users::table.group_by(users::name).select(users::id).filter(users::hair_color.is_null());
+    let expected_sql = "SELECT `users`.`id` FROM `users` \
+                        WHERE `users`.`hair_color` IS NULL \
+                        GROUP BY `users`.`name`";
+
+    assert_eq!(expected_sql, &debug_sql!(source));
+}
+
+#[test]
+// This test is a shim for a feature which is not sufficiently implemented. It
+// has been added as we have a user who needs a reasonable workaround, but this
+// functionality will change and this test is allowed to change post-1.0
+fn boxed_queries_have_group_by_method() {
+    let source = users::table.into_boxed::<Debug>()
+        .group_by(users::name)
+        .select(users::id)
+        .filter(users::hair_color.is_null());
     let expected_sql = "SELECT `users`.`id` FROM `users` \
                         WHERE `users`.`hair_color` IS NULL \
                         GROUP BY `users`.`name`";


### PR DESCRIPTION
The fact that this wasn't added in the first place is probably an
oversight.