### PR TITLE
Add rustfmt info to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,15 +130,26 @@ To run rustfmt tests locally:
    ```
 
 3. Run rustfmt using cargo from the root of your diesel repo.
+   
+   To see changes that need to be made, run
 
    ```
    cargo fmt --all -- --write-mode=diff
    ```
 
    If all code is properly formatted (e.g. if you have not made any changes),
-   this should run without error.
+   this should run without error or output.
    If your code needs to be reformatted,
    you will see a diff between your code and properly formatted code.
+   If you see code here that you didn't make any changes to
+   then you are probably running the wrong version of rustfmt.
+   Once you are ready to apply the formatting changes, run 
+
+   ```
+   cargo fmt --all
+   ```
+
+   You won't see any output, but all your files will be corrected.
 
 You can also use rustfmt to make corrections or highlight issues in your editor.
 Check out [their README](https://github.com/rust-lang-nursery/rustfmt) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ Thank you! We'll try to respond as quickly as possible.
 
 ## Contribute code to Diesel
 
+
 ### Setting up Diesel locally
 
 1. Install Rust using [rustup], which allows you to easily switch between Rust
@@ -60,7 +61,10 @@ Thank you! We'll try to respond as quickly as possible.
    continuous integration. Find it by looking for a line like
    `rust: nightly-2017-06-06` in the `.travis.yml` file. You can install and
    set a custom nightly version for a project using
-   `rustup override add nightly-2017-06-06`.
+
+   ```
+   rustup override add nightly-2017-06-06
+   ```
 
 2. Install the system libraries needed to interface with the database systems
    you wish to use.
@@ -107,6 +111,37 @@ Thank you! We'll try to respond as quickly as possible.
    everything.)
 
 [rustup]: https://www.rustup.rs
+
+### Coding Style
+
+We follow the [Rust Style Guide](https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md), enforced using [rustfmt](https://github.com/rust-lang-nursery/rustfmt).
+To run rustfmt tests locally:
+
+1. Use rustup to set rust toolchain
+   to the nightly version specified in Diesel's [.travis.yml](./.travis.yml)
+   (see above).
+
+2. Install the nightly version of rustfmt used in
+   Diesel's continuous integration.
+   Look for and run the line from [.travis.yml](./.travis.yml) that looks like
+
+   ```
+   cargo install rustfmt-nightly --vers x.x.x
+   ```
+
+3. Run rustfmt using cargo from the root of your diesel repo.
+
+   ```
+   cargo fmt --all -- --write-mode=diff
+   ```
+
+   If all code is properly formatted (e.g. if you have not made any changes),
+   this should run without error.
+   If your code needs to be reformatted,
+   you will see a diff between your code and properly formatted code.
+
+You can also use rustfmt to make corrections or highlight issues in your editor.
+Check out [their README](https://github.com/rust-lang-nursery/rustfmt) for details.
 
 
 ### Common Abbreviations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,6 @@ Thank you! We'll try to respond as quickly as possible.
 
 ## Contribute code to Diesel
 
-
 ### Setting up Diesel locally
 
 1. Install Rust using [rustup], which allows you to easily switch between Rust
@@ -63,7 +62,7 @@ Thank you! We'll try to respond as quickly as possible.
    set a custom nightly version for a project using
 
    ```
-   rustup override add nightly-2017-06-06
+   rustup override add nightly-2017-09-20
    ```
 
 2. Install the system libraries needed to interface with the database systems


### PR DESCRIPTION
Pretty self explanatory.

CONTRIBUTING.md could probably use some reorganization once some of the `draft_guides` are deployed to the website. Maybe even formalize it into a contributor guide that itself is deployed to the website?