### PR TITLE
Infer `joinable!` from foreign keys in the DB

### DIFF
--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -13,9 +13,9 @@ cfg_if! {
             let connection_url = database_url_from_env("PG_DATABASE_URL");
             let connection = PgConnection::establish(&connection_url).unwrap();
             connection.begin_test_transaction().unwrap();
-            connection.execute("DROP TABLE IF EXISTS users").unwrap();
-            connection.execute("DROP TABLE IF EXISTS animals").unwrap();
-            connection.execute("DROP TABLE IF EXISTS posts").unwrap();
+            connection.execute("DROP TABLE IF EXISTS users CASCADE").unwrap();
+            connection.execute("DROP TABLE IF EXISTS animals CASCADE").unwrap();
+            connection.execute("DROP TABLE IF EXISTS posts CASCADE").unwrap();
 
             connection
         }
@@ -99,9 +99,9 @@ cfg_if! {
         fn connection_no_data() -> MysqlConnection {
             let connection_url = database_url_from_env("MYSQL_UNIT_TEST_DATABASE_URL");
             let connection = MysqlConnection::establish(&connection_url).unwrap();
-            connection.execute("DROP TABLE IF EXISTS users").unwrap();
-            connection.execute("DROP TABLE IF EXISTS animals").unwrap();
-            connection.execute("DROP TABLE IF EXISTS posts").unwrap();
+            connection.execute("DROP TABLE IF EXISTS users CASCADE").unwrap();
+            connection.execute("DROP TABLE IF EXISTS animals CASCADE").unwrap();
+            connection.execute("DROP TABLE IF EXISTS posts CASCADE").unwrap();
 
             connection
         }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -835,7 +835,7 @@ macro_rules! joinable_inner {
             right_table_expr = $right_table,
             foreign_key = $foreign_key,
             primary_key_ty = <$parent_table as $crate::query_source::Table>::PrimaryKey,
-            primary_key_expr = $parent_table.primary_key(),
+            primary_key_expr = <$parent_table as $crate::query_source::Table>::primary_key(&$parent_table),
         );
     };
 

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -7,6 +7,7 @@ use diesel::types::{HasSqlType, FromSqlRow};
 
 #[cfg(feature="uses_information_schema")]
 use super::information_schema::UsesInformationSchema;
