### PR TITLE
Remove path handling from `diesel_infer_schema`

### DIFF
--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -68,19 +68,9 @@ fn column_def_tokens(
             e,
         ).into()),
     };
-    let tpe = if column_type.path[0] == "diesel" && column_type.path[1] == "types" {
-        let path_segments = column_type.path
-            .into_iter()
-            .skip(2)
-            .map(syn::PathSegment::from)
-            .collect();
-        syn::Path { global: false, segments: path_segments }
-    } else {
-        let path_segments = column_type.path
-            .into_iter()
-            .map(syn::PathSegment::from)
-            .collect();
-        syn::Path { global: true, segments: path_segments }
+    let tpe = syn::Path {
+        global: false,
+        segments: vec![syn::PathSegment::from(column_type.rust_name)],
     };
     let mut tpe = quote!(#tpe);
 

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -17,7 +17,7 @@ pub struct ColumnInformation {
 }
 
 pub struct ColumnType {
-    pub path: Vec<String>,
+    pub rust_name: String,
     pub is_array: bool,
     pub is_nullable: bool,
 }

--- a/diesel_infer_schema/src/mysql.rs
+++ b/diesel_infer_schema/src/mysql.rs
@@ -68,7 +68,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
     let tpe = determine_type_name(&attr.type_name)?;
 
     Ok(ColumnType {
-        path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
+        rust_name: capitalize(tpe),
         is_array: false,
         is_nullable: attr.nullable,
     })

--- a/diesel_infer_schema/src/pg.rs
+++ b/diesel_infer_schema/src/pg.rs
@@ -23,7 +23,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
     }
 
     Ok(ColumnType {
-        path: vec!["diesel".into(), "types".into(), capitalize(tpe)],
+        rust_name: capitalize(tpe),
         is_array: is_array,
         is_nullable: attr.nullable,
     })

--- a/diesel_infer_schema/src/sqlite.rs
+++ b/diesel_infer_schema/src/sqlite.rs
@@ -148,41 +148,37 @@ pub fn get_primary_keys(conn: &SqliteConnection, table: &TableData) -> QueryResu
         .collect())
 }
 
-fn diesel_type(t: &str) -> Vec<String> {
-    vec!["diesel".into(), "types".into(), t.into()]
-}
-
 pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
     let type_name = attr.type_name.to_lowercase();
     let path = if is_bool(&type_name) {
-        diesel_type("Bool")
+        String::from("Bool")
     } else if is_smallint(&type_name) {
-        diesel_type("SmallInt")
+        String::from("SmallInt")
     } else if is_bigint(&type_name) {
-        diesel_type("BigInt")
+        String::from("BigInt")
     } else if type_name.contains("int") {
-        diesel_type("Integer")
+        String::from("Integer")
     } else if is_text(&type_name) {
-        diesel_type("Text")
+        String::from("Text")
     } else if type_name.contains("blob") || type_name.is_empty() {
-        diesel_type("Binary")
+        String::from("Binary")
     } else if is_float(&type_name) {
-        diesel_type("Float")
+        String::from("Float")
     } else if is_double(&type_name) {
-        diesel_type("Double")
+        String::from("Double")
     } else if type_name == "datetime" || type_name == "timestamp" {
-        diesel_type("Timestamp")
+        String::from("Timestamp")
     } else if type_name == "date" {
-        diesel_type("Date")
+        String::from("Date")
     } else if type_name == "time" {
-        diesel_type("Time")
+        String::from("Time")
     }
     else {
         return Err(format!("Unsupported type: {}", type_name).into())
     };
 
     Ok(ColumnType {
-        path: path,
+        rust_name: path,
         is_array: false,
         is_nullable: attr.nullable,
     })


### PR DESCRIPTION
The only path we ever apply to a type here is `diesel::types::whatever`,
and we are always stripping it off later. We're no longer planning on
infering paths here, and instead rely on `use whatever::types::*` in the
table definition, so we can safely get rid of this.