### PR TITLE
Move various "DSL" type things into a top-level `dsl` module

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -1,7 +1,6 @@
+use dsl::{Eq, EqAny, Filter, FindBy};
 use expression::AsExpression;
-use expression::helper_types::{Eq, EqAny};
 use expression::array_comparison::AsInExpression;
-use helper_types::{Filter, FindBy};
 use prelude::*;
 use super::{HasTable, Identifiable};
 

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,6 +1,6 @@
 use backend::Backend;
+use dsl::SqlTypeOf;
 use expression::*;
-use expression::helper_types::SqlTypeOf;
 use query_builder::*;
 use result::QueryResult;
 use types::Bool;

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -8,14 +8,14 @@ use types::BigInt;
 ///
 /// As with most bare functions, this is not exported by default. You can import
 /// it specifically as `diesel::expression::count`, or glob import
-/// `diesel::expression::dsl::*`
+/// `diesel::dsl::*`
 ///
 /// # Examples
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use diesel::expression::dsl::*;
+/// # use diesel::dsl::*;
 /// #
 /// # table! {
 /// #     users {
@@ -42,14 +42,14 @@ pub fn count<T: Expression>(t: T) -> Count<T> {
 ///
 /// As with most bare functions, this is not exported by default. You can import
 /// it specifically as `diesel::expression::count_star`, or glob import
-/// `diesel::expression::dsl::*`
+/// `diesel::dsl::*`
 ///
 /// # Examples
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use diesel::expression::dsl::*;
+/// # use diesel::dsl::*;
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -26,7 +26,7 @@ use types::Bool;
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     use diesel::select;
-/// #     use diesel::expression::dsl::exists;
+/// #     use diesel::dsl::exists;
 /// #     let connection = establish_connection();
 /// let sean_exists = select(exists(users.filter(name.eq("Sean"))))
 ///     .get_result(&connection);

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -17,6 +17,7 @@ macro_rules! fold_function {
         }
 
         #[derive(Debug, Clone, Copy)]
+        #[doc(hidden)]
         pub struct $type_name<T> {
             target: T,
         }
@@ -57,7 +58,7 @@ Foldable.
 ```rust
 # #[macro_use] extern crate diesel;
 # include!(\"../../doctest_setup.rs\");
-# use diesel::expression::dsl::*;
+# use diesel::dsl::*;
 #
 # table! {
 #     users {
@@ -86,7 +87,7 @@ Foldable.
 ```rust
 # #[macro_use] extern crate diesel;
 # include!(\"../../doctest_setup.rs\");
-# use diesel::expression::dsl::*;
+# use diesel::dsl::*;
 #
 # table! {
 #     users {

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -17,6 +17,7 @@ macro_rules! ord_function {
         }
 
         #[derive(Debug, Clone, Copy)]
+        #[doc(hidden)]
         pub struct $type_name<T> {
             target: T,
         }
@@ -56,7 +57,7 @@ ordered.
 ```rust
 # #[macro_use] extern crate diesel;
 # include!(\"../../doctest_setup.rs\");
-# use diesel::expression::dsl::*;
+# use diesel::dsl::*;
 #
 # table! {
 #     users {
@@ -85,7 +86,7 @@ ordered.
 ```rust
 # #[macro_use] extern crate diesel;
 # include!(\"../../doctest_setup.rs\");
-# use diesel::expression::dsl::*;
+# use diesel::dsl::*;
 #
 # table! {
 #     users {

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -38,7 +38,7 @@ expression, and the return value will be an expression of type Date.
 # #[macro_use] extern crate diesel;
 # extern crate chrono;
 # include!(\"../../doctest_setup.rs\");
-# use diesel::expression::dsl::*;
+# use diesel::dsl::*;
 #
 # table! {
 #     users {

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -40,12 +40,11 @@ pub mod nullable;
 #[doc(hidden)]
 #[macro_use]
 pub mod operators;
+#[doc(hidden)]
 pub mod sql_literal;
 mod unchecked_bind;
 
-/// Reexports various top level functions and core extensions that are too
-/// generic to export by default. This module exists to conveniently glob import
-/// in functions where you need them.
+#[doc(hidden)]
 pub mod dsl {
     #[doc(inline)]
     pub use super::count::{count, count_star};
@@ -66,7 +65,7 @@ pub mod dsl {
     pub use pg::expression::dsl::*;
 }
 
-pub use self::dsl::*;
+#[doc(inline)]
 pub use self::sql_literal::SqlLiteral;
 
 use backend::Backend;

--- a/diesel/src/expression/not.rs
+++ b/diesel/src/expression/not.rs
@@ -1,5 +1,5 @@
+use dsl::Not;
 use expression::AsExpression;
-use expression::helper_types::Not;
 use expression::grouped::Grouped;
 use types::Bool;
 
@@ -21,7 +21,7 @@ use types::Bool;
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = establish_connection();
-/// use diesel::expression::not;
+/// use diesel::dsl::not;
 ///
 /// let users_with_name = users.select(id).filter(name.eq("Sean"));
 /// let users_not_with_name = users.select(id).filter(

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -12,6 +12,7 @@ macro_rules! __diesel_operator_body {
         backend_ty = $backend_ty:ty,
     ) => {
         #[derive(Debug, Clone, Copy)]
+        #[doc(hidden)]
         pub struct $name<$($ty_param,)+> {
             $($field_name: $ty_param,)+
         }

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -52,7 +52,7 @@ impl<ST> SqlLiteral<ST> {
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
-    /// #     use diesel::expression::dsl::sql;
+    /// #     use diesel::dsl::sql;
     /// #     use diesel::types::{Integer, Text};
     /// #     let connection = establish_connection();
     /// #[cfg(feature="postgres")]
@@ -83,7 +83,7 @@ impl<ST> SqlLiteral<ST> {
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
-    /// #     use diesel::expression::dsl::sql;
+    /// #     use diesel::dsl::sql;
     /// #     use diesel::types::{Integer, Text};
     /// #     let connection = establish_connection();
     /// #     diesel::insert(&NewUser::new("Jim")).into(users)
@@ -154,7 +154,7 @@ impl<ST> NonAggregate for SqlLiteral<ST> {}
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_codegen;
-/// use diesel::expression::sql;
+/// use diesel::dsl::sql;
 /// use diesel::types::{Bool, Integer, Text};
 /// # include!("../doctest_setup.rs");
 /// # table! {

--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -1,5 +1,5 @@
+use dsl::AsExprOf;
 use expression::AsExpression;
-use expression::helper_types::AsExprOf;
 use expression::operators::{Escape, Like, NotLike};
 use types::VarChar;
 /// Adds the `escape` method to `LIKE` and `NOT LIKE`. This is used to specify

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -63,6 +63,17 @@ pub mod result;
 pub mod row;
 mod util;
 
+pub mod dsl {
+    //! Includes various helper types and bare functions which are named too
+    //! generically to be included in prelude, but are often used when using Diesel.
+
+    #[doc(inline)]
+    pub use helper_types::*;
+
+    #[doc(inline)]
+    pub use expression::dsl::*;
+}
+
 pub mod helper_types {
     //! Provide helper types for concisely writing the return type of functions.
     //! As with iterators, it is unfortunately difficult to return a partially
@@ -76,7 +87,9 @@ pub mod helper_types {
     //! be `Limit<Order<FindBy<users, first_name, &str>, Asc<last_name>>>`
     use super::query_dsl::*;
     use super::query_source::joins;
-    use super::expression::helper_types::Eq;
+
+    #[doc(inline)]
+    pub use expression::helper_types::*;
 
     /// Represents the return type of `.select(selection)`
     pub type Select<Source, Selection> = <Source as SelectDsl<Selection>>::Output;

--- a/diesel/src/macros/as_changeset.rs
+++ b/diesel/src/macros/as_changeset.rs
@@ -255,7 +255,7 @@ macro_rules! AsChangeset_changeset_ty {
             $($rest:tt)*
         },
     ) => {
-        Option<$crate::expression::helper_types::Eq<
+        Option<$crate::dsl::Eq<
             $table_name::$column_name,
             &'update $field_ty,
         >>
@@ -272,7 +272,7 @@ macro_rules! AsChangeset_changeset_ty {
             $($ignore:tt)*
         },
     ) => {
-        $crate::expression::helper_types::Eq<
+        $crate::dsl::Eq<
             $table_name::$column_name,
             &'update $field_ty,
         >

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -165,7 +165,7 @@ macro_rules! impl_Insertable {
                 ($(
                     $crate::insertable::ColumnInsertValue<
                         $table_name::$column_name,
-                        $crate::expression::helper_types::AsExpr<
+                        $crate::dsl::AsExpr<
                             &'insert $field_ty,
                             $table_name::$column_name,
                         >,
@@ -175,7 +175,7 @@ macro_rules! impl_Insertable {
             type Values = ($(
                 $crate::insertable::ColumnInsertValue<
                     $table_name::$column_name,
-                    $crate::expression::helper_types::AsExpr<
+                    $crate::dsl::AsExpr<
                         &'insert $field_ty,
                         $table_name::$column_name,
                     >,

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -73,9 +73,9 @@ macro_rules! __diesel_column {
 
         impl<T> $crate::EqAll<T> for $column_name where
             T: $crate::expression::AsExpression<$($Type)*>,
-            $crate::expression::helper_types::Eq<$column_name, T>: $crate::Expression<SqlType=$crate::types::Bool>,
+            $crate::dsl::Eq<$column_name, T>: $crate::Expression<SqlType=$crate::types::Bool>,
         {
-            type Output = $crate::expression::helper_types::Eq<Self, T>;
+            type Output = $crate::dsl::Eq<Self, T>;
 
             fn eq_all(self, rhs: T) -> Self::Output {
                 $crate::expression::operators::Eq::new(self, rhs.as_expression())
@@ -932,7 +932,7 @@ macro_rules! joinable_inner {
     ) => {
         impl $crate::JoinTo<$right_table_ty> for $left_table_ty {
             type FromClause = $right_table_ty;
-            type OnClause = $crate::expression::helper_types::Eq<
+            type OnClause = $crate::dsl::Eq<
                 $crate::expression::nullable::Nullable<$foreign_key>,
                 $crate::expression::nullable::Nullable<$primary_key_ty>,
             >;

--- a/diesel/src/migrations/connection.rs
+++ b/diesel/src/migrations/connection.rs
@@ -30,7 +30,7 @@ where
     }
 
     fn latest_run_migration_version(&self) -> QueryResult<Option<String>> {
-        use expression::dsl::max;
+        use dsl::max;
         __diesel_schema_migrations.select(max(version)).first(self)
     }
 

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -167,7 +167,7 @@ mod tests {
     use self::chrono::{Duration, NaiveDate, NaiveTime, Utc};
     use self::dotenv::dotenv;
 
-    use expression::dsl::{now, sql};
+    use dsl::{now, sql};
     use prelude::*;
     use select;
     use types::{Date, Datetime, Time, Timestamp};

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -164,7 +164,7 @@ mod tests {
     use std::env;
 
     use expression::AsExpression;
-    use expression::dsl::sql;
+    use dsl::sql;
     use prelude::*;
     use super::*;
     use types::{Integer, VarChar};

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -8,14 +8,14 @@ use types::Array;
 ///
 /// As with most bare functions, this is not exported by default. You can import
 /// it specifically from `diesel::expression::any`, or glob import
-/// `diesel::expression::dsl::*`
+/// `diesel::dsl::*`
 ///
 /// # Example
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../../doctest_setup.rs");
-/// # use diesel::expression::dsl::*;
+/// # use diesel::dsl::*;
 /// #
 /// # table! {
 /// #     users {
@@ -44,15 +44,14 @@ where
 /// Creates a PostgreSQL `ALL` expression.
 ///
 /// As with most bare functions, this is not exported by default. You can import
-/// it specifically from `diesel::expression::all`, or glob import
-/// `diesel::expression::dsl::*`
+/// it specifically as `diesel::dsl::all`.
 ///
 /// # Example
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../../doctest_setup.rs");
-/// # use diesel::expression::dsl::*;
+/// # use diesel::dsl::*;
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -13,7 +13,7 @@ use data_types::PgInterval;
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../../../doctest_setup.rs");
-/// # use diesel::expression::dsl::*;
+/// # use diesel::dsl::*;
 /// #
 /// # table! {
 /// #     users {
@@ -104,7 +104,7 @@ pub trait MicroIntervalDsl: Sized + Mul<Self, Output = Self> {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../../../doctest_setup.rs");
-/// # use diesel::expression::dsl::*;
+/// # use diesel::dsl::*;
 /// #
 /// # table! {
 /// #     users {
@@ -156,7 +156,7 @@ pub trait DayAndMonthIntervalDsl: Sized + Mul<Self, Output = Self> {
     /// months.
     ///
     /// ```rust
-    /// # use diesel::expression::dsl::*;
+    /// # use diesel::dsl::*;
     /// assert_eq!(1.08.years(), 1.year());
     /// assert_eq!(1.09.years(), 1.year() + 1.month());
     /// ```
@@ -249,7 +249,7 @@ mod tests {
 
     use {select, types};
     use data_types::PgInterval;
-    use expression::dsl::sql;
+    use dsl::sql;
     use prelude::*;
     use super::*;
 

--- a/diesel/src/pg/expression/extensions/mod.rs
+++ b/diesel/src/pg/expression/extensions/mod.rs
@@ -1,6 +1,6 @@
 //! This module contains extensions that are added to core types to aid in
 //! building expressions. These traits are not exported by default. The are also
-//! re-exported in `diesel::expression::dsl`
+//! re-exported in `diesel::dsl`
 mod interval_dsl;
 
 pub use self::interval_dsl::{DayAndMonthIntervalDsl, MicroIntervalDsl};

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -10,7 +10,7 @@ pub mod helper_types;
 mod date_and_time;
 
 /// PostgreSQL specific expression DSL methods. This module will be glob
-/// imported by [`expression::dsl`](../../expression/dsl/index.html) when
+/// imported by [`diesel::dsl`](../../dsl/index.html) when
 /// compiled with the `feature = "postgres"` flag.
 pub mod dsl {
     #[doc(inline)]

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -152,7 +152,7 @@ mod tests {
     use self::dotenv::dotenv;
 
     use select;
-    use expression::dsl::{now, sql};
+    use dsl::{now, sql};
     use prelude::*;
     use types::{Date, Time, Timestamp, Timestamptz};
 

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -44,7 +44,7 @@ mod tests {
     use self::time::{Duration, Timespec};
 
     use select;
-    use expression::dsl::{now, sql};
+    use dsl::{now, sql};
     use prelude::*;
     use types::Timestamp;
 

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -70,7 +70,7 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use select;
-    use expression::dsl::{now, sql};
+    use dsl::{now, sql};
     use prelude::*;
     use types::Timestamp;
 

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -1,5 +1,5 @@
+use dsl::Select;
 use expression::Expression;
-use helper_types::Select;
 use query_dsl::SelectDsl;
 use super::delete_statement::DeleteStatement;
 use super::insert_statement::Insert;

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -105,8 +105,8 @@ where
     }
 }
 
+use dsl::Filter;
 use expression_methods::EqAll;
-use helper_types::Filter;
 use query_source::Table;
 
 impl<F, S, D, W, O, L, Of, G, PK> FindDsl<PK> for SelectStatement<F, S, D, W, O, L, Of, G>

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -1,5 +1,5 @@
 use associations::{HasTable, Identifiable};
-use helper_types::Find;
+use dsl::Find;
 use query_dsl::FindDsl;
 
 #[doc(hidden)]

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -1,5 +1,5 @@
+use dsl::Filter;
 use expression_methods::*;
-use helper_types::Filter;
 use query_builder::{AsQuery, Query};
 use query_source::*;
 

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,6 +1,6 @@
 use backend::Backend;
 use connection::Connection;
-use helper_types::Limit;
+use dsl::Limit;
 use query_builder::{AsQuery, QueryFragment, QueryId};
 use query_source::Queryable;
 use result::{first_or_not_found, QueryResult};

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -1,5 +1,5 @@
 use associations::HasTable;
-use helper_types::*;
+use dsl::*;
 use query_builder::{AsChangeset, IntoUpdateTarget};
 use query_dsl::*;
 use result::QueryResult;

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -133,7 +133,7 @@ fn error_message(err_code: libc::c_int) -> &'static str {
 #[cfg(test)]
 mod tests {
     use expression::AsExpression;
-    use expression::dsl::sql;
+    use dsl::sql;
     use prelude::*;
     use super::*;
     use types::Integer;

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -110,7 +110,7 @@ mod tests {
     use self::dotenv::dotenv;
 
     use select;
-    use expression::dsl::{now, sql};
+    use dsl::{now, sql};
     use prelude::*;
     use types::{Date, Time, Timestamp};
 

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -1,5 +1,5 @@
 use clap::ArgMatches;
-use diesel::expression::sql;
+use diesel::dsl::sql;
 use diesel::types::Bool;
 use diesel::*;
 #[cfg(any(feature = "postgres", feature = "mysql"))]

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -1,6 +1,6 @@
 use support::{database, project};
 use diesel::{select, LoadDsl};
-use diesel::expression::sql;
+use diesel::dsl::sql;
 use diesel::types::Bool;
 
 #[test]

--- a/diesel_cli/tests/support/mysql_database.rs
+++ b/diesel_cli/tests/support/mysql_database.rs
@@ -1,5 +1,5 @@
 use diesel::connection::SimpleConnection;
-use diesel::expression::sql;
+use diesel::dsl::sql;
 use diesel::types::Bool;
 use diesel::*;
 

--- a/diesel_cli/tests/support/postgres_database.rs
+++ b/diesel_cli/tests/support/postgres_database.rs
@@ -1,5 +1,5 @@
 use diesel::connection::SimpleConnection;
-use diesel::expression::sql;
+use diesel::dsl::sql;
 use diesel::types::Bool;
 use diesel::{select, Connection, LoadDsl, PgConnection};
 

--- a/diesel_cli/tests/support/sqlite_database.rs
+++ b/diesel_cli/tests/support/sqlite_database.rs
@@ -1,5 +1,5 @@
 use diesel::connection::SimpleConnection;
-use diesel::expression::sql;
+use diesel::dsl::sql;
 use diesel::sqlite::SqliteConnection;
 use diesel::types::Bool;
 use diesel::{select, Connection, LoadDsl};

--- a/diesel_codegen/tests/queryable.rs
+++ b/diesel_codegen/tests/queryable.rs
@@ -1,4 +1,4 @@
-use diesel::expression::dsl::sql;
+use diesel::dsl::sql;
 use diesel::*;
 use diesel::types::Integer;
 

--- a/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
@@ -16,7 +16,7 @@ table! {
 }
 
 fn main() {
-    use diesel::expression::dsl::*;
+    use diesel::dsl::*;
     let source = users::table.select(sum(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause

--- a/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::expression::dsl::*;
+use diesel::dsl::*;
 
 table! {
     stuff {

--- a/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::expression::count;
+use diesel::dsl::count;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/cannot_pass_aggregate_to_where.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_pass_aggregate_to_where.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::expression::count;
+use diesel::dsl::count;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/custom_returning_requires_nonaggregate.rs
+++ b/diesel_compile_tests/tests/compile-fail/custom_returning_requires_nonaggregate.rs
@@ -4,7 +4,7 @@ extern crate diesel;
 extern crate diesel_codegen;
 
 use diesel::*;
-use diesel::expression::count;
+use diesel::dsl::count;
 
 table! {
     users {

--- a/diesel_compile_tests/tests/compile-fail/ordering_functions_require_ord.rs
+++ b/diesel_compile_tests/tests/compile-fail/ordering_functions_require_ord.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::expression::{max, min};
+use diesel::dsl::{max, min};
 
 table! {
     stuff (b) {

--- a/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
@@ -3,7 +3,7 @@
 
 use diesel::*;
 use diesel::types::*;
-use diesel::expression::dsl::*;
+use diesel::dsl::*;
 use diesel::pg::upsert::*;
 
 table! {

--- a/diesel_compile_tests/tests/compile-fail/select_sql_still_ensures_result_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_sql_still_ensures_result_type.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::expression::dsl::sql;
+use diesel::dsl::sql;
 
 table! {
     users {

--- a/diesel_infer_schema/src/sqlite.rs
+++ b/diesel_infer_schema/src/sqlite.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use diesel::*;
-use diesel::expression::dsl::sql;
+use diesel::dsl::sql;
 use diesel::sqlite::{Sqlite, SqliteConnection};
 
 use table_data::TableName;

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -1,6 +1,6 @@
 use schema::connection_without_transaction;
 use diesel::*;
-use diesel::expression::dsl::sql;
+use diesel::dsl::sql;
 
 table! {
     auto_time {

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -1,7 +1,7 @@
 use schema::{connection, TestConnection};
 use diesel::*;
 use diesel::data_types::*;
-use diesel::expression::dsl::*;
+use diesel::dsl::*;
 use diesel::types::Nullable;
 
 table! {
@@ -180,7 +180,7 @@ fn time_is_deserialized_properly() {
 #[test]
 #[cfg(feature = "postgres")]
 fn interval_is_deserialized_properly() {
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
     let connection = connection();
 
     let data = select(sql::<
@@ -207,7 +207,7 @@ fn interval_is_deserialized_properly() {
 #[cfg(feature = "postgres")]
 fn adding_interval_to_timestamp() {
     use self::has_timestamps::dsl::*;
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
 
     let connection = connection();
     setup_test_table(&connection);
@@ -230,7 +230,7 @@ fn adding_interval_to_timestamp() {
 #[cfg(feature = "postgres")]
 fn adding_interval_to_nullable_things() {
     use self::nullable_date_and_time::dsl::*;
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
 
     let connection = connection();
     setup_test_table(&connection);

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -6,7 +6,7 @@ use schema::users::dsl::*;
 use diesel::*;
 use diesel::backend::Backend;
 use diesel::query_builder::*;
-use diesel::expression::dsl::*;
+use diesel::dsl::*;
 
 #[test]
 fn test_count_counts_the_rows() {

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -322,7 +322,7 @@ fn or_doesnt_mess_with_precidence_of_previous_statements() {
 #[test]
 fn not_does_not_affect_expressions_other_than_those_passed_to_it() {
     use schema::users::dsl::*;
-    use diesel::expression::dsl::not;
+    use diesel::dsl::not;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let count = users
@@ -337,7 +337,7 @@ fn not_does_not_affect_expressions_other_than_those_passed_to_it() {
 #[test]
 fn not_affects_arguments_passed_when_they_contain_higher_operator_precedence() {
     use schema::users::dsl::*;
-    use diesel::expression::dsl::not;
+    use diesel::dsl::not;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let count = users

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -209,7 +209,7 @@ fn filter_by_ilike() {
 #[cfg(feature = "postgres")]
 fn filter_by_any() {
     use schema::users::dsl::*;
-    use diesel::expression::dsl::any;
+    use diesel::dsl::any;
 
     let connection = connection_with_3_users();
     let sean = User::new(1, "Sean");

--- a/diesel_tests/tests/internal_details.rs
+++ b/diesel_tests/tests/internal_details.rs
@@ -1,7 +1,7 @@
 use schema::*;
 use diesel::types::*;
 use diesel::expression::AsExpression;
-use diesel::expression::dsl::sql;
+use diesel::dsl::sql;
 use diesel::*;
 
 #[test]
@@ -41,7 +41,7 @@ fn query_which_cannot_be_transmitted_gives_proper_error_message() {
 fn empty_query_gives_proper_error_instead_of_panicking() {
     use diesel::result::Error::DatabaseError;
     use diesel::result::DatabaseErrorKind::__Unknown;
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
 
     let connection = connection();
     let query = sql::<Integer>("");

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -1,5 +1,3 @@
-#![recursion_limit="1024"]
-
 use diesel::*;
 use dotenv::dotenv;
 use std::env;

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -49,7 +49,7 @@ fn with_safe_select() {
 
 #[test]
 fn with_select_sql() {
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
 
     let connection = connection();
     connection

--- a/diesel_tests/tests/transactions.rs
+++ b/diesel_tests/tests/transactions.rs
@@ -126,7 +126,7 @@ fn drop_test_table(connection: &TestConnection, table_name: &str) {
 }
 
 fn count_test_table(connection: &TestConnection, table_name: &str) -> i64 {
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
     select(sql::<types::BigInt>(
         &format!("COUNT(*) FROM {}", table_name),
     )).first(connection)

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1026,7 +1026,7 @@ where
     TestBackend: HasSqlType<T>,
     T: QueryId + SingleValue,
 {
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
     let connection = connection();
     select(sql::<T>(sql_str)).first(&connection).unwrap()
 }
@@ -1043,7 +1043,7 @@ where
     U::Expression: QueryFragment<TestBackend> + QueryId,
     T: QueryId + SingleValue,
 {
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
     let connection = connection();
     let query = select(
         sql::<T>(sql_str)
@@ -1060,7 +1060,7 @@ where
 #[test]
 #[should_panic(expected = "Received more than 4 bytes decoding i32")]
 fn debug_check_catches_reading_bigint_as_i32_when_using_raw_sql() {
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
     use diesel::types::Integer;
 
     let connection = connection();
@@ -1074,7 +1074,7 @@ fn debug_check_catches_reading_bigint_as_i32_when_using_raw_sql() {
 #[test]
 fn test_range_from_sql() {
     use std::collections::Bound;
-    use diesel::expression::sql;
+    use diesel::dsl::sql;
 
     let connection = connection();
 
@@ -1104,7 +1104,6 @@ fn test_range_from_sql() {
 #[test]
 fn test_range_to_sql() {
     use std::collections::Bound;
-    use diesel::expression::sql;
 
     let expected_value = "'[1,2]'::int4range";
     let value = (Bound::Included(1), Bound::Excluded(3));

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -352,7 +352,7 @@ fn upsert_with_no_changes_executes_do_nothing() {
 #[test]
 #[cfg(feature = "postgres")]
 fn upsert_with_sql_literal_for_target() {
-    use diesel::expression::dsl::sql;
+    use diesel::dsl::sql;
     use diesel::pg::upsert::*;
     use diesel::types::Text;
     use schema::users::dsl::*;

--- a/examples/postgres/all_about_updates/src/lib.rs
+++ b/examples/postgres/all_about_updates/src/lib.rs
@@ -50,7 +50,7 @@ fn examine_sql_from_publish_all_posts() {
 
 pub fn publish_pending_posts(conn: &PgConnection) -> QueryResult<usize> {
     use posts::dsl::*;
-    use diesel::expression::dsl::now;
+    use diesel::dsl::now;
 
     let target = posts.filter(publish_at.lt(now));
     diesel::update(target).set(draft.eq(false)).execute(conn)
@@ -59,7 +59,7 @@ pub fn publish_pending_posts(conn: &PgConnection) -> QueryResult<usize> {
 #[test]
 fn examine_sql_from_publish_pending_posts() {
     use posts::dsl::*;
-    use diesel::expression::dsl::now;
+    use diesel::dsl::now;
 
     let target = posts.filter(publish_at.lt(now));
     assert_eq!(


### PR DESCRIPTION
It's too much work to keep track of whether something is in
`diesel::helper_types`, `diesel::expression::helper_types`, or
`diesel::expression::dsl`. This moves all of them into a single place.
The `helper_type` modules are left in the documentation, as I think
there's some value in their module level documentation. The
`expression::dsl` module is hidden from docs.