### PR TITLE
Fix MySQL NaiveDate deserialization

### DIFF
--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -24,7 +24,7 @@ fn parse_sqlite_date(date: &str) -> Result<NaiveDate, Box<Error+Send+Sync>> {
 
     match NaiveDate::from_ymd_opt(ymd[0] as i32, ymd[1], ymd[2]) {
         Some(d) => Ok(d),
-        None => Err("Invalid date.".into()),
+        None => Err(format! ("Cannot parse this date: {:?}", ymd).into()),
     }
 }
 


### PR DESCRIPTION
Old behavior could cause panic in `chrono`.

See #1130.

If this approach is correct I can replace `from_ymd` with `from_ymd_opt` in other places too. Same with `and_hms_micro`.