### PR TITLE
Don't deny warning when developing, only on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ matrix:
   - rust: nightly-2017-04-25
     env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
     script:
-    - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans)
-    - (cd diesel_cli && cargo rustc --no-default-features --features "lint sqlite postgres mysql" -- -Zno-trans)
-    - (cd diesel_codegen && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
-    - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
+    - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans --deny warnings)
+    - (cd diesel_cli && cargo rustc --no-default-features --features "lint sqlite postgres mysql" -- -Zno-trans --deny warnings)
+    - (cd diesel_codegen && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans --deny warnings)
+    - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans --deny warnings)
     - (cd diesel_compile_tests && travis-cargo test)
 env:
   # TODO: why is there no database specified for Postgres?

--- a/bin/check
+++ b/bin/check
@@ -4,7 +4,7 @@ set -e
 BACKENDS="sqlite postgres mysql"
 
 check() {
-    cargo rustc --quiet --features "lint $BACKENDS $1" -- -Zno-trans
+    cargo rustc --quiet --features "lint $BACKENDS $1" -- -Zno-trans --deny warnings
 }
 
 (cd diesel &&

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(feature = "unstable", feature(specialization))]
 
 // Built-in Lints
-#![deny(warnings, missing_debug_implementations, missing_copy_implementations)]
+#![warn(missing_debug_implementations, missing_copy_implementations)]
 
 // Clippy lints
 #![cfg_attr(feature = "clippy", allow(unstable_features))]

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -1,5 +1,5 @@
 // Built-in Lints
-#![deny(warnings, missing_copy_implementations)]
+#![warn(missing_copy_implementations)]
 
 // Clippy lints
 #![cfg_attr(feature = "clippy", allow(unstable_features))]

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -1,5 +1,5 @@
 // Built-in Lints
-#![deny(warnings, missing_copy_implementations)]
+#![warn(missing_copy_implementations)]
 
 // Clippy lints
 #![cfg_attr(feature = "clippy", allow(needless_pass_by_value))]

--- a/diesel_infer_schema/src/lib.rs
+++ b/diesel_infer_schema/src/lib.rs
@@ -1,5 +1,5 @@
 // Built-in Lints
-#![deny(warnings, missing_debug_implementations, missing_copy_implementations)]
+#![warn(missing_debug_implementations, missing_copy_implementations)]
 
 // Clippy lints
 #![cfg_attr(feature = "clippy", allow(unstable_features))]


### PR DESCRIPTION
This changes the lint settings to only emit warnings by default. This means that during development, you'll get to see warnings, but rustc will continue on with compiling diesel.

When explicitly checking the code for code style (on CI in the clippy build step, or when using `bin/check`), we supply `--deny warnings` as a flag to `rustc` to error out on warnings.

This does not change anything when using diesel as a dependency, as cargo automatically sets all lints to allow in that case.