### PR TITLE
Add a way to rename a column in the table! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `infer_schema!` will now automatically detect which tables can be joined based
   on the presence of foreign key constraints.
 
+* Added a way to rename columns in the table macro with `#[sql_name="the_column_name"]`
+
 ### Changed
 
 * The deprecated `debug_sql!` and `print_sql!` functions will now generate


### PR DESCRIPTION
The renaming is done with a `real_name` attribute.

2 passes were added to the table macro.
The first one parses the `real_name` attribute if there is no
`current_column_real_name`.
The second one adds a default `current_column_real_name` if we find a column
definition without any.