### PR TITLE
Add db client installation guide

### DIFF
--- a/guide_drafts/backend_installation.md
+++ b/guide_drafts/backend_installation.md
@@ -1,24 +1,34 @@
 # Installing Backend Client Libraries
 
-Diesel supports SQLite, PostgreSQL, and MySQL as backend databases. By default, `diesel_cli` requires the client library of all three backends to be installed. If one is missing, then `cargo install diesel_cli` you will throw an error like:
+Diesel supports SQLite, PostgreSQL, and MySQL as backend databases.
+By default, `diesel_cli`
+requires the client library of all three backends to be installed.
+If one is missing, then `cargo install diesel_cli` you will throw an error like:
 
 ```
 note: ld: library not found for -lmysqlclient
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 ```
-To install `diesel_cli` without all backends, specify `--no-default-features`. Use `--features` option to specify `postgres`, `sqlite`, and/or `mysql`. For example, to install with sqlite only, run:
+To install `diesel_cli` without all backends,
+specify `--no-default-features`.
+Use `--features` option to specify `postgres`, `sqlite`, and/or `mysql`.
+For example, to install with sqlite only, run:
 
 ```
 cargo install diesel_cli --no-default-features --features sqlite
 ```
 
-For projects that depend on diesel, you can specify which backend is required in the `Cargo.toml`. For example:
+For projects that depend on diesel,
+you can specify which backend is required in the `Cargo.toml`.
+For example:
 ```
 [dependencies]
 diesel = { version = "X.X.X", features = ["sqlite"] }
 ```
 
-Below are command to run to install appropriate database clients with various package managers.
+Below are command to run
+to install appropriate database clients
+with various package managers.
 
 ## Debian/Ubuntu
 

--- a/guide_drafts/backend_installation.md
+++ b/guide_drafts/backend_installation.md
@@ -1,6 +1,6 @@
 # Installing Backend Client Libraries
 
-Diesel supports SQLite, PostgreSQL, and MySQL as backend databases.
+Diesel supports SQLite, PostgreSQL, and MySQL as database backends.
 By default, `diesel_cli`
 requires the client library of all three backends to be installed.
 If one is missing, then `cargo install diesel_cli` you will throw an error like:
@@ -9,9 +9,10 @@ If one is missing, then `cargo install diesel_cli` you will throw an error like:
 note: ld: library not found for -lmysqlclient
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 ```
+
 To install `diesel_cli` without all backends,
 specify `--no-default-features`.
-Use `--features` option to specify `postgres`, `sqlite`, and/or `mysql`.
+Use cargo's `--features` option to specify `postgres`, `sqlite`, and/or `mysql`.
 For example, to install with sqlite only, run:
 
 ```
