### PR TITLE
Flush pending results in `MysqlConnection#execute` and `batch_execute`

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -123,3 +123,42 @@ impl MysqlConnection {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate dotenv;
+
+    use super::*;
+    use std::env;
+
+    fn connection() -> MysqlConnection {
+        let _ = dotenv::dotenv();
+        let database_url = env::var("MYSQL_UNIT_TEST_DATABASE_URL")
+            .or_else(|_| env::var("MYSQL_DATABASE_URL"))
+            .or_else(|_| env::var("DATABASE_URL"))
+            .expect("DATABASE_URL must be set in order to run unit tests");
+        MysqlConnection::establish(&database_url).unwrap()
+    }
+
+    #[test]
+    fn batch_execute_handles_single_queries_with_results() {
+        let connection = connection();
+        assert!(connection.batch_execute("SELECT 1").is_ok());
+        assert!(connection.batch_execute("SELECT 1").is_ok());
+    }
+
+    #[test]
+    fn batch_execute_handles_multi_queries_with_results() {
+        let connection = connection();
+        let query = "SELECT 1; SELECT 2; SELECT 3;";
+        assert!(connection.batch_execute(query).is_ok());
+        assert!(connection.batch_execute(query).is_ok());
+    }
+
+    #[test]
+    fn execute_handles_queries_which_return_results() {
+        let connection = connection();
+        assert!(connection.execute("SELECT 1").is_ok());
+        assert!(connection.execute("SELECT 1").is_ok());
+    }
+}


### PR DESCRIPTION
Whenever any call to `mysql_query` (the fake one) or `mysql_real_query`
(make sure you don't use the fake one) contains anything which could
return a result, the caller is responsible for what is effectively
flushing the network buffer. MySQL is not reading any packets from the
response until after we call things like `mysql_next_result`. If we
don't ensure that we've cleared those packets out, we'll get an error
indicating that commands are being run out of sync. This means that any
migration containing a `SELECT` will fail, and our `SELECT 1` ping from
r2d2-diesel won't work.

Fixes #728