### PR TITLE
[DO NOT MERGE] Potential API change to `table!`

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -577,7 +577,14 @@ macro_rules! table_body {
             ///
             /// This is the type which provides the base methods of the query
             /// builder, such as `.select` and `.filter`.
-            pub struct table;
+            pub struct table {
+                $(pub $column_name: $column_name,)+
+            }
+
+            #[allow(non_upper_case_globals)]
+            pub const table: table = table {
+                $($column_name: $column_name,)+
+            };
 
             impl table {
                 #[allow(dead_code)]


### PR DESCRIPTION
The goal that I'm trying to accomplish with this change is to allow you to reference `users` without the `::table`, but not have to `use users::dsl::*`. I've found that when I'm writing functions which are working with a large number of tables (e.g. I can't import `dsl`), having `::table` all over the place feels really verbose. This change is possible because Rust has two namespaces: "values" (constants, functions, etc) and "types" (structs, enums, type aliases, modules, etc).

However, I'm not 100% sure I want to make this change on its own. A common point of confusion among new users is when the `dsl` module should be imported, and what exactly that does. (I've also seen people do `users::table` when `users::dsl::table` is in scope, which gives a confusing error because `users::table` will be referencing `http://docs.diesel.rs/diesel/associations/trait.HasTable.html#tymethod.table`). This will just make that situation more confusing. Knowing when you can do `users::id` vs `users.id` vs `id` requires knowledge of exactly what we generate, and thorough knowledge of name resolution in Rust. It's something that's extremely hard for us to document well in the places people will be looking for it. Additionally, this many `use` lines just feels even more verbose. I'd want a solution that requires a single `use` line, or a way to eliminate them entirely.

So I think if we make this change, we should try to make this the canonical way to do things, or at least have `users.id` *always* work. This is actually possible, since we can re-export just the constant but not the type at the same level as the module. The main downside to doing that is all code which looks like this would break:

```rust
use schema::*;

let users = ...
```

This would error since you cannot have a let binding with the same name as a constant. This only affects code that was not using the `dsl` module, since you also cannot have a let binding with the same name as a unit struct.

I generally think that `let users = users::table.stuff` is a bit funky looking anyway, so I'm not sure if I'm actually concerned about this or not. If nothing else it'll cause a lot of breakage in our own test suite since I *always* `use schema::*`, but it's possible that the migration will be easier. If nothing else, I want to see how much work it is to migrate our test suite and crates.io, and also how much this improves the codebase of crates.io

If we do make this change, I think we can remove the `dsl` module entirely, and code which wants that can do `use users::columns::*` instead which is much more explicit about exactly what happens.