### PR TITLE
Allow `#[derive(Queryable)]` for structs with `Queryable` fields

### DIFF
--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -128,6 +128,19 @@ where
     }
 }
 
+impl<'a, T: ?Sized, ST, DB> ::Queryable<ST, DB> for Cow<'a, T>
+where
+    T: 'a + ToOwned,
+    DB: Backend + HasSqlType<ST>,
+    Self: ::types::FromSqlRow<ST, DB>,
+{
+    type Row = Self;
+
+    fn build(row: Self::Row) -> Self {
+        row
+    }
+}
+
 use expression::bound::Bound;
 use expression::{AsExpression, Expression};
 impl<'a, T: ?Sized, ST> ::expression::AsExpression<ST> for Cow<'a, T>

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "1024"]
+
 // Built-in Lints
 #![deny(warnings, missing_copy_implementations)]
 // Clippy lints

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "1024"]
-
 // Built-in Lints
 #![deny(warnings, missing_copy_implementations)]
 // Clippy lints

--- a/diesel_codegen/src/model.rs
+++ b/diesel_codegen/src/model.rs
@@ -1,4 +1,5 @@
 use syn;
+use std::slice;
 
 use attr::Attr;
 use util::*;
@@ -102,6 +103,10 @@ impl ModelAttrs {
         match *self {
             ModelAttrs::Struct(ref attrs) | ModelAttrs::Tuple(ref attrs) => &*attrs,
         }
+    }
+
+    pub fn iter(&self) -> slice::Iter<Attr> {
+        self.as_slice().iter()
     }
 
     pub fn is_tuple(&self) -> bool {

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -29,11 +29,12 @@ pub fn derive_queryable(item: syn::DeriveInput) -> Tokens {
         quote!(
             impl#generics diesel::Queryable<__ST, __DB> for #struct_ty where
                 __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
-                #row_ty: diesel::types::FromSqlRow<__ST, __DB>,
+                #row_ty: diesel::Queryable<__ST, __DB>,
             {
-               type Row = #row_ty;
+               type Row = <#row_ty as diesel::Queryable<__ST, __DB>>::Row;
 
-               fn build(#row_pat: Self::Row) -> Self {
+               fn build(row: Self::Row) -> Self {
+                   let #row_pat = diesel::Queryable::build(row);
                    #build_expr
                }
             }

--- a/diesel_codegen/src/queryable.rs
+++ b/diesel_codegen/src/queryable.rs
@@ -14,11 +14,11 @@ pub fn derive_queryable(item: syn::DeriveInput) -> Tokens {
         .build();
     let struct_ty = &model.ty;
 
-    let row_ty = model.attrs.as_slice().iter().map(|a| &a.ty);
+    let row_ty = model.attrs.iter().map(|a| &a.ty);
     let row_ty = quote!((#(#row_ty,)*));
 
     let build_expr = build_expr_for_model(&model);
-    let field_names = model.attrs.as_slice().iter().map(Attr::name_for_pattern);
+    let field_names = model.attrs.iter().map(Attr::name_for_pattern);
     let row_pat = quote!((#(#field_names,)*));
 
     let model_name_uppercase = model.name.as_ref().to_uppercase();
@@ -44,19 +44,13 @@ pub fn derive_queryable(item: syn::DeriveInput) -> Tokens {
 
 fn build_expr_for_model(model: &Model) -> Tokens {
     let struct_name = &model.name;
-    let field_names = model.attrs.as_slice().iter().map(Attr::name_for_pattern);
-
-    let field_assignments = field_names.map(|field_name| if model.is_tuple_struct() {
-        quote!(#field_name)
-    } else {
-        quote!(#field_name: #field_name)
-    });
+    let field_names = model.attrs.iter().map(Attr::name_for_pattern);
 
     if model.is_tuple_struct() {
-        quote!(#struct_name(#(#field_assignments),*))
+        quote!(#struct_name(#(#field_names),*))
     } else {
         quote!(#struct_name {
-            #(#field_assignments,)*
+            #(#field_names,)*
         })
     }
 }

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -326,10 +326,7 @@ fn nested_queryable_derives() {
         .unwrap();
     let post = posts::table.first(&conn).unwrap();
 
-    let expected = UserAndPost {
-        user: sean,
-        post,
-    };
+    let expected = UserAndPost { user: sean, post };
     let actual = users::table.inner_join(posts::table).get_result(&conn);
 
     assert_eq!(Ok(expected), actual);

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -309,3 +309,28 @@ fn derive_insertable_with_field_that_cannot_convert_expression_to_nullable() {
 
     assert!(jim.is_some());
 }
+
+#[test]
+fn nested_queryable_derives() {
+    #[derive(Queryable, Debug, PartialEq)]
+    struct UserAndPost {
+        user: User,
+        post: Post,
+    }
+
+    let conn = connection_with_sean_and_tess_in_users_table();
+    let sean = find_user_by_name("Sean", &conn);
+    insert(&sean.new_post("Hi", None))
+        .into(posts::table)
+        .execute(&conn)
+        .unwrap();
+    let post = posts::table.first(&conn).unwrap();
+
+    let expected = UserAndPost {
+        user: sean,
+        post,
+    };
+    let actual = users::table.inner_join(posts::table).get_result(&conn);
+
+    assert_eq!(Ok(expected), actual);
+}

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -20,6 +20,7 @@ pub enum MyEnum {
 }
 
 mod impls_for_insert_and_query {
+    use diesel::Queryable;
     use diesel::expression::AsExpression;
     use diesel::expression::bound::Bound;
     use diesel::pg::Pg;
@@ -67,6 +68,14 @@ mod impls_for_insert_and_query {
                 Some(_) => Err("Unrecognized enum variant".into()),
                 None => Err("Unexpected null for non-null column".into()),
             }
+        }
+    }
+
+    impl Queryable<MyType, Pg> for MyEnum {
+        type Row = Self;
+
+        fn build(row: Self::Row) -> Self {
+            row
         }
     }
 }


### PR DESCRIPTION
Previously we only allowed structs to have fields which implementd
`ToSqlRow`. This meant that `Queryable` could not be composed. This
lifts the restriction to allow any `Queryable` type. This does mean that
things which implement `FromSqlRow` will also need to implement
`Queryable` to be used here, but they should have already been doing
that.

Fixes #1006.