### PR TITLE
Infer `enable_multi_table_joins!` for all possible combination of tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,17 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `TextExpressionMethods` is now implemented for expressions of type
   `Nullable<Text>` as well as `Text`.
 
+* `allow_tables_to_appear_in_same_query!` can now take more than 2 tables, and is the same
+  as invoking it separately for every combination of those tables.
+
 ### Changed
 
 * The signatures of `QueryId`, `Column`, and `FromSqlRow` have all changed to
   use associated constants where appropriate.
+
+* You will now need to invoke `allow_tables_to_appear_in_same_query!` any time two tables
+  appear together in the same query, even if there is a `joinable!` invocation
+  for those tables.
 
 ### Deprecated
 
@@ -63,6 +70,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Deprecated `.values(x.on_conflict(y, do_update().set(z)))` in favor of
   `.values(x).on_conflict(y).do_update().set(z)`
+
+* Deprecated `enable_multi_table_joins` in favor of
+  `allow_tables_to_appear_in_same_query!`
 
 ### Removed
 

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -256,6 +256,7 @@ mod schema {
             body -> VarChar,
         }
     }
+
     table! {
         posts {
             id -> Integer,
@@ -263,11 +264,14 @@ mod schema {
             title -> VarChar,
         }
     }
+
     table! {
         users {
             id -> Integer,
             name -> VarChar,
         }
     }
+
+    joinable!(posts -> users (user_id));
+    allow_tables_to_appear_in_same_query!(comments, posts, users);
 }
-joinable!(schema::posts -> schema::users(user_id));

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -426,18 +426,19 @@ pub trait NullableExpressionMethods: Expression + Sized {
     ///     }
     /// }
     /// #
-    /// #  pub struct User {
-    /// #      id: i32,
-    /// #      name: VarChar,
-    /// #  }
+    /// # pub struct User {
+    /// #     id: i32,
+    /// #     name: VarChar,
+    /// # }
     /// #
-    /// #  pub struct Post {
-    /// #      id: i32,
-    /// #      user_id: i32,
-    /// #      author_name: Option<VarChar>,
-    /// #  }
+    /// # pub struct Post {
+    /// #     id: i32,
+    /// #     user_id: i32,
+    /// #     author_name: Option<VarChar>,
+    /// # }
     /// #
-    /// #  joinable!(posts -> users (user_id));
+    /// # joinable!(posts -> users (user_id));
+    /// # allow_tables_to_appear_in_same_query!(posts, users);
     ///
     /// fn main() {
     ///     use users::dsl::*;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -907,8 +907,10 @@ macro_rules! __diesel_table_query_source_impl {
 /// # include!("../doctest_setup.rs");
 /// use schema::*;
 ///
+/// # /*
 /// joinable!(posts -> users (user_id));
 /// allow_tables_to_appear_in_same_query!(posts, users);
+/// # */
 ///
 /// # fn main() {
 /// let implicit_on_clause = users::table.inner_join(posts::table);

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -97,6 +97,19 @@ impl Display for TableDefinitions {
         for foreign_key in &self.fk_constraints {
             writeln!(f, "{}", Joinable(foreign_key))?;
         }
+
+        if self.tables.len() > 1 {
+            write!(f, "\nallow_tables_to_appear_in_same_query!(")?;
+            {
+                let mut out = PadAdapter::new(f);
+                write!(out, "\n")?;
+                for table in &self.tables {
+                    writeln!(out, "{},", table.name.name)?;
+                }
+            }
+            writeln!(f, ");")?;
+        }
+
         Ok(())
     }
 }

--- a/diesel_cli/tests/print_schema/print_schema_order/mysql/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_order/mysql/expected.rs
@@ -39,3 +39,9 @@ table! {
         id -> Integer,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    abc,
+    def,
+    ghi,
+);

--- a/diesel_cli/tests/print_schema/print_schema_order/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_order/postgres/expected.rs
@@ -39,3 +39,9 @@ table! {
         id -> Int4,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    abc,
+    def,
+    ghi,
+);