@@ -19,66 +20,86 @@ cargo install diesel_cli --no-default-features --features sqlite
 ```
 
 For projects that depend on diesel,
-you can specify which backend is required in the `Cargo.toml`.
+you can specify which backends are required in the `Cargo.toml`.
 For example:
+
 ```
 [dependencies]
 diesel = { version = "X.X.X", features = ["sqlite"] }
 ```
 
-Below are command to run
+Below are commands to run
 to install appropriate database clients
 with various package managers.
 
 ## Debian/Ubuntu
 
 ### SQLite
+
 `sudo apt-get install libsqlite3-dev`
 
 ### PostgreSQL
+
 `sudo apt-get install postgresql-server-dev-all`
 
 ### MySQL
 
-1. Install add the MySQL APT repository. 
+1. Install the folowing to add the MySQL APT repository. 
 
-```
-wget https://dev.mysql.com/get/mysql-apt-config_0.8.7-1_all.deb
-sudo dpkg -i mysql-apt-config_0.8.7-1_all.deb
-```
-Select `<Ok>`.
+    ```
+    wget https://dev.mysql.com/get/mysql-apt-config_0.8.7-1_all.deb
+    sudo dpkg -i mysql-apt-config_0.8.7-1_all.deb
+    ```
+
+    Select `<Ok>`.
 
 2. Retrieve new lists of packages
-```
-sudo apt-get update
-```
+
+    ```
+    sudo apt-get update
+    ```
+
 3. Install the client library
-```
-sudo apt-get install libmysqlclient-dev
-```
+
+    ```
+    sudo apt-get install libmysqlclient-dev
+    ```
+
 See [MySQL docs](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/) for more details.
 
 ## CentOS/Fedora
 ### SQLite
-`sudo yum install sqlite-devel`
-### PostgreSQL
-`sudo yum install postgresql-devel`
-### MySQL
-`sudo yum install mysql-devel`
 
+`sudo yum install sqlite-devel`
+
+### PostgreSQL
+
+`sudo yum install postgresql-devel`
+
+### MySQL
+
+`sudo yum install mysql-devel`
 
 ## Arch
 ### SQLite
+
 `sudo pacman -Su sqlite`
+
 ### PostgreSQL
+
 `sudo pacman -Su postgresql`
+
 ### MySQL
+
 `sudo pacman -Su mysql`
 
 ## Mac OSX 
 ### SQLite
 Already installed by default.
 ### PostgreSQL
+
 `brew install postgresql`
+
 ### MySQL
+
 `brew install mysql`

--- a/guide_drafts/backend_installation.md
+++ b/guide_drafts/backend_installation.md
@@ -1,0 +1,74 @@
+# Installing Backend Client Libraries
+
+Diesel supports SQLite, PostgreSQL, and MySQL as backend databases. By default, `diesel_cli` requires the client library of all three backends to be installed. If one is missing, then `cargo install diesel_cli` you will throw an error like:
+
+```
+note: ld: library not found for -lmysqlclient
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+```
+To install `diesel_cli` without all backends, specify `--no-default-features`. Use `--features` option to specify `postgres`, `sqlite`, and/or `mysql`. For example, to install with sqlite only, run:
+
+```
+cargo install diesel_cli --no-default-features --features sqlite
+```
+
+For projects that depend on diesel, you can specify which backend is required in the `Cargo.toml`. For example:
+```
+[dependencies]
+diesel = { version = "X.X.X", features = ["sqlite"] }
+```
+
+Below are command to run to install appropriate database clients with various package managers.
+
+## Debian/Ubuntu
+
+### SQLite
+`sudo apt-get install libsqlite3-dev`
+
+### PostgreSQL
+`sudo apt-get install postgresql-server-dev-all`
+
+### MySQL
+
+1. Install add the MySQL APT repository. 
+
+```
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.7-1_all.deb
+sudo dpkg -i mysql-apt-config_0.8.7-1_all.deb
+```
+Select `<Ok>`.
+
+2. Retrieve new lists of packages
+```
+sudo apt-get update
+```
+3. Install the client library
+```
+sudo apt-get install libmysqlclient-dev
+```
+See [MySQL docs](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/) for more details.
+
+## CentOS/Fedora
+### SQLite
+`sudo yum install sqlite-devel`
+### PostgreSQL
+`sudo yum install postgresql-devel`
+### MySQL
+`sudo yum install mysql-devel`
+
+
+## Arch
+### SQLite
+`sudo pacman -Su sqlite`
+### PostgreSQL
+`sudo pacman -Su postgresql`
+### MySQL
+`sudo pacman -Su mysql`
+
+## Mac OSX 
+### SQLite
+Already installed by default.
+### PostgreSQL
+`brew install postgresql`
+### MySQL
+`brew install mysql`


### PR DESCRIPTION
#1093 

This basically expands the getting started guide's direction to install database client libraries "using the usual way to do this depending on your operating system".

I tested all of these except OS X commands which I got from @sgrif . `apt-get` I tested on Debian. `yum` I tested on CentOS. Of course, it would be nice to add Windows.

I'm a little concerned that `sudo apt-get install postgresql-server-dev-all` is installing way more than necessary and there might be a skinnier package that would work. Not sure how big a deal that is.