### PR TITLE
Clarify the wording on an infer_schema error message

### DIFF
--- a/diesel_codegen/src/database_url.rs
+++ b/diesel_codegen/src/database_url.rs
@@ -29,8 +29,8 @@ fn load_dotenv_file() -> Result<(), String> {
 
 #[cfg(not(feature = "dotenv"))]
 fn load_dotenv_file() -> Result<(), String> {
-    Err(String::from("The dotenv feature is required to use strings starting \
-        with `dotenv:`"))
+    Err(String::from("diesel_codegen must be compiled with the dotenv feature \
+        to use strings starting with `dotenv:`"))
 }
 
 #[test]

--- a/diesel_codegen/src/database_url.rs
+++ b/diesel_codegen/src/database_url.rs
@@ -29,8 +29,8 @@ fn load_dotenv_file() -> Result<(), String> {
 
 #[cfg(not(feature = "dotenv"))]
 fn load_dotenv_file() -> Result<(), String> {
-    Err(String::from("diesel_codegen must be compiled with the dotenv feature \
-        to use strings starting with `dotenv:`"))
+    Err(String::from("diesel_codegen must be compiled with the \"dotenv\" \
+        feature to correctly interpret strings starting with `dotenv:`"))
 }
 
 #[test]


### PR DESCRIPTION
This error message could be interpreted to be saying that when the
dotenv feature is enabled, the string must begin with `dotenv:`. I
believe the new wording clarifies that the issue is that the dotenv
feature has not been enabled in the first place.