### PR TITLE
Don't infer `joinable!` for joins which are unsupported

### DIFF
--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -22,6 +22,11 @@ pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
         .expect(&error_message("table names", &database_url, schema_name));
     let foreign_keys = load_foreign_key_constraints(&database_url, schema_name)
         .expect(&error_message("foreign keys", &database_url, schema_name));
+    let foreign_keys = remove_unsafe_foreign_keys_for_codegen(
+        &database_url,
+        foreign_keys,
+        &table_names,
+    );
 
     let tables = table_names.iter()
         .map(|table| {

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -24,7 +24,7 @@ pub fn derive_infer_schema(input: syn::MacroInput) -> quote::Tokens {
         .expect(&error_message("foreign keys", &database_url, schema_name));
     let foreign_keys = remove_unsafe_foreign_keys_for_codegen(
         &database_url,
-        foreign_keys,
+        &foreign_keys,
         &table_names,
     );
 

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -22,13 +22,6 @@ pub struct ColumnType {
     pub is_nullable: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ForeignKeyConstraint {
-    pub child_table: TableData,
-    pub parent_table: TableData,
-    pub foreign_key: String,
-}
-
 impl ColumnInformation {
     pub fn new<T, U>(column_name: T, type_name: U, nullable: bool) -> Self where
         T: Into<String>,
@@ -63,5 +56,23 @@ impl<ST> Queryable<ST, Sqlite> for ColumnInformation where
 
     fn build(row: Self::Row) -> Self {
         ColumnInformation::new(row.1, row.2, !row.3)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignKeyConstraint {
+    pub child_table: TableData,
+    pub parent_table: TableData,
+    pub foreign_key: String,
+    pub primary_key: String,
+}
+
+impl ForeignKeyConstraint {
+    pub fn ordered_tables(&self) -> (&TableData, &TableData) {
+        use std::cmp::{min, max};
+        (
+            min(&self.parent_table, &self.child_table),
+            max(&self.parent_table, &self.child_table),
+        )
     }
 }

--- a/diesel_infer_schema/src/foreign_keys.rs
+++ b/diesel_infer_schema/src/foreign_keys.rs
@@ -1,0 +1,35 @@
+use data_structures::ForeignKeyConstraint;
+use inference::{establish_connection, get_primary_keys};
+use table_data::TableData;
+
+pub fn remove_unsafe_foreign_keys_for_codegen(
+    database_url: &str,
+    foreign_keys: Vec<ForeignKeyConstraint>,
+    safe_tables: &[TableData],
+) -> Vec<ForeignKeyConstraint> {
+    let conn = establish_connection(database_url)
+        .expect(&format!("Could not connect to `{}`", database_url));
+
+    let duplicates = foreign_keys.iter()
+        .map(|fk| fk.ordered_tables())
+        .filter(|tables| {
+            let dup_count = foreign_keys.iter()
+                .filter(|fk| tables == &fk.ordered_tables())
+                .count();
+            dup_count > 1
+        })
+        .collect::<Vec<_>>();
+
+    foreign_keys.iter()
+        .filter(|fk| fk.parent_table != fk.child_table)
+        .filter(|fk| safe_tables.contains(&fk.parent_table))
+        .filter(|fk| safe_tables.contains(&fk.child_table))
+        .filter(|fk| {
+            let pk_columns = get_primary_keys(&conn, &fk.parent_table)
+                .expect(&format!("Error loading primary keys for `{}`", fk.parent_table));
+            pk_columns.len() == 1 && pk_columns[0] == fk.primary_key
+        })
+        .filter(|fk| !duplicates.contains(&fk.ordered_tables()))
+        .cloned()
+        .collect()
+}

--- a/diesel_infer_schema/src/foreign_keys.rs
+++ b/diesel_infer_schema/src/foreign_keys.rs
@@ -4,7 +4,7 @@ use table_data::TableData;
 
 pub fn remove_unsafe_foreign_keys_for_codegen(
     database_url: &str,
-    foreign_keys: Vec<ForeignKeyConstraint>,
+    foreign_keys: &[ForeignKeyConstraint],
     safe_tables: &[TableData],
 ) -> Vec<ForeignKeyConstraint> {
     let conn = establish_connection(database_url)

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -212,16 +212,17 @@ pub fn load_foreign_key_constraints<Conn>(connection: &Conn, schema_name: Option
                 .filter(kcu::constraint_name.eq(&fk_name))
                 .select(((kcu::table_name, kcu::table_schema), kcu::column_name))
                 .first(connection)?;
-            let pk_table = kcu::table
+            let (pk_table, pk_column) = kcu::table
                 .filter(kcu::constraint_schema.eq(pk_schema))
                 .filter(kcu::constraint_name.eq(pk_name))
-                .select((kcu::table_name, kcu::table_schema))
+                .select(((kcu::table_name, kcu::table_schema), kcu::column_name))
                 .first(connection)?;
 
             Ok(ForeignKeyConstraint {
                 child_table: fk_table,
                 parent_table: pk_table,
                 foreign_key: fk_column,
+                primary_key: pk_column,
             })
         }).collect()
 }
@@ -366,11 +367,13 @@ mod tests {
             child_table: table_2.clone(),
             parent_table: table_1.clone(),
             foreign_key: "fk_one".into(),
+            primary_key: "id".into(),
         };
         let fk_two = ForeignKeyConstraint {
             child_table: table_3.clone(),
             parent_table: table_2.clone(),
             foreign_key: "fk_two".into(),
+            primary_key: "id".into(),
         };
         assert_eq!(Ok(vec![fk_one, fk_two]), load_foreign_key_constraints(&connection, Some("test_schema")));
     }

--- a/diesel_infer_schema/src/lib.rs
+++ b/diesel_infer_schema/src/lib.rs
@@ -25,6 +25,7 @@ extern crate diesel;
 
 mod codegen;
 mod data_structures;
+mod foreign_keys;
 mod inference;
 mod table_data;
 
@@ -38,5 +39,6 @@ mod pg;
 mod sqlite;
 
 pub use codegen::*;
+pub use foreign_keys::remove_unsafe_foreign_keys_for_codegen;
 pub use inference::{load_table_names, load_foreign_key_constraints};
 pub use table_data::TableData;

--- a/diesel_infer_schema/src/mysql.rs
+++ b/diesel_infer_schema/src/mysql.rs
@@ -24,6 +24,7 @@ mod information_schema {
             column_name -> VarChar,
             referenced_table_schema -> VarChar,
             referenced_table_name -> VarChar,
+            referenced_column_name -> VarChar,
         }
     }
 
@@ -54,11 +55,17 @@ pub fn load_foreign_key_constraints(connection: &MysqlConnection, schema_name: O
             (kcu::table_name, kcu::table_schema),
             (kcu::referenced_table_name, kcu::referenced_table_schema),
             kcu::column_name,
+            kcu::referenced_column_name,
         ))
         .load(connection)?
         .into_iter()
-        .map(|(child_table, parent_table, foreign_key)| {
-            ForeignKeyConstraint { child_table, parent_table, foreign_key }
+        .map(|(child_table, parent_table, foreign_key, primary_key)| {
+            ForeignKeyConstraint {
+                child_table,
+                parent_table,
+                foreign_key,
+                primary_key,
+            }
         })
         .collect();
     Ok(constraints)

--- a/diesel_infer_schema/src/sqlite.rs
+++ b/diesel_infer_schema/src/sqlite.rs
@@ -74,6 +74,7 @@ pub fn load_foreign_key_constraints(connection: &SqliteConnection, schema_name: 
                         child_table: child_table.clone(),
                         parent_table,
                         foreign_key: row.foreign_key,
+                        primary_key: row.primary_key,
                     }
                 }).collect())
         }).collect::<QueryResult<Vec<Vec<_>>>>()?;
