### PR TITLE
Add the Blob type to diesel

### DIFF
--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -196,7 +196,7 @@ pub type VarChar = Text;
 
 /// The binary SQL type.
 ///
-/// On MySQL, it is also aliased by `Tinyblob`, `Mediumblob`, `Longblob`, `Bit` and `Varbinary`.
+/// On MySQL, it is also aliased by `Tinyblob`, `Blob`, `Mediumblob`, `Longblob`, `Bit` and `Varbinary`.
 ///
 /// ### [`ToSql`](/diesel/types/trait.ToSql.html) impls
 ///
@@ -212,6 +212,7 @@ pub type VarChar = Text;
 #[derive(Debug, Clone, Copy, Default)] pub struct Binary;
 
 #[doc(hidden)] pub type Tinyblob = Binary;
+#[doc(hidden)] pub type Blob = Binary;
 #[doc(hidden)] pub type Mediumblob = Binary;
 #[doc(hidden)] pub type Longblob = Binary;
 #[doc(hidden)] pub type Varbinary = Binary;

--- a/diesel_tests/tests/schema_inference.rs
+++ b/diesel_tests/tests/schema_inference.rs
@@ -208,3 +208,51 @@ mod postgres {
         assert_eq!(Ok(vec![inferred_ranges]), all_the_ranges::table.load(&conn));
     }
 }
+
+#[cfg(feature = "mysql")]
+mod mysql {
+    use diesel::*;
+    use schema::*;
+
+    #[derive(Insertable)]
+    #[table_name="all_the_blobs"]
+    struct InferredBlobs<'a> {
+        id: i32,
+        tiny: &'a [u8],
+        normal: &'a [u8],
+        medium: &'a [u8],
+        big: &'a [u8],
+    }
+
+    #[derive(Queryable, Debug, PartialEq)]
+    struct Blobs {
+        id: i32,
+        tiny: Vec<u8>,
+        normal: Vec<u8>,
+        medium: Vec<u8>,
+        big: Vec<u8>,
+    }
+
+    #[test]
+    fn blobs_are_correctly_inferred() {
+        let conn = connection();
+        let inferred_blobs = InferredBlobs {
+            id: 0,
+            tiny: &[0x01],
+            normal: &[0x02],
+            medium: &[0x03],
+            big: &[0x04],
+        };
+
+        let blobs = Blobs {
+            id: 0,
+            tiny: vec![0x01],
+            normal: vec![0x02],
+            medium: vec![0x03],
+            big: vec![0x04],
+        };
+
+        insert(&inferred_blobs).into(all_the_blobs::table).execute(&conn).unwrap();
+        assert_eq!(Ok(vec![blobs]), all_the_blobs::table.load(&conn));
+    }
+}

--- a/migrations/mysql/20170811104602_add_blob_types/down.sql
+++ b/migrations/mysql/20170811104602_add_blob_types/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE all_the_blobs;

--- a/migrations/mysql/20170811104602_add_blob_types/up.sql
+++ b/migrations/mysql/20170811104602_add_blob_types/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE all_the_blobs (
+    id INTEGER PRIMARY KEY, -- Can't use a blob as a pk
+    tiny TINYBLOB NOT NULL,
+    normal BLOB NOT NULL,
+    medium MEDIUMBLOB NOT NULL,
+    big LONGBLOB NOT NULL
+)


### PR DESCRIPTION
As for tiny/medium/bigblob, it's just an alias to binary

Fixes #1089