### PR TITLE
Move `default_schema` handling into table loading

### DIFF
--- a/diesel_infer_schema/src/codegen.rs
+++ b/diesel_infer_schema/src/codegen.rs
@@ -23,22 +23,21 @@ pub fn expand_infer_table_from_schema(database_url: &str, table: &TableData)
     for a in data {
         tokens.push(column_def_tokens(table, &a, &connection)?);
     }
-    let default_schema = default_schema(&connection);
-    if table.schema != default_schema {
-        if let Some(ref schema) = table.schema {
-            let schema_name = syn::Ident::new(&schema[..]);
-            return Ok(quote!(table! {
-                #schema_name.#table_name (#(#primary_keys),*) {
-                    #(#tokens),*,
-                }
-            }));
-        }
+
+    if let Some(ref schema) = table.schema {
+        let schema_name = syn::Ident::new(&**schema);
+        Ok(quote!(table! {
+            #schema_name.#table_name (#(#primary_keys),*) {
+                #(#tokens),*,
+            }
+        }))
+    } else {
+        Ok(quote!(table! {
+            #table_name (#(#primary_keys),*) {
+                #(#tokens),*,
+            }
+        }))
     }
-    Ok(quote!(table! {
-        #table_name (#(#primary_keys),*) {
-            #(#tokens),*,
-        }
-    }))
 }
 
 pub fn handle_schema<I>(tables: I, schema_name: Option<&str>) -> quote::Tokens
@@ -91,20 +90,4 @@ fn column_def_tokens(
         tpe = quote!(Nullable<#tpe>);
     }
     Ok(quote!(#column_name -> #tpe))
-}
-
-fn default_schema(conn: &InferConnection) -> Option<String> {
-    #[cfg(feature="mysql")]
-    use information_schema::UsesInformationSchema;
-    #[cfg(feature="mysql")]
-    use diesel::mysql::Mysql;
-
-    match *conn {
-        #[cfg(feature="sqlite")]
-        InferConnection::Sqlite(_) => None,
-        #[cfg(feature="postgres")]
-        InferConnection::Pg(_) => Some("public".into()),
-        #[cfg(feature="mysql")]
-        InferConnection::Mysql(ref c) => Mysql::default_schema(c).ok(),
-    }
 }

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -164,18 +164,24 @@ pub fn load_table_names<Conn>(connection: &Conn, schema_name: Option<&str>)
 {
     use self::information_schema::tables::dsl::*;
 
+    let default_schema = Conn::Backend::default_schema(connection)?;
     let schema_name = match schema_name {
-        Some(name) => name.into(),
-        None => Conn::Backend::default_schema(connection)?,
+        Some(name) => name,
+        None => &default_schema,
     };
 
-    tables.select((table_name, table_schema))
+    let mut table_names = tables.select((table_name, table_schema))
         .filter(table_schema.eq(schema_name))
         .filter(table_name.not_like("\\_\\_%"))
         .filter(table_type.like("BASE TABLE"))
         .order(table_name)
-        .load(connection)
-        .map_err(Into::into)
+        .load::<TableData>(connection)?;
+    if schema_name == default_schema {
+        for table in &mut table_names {
+            table.schema = None;
+        }
+    }
+    Ok(table_names)
 }
 
 #[cfg_attr(feature = "clippy", allow(similar_names))]
@@ -254,8 +260,8 @@ mod tests {
 
         let table_names = load_table_names(&connection, None).unwrap();
 
-        assert!(table_names.contains(&TableData::new("a_regular_table", "public")));
-        assert!(!table_names.contains(&TableData::new("a_view", "public")));
+        assert!(table_names.contains(&TableData::from_name("a_regular_table")));
+        assert!(!table_names.contains(&TableData::from_name("a_view")));
     }
 
     #[test]
@@ -266,9 +272,12 @@ mod tests {
             .unwrap();
 
         let table_names = load_table_names(&connection, None).unwrap();
-        for TableData { schema, .. } in table_names {
-            assert_eq!(Some("public".into()), schema);
+        for &TableData { ref schema, .. } in &table_names {
+            assert_eq!(None, *schema);
         }
+        assert!(table_names.contains(&TableData::from_name(
+            "load_table_names_loads_from_public_schema_if_none_given",
+        )));
     }
 
     #[test]


### PR DESCRIPTION
The concept of `default_schema` is only a thing for `information_schema`
implementors, so we should handle it there.