--- a/diesel_cli/tests/print_schema/print_schema_order/sqlite/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_order/sqlite/expected.rs
@@ -39,3 +39,9 @@ table! {
         id -> Nullable<Integer>,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    abc,
+    def,
+    ghi,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple/mysql/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_simple/mysql/expected.rs
@@ -25,3 +25,8 @@ table! {
         id -> Integer,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.rs
@@ -25,3 +25,8 @@ table! {
         id -> Int4,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.rs
@@ -25,3 +25,8 @@ table! {
         id -> Nullable<Integer>,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/mysql/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/mysql/expected.rs
@@ -9,3 +9,8 @@ table! {
         id -> Integer,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/postgres/expected.rs
@@ -9,3 +9,8 @@ table! {
         id -> Int4,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.rs
@@ -9,3 +9,8 @@ table! {
         id -> Nullable<Integer>,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.rs
@@ -34,4 +34,9 @@ pub mod custom_schema {
     }
 
     joinable!(b -> a (parent));
+
+    allow_tables_to_appear_in_same_query!(
+        a,
+        b,
+    );
 }

--- a/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/postgres/expected.rs
@@ -54,3 +54,9 @@ table! {
 
 joinable!(comments -> posts (post_id));
 joinable!(posts -> users (user_id));
+
+allow_tables_to_appear_in_same_query!(
+    comments,
+    posts,
+    users,
+);

--- a/diesel_codegen/src/schema_inference.rs
+++ b/diesel_codegen/src/schema_inference.rs
@@ -1,5 +1,5 @@
-use syn;
 use quote;
+use syn;
 
 use database_url::extract_database_url;
 use diesel_infer_schema::*;
@@ -43,8 +43,10 @@ pub fn derive_infer_schema(input: syn::DeriveInput) -> quote::Tokens {
         let foreign_key = syn::Ident::new(fk.foreign_key);
         quote!(joinable!(#child_table -> #parent_table (#foreign_key));)
     });
+    let table_idents = table_names.iter().map(|t| syn::Ident::from(&*t.name));
+    let multi_table_joins = quote!(allow_tables_to_appear_in_same_query!(#(#table_idents,)*););
 
-    let tokens = quote!(#(#tables)* #(#joinables)*);
+    let tokens = quote!(#(#tables)* #(#joinables)* #multi_table_joins);
     if let Some(schema_name) = schema_name {
         let schema_ident = syn::Ident::new(schema_name);
         quote!(pub mod #schema_ident { #tokens })

--- a/diesel_codegen/tests/associations.rs
+++ b/diesel_codegen/tests/associations.rs
@@ -26,6 +26,8 @@ fn simple_belongs_to() {
         }
     }
 
+    allow_tables_to_appear_in_same_query!(users, posts);
+
     #[derive(Identifiable)]
     pub struct User {
         id: i32,
@@ -91,6 +93,8 @@ fn custom_foreign_key() {
         }
     }
 
+    allow_tables_to_appear_in_same_query!(users, posts);
+
     #[derive(Identifiable)]
     pub struct User {
         id: i32,
@@ -147,7 +151,6 @@ fn self_referential() {
             parent_id -> Nullable<Integer>,
         }
     }
-
 
     #[derive(Associations, Identifiable)]
     #[belongs_to(Tree, foreign_key = "parent_id")]

--- a/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/aggregate_expression_requires_column_from_same_table.rs
@@ -20,17 +20,13 @@ fn main() {
     let source = users::table.select(sum(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
-    //~| ERROR E0277
     let source = users::table.select(avg(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
-    //~| ERROR E0277
     let source = users::table.select(max(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
-    //~| ERROR E0277
     let source = users::table.select(min(posts::id));
     //~^ ERROR E0277
     //~| ERROR AppearsInFromClause
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -30,7 +30,6 @@ fn main() {
 
     let _ = LoadDsl::load::<Stuff>(
     //~^ ERROR E0277
-    //~| ERROR E0271
         stuff.filter(name.eq(any(more_stuff::names))),
         &conn,
     );

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_filter.rs
@@ -21,5 +21,4 @@ table! {
 fn main() {
     users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
     //~^ ERROR AppearsInFromClause
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_require_selectable_expression_for_order.rs
@@ -21,5 +21,4 @@ table! {
 fn main() {
     users::table.into_boxed::<Pg>().order(posts::title.desc());
     //~^ ERROR AppearsInFromClause
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_join_to_non_joinable_table.rs
@@ -25,8 +25,7 @@ table! {
 }
 
 joinable!(comments -> posts (post_id));
-allow_tables_to_appear_in_same_query!(users, posts);
-allow_tables_to_appear_in_same_query!(users, comments);
+allow_tables_to_appear_in_same_query!(comments, posts, users);
 
 fn main() {
     let _ = users::table.inner_join(posts::table);

--- a/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/custom_returning_requires_selectable_expression.rs
@@ -37,5 +37,4 @@ fn main() {
     let stmt = insert_into(users).values(&new_user).returning((name, bad::age));
     //~^ ERROR SelectableExpression
     //~| ERROR AppearsInFromClause
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/order_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/order_requires_column_from_same_table.rs
@@ -18,5 +18,4 @@ table! {
 fn main() {
     let source = users::table.order(posts::id);
     //~^ ERROR E0277
-    //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
@@ -63,8 +63,6 @@ fn main() {
     //~^ ERROR E0277
     //~| ERROR E0277
     //~| ERROR no method named `execute`
-    //~| ERROR E0271
-    //~| ERROR E0271
 
     // Update column with value that is not selectable
     insert_into(users)
@@ -72,8 +70,7 @@ fn main() {
         .on_conflict(id)
         .do_update()
         .set(name.eq(posts::title));
-        //~^ ERROR E0271
-        //~| ERROR E0277
+        //~^ ERROR E0277
 
     // Update column with excluded value that is not selectable
     insert_into(users).values(&NewUser("Sean").on_conflict(id, do_update().set(name.eq(excluded(posts::title))))).execute(&connection);

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -19,6 +19,7 @@ table! {
 }
 
 joinable!(posts -> users (user_id));
+allow_tables_to_appear_in_same_query!(posts, users);
 sql_function!(lower, lower_t, (x: Text) -> Text);
 
 fn main() {

--- a/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -23,9 +23,7 @@ fn main() {
     //~^ ERROR Selectable
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0271
     let stuff = users::table.select((posts::id, users::name));
     //~^ ERROR Selectable
     //~| ERROR E0277
-    //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/update_requires_column_be_from_same_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_requires_column_be_from_same_table.rs
@@ -24,5 +24,4 @@ fn main() {
     //~^ ERROR type mismatch
     let command = update(users).set(name.eq(posts::title));
     //~^ ERROR E0277
-    //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/update_requires_valid_where_clause.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_requires_valid_where_clause.rs
@@ -23,11 +23,9 @@ fn main() {
     //~| ERROR E0277
 
     update(users::table).filter(posts::id.eq(1));
-    //~^ ERROR E0271
-    //~| ERROR E0277
+    //~^ ERROR E0277
 
     update(users::table).set(users::id.eq(1))
         .filter(posts::id.eq(1));
-        //~^ ERROR E0271
-        //~| ERROR E0277
+        //~^ ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
+++ b/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
@@ -38,7 +38,6 @@ fn main() {
 
     let _ = LoadDsl::load::<User>(
     //~^ ERROR E0277
-    //~| ERROR E0271
         users::table.filter(name.eq(bar(title))),
         &conn,
     );

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -45,6 +45,7 @@ mod eager_loading_with_string_keys {
 
     table! { users { id -> Text, } }
     table! { posts { id -> Text, user_id -> Text, } }
+    allow_tables_to_appear_in_same_query!(users, posts);
 
     #[derive(Queryable, Identifiable, Debug, PartialEq, Clone)]
     pub struct User {
@@ -276,6 +277,8 @@ fn custom_foreign_key() {
             title -> Text,
         }
     }
+
+    allow_tables_to_appear_in_same_query!(users1, posts1);
 
     #[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
     #[table_name = "users1"]

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -300,8 +300,3 @@ pub fn find_user_by_name(name: &str, connection: &TestConnection) -> User {
         .first(connection)
         .unwrap()
 }
-
-allow_tables_to_appear_in_same_query!(users, comments);
-allow_tables_to_appear_in_same_query!(posts, likes);
-allow_tables_to_appear_in_same_query!(followings, likes);
-allow_tables_to_appear_in_same_query!(followings, comments);


### PR DESCRIPTION
This macro is basically a workaround for a lack of certain language
features. It's confusing, and unclear to users when they do or do not
need to invoke it. There's no downside to just speculatively adding it
for all tables, so let's do that.

However, for simplicity, I've opted to also remove the code that makes
`JoinTo` imply this. This will actually improve the error messages
(users won't see an error about a missing `JoinTo` implementation when
trying to use a table as a subselect), and makes it more clear when this
macro needs to be invoked, *especially* after we rename it to
`allow_tables_to_appear_in_same_query!`

I've checked the compile times both on crates.io (~20 tables) and our own test suite (~25 tables)
with this change, and didn't see any significant increase in compile times.

Fixes #1237.
Fixes #1129.