### PR TITLE
Add For Update Symbol(FU) to Symbol List - [ci skip]

### DIFF
--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -8,6 +8,7 @@
 //! L: Limit Clause
 //! Of: Offset Clause
 //! G: Group By Clause
+//! FU: For Update Clause
 mod dsl_impls;
 mod boxed;
 


### PR DESCRIPTION
Since Sean added support for `FOR UPDATE` in 0921a38139175f5999008617bcae19776f9e4927, FU needs to be added to the abbreviations list.