### PR TITLE
feat: Support batch insert for sqlite

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -31,5 +31,4 @@ pub trait TypeMetadata {
 }
 
 pub trait SupportsReturningClause {}
-pub trait SupportsDefaultKeyword {}
 pub trait UsesAnsiSavepointSyntax {}

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use backend::{Backend, SupportsDefaultKeyword};
+use backend::Backend;
 use result::QueryResult;
 use query_builder::AstPass;
 use query_source::Table;
@@ -39,7 +39,7 @@ type ValuesFn<Item, T, DB> = fn(Item)
 impl<Iter, T, DB> Insertable<T, DB> for Iter
 where
     T: Table,
-    DB: Backend + SupportsDefaultKeyword,
+    DB: Backend,
     Iter: IntoIterator,
     Iter::Item: Insertable<T, DB>,
     Iter::IntoIter: Clone,

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -243,6 +243,7 @@ mod tests {
         users {
             id -> Integer,
             name -> VarChar,
+            #[default_value="'Green'"]
             hair_color -> Nullable<VarChar>,
         }
     }

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -42,5 +42,4 @@ impl TypeMetadata for Mysql {
     type MetadataLookup = ();
 }
 
-impl SupportsDefaultKeyword for Mysql {}
 impl UsesAnsiSavepointSyntax for Mysql {}

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -37,5 +37,4 @@ impl TypeMetadata for Pg {
 }
 
 impl SupportsReturningClause for Pg {}
-impl SupportsDefaultKeyword for Pg {}
 impl UsesAnsiSavepointSyntax for Pg {}

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -38,6 +38,7 @@ pub trait Column: Expression {
     type Table: Table;
 
     const NAME: &'static str;
+    const DEFAULT: &'static str;
 }
 
 /// A SQL database table. Types which implement this trait should have been

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use associations::BelongsTo;
-use backend::{Backend, SupportsDefaultKeyword};
+use backend::Backend;
 use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
 use insertable::{ColumnInsertValue, InsertValues};
 use query_builder::*;
