### PR TITLE
Pass the right hand side to `JoinTo`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: nightly-2017-04-25
+  - rust: nightly-2017-06-06
     env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
     script:
     - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans)

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 [dependencies]
 byteorder = "1.0"
 chrono = { version = "0.4", optional = true }
-clippy = { optional = true, version = "=0.0.126" }
+clippy = { optional = true, version = "=0.0.138" }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.9.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -114,6 +114,7 @@ impl<DB, Statement> StatementCache<DB, Statement> where
     DB::QueryBuilder: Default,
     StatementCacheKey<DB>: Hash + Eq,
 {
+    #[cfg_attr(feature="clippy", allow(new_without_default_derive))]
     pub fn new() -> Self {
         StatementCache {
             cache: RefCell::new(HashMap::new())

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -16,6 +16,7 @@ pub struct RawBytesBindCollector<DB: Backend + TypeMetadata> {
 }
 
 impl<DB: Backend + TypeMetadata> RawBytesBindCollector<DB> {
+    #[cfg_attr(feature="clippy", allow(new_without_default_derive))]
     pub fn new() -> Self {
         RawBytesBindCollector {
             metadata: Vec::new(),

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -306,9 +306,10 @@ impl<F, S, D, W, O, L, Of, G, Rhs> JoinTo<Rhs>
     for SelectStatement<F, S, D, W, O, L, Of, G> where
         F: JoinTo<Rhs>,
 {
-    type JoinOnClause = F::JoinOnClause;
+    type FromClause = F::FromClause;
+    type OnClause = F::OnClause;
 
-    fn join_on_clause() -> Self::JoinOnClause {
-        F::join_on_clause()
+    fn join_target(rhs: Rhs) -> (Self::FromClause, Self::OnClause) {
+        F::join_target(rhs)
     }
 }

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -31,12 +31,13 @@ pub trait JoinWithImplicitOnClause<Rhs, Kind> {
 
 impl<Lhs, Rhs, Kind> JoinWithImplicitOnClause<Rhs, Kind> for Lhs where
     Lhs: JoinTo<Rhs>,
-    Lhs: InternalJoinDsl<Rhs, Kind, <Lhs as JoinTo<Rhs>>::JoinOnClause>,
+    Lhs: InternalJoinDsl<<Lhs as JoinTo<Rhs>>::FromClause, Kind, <Lhs as JoinTo<Rhs>>::OnClause>,
 {
-    type Output = <Lhs as InternalJoinDsl<Rhs, Kind, Lhs::JoinOnClause>>::Output;
+    type Output = <Lhs as InternalJoinDsl<Lhs::FromClause, Kind, Lhs::OnClause>>::Output;
 
     fn join_with_implicit_on_clause(self, rhs: Rhs, kind: Kind) -> Self::Output {
-        self.join(rhs, kind, Lhs::join_on_clause())
+        let (from, on) = Lhs::join_target(rhs);
+        self.join(from, kind, on)
     }
 }
 

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -154,9 +154,11 @@ impl<From, T> SelectableExpression<SelectStatement<From>>
 /// the [association annotations](../associations/index.html) from codegen.
 pub trait JoinTo<T> {
     #[doc(hidden)]
-    type JoinOnClause;
+    type FromClause;
     #[doc(hidden)]
-    fn join_on_clause() -> Self::JoinOnClause;
+    type OnClause;
+    #[doc(hidden)]
+    fn join_target(rhs: T) -> (Self::FromClause, Self::OnClause);
 }
 
 #[doc(hidden)]
@@ -228,20 +230,22 @@ impl<DB: Backend> QueryFragment<DB> for LeftOuter {
 impl<Left, Mid, Right, Kind> JoinTo<Right> for Join<Left, Mid, Kind> where
     Left: JoinTo<Right>,
 {
-    type JoinOnClause = Left::JoinOnClause;
+    type FromClause = Left::FromClause;
+    type OnClause = Left::OnClause;
 
-    fn join_on_clause() -> Self::JoinOnClause {
-        Left::join_on_clause()
+    fn join_target(rhs: Right) -> (Self::FromClause, Self::OnClause) {
+        Left::join_target(rhs)
     }
 }
 
 impl<Join, On, Right> JoinTo<Right> for JoinOn<Join, On> where
     Join: JoinTo<Right>,
 {
-    type JoinOnClause = Join::JoinOnClause;
+    type FromClause = Join::FromClause;
+    type OnClause = Join::OnClause;
 
-    fn join_on_clause() -> Self::JoinOnClause {
-        Join::join_on_clause()
+    fn join_target(rhs: Right) -> (Self::FromClause, Self::OnClause) {
+        Join::join_target(rhs)
     }
 }
 

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ clap = "2.20.3"
 diesel = { version = "0.14.0", default-features = false }
 dotenv = ">=0.8, <0.11"
 diesel_infer_schema = "0.14.0"
-clippy = { optional = true, version = "=0.0.126" }
+clippy = { optional = true, version = "=0.0.138" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -16,7 +16,7 @@ quote = "0.3.12"
 dotenv = { version = ">=0.8, <0.11", optional = true }
 diesel = { version = "0.14.0", default-features = false }
 diesel_infer_schema = { version = "0.14.0", default-features = false, optional = true }
-clippy = { optional = true, version = "=0.0.126" }
+clippy = { optional = true, version = "=0.0.138" }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.14.0", features = ["extras", "sqlite", "postgres", "mysql"] }
 diesel_codegen = { version = "0.14.0" }
-compiletest_rs = "=0.2.5"
+compiletest_rs = "=0.2.7"
 
 [replace]
 "diesel:0.14.1" = { path = "../diesel" }

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 diesel = { version = "0.14.0", default-features = false }
 syn = "0.11.4"
 quote = "0.3.1"
-clippy = { optional = true, version = "=0.0.126" }
+clippy = { optional = true, version = "=0.0.138" }
 
 [dev-dependencies]
 dotenv = ">=0.8, <0.11"


### PR DESCRIPTION
This is a refactoring in preparation for ad-hoc join clauses. I'm
imagining the API being roughly `lhs.inner_join(rhs.on(on_clause))`,
which will mean we will have a struct containing the rhs and the on
clause. The `JoinTo` impl for this struct will need to just destructure
it and return those pieces, so this sets up the trait changes for all
existing implementations.

I had to bump clippy as part of this change, as it hits a rustc bug that
was fixed on more recent nightlies. However, I couldn't bump to the
*latest* clippy, as recent nightlies are broken for us due to
https://github.com/rust-lang/rust/issues/43153