### PR TITLE
Fixing passing --database-url as global cli arg

### DIFF
--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -133,6 +133,7 @@ pub fn build_cli() -> App<'static, 'static> {
         .subcommand(generate_bash_completion_subcommand)
         .subcommand(infer_schema_subcommand)
         .setting(AppSettings::SubcommandRequiredElseHelp)
+        .setting(AppSettings::PropagateGlobalValuesDown)
 }
 
 fn migration_dir_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -312,10 +312,15 @@ pub fn schema_table_exists(database_url: &str) -> DatabaseResult<bool> {
     }.map_err(Into::into)
 }
 
-pub fn database_url(matches: &ArgMatches) -> String {
+fn database_url_from_cli(matches: &ArgMatches) -> Option<String> {
     matches
         .value_of("DATABASE_URL")
-        .map(|s| s.into())
+        .map(Into::into)
+        .or_else(|| matches.subcommand().1.and_then(|s| database_url_from_cli(s)))
+}
+
+pub fn database_url(matches: &ArgMatches) -> String {
+    database_url_from_cli(matches)
         .or_else(|| env::var("DATABASE_URL").ok())
         .unwrap_or_else(|| handle_error(DatabaseError::DatabaseUrlMissing))
 }

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -318,7 +318,12 @@ fn database_url_from_cli(matches: &ArgMatches) -> Option<String> {
     matches
         .value_of("DATABASE_URL")
         .map(Into::into)
-        .or_else(|| matches.subcommand().1.and_then(|s| database_url_from_cli(s)))
+        .or_else(|| {
+            matches
+                .subcommand()
+                .1
+                .and_then(|s| database_url_from_cli(s))
+        })
 }
 
 pub fn database_url(matches: &ArgMatches) -> String {

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -312,6 +312,8 @@ pub fn schema_table_exists(database_url: &str) -> DatabaseResult<bool> {
     }.map_err(Into::into)
 }
 
+// FIXME: remove the recursive call here as soon as
+// https://github.com/kbknapp/clap-rs/issues/978 is fixed
 fn database_url_from_cli(matches: &ArgMatches) -> Option<String> {
     matches
         .value_of("DATABASE_URL")

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -191,7 +191,7 @@ fn migration_run_runs_pending_migrations_custom_database_url_1() {
 
     assert!(!db.table_exists("users"));
 
-    let result = p.command("migration")
+    let result = p.command_without_database_url("migration")
         .arg("run")
         .arg("--database-url")
         .arg(db_url)
@@ -223,7 +223,7 @@ fn migration_run_runs_pending_migrations_custom_database_url_2() {
 
     assert!(!db.table_exists("users"));
 
-    let result = p.command("migration")
+    let result = p.command_without_database_url("migration")
         .arg("--database-url")
         .arg(db_url)
         .arg("run")

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -173,3 +173,67 @@ fn any_pending_migrations_after_running_and_creating() {
 
     assert!(result.stdout().contains("true\n"));
 }
+
+#[test]
+fn migration_run_runs_pending_migrations_custom_database_url_1() {
+    let p = project("migration_run").folder("migrations").build();
+    let db_url = p.database_url();
+    let db = database(&db_url);
+
+    // Make sure the project is setup
+    p.command("setup").run();
+
+    p.create_migration(
+        "12345_create_users_table",
+        "CREATE TABLE users ( id INTEGER )",
+        "DROP TABLE users",
+    );
+
+    assert!(!db.table_exists("users"));
+
+    let result = p.command("migration")
+        .arg("run")
+        .arg("--database-url")
+        .arg(db_url)
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(
+        result.stdout().contains("Running migration 12345"),
+        "Unexpected stdout {}",
+        result.stdout()
+    );
+    assert!(db.table_exists("users"));
+}
+
+#[test]
+fn migration_run_runs_pending_migrations_custom_database_url_2() {
+    let p = project("migration_run").folder("migrations").build();
+    let db_url = p.database_url();
+    let db = database(&db_url);
+
+    // Make sure the project is setup
+    p.command("setup").run();
+
+    p.create_migration(
+        "12345_create_users_table",
+        "CREATE TABLE users ( id INTEGER )",
+        "DROP TABLE users",
+    );
+
+    assert!(!db.table_exists("users"));
+
+    let result = p.command("migration")
+        .arg("--database-url")
+        .arg(db_url)
+        .arg("run")
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(
+        result.stdout().contains("Running migration 12345"),
+        "Unexpected stdout {}",
+        result.stdout()
+    );
+    assert!(db.table_exists("users"));
+}

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -176,7 +176,9 @@ fn any_pending_migrations_after_running_and_creating() {
 
 #[test]
 fn migration_run_runs_pending_migrations_custom_database_url_1() {
-    let p = project("migration_run_custom_db_url_1").folder("migrations").build();
+    let p = project("migration_run_custom_db_url_1")
+        .folder("migrations")
+        .build();
     let db_url = p.database_url();
     let db = database(&db_url);
 
@@ -208,7 +210,9 @@ fn migration_run_runs_pending_migrations_custom_database_url_1() {
 
 #[test]
 fn migration_run_runs_pending_migrations_custom_database_url_2() {
-    let p = project("migration_run_custom_db_url_2").folder("migrations").build();
+    let p = project("migration_run_custom_db_url_2")
+        .folder("migrations")
+        .build();
     let db_url = p.database_url();
     let db = database(&db_url);
 

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -176,7 +176,7 @@ fn any_pending_migrations_after_running_and_creating() {
 
 #[test]
 fn migration_run_runs_pending_migrations_custom_database_url_1() {
-    let p = project("migration_run").folder("migrations").build();
+    let p = project("migration_run_custom_db_url_1").folder("migrations").build();
     let db_url = p.database_url();
     let db = database(&db_url);
 
@@ -208,7 +208,7 @@ fn migration_run_runs_pending_migrations_custom_database_url_1() {
 
 #[test]
 fn migration_run_runs_pending_migrations_custom_database_url_2() {
-    let p = project("migration_run").folder("migrations").build();
+    let p = project("migration_run_custom_db_url_2").folder("migrations").build();
     let db_url = p.database_url();
     let db = database(&db_url);
 


### PR DESCRIPTION
--database-url is passed as global cli argument, this means it may be
  not part of the current ArgMatches. To solve this we need to look recursivly in all current subcommands for the database-url