### PR TITLE
Deprecate `on_conflict`, `do_nothing`, and `do_update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added `on_conflict_do_nothing` on `InsertStatement` as a replacement for
   `on_conflict_do_nothing` on `Insertable` structs.
 
+* Added `on_conflict` on `InsertStatement` as a replacement for
+  `on_conflict` on `Insertable` structs.
+
 ### Changed
 
 * The signatures of `QueryId`, `Column`, and `FromSqlRow` have all changed to
@@ -43,6 +46,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Deprecated `.values(x.on_conflict_do_nothing())` in favor of
   `.values(x).on_conflict_do_nothing()`
+
+* Deprecated `.values(x.on_conflict(y, do_nothing()))` in favor of
+  `.values(x).on_conflict(y).do_nothing()`
+
+* Deprecated `.values(x.on_conflict(y, do_update().set(z)))` in favor of
+  `.values(x).on_conflict(y).do_update().set(z)`
 
 ### Removed
 

--- a/diesel/src/pg/upsert/mod.rs
+++ b/diesel/src/pg/upsert/mod.rs
@@ -1,8 +1,16 @@
+//! Types and functions related to PG's `ON CONFLICT` clause
+//!
+//! See [the methods on `InsertStatement`](../../query_builder/insert_statement/struct.InsertStatement.html#impl-1)
+//! for usage examples.
+
 mod on_conflict_actions;
 mod on_conflict_clause;
 mod on_conflict_extension;
 mod on_conflict_target;
 
-pub use self::on_conflict_actions::{do_nothing, do_update, excluded};
-pub use self::on_conflict_extension::OnConflictExtension;
+#[cfg(feature = "with-deprecated")]
+#[allow(deprecated)]
+pub use self::on_conflict_actions::{do_nothing, do_update};
+pub use self::on_conflict_actions::excluded;
+pub use self::on_conflict_extension::*;
 pub use self::on_conflict_target::on_constraint;

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -10,6 +10,8 @@ use result::QueryResult;
 /// nothing when *any* constraint conflicts, use
 /// [`on_conflict_do_nothing()`](trait.OnConflictExtension.html#method.on_conflict_do_nothing)
 /// instead.
+#[cfg(feature = "with-deprecated")]
+#[deprecated(since = "0.99.0", note = "use `.values(...).on_conflict(...).do_nothing()` instead")]
 pub fn do_nothing() -> DoNothing {
     DoNothing
 }
@@ -115,6 +117,8 @@ pub fn do_nothing() -> DoNothing {
 /// let users_in_db = users.load(&conn);
 /// assert_eq!(Ok(vec![(1, "Sean".to_string()), (2, "Tess".to_string())]), users_in_db);
 /// # }
+#[cfg(feature = "with-deprecated")]
+#[deprecated(since = "0.99.0", note = "use `.values(...).on_conflict(...).do_update()` instead")]
 pub fn do_update() -> IncompleteDoUpdate {
     IncompleteDoUpdate
 }
@@ -136,8 +140,10 @@ impl QueryFragment<Pg> for DoNothing {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg(feature = "with-deprecated")]
 pub struct IncompleteDoUpdate;
 
+#[cfg(feature = "with-deprecated")]
 impl IncompleteDoUpdate {
     pub fn set<T: AsChangeset>(self, changeset: T) -> DoUpdate<T> {
         DoUpdate {
@@ -150,6 +156,12 @@ impl IncompleteDoUpdate {
 #[derive(Debug, Clone, Copy)]
 pub struct DoUpdate<T> {
     changeset: T,
+}
+
+impl<T> DoUpdate<T> {
+    pub(crate) fn new(changeset: T) -> Self {
+        DoUpdate { changeset }
+    }
 }
 
 impl<T> QueryFragment<Pg> for DoUpdate<T>
@@ -198,12 +210,14 @@ where
 }
 
 #[doc(hidden)]
+#[cfg(feature = "with-deprecated")]
 pub trait IntoConflictAction<T> {
     type Action: QueryFragment<Pg>;
 
     fn into_conflict_action(self) -> Self::Action;
 }
 
+#[cfg(feature = "with-deprecated")]
 impl<T> IntoConflictAction<T> for DoNothing {
     type Action = Self;
 
@@ -212,6 +226,7 @@ impl<T> IntoConflictAction<T> for DoNothing {
     }
 }
 
+#[cfg(feature = "with-deprecated")]
 impl<Table, Changes> IntoConflictAction<Table> for DoUpdate<Changes>
 where
     Table: QuerySource,

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -2,6 +2,7 @@ use backend::Backend;
 use insertable::*;
 use pg::Pg;
 use query_builder::*;
+#[cfg(feature = "with-deprecated")]
 use query_builder::insert_statement::*;
 use query_source::Table;
 use result::QueryResult;
@@ -20,12 +21,14 @@ impl<T> OnConflictDoNothing<T> {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg(feature = "with-deprecated")]
 pub struct OnConflict<Records, Target, Action> {
     records: Records,
     target: Target,
     action: Action,
 }
 
+#[cfg(feature = "with-deprecated")]
 impl<Records, Target, Action> OnConflict<Records, Target, Action> {
     pub fn new(records: Records, target: Target, action: Action) -> Self {
         OnConflict {
@@ -53,6 +56,7 @@ where
     }
 }
 
+#[cfg(feature = "with-deprecated")]
 impl<'a, Records, Target, Action, Tab> Insertable<Tab> for &'a OnConflict<Records, Target, Action>
 where
     Records: Insertable<Tab> + Copy,

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -1,5 +1,7 @@
 use expression::operators::Eq;
+use query_builder::AsChangeset;
 use query_builder::insert_statement::{InsertStatement, UndecoratedInsertRecord};
+use query_source::QuerySource;
 use super::on_conflict_actions::*;
 use super::on_conflict_clause::*;
 use super::on_conflict_target::*;
@@ -83,7 +85,7 @@ pub trait OnConflictExtension {
     /// # }
     /// ```
     #[cfg(feature = "with-deprecated")]
