### PR TITLE
Refactor `InsertValues` for tuples

### DIFF
--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -170,7 +170,7 @@ macro_rules! impl_Insertable {
                             $table_name::$column_name,
                         >,
                     >
-                ,)+): $crate::insertable::InsertValues<DB>,
+                ,)+): $crate::insertable::InsertValues<$table_name::table, DB>,
         {
             type Values = ($(
                 $crate::insertable::ColumnInsertValue<

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -96,9 +96,10 @@ pub struct OnConflictValues<Values, Target, Action> {
     action: Action,
 }
 
-impl<Values, Target, Action> InsertValues<Pg> for OnConflictValues<Values, Target, Action>
+impl<Tab, Values, Target, Action> InsertValues<Tab, Pg> for OnConflictValues<Values, Target, Action>
 where
-    Values: InsertValues<Pg>,
+    Tab: Table,
+    Values: InsertValues<Tab, Pg>,
     Target: QueryFragment<Pg>,
     Action: QueryFragment<Pg>,
 {
@@ -112,5 +113,9 @@ where
         self.target.walk_ast(out.reborrow())?;
         self.action.walk_ast(out.reborrow())?;
         Ok(())
+    }
+
+    fn is_noop(&self) -> bool {
+        self.values.is_noop()
     }
 }


### PR DESCRIPTION
Note: This depends on #1161. The second commit is the only one that is new here.

This changes the implementation of `InsertValues` on tuples to not care
about its interior type, and moves the SQLite special handling to
`ColumnInsertValue` directly.

The addition of the `Table` parameter on `InsertValues` is required for
the tuple implementation to enforce that all values are targeting the
same table.

One side effect of this structure is that it will (eventually) allow
arbitrary nesting of `Insertable` types. This is important for use cases
like rocket, where you will likely have a `user_id` field which comes
from the session, but we want you to derive `Insertable` and `FromForm`
on the same struct. This means we should be able to write code like the
following:

    #[derive(Insertable, FromForm)]
    #[table_name = "posts"]
    struct NewPost {
        title: String,
        body: String,
    }

    #[post("/posts", data = "<form>")]
    fn create_post(data: NewPost, user: AuthenticatedUser, conn: DbConn)
        -> QueryResult<Redirect>
    {
        use schema::posts::dsl::*;

        let created = insert(&(user_id.eq(user.id), data))
            .into(posts)
            .returning(id)
            .get_result::<i32>(&*conn)?;
        let url = format!("/posts/{}", created);
        Ok(Redirect::to(&url))
    }

This should also let us simplify the `default_values` code dramatically.
