### PR TITLE
Don't generate join code from `#[belongs_to]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   backend specific SQL. (The specific backend they will generate for will be
   arbitrarily chosen based on the backends enabled).
 
+* `#[belongs_to]` will no longer generate the code required to join between two
+  tables. You will need to explicitly invoke `joinable!` instead.
+
 ### Removed
 
 * `debug_sql!` has been deprecated in favor of `diesel::debug_sql`.
@@ -33,6 +36,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `print_sql!` has been deprecated without replacement.
 
 * `diesel::backend::Debug` has been removed.
+
+### Fixed
+
+* Diesel now properly supports joins in the form:
+  `grandchild.join(child.join(parent))`. Previously only
+  `parent.join(child.join(grandchild))` would compile.
 
 [bigdecimal-0.14.0]: https://crates.io/crates/bigdecimal
 

--- a/diesel/src/macros/associations/belongs_to.rs
+++ b/diesel/src/macros/associations/belongs_to.rs
@@ -159,17 +159,6 @@ macro_rules! BelongsTo {
                 $child_table_name::$foreign_key_name
             }
         }
-
-        BelongsTo! {
-            @generate_joins,
-            (
-                struct_name = $struct_name,
-                parent_struct = $parent_struct,
-                foreign_key_name = $foreign_key_name,
-                child_table_name = $child_table_name,
-            ),
-            $($rest)*
-        }
     };
 
     // Generate code when FK is optional
@@ -196,54 +185,6 @@ macro_rules! BelongsTo {
                 $child_table_name::$foreign_key_name
             }
         }
-
-        BelongsTo! {
-            @generate_joins,
-            (
-                struct_name = $struct_name,
-                parent_struct = $parent_struct,
-                foreign_key_name = $foreign_key_name,
-                child_table_name = $child_table_name,
-            ),
-            $($rest)*
-        }
-    };
-
-    // Generate code that does not differ based on the fk being optional
-    (
-        @generate_joins,
-        (
-            struct_name = $struct_name:ident,
-            parent_struct = $parent_struct:ident,
-            foreign_key_name = $foreign_key_name:ident,
-            child_table_name = $child_table_name:ident,
-        ),
-        fields = [$({
-            field_name: $field_name:ident,
-            column_name: $column_name:ident,
-            field_ty: $field_ty:ty,
-            field_kind: $field_kind:ident,
-            $($rest:tt)*
-        })+],
-    ) => {
-        static_cond!(if $struct_name != $parent_struct {
-            joinable_inner!(
-                left_table_ty = $child_table_name::table,
-                right_table_ty = <$parent_struct as $crate::associations::HasTable>::Table,
-                right_table_expr = <$parent_struct as $crate::associations::HasTable>::table(),
-                foreign_key = $child_table_name::$foreign_key_name,
-                primary_key_ty = <<$parent_struct as $crate::associations::HasTable>::Table as $crate::Table>::PrimaryKey,
-                primary_key_expr = $crate::Table::primary_key(&<$parent_struct as $crate::associations::HasTable>::table()),
-            );
-            joinable_inner!(
-                left_table_ty = $child_table_name::table,
-                right_table_ty = $crate::query_source::joins::PleaseGenerateInverseJoinImpls<<$parent_struct as $crate::associations::HasTable>::Table>,
-                right_table_expr = <$parent_struct as $crate::associations::HasTable>::table(),
-                foreign_key = $child_table_name::$foreign_key_name,
-                primary_key_ty = <<$parent_struct as $crate::associations::HasTable>::Table as $crate::Table>::PrimaryKey,
-                primary_key_expr = $crate::Table::primary_key(&<$parent_struct as $crate::associations::HasTable>::table()),
-            );
-        });
     };
 
     // Handle struct with no generics

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -266,22 +266,6 @@ impl<T, Join, On> AppearsInFromClause<T> for JoinOn<Join, On> where
     type Count = Join::Count;
 }
 
