### PR TITLE
Implement `TextExpressionMethods` for nullable columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Subselects can now reference columns from the outer table. For example,
   `users.filter(exists(posts.filter(user_id.eq(users::id))))` will now compile.
 
+* `TextExpressionMethods` is now implemented for expressions of type
+  `Nullable<Text>` as well as `Text`.
+
 ### Changed
 
 * The signatures of `QueryId`, `Column`, and `FromSqlRow` have all changed to

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -26,8 +26,8 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// #     let connection = connection_no_data();
     /// #     connection.execute("CREATE TABLE users (
     /// #         id INTEGER PRIMARY KEY,
-    /// #         name VARCHAR NOT NULL,
-    /// #         hair_color VARCHAR
+    /// #         name VARCHAR(255) NOT NULL,
+    /// #         hair_color VARCHAR(255)
     /// #     )").unwrap();
     /// #
     /// #     insert_into(users)

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -1,8 +1,8 @@
 use expression::{AsExpression, Expression};
 use expression::operators::{Concat, Like, NotLike};
-use types::Text;
+use types::{Nullable, Text};
 
-pub trait TextExpressionMethods: Expression<SqlType = Text> + Sized {
+pub trait TextExpressionMethods: Expression + Sized {
     /// Concatenates two strings using the `||` operator.
     ///
     /// # Example
@@ -15,12 +15,28 @@ pub trait TextExpressionMethods: Expression<SqlType = Text> + Sized {
     /// #     users {
     /// #         id -> Integer,
     /// #         name -> VarChar,
+    /// #         hair_color -> Nullable<Text>,
     /// #     }
     /// # }
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
-    /// #     let connection = establish_connection();
+    /// #     use diesel::insert_into;
+    /// #
+    /// #     let connection = connection_no_data();
+    /// #     connection.execute("CREATE TABLE users (
+    /// #         id INTEGER PRIMARY KEY,
+    /// #         name VARCHAR NOT NULL,
+    /// #         hair_color VARCHAR
+    /// #     )").unwrap();
+    /// #
+    /// #     insert_into(users)
+    /// #         .values(&vec![
+    /// #             (id.eq(1), name.eq("Sean"), hair_color.eq(Some("Green"))),
+    /// #             (id.eq(2), name.eq("Tess"), hair_color.eq(None)),
+    /// #         ])
+    /// #         .execute(&connection)
+    /// #         .unwrap();
     /// #
     /// let names = users.select(name.concat(" the Greatest")).load(&connection);
     /// let expected_names = vec![
@@ -28,21 +44,40 @@ pub trait TextExpressionMethods: Expression<SqlType = Text> + Sized {
     ///     "Tess the Greatest".to_string(),
     /// ];
     /// assert_eq!(Ok(expected_names), names);
+    ///
+    /// // If the value is nullable, the output will be nullable
+    /// let names = users.select(hair_color.concat("ish")).load(&connection);
+    /// let expected_names = vec![
+    ///     Some("Greenish".to_string()),
+    ///     None,
+    /// ];
+    /// assert_eq!(Ok(expected_names), names);
     /// # }
     /// ```
-    fn concat<T: AsExpression<Text>>(self, other: T) -> Concat<Self, T::Expression> {
+    fn concat<T: AsExpression<Self::SqlType>>(self, other: T) -> Concat<Self, T::Expression> {
         Concat::new(self, other.as_expression())
     }
 
     /// Returns a SQL `LIKE` expression
-    fn like<T: AsExpression<Text>>(self, other: T) -> Like<Self, T::Expression> {
+    fn like<T: AsExpression<Self::SqlType>>(self, other: T) -> Like<Self, T::Expression> {
         Like::new(self.as_expression(), other.as_expression())
     }
 
     /// Returns a SQL `NOT LIKE` expression
-    fn not_like<T: AsExpression<Text>>(self, other: T) -> NotLike<Self, T::Expression> {
+    fn not_like<T: AsExpression<Self::SqlType>>(self, other: T) -> NotLike<Self, T::Expression> {
         NotLike::new(self.as_expression(), other.as_expression())
     }
 }
 
-impl<T: Expression<SqlType = Text>> TextExpressionMethods for T {}
+#[doc(hidden)]
+pub trait TextOrNullableText {}
+
+impl TextOrNullableText for Text {}
+impl TextOrNullableText for Nullable<Text> {}
+
+impl<T> TextExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: TextOrNullableText,
+{
+}


### PR DESCRIPTION
The most difficult part here is getting `Concat` to have its return type
be based on the type of its arguments. Since there's no easy way for me
to carry any possible `ty` value as a series of `tt` without accepting a
subset of possible `ty` values, I've opted only to handle the magic
`ReturnBasedOnArgs` value in the one place we need it.