### PR TITLE
Provide a predictable sort for `joinable!` calls in print-schema.

### DIFF
--- a/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/postgres/expected.rs
@@ -52,5 +52,5 @@ table! {
     }
 }
 
-joinable!(posts -> users (user_id));
 joinable!(comments -> posts (post_id));
+joinable!(posts -> users (user_id));

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -92,7 +92,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ForeignKeyConstraint {
     pub child_table: TableName,
     pub parent_table: TableName,

--- a/diesel_infer_schema/src/inference.rs
+++ b/diesel_infer_schema/src/inference.rs
@@ -208,7 +208,7 @@ pub fn load_foreign_key_constraints(
 ) -> Result<Vec<ForeignKeyConstraint>, Box<Error>> {
     let connection = try!(establish_connection(database_url));
 
-    match connection {
+    let constraints = match connection {
         #[cfg(feature = "sqlite")]
         InferConnection::Sqlite(c) => ::sqlite::load_foreign_key_constraints(&c, schema_name),
         #[cfg(feature = "postgres")]
@@ -219,7 +219,9 @@ pub fn load_foreign_key_constraints(
         InferConnection::Mysql(c) => {
             ::mysql::load_foreign_key_constraints(&c, schema_name).map_err(Into::into)
         }
-    }
+    };
+
+    constraints.map(|mut ct| { ct.sort(); ct })
 }
 
 macro_rules! doc_comment {


### PR DESCRIPTION
**TLDR: I can haz stable `joinable!` output from `diesel print-schema`?**

## Why?

In switching https://github.com/dikaiosune/rust-dashboard over to use `diesel print-schema` instead of calling `infer_schema!` directly in the code, I've hit a small snag.

My goal is to run `diff src/schema_which_is_committed_to_git.rs schema_which_i_generate_in_ci_from_the_migrations_i_ran.rs` and fail the CI job if the committed migrations result in a schema different from what's committed to source control. Unfortunately, today it seems that identical versions of `diesel_cli` can produce [identical `joinable!` calls but in different orders](https://travis-ci.org/dikaiosune/rust-dashboard/jobs/270927391#L622-L650). Ideally, the output of the foreign key constraints would be predictably sorted. So, uh, that's what I did.

## Risks

This seems like a pretty small change code-wise, although it would involve a publicly visible trait impl which would break backcompat to later remove.