@@ -116,7 +117,7 @@ struct ForeignKeyListRow {
     _seq: i32,
     parent_table: String,
     foreign_key: String,
-    _to: String,
+    primary_key: String,
     _on_update: String,
     _on_delete: String,
     _match: String,
@@ -131,7 +132,7 @@ impl Queryable<pragma_foreign_key_list::SqlType, Sqlite> for ForeignKeyListRow {
             _seq: row.1,
             parent_table: row.2,
             foreign_key: row.3,
-            _to: row.4,
+            primary_key: row.4,
             _on_update: row.5,
             _on_delete: row.6,
             _match: row.7,
@@ -305,11 +306,13 @@ fn load_foreign_key_constraints_loads_foreign_keys() {
         child_table: table_2.clone(),
         parent_table: table_1.clone(),
         foreign_key: "fk_one".into(),
+        primary_key: "id".into(),
     };
     let fk_two = ForeignKeyConstraint {
         child_table: table_3.clone(),
         parent_table: table_2.clone(),
         foreign_key: "fk_two".into(),
+        primary_key: "id".into(),
     };
     let fks = load_foreign_key_constraints(&connection, None).unwrap();
     assert_eq!(vec![fk_one, fk_two], fks);

--- a/diesel_infer_schema/src/table_data.rs
+++ b/diesel_infer_schema/src/table_data.rs
@@ -4,7 +4,7 @@ use diesel::types::{FromSqlRow, HasSqlType};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TableData {
     pub name: String,
     pub schema: Option<String>,

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -60,6 +60,7 @@ mod eager_loading_with_string_keys {
         let connection = connection();
         drop_table_cascade(&connection, "users");
         drop_table_cascade(&connection, "posts");
+        drop_table_cascade(&connection, "fk_doesnt_reference_pk");
         connection.batch_execute(r#"
             CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
             CREATE TABLE posts (id TEXT PRIMARY KEY NOT NULL, user_id TEXT NOT NULL);

--- a/migrations/mysql/20170805195107_tables_which_make_infer_joinable_blow_up/down.sql
+++ b/migrations/mysql/20170805195107_tables_which_make_infer_joinable_blow_up/down.sql
@@ -1,0 +1,6 @@
+DROP TABLE self_referential_fk;
+DROP TABLE fk_doesnt_reference_pk;
+DROP TABLE composite_fk;
+DROP TABLE multiple_fks_to_same_table;
+DROP TABLE cyclic_fk_1 CASCADE;
+DROP TABLE cyclic_fk_2 CASCADE;

--- a/migrations/mysql/20170805195107_tables_which_make_infer_joinable_blow_up/up.sql
+++ b/migrations/mysql/20170805195107_tables_which_make_infer_joinable_blow_up/up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE self_referential_fk (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  parent_id INTEGER NOT NULL
+);
+
+ALTER TABLE self_referential_fk ADD CONSTRAINT self_referential_fk_parent_id_fk FOREIGN KEY (parent_id) REFERENCES self_referential_fk (id);
+
+CREATE TABLE fk_doesnt_reference_pk (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  random TEXT REFERENCES posts (title)
+);
+
+CREATE TABLE composite_fk (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  post_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  FOREIGN KEY (user_id, post_id) REFERENCES followings (user_id, post_id)
+);
+
+CREATE TABLE multiple_fks_to_same_table (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  post_id_1 INTEGER REFERENCES posts,
+  post_id_2 INTEGER REFERENCES posts
+);
+
+CREATE TABLE cyclic_fk_1 (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  cyclic_fk_2_id INTEGER
+);
+
+CREATE TABLE cyclic_fk_2 (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  cyclic_fk_1_id INTEGER REFERENCES cyclic_fk_1 (id)
+);
+
+ALTER TABLE cyclic_fk_1 ADD CONSTRAINT cyclic_fk_1_cyclic_fk_2_id_fk FOREIGN KEY (cyclic_fk_2_id) REFERENCES cyclic_fk_2 (id);

--- a/migrations/postgresql/20170805195107_tables_which_make_infer_joinable_blow_up/down.sql
+++ b/migrations/postgresql/20170805195107_tables_which_make_infer_joinable_blow_up/down.sql
@@ -1,0 +1,7 @@
+DROP TABLE self_referential_fk;
+DROP TABLE fk_doesnt_reference_pk;
+ALTER TABLE posts DROP CONSTRAINT title_is_unique;
+DROP TABLE composite_fk;
+DROP TABLE multiple_fks_to_same_table;
+DROP TABLE cyclic_fk_2 CASCADE;
+DROP TABLE cyclic_fk_1 CASCADE;

--- a/migrations/postgresql/20170805195107_tables_which_make_infer_joinable_blow_up/up.sql
+++ b/migrations/postgresql/20170805195107_tables_which_make_infer_joinable_blow_up/up.sql
@@ -1,0 +1,37 @@
+CREATE TABLE self_referential_fk (
+  id SERIAL PRIMARY KEY,
+  parent_id INTEGER NOT NULL
+);
+
+ALTER TABLE self_referential_fk ADD CONSTRAINT self_referential_fk_parent_id_fk FOREIGN KEY (parent_id) REFERENCES self_referential_fk;
+
+ALTER TABLE posts ADD CONSTRAINT title_is_unique UNIQUE (title);
+CREATE TABLE fk_doesnt_reference_pk (
+  id SERIAL PRIMARY KEY,
+  random TEXT REFERENCES posts (title)
+);
+
+CREATE TABLE composite_fk (
+  id SERIAL PRIMARY KEY,
+  post_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  FOREIGN KEY (user_id, post_id) REFERENCES followings
+);
+
+CREATE TABLE multiple_fks_to_same_table (
+  id SERIAL PRIMARY KEY,
+  post_id_1 INTEGER REFERENCES posts,
+  post_id_2 INTEGER REFERENCES posts
+);
+
+CREATE TABLE cyclic_fk_1 (
+  id SERIAL PRIMARY KEY,
+  cyclic_fk_2_id INTEGER
+);
+
+CREATE TABLE cyclic_fk_2 (
+  id SERIAL PRIMARY KEY,
+  cyclic_fk_1_id INTEGER REFERENCES cyclic_fk_1
+);
+
+ALTER TABLE cyclic_fk_1 ADD CONSTRAINT cyclic_fk_1_cyclic_fk_2_id_fk FOREIGN KEY (cyclic_fk_2_id) REFERENCES cyclic_fk_2;

--- a/migrations/sqlite/20170805195107_tables_which_make_infer_joinable_blow_up/down.sql
+++ b/migrations/sqlite/20170805195107_tables_which_make_infer_joinable_blow_up/down.sql
@@ -1,0 +1,7 @@
+DROP TABLE self_referential_fk;
+DROP INDEX posts_title_is_unique;
+DROP TABLE fk_doesnt_reference_pk;
+DROP TABLE composite_fk;
+DROP TABLE multiple_fks_to_same_table;
+DROP TABLE cyclic_fk_2;
+DROP TABLE cyclic_fk_1;

--- a/migrations/sqlite/20170805195107_tables_which_make_infer_joinable_blow_up/up.sql
+++ b/migrations/sqlite/20170805195107_tables_which_make_infer_joinable_blow_up/up.sql
@@ -1,0 +1,39 @@
+CREATE TABLE self_referential_fk (
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER NOT NULL,
+  FOREIGN KEY (parent_id) REFERENCES self_referential_fk (id)
+);
+
+CREATE UNIQUE INDEX posts_title_is_unique ON posts (title);
+CREATE TABLE fk_doesnt_reference_pk (
+  id INTEGER PRIMARY KEY,
+  random TEXT,
+  FOREIGN KEY (random) REFERENCES posts (title)
+);
+
+CREATE TABLE composite_fk (
+  id INTEGER PRIMARY KEY,
+  post_id INTEGER NOT NULL,
+  user_id INTEGER NOT NULL,
+  FOREIGN KEY (user_id, post_id) REFERENCES followings (user_id, post_id)
+);
+
+CREATE TABLE multiple_fks_to_same_table (
+  id INTEGER PRIMARY KEY,
+  post_id_1,
+  post_id_2,
+  FOREIGN KEY (post_id_1) REFERENCES posts (id),
+  FOREIGN KEY (post_id_2) REFERENCES posts (id)
+);
+
+CREATE TABLE cyclic_fk_1 (
+  id INTEGER PRIMARY KEY,
+  cyclic_fk_2_id,
+  FOREIGN KEY (cyclic_fk_2_id) REFERENCES cyclic_fk_2 (id)
+);
+
+CREATE TABLE cyclic_fk_2 (
+  id INTEGER PRIMARY KEY,
+  cyclic_fk_1_id,
+  FOREIGN KEY (cyclic_fk_1_id) REFERENCES cyclic_fk_1 (id)
+);


### PR DESCRIPTION
We will no longer infer `joinable!` for any of the following types of
foreign keys:

- Foreign keys between tables excluded from `infer_schema!`
- Self-referential FKs
- Foreign keys which reference a column other than the primary key
- Composite foreign keys
- Foreign keys where there are more than one foreign key linking two
  tables (we could theoretically infer joinable for one of them, but I
  think figuring out which one would be confusing to users)

There are no explicit tests needed for this, as the mere presence of
these tables makes `infer_schema!` blow up without this change.