### PR TITLE
rm `IntoInsertStatement`

### DIFF
--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -158,7 +158,7 @@ macro_rules! impl_Insertable {
         lifetimes = ($($lifetime:tt),*),
         self_to_columns = $self_to_columns:pat,
         columns = ($($column_name:ident, $field_ty:ty, $field_kind:ident),+),
-    ) => { __diesel_parse_as_item! {
+    ) => {
         impl<$($lifetime,)* 'insert, DB> $crate::insertable::Insertable<$table_name::table, DB>
             for &'insert $struct_ty where
                 DB: $crate::backend::Backend,
@@ -193,26 +193,21 @@ macro_rules! impl_Insertable {
             }
         }
 
-    } __diesel_parse_as_item! {
-        impl<$($lifetime: 'insert,)* 'insert, Op> $crate::query_builder::insert_statement::IntoInsertStatement<$table_name::table, Op>
+        impl<$($lifetime,)* 'insert, DB> $crate::insertable::CanInsertInSingleQuery<DB>
             for &'insert $struct_ty
+        where
+            DB: $crate::backend::Backend,
         {
-            type InsertStatement = $crate::query_builder::insert_statement::InsertStatement<$table_name::table, Self, Op>;
-
-            fn into_insert_statement(self, target: $table_name::table, operator: Op) -> Self::InsertStatement {
-                $crate::query_builder::insert_statement::InsertStatement::no_returning_clause(
-                    target,
-                    self,
-                    operator,
-                )
+            fn rows_to_insert(&self) -> usize {
+                1
             }
         }
-    } __diesel_parse_as_item! {
+
         impl<$($lifetime: 'insert,)* 'insert> $crate::query_builder::insert_statement::UndecoratedInsertRecord<$table_name::table>
             for &'insert $struct_ty
         {
         }
-    }};
+    };
 }
 
 #[doc(hidden)]

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -34,23 +34,6 @@ impl<Records, Target, Action> OnConflict<Records, Target, Action> {
     }
 }
 
-impl<'a, T, Tab, Op> IntoInsertStatement<Tab, Op> for &'a OnConflictDoNothing<T> {
-    type InsertStatement = InsertStatement<Tab, Self, Op>;
-
-    fn into_insert_statement(self, target: Tab, operator: Op) -> Self::InsertStatement {
-        InsertStatement::no_returning_clause(target, self, operator)
-    }
-}
-
-impl<'a, Recods, Target, Action, Tab, Op> IntoInsertStatement<Tab, Op>
-    for &'a OnConflict<Recods, Target, Action> {
-    type InsertStatement = InsertStatement<Tab, Self, Op>;
-
-    fn into_insert_statement(self, target: Tab, operator: Op) -> Self::InsertStatement {
-        InsertStatement::no_returning_clause(target, self, operator)
-    }
-}
-
 impl<'a, T, Tab> Insertable<Tab, Pg> for &'a OnConflictDoNothing<T>
 where
     Tab: Table,
@@ -65,6 +48,15 @@ where
             target: NoConflictTarget,
             action: DoNothing,
         }
+    }
+}
+
+impl<'a, T> CanInsertInSingleQuery<Pg> for &'a OnConflictDoNothing<T>
+where
+    T: CanInsertInSingleQuery<Pg>,
+{
+    fn rows_to_insert(&self) -> usize {
+        self.0.rows_to_insert()
     }
 }
 
@@ -85,6 +77,16 @@ where
             target: self.target.clone(),
             action: self.action.into_conflict_action(),
         }
+    }
+}
+
+impl<'a, Records, Target, Action> CanInsertInSingleQuery<Pg>
+    for &'a OnConflict<Records, Target, Action>
+where
+    Records: CanInsertInSingleQuery<Pg>,
+{
+    fn rows_to_insert(&self) -> usize {
+        self.records.rows_to_insert()
     }
 }
 

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -275,8 +275,9 @@ where
 /// query can return the inserted rows if you choose.
 #[cfg(feature = "with-deprecated")]
 #[deprecated(since = "0.99.0", note = "use `insert(&default_values())` instead")]
-pub fn insert_default_values() -> IncompleteInsertStatement<DefaultValues, Insert> {
-    IncompleteInsertStatement::new(DefaultValues, Insert)
+pub fn insert_default_values() -> IncompleteInsertStatement<&'static DefaultValues, Insert> {
+    static STATIC_DEFAULT_VALUES: &'static DefaultValues = &DefaultValues;
+    insert(STATIC_DEFAULT_VALUES)
 }
 
 pub fn default_values() -> DefaultValues {

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -267,6 +267,19 @@ fn insert_empty_slice_with_returning() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
+fn upsert_empty_slice() {
+    use diesel::pg::upsert::*;
+    let connection = connection();
+
+    let inserted_records = insert(&Vec::<NewUser>::new().on_conflict_do_nothing())
+        .into(users::table)
+        .execute(&connection);
+
+    assert_eq!(Ok(0), inserted_records);
+}
+
+#[test]
 #[cfg(not(feature = "mysql"))]
 fn insert_only_default_values_deprecated() {
     use schema::users::table as users;


### PR DESCRIPTION
This gets rid of `IntoInsertStatement`, and turns `BatchInsertStatement`
into the only visible type for constructing queries. In its
implementations of `LoadDsl` and `ExecuteDsl`, it ends up constructing
`InsertStatement` which is what actually performs the execution.

The names are now super poor and misleading. The reason I've opted not
to rename them in this commit is that I actually think I'm going to end
up getting rid of `BatchInsertStatement` entirely, and only have
`InsertStatement`. If we don't end up going that route, I'm going to
rename `InsertStatement` to `ExecutableInsertStatement` and rename
`BatchInsertStatement` to just `InsertStatement`.

Aside from simplifying our codebase, this change also makes sure that
all insert statements constructed will include the 0-row checking case.
I think we can eventually just move this into the `QueryFragment` impl
by doing `SELECT returning_clause FROM table WHERE 1=0`. This would mean
the only thing we have to special case is SQLite batch insert.

Fixes #797