### PR TITLE
Assume the type is in scope for {queryable,expression}_impls

### DIFF
--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -5,7 +5,7 @@ use byteorder::WriteBytesExt;
 use mysql::{Mysql, MysqlType};
 use std::error::Error as StdError;
 use std::io::Write;
-use types::{ToSql, ToSqlOutput, IsNull, FromSql, HasSqlType};
+use types::{ToSql, ToSqlOutput, IsNull, FromSql, HasSqlType, Tinyint};
 
 primitive_impls!(Tinyint -> (i8, mysql: (Tiny)));
 

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use self::time::{Timespec, Duration};
 
 use pg::Pg;
-use types::{self, ToSql, ToSqlOutput, FromSql, IsNull};
+use types::{self, ToSql, ToSqlOutput, FromSql, IsNull, Timestamp};
 
 expression_impls! {
     Timestamp -> Timespec,

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::ops::Add;
 
 use pg::{Pg, PgTypeMetadata, PgMetadataLookup};
-use types::{self, FromSql, ToSql, ToSqlOutput, IsNull};
+use types::{self, FromSql, ToSql, ToSqlOutput, IsNull, Date, Interval, Time, Timestamp, Timestamptz};
 
 primitive_impls!(Timestamptz -> (pg: (1184, 1185)));
 primitive_impls!(Timestamptz);

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use pg::Pg;
-use types::{self, ToSql, ToSqlOutput, FromSql, IsNull};
+use types::{self, ToSql, ToSqlOutput, FromSql, IsNull, Timestamp};
 
 expression_impls! {
     Timestamp -> SystemTime,

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::io::prelude::*;
 
 use pg::Pg;
-use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql, Oid};
 
 primitive_impls!(Oid -> (u32, pg: (26, 1018)));
 

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -6,7 +6,7 @@ use std::io::prelude::*;
 use std::error::Error;
 
 use pg::Pg;
-use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql, Json, Jsonb};
 
 // The OIDs used to identify `json` and `jsonb` are not documented anywhere
 // obvious, but they are discussed on various PostgreSQL mailing lists,

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -20,7 +20,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, NetworkEndian};
 pub struct PgMoney(pub i64);
 
 use pg::Pg;
-use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql, Money};
 
 // https://github.com/postgres/postgres/blob/502a3832cc54c7115dacb8a2dae06f0620995ac6/src/include/catalog/pg_type.h#L429-L432
 primitive_impls!(Money -> (PgMoney, pg: (790, 791)));

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -6,8 +6,8 @@ use std::error::Error;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use pg::Pg;
-use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
-use self::ipnetwork::{IpNetwork,Ipv4Network,Ipv6Network};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql, Cidr, Inet, MacAddr};
+use self::ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 
 #[cfg(windows)]
 const AF_INET: u8 = 2;

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 use pg::Pg;
 use pg::data_types::PgNumeric;
-use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql, Numeric};
 
 primitive_impls!(Numeric -> (PgNumeric, pg: (1700, 1231)));
 

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::error::Error;
 
 use pg::Pg;
-use types::{self, ToSql, ToSqlOutput, IsNull, FromSql};
+use types::{self, ToSql, ToSqlOutput, IsNull, FromSql, Uuid};
 
 primitive_impls!(Uuid -> (uuid::Uuid, pg: (2950, 2951)));
 

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use sqlite::{Sqlite, SqliteType};
 use sqlite::connection::SqliteValue;
-use types::{self, FromSql, ToSql, ToSqlOutput, IsNull, HasSqlType};
+use types::{self, FromSql, ToSql, ToSqlOutput, IsNull, HasSqlType, Date, Time, Timestamp};
 
 #[cfg(feature = "chrono")]
 mod chrono;

