### PR TITLE
Deriving AsChangeset on a structure containing only the pk is now unsupported 

### DIFF
--- a/diesel_codegen/src/as_changeset.rs
+++ b/diesel_codegen/src/as_changeset.rs
@@ -19,6 +19,12 @@ pub fn derive_as_changeset(item: syn::MacroInput) -> quote::Tokens {
         })
         .collect::<Vec<_>>();
 
+    if attrs.is_empty() {
+        panic!("Deriving `AsChangeset` on a structure that only contains the primary key isn't \
+            supported. If you want to change the primary key of a row, you should do so with \
+            `.set(table::id.eq(new_id))`. `AsChangeset` never changes the primary key of a row.");
+    }
+
     if lifetimes.is_empty() {
         lifetimes.push(syn::LifetimeDef::new("'a"));
     }

--- a/diesel_compile_tests/tests/compile-fail/as_changeset_on_struct_with_only_primary_key_should_panic.rs
+++ b/diesel_compile_tests/tests/compile-fail/as_changeset_on_struct_with_only_primary_key_should_panic.rs
@@ -1,0 +1,23 @@
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
+
+table!(
+    foo {
+        id -> Integer,
+        bar -> Integer,
+    }
+);
+
+#[derive(AsChangeset)]
+#[table_name="foo"]
+struct Foo1 {
+    id: i32,
+    bar: i32,
+}
+
+#[derive(AsChangeset)]
+//~^ ERROR: proc-macro derive panicked
+#[table_name="foo"]
+struct Foo2 {
+    id: i32,
+}


### PR DESCRIPTION
It will now panic with a meaningful message instead of throwing a syntax
error.