### PR TITLE
Call `Insertable::values` much earlier in the chain

### DIFF
--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -315,7 +315,7 @@ diesel_postfix_operator!(Desc, " DESC", ());
 diesel_prefix_operator!(Not, "NOT ");
 
 use backend::Backend;
-use insertable::{ColumnInsertValue, InsertValues, Insertable};
+use insertable::{ColumnInsertValue, Insertable};
 use query_source::Column;
 use query_builder::*;
 use result::QueryResult;
@@ -351,11 +351,9 @@ where
     }
 }
 
-impl<'a, T, U, DB> Insertable<T::Table, DB> for &'a Eq<T, U>
+impl<'a, T, U> Insertable<T::Table> for &'a Eq<T, U>
 where
     T: Column + Copy,
-    DB: Backend,
-    ColumnInsertValue<T, &'a U>: InsertValues<T::Table, DB>,
 {
     type Values = ColumnInsertValue<T, &'a U>;
 

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -159,18 +159,8 @@ macro_rules! impl_Insertable {
         self_to_columns = $self_to_columns:pat,
         columns = ($($column_name:ident, $field_ty:ty, $field_kind:ident),+),
     ) => {
-        impl<$($lifetime,)* 'insert, DB> $crate::insertable::Insertable<$table_name::table, DB>
-            for &'insert $struct_ty where
-                DB: $crate::backend::Backend,
-                ($(
-                    $crate::insertable::ColumnInsertValue<
-                        $table_name::$column_name,
-                        $crate::dsl::AsExpr<
-                            &'insert $field_ty,
-                            $table_name::$column_name,
-                        >,
-                    >
-                ,)+): $crate::insertable::InsertValues<$table_name::table, DB>,
+        impl<$($lifetime,)* 'insert> $crate::insertable::Insertable<$table_name::table>
+            for &'insert $struct_ty
         {
             type Values = ($(
                 $crate::insertable::ColumnInsertValue<
@@ -190,16 +180,6 @@ macro_rules! impl_Insertable {
                 ($(
                     Insertable_column_expr!($table_name::$column_name, $column_name, $field_kind)
                 ,)+)
-            }
-        }
-
-        impl<$($lifetime,)* DB> $crate::insertable::CanInsertInSingleQuery<DB>
-            for $struct_ty
-        where
-            DB: $crate::backend::Backend,
-        {
-            fn rows_to_insert(&self) -> usize {
-                1
             }
         }
 

--- a/diesel/src/migrations/schema.rs
+++ b/diesel/src/migrations/schema.rs
@@ -4,13 +4,3 @@ table! {
         run_on -> Timestamp,
     }
 }
-
-#[derive(Debug, Copy, Clone)]
-pub struct NewMigration<'a>(pub &'a str);
-impl_Insertable! {
-    (__diesel_schema_migrations)
-    pub struct NewMigration<'a>(
-        #[column_name(version)]
-        pub &'a str,
-    );
-}

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -103,14 +103,12 @@ macro_rules! tuple_impls {
                 }
             }
 
-            impl<'a, $($T,)+ Tab, DB> Insertable<Tab, DB> for &'a ($($T,)+)
+            impl<'a, $($T,)+ Tab> Insertable<Tab> for &'a ($($T,)+)
             where
