### PR TITLE
Finish the update guide, actually run its tests

### DIFF
--- a/examples/postgres/all_about_updates/Cargo.toml
+++ b/examples/postgres/all_about_updates/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
-diesel = { version = "0.11.0", features = ["postgres"] }
-diesel_codegen = "0.11.0"
+diesel = { version = "0.15.0", features = ["postgres"] }
+diesel_codegen = "0.15.0"

--- a/examples/postgres/all_about_updates/src/lib.rs
+++ b/examples/postgres/all_about_updates/src/lib.rs
@@ -17,8 +17,6 @@ table! {
     }
 }
 
-numeric_expr!(posts::visit_count);
-
 #[derive(Queryable, Identifiable, AsChangeset)]
 pub struct Post {
     pub id: i64,

--- a/examples/postgres/test_all
+++ b/examples/postgres/test_all
@@ -13,6 +13,6 @@ for dir in $(find . -maxdepth 1 -mindepth 1 -type d); do
     ../../../bin/diesel database reset
   fi
 
-  cargo build
+  cargo test
   cd ..
 done


### PR DESCRIPTION
This finishes all the TODOs I had left previously. I also noticed that
we weren't actually running the test suite for this example, so I've
updated it to be run. The suite was failing due to `numeric_expr!` being
inferred, which prompted me to remove the point in the guide mentioning
it as well.

The explanation of `get_result` and `get_results` assumes that someone
is already familiar with `Queryable` and/or `load`, which I don't like.
However I think we will have a separate guide that explains those in
depth, and we can cross-link to that here when we do so.