+use super::table_data::TableData;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnInformation {
@@ -19,6 +20,13 @@ pub struct ColumnType {
     pub path: Vec<String>,
     pub is_array: bool,
     pub is_nullable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignKeyConstraint {
+    pub child_table: TableData,
+    pub parent_table: TableData,
+    pub foreign_key: String,
 }
 
 impl ColumnInformation {

--- a/diesel_infer_schema/src/lib.rs
+++ b/diesel_infer_schema/src/lib.rs
@@ -38,5 +38,5 @@ mod pg;
 mod sqlite;
 
 pub use codegen::*;
-pub use inference::load_table_names;
+pub use inference::{load_table_names, load_foreign_key_constraints};
 pub use table_data::TableData;

--- a/diesel_infer_schema/src/table_data.rs
+++ b/diesel_infer_schema/src/table_data.rs
@@ -4,7 +4,7 @@ use diesel::types::{FromSqlRow, HasSqlType};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableData {
     pub name: String,
     pub schema: Option<String>,

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -37,7 +37,7 @@ fn eager_loading_associations_for_multiple_records() {
 mod eager_loading_with_string_keys {
     use diesel::*;
     use diesel::connection::SimpleConnection;
-    use schema::connection;
+    use schema::{connection, drop_table_cascade};
 
     table! { users { id -> Text, } }
     table! { posts { id -> Text, user_id -> Text, } }
@@ -58,9 +58,9 @@ mod eager_loading_with_string_keys {
     #[cfg(not(feature="mysql"))] // FIXME: Figure out how to handle tests that modify schema
     fn eager_loading_associations_for_multiple_records() {
         let connection = connection();
+        drop_table_cascade(&connection, "users");
+        drop_table_cascade(&connection, "posts");
         connection.batch_execute(r#"
-            DROP TABLE users;
-            DROP TABLE posts;
             CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
             CREATE TABLE posts (id TEXT PRIMARY KEY NOT NULL, user_id TEXT NOT NULL);
             INSERT INTO users (id) VALUES ('Sean'), ('Tess');

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -43,6 +43,7 @@ fn find_with_composite_pk() {
     let third_following = Following { user_id: 2, post_id: 1, email_notifications: false };
 
     let connection = connection();
+    disable_foreign_keys(&connection);
     insert(&vec![first_following, second_following, third_following])
         .into(followings)
         .execute(&connection)

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -70,7 +70,7 @@ fn batch_insert_with_defaults() {
     use schema_dsl::*;
 
     let connection = connection();
-    connection.execute("DROP TABLE users").unwrap();
+    drop_table_cascade(&connection, "users");
     create_table("users", (
         integer("id").primary_key().auto_increment(),
         string("name").not_null(),
@@ -99,7 +99,7 @@ fn insert_with_defaults() {
     use schema_dsl::*;
 
     let connection = connection();
-    connection.execute("DROP TABLE users").unwrap();
+    drop_table_cascade(&connection, "users");
     create_table("users", (
         integer("id").primary_key().auto_increment(),
         string("name").not_null(),
@@ -120,7 +120,7 @@ fn insert_with_defaults() {
 fn insert_returning_count_returns_number_of_rows_inserted() {
     use schema::users::table as users;
     let connection = connection();
-    connection.execute("DROP TABLE users").unwrap();
+    drop_table_cascade(&connection, "users");
     connection.execute("CREATE TABLE users (
         id SERIAL PRIMARY KEY,
         name VARCHAR NOT NULL,
@@ -222,7 +222,7 @@ fn insert_only_default_values() {
     use schema_dsl::*;
     let connection = connection();
 
-    connection.execute("DROP TABLE users").unwrap();
+    drop_table_cascade(&connection, "users");
     create_table("users", (
         integer("id").primary_key().auto_increment(),
         string("name").not_null().default("'Sean'"),
@@ -241,7 +241,7 @@ fn insert_only_default_values_with_returning() {
     use schema_dsl::*;
     let connection = connection();
 
-    connection.execute("DROP TABLE users").unwrap();
+    drop_table_cascade(&connection, "users");
     create_table("users", (
         integer("id").primary_key().auto_increment(),
         string("name").not_null().default("'Sean'"),

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -134,7 +134,7 @@ fn selecting_columns_and_tables_with_reserved_names() {
 #[cfg(not(feature="mysql"))] // FIXME: Figure out how to handle tests that modify schema
 fn selecting_columns_with_different_definition_order() {
     let connection = connection();
-    connection.execute("DROP TABLE users").unwrap();
+    drop_table_cascade(&connection, "users");
     create_table("users", (
         integer("id").primary_key().auto_increment(),
         string("hair_color"),

--- a/migrations/mysql/20170804172328_add_foreign_keys/down.sql
+++ b/migrations/mysql/20170804172328_add_foreign_keys/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE posts DROP FOREIGN KEY posts_user_id_fkey;
+ALTER TABLE comments DROP FOREIGN KEY comments_post_id_fkey;
+ALTER TABLE followings DROP FOREIGN KEY followings_user_id_fkey;
+ALTER TABLE followings DROP FOREIGN KEY followings_post_id_fkey;
+ALTER TABLE likes DROP FOREIGN KEY likes_comment_id_fkey;
+ALTER TABLE likes DROP FOREIGN KEY likes_user_id_fkey;

--- a/migrations/mysql/20170804172328_add_foreign_keys/up.sql
+++ b/migrations/mysql/20170804172328_add_foreign_keys/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id);
+ALTER TABLE comments ADD CONSTRAINT comments_post_id_fkey FOREIGN KEY (post_id) REFERENCES posts (id);
+ALTER TABLE followings ADD CONSTRAINT followings_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id);
+ALTER TABLE followings ADD CONSTRAINT followings_post_id_fkey FOREIGN KEY (post_id) REFERENCES posts (id);
+ALTER TABLE likes ADD CONSTRAINT likes_comment_id_fkey FOREIGN KEY (comment_id) REFERENCES comments (id);
+ALTER TABLE likes ADD CONSTRAINT likes_user_id_fkey FOREIGN KEY (user_id) REFERENCES users (id);

--- a/migrations/postgresql/20170804172328_add_foreign_keys/down.sql
+++ b/migrations/postgresql/20170804172328_add_foreign_keys/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE posts DROP CONSTRAINT posts_user_id_fkey;
+ALTER TABLE comments DROP CONSTRAINT comments_post_id_fkey;
+ALTER TABLE followings DROP CONSTRAINT followings_user_id_fkey;
+ALTER TABLE followings DROP CONSTRAINT followings_post_id_fkey;
+ALTER TABLE likes DROP CONSTRAINT likes_comment_id_fkey;
+ALTER TABLE likes DROP CONSTRAINT likes_user_id_fkey;

--- a/migrations/postgresql/20170804172328_add_foreign_keys/up.sql
+++ b/migrations/postgresql/20170804172328_add_foreign_keys/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users DEFERRABLE;
+ALTER TABLE comments ADD CONSTRAINT comments_post_id_fkey FOREIGN KEY (post_id) REFERENCES posts DEFERRABLE;
+ALTER TABLE followings ADD CONSTRAINT followings_user_id_fkey FOREIGN KEY (user_id) REFERENCES users DEFERRABLE;
+ALTER TABLE followings ADD CONSTRAINT followings_post_id_fkey FOREIGN KEY (post_id) REFERENCES posts DEFERRABLE;
+ALTER TABLE likes ADD CONSTRAINT likes_comment_id_fkey FOREIGN KEY (comment_id) REFERENCES comments DEFERRABLE;
+ALTER TABLE likes ADD CONSTRAINT likes_user_id_fkey FOREIGN KEY (user_id) REFERENCES users DEFERRABLE;

--- a/migrations/sqlite/20170804172328_add_foreign_keys/down.sql
+++ b/migrations/sqlite/20170804172328_add_foreign_keys/down.sql
@@ -1,0 +1,33 @@
+-- SQLite has no useful ALTER TABLE statement for this, so we must drop and
+-- re-create them. Table definitions came from `SELECT sql FROM sqlite_master`
+
+DROP TABLE likes;
+CREATE TABLE likes (
+  comment_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  PRIMARY KEY (comment_id, user_id)
+);
+
+DROP TABLE followings;
+CREATE TABLE followings (
+  user_id INTEGER NOT NULL,
+  post_id INTEGER NOT NULL,
+  email_notifications BOOLEAN NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, post_id)
+);
+
+DROP TABLE comments;
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  post_id INTEGER NOT NULL,
+  text TEXT NOT NULL
+);
+
+DROP TABLE posts;
+CREATE TABLE posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  user_id INTEGER NOT NULL,
+  title VARCHAR NOT NULL,
+  body TEXT
+);
+CREATE INDEX posts_user_id ON posts (user_id);

--- a/migrations/sqlite/20170804172328_add_foreign_keys/up.sql
+++ b/migrations/sqlite/20170804172328_add_foreign_keys/up.sql
@@ -1,0 +1,39 @@
+-- SQLite has no useful ALTER TABLE statement for this, so we must drop and
+-- re-create them. Table definitions came from `SELECT sql FROM sqlite_master`
+
+DROP TABLE posts;
+CREATE TABLE posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  user_id INTEGER NOT NULL,
+  title VARCHAR NOT NULL,
+  body TEXT,
+  FOREIGN KEY (user_id) REFERENCES users (id)
+);
+CREATE INDEX posts_user_id ON posts (user_id);
+
+DROP TABLE comments;
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  post_id INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  FOREIGN KEY (post_id) REFERENCES posts (id)
+);
+
+DROP TABLE followings;
+CREATE TABLE followings (
+  user_id INTEGER NOT NULL,
+  post_id INTEGER NOT NULL,
+  email_notifications BOOLEAN NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, post_id),
+  FOREIGN KEY (user_id) REFERENCES users (id),
+  FOREIGN KEY (post_id) REFERENCES posts (id)
+);
+
+DROP TABLE likes;
+CREATE TABLE likes (
+  comment_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  PRIMARY KEY (comment_id, user_id),
+  FOREIGN KEY (user_id) REFERENCES users (id),
+  FOREIGN KEY (comment_id) REFERENCES comments (id)
+);


### PR DESCRIPTION
I had hoped this would be less of a pain than it turned out to be. This
was another case where MySQL doesn't properly follow the
`information_schema` standard and we had to give it special treatment.
We also had several tests which were dropping a table which now has a
foreign key (no backend agnostic way to do that), as well as one test
which was violating referential integrity (it was less of a pain to
disable/defer the checks than to insert the required data).

There are several things this PR does not yet handle, but we should do
before we release:

- Dump this in `diesel print-schema` as well
- Ensure that the child and parent table are both in the tables we are
  generating `table!` invocations for
- Skip FKs which don't point at the primary key
- Skip FKs with more than one column
- Skip FKs when there are more than one of them linking two tables