--- a/diesel/src/types/impls/date_and_time.rs
+++ b/diesel/src/types/impls/date_and_time.rs
@@ -2,6 +2,7 @@
 mod chrono {
     extern crate chrono;
     use self::chrono::*;
+    use types::{Date, Time, Timestamp};
 
     expression_impls! {
         Date -> NaiveDate,

--- a/diesel/src/types/impls/decimal.rs
+++ b/diesel/src/types/impls/decimal.rs
@@ -1,6 +1,8 @@
 #[cfg(feature="bigdecimal")]
 mod bigdecimal {
     extern crate bigdecimal;
+    use types::Numeric;
+
     expression_impls! {
         Numeric -> bigdecimal::BigDecimal,
     }

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -14,44 +14,44 @@ macro_rules! not_none {
 macro_rules! expression_impls {
     ($($Source:ident -> $Target:ty),+,) => {
         $(
-            impl<'a> $crate::expression::AsExpression<$crate::types::$Source> for $Target {
-                type Expression = $crate::expression::bound::Bound<$crate::types::$Source, Self>;
+            impl<'a> $crate::expression::AsExpression<$Source> for $Target {
+                type Expression = $crate::expression::bound::Bound<$Source, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a, 'expr> $crate::expression::AsExpression<$crate::types::$Source> for &'expr $Target {
-                type Expression = $crate::expression::bound::Bound<$crate::types::$Source, Self>;
+            impl<'a, 'expr> $crate::expression::AsExpression<$Source> for &'expr $Target {
+                type Expression = $crate::expression::bound::Bound<$Source, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a> $crate::expression::AsExpression<$crate::types::Nullable<$crate::types::$Source>> for $Target {
-                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$crate::types::$Source>, Self>;
+            impl<'a> $crate::expression::AsExpression<$crate::types::Nullable<$Source>> for $Target {
+                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$Source>, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a, 'expr> $crate::expression::AsExpression<$crate::types::Nullable<$crate::types::$Source>> for &'expr $Target {
-                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$crate::types::$Source>, Self>;
+            impl<'a, 'expr> $crate::expression::AsExpression<$crate::types::Nullable<$Source>> for &'expr $Target {
+                type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$Source>, Self>;
 
                 fn as_expression(self) -> Self::Expression {
                     $crate::expression::bound::Bound::new(self)
                 }
             }
 
-            impl<'a, DB> $crate::types::ToSql<$crate::types::Nullable<$crate::types::$Source>, DB> for $Target where
-                DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
-                $Target: $crate::types::ToSql<$crate::types::$Source, DB>,
+            impl<'a, DB> $crate::types::ToSql<$crate::types::Nullable<$Source>, DB> for $Target where
+                DB: $crate::backend::Backend + $crate::types::HasSqlType<$Source>,
+                $Target: $crate::types::ToSql<$Source, DB>,
             {
                 fn to_sql<W: ::std::io::Write>(&self, out: &mut $crate::types::ToSqlOutput<W, DB>) -> Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
-                    $crate::types::ToSql::<$crate::types::$Source, DB>::to_sql(self, out)
+                    $crate::types::ToSql::<$Source, DB>::to_sql(self, out)
                 }
             }
         )+
@@ -62,18 +62,18 @@ macro_rules! expression_impls {
 #[macro_export]
 macro_rules! queryable_impls {
     ($($Source:ident -> $Target:ty),+,) => {$(
-        impl<DB> $crate::types::FromSqlRow<$crate::types::$Source, DB> for $Target where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
-            $Target: $crate::types::FromSql<$crate::types::$Source, DB>,
+        impl<DB> $crate::types::FromSqlRow<$Source, DB> for $Target where
+            DB: $crate::backend::Backend + $crate::types::HasSqlType<$Source>,
+            $Target: $crate::types::FromSql<$Source, DB>,
         {
             fn build_from_row<R: $crate::row::Row<DB>>(row: &mut R) -> Result<Self, Box<::std::error::Error+Send+Sync>> {
-                $crate::types::FromSql::<$crate::types::$Source, DB>::from_sql(row.take())
+                $crate::types::FromSql::<$Source, DB>::from_sql(row.take())
             }
         }
 
-        impl<DB> $crate::query_source::Queryable<$crate::types::$Source, DB> for $Target where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<$crate::types::$Source>,
-            $Target: $crate::types::FromSqlRow<$crate::types::$Source, DB>,
+        impl<DB> $crate::query_source::Queryable<$Source, DB> for $Target where
+            DB: $crate::backend::Backend + $crate::types::HasSqlType<$Source>,
+            $Target: $crate::types::FromSqlRow<$Source, DB>,
         {
             type Row = Self;
 
@@ -93,7 +93,7 @@ macro_rules! primitive_impls {
 
     ($Source:ident -> (sqlite: ($tpe:ident) $($rest:tt)*)) => {
         #[cfg(feature = "sqlite")]
-        impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::sqlite::Sqlite {
+        impl $crate::types::HasSqlType<$Source> for $crate::sqlite::Sqlite {
             fn metadata(_: &()) -> $crate::sqlite::SqliteType {
                 $crate::sqlite::SqliteType::$tpe
             }
@@ -104,7 +104,7 @@ macro_rules! primitive_impls {
 
     ($Source:ident -> (pg: ($oid:expr, $array_oid:expr) $($rest:tt)*)) => {
         #[cfg(feature = "postgres")]
-        impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::pg::Pg {
+        impl $crate::types::HasSqlType<$Source> for $crate::pg::Pg {
             fn metadata(_: &$crate::pg::PgMetadataLookup) -> $crate::pg::PgTypeMetadata {
                 $crate::pg::PgTypeMetadata {
                     oid: $oid,
@@ -118,7 +118,7 @@ macro_rules! primitive_impls {
 
     ($Source:ident -> (mysql: ($tpe:ident) $($rest:tt)*)) => {
         #[cfg(feature = "mysql")]
-        impl $crate::types::HasSqlType<$crate::types::$Source> for $crate::mysql::Mysql {
+        impl $crate::types::HasSqlType<$Source> for $crate::mysql::Mysql {
             fn metadata(_: &()) -> $crate::mysql::MysqlType {
                 $crate::mysql::MysqlType::$tpe
             }
@@ -143,7 +143,7 @@ macro_rules! primitive_impls {
     };
 
     ($Source:ident) => {
-        impl $crate::query_builder::QueryId for $crate::types::$Source {
+        impl $crate::query_builder::QueryId for $Source {
             type QueryId = Self;
 
             fn has_static_query_id() -> bool {
@@ -151,10 +151,10 @@ macro_rules! primitive_impls {
             }
         }
 
-        impl $crate::types::NotNull for $crate::types::$Source {
+        impl $crate::types::NotNull for $Source {
         }
 
-        impl $crate::types::SingleValue for $crate::types::$Source {
+        impl $crate::types::SingleValue for $Source {
         }
     }
 }

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -2,7 +2,8 @@ use std::error::Error;
 use std::io::Write;
 
 use backend::Backend;
-use types::{self, HasSqlType, FromSql, ToSql, ToSqlOutput, IsNull, NotNull};
+use types::{self, HasSqlType, FromSql, ToSql, ToSqlOutput, IsNull, NotNull, Binary, BigInt,
+Bool, Date, Double, Float, Integer, SmallInt, Text, Time, Timestamp};
 
 primitive_impls!(Bool -> (bool, pg: (16, 1000), sqlite: (Integer), mysql: (Tiny)));
 


### PR DESCRIPTION
This allow the usage of those two macros with custom types that are not
in diesel::types.