### PR TITLE
Don't allocate when encoding `char` in `EscapeExpressionMethods`

### DIFF
--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -35,11 +35,8 @@ use types::VarChar;
 /// # }
 /// ```
 pub trait EscapeExpressionMethods: Sized {
-    fn escape(self, character: char) -> Escape<Self, AsExprOf<String, VarChar>> {
-        Escape::new(
-            self,
-            AsExpression::<VarChar>::as_expression(character.to_string()),
-        )
+    fn escape(self, character: char) -> Escape<Self, AsExprOf<char, VarChar>> {
+        Escape::new(self, AsExpression::<VarChar>::as_expression(character))
     }
 }
 

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -23,6 +23,7 @@ primitive_impls!(Time);
 primitive_impls!(Timestamp);
 
 expression_impls!(Text -> &'a str);
+expression_impls!(Text -> char);
 expression_impls!(Binary -> &'a [u8]);
 
 impl NotNull for () {}
@@ -55,6 +56,21 @@ where
         out: &mut ToSqlOutput<W, DB>,
     ) -> Result<IsNull, Box<Error + Send + Sync>> {
         (self as &str).to_sql(out)
+    }
+}
+
+impl<DB> ToSql<types::Text, DB> for char
+where
+    DB: Backend,
+    for<'a> &'a str: ToSql<types::Text, DB>,
+{
+    fn to_sql<W: Write>(
+        &self,
+        out: &mut ToSqlOutput<W, DB>,
+    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+        let mut buf = [0; 4];
+        let s = &*self.encode_utf8(&mut buf);
+        s.to_sql(out)
     }
 }
 


### PR DESCRIPTION
Not that the 4 byte heap allocation is a huge bottleneck, but we can do
this without allocating so why not