### PR TITLE
Loosen the bounds on `SelectDsl`

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -40,11 +40,11 @@ where
     }
 }
 
-impl<F, S, D, W, O, L, Of, G, FU, Selection, Type> SelectDsl<Selection>
+impl<F, S, D, W, O, L, Of, G, FU, Selection> SelectDsl<Selection>
     for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
-    Selection: Expression<SqlType = Type>,
-    SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G, FU>: Query<SqlType = Type>,
+    Selection: Expression,
+    SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G, FU>: Expression,
 {
     type Output = SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G, FU>;
 

--- a/diesel/src/query_dsl/select_dsl.rs
+++ b/diesel/src/query_dsl/select_dsl.rs
@@ -1,5 +1,4 @@
-use expression::*;
-use query_builder::{AsQuery, Query};
+use expression::Expression;
 use query_source::Table;
 
 /// Sets the select clause of a query. If there was already a select clause, it
@@ -7,7 +6,10 @@ use query_source::Table;
 /// for the query (only contains columns from the target table, doesn't mix
 /// aggregate + non-aggregate expressions, etc).
 pub trait SelectDsl<Selection: Expression> {
-    type Output: Query<SqlType = <Selection as Expression>::SqlType>;
+    // FIXME: Once we've refactored the `impl Expression` on `SelectStatement`
+    // to not conditionally be `types::Array`, it is probably worthwhile to
+    // add a `: Expression<SqlType = Selection::SqlType>` bound here.
+    type Output;
 
     fn select(self, selection: Selection) -> Self::Output;
 }
@@ -15,7 +17,7 @@ pub trait SelectDsl<Selection: Expression> {
 impl<T, Selection> SelectDsl<Selection> for T
 where
     Selection: Expression,
-    T: Table + AsQuery,
+    T: Table,
     T::Query: SelectDsl<Selection>,
 {
     type Output = <T::Query as SelectDsl<Selection>>::Output;


### PR DESCRIPTION
This removes the `AsQuery` bounds from `SelectDsl`, so that `.select`
can be called on something that is not a valid query. This is important
because a `SelectStatement` that is intended to be used as a subselect
may reference an outer table, making it an invalid query but a valid
subselect.

This does *not* change the allowed arguments. While it is technically
valid to reference a column from the outer table in a subselect, there
is virtually no reason to do so. By continuing to require
`SelectableExpression<FromClause>` at the point where `select` is
called, we give much better errors.

One thing that is lost with this change is that the signature of
`SelectDsl` no longer requires that the output query have the same SQL
type as the selection. This is something I'd like to bring back, but
right now the way we implement `Expression` for `SelectStatement`
basically makes it impossible to do so.