### PR TITLE
Fix a warning when compiling diesel_cli

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 
 [[bin]]
 name = "diesel"
+path = "src/main.rs"
 
 [dependencies]
 chrono = "0.4"


### PR DESCRIPTION
```
warning: path `/home/eijebong/code/diesel/diesel_cli/src/main.rs` was erroneously implicitly accepted for binary `diesel`,
please set bin.path in Cargo.toml
```