### PR TITLE
Implement `Insertable` for `Eq`

### DIFF
--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -401,13 +401,25 @@ where
     }
 }
 
-impl<'a, T, U> Insertable<T::Table> for &'a Eq<T, U>
+impl<T, U> Insertable<T::Table> for Eq<T, U>
 where
-    T: Column + Copy,
+    T: Column,
 {
-    type Values = ColumnInsertValue<T, &'a U>;
+    type Values = ColumnInsertValue<T, U>;
 
     fn values(self) -> Self::Values {
-        ColumnInsertValue::Expression(self.left, &self.right)
+        ColumnInsertValue::Expression(self.left, self.right)
+    }
+}
+
+impl<'a, T, Tab, U> Insertable<Tab> for &'a Eq<T, U>
+where
+    T: Copy,
+    Eq<T, &'a U>: Insertable<Tab>,
+{
+    type Values = <Eq<T, &'a U> as Insertable<Tab>>::Values;
+
+    fn values(self) -> Self::Values {
+        Eq::new(self.left, &self.right).values()
     }
 }

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -103,16 +103,25 @@ macro_rules! tuple_impls {
                 }
             }
 
-            impl<'a, $($T,)+ Tab> Insertable<Tab> for &'a ($($T,)+)
+            impl<$($T,)+ Tab> Insertable<Tab> for ($($T,)+)
             where
-                $(&'a $T: Insertable<Tab> + UndecoratedInsertRecord<Tab>,)+
+                $($T: Insertable<Tab> + UndecoratedInsertRecord<Tab>,)+
             {
-                type Values = ($(
-                    <&'a $T as Insertable<Tab>>::Values,
-                )+);
+                type Values = ($($T::Values,)+);
 
                 fn values(self) -> Self::Values {
                     ($(self.$idx.values(),)+)
+                }
+            }
+
+            impl<'a, $($T,)+ Tab> Insertable<Tab> for &'a ($($T,)+)
+            where
+                ($(&'a $T,)+): Insertable<Tab>,
+            {
+                type Values = <($(&'a $T,)+) as Insertable<Tab>>::Values;
+
+                fn values(self) -> Self::Values {
+                    ($(&self.$idx,)+).values()
                 }
             }
 

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -341,6 +341,21 @@ fn insert_single_bare_value() {
     let connection = connection();
 
     insert_into(users)
+        .values(name.eq("Sean"))
+        .execute(&connection)
+        .unwrap();
+
+    let expected_names = vec!["Sean".to_string()];
+    let actual_names = users.select(name).load(&connection);
+    assert_eq!(Ok(expected_names), actual_names);
+}
+
+#[test]
+fn insert_single_bare_value_reference() {
+    use schema::users::dsl::*;
+    let connection = connection();
+
+    insert_into(users)
         .values(&name.eq("Sean"))
         .execute(&connection)
         .unwrap();
@@ -369,6 +384,21 @@ fn insert_multiple_bare_values() {
 
 #[test]
 fn insert_single_tuple() {
+    use schema::users::dsl::*;
+    let connection = connection();
+
+    insert_into(users)
+        .values((name.eq("Sean"), hair_color.eq("Brown")))
+        .execute(&connection)
+        .unwrap();
+
+    let expected_data = vec![("Sean".to_string(), Some("Brown".to_string()))];
+    let actual_data = users.select((name, hair_color)).load(&connection);
+    assert_eq!(Ok(expected_data), actual_data);
+}
+
+#[test]
+fn insert_single_tuple_reference() {
     use schema::users::dsl::*;
     let connection = connection();
 


### PR DESCRIPTION
If you're just inserting a bare value, there's no reason you should need
to pass a reference here. I'm actually not even sure that we need the
reference impl really, but I'm leaving it for now until I can explore
removing it.