### PR TITLE
Allow subselects to reference columns from the outer table

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -139,7 +139,6 @@ pub trait MaybeEmpty {
 
 impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<ST> for SelectStatement<S, F, W, O, L, Of, G, FU>
 where
-    Self: Query<SqlType = ST>,
     Subselect<Self, ST>: Expression<SqlType = ST>,
 {
     type InExpression = Subselect<Self, ST>;
@@ -221,7 +220,7 @@ pub struct Subselect<T, ST> {
     _sql_type: PhantomData<ST>,
 }
 
-impl<T: Query, ST> Expression for Subselect<T, ST> {
+impl<T: Expression, ST> Expression for Subselect<T, ST> {
     type SqlType = ST;
 }
 
@@ -234,14 +233,14 @@ impl<T, ST> MaybeEmpty for Subselect<T, ST> {
 impl<T, ST, QS> SelectableExpression<QS> for Subselect<T, ST>
 where
     Subselect<T, ST>: AppearsOnTable<QS>,
-    T: Query,
+    T: SelectableExpression<QS>,
 {
 }
 
 impl<T, ST, QS> AppearsOnTable<QS> for Subselect<T, ST>
 where
     Subselect<T, ST>: Expression,
-    T: Query,
+    T: AppearsOnTable<QS>,
 {
 }
 

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -36,8 +36,8 @@ use types::Bool;
 /// assert_eq!(Ok(false), jim_exists);
 /// # }
 /// ```
-pub fn exists<T: AsQuery>(query: T) -> Exists<T::Query> {
-    Exists(query.as_query())
+pub fn exists<T>(query: T) -> Exists<T> {
+    Exists(query)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -45,7 +45,7 @@ pub struct Exists<T>(T);
 
 impl<T> Expression for Exists<T>
 where
-    T: Query,
+    T: Expression,
 {
     type SqlType = Bool;
 }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -745,6 +745,10 @@ macro_rules! table_body {
                 type Count = Once;
             }
 
+            impl AppearsInFromClause<table> for () {
+                type Count = Never;
+            }
+
             impl<T> AppearsInFromClause<T> for table where
                 T: Table + JoinTo<table>,
             {
@@ -1103,6 +1107,7 @@ mod tests {
     }
 
     mod my_types {
+        #[derive(Debug, Clone, Copy)]
         pub struct MyCustomType;
     }
 

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -85,12 +85,10 @@ where
     }
 }
 
-impl<ST, F, S, D, W, O, L, Of, G, FU, Predicate> FilterDsl<Predicate>
+impl<F, S, D, W, O, L, Of, G, FU, Predicate> FilterDsl<Predicate>
     for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
-    Self: AsQuery<SqlType = ST>,
-    SelectStatement<F, S, D, W::Output, O, L, Of, G, FU>: Query<SqlType = ST>,
-    Predicate: AppearsOnTable<F, SqlType = Bool> + NonAggregate,
+    Predicate: Expression<SqlType = Bool> + NonAggregate,
     W: WhereAnd<Predicate>,
 {
     type Output = SelectStatement<F, S, D, W::Output, O, L, Of, G, FU>;
@@ -327,6 +325,7 @@ where
 impl<F, W> IntoUpdateTarget for SelectStatement<F, DefaultSelectClause, NoDistinctClause, W>
 where
     SelectStatement<F, DefaultSelectClause, NoDistinctClause, W>: HasTable,
+    W: ValidWhereClause<F>,
 {
     type WhereClause = W;
 

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -17,7 +17,7 @@ pub use self::boxed::BoxedSelectStatement;
 use backend::Backend;
 use expression::*;
 use query_source::*;
-use query_source::joins::AppendSelection;
+use query_source::joins::{AppendSelection, Inner, Join};
 use result::QueryResult;
 use super::distinct_clause::NoDistinctClause;
 use super::for_update_clause::NoForUpdateClause;
@@ -26,7 +26,7 @@ use super::limit_clause::NoLimitClause;
 use super::offset_clause::NoOffsetClause;
 use super::order_clause::NoOrderClause;
 use super::select_clause::*;
-use super::where_clause::NoWhereClause;
+use super::where_clause::*;
 use super::{AstPass, Query, QueryFragment};
 
 #[derive(Debug, Clone, Copy)]
@@ -100,6 +100,7 @@ impl<F> SelectStatement<F> {
 impl<F, S, D, W, O, L, Of, G, FU> Query for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
     S: SelectClauseExpression<F>,
+    W: ValidWhereClause<F>,
 {
     type SqlType = S::SelectClauseSqlType;
 }
@@ -188,9 +189,10 @@ where
 }
 
 impl<S, F, D, W, O, L, Of, G, FU, QS> AppearsOnTable<QS>
-    for SelectStatement<S, F, D, W, O, L, Of, FU, G>
+    for SelectStatement<F, S, D, W, O, L, Of, FU, G>
 where
     Self: Expression,
+    W: ValidWhereClause<Join<F, QS, Inner>>,
 {
 }
 

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -78,3 +78,15 @@ where
         Some(Box::new(self.0))
     }
 }
+
+/// Marker trait indicating that a `WHERE` clause is valid for a given query
+/// source.
+pub trait ValidWhereClause<QS> {}
+
+impl<QS> ValidWhereClause<QS> for NoWhereClause {}
+
+impl<QS, Expr> ValidWhereClause<QS> for WhereClause<Expr>
+where
+    Expr: AppearsOnTable<QS>,
+{
+}

--- a/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -1,5 +1,5 @@
-#[macro_use]
-extern crate diesel;
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
 
 use diesel::*;
 use diesel::dsl::*;
@@ -17,10 +17,21 @@ table! {
     }
 }
 
+#[derive(Queryable)]
+struct Stuff {
+    id: i32,
+    name: String,
+}
+
 fn main() {
     use self::stuff::dsl::*;
 
-    stuff.filter(name.eq(any(more_stuff::names)));
+    let conn = PgConnection::establish("").unwrap();
+
+    let _ = LoadDsl::load::<Stuff>(
     //~^ ERROR E0277
     //~| ERROR E0271
+        stuff.filter(name.eq(any(more_stuff::names))),
+        &conn,
+    );
 }

--- a/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -1,7 +1,8 @@
-#[macro_use]
-extern crate diesel;
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
 
 use diesel::*;
+use diesel::pg::Pg;
 
 table! {
     users {
@@ -17,11 +18,50 @@ table! {
     }
 }
 
+#[derive(Queryable)]
+struct User {
+    id: i32,
+    name: String,
+}
+
 fn main() {
-    let _ = users::table.filter(posts::id.eq(1));
+    let conn = PgConnection::establish("").unwrap();
+
+    let _ = LoadDsl::load::<User>(
     //~^ ERROR AppearsInFromClause
     //~| ERROR E0277
-    let _ = users::table.filter(users::name.eq(posts::title));
+        users::table.filter(posts::id.eq(1)),
+        &conn,
+    );
+
+    let _ = users::table
+        .into_boxed::<Pg>()
+        .filter(posts::id.eq(1));
+        //~^ ERROR AppearsInFromClause
+        //~| ERROR E0277
+
+    let _ = BoxedDsl::into_boxed::<Pg>(
     //~^ ERROR AppearsInFromClause
     //~| ERROR E0277
+        users::table.filter(posts::id.eq(1))
+    );
+
+    let _ = LoadDsl::load::<User>(
+    //~^ ERROR AppearsInFromClause
+    //~| ERROR E0277
+        users::table.filter(users::name.eq(posts::title)),
+        &conn,
+    );
+
+    let _ = users::table.into_boxed::<Pg>()
+        .filter(users::name.eq(posts::title));
+        //~^ ERROR AppearsInFromClause
+        //~| ERROR E0277
+
+    let _ = BoxedDsl::into_boxed::<Pg>(
+    //~^ ERROR AppearsInFromClause
+    //~| ERROR E0277
+        users::table
+            .filter(users::name.eq(posts::title))
+    );
 }

--- a/diesel_compile_tests/tests/compile-fail/filter_requires_bool_nonaggregate_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_requires_bool_nonaggregate_expression.rs
@@ -1,0 +1,20 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+fn main() {
+    use diesel::dsl::sum;
+
+    let _ = users::table.filter(users::name);
+    //~^ ERROR type mismatch resolving `<users::columns::name as diesel::Expression>::SqlType == diesel::types::Bool`
+    let _ = users::table.filter(sum(users::id).eq(1));
+    //~^ ERROR NonAggregate
+}

--- a/diesel_compile_tests/tests/compile-fail/subselect_cannot_reference_random_tables.rs
+++ b/diesel_compile_tests/tests/compile-fail/subselect_cannot_reference_random_tables.rs
@@ -1,0 +1,53 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+    }
+}
+
+table! {
+    comments {
+        id -> Integer,
+    }
+}
+
+enable_multi_table_joins!(users, posts);
+enable_multi_table_joins!(users, comments);
+enable_multi_table_joins!(posts, comments);
+
+fn main() {
+    use diesel::dsl::{any, exists};
+
+    let conn = PgConnection::establish("").unwrap();
+
+    let _ = LoadDsl::load::<(i32,)>(
+    //~^ ERROR E0271
+        users::table
+            .filter(users::id.eq_any(posts::table.select(posts::id).filter(comments::id.eq(1)))),
+        &conn,
+    );
+
+    let _ = LoadDsl::load::<(i32,)>(
+    //~^ ERROR E0271
+        users::table.filter(users::id.eq(any(
+            posts::table.select(posts::id).filter(comments::id.eq(1)),
+        ))),
+        &conn,
+    );
+
+    let _ = LoadDsl::load::<(i32,)>(
+    //~^ ERROR E0271
+        users::table.filter(exists(posts::table.filter(comments::id.eq(1)))),
+        &conn,
+    );
+}

--- a/diesel_compile_tests/tests/compile-fail/update_requires_valid_where_clause.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_requires_valid_where_clause.rs
@@ -19,7 +19,7 @@ fn main() {
     update(users::table).filter(users::id.eq(1));
 
     update(users::table.filter(posts::id.eq(1)));
-    //~^ ERROR E0271
+    //~^ ERROR E0277
     //~| ERROR E0277
 
     update(users::table).filter(posts::id.eq(1));

--- a/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
+++ b/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
@@ -1,5 +1,5 @@
-#[macro_use]
-extern crate diesel;
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
 
 use diesel::*;
 use diesel::types::*;
@@ -18,6 +18,12 @@ table! {
     }
 }
 
+#[derive(Queryable)]
+struct User {
+    id: i32,
+    name: String,
+}
+
 sql_function!(foo, foo_t, (x: Integer) -> Integer);
 sql_function!(bar, bar_t, (x: VarChar) -> VarChar);
 
@@ -25,9 +31,15 @@ fn main() {
     use self::users::name;
     use self::posts::title;
 
+    let conn = PgConnection::establish("").unwrap();
+
     let _ = users::table.filter(name.eq(foo(1)));
     //~^ ERROR type mismatch
-    let _ = users::table.filter(name.eq(bar(title)));
+
+    let _ = LoadDsl::load::<User>(
     //~^ ERROR E0277
     //~| ERROR E0271
+        users::table.filter(name.eq(bar(title))),
+        &conn,
+    );
 }

--- a/diesel_infer_schema/src/information_schema.rs
+++ b/diesel_infer_schema/src/information_schema.rs
@@ -113,6 +113,7 @@ mod information_schema {
     }
 
     enable_multi_table_joins!(table_constraints, referential_constraints);
+    enable_multi_table_joins!(key_column_usage, table_constraints);
 }
 
 pub fn get_table_data<Conn>(conn: &Conn, table: &TableName) -> QueryResult<Vec<ColumnInformation>>


### PR DESCRIPTION
This changes the semantics of `exists`, and the various array_comparison
functions/methods to allow the subselect passed to them to reference
columns from the outer table. In other words, this allows subselects
which are not valid queries on their own, but are valid expressions in
this context.

Note that this only allows the where clause to reference the outer
table, as it's much less useful to do so from elsewhere in the query.

There are a few side effects of this change that will need to be
addressed later on. The first is that `exists` can now take any
expression, not just select statements. We should limit this to
`BoxedSelectStatement` and `SelectStatement`. Second is that you can no
longer pass a subselect to the same table. I'm not entirely sure how we
go about fixing this just yet, but that's a much more niche use case
anyway.

There is still additional work to be done to make this useable though,
as it will still be impossible to construct many queries while most of
our DSL methods still have `AsQuery` bounds. They will need to be
loosened in a similar fashion to #1200.