### PR TITLE
Loosen the rest of `query_dsl`

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -65,8 +65,8 @@ where
 
 impl<ST, F, S, D, W, O, L, Of, G> DistinctDsl for SelectStatement<F, S, D, W, O, L, Of, G>
 where
-    SelectStatement<F, S, D, W, O, L, Of, G>: AsQuery<SqlType = ST>,
-    SelectStatement<F, S, DistinctClause, W, O, L, Of, G>: AsQuery<SqlType = ST>,
+    Self: Expression<SqlType = ST>,
+    SelectStatement<F, S, DistinctClause, W, O, L, Of, G>: Expression<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, DistinctClause, W, O, L, Of, G>;
 
@@ -130,8 +130,8 @@ impl<ST, F, S, D, W, O, L, Of, G, FU, Expr> OrderDsl<Expr>
     for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
     Expr: AppearsOnTable<F>,
-    Self: AsQuery<SqlType = ST>,
-    SelectStatement<F, S, D, W, OrderClause<Expr>, L, Of, G, FU>: AsQuery<SqlType = ST>,
+    Self: Expression<SqlType = ST>,
+    SelectStatement<F, S, D, W, OrderClause<Expr>, L, Of, G, FU>: Expression<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, D, W, OrderClause<Expr>, L, Of, G, FU>;
 
@@ -156,8 +156,8 @@ pub type Limit = <i64 as AsExpression<types::BigInt>>::Expression;
 
 impl<ST, F, S, D, W, O, L, Of, G, FU> LimitDsl for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
-    Self: AsQuery<SqlType = ST>,
-    SelectStatement<F, S, D, W, O, LimitClause<Limit>, Of, G, FU>: Query<SqlType = ST>,
+    Self: Expression<SqlType = ST>,
+    SelectStatement<F, S, D, W, O, LimitClause<Limit>, Of, G, FU>: Expression<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, D, W, O, LimitClause<Limit>, Of, G, FU>;
 
@@ -182,8 +182,8 @@ pub type Offset = Limit;
 
 impl<ST, F, S, D, W, O, L, Of, G, FU> OffsetDsl for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
-    Self: AsQuery<SqlType = ST>,
-    SelectStatement<F, S, D, W, O, L, OffsetClause<Offset>, G, FU>: AsQuery<SqlType = ST>,
+    Self: Expression<SqlType = ST>,
+    SelectStatement<F, S, D, W, O, L, OffsetClause<Offset>, G, FU>: Expression<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, D, W, O, L, OffsetClause<Offset>, G, FU>;
 

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -1,4 +1,3 @@
-use query_builder::AsQuery;
 use query_source::Table;
 
 /// Adds the `DISTINCT` keyword to a query.
@@ -31,15 +30,15 @@ use query_source::Table;
 /// assert_eq!(Ok(vec![sean.clone()]), distinct_names);
 /// # }
 /// ```
-pub trait DistinctDsl: AsQuery {
-    type Output: AsQuery<SqlType = Self::SqlType>;
+pub trait DistinctDsl {
+    type Output;
     fn distinct(self) -> Self::Output;
 }
 
-impl<T, ST> DistinctDsl for T
+impl<T> DistinctDsl for T
 where
-    T: Table + AsQuery<SqlType = ST>,
-    T::Query: DistinctDsl<SqlType = ST>,
+    T: Table,
+    T::Query: DistinctDsl,
 {
     type Output = <T::Query as DistinctDsl>::Output;
 

--- a/diesel/src/query_dsl/limit_dsl.rs
+++ b/diesel/src/query_dsl/limit_dsl.rs
@@ -1,19 +1,18 @@
-use query_builder::AsQuery;
 use query_source::Table;
 
 /// Sets the limit clause of a query. If there was already a limit clause, it
 /// will be overridden. This is automatically implemented for the various query
 /// builder types.
-pub trait LimitDsl: AsQuery {
-    type Output: AsQuery<SqlType = Self::SqlType>;
+pub trait LimitDsl {
+    type Output;
 
     fn limit(self, limit: i64) -> Self::Output;
 }
 
-impl<T, ST> LimitDsl for T
+impl<T> LimitDsl for T
 where
-    T: Table + AsQuery<SqlType = ST>,
-    T::Query: LimitDsl<SqlType = ST>,
+    T: Table,
+    T::Query: LimitDsl,
 {
     type Output = <T::Query as LimitDsl>::Output;
 

--- a/diesel/src/query_dsl/offset_dsl.rs
+++ b/diesel/src/query_dsl/offset_dsl.rs
@@ -1,19 +1,18 @@
-use query_builder::AsQuery;
 use query_source::Table;
 
 /// Sets the offset clause of a query. If there was already a offset clause, it
 /// will be overridden. This is automatically implemented for the various query
 /// builder types.
-pub trait OffsetDsl: AsQuery {
-    type Output: AsQuery<SqlType = Self::SqlType>;
+pub trait OffsetDsl {
+    type Output;
 
     fn offset(self, offset: i64) -> Self::Output;
 }
 
-impl<T, ST> OffsetDsl for T
+impl<T> OffsetDsl for T
 where
-    T: Table + AsQuery<SqlType = ST>,
-    T::Query: OffsetDsl<SqlType = ST>,
+    T: Table,
+    T::Query: OffsetDsl,
 {
     type Output = <T::Query as OffsetDsl>::Output;
 

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -1,5 +1,4 @@
 use expression::Expression;
-use query_builder::AsQuery;
 use query_source::Table;
 
 /// Sets the order clause of a query. If there was already a order clause, it
@@ -41,17 +40,17 @@ use query_source::Table;
 /// assert_eq!(vec![(String::from("Saul"), 3), (String::from("Stan"), 6), (String::from("Stan"), 5), (String::from("Steve"), 4)], ordered_name_id_pairs);
 /// # }
 /// ```
-pub trait OrderDsl<Expr: Expression>: AsQuery {
-    type Output: AsQuery<SqlType = Self::SqlType>;
+pub trait OrderDsl<Expr: Expression> {
+    type Output;
 
     fn order(self, expr: Expr) -> Self::Output;
 }
 
-impl<T, Expr, ST> OrderDsl<Expr> for T
+impl<T, Expr> OrderDsl<Expr> for T
 where
     Expr: Expression,
-    T: Table + AsQuery<SqlType = ST>,
-    T::Query: OrderDsl<Expr, SqlType = ST>,
+    T: Table,
+    T::Query: OrderDsl<Expr>,
 {
     type Output = <T::Query as OrderDsl<Expr>>::Output;
 


### PR DESCRIPTION
See 6e7a1ba5a830a4309bad85bdf56b6841e6cb1edb for more information on why
we want to do this. This loosens everything else in our query builder
DSL with the exception of two:

- `GroupByDsl` because it is not yet public API
- `JoinDsl` because we use `AsQuery` to avoid polluting the namespace of
  every type out there, and I'm not sure what I want to do with it yet.