### PR TITLE
Disabled the backtrace default feature on dotenv dependency.

### DIFF
--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["orm", "database", "postgres", "sql", "codegen"]
 [dependencies]
 syn = { version = "0.11.4", features = ["aster"] }
 quote = "0.3.12"
-dotenv = { version = ">=0.8, <0.11", optional = true }
+dotenv = { version = ">=0.8, <0.11", optional = true, default-features = false }
 diesel = { version = "0.14.0", default-features = false }
 diesel_infer_schema = { version = "0.14.0", default-features = false, optional = true }
 clippy = { optional = true, version = "=0.0.138" }


### PR DESCRIPTION
The dotenv crate uses error-chain, which by default has the backtraces feature on. This forces the feature on globally for all crates that use error-chain.

In my experience the backtraces feature may break containerized builds since it requires a 3rd party library to be installed, plus backtraces are detrimental to performance on MacOS. Fortunately dotenv recently gained the option that allows opting out of the feature. I think it would be wise to have captyring backtraces by default off in Diesel too. (It's likely to be that having a separate feature for backtraces on dotenv is overkill too, and it would be better just to have them off there too, but that's another discussion.) If someone wants them, they can do that by depending directly on error-chain while keeping the feature on.