### PR TITLE
Allow the `ON` clause of a join to be manually specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for the PG `IS DISTINCT FROM` operator
 
+* The `ON` clause of a join can now be manually specified. See [the
+  docs][join-on-dsl-1.0.0] for details.
+
+[join-on-dsl-1.0.0]: http://docs.diesel.rs/diesel/prelude/trait.JoinOnDsl.html#method.on
+
 ### Changed
 
 * Diesel will now automatically invoke `numeric_expr!` for your columns in the

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -1,5 +1,6 @@
 use query_builder::AsQuery;
-use query_source::{joins, Table, JoinTo};
+use query_source::{Table, JoinTo, QuerySource};
+use query_source::joins::{self, OnClauseWrapper};
 
 #[doc(hidden)]
 /// `JoinDsl` support trait to emulate associated type constructors
@@ -107,3 +108,52 @@ pub trait JoinDsl: Sized {
 
 impl<T: AsQuery> JoinDsl for T {
 }
+
+pub trait JoinOnDsl: Sized {
+    /// Specify the `ON` clause for a join statement. This will override
+    /// any implicit `ON` clause that would come from `#[belongs_to]`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("src/doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         user_id -> Integer,
+    /// #         title -> Text,
+    /// #     }
+    /// # }
+    /// #
+    /// # enable_multi_table_joins!(users, posts);
+    /// #
+    /// # fn main() {
+    /// #     let connection = establish_connection();
+    /// let data = users::table
+    ///     .left_join(posts::table.on(
+    ///         users::id.eq(posts::user_id).and(
+    ///             posts::title.eq("My first post"))
+    ///     ))
+    ///     .select((users::name, posts::title.nullable()))
+    ///     .load(&connection);
+    /// let expected = vec![
+    ///     ("Sean".to_string(), Some("My first post".to_string())),
+    ///     ("Tess".to_string(), None),
+    /// ];
+    /// assert_eq!(Ok(expected), data);
+    /// # }
+    fn on<On>(self, on: On) -> OnClauseWrapper<Self, On> {
+        OnClauseWrapper::new(self, on)
+    }
+}
+
+impl<T: QuerySource> JoinOnDsl for T {}

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -24,7 +24,7 @@ pub use self::distinct_dsl::DistinctDsl;
 pub use self::filter_dsl::{FilterDsl, FindDsl};
 #[doc(hidden)]
 pub use self::group_by_dsl::GroupByDsl;
-pub use self::join_dsl::{InternalJoinDsl, JoinDsl};
+pub use self::join_dsl::{InternalJoinDsl, JoinDsl, JoinOnDsl};
 pub use self::limit_dsl::LimitDsl;
 pub use self::load_dsl::{LoadDsl, ExecuteDsl, FirstDsl, LoadQuery};
 pub use self::offset_dsl::OffsetDsl;

--- a/diesel_compile_tests/tests/compile-fail/join_with_explicit_on_requires_valid_boolean_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/join_with_explicit_on_requires_valid_boolean_expression.rs
@@ -1,0 +1,36 @@
+#[macro_use] extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+    }
+}
+
+table! {
+    comments {
+        id -> Integer,
+    }
+}
+
+enable_multi_table_joins!(users, posts);
+enable_multi_table_joins!(users, comments);
+enable_multi_table_joins!(posts, comments);
+
+fn main() {
+    // Sanity check, make sure valid joins compile
+    let _ = users::table.inner_join(posts::table.on(users::id.eq(posts::id)));
+    // Invalid, references column that isn't being queried
+    let _ = users::table.inner_join(posts::table.on(users::id.eq(comments::id)));
+    //~^ ERROR E0271
+    // Invalid, type is not boolean
+    let _ = users::table.inner_join(posts::table.on(users::id));
+    //~^ ERROR E0271
+}


### PR DESCRIPTION
This allows ad-hoc joins with on clauses that aren't necessarily a
foreign key relationship. Joining with a manually specified on clause
does *not* require that the tables have an association between them (but
an invocation of `enable_multi_table_joins!` will be required in that
case).