### PR TITLE
Refactor encoding `BigDecimal` on PG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `grandchild.join(child.join(parent))`. Previously only
   `parent.join(child.join(grandchild))` would compile.
 
+* When encoding a `BigDecimal` on PG, `1.0` is no longer encoded as if it were
+  `1`.
+
 [bigdecimal-0.16.0]: https://crates.io/crates/bigdecimal
 [range-0.16.0]: http://docs.diesel.rs/diesel/pg/types/sql_types/struct.Range.html
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -28,7 +28,7 @@ ipnetwork = { version = "0.12.2", optional = true }
 num-bigint = { version = "0.1.37", optional = true }
 num-traits = { version = "0.1.35", optional = true }
 num-integer = { version = "0.1.32", optional = true }
-bigdecimal = { version = "0.0.7", optional = true }
+bigdecimal = { version = "0.0.10", optional = true }
 bitflags = { version = "0.9", optional = true }
 
 [dev-dependencies]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -19,7 +19,7 @@ quickcheck = { version = "0.3.1", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.6.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = "0.12.2"
-bigdecimal = "0.0.7"
+bigdecimal = "0.0.10"
 
 [features]
 default = []

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -443,6 +443,7 @@ fn pg_numeric_bigdecimal_to_sql() {
     quickcheck(correct_rep as fn(u64, u64) -> bool);
 
     let test_values = vec![
+        "0.1",
         "1.0",
         "141.0",
         "-1.0",
@@ -498,6 +499,7 @@ fn pg_numeric_bigdecimal_from_sql() {
     use self::bigdecimal::BigDecimal;
 
     let values = vec![
+        "0.1",
         "1.0",
         "141.0",
         "-1.0",


### PR DESCRIPTION
I had originally worked on this as part of 0.15.2, but have been
sitting on it until a new version was released so we could use
`to_bigint_and_exponent`.

The new code takes a different approach to the encoding. I've
specifically broken the code into a `From` impl to make it easier for us
to test the output.

There was an impedence mismatch in the old code. Ultimately the way
`BigDecimal` is represented is as a `BigInteger` with a scale. The way
we're transmitting it is as a `BigInteger` with a weight and scale.
Splitting it into separate integral and fractional parts, and applying
different logic was making the code difficult to understand, and
introducing unneccessary complications.

There are two differences to how `BigUint` is represented vs how PG
wants it. The first is that PG is base 10000, while `BigUint` is base
2^16. The second is that in `BigUint`, `scale` represents both the
number of significant digits, *and* the position of the decimal point.
In PG, `scale` only represents the number of significant digits, and
there is a separate `weight` to represent the position of the decimal
point.

This means that `BigUint` will store trailing zeroes that we need
to strip, but PG will need to ensure that the decimal falls on a digit
boundary in base 10k. The majority of the logic here is to handle that
portion. I've tried to make it as clear as possible what's going on
through proper naming. Unfortunately the fairly simple code of iterating
over the digits in base 10k gets drowned out by the cleanup.

The code could potentially be simplified if we could easily iterate over
the digits in big-endian order, but I could find an easy way to do that
mathematically.