### PR TITLE
Deny warnings in pg integration tests

### DIFF
--- a/diesel_tests/build.rs
+++ b/diesel_tests/build.rs
@@ -54,6 +54,7 @@ fn main() {
     let migrations_dir = migrations::find_migrations_directory()
         .unwrap()
         .join(MIGRATION_SUBDIR);
+    println!("cargo:rerun-if-changed={}", MIGRATION_SUBDIR);
     migrations::run_pending_migrations_in_directory(
         &connection(),
         &migrations_dir,

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -326,8 +326,8 @@ fn nested_queryable_derives() {
 
     let conn = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &conn);
-    insert(&sean.new_post("Hi", None))
-        .into(posts::table)
+    insert_into(posts::table)
+        .values(&sean.new_post("Hi", None))
         .execute(&conn)
         .unwrap();
     let post = posts::table.first(&conn).unwrap();

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -394,9 +394,11 @@ fn filter_subselect_referencing_outer_table() {
     let conn = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &conn);
 
-    let new_posts = vec![sean.new_post("Hello", None), sean.new_post("Hello 2", None)];
-    insert(&new_posts)
-        .into(posts::table)
+    insert_into(posts::table)
+        .values(&vec![
+            sean.new_post("Hello", None),
+            sean.new_post("Hello 2", None),
+        ])
         .execute(&conn)
         .unwrap();
 
@@ -426,9 +428,11 @@ fn filter_subselect_with_pg_any() {
     let conn = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &conn);
 
-    let new_posts = vec![sean.new_post("Hello", None), sean.new_post("Hello 2", None)];
-    insert(&new_posts)
-        .into(posts::table)
+    insert_into(posts::table)
+        .values(&vec![
+            sean.new_post("Hello", None),
+            sean.new_post("Hello 2", None),
+        ])
         .execute(&conn)
         .unwrap();
 

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -274,6 +274,7 @@ fn upsert_empty_slice() {
 
 #[test]
 #[cfg(not(feature = "mysql"))]
+#[allow(deprecated)]
 fn insert_only_default_values_deprecated() {
     use schema::users::table as users;
     use schema_dsl::*;

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "1024"]
+#![cfg_attr(feature = "postgres", deny(warnings))]
 
 #[macro_use]
 extern crate assert_matches;

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -270,7 +270,6 @@ fn select_can_be_called_on_query_that_is_valid_subselect_but_invalid_query() {
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
     let tess = find_user_by_name("Tess", &connection);
-    let new_post = tess.new_post("Tess", None);
     insert_into(posts::table)
         .values(&vec![
             tess.new_post("Tess", None),

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -4,7 +4,6 @@ extern crate chrono;
 
 pub use quickcheck::quickcheck;
 use self::chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-use self::chrono::naive::{MAX_DATE, MIN_DATE};
 
 pub use schema::{connection, TestConnection};
 pub use diesel::*;
@@ -308,6 +307,8 @@ fn mk_bigdecimal(data: (i64, u64)) -> bigdecimal::BigDecimal {
 
 #[cfg(feature = "postgres")]
 pub fn mk_naive_date(days: u32) -> NaiveDate {
+    use self::chrono::naive::MAX_DATE;
+
     let earliest_pg_date = NaiveDate::from_ymd(-4713, 11, 24);
     let latest_chrono_date = MAX_DATE;
     let num_days_representable = latest_chrono_date
@@ -328,6 +329,8 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
 
 #[cfg(feature = "sqlite")]
 pub fn mk_naive_date(days: u32) -> NaiveDate {
+    use self::chrono::naive::{MAX_DATE, MIN_DATE};
+
     let earliest_sqlite_date = MIN_DATE;
     let latest_sqlite_date = MAX_DATE;
     let num_days_representable = latest_sqlite_date

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -331,8 +331,6 @@ fn update_with_no_changes() {
 #[test]
 #[cfg(feature = "postgres")]
 fn upsert_with_no_changes_executes_do_nothing() {
-    use diesel::pg::upsert::*;
-
     #[derive(AsChangeset)]
     #[table_name = "users"]
     struct Changes {

--- a/migrations/postgresql/2017-09-26-151545_fix_posts_tags/down.sql
+++ b/migrations/postgresql/2017-09-26-151545_fix_posts_tags/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ALTER COLUMN tags TYPE varchar[];

--- a/migrations/postgresql/2017-09-26-151545_fix_posts_tags/up.sql
+++ b/migrations/postgresql/2017-09-26-151545_fix_posts_tags/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ALTER COLUMN tags TYPE text[];


### PR DESCRIPTION
The number of warnings in our test suite is steadily growing, and I'd
like to squash that problem sooner rather than later. Right now this
only tackles the warnings from PG, as that has the smallest number.
There will be follow-up PRs for the other backends.