### PR TITLE
Deprecate `on_conflict_do_nothing`, add it to `InsertStatement` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added `replace_into(table).values(values)` as a replacement for
   `insert_or_replace(values).into(table)`.
 
+* Added `on_conflict_do_nothing` on `InsertStatement` as a replacement for
+  `on_conflict_do_nothing` on `Insertable` structs.
+
 ### Changed
 
 * The signatures of `QueryId`, `Column`, and `FromSqlRow` have all changed to
@@ -37,6 +40,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Deprecated `insert_or_replace(values).into(table)` in favor of
   `replace_into(table).values(values)`.
+
+* Deprecated `.values(x.on_conflict_do_nothing())` in favor of
+  `.values(x).on_conflict_do_nothing()`
 
 ### Removed
 

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -183,10 +183,29 @@ macro_rules! impl_Insertable {
             }
         }
 
-        impl<$($lifetime: 'insert,)* 'insert> $crate::query_builder::insert_statement::UndecoratedInsertRecord<$table_name::table>
-            for &'insert $struct_ty
+        impl<$($lifetime,)*> $crate::query_builder::insert_statement::UndecoratedInsertRecord<$table_name::table>
+            for $struct_ty
         {
         }
+
+        __diesel_impl_on_conflict_extension!($struct_ty, $($lifetime,)*);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "postgres")]
+macro_rules! __diesel_impl_on_conflict_extension {
+    ($struct_ty:ty, $($lifetimes:tt)*) => {
+        impl<$($lifetimes)*> $crate::pg::upsert::OnConflictExtension for $struct_ty {}
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "postgres"))]
+macro_rules! __diesel_impl_on_conflict_extension {
+    ($struct_ty:ty, $($lifetimes:tt)*) => {
     };
 }
 

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -9,8 +9,10 @@ use super::on_conflict_actions::*;
 use super::on_conflict_target::*;
 
 #[derive(Debug, Clone, Copy)]
+#[cfg(feature = "with-deprecated")]
 pub struct OnConflictDoNothing<T>(T);
 