-    #[deprecated(since = "0.99.0", note = "use `.values().on_conflict_do_nothing()` instead")]
+    #[deprecated(since = "0.99.0", note = "use `.values(...).on_conflict_do_nothing()` instead")]
     fn on_conflict_do_nothing(&self) -> OnConflictDoNothing<&Self> {
         OnConflictDoNothing::new(self)
     }
@@ -195,6 +197,8 @@ pub trait OnConflictExtension {
     ///
     /// See the documentation for [`on_constraint`](fn.on_constraint.html) and [`do_update`] for
     /// more examples.
+    #[deprecated(since = "0.99.0", note = "use `.values(...).on_conflict(...)` instead")]
+    #[cfg(feature = "with-deprecated")]
     fn on_conflict<Target, Action>(
         &self,
         target: Target,
@@ -275,5 +279,279 @@ where
         self,
     ) -> InsertStatement<T, OnConflictValues<U, NoConflictTarget, DoNothing>, Op, Ret> {
         self.replace_values(OnConflictValues::do_nothing)
+    }
+
+    /// Adds an `ON CONFLICT` to the insert statement, if a conflict occurs
+    /// for the given unique constraint.
+    ///
+    /// `Target` can be one of:
+    ///
+    /// - A column
+    /// - A tuple of columns
+    /// - [`on_constraint("constraint_name")`][`on_constraint`]
+    ///
+    /// # Examples
+    ///
+    /// ### Specifying a column as the target
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("on_conflict_docs_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// conn.execute("CREATE UNIQUE INDEX users_name ON users (name)").unwrap();
+    /// let user = User { id: 1, name: "Sean", };
+    /// let same_name_different_id = User { id: 2, name: "Sean" };
+    /// let same_id_different_name = User { id: 1, name: "Pascal" };
+    ///
+    /// assert_eq!(Ok(1), diesel::insert_into(users).values(&user).execute(&conn));
+    ///
+    /// let inserted_row_count = diesel::insert_into(users)
+    ///     .values(&same_name_different_id)
+    ///     .on_conflict(name)
+    ///     .do_nothing()
+    ///     .execute(&conn);
+    /// assert_eq!(Ok(0), inserted_row_count);
+    ///
+    /// let pk_conflict_result = diesel::insert_into(users)
+    ///     .values(&same_id_different_name)
+    ///     .on_conflict(name)
+    ///     .do_nothing()
+    ///     .execute(&conn);
+    /// assert!(pk_conflict_result.is_err());
+    /// # }
+    /// ```
+    ///
+    /// ### Specifying multiple columns as the target
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #         hair_color -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Clone, Copy, Insertable)]
+    /// # #[table_name="users"]
+    /// # struct User<'a> {
+    /// #     id: i32,
+    /// #     name: &'a str,
+    /// #     hair_color: &'a str,
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// use diesel::pg::upsert::*;
+    ///
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE users").unwrap();
+    /// #     conn.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT, hair_color TEXT)").unwrap();
+    /// conn.execute("CREATE UNIQUE INDEX users_name_hair_color ON users (name, hair_color)").unwrap();
+    /// let user = User { id: 1, name: "Sean", hair_color: "black" };
+    /// let same_name_different_hair_color = User { id: 2, name: "Sean", hair_color: "brown" };
+    /// let same_same_name_same_hair_color = User { id: 3, name: "Sean", hair_color: "black" };
+    ///
+    /// assert_eq!(Ok(1), diesel::insert_into(users).values(&user).execute(&conn));
+    ///
+    /// let inserted_row_count = diesel::insert_into(users)
+    ///     .values(&same_name_different_hair_color)
+    ///     .on_conflict((name, hair_color))
+    ///     .do_nothing()
+    ///     .execute(&conn);
+    /// assert_eq!(Ok(1), inserted_row_count);
+    ///
+    /// let inserted_row_count = diesel::insert_into(users)
+    ///     .values(&same_same_name_same_hair_color)
+    ///     .on_conflict((name, hair_color))
+    ///     .do_nothing()
+    ///     .execute(&conn);
+    /// assert_eq!(Ok(0), inserted_row_count);
+    /// # }
+    /// ```
+    ///
+    /// See the documentation for [`on_constraint`] and [`do_update`] for
+    /// more examples.
+    ///
+    /// [`on_constraint`]: ../../pg/upsert/fn.on_constraint.html
+    /// [`do_update`]: ../../pg/upsert/struct.IncompleteOnConflict.html#method.do_update
+    pub fn on_conflict<Target>(
+        self,
+        target: Target,
+    ) -> IncompleteOnConflict<Self, ConflictTarget<Target>>
+    where
+        ConflictTarget<Target>: OnConflictTarget<T>,
+    {
+        IncompleteOnConflict {
+            stmt: self,
+            target: ConflictTarget(target),
+        }
+    }
+}
+
+/// A partially constructed `ON CONFLICT` clause.
+#[derive(Debug, Clone, Copy)]
+pub struct IncompleteOnConflict<Stmt, Target> {
+    stmt: Stmt,
+    target: Target,
+}
+
+impl<T, U, Op, Ret, Target> IncompleteOnConflict<InsertStatement<T, U, Op, Ret>, Target> {
+    /// Creates a query with `ON CONFLICT (target) DO NOTHING`
+    ///
+    /// If you want to do nothing when *any* constraint conflicts, use
+    /// [`on_conflict_do_nothing`] instead. See [`on_conflict`] for usage
+    /// examples.
+    ///
+    /// [`on_conflict_do_nothing`]: ../../query_builder/insert_statement/struct.InsertStatement.html#method.on_conflict_do_nothing
+    /// [`on_conflict`]: ../../query_builder/insert_statement/struct.InsertStatement.html#method.on_conflict
+    pub fn do_nothing(self) -> InsertStatement<T, OnConflictValues<U, Target, DoNothing>, Op, Ret> {
+        let target = self.target;
+        self.stmt
+            .replace_values(|values| OnConflictValues::new(values, target, DoNothing))
+    }
+}
+
+impl<Stmt, Target> IncompleteOnConflict<Stmt, Target> {
+    /// Used to create a query in the form `ON CONFLICT (...) DO UPDATE ...`
+    ///
+    /// Call `.set` on the result of this function with the changes you want to
+    /// apply. The argument to `set` can be anything that implements `AsChangeset`
+    /// (e.g. anything you could pass to `set` on a normal update statement).
+    ///
+    /// Note: When inserting more than one row at a time, this query can still fail
+    /// if the rows being inserted conflict with each other.
+    ///
+    /// # Examples
+    ///
+    /// ## Set specific value on conflict
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("on_conflict_docs_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// let user = User { id: 1, name: "Pascal" };
+    /// let user2 = User { id: 1, name: "Sean" };
+    ///
+    /// assert_eq!(Ok(1), diesel::insert_into(users).values(&user).execute(&conn));
+    ///
+    /// let insert_count = diesel::insert_into(users)
+    ///     .values(&user2)
+    ///     .on_conflict(id)
+    ///     .do_update()
+    ///     .set(name.eq("I DONT KNOW ANYMORE"))
+    ///     .execute(&conn);
+    /// assert_eq!(Ok(1), insert_count);
+    ///
+    /// let users_in_db = users.load(&conn);
+    /// assert_eq!(Ok(vec![(1, "I DONT KNOW ANYMORE".to_string())]), users_in_db);
+    /// # }
+    /// ```
+    ///
+    /// ## Set `AsChangeset` struct on conflict
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("on_conflict_docs_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// let user = User { id: 1, name: "Pascal" };
+    /// let user2 = User { id: 1, name: "Sean" };
+    ///
+    /// assert_eq!(Ok(1), diesel::insert_into(users).values(&user).execute(&conn));
+    ///
+    /// let insert_count = diesel::insert_into(users)
+    ///     .values(&user2)
+    ///     .on_conflict(id)
+    ///     .do_update()
+    ///     .set(&user2)
+    ///     .execute(&conn);
+    /// assert_eq!(Ok(1), insert_count);
+    ///
+    /// let users_in_db = users.load(&conn);
+    /// assert_eq!(Ok(vec![(1, "Sean".to_string())]), users_in_db);
+    /// # }
+    /// ```
+    ///
+    /// ## Use `excluded` to get the rejected value
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("on_conflict_docs_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// use diesel::pg::upsert::excluded;
+    ///
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("TRUNCATE TABLE users").unwrap();
+    /// let user = User { id: 1, name: "Pascal" };
+    /// let user2 = User { id: 1, name: "Sean" };
+    /// let user3 = User { id: 2, name: "Tess" };
+    ///
+    /// assert_eq!(Ok(1), diesel::insert_into(users).values(&user).execute(&conn));
+    ///
+    /// let insert_count = diesel::insert_into(users)
+    ///     .values(&vec![user2, user3])
+    ///     .on_conflict(id)
+    ///     .do_update()
+    ///     .set(name.eq(excluded(name)))
+    ///     .execute(&conn);
+    /// assert_eq!(Ok(2), insert_count);
+    ///
+    /// let users_in_db = users.load(&conn);
+    /// assert_eq!(Ok(vec![(1, "Sean".to_string()), (2, "Tess".to_string())]), users_in_db);
+    /// # }
+    /// ```
+    pub fn do_update(self) -> IncompleteDoUpdate<Stmt, Target> {
+        IncompleteDoUpdate {
+            stmt: self.stmt,
+            target: self.target,
+        }
+    }
+}
+
+/// A partially constructed `ON CONFLICT DO UPDATE` clause.
+#[derive(Debug, Clone, Copy)]
+pub struct IncompleteDoUpdate<Stmt, Target> {
+    stmt: Stmt,
+    target: Target,
+}
+
+impl<T, U, Op, Ret, Target> IncompleteDoUpdate<InsertStatement<T, U, Op, Ret>, Target> {
+    /// See [`do_update`] for usage examples.
+    ///
+    /// [`do_update`]: struct.IncompleteOnConflict.html#method.do_update
+    pub fn set<Changes>(
+        self,
+        changes: Changes,
+    ) -> InsertStatement<T, OnConflictValues<U, Target, DoUpdate<Changes::Changeset>>, Op, Ret>
+    where
+        T: QuerySource,
+        Changes: AsChangeset<Target = T>,
+    {
+        let target = self.target;
+        self.stmt.replace_values(|values| {
+            OnConflictValues::new(values, target, DoUpdate::new(changes.as_changeset()))
+        })
     }
 }

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -29,16 +29,16 @@ use result::QueryResult;
 /// assert_eq!(Ok(1), diesel::insert_into(users).values(&user).execute(&conn));
 ///
 /// let inserted_row_count = diesel::insert_into(users)
-///     .values(
-///         &same_name_different_id.on_conflict(on_constraint("users_name"), do_nothing())
-///     )
+///     .values(&same_name_different_id)
+///     .on_conflict(on_constraint("users_name"))
+///     .do_nothing()
 ///     .execute(&conn);
 /// assert_eq!(Ok(0), inserted_row_count);
 ///
 /// let pk_conflict_result = diesel::insert_into(users)
-///     .values(
-///         &same_id_different_name.on_conflict(on_constraint("users_name"), do_nothing())
-///     )
+///     .values(&same_id_different_name)
+///     .on_conflict(on_constraint("users_name"))
+///     .do_nothing()
 ///     .execute(&conn);
 /// assert!(pk_conflict_result.is_err());
 /// # }

--- a/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -24,22 +24,40 @@ struct NewUser(#[column_name(name)] &'static str);
 
 sql_function!(lower, lower_t, (x: diesel::types::Text) -> diesel::types::Text);
 
+#[allow(deprecated)]
 fn main() {
     use self::users::dsl::*;
     let connection = PgConnection::establish("postgres://localhost").unwrap();
 
     let valid_insert = insert_into(users).values(&NewUser("Sean").on_conflict(id, do_nothing())).execute(&connection);
+    // Sanity check, no error w/ deprecated API
+    let valid_insert = insert_into(users).values(&NewUser("Sean")).on_conflict(id).do_nothing().execute(&connection);
     // Sanity check, no error
 
     let column_from_other_table = insert_into(users)
         .values(&NewUser("Sean").on_conflict(posts::id, do_nothing()));
         //~^ ERROR type mismatch resolving `<posts::columns::id as diesel::Column>::Table == users::table`
 
+    let column_from_other_table = insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(posts::id);
+        //~^ ERROR type mismatch resolving `<posts::columns::id as diesel::Column>::Table == users::table`
+
     let expression_using_column_from_other_table = insert_into(users)
         .values(&NewUser("Sean").on_conflict(lower(posts::title), do_nothing()));
         //~^ ERROR the trait bound `lower_t<posts::columns::title>: diesel::Column` is not satisfied
 
+    let expression_using_column_from_other_table = insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(lower(posts::title));
+        //~^ ERROR the trait bound `lower_t<posts::columns::title>: diesel::Column` is not satisfied
+
     let random_non_expression = insert_into(users)
         .values(&NewUser("Sean").on_conflict("id", do_nothing()));
+        //~^ ERROR the trait bound `&str: diesel::Column` is not satisfied
+
+    let random_non_expression = insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict("id");
         //~^ ERROR the trait bound `&str: diesel::Column` is not satisfied
 }

--- a/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
@@ -22,20 +22,41 @@ table! {
 #[table_name="users"]
 struct NewUser(#[column_name(name)] &'static str);
 
+#[allow(deprecated)]
 fn main() {
     use self::users::dsl::*;
     let connection = PgConnection::establish("postgres://localhost").unwrap();
 
-    // Valid update as sanity check
+    // Valid update as sanity check w/ deprecated API
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq("Sean")))).execute(&connection);
+
+    // Valid update as sanity check
+    insert_into(users).values(&NewUser("Sean")).on_conflict(id).do_update().set(name.eq("Sean")).execute(&connection);
 
     // No set clause
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update())).execute(&connection);
     //~^ ERROR E0277
 
+    // No set clause
+    insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(id)
+        .do_update()
+        .execute(&connection);
+        //~^ ERROR no method named `execute`
+
     // Update column from other table
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(posts::title.eq("Sean")))).execute(&connection);
     //~^ ERROR E0271
+
+    // Update column from other table
+    insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(id)
+        .do_update()
+        .set(posts::title.eq("Sean"));
+        //~^ ERROR E0271
+
 
     // Update column with value that is not selectable
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(posts::title)))).execute(&connection);
@@ -45,15 +66,40 @@ fn main() {
     //~| ERROR E0271
     //~| ERROR E0271
 
+    // Update column with value that is not selectable
+    insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(id)
+        .do_update()
+        .set(name.eq(posts::title));
+        //~^ ERROR E0271
+        //~| ERROR E0277
+
     // Update column with excluded value that is not selectable
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(excluded(posts::title))))).execute(&connection);
     //~^ ERROR E0271
     //~| ERROR no method named `execute`
     //~| type mismatch resolving `<posts::columns::title as diesel::Column>::Table == users::table`
 
