### PR TITLE
Add a method generic version of `AsExpression`

### DIFF
--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -1,5 +1,5 @@
 use dsl::AsExprOf;
-use expression::AsExpression;
+use expression::IntoSql;
 use expression::operators::{Escape, Like, NotLike};
 use types::VarChar;
 /// Adds the `escape` method to `LIKE` and `NOT LIKE`. This is used to specify
@@ -36,10 +36,7 @@ use types::VarChar;
 /// ```
 pub trait EscapeExpressionMethods: Sized {
     fn escape(self, character: char) -> Escape<Self, AsExprOf<String, VarChar>> {
-        Escape::new(
-            self,
-            AsExpression::<VarChar>::as_expression(character.to_string()),
-        )
+        Escape::new(self, character.to_string().into_sql::<VarChar>())
     }
 }
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -141,7 +141,8 @@ pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using Diesel.
     pub use associations::{GroupedBy, Identifiable};
     pub use connection::Connection;
-    pub use expression::{AppearsOnTable, BoxableExpression, Expression, SelectableExpression};
+    pub use expression::{AppearsOnTable, BoxableExpression, Expression, IntoSql,
+                         SelectableExpression};
     pub use expression_methods::*;
     #[doc(inline)]
     pub use insertable::Insertable;

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -174,7 +174,7 @@ macro_rules! impl_Insertable {
 
             #[allow(non_shorthand_field_patterns)]
             fn values(self) -> Self::Values {
-                use $crate::expression::{AsExpression, Expression};
+                use $crate::expression::{Expression, IntoSql};
                 use $crate::insertable::ColumnInsertValue;
                 let $self_to_columns = *self;
                 ($(
@@ -222,8 +222,7 @@ macro_rules! Insertable_column_expr {
     ($column:path, $field_access:expr, regular) => {
         ColumnInsertValue::Expression(
             $column,
-            AsExpression::<<$column as Expression>::SqlType>
-                ::as_expression($field_access),
+            $field_access.into_sql::<<$column as Expression>::SqlType>(),
         )
     };
 }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -163,7 +163,6 @@ mod tests {
     use self::dotenv::dotenv;
     use std::env;
 
-    use expression::AsExpression;
     use dsl::sql;
     use prelude::*;
     use super::*;
@@ -173,7 +172,7 @@ mod tests {
     fn prepared_statements_are_cached() {
         let connection = connection();
 
-        let query = ::select(AsExpression::<Integer>::as_expression(1));
+        let query = ::select(1.into_sql::<Integer>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -184,8 +183,8 @@ mod tests {
     fn queries_with_identical_sql_but_different_types_are_cached_separately() {
         let connection = connection();
 
-        let query = ::select(AsExpression::<Integer>::as_expression(1));
-        let query2 = ::select(AsExpression::<VarChar>::as_expression("hi"));
+        let query = ::select(1.into_sql::<Integer>());
+        let query2 = ::select("hi".into_sql::<VarChar>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok("hi".to_string()), query2.get_result(&connection));
@@ -196,8 +195,8 @@ mod tests {
     fn queries_with_identical_types_and_sql_but_different_bind_types_are_cached_separately() {
         let connection = connection();
 
-        let query = ::select(AsExpression::<Integer>::as_expression(1)).into_boxed::<Pg>();
-        let query2 = ::select(AsExpression::<VarChar>::as_expression("hi")).into_boxed::<Pg>();
+        let query = ::select(1.into_sql::<Integer>()).into_boxed::<Pg>();
+        let query2 = ::select("hi".into_sql::<VarChar>()).into_boxed::<Pg>();
 
         assert_eq!(0, connection.statement_cache.len());
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -210,7 +209,7 @@ mod tests {
         let connection = connection();
 
         sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
-        let hi = AsExpression::<VarChar>::as_expression("HI");
+        let hi = "HI".into_sql::<VarChar>();
         let query = ::select(hi).into_boxed::<Pg>();
         let query2 = ::select(lower(hi)).into_boxed::<Pg>();
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -221,11 +221,10 @@ mod tests {
 
     #[test]
     fn times_with_timezones_round_trip_after_conversion() {
-        use expression::AsExpression;
         let connection = connection();
         let time = FixedOffset::east(3600).ymd(2016, 1, 2).and_hms(1, 0, 0);
         let expected = NaiveDate::from_ymd(2016, 1, 1).and_hms(20, 0, 0);
-        let query = select(AsExpression::<Timestamptz>::as_expression(time).at_time_zone("EDT"));
+        let query = select(time.into_sql::<Timestamptz>().at_time_zone("EDT"));
         assert_eq!(Ok(expected), query.get_result(&connection));
     }
 

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -182,8 +182,7 @@ where
     type Output = Self;
 
     fn limit(mut self, limit: i64) -> Self::Output {
-        let limit_expression = AsExpression::<BigInt>::as_expression(limit);
-        self.limit = Box::new(LimitClause(limit_expression));
+        self.limit = Box::new(LimitClause(limit.into_sql::<BigInt>()));
         self
     }
 }
@@ -196,8 +195,7 @@ where
     type Output = Self;
 
     fn offset(mut self, offset: i64) -> Self::Output {
-        let offset_expression = AsExpression::<BigInt>::as_expression(offset);
-        self.offset = Box::new(OffsetClause(offset_expression));
+        self.offset = Box::new(OffsetClause(offset.into_sql::<BigInt>()));
         self
     }
 }

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -1,5 +1,6 @@
 use associations::HasTable;
 use backend::Backend;
+use dsl::AsExprOf;
 use expression::*;
 use query_builder::distinct_clause::*;
 use query_builder::for_update_clause::*;
@@ -16,7 +17,7 @@ use query_dsl::boxed_dsl::InternalBoxedDsl;
 use query_source::QuerySource;
 use query_source::joins::{Join, JoinOn, JoinTo};
 use super::BoxedSelectStatement;
-use types::{self, Bool};
+use types::{BigInt, Bool};
 
 impl<F, S, D, W, O, L, Of, G, FU, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On>
     for SelectStatement<F, S, D, W, O, L, Of, G, FU>
@@ -152,7 +153,7 @@ where
 }
 
 #[doc(hidden)]
-pub type Limit = <i64 as AsExpression<types::BigInt>>::Expression;
+pub type Limit = AsExprOf<i64, BigInt>;
 
 impl<ST, F, S, D, W, O, L, Of, G, FU> LimitDsl for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
@@ -162,7 +163,7 @@ where
     type Output = SelectStatement<F, S, D, W, O, LimitClause<Limit>, Of, G, FU>;
 
     fn limit(self, limit: i64) -> Self::Output {
-        let limit_clause = LimitClause(AsExpression::<types::BigInt>::as_expression(limit));
+        let limit_clause = LimitClause(limit.into_sql::<BigInt>());
         SelectStatement::new(
             self.select,
             self.from,
@@ -188,7 +189,7 @@ where
     type Output = SelectStatement<F, S, D, W, O, L, OffsetClause<Offset>, G, FU>;
 
     fn offset(self, offset: i64) -> Self::Output {
-        let offset_clause = OffsetClause(AsExpression::<types::BigInt>::as_expression(offset));
+        let offset_clause = OffsetClause(offset.into_sql::<BigInt>());
         SelectStatement::new(
             self.select,
             self.from,

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -132,7 +132,6 @@ fn error_message(err_code: libc::c_int) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use expression::AsExpression;
     use dsl::sql;
     use prelude::*;
     use super::*;
@@ -141,7 +140,7 @@ mod tests {
     #[test]
     fn prepared_statements_are_cached_when_run() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
-        let query = ::select(AsExpression::<Integer>::as_expression(1));
+        let query = ::select(1.into_sql::<Integer>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -160,7 +159,7 @@ mod tests {
     #[test]
     fn queries_containing_sql_literal_nodes_are_not_cached() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
-        let one_as_expr = AsExpression::<Integer>::as_expression(1);
+        let one_as_expr = 1.into_sql::<Integer>();
         let query = ::select(one_as_expr.eq(sql::<Integer>("1")));
 
         assert_eq!(Ok(true), query.get_result(&connection));
@@ -170,7 +169,7 @@ mod tests {
     #[test]
     fn queries_containing_in_with_vec_are_not_cached() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
-        let one_as_expr = AsExpression::<Integer>::as_expression(1);
+        let one_as_expr = 1.into_sql::<Integer>();
         let query = ::select(one_as_expr.eq_any(vec![1, 2, 3]));
 
         assert_eq!(Ok(true), query.get_result(&connection));
@@ -180,7 +179,7 @@ mod tests {
     #[test]
     fn queries_containing_in_with_subselect_are_cached() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
-        let one_as_expr = AsExpression::<Integer>::as_expression(1);
+        let one_as_expr = 1.into_sql::<Integer>();
         let query = ::select(one_as_expr.eq_any(::select(one_as_expr)));
 
         assert_eq!(Ok(true), query.get_result(&connection));

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -143,7 +143,8 @@ where
 
 use expression::bound::Bound;
 use expression::{AsExpression, Expression};
-impl<'a, T: ?Sized, ST> ::expression::AsExpression<ST> for Cow<'a, T>
+
+impl<'a, T: ?Sized, ST> AsExpression<ST> for Cow<'a, T>
 where
     T: 'a + ToOwned,
     Bound<ST, Cow<'a, T>>: Expression<SqlType = ST>,
@@ -155,14 +156,14 @@ where
     }
 }
 
-impl<'a, 'b, T: ?Sized, ST> ::expression::AsExpression<ST> for &'b Cow<'a, T>
+impl<'a, 'b, T: ?Sized, ST> AsExpression<ST> for &'b Cow<'a, T>
 where
     T: 'a + ToOwned,
-    &'b T: AsExpression<ST>,
+    Bound<ST, &'b T>: Expression<SqlType = ST>,
 {
-    type Expression = <&'b T as AsExpression<ST>>::Expression;
+    type Expression = Bound<ST, &'b T>;
 
     fn as_expression(self) -> Self::Expression {
-        (&**self).as_expression()
+        Bound::new(&**self)
     }
 }

--- a/diesel_compile_tests/tests/compile-fail/update_requires_left_side_of_eq_to_be_a_column.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_requires_left_side_of_eq_to_be_a_column.rs
@@ -2,7 +2,6 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::expression::AsExpression;
 
 table! {
     users {
@@ -14,7 +13,7 @@ table! {
 fn main() {
     use self::users::dsl::*;
 
-    let foo = AsExpression::<types::VarChar>::as_expression("foo");
+    let foo = "foo".into_sql::<types::VarChar>();
     let command = update(users).set(foo.eq(name));
     //~^ ERROR Column
 }

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -317,10 +317,9 @@ fn filter_with_or() {
 #[test]
 fn or_doesnt_mess_with_precidence_of_previous_statements() {
     use schema::users::dsl::*;
-    use diesel::expression::AsExpression;
 
     let connection = connection_with_sean_and_tess_in_users_table();
-    let f = AsExpression::<types::Bool>::as_expression(false);
+    let f = false.into_sql::<types::Bool>();
     let count = users
         .filter(f)
         .filter(f.or(true))

--- a/diesel_tests/tests/internal_details.rs
+++ b/diesel_tests/tests/internal_details.rs
@@ -1,6 +1,5 @@
 use schema::*;
 use diesel::types::*;
-use diesel::expression::AsExpression;
 use diesel::dsl::sql;
 use diesel::*;
 
@@ -8,8 +7,8 @@ use diesel::*;
 #[cfg(not(feature = "mysql"))] // ? IS NULL is invalid syntax for MySQL
 fn bind_params_are_passed_for_null_when_not_inserting() {
     let connection = connection();
-    let query = select(sql::<Integer>("1"))
-        .filter(AsExpression::<Nullable<Integer>>::as_expression(None::<i32>).is_null());
+    let query =
+        select(sql::<Integer>("1")).filter(None::<i32>.into_sql::<Nullable<Integer>>().is_null());
     assert_eq!(Ok(1), query.first(&connection));
 }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -146,7 +146,7 @@ fn boolean_from_sql() {
 #[cfg(feature = "postgres")]
 fn boolean_treats_null_as_false_when_predicates_return_null() {
     let connection = connection();
-    let one = AsExpression::<Nullable<Integer>>::as_expression(Some(1));
+    let one = Some(1).into_sql::<Nullable<Integer>>();
     let query = select(one.eq(None::<i32>));
     assert_eq!(Ok(false), query.first(&connection));
 }

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -30,7 +30,7 @@ where
         + QueryId,
 {
     let connection = connection();
-    let query = select(AsExpression::<ST>::as_expression(value.clone()));
+    let query = select(value.clone().into_sql::<ST>());
     let result = query.get_result::<T>(&connection);
     match result {
         Ok(res) => if value != res {

--- a/guide_drafts/model-derives.md
+++ b/guide_drafts/model-derives.md
@@ -257,7 +257,7 @@ where DB: Backend,
 
     #[allow(non_shorthand_field_patterns)]
     fn values(self) -> Self::Values {
-        use diesel::expression::{AsExpression, Expression};
+        use diesel::expression::{Expression, IntoSql};
         use diesel::insertable::ColumnInsertValue;
 
         let NewUser {
@@ -270,17 +270,17 @@ where DB: Backend,
         (
             ColumnInsertValue::Expression(
                   users::first_name,
-                  AsExpression::<<users::first_name as Expression>::SqlType>::as_expression(first_name)
+                  first_name.into_sql::<<users::first_name as Expression>::SqlType>()
             ),
 
             ColumnInsertValue::Expression(
                 users::last_name,
-                AsExpression::<<users::last_name as Expression>::SqlType>::as_expression(last_name)
+                last_name.into_sql::<<users::last_name as Expression>::SqlType>()
             ),
 
             ColumnInsertValue::Expression(
                 users::last_name,
-                AsExpression::<<users::email as Expression>::SqlType>::as_expression(email)
+                email.into_sql::<<users::email as Expression>::SqlType>()
             ),
         )
     }


### PR DESCRIPTION
This effectively removes any reason for users to reference
`AsExpression` other than in where clauses. In cases where the SQL type
could not be inferred, `as_expression` was incredibly verbose to use.

The naming `as_` and `into_` are the standard rust conventions for
owned/borrowed conversions. I'm not super thrilled about `sql` as the
suffix, but it's the only thing I could think of that was concise,
specific enough to Diesel, and makes sense for people who aren't
implementing Diesel and don't necessarily know/care what an "expression"
is.