### PR TITLE
Fixes #1138 - Utilize compile_error! macro.

### DIFF
--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -140,8 +140,12 @@ cfg_if! {
             connection
         }
     } else {
-        // FIXME: https://github.com/rust-lang/rfcs/pull/1695
-        // compile_error!("At least one backend must be enabled to run tests");
+        compile_error!(
+            "At least one backend must be used to test this crate.\n \
+            Pass argument `--features \"<backend>\"` with one or more of the following backends, \
+            'mysql', 'postgres', or 'sqlite'. \n\n \
+            ex. cargo test --features \"mysql postgres sqlite\"\n"
+        );
     }
 }
 

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -520,8 +520,12 @@ mod tests {
                 conn
             }
         } else {
-            // FIXME: https://github.com/rust-lang/rfcs/pull/1695
-            // compile_error!("At least one backend must be enabled to run tests");
+            compile_error!(
+                "At least one backend must be used to test this crate.\n \
+                Pass argument `--features \"<backend>\"` with one or more of the following backends, \
+                'mysql', 'postgres', or 'sqlite'. \n\n \
+                ex. cargo test --features \"mysql postgres sqlite\"\n"
+            );
         }
     }
 }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -401,9 +401,8 @@ macro_rules! __diesel_table_impl {
         table_doc = [$($doc:expr,)*];
         $($rest:tt)*
     ) => {
-        // Remove this workaround as soon as rust issue 40872 is implemented
-        // https://github.com/rust-lang/rust/issues/40872
-        const ERROR: i32 = env!("invalid table! syntax");
+        compile_error!("Invalid `table!` syntax. Please see the `table!` macro docs for more info. \
+        `http://docs.diesel.rs/diesel/macro.table.html`");
     };
 
     // Put a parse annotation and empty fields for imports and documentation on top

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -46,7 +46,11 @@ cfg_if! {
             MysqlConnection::establish(&database_url).unwrap()
         }
     } else {
-        // FIXME: https://github.com/rust-lang/rfcs/pull/1695
-        // compile_error!("At least one backend must be enabled to run tests");
+        compile_error!(
+            "At least one backend must be used to test this crate.\n \
+            Pass argument `--features \"<backend>\"` with one or more of the following backends, \
+            'mysql', 'postgres', or 'sqlite'. \n\n \
+            ex. cargo test --features \"mysql postgres sqlite\"\n"
+        );
     }
 }

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -59,6 +59,12 @@ impl Backend {
                     available_schemes.join(" or ")
                 );
             }
+            #[cfg(not(any(feature = "mysql", feature = "sqlite", feature = "postgres")))]
+            _ => compile_error!(
+                    "At least one backend must be specified for use with this crate. \
+                    You may omit the unneeded dependencies in the following command. \n\n \
+                    ex. `cargo install diesel_cli --no-default-features --features mysql postgres sqlite` \n"
+            )
         }
     }
 }

--- a/diesel_codegen/tests/test_helpers.rs
+++ b/diesel_codegen/tests/test_helpers.rs
@@ -46,7 +46,11 @@ cfg_if! {
             MysqlConnection::establish(&database_url).unwrap()
         }
     } else {
-        // FIXME: https://github.com/rust-lang/rfcs/pull/1695
-        // compile_error!("At least one backend must be enabled to run tests");
+        compile_error!(
+            "At least one backend must be used to test this crate.\n \
+            Pass argument `--features \"<backend>\"` with one or more of the following backends, \
+            'mysql', 'postgres', or 'sqlite'. \n\n \
+            ex. cargo test --features \"mysql postgres sqlite\"\n"
+        );
     }
 }

--- a/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_1.rs
+++ b/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_1.rs
@@ -3,6 +3,6 @@
 table! {
     12
 }
-// error-pattern: invalid table! syntax
+// error-pattern: Invalid `table!` syntax. Please see the `table!` macro docs for more info. `http://docs.diesel.rs/diesel/macro.table.html`
 
 fn main() {}

--- a/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_2.rs
+++ b/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_2.rs
@@ -3,6 +3,6 @@
 table! {
      some wrong syntax
 }
-// error-pattern: invalid table! syntax
+// error-pattern: Invalid `table!` syntax. Please see the `table!` macro docs for more info. `http://docs.diesel.rs/diesel/macro.table.html`
 
 fn main() {}

--- a/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_3.rs
+++ b/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_3.rs
@@ -6,6 +6,6 @@ table! {
          id -> Integer,
      }
 }
-// error-pattern: invalid table! syntax
+// error-pattern: Invalid `table!` syntax. Please see the `table!` macro docs for more info. `http://docs.diesel.rs/diesel/macro.table.html`
 
 fn main() {}

--- a/diesel_infer_schema/src/inference.rs
+++ b/diesel_infer_schema/src/inference.rs
@@ -114,6 +114,13 @@ pub(crate) fn establish_connection(database_url: &str) -> Result<InferConnection
                 database_url,
             ).into(),
         ),
+        #[cfg(not(any(feature = "mysql", feature = "sqlite", feature = "postgres")))]
+        _ => compile_error!(
+                "At least one backend must be specified for use with this crate.\n \
+                In Cargo.toml, please specify `features = [\"postgresql\"]`, \
+                `features = [\"mysql\"]`, or `features = [\"sqlite\"]`\n\n \
+                ex. `diesel_codegen { features = [\"postgres\"] }`\n "
+        )
     }
 }
 

--- a/diesel_tests/build.rs
+++ b/diesel_tests/build.rs
@@ -4,6 +4,14 @@ use self::diesel::*;
 use self::dotenv::dotenv;
 use std::{env, io};
 
+#[cfg(not(any(feature = "mysql", feature = "sqlite", feature = "postgres")))]
+compile_error!(
+    "At least one backend must be used to test this crate.\n \
+    Pass argument `--features \"<backend>\"` with one or more of the following backends, \
+    'mysql', 'postgres', or 'sqlite'. \n\n \
+    ex. cargo test --features \"mysql postgres sqlite\"\n"
+);
+
 #[cfg(feature = "postgres")]
 fn connection() -> PgConnection {
     let database_url = database_url_from_env("PG_DATABASE_URL");


### PR DESCRIPTION
compile_error! was introduced in Rust 1.20. Use to give concise compile-time error messages.