### PR TITLE
Rejigger our peano number implementation, document it

### DIFF
--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -1,10 +1,11 @@
+use backend::Backend;
 use expression::SelectableExpression;
 use expression::grouped::Grouped;
 use expression::nullable::Nullable;
 use prelude::*;
 use query_builder::*;
 use result::QueryResult;
-use super::QuerySource;
+use super::{AppearsInFromClause, Plus, QuerySource};
 use types::Bool;
 use util::TupleAppend;
 
@@ -206,8 +207,6 @@ where
     }
 }
 
-use backend::Backend;
-
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Inner;
@@ -256,8 +255,6 @@ where
     }
 }
 
-use super::{AppearsInFromClause, Never, Succ};
-
 impl<T, Left, Right, Kind> AppearsInFromClause<T> for Join<Left, Right, Kind>
 where
     Left: AppearsInFromClause<T>,
@@ -272,21 +269,6 @@ where
     Join: AppearsInFromClause<T>,
 {
     type Count = Join::Count;
-}
-
-pub trait Plus<T> {
-    type Output;
-}
-
-impl<T, U> Plus<T> for Succ<U>
-where
-    U: Plus<T>,
-{
-    type Output = Succ<U::Output>;
-}
-
-impl<T> Plus<T> for Never {
-    type Output = T;
 }
 
 #[doc(hidden)]

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -3,6 +3,7 @@
 //! the methods on [`Table`](/diesel/query_source/trait.Table.html)
 #[doc(hidden)]
 pub mod joins;
+mod peano_numbers;
 
 use backend::Backend;
 use expression::{Expression, NonAggregate, SelectableExpression};
@@ -10,6 +11,7 @@ use query_builder::*;
 use types::{FromSqlRow, HasSqlType};
 
 pub use self::joins::JoinTo;
+pub use self::peano_numbers::*;
 
 /// Trait indicating that a record can be queried from the database. This trait
 /// can be derived automatically using `diesel_codegen`. This trait can only be derived for
@@ -53,9 +55,3 @@ pub trait Table: QuerySource + AsQuery + Sized {
 pub trait AppearsInFromClause<QS> {
     type Count;
 }
-
-#[allow(missing_debug_implementations, missing_copy_implementations)]
-pub struct Never;
-#[allow(missing_debug_implementations, missing_copy_implementations)]
-pub struct Succ<T>(T);
-pub type Once = Succ<Never>;

--- a/diesel/src/query_source/peano_numbers.rs
+++ b/diesel/src/query_source/peano_numbers.rs
@@ -1,0 +1,44 @@
+//! A simple implementation of peano numbers.
+//!
+//! This is used to enforce that columns can only be selected from a given from
+//! clause if their table appears exactly one time.
+
+/// A table never appears in the from clause.
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Never;
+
+/// A table appears in the from clause exactly one time.
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct Once;
+
+/// A table appears in the from clause two or more times.
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub struct MoreThanOnce;
+
+/// Add two peano numbers together.
+///
+/// This is used to determine the number of times a table appears in a from
+/// clause when the from clause contains a join.
+pub trait Plus<T> {
+    type Output;
+}
+
+impl<T> Plus<T> for Never {
+    type Output = T;
+}
+
+impl<T> Plus<T> for MoreThanOnce {
+    type Output = Self;
+}
+
+impl Plus<Never> for Once {
+    type Output = Self;
+}
+
+impl Plus<Once> for Once {
+    type Output = MoreThanOnce;
+}
+
+impl Plus<MoreThanOnce> for Once {
+    type Output = MoreThanOnce;
+}

--- a/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -18,6 +18,8 @@ table! {
     }
 }
 
+enable_multi_table_joins!(users, posts);
+
 #[derive(Queryable)]
 struct User {
     id: i32,
@@ -28,8 +30,7 @@ fn main() {
     let conn = PgConnection::establish("").unwrap();
 
     let _ = LoadDsl::load::<User>(
-    //~^ ERROR AppearsInFromClause
-    //~| ERROR E0277
+    //~^ ERROR type mismatch resolving `<users::table as diesel::query_source::AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
         users::table.filter(posts::id.eq(1)),
         &conn,
     );
@@ -38,17 +39,14 @@ fn main() {
         .into_boxed::<Pg>()
         .filter(posts::id.eq(1));
         //~^ ERROR AppearsInFromClause
-        //~| ERROR E0277
 
     let _ = BoxedDsl::into_boxed::<Pg>(
     //~^ ERROR AppearsInFromClause
-    //~| ERROR E0277
         users::table.filter(posts::id.eq(1))
     );
 
     let _ = LoadDsl::load::<User>(
     //~^ ERROR AppearsInFromClause
-    //~| ERROR E0277
         users::table.filter(users::name.eq(posts::title)),
         &conn,
     );
@@ -56,11 +54,9 @@ fn main() {
     let _ = users::table.into_boxed::<Pg>()
         .filter(users::name.eq(posts::title));
         //~^ ERROR AppearsInFromClause
-        //~| ERROR E0277
 
     let _ = BoxedDsl::into_boxed::<Pg>(
     //~^ ERROR AppearsInFromClause
-    //~| ERROR E0277
         users::table
             .filter(users::name.eq(posts::title))
     );


### PR DESCRIPTION
`Succ<Never>` is a really poor type to have appear in error messages.
Since we never care about the precise value unless that value is 1, I've
replaced it with two concrete types to represent one and more than one.
The error message still isn't *great*, but it's at least passable.