+#[cfg(feature = "with-deprecated")]
 impl<T> OnConflictDoNothing<T> {
     pub fn new(records: T) -> Self {
         OnConflictDoNothing(records)
@@ -34,6 +36,7 @@ impl<Records, Target, Action> OnConflict<Records, Target, Action> {
     }
 }
 
+#[cfg(feature = "with-deprecated")]
 impl<'a, T, Tab> Insertable<Tab> for &'a OnConflictDoNothing<T>
 where
     T: Insertable<Tab> + Copy,
@@ -75,6 +78,22 @@ pub struct OnConflictValues<Values, Target, Action> {
     values: Values,
     target: Target,
     action: Action,
+}
+
+impl<Values> OnConflictValues<Values, NoConflictTarget, DoNothing> {
+    pub(crate) fn do_nothing(values: Values) -> Self {
+        Self::new(values, NoConflictTarget, DoNothing)
+    }
+}
+
+impl<Values, Target, Action> OnConflictValues<Values, Target, Action> {
+    pub(crate) fn new(values: Values, target: Target, action: Action) -> Self {
+        OnConflictValues {
+            values,
+            target,
+            action,
+        }
+    }
 }
 
 impl<Values, Target, Action> CanInsertInSingleQuery<Pg> for OnConflictValues<Values, Target, Action>

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -86,9 +86,9 @@ macro_rules! tuple_impls {
             impl<$($T: Expression + NonAggregate),+> NonAggregate for ($($T,)+) {
             }
 
-            impl<'a, $($T,)+ Tab> UndecoratedInsertRecord<Tab> for &'a ($($T,)+)
+            impl<$($T,)+ Tab> UndecoratedInsertRecord<Tab> for ($($T,)+)
             where
-                $(&'a $T: UndecoratedInsertRecord<Tab>,)+
+                $($T: UndecoratedInsertRecord<Tab>,)+
             {
             }
 
@@ -115,6 +115,9 @@ macro_rules! tuple_impls {
                     ($(self.$idx.values(),)+)
                 }
             }
+
+            #[cfg(feature = "postgres")]
+            impl<$($T,)+> ::pg::upsert::OnConflictExtension for ($($T,)+) {}
 
             #[allow(unused_assignments)]
             impl<$($T,)+ Tab, DB> InsertValues<Tab, DB> for ($($T,)+)

--- a/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
@@ -4,7 +4,6 @@
 use diesel::*;
 use diesel::types::*;
 use diesel::dsl::*;
-use diesel::pg::upsert::*;
 
 table! {
     users {
@@ -33,7 +32,8 @@ fn main() {
     users.select(id).filter(now.eq(now.at_time_zone("UTC")))
         .load::<i32>(&connection);
     //~^ ERROR type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
-    insert_into(users).values(&NewUser("Sean").on_conflict_do_nothing())
+    insert_into(users).values(&NewUser("Sean"))
+        .on_conflict_do_nothing()
         .execute(&connection);
     //~^ ERROR type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == diesel::pg::Pg`
 }

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -15,26 +15,54 @@ table! {
 #[table_name="users"]
 struct NewUser(#[column_name(name)] &'static str);
 
+#[allow(deprecated)]
 fn main() {
     use self::users::dsl::*;
     let connection = PgConnection::establish("postgres://localhost").unwrap();
 
-    insert_into(users).values(&NewUser("Sean").on_conflict_do_nothing().on_conflict_do_nothing()).execute(&connection);
-    //~^ ERROR E0277
-    insert_into(users).values(&NewUser("Sean").on_conflict(id, do_nothing()).on_conflict_do_nothing()).execute(&connection);
-    //~^ ERROR E0277
-    insert_into(users).values(&NewUser("Sean").on_conflict_do_nothing().on_conflict(id, do_nothing())).execute(&connection);
-    //~^ ERROR E0277
-    insert_into(users).values(&NewUser("Sean").on_conflict(id, do_nothing()).on_conflict(id, do_nothing())).execute(&connection);
-    //~^ ERROR E0277
-    insert_into(users).values(&vec![NewUser("Sean").on_conflict_do_nothing()]).execute(&connection);
-    //~^ ERROR E0277
-    insert_into(users).values(&vec![&NewUser("Sean").on_conflict_do_nothing()]).execute(&connection);
-    //~^ ERROR no method named `execute`
-    //~| ERROR E0277
-    insert_into(users).values(&vec![&NewUser("Sean").on_conflict(id, do_nothing())]).execute(&connection);
-    //~^ ERROR no method named `execute`
-    //~| ERROR E0277
-    insert_into(users).values(&(name.eq("Sean").on_conflict_do_nothing(),)).execute(&connection);
-    //~^ ERROR E0277
+    insert_into(users)
+        .values(&NewUser("Sean")
+                .on_conflict_do_nothing()
+                .on_conflict_do_nothing());
+                //~^ ERROR no method named `on_conflict_do_nothing` found
+    insert_into(users)
+        .values(&NewUser("Sean").on_conflict_do_nothing())
+        .on_conflict_do_nothing();
+        //~^ ERROR no method named `on_conflict_do_nothing` found
+    insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict_do_nothing()
+        .on_conflict_do_nothing();
+        //~^ ERROR no method named `on_conflict_do_nothing` found
+    insert_into(users)
+        .values(&NewUser("Sean")
+                .on_conflict(id, do_nothing())
+                .on_conflict_do_nothing());
+                //~^ ERROR no method named `on_conflict_do_nothing` found
+    insert_into(users)
+        .values(&NewUser("Sean").on_conflict(id, do_nothing()))
+        .on_conflict_do_nothing();
+        //~^ ERROR no method named `on_conflict_do_nothing` found
+    insert_into(users)
+        .values(&NewUser("Sean")
+                .on_conflict_do_nothing()
+                .on_conflict(id, do_nothing()));
+                //~^ ERROR no method named `on_conflict` found
+    insert_into(users)
+        .values(&NewUser("Sean")
+                .on_conflict(id, do_nothing())
+                .on_conflict(id, do_nothing()));
+                //~^ ERROR no method named `on_conflict` found
+    insert_into(users)
+        .values(&vec![NewUser("Sean").on_conflict_do_nothing()]);
+        //~^ ERROR UndecoratedInsertRecord
+    insert_into(users)
+        .values(&vec![&NewUser("Sean").on_conflict_do_nothing()]);
+        //~^ ERROR UndecoratedInsertRecord
+    insert_into(users)
+        .values(&vec![&NewUser("Sean").on_conflict(id, do_nothing())]);
+        //~^ ERROR UndecoratedInsertRecord
+    insert_into(users)
+        .values(&(name.eq("Sean").on_conflict_do_nothing(),));
+        //~^ ERROR UndecoratedInsertRecord
 }

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -262,11 +262,11 @@ fn insert_empty_slice_with_returning() {
 #[test]
 #[cfg(feature = "postgres")]
 fn upsert_empty_slice() {
-    use diesel::pg::upsert::*;
     let connection = connection();
 
     let inserted_records = insert_into(users::table)
-        .values(&Vec::<NewUser>::new().on_conflict_do_nothing())
+        .values(&Vec::<NewUser>::new())
+        .on_conflict_do_nothing()
         .execute(&connection);
 
     assert_eq!(Ok(0), inserted_records);


### PR DESCRIPTION
This deprecates the method `on_conflict_do_nothing` which was present on
`Insertable` structs, and instead moves it onto `InsertStatement`
instead. Code which was previously written as
`.values(x.on_conflict_do_nothing())` can be written as
`.values(x).on_conflict_do_nothing()`. This allows a more fluent form
where line breaks can be more naturally introduced (which will be a much
bigger deal for `on_conflict(..., do_update().set(...))`

/cc @alexcameron89 who originally paired with me on this