### PR TITLE
Fix passing boxed queries as subselects

### DIFF
--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -62,6 +62,19 @@ where
     type SqlType = ST;
 }
 
+impl<'a, ST, QS, DB> Expression for BoxedSelectStatement<'a, ST, QS, DB>
+where
+    Self: Query<SqlType = ST>,
+{
+    type SqlType = ST;
+}
+
+impl<'a, ST, QS, QS2, DB> AppearsOnTable<QS2> for BoxedSelectStatement<'a, ST, QS, DB>
+where
+    Self: Query<SqlType = ST>,
+{
+}
+
 impl<'a, ST, QS, DB> QueryFragment<DB> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -420,6 +420,20 @@ fn filter_subselect_referencing_outer_table() {
 }
 
 #[test]
+fn filter_subselect_with_boxed_query() {
+    use schema::users::dsl::*;
+
+    let conn = connection_with_sean_and_tess_in_users_table();
+    let sean = find_user_by_name("Sean", &conn);
+
+    let subselect = users.filter(name.eq("Sean")).select(id).into_boxed();
+
+    let expected = Ok(vec![sean]);
+    let data = users.filter(id.eq_any(subselect)).load(&conn);
+    assert_eq!(expected, data);
+}
+
+#[test]
 #[cfg(feature = "postgres")]
 fn filter_subselect_with_pg_any() {
     use diesel::dsl::any;


### PR DESCRIPTION
This functionality was broken in c85965db as `BoxedSelectStatement` did
not implement `Expression`. I've implemented `AppearsOnTable` for all
possible query sources, since a boxed select statement must only
reference its own table by design.