+    // Update column with excluded value that is not selectable
+    insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(id)
+        .do_update()
+        .set(name.eq(excluded(posts::title)));
+        //~^ ERROR type mismatch resolving `<posts::columns::title as diesel::Column>::Table == users::table`
+
     // Update column with excluded value of wrong type
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(excluded(id))))).execute(&connection);
     //~^ ERROR E0271
+
+    // Update column with excluded value of wrong type
+    insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(id)
+        .do_update()
+        .set(name.eq(excluded(id)));
+        //~^ ERROR E0271
 
     // Excluded is only valid in upsert
     // FIXME: This should not compile

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -49,10 +49,26 @@ fn main() {
                 .on_conflict(id, do_nothing()));
                 //~^ ERROR no method named `on_conflict` found
     insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict_do_nothing()
+        .on_conflict(id);
+        //~^ ERROR no method named `on_conflict` found
+    insert_into(users)
+        .values(&NewUser("Sean")
+                .on_conflict_do_nothing())
+        .on_conflict(id);
+        //~^ ERROR no method named `on_conflict` found
+    insert_into(users)
         .values(&NewUser("Sean")
                 .on_conflict(id, do_nothing())
                 .on_conflict(id, do_nothing()));
                 //~^ ERROR no method named `on_conflict` found
+    insert_into(users)
+        .values(&NewUser("Sean"))
+        .on_conflict(id)
+        .do_nothing()
+        .on_conflict(id);
+        //~^ ERROR no method named `on_conflict` found
     insert_into(users)
         .values(&vec![NewUser("Sean").on_conflict_do_nothing()]);
         //~^ ERROR UndecoratedInsertRecord


### PR DESCRIPTION
This deprecates the remaining PG upsert API from 0.16, and moves it onto
`InsertStatement` instead. This leads to a more fluent API which allows
line breaks to be more naturally added.

Additionally, our error messages are much more descriptive, and appear
much earlier with this API.

Fixes #1166.