### PR TITLE
Add support for `SELECT ... FOR UPDATE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* The `.for_update()` method has been added to select statements, allowing
+  construction of `SELECT ... FOR UPDATE`.
+
 ### Changed
 
 * The signatures of `QueryId`, `Column`, and `FromSqlRow` have all changed to

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -135,10 +135,10 @@ pub trait MaybeEmpty {
     fn is_empty(&self) -> bool;
 }
 
-impl<ST, S, F, W, O, L, Of, G> AsInExpression<ST> for SelectStatement<S, F, W, O, L, Of, G>
+impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<ST> for SelectStatement<S, F, W, O, L, Of, G, FU>
 where
-    SelectStatement<S, F, W, O, L, Of, G>: Query<SqlType = ST>,
-    Subselect<SelectStatement<S, F, W, O, L, Of>, ST>: Expression,
+    Self: Query<SqlType = ST>,
+    Subselect<Self, ST>: Expression<SqlType = ST>,
 {
     type InExpression = Subselect<Self, ST>;
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -100,6 +100,9 @@ pub mod helper_types {
     /// Represents the return type of `.filter(lhs.eq(rhs))`
     pub type FindBy<Source, Column, Value> = Filter<Source, Eq<Column, Value>>;
 
+    /// Represents the return type of `.for_update()`
+    pub type ForUpdate<Source> = <Source as ForUpdateDsl>::Output;
+
     /// Represents the return type of `.find(pk)`
     pub type Find<Source, PK> = <Source as FindDsl<PK>>::Output;
 

--- a/diesel/src/mysql/query_builder/mod.rs
+++ b/diesel/src/mysql/query_builder/mod.rs
@@ -1,36 +1,35 @@
-use super::backend::Pg;
+use super::backend::Mysql;
 use query_builder::QueryBuilder;
 use result::QueryResult;
 
+mod query_fragment_impls;
+
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
-pub struct PgQueryBuilder {
+pub struct MysqlQueryBuilder {
     sql: String,
-    bind_idx: u32,
 }
 
-impl PgQueryBuilder {
+impl MysqlQueryBuilder {
     pub fn new() -> Self {
-        PgQueryBuilder::default()
+        MysqlQueryBuilder::default()
     }
 }
 
-impl QueryBuilder<Pg> for PgQueryBuilder {
+impl QueryBuilder<Mysql> for MysqlQueryBuilder {
     fn push_sql(&mut self, sql: &str) {
         self.sql.push_str(sql);
     }
 
     fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
-        self.push_sql("\"");
-        self.push_sql(&identifier.replace('"', "\"\""));
-        self.push_sql("\"");
+        self.push_sql("`");
+        self.push_sql(&identifier.replace("`", "``"));
+        self.push_sql("`");
         Ok(())
     }
 
     fn push_bind_param(&mut self) {
-        self.bind_idx += 1;
-        let sql = format!("${}", self.bind_idx);
-        self.push_sql(&sql);
+        self.push_sql("?");
     }
 
     fn finish(self) -> String {

--- a/diesel/src/mysql/query_builder/query_fragment_impls.rs
+++ b/diesel/src/mysql/query_builder/query_fragment_impls.rs
@@ -1,0 +1,11 @@
+use mysql::Mysql;
+use query_builder::{AstPass, QueryFragment};
+use query_builder::for_update_clause::ForUpdateClause;
+use result::QueryResult;
+
+impl QueryFragment<Mysql> for ForUpdateClause {
+    fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {
+        out.push_sql(" FOR UPDATE");
+        Ok(())
+    }
+}

--- a/diesel/src/pg/query_builder/mod.rs
+++ b/diesel/src/pg/query_builder/mod.rs
@@ -1,33 +1,38 @@
-use super::backend::Mysql;
+use super::backend::Pg;
 use query_builder::QueryBuilder;
 use result::QueryResult;
 
+mod query_fragment_impls;
+
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
-pub struct MysqlQueryBuilder {
+pub struct PgQueryBuilder {
     sql: String,
+    bind_idx: u32,
 }
 
-impl MysqlQueryBuilder {
+impl PgQueryBuilder {
     pub fn new() -> Self {
-        MysqlQueryBuilder::default()
+        PgQueryBuilder::default()
     }
 }
 
-impl QueryBuilder<Mysql> for MysqlQueryBuilder {
+impl QueryBuilder<Pg> for PgQueryBuilder {
     fn push_sql(&mut self, sql: &str) {
         self.sql.push_str(sql);
     }
 
     fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
-        self.push_sql("`");
-        self.push_sql(&identifier.replace("`", "``"));
-        self.push_sql("`");
+        self.push_sql("\"");
+        self.push_sql(&identifier.replace('"', "\"\""));
+        self.push_sql("\"");
         Ok(())
     }
 
     fn push_bind_param(&mut self) {
-        self.push_sql("?");
+        self.bind_idx += 1;
+        let sql = format!("${}", self.bind_idx);
+        self.push_sql(&sql);
     }
 
     fn finish(self) -> String {

--- a/diesel/src/pg/query_builder/query_fragment_impls.rs
+++ b/diesel/src/pg/query_builder/query_fragment_impls.rs
@@ -1,0 +1,11 @@
+use pg::Pg;
+use query_builder::{AstPass, QueryFragment};
+use query_builder::for_update_clause::ForUpdateClause;
+use result::QueryResult;
+
+impl QueryFragment<Pg> for ForUpdateClause {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql(" FOR UPDATE");
+        Ok(())
+    }
+}

--- a/diesel/src/query_builder/for_update_clause.rs
+++ b/diesel/src/query_builder/for_update_clause.rs
@@ -1,0 +1,19 @@
+use backend::Backend;
+use query_builder::{AstPass, QueryFragment};
+use result::QueryResult;
+
+#[derive(Debug, Clone, Copy)]
+pub struct NoForUpdateClause;
+
+impl<DB: Backend> QueryFragment<DB> for NoForUpdateClause {
+    fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
+        Ok(())
+    }
+}
+
+impl_query_id!(NoForUpdateClause);
+
+#[derive(Debug, Clone, Copy)]
+pub struct ForUpdateClause;
+
+impl_query_id!(ForUpdateClause);

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -18,6 +18,7 @@ pub mod functions;
 #[doc(hidden)]
 pub mod nodes;
 mod distinct_clause;
+pub(crate) mod for_update_clause;
 mod group_by_clause;
 mod limit_clause;
 mod offset_clause;

--- a/diesel/src/query_dsl/locking_dsl.rs
+++ b/diesel/src/query_dsl/locking_dsl.rs
@@ -1,0 +1,39 @@
+use query_builder::AsQuery;
+use query_source::Table;
+
+/// Adds `FOR UPDATE` to the end of the select statement. This method is only
+/// available for MySQL and PostgreSQL. SQLite does not provide any form of
+/// row locking.
+///
+/// Additionally, `.for_update` cannot be used on queries with a distinct
+/// clause, group by clause, having clause, or any unions. Queries with
+/// a `FOR UPDATE` clause cannot be boxed.
+///
+/// # Example
+///
+/// ```ignore
+/// // Executes `SELECT * FROM users FOR UPDATE`
+/// users.for_update().load(&connection)
+/// ```
+pub trait ForUpdateDsl {
+    /// The query returned by `for_update`. See [`dsl::ForUpdate`] for
+    /// convenient access to this type.
+    ///
+    /// [`dsl::ForUpdate`]: ../dsl/type.ForUpdate.html
+    type Output;
+
+    /// See the trait level documentation
+    fn for_update(self) -> Self::Output;
+}
+
+impl<T> ForUpdateDsl for T
+where
+    T: Table + AsQuery,
+    T::Query: ForUpdateDsl,
+{
+    type Output = <T::Query as ForUpdateDsl>::Output;
+
+    fn for_update(self) -> Self::Output {
+        self.as_query().for_update()
+    }
+}

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -9,6 +9,7 @@ mod join_dsl;
 pub mod limit_dsl;
 #[doc(hidden)]
 pub mod load_dsl;
+mod locking_dsl;
 #[doc(hidden)]
 pub mod select_dsl;
 #[doc(hidden)]
@@ -27,6 +28,7 @@ pub use self::group_by_dsl::GroupByDsl;
 pub use self::join_dsl::{InternalJoinDsl, JoinDsl, JoinOnDsl, JoinWithImplicitOnClause};
 pub use self::limit_dsl::LimitDsl;
 pub use self::load_dsl::{ExecuteDsl, FirstDsl, LoadDsl, LoadQuery};
+pub use self::locking_dsl::ForUpdateDsl;
 pub use self::offset_dsl::OffsetDsl;
 pub use self::order_dsl::OrderDsl;
 pub use self::save_changes_dsl::SaveChangesDsl;

--- a/diesel_compile_tests/tests/compile-fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
@@ -1,0 +1,29 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    use self::users::dsl::*;
+
+    users.for_update().distinct();
+    //~^ ERROR: E0599
+    users.distinct().for_update();
+    //~^ ERROR: E0599
+
+    users.for_update().group_by(id);
+    //~^ ERROR: E0599
+    users.group_by(id).for_update();
+    //~^ ERROR: E0599
+
+    users.into_boxed().for_update();
+    //~^ ERROR: E0599
+    users.for_update().into_boxed();
+    //~^ ERROR: E0275
+}

--- a/diesel_compile_tests/tests/compile-fail/select_for_update_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_for_update_cannot_be_used_on_sqlite.rs
@@ -1,0 +1,20 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::sqlite::SqliteConnection;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    let conn = SqliteConnection::establish("").unwrap();
+    users::table
+        .for_update()
+        .load(&conn)
+        //~^ ERROR: E0277
+        .unwrap();
+}

--- a/diesel_tests/tests/schema_dsl/functions.rs
+++ b/diesel_tests/tests/schema_dsl/functions.rs
@@ -11,7 +11,7 @@ pub fn integer<'a>(name: &'a str) -> Column<'a, types::Integer> {
 }
 
 pub fn string<'a>(name: &'a str) -> Column<'a, types::VarChar> {
