### PR TITLE
Add missing docs for the `update_statement` module

### DIFF
--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -28,7 +28,7 @@ mod select_clause;
 mod select_statement;
 pub mod where_clause;
 pub mod insert_statement;
-pub mod update_statement;
+mod update_statement;
 
 pub use self::ast_pass::AstPass;
 pub use self::bind_collector::BindCollector;

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -14,7 +14,7 @@ use query_source::Table;
 use result::Error::QueryBuilderError;
 use result::QueryResult;
 
-/// The type returned by [`update`](/diesel/fn.update.html). The only thing you can do
+/// The type returned by [`update`](../fn.update.html). The only thing you can do
 /// with this type is call `set` on it.
 #[derive(Debug)]
 pub struct IncompleteUpdateStatement<T, U>(UpdateTarget<T, U>);
@@ -27,6 +27,11 @@ impl<T, U> IncompleteUpdateStatement<T, U> {
 }
 
 impl<T, U> IncompleteUpdateStatement<T, U> {
+    /// Provides the `SET` clause of the `UPDATE` statement.
+    ///
+    /// See [`update`](../fn.update.html) for usage examples, or [the update
+    /// guide](http://diesel.rs/guides/all-about-updates/) for a more exhaustive
+    /// set of examples.
     pub fn set<V>(self, values: V) -> UpdateStatement<T, U, V::Changeset, NoReturningClause>
     where
         T: Table,
@@ -93,6 +98,11 @@ where
 }
 
 #[derive(Debug, Copy, Clone)]
+/// Represents a complete `UPDATE` statement.
+///
+/// See [`update`](../fn.update.html) for usage examples, or [the update
+/// guide](http://diesel.rs/guides/all-about-updates/) for a more exhaustive
+/// set of examples.
 pub struct UpdateStatement<T, U, V, Ret = NoReturningClause> {
     table: T,
     where_clause: U,


### PR DESCRIPTION
These types were appearing in two places, since `update_statement` was
not `#[doc(hidden)]`. There was no reason it needed to be public, so
I've just made it private so these types only appear at one path, and we
can safely use relative URLs in documentation.