### PR TITLE
Loosen the bounds on `FilterDsl`

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -51,7 +51,7 @@ where
     &'a Parent: Identifiable,
     Child: HasTable + BelongsTo<Parent>,
     Id<&'a Parent>: AsExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
-    <Child as HasTable>::Table: FilterDsl<Eq<Child::ForeignKeyColumn, Id<&'a Parent>>>,
+    Child::Table: FilterDsl<Eq<Child::ForeignKeyColumn, Id<&'a Parent>>>,
     Child::ForeignKeyColumn: ExpressionMethods,
 {
     type Output = FindBy<Child::Table, Child::ForeignKeyColumn, Id<&'a Parent>>;

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -1,6 +1,7 @@
 use associations::{HasTable, Identifiable};
 use dsl::Find;
 use query_dsl::FindDsl;
+use query_source::Table;
 
 #[doc(hidden)]
 #[derive(Debug)]
@@ -26,10 +27,11 @@ pub trait IntoUpdateTarget: HasTable {
     fn into_update_target(self) -> UpdateTarget<Self::Table, Self::WhereClause>;
 }
 
-impl<T: Identifiable, V> IntoUpdateTarget for T
+impl<T, Tab, V> IntoUpdateTarget for T
 where
-    T::Table: FindDsl<T::Id>,
-    Find<T::Table, T::Id>: IntoUpdateTarget<Table = T::Table, WhereClause = V>,
+    T: Identifiable<Table = Tab>,
+    Tab: Table + FindDsl<T::Id>,
+    Find<Tab, T::Id>: IntoUpdateTarget<Table = Tab, WhereClause = V>,
 {
     type WhereClause = V;
 

--- a/diesel/src/query_dsl/belonging_to_dsl.rs
+++ b/diesel/src/query_dsl/belonging_to_dsl.rs
@@ -1,7 +1,5 @@
-use query_builder::AsQuery;
-
 pub trait BelongingToDsl<T> {
-    type Output: AsQuery;
+    type Output;
 
     fn belonging_to(other: T) -> Self::Output;
 }

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -1,6 +1,5 @@
 use dsl::Filter;
 use expression_methods::*;
-use query_builder::{AsQuery, Query};
 use query_source::*;
 
 /// Adds to the `WHERE` clause of a query. If there is already a `WHERE` clause,
@@ -31,18 +30,18 @@ use query_source::*;
 /// assert_eq!(Ok(2), tess_id);
 /// # }
 /// ```
-pub trait FilterDsl<Predicate>: AsQuery {
-    type Output: AsQuery<SqlType = Self::SqlType>;
+pub trait FilterDsl<Predicate> {
+    type Output;
 
     fn filter(self, predicate: Predicate) -> Self::Output;
 }
 
-impl<T, U, Predicate> FilterDsl<Predicate> for T
+impl<T, Predicate> FilterDsl<Predicate> for T
 where
-    T: Table + AsQuery<SqlType = <U as Query>::SqlType, Query = U>,
-    U: Query + FilterDsl<Predicate, SqlType = <U as Query>::SqlType>,
+    T: Table,
+    T::Query: FilterDsl<Predicate>,
 {
-    type Output = Filter<U, Predicate>;
+    type Output = Filter<T::Query, Predicate>;
 
     fn filter(self, predicate: Predicate) -> Self::Output {
         self.as_query().filter(predicate)
@@ -75,8 +74,8 @@ where
 /// assert_eq!(Err::<(i32, String), _>(NotFound), users.find(3).first(&connection));
 /// # }
 /// ```
-pub trait FindDsl<PK>: AsQuery {
-    type Output: AsQuery<SqlType = Self::SqlType>;
+pub trait FindDsl<PK> {
+    type Output;
 
     fn find(self, id: PK) -> Self::Output;
 }


### PR DESCRIPTION
Prior to this commit, `FilterDsl` required `AsQuery` as a supertrait,
and a bound on its output. This was used both to cause errors to appear
early, and also to ensure that implementations of `FilterDsl` don't
change the `SqlType` of the output.

However, this causes problems in two places. The first is with
subselects that reference the outer table. These select statements are
not valid queries, but they are valid expressions when used as a
subselect on the table being referenced. While this commit doesn't
enable that feature, it does lay the groundwork required for it.

The second place this caused problems was with update/delete statements,
which are not always types that implement `Query` (`Query` specifically
means something with a return type), and in the case of
`IncompleteUpdateStatement` isn't even a `QueryFragment`. With this
change we're able to move their `filter` methods to implementations of
this trait. The doctests are still run, and still show up in
documentation even though it's a trait impl now rather than a separate
method.

The changes to other DSL traits are to avoid infinite recursion problems
that happened as a result of loosening this bound.