### PR TITLE
Allow mixing and matching ad-hoc and `Insertable` values

### DIFF
--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -355,11 +355,11 @@ impl<'a, T, U, DB> Insertable<T::Table, DB> for &'a Eq<T, U>
 where
     T: Column + Copy,
     DB: Backend,
-    (ColumnInsertValue<T, &'a U>,): InsertValues<T::Table, DB>,
+    ColumnInsertValue<T, &'a U>: InsertValues<T::Table, DB>,
 {
-    type Values = (ColumnInsertValue<T, &'a U>,);
+    type Values = ColumnInsertValue<T, &'a U>;
 
     fn values(self) -> Self::Values {
-        (ColumnInsertValue::Expression(self.left, &self.right),)
+        ColumnInsertValue::Expression(self.left, &self.right)
     }
 }

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -43,6 +43,13 @@ pub trait InsertValues<T: Table, DB: Backend> {
     /// single row. Types which represent multiple rows will always return
     /// `false` for this, even if they will insert 0 rows.
     fn is_noop(&self) -> bool;
+
+    // FIXME: Once #1166 is done we should just wrap the value in a `Grouped`
+    // when it is passed to `insert`
+    #[doc(hidden)]
+    fn requires_parenthesis(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -205,7 +212,7 @@ where
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         for (i, record) in self.records.iter().enumerate() {
             if i != 0 {
-                out.push_sql(", ");
+                out.push_sql("), (");
             }
             record.values().walk_ast(out.reborrow())?;
         }

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -110,7 +110,13 @@ where
     }
 
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        if self.values.requires_parenthesis() {
+            out.push_sql("(");
+        }
         self.values.walk_ast(out.reborrow())?;
+        if self.values.requires_parenthesis() {
+            out.push_sql(")");
+        }
         out.push_sql(" ON CONFLICT");
         self.target.walk_ast(out.reborrow())?;
         self.action.walk_ast(out.reborrow())?;
@@ -119,5 +125,9 @@ where
 
     fn is_noop(&self) -> bool {
         self.values.is_noop()
+    }
+
+    fn requires_parenthesis(&self) -> bool {
+        false
     }
 }

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -71,7 +71,7 @@ where
         self.operator.walk_ast(out.reborrow())?;
         out.push_sql(" INTO ");
         self.target.from_clause().walk_ast(out.reborrow())?;
-        if self.records.values().is_noop() {
+        if values.is_noop() {
             out.push_sql(" DEFAULT VALUES");
         } else {
             out.push_sql(" (");
@@ -79,7 +79,13 @@ where
                 values.column_names(builder)?;
             }
             out.push_sql(") VALUES ");
-            self.records.values().walk_ast(out.reborrow())?;
+            if values.requires_parenthesis() {
+                out.push_sql("(");
+            }
+            values.walk_ast(out.reborrow())?;
+            if values.requires_parenthesis() {
+                out.push_sql(")");
+            }
         }
         self.returning.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -141,7 +141,6 @@ macro_rules! tuple_impls {
                 }
 
                 fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
-                    out.push_sql("(");
                     let mut needs_comma = false;
                     $(
                         let noop_element = self.$idx.is_noop();
@@ -153,7 +152,6 @@ macro_rules! tuple_impls {
                             needs_comma = true;
                         }
                     )+
-                    out.push_sql(")");
                     Ok(())
                 }
 

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -428,7 +428,6 @@ fn insert_single_tuple() {
 }
 
 #[test]
-#[should_panic] // FIXME: We need to rejigger where the parens are added for values
 fn insert_nested_tuples() {
     use schema::users::dsl::*;
     let connection = connection();
@@ -444,7 +443,6 @@ fn insert_nested_tuples() {
 }
 
 #[test]
-#[should_panic] // FIXME: We need to rejigger where the parens are added for values
 fn insert_mixed_tuple_and_insertable_struct() {
     use schema::users::dsl::*;
     let connection = connection();
@@ -500,7 +498,6 @@ fn insert_optional_field_with_null() {
 
 #[test]
 #[cfg(not(feature = "mysql"))]
-#[cfg_attr(feature = "postgres", should_panic)] // FIXME: We need to rejigger where the parens are added for values
 fn insert_optional_field_with_default() {
     use schema::users::dsl::*;
     use schema_dsl::*;


### PR DESCRIPTION
This moves the insertion of parenthesis outside of the tuple
`InsertValues` impl, to allow nesting of arbitrary tuples without
nesting parens.

This functionality is important for web applications, which will have
values like `user_id`, which will come from the session and not the form
data. We'd like to be able to have `Insertable` and traits such as
`FromForm` live on the same struct. This change enables that without
making it too painful.