### PR TITLE
Implement `Insertable` for slice and vec rather than any iterator

### DIFF
--- a/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -33,8 +33,7 @@ fn main() {
 
     // Using UFCS to get a more specific error message
     let column_from_other_table = <_ as ExecuteDsl<_>>::execute(
-        //~^ ERROR E0277
-        // FIXME: I'd like that message to mention `OnConflictTarget<users::table>`
+        //~^ ERROR type mismatch resolving `<posts::columns::id as diesel::Column>::Table == users::table`
         insert(&NewUser("Sean").on_conflict(posts::id, do_nothing())).into(users),
         &connection,
     );


### PR DESCRIPTION
This blanket impl conflicts with an impl for tuples (since tuples and
`IntoIterator` are non-local, we are not allowed to rely on the fact
that `&(A, B): !IntoIterator`). This impl would have only been useable
with tuples anyway, since `IntoInsertStatement` is implemented directly
on vec and slice, not arbitrary iterators.

Since the `Insertable` impl could now rely on slice specifically, there
was no reason for me to keep the nonsense we were doing for
`BatchInsertValues` remaining generic, either.