@@ -88,7 +88,7 @@ macro_rules! tuple_impls {
             #[cfg_attr(feature = "clippy", allow(eq_op))] // Clippy doesn't like the trivial case for 1-tuples
             impl<$($T,)+ $($ST,)+ Tab, DB> InsertValues<DB>
                 for ($(ColumnInsertValue<$T, $ST>,)+) where
-                    DB: Backend + SupportsDefaultKeyword,
+                    DB: Backend,
                     Tab: Table,
                     $($T: Column<Table=Tab>,)+
                     $($ST: Expression<SqlType=$T::SqlType> + QueryFragment<DB>,)+
@@ -112,47 +112,15 @@ macro_rules! tuple_impls {
                         if let ColumnInsertValue::Expression(_, ref value) = self.$idx {
                             value.walk_ast(out.reborrow())?;
                         } else {
-                            out.push_sql("DEFAULT");
-                        }
-                    )+
-                    out.push_sql(")");
-                    Ok(())
-                }
-            }
-
-            #[cfg(feature = "sqlite")]
-            impl<$($T,)+ $($ST,)+ Tab> InsertValues<::sqlite::Sqlite>
-                for ($(ColumnInsertValue<$T, $ST>,)+) where
-                    Tab: Table,
-                    $($T: Column<Table=Tab>,)+
-                    $($ST: Expression<SqlType=$T::SqlType> + QueryFragment<::sqlite::Sqlite>,)+
-            {
-                #[allow(unused_assignments)]
-                fn column_names(&self, out: &mut ::sqlite::SqliteQueryBuilder) -> QueryResult<()> {
-                    let mut columns_present = false;
-                    $(
-                        if let ColumnInsertValue::Expression(..) = self.$idx {
-                            if columns_present {
-                                out.push_sql(", ");
+                            match $T::DEFAULT {
+                                "NULL" => {
+                                    #[cfg(feature = "sqlite")]
+                                    out.push_sql("NULL");
+                                    #[cfg(not(feature = "sqlite"))]
+                                    out.push_sql("DEFAULT");
+                                }
+                                other => out.push_sql(other)
                             }
-                            try!(out.push_identifier($T::NAME));
-                            columns_present = true;
-                        }
-                    )+
-                    Ok(())
-                }
-
-                #[allow(unused_assignments)]
-                fn walk_ast(&self, mut out: AstPass<::sqlite::Sqlite>) -> QueryResult<()> {
-                    out.push_sql("(");
-                    let mut columns_present = false;
-                    $(
-                        if let ColumnInsertValue::Expression(_, ref value) = self.$idx {
-                            if columns_present {
-                                out.push_sql(", ");
-                            }
-                            value.walk_ast(out.reborrow())?;
-                            columns_present = true;
                         }
                     )+
                     out.push_sql(")");

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -114,6 +114,7 @@ fn table_name_to_tokens(table_name: TableName) -> quote::Tokens {
 fn column_data_to_tokens(column_data: ColumnDefinition) -> quote::Tokens {
     let docs = to_doc_comment_tokens(&column_data.docs);
     let ty = column_ty_to_tokens(column_data.ty);
+    let default_value = column_data.default_value.unwrap_or_else(|| "NULL".to_string());
     if let Some(rust_name) = column_data.rust_name {
         let rust_name = syn::Ident::new(rust_name);
         let sql_name = column_data.sql_name;
@@ -121,6 +122,7 @@ fn column_data_to_tokens(column_data: ColumnDefinition) -> quote::Tokens {
         quote!(
             #(#docs)*
             #[sql_name = #sql_name]
+            #[default_value = #default_value]
             #rust_name -> #ty
         )
     } else {
@@ -128,6 +130,7 @@ fn column_data_to_tokens(column_data: ColumnDefinition) -> quote::Tokens {
 
         quote!(
             #(#docs)*
+            #[default_value = #default_value]
             #name -> #ty
         )
     }

--- a/diesel_infer_schema/src/data_structures.rs
+++ b/diesel_infer_schema/src/data_structures.rs
@@ -14,6 +14,7 @@ pub struct ColumnInformation {
     pub column_name: String,
     pub type_name: String,
     pub nullable: bool,
+    pub default_value: Option<String>
 }
 
 #[derive(Debug)]
@@ -50,10 +51,11 @@ pub struct ColumnDefinition {
     pub ty: ColumnType,
     pub docs: String,
     pub rust_name: Option<String>,
+    pub default_value: Option<String>
 }
 
 impl ColumnInformation {
-    pub fn new<T, U>(column_name: T, type_name: U, nullable: bool) -> Self
+    pub fn new<T, U>(column_name: T, type_name: U, nullable: bool, default_value: Option<String>) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -62,6 +64,7 @@ impl ColumnInformation {
             column_name: column_name.into(),
             type_name: type_name.into(),
             nullable: nullable,
+            default_value: default_value
         }
     }
 }
@@ -75,7 +78,7 @@ where
     type Row = (String, String, String);
 
     fn build(row: Self::Row) -> Self {
-        ColumnInformation::new(row.0, row.1, row.2 == "YES")
+        ColumnInformation::new(row.0, row.1, row.2 == "YES", None)
     }
 }
 
@@ -88,7 +91,7 @@ where
     type Row = (i32, String, String, bool, Option<String>, bool);
 
     fn build(row: Self::Row) -> Self {
-        ColumnInformation::new(row.1, row.2, !row.3)
+        ColumnInformation::new(row.1, row.2, !row.3, row.4)
     }
 }
 

--- a/diesel_infer_schema/src/inference.rs
+++ b/diesel_infer_schema/src/inference.rs
@@ -279,6 +279,7 @@ pub fn load_table_data(database_url: &str, name: TableName) -> Result<TableData,
                 sql_name: c.column_name,
                 ty,
                 rust_name,
+                default_value: c.default_value
             })
         })
         .collect::<Result<_, Box<Error>>>()?;

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -420,10 +420,10 @@ mod tests {
 
         let table_1 = TableName::new("table_1", "test_schema");
         let table_2 = TableName::new("table_2", "test_schema");
-        let id = ColumnInformation::new("id", "int4", false);
-        let text_col = ColumnInformation::new("text_col", "varchar", true);
-        let not_null = ColumnInformation::new("not_null", "text", false);
-        let array_col = ColumnInformation::new("array_col", "_varchar", false);
+        let id = ColumnInformation::new("id", "int4", false, None);
+        let text_col = ColumnInformation::new("text_col", "varchar", true, None);
+        let not_null = ColumnInformation::new("not_null", "text", false, None);
+        let array_col = ColumnInformation::new("array_col", "_varchar", false, None);
         assert_eq!(
             Ok(vec![id, text_col, not_null]),
             get_table_data(&connection, &table_1)

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -83,15 +83,15 @@ fn insert_records_with_custom_returning_clause() {
 }
 
 #[test]
-#[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
+#[cfg(not(feature = "mysql"))] // FIXME: use users table
 fn batch_insert_with_defaults() {
-    use schema::users::table as users;
+    use schema::users_with_default::table as users_with_default;
     use schema_dsl::*;
 
     let connection = connection();
-    drop_table_cascade(&connection, "users");
+    drop_table_cascade(&connection, "users_with_default");
     create_table(
-        "users",
+        "users_with_default",
         (
             integer("id").primary_key().auto_increment(),
             string("name").not_null(),
@@ -100,11 +100,11 @@ fn batch_insert_with_defaults() {
     ).execute(&connection)
         .unwrap();
 
-    let new_users: &[_] = &[
-        NewUser::new("Sean", Some("Black")),
-        NewUser::new("Tess", None),
+    let new_users_with_default: &[_] = &[
+        NewUserWithDefault::new("Sean", Some("Black")),
+        NewUserWithDefault::new("Tess", None),
     ];
-    insert(new_users).into(users).execute(&connection).unwrap();
+    insert(new_users_with_default).into(users_with_default).execute(&connection).unwrap();
 
     let expected_users = vec![
         User {
@@ -118,21 +118,21 @@ fn batch_insert_with_defaults() {
             hair_color: Some("Green".to_string()),
         },
     ];
-    let actual_users = users.load(&connection).unwrap();
+    let actual_users = users_with_default.load(&connection).unwrap();
 
     assert_eq!(expected_users, actual_users);
 }
 
 #[test]
-#[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
+#[cfg(not(feature = "mysql"))] // FIXME: use users table
 fn insert_with_defaults() {
-    use schema::users::table as users;
+    use schema::users_with_default::table as users_with_default;
     use schema_dsl::*;
 
     let connection = connection();
-    drop_table_cascade(&connection, "users");
+    drop_table_cascade(&connection, "users_with_default");
     create_table(
-        "users",
+        "users_with_default",
         (
             integer("id").primary_key().auto_increment(),
             string("name").not_null(),
@@ -140,8 +140,8 @@ fn insert_with_defaults() {
         ),
     ).execute(&connection)
         .unwrap();
-    insert(&NewUser::new("Tess", None))
-        .into(users)
+    insert(&NewUserWithDefault::new("Tess", None))
+        .into(users_with_default)
         .execute(&connection)
         .unwrap();
 
@@ -152,7 +152,7 @@ fn insert_with_defaults() {
             hair_color: Some("Green".to_string()),
         },
     ];
-    let actual_users = users.load(&connection).unwrap();
+    let actual_users = users_with_default.load(&connection).unwrap();
 
     assert_eq!(expected_users, actual_users);
 }

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -150,6 +150,24 @@ impl FkTest {
     }
 }
 
+#[cfg(not(feature = "mysql"))]
+#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable)]
+#[table_name = "users_with_default"]
+pub struct NewUserWithDefault {
+    pub name: String,
+    pub hair_color: Option<String>,
+}
+
+#[cfg(not(feature = "mysql"))]
+impl NewUserWithDefault {
+    pub fn new(name: &str, hair_color: Option<&str>) -> Self {
+        NewUserWithDefault {
+            name: name.to_string(),
+            hair_color: hair_color.map(|s| s.to_string()),
+        }
+    }
+}
+
 #[derive(Queryable, Insertable)]
 #[table_name = "nullable_table"]
 pub struct NullableColumn {

--- a/migrations/postgresql/20170914084716_add_user_with_default/down.sql
+++ b/migrations/postgresql/20170914084716_add_user_with_default/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE users_with_default;

--- a/migrations/postgresql/20170914084716_add_user_with_default/up.sql
+++ b/migrations/postgresql/20170914084716_add_user_with_default/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users_with_default (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR NOT NULL,
+  hair_color VARCHAR DEFAULT 'Green'
+);

--- a/migrations/sqlite/20170914084716_add_user_with_default/down.sql
+++ b/migrations/sqlite/20170914084716_add_user_with_default/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE users_with_default;

--- a/migrations/sqlite/20170914084716_add_user_with_default/up.sql
+++ b/migrations/sqlite/20170914084716_add_user_with_default/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users_with_default (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  name VARCHAR NOT NULL,
+  hair_color VARCHAR DEFAULT 'Green'
+);


### PR DESCRIPTION
Support batch insert in sqlite with default values when using infer_schema macro.
If using table macro directly without define default value, the default value is NULL

Change-Id: I5c7bed2c8018efbb452350752b9c43755158da03