### PR TITLE
Allow ad-hoc inserts of single column rows

### DIFF
--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -315,6 +315,7 @@ diesel_postfix_operator!(Desc, " DESC", ());
 diesel_prefix_operator!(Not, "NOT ");
 
 use backend::Backend;
+use insertable::{ColumnInsertValue, InsertValues, Insertable};
 use query_source::Column;
 use query_builder::*;
 use result::QueryResult;
@@ -347,5 +348,18 @@ where
 
     fn as_changeset(self) -> Self {
         self
+    }
+}
+
+impl<'a, T, U, DB> Insertable<T::Table, DB> for &'a Eq<T, U>
+where
+    T: Column + Copy,
+    DB: Backend,
+    (ColumnInsertValue<T, &'a U>,): InsertValues<T::Table, DB>,
+{
+    type Values = (ColumnInsertValue<T, &'a U>,);
+
+    fn values(self) -> Self::Values {
+        (ColumnInsertValue::Expression(self.left, &self.right),)
     }
 }

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -1,5 +1,5 @@
 use backend::{Backend, SupportsDefaultKeyword};
-use expression::Expression;
+use expression::{AppearsOnTable, Expression};
 use result::QueryResult;
 use query_builder::{AstPass, QueryBuilder, QueryFragment};
 use query_source::{Column, Table};
@@ -49,7 +49,7 @@ impl<Col, Expr, DB> InsertValues<Col::Table, DB> for ColumnInsertValue<Col, Expr
 where
     DB: Backend + SupportsDefaultKeyword,
     Col: Column,
-    Expr: Expression<SqlType = Col::SqlType> + QueryFragment<DB>,
+    Expr: Expression<SqlType = Col::SqlType> + QueryFragment<DB> + AppearsOnTable<()>,
 {
     fn column_names(&self, out: &mut DB::QueryBuilder) -> QueryResult<()> {
         out.push_identifier(Col::NAME)?;
@@ -74,7 +74,7 @@ where
 impl<Col, Expr> InsertValues<Col::Table, Sqlite> for ColumnInsertValue<Col, Expr>
 where
     Col: Column,
-    Expr: Expression<SqlType = Col::SqlType> + QueryFragment<Sqlite>,
+    Expr: Expression<SqlType = Col::SqlType> + QueryFragment<Sqlite> + AppearsOnTable<()>,
 {
     fn column_names(&self, out: &mut <Sqlite as Backend>::QueryBuilder) -> QueryResult<()> {
         if let ColumnInsertValue::Expression(..) = *self {

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -164,6 +164,41 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// # fn main() {
 /// #     use self::users::dsl::*;
 /// #     let connection = establish_connection();
+/// let rows_inserted = diesel::insert(&name.eq("Sean"))
+///     .into(users)
+///     .execute(&connection);
+///
+/// assert_eq!(Ok(1), rows_inserted);
+///
+/// let new_users = vec![
+///     name.eq("Tess"),
+///     name.eq("Jim"),
+/// ];
+///
+/// let rows_inserted = diesel::insert(&new_users)
+///     .into(users)
+///     .execute(&connection);
+///
+/// assert_eq!(Ok(2), rows_inserted);
+/// # }
+/// ```
+///
+/// ### Using struct for values
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # include!("../doctest_setup.rs");
+/// #
+/// # table! {
+/// #     users {
+/// #         id -> Integer,
+/// #         name -> Text,
+/// #     }
+/// # }
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// #     let connection = establish_connection();
 /// // Insert one record at a time
 ///
 /// let new_user = NewUser { name: "Ruby Rhod".to_string() };

--- a/diesel_compile_tests/tests/compile-fail/columns_cannot_be_rhs_of_insert.rs
+++ b/diesel_compile_tests/tests/compile-fail/columns_cannot_be_rhs_of_insert.rs
@@ -1,0 +1,24 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Text,
+    }
+}
+
+fn main() {
+    use users::dsl::*;
+    let conn = PgConnection::establish("").unwrap();
+
+    insert(&name.eq(hair_color))
+        .into(users)
+        .execute(&conn)
+        //~^ ERROR E0599
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    let conn = PgConnection::establish("").unwrap();
+
+    insert(&posts::id.eq(1))
+        .into(users::table)
+        //~^ ERROR mismatched types
+        .execute(&conn)
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/compile-fail/insert_requires_value_of_same_type_as_column.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_requires_value_of_same_type_as_column.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Text,
+    }
+}
+
+fn main() {
+    use users::dsl::*;
+    let conn = PgConnection::establish("").unwrap();
+
+    insert(&name.eq(1));
+    //~^ ERROR E0277
+}

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -369,3 +369,32 @@ fn insert_only_default_values_with_returning() {
         ])
     );
 }
+
+#[test]
+fn insert_single_bare_value() {
+    use schema::users::dsl::*;
+    let connection = connection();
+
+    insert(&name.eq("Sean"))
+        .into(users)
+        .execute(&connection)
+        .unwrap();
+
+    let expected_names = vec!["Sean".to_string()];
+    let actual_names = users.select(name).load(&connection);
+    assert_eq!(Ok(expected_names), actual_names);
+}
+
+#[test]
+fn insert_multiple_bare_values() {
+    use schema::users::dsl::*;
+    let connection = connection();
+
+    let new_users = vec![name.eq("Sean"), name.eq("Tess")];
+
+    insert(&new_users).into(users).execute(&connection).unwrap();
+
+    let expected_names = vec!["Sean".to_string(), "Tess".to_string()];
+    let actual_names = users.select(name).load(&connection);
+    assert_eq!(Ok(expected_names), actual_names);
+}


### PR DESCRIPTION
This change allows for simple inserts where only one column is being
assigned. This will be followed by a PR to allow multi-column inserts
using tuples, but the number of tests required for that is significantly
higher, so I wanted to break this out into a separate piece.