### PR TITLE
Change `between` to take two arguments instead of a range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Changed the migration directory name format to `%Y-%m-%d-%H%M%S`.
 
+* `between` and `not_between` now take two arguments, rather than a range.
+
 ### Removed
 
 * `debug_sql!` has been deprecated in favor of `diesel::debug_query`.

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -41,15 +41,15 @@ pub type Like<Lhs, Rhs> = super::operators::Like<Lhs, AsExprOf<Rhs, types::VarCh
 /// The return type of `lhs.not_like(rhs)`
 pub type NotLike<Lhs, Rhs> = super::operators::NotLike<Lhs, AsExprOf<Rhs, types::VarChar>>;
 
-/// The return type of `lhs.between(rhs..rhs)`
-pub type Between<Lhs, Rhs> = super::operators::Between<
+/// The return type of `lhs.between(lower, upper)`
+pub type Between<Lhs, Lower, Upper> = super::operators::Between<
     Lhs,
-    super::operators::And<AsExpr<Rhs, Lhs>, AsExpr<Rhs, Lhs>>,
+    super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>,
 >;
-/// The return type of `lhs.not_between(rhs..rhs)`
-pub type NotBetween<Lhs, Rhs> = super::operators::NotBetween<
+/// The return type of `lhs.not_between(lower, upper)`
+pub type NotBetween<Lhs, Lower, Upper> = super::operators::NotBetween<
     Lhs,
-    super::operators::And<AsExpr<Rhs, Lhs>, AsExpr<Rhs, Lhs>>,
+    super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>,
 >;
 /// The return type of `not(expr)`
 pub type Not<Expr> = super::operators::Not<Grouped<AsExprOf<Expr, types::Bool>>>;

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -290,7 +290,8 @@ pub trait ExpressionMethods: Expression + Sized {
         LtEq::new(self, other.as_expression())
     }
 
-    /// Creates a SQL `BETWEEN` expression using the given range.
+    /// Creates a SQL `BETWEEN` expression using the given lower and upper
+    /// bounds.
     ///
     /// # Example
     ///
@@ -305,22 +306,22 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #
     /// let data = animals
     ///     .select(species)
-    ///     .filter(legs.between(2..6))
+    ///     .filter(legs.between(2, 6))
     ///     .first(&connection);
     /// #
     /// assert_eq!(Ok("dog".to_string()), data);
     /// # }
-    fn between<T: AsExpression<Self::SqlType>>(
-        self,
-        other: ::std::ops::Range<T>,
-    ) -> Between<Self, And<T::Expression, T::Expression>> {
-        Between::new(
-            self,
-            And::new(other.start.as_expression(), other.end.as_expression()),
-        )
+    /// ```
+    fn between<T, U>(self, lower: T, upper: U) -> Between<Self, And<T::Expression, U::Expression>>
+    where
+        T: AsExpression<Self::SqlType>,
+        U: AsExpression<Self::SqlType>,
+    {
+        Between::new(self, And::new(lower.as_expression(), upper.as_expression()))
     }
 
-    /// Creates a SQL `NOT BETWEEN` expression using the given range.
+    /// Creates a SQL `NOT BETWEEN` expression using the given lower and upper
+    /// bounds.
     ///
     /// # Example
     ///
@@ -335,19 +336,21 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #
     /// let data = animals
     ///     .select(species)
-    ///     .filter(legs.not_between(2..6))
+    ///     .filter(legs.not_between(2, 6))
     ///     .first(&connection);
     /// #
     /// assert_eq!(Ok("spider".to_string()), data);
     /// # }
-    fn not_between<T: AsExpression<Self::SqlType>>(
+    fn not_between<T, U>(
         self,
-        other: ::std::ops::Range<T>,
-    ) -> NotBetween<Self, And<T::Expression, T::Expression>> {
-        NotBetween::new(
-            self,
-            And::new(other.start.as_expression(), other.end.as_expression()),
-        )
+        lower: T,
+        upper: U,
+    ) -> NotBetween<Self, And<T::Expression, U::Expression>>
+    where
+        T: AsExpression<Self::SqlType>,
+        U: AsExpression<Self::SqlType>,
+    {
+        NotBetween::new(self, And::new(lower.as_expression(), upper.as_expression()))
     }
 
     /// Creates a SQL `DESC` expression, representing this expression in

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -121,7 +121,7 @@ fn filter_by_between() {
     assert_eq!(
         vec![sean, tess.clone(), jim.clone()],
         users
-            .filter(id.between(1..3))
+            .filter(id.between(1, 3))
             .order(id.asc())
             .load(&connection)
             .unwrap()
@@ -129,7 +129,7 @@ fn filter_by_between() {
     assert_eq!(
         vec![tess, jim],
         users
-            .filter(id.between(2..3))
+            .filter(id.between(2, 3))
             .order(id.asc())
             .load(&connection)
             .unwrap()


### PR DESCRIPTION
I want to be able to write `.between(now, now - 90.days())`. Having a
range requires that the lower and upper bound be the same type in Rust,
rather than requiring that they be the same type in SQL.