### PR TITLE
rm `BatchInsertStatement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Deprecated `insert_default_values()` in favor of `insert(&default_values())`
 
+### Removed
+
+* `IntoInsertStatement` and `BatchInsertStatement` have been removed. It's
+  unlikely that your application is using these types, but `InsertStatement` is
+  now the only "insert statement" type.
+
 ### Fixed
 
 * When using MySQL and SQLite, dates which cannot be represented by `chrono`

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -193,8 +193,8 @@ macro_rules! impl_Insertable {
             }
         }
 
-        impl<$($lifetime,)* 'insert, DB> $crate::insertable::CanInsertInSingleQuery<DB>
-            for &'insert $struct_ty
+        impl<$($lifetime,)* DB> $crate::insertable::CanInsertInSingleQuery<DB>
+            for $struct_ty
         where
             DB: $crate::backend::Backend,
         {

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -55,7 +55,10 @@ impl Statement {
     /// which `results` has previously been called?
     pub unsafe fn execute(&self) -> QueryResult<()> {
         ffi::mysql_stmt_execute(self.stmt);
-        self.did_an_error_occur()
+        self.did_an_error_occur()?;
+        ffi::mysql_stmt_store_result(self.stmt);
+        self.did_an_error_occur()?;
+        Ok(())
     }
 
     pub fn affected_rows(&self) -> usize {

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<'a, T> CanInsertInSingleQuery<Pg> for &'a OnConflictDoNothing<T>
+impl<T> CanInsertInSingleQuery<Pg> for OnConflictDoNothing<T>
 where
     T: CanInsertInSingleQuery<Pg>,
 {
@@ -80,8 +80,7 @@ where
     }
 }
 
-impl<'a, Records, Target, Action> CanInsertInSingleQuery<Pg>
-    for &'a OnConflict<Records, Target, Action>
+impl<Records, Target, Action> CanInsertInSingleQuery<Pg> for OnConflict<Records, Target, Action>
 where
     Records: CanInsertInSingleQuery<Pg>,
 {

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -66,7 +66,9 @@ where
         out.unsafe_to_cache_prepared();
 
         if self.records.rows_to_insert() == 0 {
-            out.push_sql("SELECT 1 WHERE 1=0");
+            out.push_sql("SELECT 1 FROM ");
+            self.target.from_clause().walk_ast(out.reborrow())?;
+            out.push_sql(" WHERE 1=0");
             return Ok(());
         }
 

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -126,10 +126,11 @@ pub trait ExecuteDsl<Conn: Connection<Backend = DB>, DB: Backend = <Conn as Conn
     fn execute(self, conn: &Conn) -> QueryResult<usize>;
 }
 
-impl<Conn, T> ExecuteDsl<Conn> for T
+impl<Conn, DB, T> ExecuteDsl<Conn, DB> for T
 where
-    Conn: Connection,
-    T: QueryFragment<Conn::Backend> + QueryId,
+    Conn: Connection<Backend = DB>,
+    DB: Backend,
+    T: QueryFragment<DB> + QueryId,
 {
     fn execute(self, conn: &Conn) -> QueryResult<usize> {
         conn.execute_returning_count(&self)

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -92,13 +92,13 @@ macro_rules! tuple_impls {
             {
             }
 
-            impl<'a, $($T,)+ DB> CanInsertInSingleQuery<DB> for &'a ($($T,)+)
+            impl<$($T,)+ DB> CanInsertInSingleQuery<DB> for ($($T,)+)
             where
                 DB: Backend,
-                $(&'a $T: CanInsertInSingleQuery<DB>,)+
+                $($T: CanInsertInSingleQuery<DB>,)+
             {
                 fn rows_to_insert(&self) -> usize {
-                    $(debug_assert_eq!((&self.$idx).rows_to_insert(), 1);)+
+                    $(debug_assert_eq!(self.$idx.rows_to_insert(), 1);)+
                     1
                 }
             }


### PR DESCRIPTION
This brings us back to the place we want to be, where there is only one
`InsertStatement` struct. Rather than executing 0 queries when inserting
an empty slice, we instead execute a select statement that will return 0
rows (effectively turning it into a no-op query).

It'd be technically more correct for us to stick the returning clause in
the select statement, so any assertions about the number of columns or
their types would still pass. However, that implementation would be a
bit harder to write, so for now I've opted to rely on the fact that we
will never make those assertions when we have no rows to return.

With this change, we can use the blanket impl of `ExecuteDsl` for the
"normal" case (though I had to modify it a tad to ensure it is disjoint
with the sqlite slice impl, since associated types aren't taken into
account when determining disjointness).

One alternative implementation would be to remove the blanket impl
entirely. This might be something we want to do in the future, since
right now `foo.eq(bar).execute(&conn)` actually compiles. However, we'd
need to remove the blanket impl of `LoadDsl` as well if we wanted to
elminate this select statement, which I'm less inclined to do.