### PR TITLE
Include bind parameters in `debug_sql!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added helper types for inner join and left outer join
 
-* `diesel::debug_sql` has been added as a replacement for `debug_sql!`. This
+* `diesel::debug_query` has been added as a replacement for `debug_sql!`. This
   function differs from the macro by allowing you to specify the backend, and
-  will generate the actual query which will be run.
+  will generate the actual query which will be run. The returned value will
+  implement `Display` and `Debug` to show the query in different ways
 
 * `diesel::pg::PgConnection`, `diesel::mysql::MysqlConnection`, and
   `diesel::sqlite::SqliteConnection` are now exported from `diesel::prelude`.
@@ -47,7 +48,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Removed
 
-* `debug_sql!` has been deprecated in favor of `diesel::debug_sql`.
+* `debug_sql!` has been deprecated in favor of `diesel::debug_query`.
 
 * `print_sql!` has been deprecated without replacement.
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -144,7 +144,7 @@ pub mod prelude {
 
 pub use prelude::*;
 #[doc(inline)]
-pub use query_builder::debug_sql;
+pub use query_builder::debug_query;
 #[doc(inline)]
 pub use query_builder::functions::{insert, update, delete, select, insert_default_values};
 #[cfg(feature = "sqlite")]

--- a/diesel/src/query_builder/debug_query.rs
+++ b/diesel/src/query_builder/debug_query.rs
@@ -1,0 +1,91 @@
+use std::fmt::{self, Display, Debug};
+use std::marker::PhantomData;
+use std::mem;
+
+use backend::Backend;
+use super::{QueryBuilder, QueryFragment, AstPass};
+
+/// A struct that implements `fmt::Display` and `fmt::Debug` to show the SQL
+/// representation of a query.
+///
+/// The `Display` implementation will be the exact query sent to the server,
+/// plus a comment with the values of the bind parameters. The `Debug`
+/// implementation is more structured, and able to be pretty printed.
+pub struct DebugQuery<'a, T: 'a, DB> {
+    query: &'a T,
+    _marker: PhantomData<DB>,
+}
+
+impl<'a, T, DB> DebugQuery<'a, T, DB> {
+    pub(crate) fn new(query: &'a T) -> Self {
+        DebugQuery {
+            query,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, DB> Display for DebugQuery<'a, T, DB> where
+    DB: Backend,
+    DB::QueryBuilder: Default,
+    T: QueryFragment<DB>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut query_builder = DB::QueryBuilder::default();
+        QueryFragment::<DB>::to_sql(self.query, &mut query_builder)
+            .map_err(|_| fmt::Error)?;
+        let debug_binds = DebugBinds::<_, DB>::new(self.query);
+        write!(f, "{} -- binds: {:?}", query_builder.finish(), debug_binds)
+    }
+}
+
+impl<'a, T, DB> Debug for DebugQuery<'a, T, DB> where
+    DB: Backend,
+    DB::QueryBuilder: Default,
+    T: QueryFragment<DB>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut query_builder = DB::QueryBuilder::default();
+        QueryFragment::<DB>::to_sql(self.query, &mut query_builder)
+            .map_err(|_| fmt::Error)?;
+        let debug_binds = DebugBinds::<_, DB>::new(self.query);
+        f.debug_struct("Query")
+            .field("sql", &query_builder.finish())
+            .field("binds", &debug_binds)
+            .finish()
+    }
+}
+
+/// A struct that implements `fmt::Debug` by walking the given AST and writing
+/// the `fmt::Debug` implementation of each bind parameter.
+pub struct DebugBinds<'a, T: 'a, DB> {
+    query: &'a T,
+    _marker: PhantomData<DB>,
+}
+
+impl<'a, T, DB> DebugBinds<'a, T, DB> {
+    fn new(query: &'a T) -> Self {
+        DebugBinds {
+            query,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, DB> Debug for DebugBinds<'a, T, DB> where
+    DB: Backend,
+    T: QueryFragment<DB>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut list = f.debug_list();
+        {
+            // Safe because the lifetime is shortened to one smaller
+            // than the lifetime of the formatter.
+            let list_with_shorter_lifetime = unsafe { mem::transmute(&mut list) };
+            let ast_pass = AstPass::debug_binds(list_with_shorter_lifetime);
+            self.query.walk_ast(ast_pass).map_err(|_| fmt::Error)?;
+        }
+        list.finish()?;
+        Ok(())
+    }
+}

--- a/diesel_codegen/tests/associations.rs
+++ b/diesel_codegen/tests/associations.rs
@@ -59,8 +59,8 @@ fn simple_belongs_to() {
     let filter = posts::table.filter(posts::user_id.eq(42));
 
     assert_eq!(
-        debug_sql::<Backend, _>(&belong_to),
-        debug_sql::<Backend, _>(&filter)
+        debug_query::<Backend, _>(&belong_to).to_string(),
+        debug_query::<Backend, _>(&filter).to_string()
     );
 }
 
@@ -118,8 +118,8 @@ fn custom_foreign_key() {
     let filter = posts::table.filter(posts::belongs_to_user.eq(42));
 
     assert_eq!(
-        debug_sql::<Backend, _>(&belong_to),
-        debug_sql::<Backend, _>(&filter)
+        debug_query::<Backend, _>(&belong_to).to_string(),
+        debug_query::<Backend, _>(&filter).to_string()
     );
 }
 
@@ -146,7 +146,7 @@ fn self_referential() {
     let belong_to = Tree::belonging_to(&t);
     let filter = trees::table.filter(trees::parent_id.eq(42));
     assert_eq!(
-        debug_sql::<Backend, _>(&belong_to),
-        debug_sql::<Backend, _>(&filter)
+        debug_query::<Backend, _>(&belong_to).to_string(),
+        debug_query::<Backend, _>(&filter).to_string()
     );
 }

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -4,11 +4,11 @@ use diesel::*;
 #[test]
 fn test_debug_count_output() {
     use schema::users::dsl::*;
-    let sql = debug_sql::<TestBackend, _>(&users.count());
+    let sql = debug_query::<TestBackend, _>(&users.count()).to_string();
     if cfg!(feature = "postgres") {
-        assert_eq!(sql, r#"SELECT COUNT(*) FROM "users""#);
+        assert_eq!(sql, r#"SELECT COUNT(*) FROM "users" -- binds: []"#);
     } else {
-        assert_eq!(sql, "SELECT COUNT(*) FROM `users`");
+        assert_eq!(sql, "SELECT COUNT(*) FROM `users` -- binds: []");
     }
 }
 
@@ -16,10 +16,10 @@ fn test_debug_count_output() {
 fn test_debug_output() {
     use schema::users::dsl::*;
     let command = update(users.filter(id.eq(1))).set(name.eq("new_name"));
-    let sql = debug_sql::<TestBackend, _>(&command);
+    let sql = debug_query::<TestBackend, _>(&command).to_string();
     if cfg!(feature = "postgres") {
-        assert_eq!(sql, r#"UPDATE "users" SET "name" = $1 WHERE "users"."id" = $2"#)
+        assert_eq!(sql, r#"UPDATE "users" SET "name" = $1 WHERE "users"."id" = $2 -- binds: ["new_name", 1]"#)
     } else {
-        assert_eq!(sql, "UPDATE `users` SET `name` = ? WHERE `users`.`id` = ?")
+        assert_eq!(sql, r#"UPDATE `users` SET `name` = ? WHERE `users`.`id` = ? -- binds: ["new_name", 1]"#)
     }
 }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -28,7 +28,7 @@ fn test_count_star() {
     assert_eq!(Ok(1), source.first(&connection));
 
     // Ensure we're doing COUNT(*) instead of COUNT(table.*) which is going to be more efficient
-    assert!(debug_sql::<TestBackend, _>(&source).starts_with("SELECT COUNT(*) FROM"));
+    assert!(debug_query::<TestBackend, _>(&source).to_string().starts_with("SELECT COUNT(*) FROM"));
 }
 
 table! {

--- a/diesel_tests/tests/group_by.rs
+++ b/diesel_tests/tests/group_by.rs
@@ -9,12 +9,13 @@ fn group_by_generates_group_by_sql() {
     let source = users::table.group_by(users::name).select(users::id).filter(users::hair_color.is_null());
     let mut expected_sql = "SELECT `users`.`id` FROM `users` \
         WHERE `users`.`hair_color` IS NULL \
-        GROUP BY `users`.`name`".to_string();
+        GROUP BY `users`.`name` \
+        -- binds: []".to_string();
     if cfg!(feature = "postgres") {
         expected_sql = expected_sql.replace('`', "\"");
     }
 
