### PR TITLE
Remove migration output from setup, including test

### DIFF
--- a/diesel/src/migrations/mod.rs
+++ b/diesel/src/migrations/mod.rs
@@ -269,7 +269,9 @@ fn run_migration<Conn>(conn: &Conn, migration: &Migration, output: &mut Write)
         Conn: MigrationConnection,
 {
     conn.transaction(|| {
-        try!(writeln!(output, "Running migration {}", migration.version()));
+        if migration.version() != "00000000000000" {
+            try!(writeln!(output, "Running migration {}", migration.version()));
+        }
         try!(migration.run(conn));
         try!(conn.insert_new_migration(migration.version()));
         Ok(())

--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -32,6 +32,16 @@ fn setup_creates_migrations_directory() {
 
 #[test]
 #[cfg(feature="postgres")]
+fn setup_initial_migration_returns_nothing_to_console() {
+    let p = project("setup_intial_migration_returns_nothing_to_console").build();
+
+    let result = p.command("setup").run();
+
+    assert!(!result.stdout().contains("Running migration"));
+}
+
+#[test]
+#[cfg(feature="postgres")]
 fn setup_creates_default_migration_file() {
     let p = project("setup_creates_default_migration_file").build();
 


### PR DESCRIPTION
fix #1023 

I'm not 100% sure why but it's showing I added `#[test]` and `[cfg(feature="postgres")]` to the spec below it instead of to itself but I didn't 🤔 ... 

Well I ran the spec and got it to pass. Let me know if something isn't up to par and I'll get it resolved.