### PR TITLE
feat: return directly if records is empty when do batch insert in sqlite

### DIFF
--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -195,6 +195,9 @@ where
 {
     fn execute(self, conn: &SqliteConnection) -> QueryResult<usize> {
         use connection::Connection;
+        if self.records.is_empty() {
+            return Ok(0);
+        }
         conn.transaction(|| {
             let mut result = 0;
             for record in self.records {


### PR DESCRIPTION
There is no need to start a transaction if no data to be inserted.