-    Column::new(name, "VARCHAR")
+    Column::new(name, "VARCHAR(255)")
 }
 
 pub fn timestamp<'a>(name: &'a str) -> Column<'a, types::VarChar> {

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -72,6 +72,8 @@ use diesel::types::Integer;
 use diesel::pg::Pg;
 #[cfg(feature = "sqlite")]
 use diesel::sqlite::Sqlite;
+#[cfg(feature = "mysql")]
+use diesel::mysql::Mysql;
 
 impl<'a, DB, Cols> QueryFragment<DB> for CreateTable<'a, Cols>
 where
@@ -138,6 +140,19 @@ where
         out.unsafe_to_cache_prepared();
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(" AUTOINCREMENT");
+        Ok(())
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<Col> QueryFragment<Mysql> for AutoIncrement<Col>
+where
+    Col: QueryFragment<Mysql>,
+{
+    fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        self.0.walk_ast(out.reborrow())?;
+        out.push_sql(" AUTO_INCREMENT");
         Ok(())
     }
 }


### PR DESCRIPTION
The semantics of where this modifier is allowed are taken from PG, even
though this query is also allowed on MySQL. PG's docs are much more
thorough on the semantics of `FOR UPDATE`, and where it is or is not
allowed.

I've opted *not* to allow this with boxed queries, as a boxed query has
no way to verify that it isn't mixed with a group by/having/distinct
clause. We may want to lift this restriction in the future, depending
on what we do with `group_by` there when we add proper support for it.
If we decide to allow `group_by` on boxed queries, it will require not
that the select clause is still valid. It seems likely that boxed
queries will just end up with the gotcha of "less checking is done".

Still, for the time being I've taken the conservative approach, as we
can always change that later.

If/when we add support for having, union, intersect, and except, we will
need to ensure that those methods can only be used with no for update
clause as well.

The code is structured in a way that's a bit more generic on the backend
than is strictly necessary, but I plan to follow this up with support
for MySQL's `LOCK IN SHARE MODE` (which I believe is equivalent to `FOR
SHARE` in PG), which will need this structure in place.

I've opted for a very minimal usage example, as the test which
demonstrates its behavior is long enough that it drowns out the actual
usage.