### PR TITLE
Hide the token patterns we look for in `table!`

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -243,6 +243,14 @@ macro_rules! __diesel_column {
 /// ```
 #[macro_export]
 macro_rules! table {
+    ($($tokens:tt)*) => {
+        __diesel_table_impl!($($tokens)*);
+    }
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __diesel_table_impl {
     // Put imports into the import field
     (
         @parse


### PR DESCRIPTION
The generated documentation for the `table!` macro is really bad. Macros
document all of the patterns that they match on. For complex macros such
as this one, this is not useful information to the user.

This was maybe useful back in 0.1 when the docs looked like
https://docs.rs/diesel/0.1.0/diesel/macro.table!.html, but now it's just
a bunch of opaque macro soup that the user doesn't care about. The
actual documentation is buried more than two full page scrolls down.

This makes the documented token pattern as small as possible, so that
the actual documentation can be front and center.

Before:
<img width="1026" alt="screen shot 2017-07-23 at 6 47 35 am" src="https://user-images.githubusercontent.com/1529387/28498769-641494ea-6f73-11e7-91b6-c0d4f6418db7.png">

After:
<img width="1057" alt="screen shot 2017-07-23 at 6 47 42 am" src="https://user-images.githubusercontent.com/1529387/28498770-6847efda-6f73-11e7-873c-3729622613c7.png">