### PR TITLE
Cleanup tuple struct behavior in codegen

### DIFF
--- a/diesel_codegen/src/as_changeset.rs
+++ b/diesel_codegen/src/as_changeset.rs
@@ -16,8 +16,8 @@ pub fn derive_as_changeset(item: syn::DeriveInput) -> quote::Tokens {
         .attrs
         .as_slice()
         .iter()
-        .filter(|a| match a.column_name {
-            Some(ref name) => !model.primary_key_names.contains(name),
+        .filter(|a| match a.column_name() {
+            Some(name) => !model.primary_key_names.contains(name),
             None => true,
         })
         .collect::<Vec<_>>();

--- a/diesel_codegen/src/attr.rs
+++ b/diesel_codegen/src/attr.rs
@@ -1,16 +1,14 @@
 use quote;
 use syn;
 
-use std::borrow::Cow;
-
 use util::*;
 
 #[derive(Debug)]
 pub struct Attr {
-    pub column_name: Option<syn::Ident>,
-    pub field_name: Option<syn::Ident>,
+    column_name: Option<syn::Ident>,
+    field_name: Option<syn::Ident>,
     pub ty: syn::Ty,
-    field_position: usize,
+    pub field_position: syn::Ident,
 }
 
 impl Attr {
@@ -25,15 +23,18 @@ impl Attr {
             column_name: column_name,
             field_name: field_name,
             ty: ty,
-            field_position: index,
+            field_position: index.to_string().into(),
         }
     }
 
-    pub fn name_for_pattern(&self) -> Cow<syn::Ident> {
-        match self.field_name {
-            Some(ref name) => Cow::Borrowed(name),
-            None => Cow::Owned(format!("field_{}", self.field_position).into()),
-        }
+    pub fn field_name(&self) -> &syn::Ident {
+        self.field_name.as_ref().unwrap_or(&self.field_position)
+    }
+
+    pub fn column_name(&self) -> Option<&syn::Ident> {
+        self.column_name
+            .as_ref()
+            .or_else(|| self.field_name.as_ref())
     }
 
     fn field_kind(&self) -> &str {

--- a/diesel_codegen/src/identifiable.rs
+++ b/diesel_codegen/src/identifiable.rs
@@ -11,7 +11,7 @@ pub fn derive_identifiable(item: syn::DeriveInput) -> Tokens {
     let primary_key_names = model.primary_key_names;
     let fields = model.attrs.as_slice();
     for pk in &primary_key_names {
-        if !fields.iter().any(|f| f.field_name.as_ref() == Some(pk)) {
+        if !fields.iter().any(|f| f.field_name() == pk) {
             panic!("Could not find a field named `{}` on `{}`", pk, &model.name);
         }
     }


### PR DESCRIPTION
If a struct is declared as `Foo(i32, i32)`, we can construct it as:
`Foo { 0: 1, 1: 2 }`. Because of this, we have virtually no reason to
care whether something is a tuple struct or not, and we can remove a lot
of this conditional code.