### PR TITLE
Add support for the Datetime type for MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for the [Range][range-0.16.0] type on postgreSQL.
 
+* Added support for the Datetime type on MySQL.
+
 * `infer_schema!` will now automatically detect which tables can be joined based
   on the presence of foreign key constraints.
 

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -62,6 +62,12 @@ impl HasSqlType<::types::Timestamp> for Mysql {
     }
 }
 
+impl HasSqlType<Datetime> for Mysql {
+    fn metadata(_: &()) -> MysqlType {
+        MysqlType::DateTime
+    }
+}
+
 impl HasSqlType<::types::Numeric> for Mysql {
     fn metadata(_: &()) -> MysqlType {
         MysqlType::String
@@ -76,3 +82,15 @@ impl QueryId for ::types::Numeric {
         true
     }
 }
+
+/// Represents the MySQL datetime type.
+/// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
+///
+/// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
+///
+/// ### [`FromSql`](/diesel/types/trait.FromSql.html) impls
+///
+/// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
+///
+/// [NaiveDateTime]: https://lifthrasiir.github.io/rust-chrono/chrono/naive/datetime/struct.NaiveDateTime.html
+#[derive(Debug, Clone, Copy, Default)] pub struct Datetime;

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -193,6 +193,7 @@ mod mysql_types {
 
     test_round_trip!(i8_roundtrips, Tinyint, i8);
     test_round_trip!(naive_datetime_roundtrips, Timestamp, (i64, u32), mk_naive_datetime);
+    test_round_trip!(naive_datetime_roundtrips_to_datetime, Datetime, (i64, u32), mk_naive_datetime);
     test_round_trip!(naive_time_roundtrips, Time, (u32, u32), mk_naive_time);
     test_round_trip!(naive_date_roundtrips, Date, u32, mk_naive_date);
     test_round_trip!(bigdecimal_roundtrips, Numeric, (i64, u64), mk_bigdecimal);


### PR DESCRIPTION
This is mostly the same as for the Timestamp type so I reused both FromSql and
ToSql implementations.