-    assert_eq!(expected_sql, debug_sql::<TestBackend, _>(&source));
+    assert_eq!(expected_sql, debug_query::<TestBackend, _>(&source).to_string());
 }
 
 #[test]
@@ -28,10 +29,11 @@ fn boxed_queries_have_group_by_method() {
         .filter(users::hair_color.is_null());
     let mut expected_sql = "SELECT `users`.`id` FROM `users` \
         WHERE `users`.`hair_color` IS NULL \
-        GROUP BY `users`.`name`".to_string();
+        GROUP BY `users`.`name` \
+        -- binds: []".to_string();
     if cfg!(feature = "postgres") {
         expected_sql = expected_sql.replace('`', "\"");
     }
 
-    assert_eq!(expected_sql, debug_sql(&source));
+    assert_eq!(expected_sql, debug_query(&source).to_string());
 }


### PR DESCRIPTION
I've implemented this as a separate AST pass, rather than the
`CollectBinds` pass of the `Debug` backend. This is because we will
ultimately want to use this same code for logging, which won't have the
`QueryFragment<Debug>` constraint. Ultimately I think I want to get rid
of the `Debug` backend entirely once logging is implemented.

I had originally implemented this by adding two additional lifetime
parameters onto `AstPass`. However, I really disliked how opaque and
random these two extra parameters felt, and it made the type harder to
document (and use). Shortening an invariant lifetime like this is
actually one of the documented use cases that `mem::transmute` is useful
for. I don't like introducing unsafe code in general, but I felt that
the tradeoff was worth it in this case.