### PR TITLE
Add underscores to long literals in test code

### DIFF
--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -265,7 +265,7 @@ mod tests {
         let query = select(sql::<Date>("'2018-1-1'::date").eq(january_first_2018));
         assert!(query.get_result::<bool>(&connection).unwrap());
 
-        let distant_future = NaiveDate::from_ymd(72400, 1, 8);
+        let distant_future = NaiveDate::from_ymd(72_400, 1, 8);
         let query = select(sql::<Date>("'72400-1-8'::date").eq(distant_future));
         assert!(query.get_result::<bool>(&connection).unwrap());
     }
@@ -293,7 +293,7 @@ mod tests {
         let query = select(sql::<Date>("'2018-1-1'::date"));
         assert_eq!(Ok(january_first_2018), query.get_result::<NaiveDate>(&connection));
 
-        let distant_future = NaiveDate::from_ymd(72400, 1, 8);
+        let distant_future = NaiveDate::from_ymd(72_400, 1, 8);
         let query = select(sql::<Date>("'72400-1-8'::date"));
         assert_eq!(Ok(distant_future), query.get_result::<NaiveDate>(&connection));
     }

--- a/diesel/src/pg/types/floats/quickcheck_impls.rs
+++ b/diesel/src/pg/types/floats/quickcheck_impls.rs
@@ -57,7 +57,7 @@ struct Digit(i16);
 impl Arbitrary for Digit {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let mut n = -1;
-        while n < 0 || n >= 10000 {
+        while n < 0 || n >= 10_000 {
             n = i16::arbitrary(g);
         }
         Digit(n)

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -297,11 +297,11 @@ pub mod sql_types {
     /// #     )").unwrap();
     /// let new_item = NewItem {
     ///     name: "Shiny Thing".into(),
-    ///     price: Cents(123456),
+    ///     price: Cents(123_456),
     /// };
     /// let inserted_item = insert(&new_item).into(items)
     ///     .get_result::<Item>(&connection).unwrap();
-    /// assert_eq!(Cents(123456), inserted_item.price);
+    /// assert_eq!(Cents(123_456), inserted_item.price);
     /// # }
     /// ```
     #[derive(Debug, Clone, Copy, Default)] pub struct Money;

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -191,7 +191,7 @@ mod tests {
         let query = select(sql::<Date>("'2018-01-01'").eq(january_first_2018));
         assert!(query.get_result::<bool>(&connection).unwrap());
 
-        let distant_future = NaiveDate::from_ymd(72400, 1, 8);
+        let distant_future = NaiveDate::from_ymd(72_400, 1, 8);
         let query = select(sql::<Date>("'72400-01-08'").eq(distant_future));
         assert!(query.get_result::<bool>(&connection).unwrap());
     }
@@ -215,7 +215,7 @@ mod tests {
         let query = select(sql::<Date>("'2018-01-01'"));
         assert_eq!(Ok(january_first_2018), query.get_result::<NaiveDate>(&connection));
 
-        let distant_future = NaiveDate::from_ymd(72400, 1, 8);
+        let distant_future = NaiveDate::from_ymd(72_400, 1, 8);
         let query = select(sql::<Date>("'72400-01-08'"));
         assert_eq!(Ok(distant_future), query.get_result::<NaiveDate>(&connection));
     }
@@ -235,7 +235,7 @@ mod tests {
         let query = select(sql::<Date>("'2018-01-01'"));
         assert_eq!(Ok(january_first_2018), query.get_result::<NaiveDate>(&connection));
 
-        let distant_future = NaiveDate::from_ymd(72400, 1, 8).and_hms(23, 59, 59).with_nanosecond(100000).unwrap();
+        let distant_future = NaiveDate::from_ymd(72_400, 1, 8).and_hms(23, 59, 59).with_nanosecond(100_000).unwrap();
         let query = select(sql::<Timestamp>("'72400-01-08 23:59:59.000100'"));
         assert_eq!(Ok(distant_future), query.get_result::<NaiveDateTime>(&connection));
    }
@@ -251,11 +251,11 @@ mod tests {
         let query = select(sql::<Timestamp>("'-398-04-11 20:00:20.000000'").eq(distant_past));
         assert!(query.get_result::<bool>(&connection).unwrap());
 
-        let january_first_2018 = NaiveDate::from_ymd(2018, 1, 1).and_hms(12, 00, 00).with_nanosecond(500000).unwrap();
+        let january_first_2018 = NaiveDate::from_ymd(2018, 1, 1).and_hms(12, 00, 00).with_nanosecond(500_000).unwrap();
         let query = select(sql::<Timestamp>("'2018-01-01 12:00:00.000500'").eq(january_first_2018));
         assert!(query.get_result::<bool>(&connection).unwrap());
 
-        let distant_future = NaiveDate::from_ymd(72400, 1, 8).and_hms(0, 0, 0);
+        let distant_future = NaiveDate::from_ymd(72_400, 1, 8).and_hms(0, 0, 0);
         let query = select(sql::<Timestamp>("'72400-01-08 00:00:00.000000'").eq(distant_future));
         assert!(query.get_result::<bool>(&connection).unwrap());
     }

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -156,16 +156,16 @@ fn i16_to_sql_smallint() {
 fn i32_from_sql() {
     assert_eq!(0, query_single_value::<Integer, i32>("0"));
     assert_eq!(-1, query_single_value::<Integer, i32>("-1"));
-    assert_eq!(70000, query_single_value::<Integer, i32>("70000"));
+    assert_eq!(70_000, query_single_value::<Integer, i32>("70000"));
 }
 
 #[test]
 fn i32_to_sql_integer() {
     assert!(query_to_sql_equality::<Integer, i32>("0", 0));
     assert!(query_to_sql_equality::<Integer, i32>("-1", -1));
-    assert!(query_to_sql_equality::<Integer, i32>("70000", 70000));
+    assert!(query_to_sql_equality::<Integer, i32>("70000", 70_000));
     assert!(!query_to_sql_equality::<Integer, i32>("0", 1));
-    assert!(!query_to_sql_equality::<Integer, i32>("70000", 69999));
+    assert!(!query_to_sql_equality::<Integer, i32>("70000", 69_999));
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn i32_to_sql_integer() {
 fn i64_from_sql() {
     assert_eq!(0, query_single_value::<BigInt, i64>("0::int8"));
     assert_eq!(-1, query_single_value::<BigInt, i64>("-1::int8"));
-    assert_eq!(283745982374,
+    assert_eq!(283_745_982_374,
                query_single_value::<BigInt, i64>("283745982374::int8"));
 }
 
@@ -182,9 +182,9 @@ fn i64_from_sql() {
 fn i64_to_sql_bigint() {
     assert!(query_to_sql_equality::<BigInt, i64>("0::int8", 0));
     assert!(query_to_sql_equality::<BigInt, i64>("-1::int8", -1));
-    assert!(query_to_sql_equality::<BigInt, i64>("283745982374::int8", 283745982374));
+    assert!(query_to_sql_equality::<BigInt, i64>("283745982374::int8", 283_745_982_374));
     assert!(!query_to_sql_equality::<BigInt, i64>("0::int8", 1));
-    assert!(!query_to_sql_equality::<BigInt, i64>("283745982374::int8", 283745982373));
+    assert!(!query_to_sql_equality::<BigInt, i64>("283745982374::int8", 283_745_982_373));
 }
 
 use std::{f32, f64};
@@ -383,10 +383,10 @@ fn timestamp_from_sql() {
     use diesel::data_types::PgTimestamp;
 
     let query = "'2015-11-13 13:26:48.041057-07'::timestamp";
-    let expected_value = PgTimestamp(500736408041057);
+    let expected_value = PgTimestamp(500_736_408_041_057);
     assert_eq!(expected_value, query_single_value::<Timestamp, PgTimestamp>(query));
     let query = "'2015-11-13 13:26:49.041057-07'::timestamp";
-    let expected_value = PgTimestamp(500736409041057);
+    let expected_value = PgTimestamp(500_736_409_041_057);
     assert_eq!(expected_value, query_single_value::<Timestamp, PgTimestamp>(query));
 }
 
@@ -396,10 +396,10 @@ fn pg_timestamp_to_sql_timestamp() {
     use diesel::data_types::PgTimestamp;
 
     let expected_value = "'2015-11-13 13:26:48.041057-07'::timestamp";
-    let value = PgTimestamp(500736408041057);
+    let value = PgTimestamp(500_736_408_041_057);
     assert!(query_to_sql_equality::<Timestamp, PgTimestamp>(expected_value, value));
     let expected_value = "'2015-11-13 13:26:49.041057-07'::timestamp";
-    let value = PgTimestamp(500736409041057);
+    let value = PgTimestamp(500_736_409_041_057);
     assert!(query_to_sql_equality::<Timestamp, PgTimestamp>(expected_value, value));
     let expected_non_equal_value = "'2015-11-13 13:26:48.041057-07'::timestamp";
     assert!(!query_to_sql_equality::<Timestamp, PgTimestamp>(expected_non_equal_value, value));
@@ -755,7 +755,7 @@ fn third_party_crates_can_add_new_types() {
 
     assert_eq!(0, query_single_value::<MyInt, i32>("0"));
     assert_eq!(-1, query_single_value::<MyInt, i32>("-1"));
-    assert_eq!(70000, query_single_value::<MyInt, i32>("70000"));
+    assert_eq!(70_000, query_single_value::<MyInt, i32>("70000"));
 }
 
 fn query_single_value<T, U: Queryable<T, TestBackend>>(sql_str: &str) -> U where


### PR DESCRIPTION
Updating to rust nightly 2017-08-31 made clippy start
failing builds on long literals. (e.g., 72400 should be 72_400).
This adds underscores to long literals in test code.

See https://github.com/diesel-rs/diesel/issues/1143 on why this wasn't caught in CI. 