-                Tab: Table,
-                DB: Backend,
-                $(&'a $T: Insertable<Tab, DB> + UndecoratedInsertRecord<Tab>,)+
+                $(&'a $T: Insertable<Tab> + UndecoratedInsertRecord<Tab>,)+
             {
                 type Values = ($(
-                    <&'a $T as Insertable<Tab, DB>>::Values,
+                    <&'a $T as Insertable<Tab>>::Values,
                 )+);
 
                 fn values(self) -> Self::Values {

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -27,9 +27,7 @@ mod query_helper;
 
 use chrono::*;
 use clap::{ArgMatches, Shell};
-use diesel::migrations::schema::*;
-use diesel::types::{FromSql, VarChar};
-use diesel::{migrations, Connection, Insertable};
+use diesel::migrations::{self, MigrationConnection};
 use std::any::Any;
 use std::io::stdout;
 use std::path::{Path, PathBuf};
@@ -263,9 +261,7 @@ fn search_for_cargo_toml_directory(path: &Path) -> DatabaseResult<PathBuf> {
 /// transaction. If either part fails, the transaction is not committed.
 fn redo_latest_migration<Conn>(conn: &Conn, migrations_dir: &Path)
 where
-    Conn: Connection + Any,
-    String: FromSql<VarChar, Conn::Backend>,
-    for<'a> &'a NewMigration<'a>: Insertable<__diesel_schema_migrations::table, Conn::Backend>,
+    Conn: MigrationConnection + Any,
 {
     let migration_inner = || {
         let reverted_version = try!(migrations::revert_latest_migration_in_directory(

--- a/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
@@ -20,14 +20,10 @@ fn main() {
     let conn = PgConnection::establish("").unwrap();
 
     insert_into(users::table)
-        .values(&posts::id.eq(1))
-        .execute(&conn)
-        //~^ ERROR E0599
-        .unwrap();
+        .values(&posts::id.eq(1));
+        //~^ ERROR type mismatch resolving `<posts::columns::id as diesel::Column>::Table == users::table`
 
     insert_into(users::table)
-        .values(&(posts::id.eq(1), users::id.eq(2)))
-        .execute(&conn)
-        //~^ ERROR E0599
-        .unwrap();
+        .values(&(posts::id.eq(1), users::id.eq(2)));
+        //~^ ERROR type mismatch resolving `<posts::columns::id as diesel::Column>::Table == users::table`
 }

--- a/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -31,22 +31,15 @@ fn main() {
     let valid_insert = insert_into(users).values(&NewUser("Sean").on_conflict(id, do_nothing())).execute(&connection);
     // Sanity check, no error
 
-    // Using UFCS to get a more specific error message
-    let column_from_other_table = <_ as ExecuteDsl<_>>::execute(
+    let column_from_other_table = insert_into(users)
+        .values(&NewUser("Sean").on_conflict(posts::id, do_nothing()));
         //~^ ERROR type mismatch resolving `<posts::columns::id as diesel::Column>::Table == users::table`
-        insert_into(users).values(&NewUser("Sean").on_conflict(posts::id, do_nothing())),
-        &connection,
-    );
 
-    let expression_using_column_from_other_table = <_ as ExecuteDsl<_>>::execute(
-        //~^ ERROR E0277
-        insert_into(users).values(&NewUser("Sean").on_conflict(lower(posts::title), do_nothing())),
-        &connection,
-    );
+    let expression_using_column_from_other_table = insert_into(users)
+        .values(&NewUser("Sean").on_conflict(lower(posts::title), do_nothing()));
+        //~^ ERROR the trait bound `lower_t<posts::columns::title>: diesel::Column` is not satisfied
 
-    let random_non_expression = <_ as ExecuteDsl<_>>::execute(
-        //~^ ERROR E0277
-        insert_into(users).values(&NewUser("Sean").on_conflict("id", do_nothing())),
-        &connection,
-    );
+    let random_non_expression = insert_into(users)
+        .values(&NewUser("Sean").on_conflict("id", do_nothing()));
+        //~^ ERROR the trait bound `&str: diesel::Column` is not satisfied
 }

--- a/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
@@ -31,22 +31,25 @@ fn main() {
 
     // No set clause
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update())).execute(&connection);
-    //~^ ERROR no method named `execute`
+    //~^ ERROR E0277
 
     // Update column from other table
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(posts::title.eq("Sean")))).execute(&connection);
-    //~^ ERROR no method named `execute`
+    //~^ ERROR E0271
 
     // Update column with value that is not selectable
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(posts::title)))).execute(&connection);
     //~^ ERROR E0277
+    //~| ERROR E0277
     //~| ERROR no method named `execute`
+    //~| ERROR E0271
     //~| ERROR E0271
 
     // Update column with excluded value that is not selectable
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(excluded(posts::title))))).execute(&connection);
     //~^ ERROR E0271
     //~| ERROR no method named `execute`
+    //~| type mismatch resolving `<posts::columns::title as diesel::Column>::Table == users::table`
 
     // Update column with excluded value of wrong type
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(excluded(id))))).execute(&connection);

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -20,19 +20,21 @@ fn main() {
     let connection = PgConnection::establish("postgres://localhost").unwrap();
 
     insert_into(users).values(&NewUser("Sean").on_conflict_do_nothing().on_conflict_do_nothing()).execute(&connection);
-    //~^ ERROR no method named `execute`
+    //~^ ERROR E0277
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_nothing()).on_conflict_do_nothing()).execute(&connection);
-    //~^ ERROR no method named `execute`
+    //~^ ERROR E0277
     insert_into(users).values(&NewUser("Sean").on_conflict_do_nothing().on_conflict(id, do_nothing())).execute(&connection);
-    //~^ ERROR no method named `execute`
+    //~^ ERROR E0277
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_nothing()).on_conflict(id, do_nothing())).execute(&connection);
-    //~^ ERROR no method named `execute`
+    //~^ ERROR E0277
     insert_into(users).values(&vec![NewUser("Sean").on_conflict_do_nothing()]).execute(&connection);
-    //~^ ERROR E0599
+    //~^ ERROR E0277
     insert_into(users).values(&vec![&NewUser("Sean").on_conflict_do_nothing()]).execute(&connection);
-    //~^ ERROR E0599
+    //~^ ERROR no method named `execute`
+    //~| ERROR E0277
     insert_into(users).values(&vec![&NewUser("Sean").on_conflict(id, do_nothing())]).execute(&connection);
-    //~^ ERROR E0599
+    //~^ ERROR no method named `execute`
+    //~| ERROR E0277
     insert_into(users).values(&(name.eq("Sean").on_conflict_do_nothing(),)).execute(&connection);
-    //~^ ERROR E0599
+    //~^ ERROR E0277
 }


### PR DESCRIPTION
This change has two main benefits:

1. If an error message that is not related to the backend being used is
  going to occur, it will occur on the call to `values`, not the call to
  `execute`. This generally means better error messages.
2. It removes the `Copy` constraint from `InsertStatement`, which will
  let us deal with owned values more frequently (and follow the same
  rules as `SelectStatement`, which can be executed multiple times only if
  it is `Copy`