### PR TITLE
Properly encode `BigDecimal` values whose first digit is 10k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
 ### Added
 
 * Added helper types for inner join and left outer join
+
+### Fixed
+
+* `BigDecimal` now properly encodes numbers starting with `10000` on postgres.
+  See [issue #1044][] for details.
+
+[issue #1044]: https://github.com/diesel-rs/diesel/issues/1044
 
 ## [0.15.1] - 2017-07-24
 

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -26,7 +26,7 @@ mod bigdecimal {
 
         let mut integer_part = absolute.to_bigint().expect("Can always take integer part of BigDecimal");
 
-        while ten_k < integer_part {
+        while ten_k <= integer_part {
             weight += 1;
             // digit is integer_part REM 10_000
             let (div, digit) = integer_part.div_rem(&ten_k);


### PR DESCRIPTION
When serializing a numeric column, we need to take a decimal value and
convert it to a list of its digits in base 10k. The serialization code
had a bug when the first digit was exactly `10000`, resulting in the
digits being `[10000, ...]` instead of `[1, 0, ...]`. This bug only
affected the integral part, as the decimal portion uses different logic
in order ot strip trailing zeroes.

Fixes #1044.