### PR TITLE
Enable joining from boxed queries

### DIFF
--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -76,10 +76,10 @@ impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB> 
             where_clause.walk_ast(out.reborrow())?;
         }
 
+        self.group_by.walk_ast(out.reborrow())?;
         self.order.walk_ast(out.reborrow())?;
         self.limit.walk_ast(out.reborrow())?;
         self.offset.walk_ast(out.reborrow())?;
-        self.group_by.walk_ast(out.reborrow())?;
         Ok(())
     }
 }
@@ -97,10 +97,10 @@ impl<'a, ST, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, (), DB> wher
             where_clause.walk_ast(out.reborrow())?;
         }
 
+        self.group_by.walk_ast(out.reborrow())?;
         self.order.walk_ast(out.reborrow())?;
         self.limit.walk_ast(out.reborrow())?;
         self.offset.walk_ast(out.reborrow())?;
-        self.group_by.walk_ast(out.reborrow())?;
         Ok(())
     }
 }


### PR DESCRIPTION
Looks like this commit didn't make it in the 0.15.0 release, we think this is what we need for the `group_by` statement. This is the only thing that wasn't included from the branch we were testing with and isn't currently in master. 

When we try crates.io with Diesel 0.15.0, we're getting the error 
```
ERROR:conduit_log_requests: 127.0.0.1:64825 [2017-07-24T10:37:29-04:00] 
Get /api/v1/crates - 4ms 500: syntax error at or near "GROUP" syntax error at or near "GROUP"
```