### PR TITLE
Always implement `AsExpression` for double references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * MySQL URLs will now properly percent decode the username and password.
 
+* References to types other than `str` and slice can now appear on structs which
+  derive `Insertable` or `AsChangeset`.
+
 ## [0.16.0] - 2017-08-24
 
 ### Added

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -111,8 +111,10 @@ array_as_expression!(Vec<T>, Array<ST>);
 array_as_expression!(Vec<T>, Nullable<Array<ST>>);
 array_as_expression!(&'a Vec<T>, Array<ST>);
 array_as_expression!(&'a Vec<T>, Nullable<Array<ST>>);
+array_as_expression!(&'a &'b Vec<T>, Array<ST>);
+array_as_expression!(&'a &'b Vec<T>, Nullable<Array<ST>>);
 
-impl<'a, ST, T> ToSql<Array<ST>, Pg> for &'a [T]
+impl<ST, T> ToSql<Array<ST>, Pg> for [T]
 where
     Pg: HasSqlType<ST>,
     T: ToSql<ST, Pg>,
@@ -148,10 +150,10 @@ where
     }
 }
 
-impl<'a, ST, T> ToSql<Nullable<Array<ST>>, Pg> for &'a [T]
+impl<ST, T> ToSql<Nullable<Array<ST>>, Pg> for [T]
 where
     Pg: HasSqlType<ST>,
-    &'a [T]: ToSql<Array<ST>, Pg>,
+    [T]: ToSql<Array<ST>, Pg>,
 {
     fn to_sql<W: Write>(
         &self,
@@ -164,7 +166,7 @@ where
 impl<ST, T> ToSql<Array<ST>, Pg> for Vec<T>
 where
     Pg: HasSqlType<ST>,
-    for<'a> &'a [T]: ToSql<Array<ST>, Pg>,
+    [T]: ToSql<Array<ST>, Pg>,
     T: fmt::Debug,
 {
     fn to_sql<W: Write>(

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -31,11 +31,11 @@ queryable_impls!(Time -> String);
 queryable_impls!(Timestamp -> String);
 
 expression_impls!(Date -> String);
-expression_impls!(Date -> &'a str);
+expression_impls!(Date -> str, unsized);
 expression_impls!(Time -> String);
-expression_impls!(Time -> &'a str);
+expression_impls!(Time -> str, unsized);
 expression_impls!(Timestamp -> String);
-expression_impls!(Timestamp -> &'a str);
+expression_impls!(Timestamp -> str, unsized);
 
 impl FromSql<types::Date, Sqlite> for String {
     fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
@@ -43,7 +43,7 @@ impl FromSql<types::Date, Sqlite> for String {
     }
 }
 
-impl<'a> ToSql<types::Date, Sqlite> for &'a str {
+impl ToSql<types::Date, Sqlite> for str {
     fn to_sql<W: Write>(
         &self,
         out: &mut ToSqlOutput<W, Sqlite>,
@@ -67,7 +67,7 @@ impl FromSql<types::Time, Sqlite> for String {
     }
 }
 
-impl<'a> ToSql<types::Time, Sqlite> for &'a str {
+impl ToSql<types::Time, Sqlite> for str {
     fn to_sql<W: Write>(
         &self,
         out: &mut ToSqlOutput<W, Sqlite>,
@@ -91,7 +91,7 @@ impl FromSql<types::Timestamp, Sqlite> for String {
     }
 }
 
-impl<'a> ToSql<types::Timestamp, Sqlite> for &'a str {
+impl ToSql<types::Timestamp, Sqlite> for str {
     fn to_sql<W: Write>(
         &self,
         out: &mut ToSqlOutput<W, Sqlite>,

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -22,8 +22,8 @@ primitive_impls!(Date);
 primitive_impls!(Time);
 primitive_impls!(Timestamp);
 
-expression_impls!(Text -> &'a str);
-expression_impls!(Binary -> &'a [u8]);
+expression_impls!(Text -> str, unsized);
+expression_impls!(Binary -> [u8], unsized);
 
 impl NotNull for () {}
 
@@ -34,7 +34,7 @@ impl<DB: Backend<RawValue = [u8]>> FromSql<types::Text, DB> for String {
     }
 }
 
-impl<'a, DB: Backend> ToSql<types::Text, DB> for &'a str {
+impl<DB: Backend> ToSql<types::Text, DB> for str {
     fn to_sql<W: Write>(
         &self,
         out: &mut ToSqlOutput<W, DB>,
@@ -48,7 +48,7 @@ impl<'a, DB: Backend> ToSql<types::Text, DB> for &'a str {
 impl<DB> ToSql<types::Text, DB> for String
 where
     DB: Backend,
-    for<'a> &'a str: ToSql<types::Text, DB>,
+    str: ToSql<types::Text, DB>,
 {
     fn to_sql<W: Write>(
         &self,
@@ -67,7 +67,7 @@ impl<DB: Backend<RawValue = [u8]>> FromSql<types::Binary, DB> for Vec<u8> {
 impl<DB> ToSql<types::Binary, DB> for Vec<u8>
 where
     DB: Backend,
-    for<'a> &'a [u8]: ToSql<types::Binary, DB>,
+    [u8]: ToSql<types::Binary, DB>,
 {
     fn to_sql<W: Write>(
         &self,
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<'a, DB: Backend> ToSql<types::Binary, DB> for &'a [u8] {
+impl<DB: Backend> ToSql<types::Binary, DB> for [u8] {
     fn to_sql<W: Write>(
         &self,
         out: &mut ToSqlOutput<W, DB>,

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -501,7 +501,7 @@ pub trait ToSql<A, DB: Backend + HasSqlType<A>>: fmt::Debug {
 impl<'a, A, T, DB> ToSql<A, DB> for &'a T
 where
     DB: Backend + HasSqlType<A>,
-    T: ToSql<A, DB>,
+    T: ToSql<A, DB> + ?Sized,
 {
     fn to_sql<W: Write>(
         &self,


### PR DESCRIPTION
The only time that a double reference `AsExpression` impl comes up is
from the derived impl of `Insertable` and `AsChangeset`. We can't vary
the generated code based on whether the type of a field is `Copy`, so we
have to assume that it isn't and always take a reference.

Previously we only did this for `str` and slices, as `String` and `Vec`
are the only non-copy types that we support (I think `BigDecimal` may
fall into that category now, but it's unlikely that avoiding a single
clone of that type is ever relevant).

Still, there's no reason that we shouldn't allow references of any type
to appear in `Insertable` structs. To avoid code bloat, I've cleaned
things up a bit and implemented more stuff on `str` and `[T]` directly,
letting the blanket reference impl apply to those types when it's
relevant.

Fixes #1242.