-#[allow(missing_debug_implementations, missing_copy_implementations)]
-#[doc(hidden)]
-/// A hack to allow bidirectional joins to be generated from `#[belongs_to]`
-///
-/// This type needs to exist because it is illegal in Rust today to write
-/// `impl JoinTo<posts> for <User as HasTable>::Table`, even though the type
-/// is fully monomorphic and projects to a local type. If this restriction
-/// were ever lifted in the future, this type could be removed.
-///
-/// Instead, after generating `impl JoinTo<<User as HasTable>::Table> for
-/// posts`, we *also* generate `impl JoinTo<PleaseGenerateInverseJoinImpls<<User
-/// as HasTable>::table> for posts`, and rely on the fact that `users::table`
-/// will have a blanket impl on itself for anything that joins to
-/// `PleaseGenerateInverseJoinImpls`.
-pub struct PleaseGenerateInverseJoinImpls<T>(T);
-
 pub trait Plus<T> {
     type Output;
 }

--- a/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
@@ -21,28 +21,16 @@ fn main() {
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     let source = users::table.select(avg(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
     let source = users::table.select(max(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     let source = users::table.select(min(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -22,8 +22,5 @@ fn main() {
 
     stuff.filter(name.eq(any(more_stuff::names)));
     //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
@@ -22,7 +22,4 @@ fn main() {
     users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
     //~^ ERROR AppearsInFromClause
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
@@ -22,7 +22,4 @@ fn main() {
     users::table.into_boxed::<Pg>().order(posts::title.desc());
     //~^ ERROR AppearsInFromClause
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
@@ -30,13 +30,13 @@ enable_multi_table_joins!(users, comments);
 
 fn main() {
     let _ = users::table.inner_join(posts::table);
-    //~^ ERROR 0275
+    //~^ ERROR 0277
     let _ = users::table.left_outer_join(posts::table);
-    // We would get an error here but 0275 halts everything
+    //~^ ERROR 0277
 
     // Sanity check to make sure the error is when users
     // become involved
     let join = posts::table.inner_join(comments::table);
     let _ = users::table.inner_join(join);
-    // We would get an error here but 0275 halts everything
+    //~^ ERROR 0277
 }

--- a/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
@@ -38,7 +38,4 @@ fn main() {
     //~^ ERROR SelectableExpression
     //~| ERROR AppearsInFromClause
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -21,13 +21,7 @@ fn main() {
     let _ = users::table.filter(posts::id.eq(1));
     //~^ ERROR AppearsInFromClause
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     let _ = users::table.filter(users::name.eq(posts::title));
     //~^ ERROR AppearsInFromClause
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/order_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/order_requires_column_from_same_table.rs
@@ -18,8 +18,5 @@ table! {
 fn main() {
     let source = users::table.order(posts::id);
     //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
@@ -41,9 +41,6 @@ fn main() {
     insert(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(posts::title)))).into(users).execute(&connection);
     //~^ ERROR E0277
     //~| ERROR no method named `execute`
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0271
 
     // Update column with excluded value that is not selectable

--- a/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -23,15 +23,9 @@ fn main() {
     //~^ ERROR Selectable
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0271
     let stuff = users::table.select((posts::id, users::name));
     //~^ ERROR Selectable
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/update_requires_column_be_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_requires_column_be_from_same_table.rs
@@ -24,8 +24,5 @@ fn main() {
     //~^ ERROR type mismatch
     let command = update(users).set(name.eq(posts::title));
     //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
+++ b/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
@@ -29,8 +29,5 @@ fn main() {
     //~^ ERROR type mismatch
     let _ = users::table.filter(name.eq(bar(title)));
     //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0271
 }

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -14,8 +14,9 @@ fn association_where_struct_name_doesnt_match_table_name() {
     let connection = connection_with_sean_and_tess_in_users_table();
 
     let sean = find_user_by_name("Sean", &connection);
-    let post: Post = insert(&sean.new_post("Hello", None)).into(posts::table)
-        .get_result(&connection).unwrap();
+    insert(&sean.new_post("Hello", None)).into(posts::table)
+        .execute(&connection).unwrap();
+    let post = posts::table.first::<Post>(&connection).unwrap();
     insert(&NewComment(post.id, "comment")).into(comments::table)
         .execute(&connection).unwrap();
 

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -1,30 +1,28 @@
 use diesel::*;
 use schema::*;
 
-// FIXME: Bring this test back once we can figure out how to allow multiple structs
-// on the same table to use `#[belongs_to]` without overlapping the `JoinTo` impls
-// #[test]
-// fn association_where_struct_name_doesnt_match_table_name() {
-//     #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
-//     #[belongs_to(Post)]
-//     #[table_name="comments"]
-//     struct OtherComment {
-//         id: i32,
-//         post_id: i32
-//     }
+#[test]
+fn association_where_struct_name_doesnt_match_table_name() {
+    #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
+    #[belongs_to(Post)]
+    #[table_name="comments"]
+    struct OtherComment {
+        id: i32,
+        post_id: i32
+    }
 
-//     let connection = connection_with_sean_and_tess_in_users_table();
+    let connection = connection_with_sean_and_tess_in_users_table();
 
-//     let sean = find_user_by_name("Sean", &connection);
-//     let post: Post = insert(&sean.new_post("Hello", None)).into(posts::table)
-//         .get_result(&connection).unwrap();
-//     insert(&NewComment(post.id, "comment")).into(comments::table)
-//         .execute(&connection).unwrap();
+    let sean = find_user_by_name("Sean", &connection);
+    let post: Post = insert(&sean.new_post("Hello", None)).into(posts::table)
+        .get_result(&connection).unwrap();
+    insert(&NewComment(post.id, "comment")).into(comments::table)
+        .execute(&connection).unwrap();
 
-//     let comment_text = OtherComment::belonging_to(&post).select(comments::text)
-//         .first::<String>(&connection);
-//     assert_eq!(Ok("comment".into()), comment_text);
-// }
+    let comment_text = OtherComment::belonging_to(&post).select(comments::text)
+        .first::<String>(&connection);
+    assert_eq!(Ok("comment".into()), comment_text);
+}
 
 #[test]
 #[cfg(not(any(feature="sqlite", feature="mysql")))]

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -373,6 +373,22 @@ fn selecting_parent_child_grandchild() {
 }
 
 #[test]
+fn selecting_grandchild_child_parent() {
+    let (connection, test_data) = connection_with_fixture_data_for_multitable_joins();
+    let TestData { sean, posts, comments, .. } = test_data;
+
+    let data = comments::table.inner_join(posts::table.inner_join(users::table))
+        .order((users::id, posts::id, comments::id))
+        .load(&connection);
+    let expected = vec![
+        (comments[0].clone(), (posts[0].clone(), sean.clone())),
+        (comments[2].clone(), (posts[0].clone(), sean.clone())),
+        (comments[1].clone(), (posts[2].clone(), sean.clone())),
+    ];
+    assert_eq!(Ok(expected), data);
+}
+
+#[test]
 fn selecting_four_tables_deep() {
     let (connection, test_data) = connection_with_fixture_data_for_multitable_joins();
     let TestData { sean, posts, comments, likes, .. } = test_data;

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -11,6 +11,13 @@ infer_schema!("dotenv:MYSQL_DATABASE_URL");
 #[cfg(not(feature="backend_specific_database_url"))]
 infer_schema!("dotenv:DATABASE_URL");
 
+joinable!(posts -> users (user_id));
+joinable!(comments -> posts (post_id));
+joinable!(followings -> users (user_id));
+joinable!(followings -> posts (post_id));
+joinable!(likes -> comments (comment_id));
+joinable!(likes -> users (user_id));
+
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, Associations)]
 #[table_name = "users"]
 pub struct User {


### PR DESCRIPTION
The root of this problem is that `<User as HasTable>::Table` is not
considered by Rust to be a local type. We do not have the the
information required in `belongs_to` to generate the exact equivalent
code as `joinable!`

I had attempted to work around this with a
`PleaseGenerateInverseJoinImpls`, which worked for getting the `users:
JoinTo<posts>`. However, we *also* rely on that impl for the inverse of
all the composite impls in Diesel. So `posts:
JoinTo<SelectStatement>` wants `SelectStatement:
JoinTo<PleaseGenerateInverseJoinImpls<posts>`, which ultimately
simplifies down to `users:
JoinTo<PleaseGenerateInverseJoinImpls<posts>>`. Even if we could
generate that impl (we can't), that impl would be recursive, and thus
overlapping.

Ultimately we either need the language to change, or we need to generate
this code somewhere that we can directly reference both the parent and
child tables. I think the long term solution here is for us to follow
this PR up with one which infers the `joinable!` impls from foreign key
constraints in the database.

I don't like how much this generated code is coupled to the specific
impls we provide in Diesel. However, if I tried to accomplish the same
with a marker trait version of `PleaseGenerateInverseJoinImpls`, the
result is that a missing `joinable!` will result in "overflow attempting
to evaluate...", instead of complaining about a trait not being
implemented.

Fixes #1068.