### PR TITLE
Allow `filter` to be called on `UpdateStatement` and `DeleteStatement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added `on_conflict` on `InsertStatement` as a replacement for
   `on_conflict` on `Insertable` structs.
 
+* `filter` can now be called on update and delete statements. This means that
+  instead of `update(users.filter(...))` you can write
+  `update(users).filter(...)`. This allows line breaks to more naturally be
+  introduced.
+
 ### Changed
 
 * The signatures of `QueryId`, `Column`, and `FromSqlRow` have all changed to

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -1,5 +1,5 @@
 use backend::Backend;
-use expression::{SelectableExpression, AppearsOnTable};
+use expression::{AppearsOnTable, SelectableExpression};
 use query_builder::*;
 use query_builder::returning_clause::*;
 use query_builder::where_clause::*;

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -1,7 +1,8 @@
 use backend::Backend;
-use expression::SelectableExpression;
+use expression::{SelectableExpression, AppearsOnTable};
 use query_builder::*;
 use query_builder::returning_clause::*;
+use query_builder::where_clause::*;
 use query_source::Table;
 use result::QueryResult;
 
@@ -19,6 +20,54 @@ impl<T, U> DeleteStatement<T, U, NoReturningClause> {
             table: table,
             where_clause: where_clause,
             returning: NoReturningClause,
+        }
+    }
+}
+
+impl<T, U, Ret> DeleteStatement<T, U, Ret> {
+    /// Adds the given predicate to the `WHERE` clause of the statement being
+    /// constructed.
+    ///
+    /// If there is already a `WHERE` clause, the predicate will be appended
+    /// with `AND`. There is no difference in behavior between
+    /// `delete(table.filter(x))` and `delete(table).filter(x)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// let deleted_rows = diesel::delete(users)
+    ///     .filter(name.eq("Sean"))
+    ///     .execute(&connection);
+    /// assert_eq!(Ok(1), deleted_rows);
+    ///
+    /// let expected_names = vec!["Tess".to_string()];
+    /// let names = users.select(name).load(&connection);
+    ///
+    /// assert_eq!(Ok(expected_names), names);
+    /// # }
+    /// ```
+    pub fn filter<V>(self, predicate: V) -> DeleteStatement<T, U::Output, Ret>
+    where
+        U: WhereAnd<V>,
+        V: AppearsOnTable<T>,
+    {
+        DeleteStatement {
+            table: self.table,
+            where_clause: self.where_clause.and(predicate),
+            returning: self.returning,
         }
     }
 }

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -28,7 +28,7 @@ use super::{IncompleteInsertStatement, IncompleteUpdateStatement, IntoUpdateTarg
 /// # fn main() {
 /// #     use users::dsl::*;
 /// #     let connection = establish_connection();
-/// let updated_row = diesel::update(users.filter(id.eq(1)))
+/// let updated_row = diesel::update(users.find(1))
 ///     .set(name.eq("James"))
 ///     .get_result(&connection);
 /// // On backends that support it, you can call `get_result` instead of `execute`
@@ -66,7 +66,7 @@ use super::{IncompleteInsertStatement, IncompleteUpdateStatement, IntoUpdateTarg
 /// #     surname VARCHAR)").unwrap();
 /// # connection.execute("INSERT INTO users(name, surname) VALUES('Sean', 'Griffin')").unwrap();
 ///
-/// let updated_row = diesel::update(users.filter(id.eq(1)))
+/// let updated_row = diesel::update(users.find(1))
 ///     .set((name.eq("James"), surname.eq("Bond")))
 ///     .get_result(&connection);
 ///

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -33,14 +33,15 @@ pub mod update_statement;
 pub use self::ast_pass::AstPass;
 pub use self::bind_collector::BindCollector;
 pub use self::debug_query::DebugQuery;
+pub use self::delete_statement::DeleteStatement;
+#[doc(inline)]
+pub use self::insert_statement::IncompleteInsertStatement;
 pub use self::query_id::QueryId;
 #[doc(hidden)]
 pub use self::select_statement::{BoxedSelectStatement, SelectStatement};
 #[doc(inline)]
 pub use self::update_statement::{AsChangeset, Changeset, IncompleteUpdateStatement,
                                  IntoUpdateTarget, UpdateStatement, UpdateTarget};
-#[doc(inline)]
-pub use self::insert_statement::IncompleteInsertStatement;
 
 use std::error::Error;
 

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -80,12 +80,10 @@ impl<T, U> IncompleteUpdateStatement<T, U> {
         U: WhereAnd<V>,
         V: AppearsOnTable<T>,
     {
-        IncompleteUpdateStatement::new(
-            UpdateTarget {
-                table: self.0.table,
-                where_clause: self.0.where_clause.and(predicate),
-            }
-        )
+        IncompleteUpdateStatement::new(UpdateTarget {
+            table: self.0.table,
+            where_clause: self.0.where_clause.and(predicate),
+        })
     }
 }
 

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -5,9 +5,10 @@ pub use self::changeset::{AsChangeset, Changeset};
 pub use self::target::{IntoUpdateTarget, UpdateTarget};
 
 use backend::Backend;
-use expression::{Expression, NonAggregate, SelectableExpression};
+use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
 use query_builder::*;
 use query_builder::returning_clause::*;
+use query_builder::where_clause::*;
 use query_source::Table;
 use result::Error::QueryBuilderError;
 use result::QueryResult;
@@ -38,6 +39,54 @@ impl<T, U> IncompleteUpdateStatement<T, U> {
             returning: NoReturningClause,
         }
     }
+
+    /// Adds the given predicate to the `WHERE` clause of the statement being
+    /// constructed.
+    ///
+    /// If there is already a `WHERE` clause, the predicate will be appended
+    /// with `AND`. There is no difference in behavior between
+    /// `update(table.filter(x))` and `update(table).filter(x)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// let updated_rows = diesel::update(users)
+    ///     .filter(name.eq("Sean"))
+    ///     .set(name.eq("Jim"))
+    ///     .execute(&connection);
+    /// assert_eq!(Ok(1), updated_rows);
+    ///
+    /// let expected_names = vec!["Jim".to_string(), "Tess".to_string()];
+    /// let names = users.select(name).order(id).load(&connection);
+    ///
+    /// assert_eq!(Ok(expected_names), names);
+    /// # }
+    /// ```
+    pub fn filter<V>(self, predicate: V) -> IncompleteUpdateStatement<T, U::Output>
+    where
+        U: WhereAnd<V>,
+        V: AppearsOnTable<T>,
+    {
+        IncompleteUpdateStatement::new(
+            UpdateTarget {
+                table: self.0.table,
+                where_clause: self.0.where_clause.and(predicate),
+            }
+        )
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -46,6 +95,56 @@ pub struct UpdateStatement<T, U, V, Ret = NoReturningClause> {
     where_clause: U,
     values: V,
     returning: Ret,
+}
+
+impl<T, U, V, Ret> UpdateStatement<T, U, V, Ret> {
+    /// Adds the given predicate to the `WHERE` clause of the statement being
+    /// constructed.
+    ///
+    /// If there is already a `WHERE` clause, the predicate will be appended
+    /// with `AND`. There is no difference in behavior between
+    /// `update(table.filter(x))` and `update(table).filter(x)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     users {
+    /// #         id -> Integer,
+    /// #         name -> VarChar,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// let updated_rows = diesel::update(users)
+    ///     .set(name.eq("Jim"))
+    ///     .filter(name.eq("Sean"))
+    ///     .execute(&connection);
+    /// assert_eq!(Ok(1), updated_rows);
+    ///
+    /// let expected_names = vec!["Jim".to_string(), "Tess".to_string()];
+    /// let names = users.select(name).order(id).load(&connection);
+    ///
+    /// assert_eq!(Ok(expected_names), names);
+    /// # }
+    /// ```
+    pub fn filter<W>(self, predicate: W) -> UpdateStatement<T, U::Output, V, Ret>
+    where
+        U: WhereAnd<W>,
+        W: AppearsOnTable<T>,
+    {
+        UpdateStatement {
+            table: self.table,
+            where_clause: self.where_clause.and(predicate),
+            values: self.values,
+            returning: self.returning,
+        }
+    }
 }
 
 impl<T, U, V, Ret, DB> QueryFragment<DB> for UpdateStatement<T, U, V, Ret>

--- a/diesel_compile_tests/tests/compile-fail/update_requires_valid_where_clause.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_requires_valid_where_clause.rs
@@ -1,0 +1,33 @@
+#[macro_use] extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    // Sanity check: Valid update
+    update(users::table).filter(users::id.eq(1));
+
+    update(users::table.filter(posts::id.eq(1)));
+    //~^ ERROR E0271
+    //~| ERROR E0277
+
+    update(users::table).filter(posts::id.eq(1));
+    //~^ ERROR E0271
+    //~| ERROR E0277
+
+    update(users::table).set(users::id.eq(1))
+        .filter(posts::id.eq(1));
+        //~^ ERROR E0271
+        //~| ERROR E0277
+}

--- a/examples/postgres/all_about_updates/src/lib.rs
+++ b/examples/postgres/all_about_updates/src/lib.rs
@@ -52,8 +52,10 @@ pub fn publish_pending_posts(conn: &PgConnection) -> QueryResult<usize> {
     use posts::dsl::*;
     use diesel::dsl::now;
 
-    let target = posts.filter(publish_at.lt(now));
-    diesel::update(target).set(draft.eq(false)).execute(conn)
+    diesel::update(posts)
+        .filter(publish_at.lt(now))
+        .set(draft.eq(false))
+        .execute(conn)
 }
 
 #[test]
@@ -61,12 +63,14 @@ fn examine_sql_from_publish_pending_posts() {
     use posts::dsl::*;
     use diesel::dsl::now;
 
-    let target = posts.filter(publish_at.lt(now));
+    let query = diesel::update(posts)
+        .filter(publish_at.lt(now))
+        .set(draft.eq(false));
     assert_eq!(
         "UPDATE \"posts\" SET \"draft\" = $1 \
          WHERE \"posts\".\"publish_at\" < CURRENT_TIMESTAMP \
          -- binds: [false]",
-        debug_query(&diesel::update(target).set(draft.eq(false))).to_string()
+        debug_query(&query).to_string()
     );
 }
 


### PR DESCRIPTION
This change is in the same spirit as #1166. By allowing the method to be
chained as part of the query, instead of on the argument to a function,
it becomes much easier to introduce line breaks naturally.

Why isn't this `impl FilterDsl`?
--------------------------------

Today `FilterDsl` is structured in such a way that it assumes that it's
only implemented on valid complete queries, and that it will return a
valid complete query (partially to ensure that the call to `filter`
can't change the SQL type). Since these structs are only complete
queries when they have a returning clause (and
`IncompleteUpdateStatement` is never a complete query), we would have to
loosen those bounds.

We may want to make that change eventually, but for now I opted to
implement these as inherent methods.

Why not add `find` as well?
---------------------------

We could. To me, `update(users).set(...).find(1)` just feels off. Given
that `find` is typically much shorter, I've opted to exclude it for now.