### PR TITLE
Explicitly set the time zone and client encoding at connection startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   remove the `Nullable` portion (Unless you are using it with fields that are
   actually nullable)
 
+* Connections will now explicitly set the session time zone to UTC when the
+  connection is established
+
 ## [0.14.1] - 2017-07-10
 
 ### Changed

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -115,7 +115,11 @@ impl MysqlConnection {
     }
 
     fn set_config_options(&self) -> QueryResult<()> {
-        try!(self.execute("SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT'))"));
+        self.execute("SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT'))")?;
+        self.execute("SET time_zone = '+00:00';")?;
+        self.execute("SET character_set_client = 'utf8mb4'")?;
+        self.execute("SET character_set_connection = 'utf8mb4'")?;
+        self.execute("SET character_set_results = 'utf8mb4'")?;
         Ok(())
     }
 }


### PR DESCRIPTION
Diesel generally assumes that the database time zone is UTC, and that
the encoding is UTF8. These are the most common configurations, but this
explicitly sets our assumptions when the connection is established.

SQLite does not have a way to configure either of these, it is always
UTF8 and UTC.

Fixes #1024