### PR TITLE
Export the connection types in `prelude`

### DIFF
--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -9,9 +9,9 @@ cfg_if! {
         #[allow(dead_code)]
         type DB = diesel::pg::Pg;
 
-        fn connection_no_data() -> diesel::pg::PgConnection {
+        fn connection_no_data() -> PgConnection {
             let connection_url = database_url_from_env("PG_DATABASE_URL");
-            let connection = diesel::pg::PgConnection::establish(&connection_url).unwrap();
+            let connection = PgConnection::establish(&connection_url).unwrap();
             connection.begin_test_transaction().unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
             connection.execute("DROP TABLE IF EXISTS animals").unwrap();
@@ -21,7 +21,7 @@ cfg_if! {
         }
 
         #[allow(dead_code)]
-        fn establish_connection() -> diesel::pg::PgConnection {
+        fn establish_connection() -> PgConnection {
             let connection = connection_no_data();
 
             connection.execute("CREATE TABLE users (
@@ -56,12 +56,12 @@ cfg_if! {
         #[allow(dead_code)]
         type DB = diesel::sqlite::Sqlite;
 
-        fn connection_no_data() -> diesel::sqlite::SqliteConnection {
-            diesel::sqlite::SqliteConnection::establish(":memory:").unwrap()
+        fn connection_no_data() -> SqliteConnection {
+            SqliteConnection::establish(":memory:").unwrap()
         }
 
         #[allow(dead_code)]
-        fn establish_connection() -> diesel::sqlite::SqliteConnection {
+        fn establish_connection() -> SqliteConnection {
             let connection = connection_no_data();
 
             connection.execute("CREATE TABLE users (
@@ -96,9 +96,9 @@ cfg_if! {
         #[allow(dead_code)]
         type DB = diesel::mysql::Mysql;
 
-        fn connection_no_data() -> diesel::mysql::MysqlConnection {
+        fn connection_no_data() -> MysqlConnection {
             let connection_url = database_url_from_env("MYSQL_UNIT_TEST_DATABASE_URL");
-            let connection = diesel::mysql::MysqlConnection::establish(&connection_url).unwrap();
+            let connection = MysqlConnection::establish(&connection_url).unwrap();
             connection.execute("DROP TABLE IF EXISTS users").unwrap();
             connection.execute("DROP TABLE IF EXISTS animals").unwrap();
             connection.execute("DROP TABLE IF EXISTS posts").unwrap();
@@ -107,7 +107,7 @@ cfg_if! {
         }
 
         #[allow(dead_code)]
-        fn establish_connection() -> diesel::mysql::MysqlConnection {
+        fn establish_connection() -> MysqlConnection {
             let connection = connection_no_data();
 
             connection.execute("CREATE TABLE users (

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -130,6 +130,13 @@ pub mod prelude {
     pub use query_dsl::*;
     pub use query_source::{QuerySource, Queryable, Table, Column, JoinTo};
     pub use result::{QueryResult, ConnectionError, ConnectionResult, OptionalExtension};
+
+    #[cfg(feature = "postgres")]
+    pub use pg::PgConnection;
+    #[cfg(feature = "sqlite")]
+    pub use sqlite::SqliteConnection;
+    #[cfg(feature = "mysql")]
+    pub use mysql::MysqlConnection;
 }
 
 pub use prelude::*;

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -124,7 +124,6 @@ impl FromSql<Date, Mysql> for NaiveDate {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     extern crate dotenv;
     extern crate chrono;
@@ -133,7 +132,6 @@ mod tests {
     use self::dotenv::dotenv;
 
     use expression::dsl::{sql, now};
-    use mysql::MysqlConnection;
     use prelude::*;
     use select;
     use types::{Date, Time, Timestamp};

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -250,7 +250,6 @@ mod tests {
     use ::{types, select};
     use data_types::PgInterval;
     use expression::dsl::sql;
-    use pg::PgConnection;
     use prelude::*;
     use super::*;
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -137,7 +137,6 @@ mod tests {
 
     use ::select;
     use expression::dsl::{sql, now};
-    use pg::PgConnection;
     use prelude::*;
     use types::{Date, Time, Timestamp, Timestamptz};
 

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -47,7 +47,6 @@ mod tests {
 
     use ::select;
     use expression::dsl::{sql, now};
-    use pg::PgConnection;
     use prelude::*;
     use types::Timestamp;
 

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -73,7 +73,6 @@ mod tests {
 
     use ::select;
     use expression::dsl::{sql, now};
-    use pg::PgConnection;
     use prelude::*;
     use types::Timestamp;
 

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -97,7 +97,6 @@ mod tests {
 
     use ::select;
     use expression::dsl::{sql, now};
-    use sqlite::SqliteConnection;
     use prelude::*;
     use types::{Date, Time, Timestamp};
 

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -2,8 +2,6 @@ use prelude::*;
 
 cfg_if! {
     if #[cfg(feature = "sqlite")] {
-        use sqlite::SqliteConnection;
-
         pub type TestConnection = SqliteConnection;
 
         pub fn connection() -> TestConnection {
@@ -14,8 +12,6 @@ cfg_if! {
 
         use self::dotenv::dotenv;
         use std::env;
-
-        use pg::PgConnection;
 
         pub type TestConnection = PgConnection;
 
@@ -33,8 +29,6 @@ cfg_if! {
 
         use self::dotenv::dotenv;
         use std::env;
-
-        use mysql::MysqlConnection;
 
         pub type TestConnection = MysqlConnection;
 

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -1,11 +1,5 @@
 use clap::ArgMatches;
 use diesel::expression::sql;
-#[cfg(feature="postgres")]
-use diesel::pg::PgConnection;
-#[cfg(feature="sqlite")]
-use diesel::sqlite::SqliteConnection;
-#[cfg(feature="mysql")]
-use diesel::mysql::MysqlConnection;
 use diesel::types::Bool;
 use diesel::*;
 #[cfg(any(feature="postgres", feature="mysql"))]

--- a/diesel_cli/tests/support/mysql_database.rs
+++ b/diesel_cli/tests/support/mysql_database.rs
@@ -1,5 +1,4 @@
 use diesel::expression::sql;
-use diesel::mysql::MysqlConnection;
 use diesel::types::Bool;
 use diesel::*;
 

--- a/diesel_cli/tests/support/postgres_database.rs
+++ b/diesel_cli/tests/support/postgres_database.rs
@@ -1,7 +1,6 @@
 use diesel::expression::sql;
-use diesel::pg::PgConnection;
 use diesel::types::Bool;
-use diesel::{Connection, select, LoadDsl};
+use diesel::{Connection, PgConnection, select, LoadDsl};
 
 pub struct Database {
     url: String

--- a/diesel_codegen/tests/test_helpers.rs
+++ b/diesel_codegen/tests/test_helpers.rs
@@ -2,8 +2,6 @@ use diesel::prelude::*;
 
 cfg_if! {
     if #[cfg(feature = "sqlite")] {
-        use diesel::sqlite::SqliteConnection;
-
         pub type TestConnection = SqliteConnection;
 
         pub fn connection() -> TestConnection {
@@ -14,8 +12,6 @@ cfg_if! {
 
         use self::dotenv::dotenv;
         use std::env;
-
-        use diesel::pg::PgConnection;
 
         pub type TestConnection = PgConnection;
 
@@ -33,8 +29,6 @@ cfg_if! {
 
         use self::dotenv::dotenv;
         use std::env;
-
-        use diesel::mysql::MysqlConnection;
 
         pub type TestConnection = MysqlConnection;
 

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_must_be_used_with_proper_connection.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_must_be_used_with_proper_connection.rs
@@ -3,7 +3,6 @@ extern crate diesel;
 
 use diesel::*;
 use diesel::pg::Pg;
-use diesel::sqlite::SqliteConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
+++ b/diesel_compile_tests/tests/compile-fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
@@ -4,7 +4,6 @@ extern crate diesel;
 extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -2,7 +2,6 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::sqlite::SqliteConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -2,7 +2,6 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 
 table! {
     int_primary_key {

--- a/diesel_compile_tests/tests/compile-fail/ilike_only_compiles_for_pg.rs
+++ b/diesel_compile_tests/tests/compile-fail/ilike_only_compiles_for_pg.rs
@@ -4,8 +4,6 @@ extern crate diesel;
 extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::sqlite::SqliteConnection;
-use diesel::mysql::MysqlConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -2,7 +2,6 @@
 #[macro_use] extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 use diesel::pg::upsert::*;
 
 table! {

--- a/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
@@ -2,7 +2,6 @@
 #[macro_use] extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::sqlite::SqliteConnection;
 use diesel::types::*;
 use diesel::expression::dsl::*;
 use diesel::pg::upsert::*;
@@ -27,14 +26,14 @@ fn main() {
 
     users.select(id).filter(name.eq(any(Vec::<String>::new())))
         .load::<i32>(&connection);
-    //~^ ERROR type mismatch resolving `<diesel::sqlite::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
+    //~^ ERROR type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
     users.select(id).filter(name.is_not_distinct_from("Sean"))
         .load::<i32>(&connection);
-    //~^ ERROR type mismatch resolving `<diesel::sqlite::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
+    //~^ ERROR type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
     users.select(id).filter(now.eq(now.at_time_zone("UTC")))
         .load::<i32>(&connection);
-    //~^ ERROR type mismatch resolving `<diesel::sqlite::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
+    //~^ ERROR type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
     insert(&NewUser("Sean").on_conflict_do_nothing()).into(users)
         .execute(&connection);
-    //~^ ERROR type mismatch resolving `<diesel::sqlite::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
+    //~^ ERROR type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
 }

--- a/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
@@ -2,7 +2,6 @@
 #[macro_use] extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 use diesel::pg::upsert::*;
 
 table! {

--- a/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
+++ b/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
@@ -1,7 +1,6 @@
 #[macro_use] extern crate diesel;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/returning_clause_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/returning_clause_requires_selectable_expression.rs
@@ -2,7 +2,6 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -1,7 +1,6 @@
 #[macro_use] extern crate diesel;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 use diesel::types::Text;
 
 table! {

--- a/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
@@ -2,7 +2,6 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/select_sql_still_ensures_result_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_sql_still_ensures_result_type.rs
@@ -3,7 +3,6 @@ extern crate diesel;
 
 use diesel::*;
 use diesel::expression::dsl::sql;
-use diesel::pg::PgConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/sqlite_upsert_cannot_be_used_on_pg.rs
+++ b/diesel_compile_tests/tests/compile-fail/sqlite_upsert_cannot_be_used_on_pg.rs
@@ -4,7 +4,6 @@ extern crate diesel;
 extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 
 table! {
     users {
@@ -21,5 +20,5 @@ struct User {
 fn main() {
     let connection = PgConnection::establish("").unwrap();
     insert_or_replace(&User { id: 1 }).into(users::table).execute(&connection).unwrap();
-    //~^ ERROR type mismatch resolving `<diesel::pg::PgConnection as diesel::Connection>::Backend == diesel::sqlite::Sqlite`
+    //~^ ERROR type mismatch resolving `<diesel::PgConnection as diesel::Connection>::Backend == diesel::sqlite::Sqlite`
 }

--- a/diesel_compile_tests/tests/compile-fail/update_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -2,7 +2,6 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::sqlite::SqliteConnection;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -2,7 +2,6 @@
 #[macro_use] extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::pg::PgConnection;
 use diesel::pg::upsert::*;
 
 table! {

--- a/diesel_infer_schema/src/inference.rs
+++ b/diesel_infer_schema/src/inference.rs
@@ -1,13 +1,7 @@
 use std::error::Error;
 
-use diesel::Connection;
+use diesel::prelude::*;
 use diesel::result::Error::NotFound;
-#[cfg(feature = "postgres")]
-use diesel::pg::PgConnection;
-#[cfg(feature = "sqlite")]
-use diesel::sqlite::SqliteConnection;
-#[cfg(feature = "mysql")]
-use diesel::mysql::MysqlConnection;
 
 use table_data::TableData;
 use data_structures::{ColumnInformation, ColumnType};

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -169,7 +169,6 @@ pub fn load_table_names<Conn>(connection: &Conn, schema_name: Option<&str>)
 mod tests {
     extern crate dotenv;
 
-    use diesel::pg::PgConnection;
     use self::dotenv::dotenv;
     use std::env;
     use super::*;

--- a/diesel_tests/build.rs
+++ b/diesel_tests/build.rs
@@ -5,23 +5,17 @@ use self::dotenv::dotenv;
 use std::{io, env};
 
 #[cfg(feature = "postgres")]
-use self::diesel::pg::PgConnection;
-#[cfg(feature = "postgres")]
 fn connection() -> PgConnection {
     let database_url = database_url_from_env("PG_DATABASE_URL");
     PgConnection::establish(&database_url).unwrap()
 }
 
 #[cfg(feature = "sqlite")]
-use self::diesel::sqlite::SqliteConnection;
-#[cfg(feature = "sqlite")]
 fn connection() -> SqliteConnection {
     let database_url = database_url_from_env("SQLITE_DATABASE_URL");
     SqliteConnection::establish(&database_url).unwrap()
 }
 
-#[cfg(feature = "mysql")]
-use self::diesel::mysql::MysqlConnection;
 #[cfg(feature = "mysql")]
 fn connection() -> MysqlConnection {
     let database_url = database_url_from_env("MYSQL_DATABASE_URL");

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -163,11 +163,11 @@ pub struct Like {
 }
 
 #[cfg(feature = "postgres")]
-pub type TestConnection = ::diesel::pg::PgConnection;
+pub type TestConnection = PgConnection;
 #[cfg(feature = "sqlite")]
-pub type TestConnection = ::diesel::sqlite::SqliteConnection;
+pub type TestConnection = SqliteConnection;
 #[cfg(feature = "mysql")]
-pub type TestConnection = ::diesel::mysql::MysqlConnection;
+pub type TestConnection = MysqlConnection;
 
 pub type TestBackend = <TestConnection as Connection>::Backend;
 
@@ -185,7 +185,7 @@ pub fn connection_without_transaction() -> TestConnection {
     let connection_url = env::var("PG_DATABASE_URL")
         .or_else(|_| env::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
-    ::diesel::pg::PgConnection::establish(&connection_url).unwrap()
+    PgConnection::establish(&connection_url).unwrap()
 }
 
 #[cfg(feature = "sqlite")]
@@ -193,7 +193,7 @@ embed_migrations!("../migrations/sqlite");
 
 #[cfg(feature = "sqlite")]
 pub fn connection_without_transaction() -> TestConnection {
-    let connection = ::diesel::sqlite::SqliteConnection::establish(":memory:").unwrap();
+    let connection = SqliteConnection::establish(":memory:").unwrap();
     embedded_migrations::run(&connection).unwrap();
     connection
 }
@@ -204,7 +204,7 @@ pub fn connection_without_transaction() -> TestConnection {
     let connection_url = env::var("MYSQL_DATABASE_URL")
         .or_else(|_| env::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
-    ::diesel::mysql::MysqlConnection::establish(&connection_url).unwrap()
+    MysqlConnection::establish(&connection_url).unwrap()
 }
 
 sql_function!(nextval, nextval_t, (a: types::VarChar) -> types::BigInt);

--- a/examples/mysql/getting_started_step_1/src/lib.rs
+++ b/examples/mysql/getting_started_step_1/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::mysql::MysqlConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/mysql/getting_started_step_2/src/lib.rs
+++ b/examples/mysql/getting_started_step_2/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::mysql::MysqlConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/mysql/getting_started_step_3/src/lib.rs
+++ b/examples/mysql/getting_started_step_3/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::mysql::MysqlConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/postgres/all_about_updates/src/lib.rs
+++ b/examples/postgres/all_about_updates/src/lib.rs
@@ -4,7 +4,6 @@
 use std::time::SystemTime;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 
 table! {
     posts {

--- a/examples/postgres/getting_started_step_1/src/lib.rs
+++ b/examples/postgres/getting_started_step_1/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/postgres/getting_started_step_2/src/lib.rs
+++ b/examples/postgres/getting_started_step_2/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/postgres/getting_started_step_3/src/lib.rs
+++ b/examples/postgres/getting_started_step_3/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/sqlite/getting_started_step_1/src/lib.rs
+++ b/examples/sqlite/getting_started_step_1/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::sqlite::SqliteConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/sqlite/getting_started_step_2/src/lib.rs
+++ b/examples/sqlite/getting_started_step_2/src/lib.rs
@@ -6,7 +6,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::sqlite::SqliteConnection;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/sqlite/getting_started_step_3/src/lib.rs
+++ b/examples/sqlite/getting_started_step_3/src/lib.rs
@@ -9,7 +9,6 @@ pub mod schema;
 pub mod models;
 
 use diesel::prelude::*;
-use diesel::sqlite::SqliteConnection;
 use dotenv::dotenv;
 use std::env;
 


### PR DESCRIPTION
It is very rare for you to be importing `prelude::*`, and not want these
types. They are named uniquely enough to not be concerning