### PR TITLE
Implement `FromSqlRow<Nullable<ST>, DB> for Option<T>` with blanket impl

### DIFF
--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -75,16 +75,6 @@ impl<T, ST> FromSqlRow<Array<ST>, Pg> for Vec<T> where
     }
 }
 
-#[cfg(not(feature="unstable"))]
-impl<T, ST> FromSqlRow<Nullable<Array<ST>>, Pg> for Option<Vec<T>> where
-    Pg: HasSqlType<ST>,
-    Option<Vec<T>>: FromSql<Nullable<Array<ST>>, Pg>,
-{
-    fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error+Send+Sync>> {
-        FromSql::<Nullable<Array<ST>>, Pg>::from_sql(row.take())
-    }
-}
-
 impl<T, ST> Queryable<Array<ST>, Pg> for Vec<T> where
     T: FromSql<ST, Pg> + Queryable<ST, Pg>,
     Pg: HasSqlType<ST>,

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -71,16 +71,6 @@ macro_rules! queryable_impls {
             }
         }
 
-        #[cfg(not(feature = "unstable"))]
-        impl<DB> $crate::types::FromSqlRow<$crate::types::Nullable<$crate::types::$Source>, DB> for Option<$Target> where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
-            Option<$Target>: $crate::types::FromSql<$crate::types::Nullable<$crate::types::$Source>, DB>,
-        {
-            fn build_from_row<R: $crate::row::Row<DB>>(row: &mut R) -> Result<Self, Box<::std::error::Error+Send+Sync>> {
-                $crate::types::FromSql::<$crate::types::Nullable<$crate::types::$Source>, DB>::from_sql(row.take())
-            }
-        }
-
         impl<DB> $crate::query_source::Queryable<$crate::types::$Source, DB> for $Target where
             DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
             $Target: $crate::types::FromSqlRow<$crate::types::$Source, DB>,

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -8,7 +8,7 @@ use query_builder::*;
 use query_source::{QuerySource, Queryable, Table, Column};
 use result::QueryResult;
 use row::Row;
-use types::{HasSqlType, FromSqlRow, Nullable, NotNull};
+use types::{HasSqlType, FromSqlRow, NotNull};
 use util::TupleAppend;
 
 macro_rules! tuple_impls {
@@ -42,27 +42,6 @@ macro_rules! tuple_impls {
             {
                 fn build_from_row<RowT: Row<DB>>(row: &mut RowT) -> Result<Self, Box<Error+Send+Sync>> {
                     Ok(($(try!($T::build_from_row(row)),)+))
-                }
-
-                fn fields_needed() -> usize {
-                    $($T::fields_needed() +)+ 0
-                }
-            }
-
-            impl<$($T),+, $($ST),+, DB> FromSqlRow<Nullable<($($ST,)+)>, DB> for Option<($($T,)+)> where
-                DB: Backend,
-                $($T: FromSqlRow<$ST, DB>),+,
-                $(DB: HasSqlType<$ST>),+,
-                DB: HasSqlType<($($ST,)+)>,
-            {
-                fn build_from_row<RowT: Row<DB>>(row: &mut RowT) -> Result<Self, Box<Error+Send+Sync>> {
-                    let fields_needed = <Self as FromSqlRow<Nullable<($($ST,)+)>, DB>>::fields_needed();
-                    if row.next_is_null(fields_needed) {
-                        row.advance(fields_needed);
-                        Ok(None)
-                    } else {
-                        Ok(Some(($(try!($T::build_from_row(row)),)+)))
-                    }
                 }
 
                 fn fields_needed() -> usize {

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -357,22 +357,6 @@ pub trait FromSqlRow<A, DB: Backend + HasSqlType<A>>: Sized {
     }
 }
 
-#[cfg(feature = "unstable")]
-impl<T, ST, DB> FromSqlRow<Nullable<ST>, DB> for Option<T> where
-    T: FromSqlRow<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
-    ST: NotNull,
-{
-    default fn build_from_row<R: Row<DB>>(row: &mut R) -> Result<Self, Box<Error+Send+Sync>> {
-        if row.next_is_null(1) {
-            row.take();
-            Ok(None)
-        } else {
-            T::build_from_row(row).map(Some)
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// Tiny enum to make the return type of `ToSql` more descriptive
 pub enum IsNull {


### PR DESCRIPTION
This is one of those things that was definitely impossible, but I could
never quite remember why, and so every 2 months or so I look at it and
go "this should be possible as a blanket impl", implement it, and get a
compiler error that makes me remember why it's impossible. I have tried
this at least 4-5 times as part of that flow in the past.

I have no clue why it's possible this time. But it is. So yay?

This is something that is actually important to have as a blanket impl,
because a downstream crate *can not* write this impl themselves for
their types, as `Option` is not `#[fundamental]`