### PR TITLE
Allow ad-hoc inserts using tuples

### DIFF
--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -216,7 +216,7 @@ macro_rules! Insertable_column_expr {
     ($column:path, $field_access:expr, option) => {
         match *$field_access {
             Some(ref value) => Insertable_column_expr!($column, value, regular),
-            None => ColumnInsertValue::Default($column),
+            None => ColumnInsertValue::Default,
         }
     };
 

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -183,6 +183,43 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// # }
 /// ```
 ///
+/// ### Using a tuple for values
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # include!("../doctest_setup.rs");
+/// #
+/// # table! {
+/// #     users {
+/// #         id -> Integer,
+/// #         name -> Text,
+/// #     }
+/// # }
+/// #
+/// # fn main() {
+/// #     use self::users::dsl::*;
+/// #     let connection = establish_connection();
+/// #     diesel::delete(users).execute(&connection).unwrap();
+/// let new_user = (id.eq(1), name.eq("Sean"));
+/// let rows_inserted = diesel::insert(&new_user)
+///     .into(users)
+///     .execute(&connection);
+///
+/// assert_eq!(Ok(1), rows_inserted);
+///
+/// let new_users = vec![
+///     (id.eq(2), name.eq("Tess")),
+///     (id.eq(2), name.eq("Jim")),
+/// ];
+///
+/// let rows_inserted = diesel::insert(&new_users)
+///     .into(users)
+///     .execute(&connection);
+///
+/// // assert_eq!(Ok(2), rows_inserted);
+/// # }
+/// ```
+///
 /// ### Using struct for values
 ///
 /// ```rust

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -279,6 +279,12 @@ where
 {
 }
 
+impl<'a, Lhs, Rhs, Tab> UndecoratedInsertRecord<Tab> for &'a Option<Eq<Lhs, Rhs>>
+where
+    &'a Eq<Lhs, Rhs>: UndecoratedInsertRecord<Tab>,
+{
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct DefaultValues;

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -3,8 +3,9 @@ use std::error::Error;
 use associations::BelongsTo;
 use backend::Backend;
 use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
-use insertable::InsertValues;
+use insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
 use query_builder::*;
+use query_builder::insert_statement::UndecoratedInsertRecord;
 use query_source::{QuerySource, Queryable, Table};
 use result::QueryResult;
 use row::Row;
@@ -83,6 +84,38 @@ macro_rules! tuple_impls {
             }
 
             impl<$($T: Expression + NonAggregate),+> NonAggregate for ($($T,)+) {
+            }
+
+            impl<'a, $($T,)+ Tab> UndecoratedInsertRecord<Tab> for &'a ($($T,)+)
+            where
+                $(&'a $T: UndecoratedInsertRecord<Tab>,)+
+            {
+            }
+
+            impl<'a, $($T,)+ DB> CanInsertInSingleQuery<DB> for &'a ($($T,)+)
+            where
+                DB: Backend,
+                $(&'a $T: CanInsertInSingleQuery<DB>,)+
+            {
+                fn rows_to_insert(&self) -> usize {
+                    $(debug_assert_eq!((&self.$idx).rows_to_insert(), 1);)+
+                    1
+                }
+            }
+
+            impl<'a, $($T,)+ Tab, DB> Insertable<Tab, DB> for &'a ($($T,)+)
+            where
+                Tab: Table,
+                DB: Backend,
+                $(&'a $T: Insertable<Tab, DB> + UndecoratedInsertRecord<Tab>,)+
+            {
+                type Values = ($(
+                    <&'a $T as Insertable<Tab, DB>>::Values,
+                )+);
+
+                fn values(self) -> Self::Values {
+                    ($(self.$idx.values(),)+)
+                }
             }
 
             #[allow(unused_assignments)]

--- a/diesel_compile_tests/tests/compile-fail/default_values_cannot_be_used_in_tuple_insert.rs
+++ b/diesel_compile_tests/tests/compile-fail/default_values_cannot_be_used_in_tuple_insert.rs
@@ -1,0 +1,24 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+use diesel::pg::PgConnection;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Text,
+    }
+}
+
+fn main() {
+    use users::dsl::*;
+    let conn = PgConnection::establish("").unwrap();
+
+    ExecuteDsl::execute(
+    //~^ ERROR ExecuteDsl
+        insert(&(default_values(), name.eq("Sean"))).into(users),
+        &conn,
+    );
+}

--- a/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
@@ -24,4 +24,10 @@ fn main() {
         .execute(&conn)
         //~^ ERROR E0599
         .unwrap();
+
+    insert(&(posts::id.eq(1), users::id.eq(2)))
+        .into(users::table)
+        .execute(&conn)
+        //~^ ERROR E0599
+        .unwrap();
 }

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -33,4 +33,6 @@ fn main() {
     //~^ ERROR E0599
     insert(&vec![&NewUser("Sean").on_conflict(id, do_nothing())]).into(users).execute(&connection);
     //~^ ERROR E0599
+    insert(&(name.eq("Sean").on_conflict_do_nothing(),)).into(users).execute(&connection);
+    //~^ ERROR E0599
 }


### PR DESCRIPTION
This provides a more lightweight API for inserts that mirrors what is
possible with `.set` for updates. The implementation provided ensures
that all elements within the tuple are valid for the same table, and
that there's no funkiness like sticking an upsert value in there.
(Secret way to break Diesel -- It will totally allow you to stick a
`Vec` in there, and will generate invalid SQL as a result. We should fix
that one eventually, but it's pretty low priority)

One thing I would also like to allow is to allow mixing ad-hoc values
and `Insertable` structs. (See 10374a5026bcab2202f7f67f057493c4636d547b
for rationale). I tried a naive approach where I moved the parens out
from the `InsertValues` impl on tuples, and into `InsertStatement`, but
that breaks PG upsert, so I'll need to spend more time on it. I've left
the test cases for that in place, but I will defer actually making them
pass for a later PR in order to keep the PR size and scope reasonable.

I expected to need more tests/compile-tests, but what's included here
felt like it pretty exhaustively tests everything.

Fixes #789