### PR TITLE
Change migration output information to show file_path()

### DIFF
--- a/diesel_cli/tests/migration_redo.rs
+++ b/diesel_cli/tests/migration_redo.rs
@@ -15,8 +15,8 @@ fn migration_redo_runs_the_last_migration_down_and_up() {
     let result = p.command("migration").arg("redo").run();
 
     let expected_stdout = "\
-Rolling back migration 12345
-Running migration 12345
+Rolling back migration 12345_create_users_table
+Running migration 12345_create_users_table
 ";
 
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -47,8 +47,8 @@ fn migration_redo_respects_migration_dir_var() {
         .run();
 
     let expected_stdout = "\
-Rolling back migration 12345
-Running migration 12345
+Rolling back migration 12345_create_users_table
+Running migration 12345_create_users_table
 ";
 
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -79,8 +79,8 @@ fn migration_redo_respects_migration_dir_env() {
         .run();
 
     let expected_stdout = "\
-Rolling back migration 12345
-Running migration 12345
+Rolling back migration 12345_create_users_table
+Running migration 12345_create_users_table
 ";
 
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -323,11 +323,7 @@ where
 {
     conn.transaction(|| {
         if migration.version() != "00000000000000" {
-            try!(writeln!(
-                output,
-                "Running migration {}",
-                migration.version()
-            ));
+            try!(writeln!(output, "Running migration {}", name(&migration)));
         }
         try!(migration.run(conn));
         try!(conn.insert_new_migration(migration.version()));
@@ -344,7 +340,7 @@ fn revert_migration<Conn: Connection>(
         try!(writeln!(
             output,
             "Rolling back migration {}",
-            migration.version()
+            name(&migration)
         ));
         try!(migration.revert(conn));
         let target = __diesel_schema_migrations.filter(version.eq(migration.version()));

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -2,6 +2,7 @@ use diesel::connection::SimpleConnection;
 use super::{MigrationError, RunMigrationsError};
 
 use std::path::{Path, PathBuf};
+use std::fmt;
 
 pub trait Migration {
     fn version(&self) -> &str;
@@ -9,6 +10,33 @@ pub trait Migration {
     fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError>;
     fn file_path(&self) -> Option<&Path> {
         None
+    }
+}
+
+#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy)]
+pub struct MigrationName<'a> {
+    pub migration: &'a Migration,
+}
+
+pub fn name(migration: &Migration) -> MigrationName {
+    MigrationName {
+        migration: migration,
+    }
+}
+
+impl<'a> fmt::Display for MigrationName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let file_name = self.migration
+            .file_path()
+            .and_then(|file_path| file_path.file_name())
+            .and_then(|file| file.to_str());
+        if let Some(name) = file_name {
+            f.write_str(name)?;
+        } else {
+            f.write_str(self.migration.version())?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
connect #1091 

So this is my first iteration of the solution for #1091. 

When running/reverting migrations it will look like:
```bash
~/path/diesel_cli_test(master*) » diesel migration run                                                                                                                jd@Jonathans-MacBook-Pro
Running migration 20170924041631_create_posts
------------------------------------------------------------
~/path/diesel_cli_test(master*) » diesel migration revert                                                                                                             jd@Jonathans-MacBook-Pro
Rolling back migration 20170924041631_create_posts
```

This may need to be refactored. The first thing I tried was to use 
```rust
fn format_migration_output(migration: &Migration) -> String {
    let output = migration.file_path().unwrap()
        .components()
        .map(|x| x.as_os_str().to_str())
        .collect::<Vec<_>>()
        .last()
        .unwrap()
        .unwrap();
    (format!("{}", output))
}
```

Anyone have any thoughts on refactoring this? Also is this a good solution? Or do we want to parse the output string further to be prettier?

#### Todo
- [x]  Refactor? (Pending Feedback)
- [x] Add/update test coverage
- [ ] Add to Changelog

Edit: Update comment as of [this commit](https://github.com/diesel-rs/diesel/pull/1195/commits/680228a1be9c3f4881d798e97945130b62c0672f)