### PR TITLE
Implement `Insertable` and `AsChangeset` in terms of tuples

### DIFF
--- a/diesel/src/macros/as_changeset.rs
+++ b/diesel/src/macros/as_changeset.rs
@@ -219,20 +219,20 @@ macro_rules! impl_AsChangeset {
                 for &'update $struct_ty
             {
                 type Target = $table_name::table;
-                type Changeset = $changeset_ty;
+                type Changeset = <$changeset_ty as $crate::query_builder::AsChangeset>::Changeset;
 
                 #[allow(non_shorthand_field_patterns)]
                 fn as_changeset(self) -> Self::Changeset {
                     use $crate::prelude::ExpressionMethods;
                     let $self_to_columns = *self;
-                    ($(
+                    $crate::query_builder::AsChangeset::as_changeset(($(
                         AsChangeset_column_expr!(
                             $table_name::$column_name,
                             $column_name,
                             none_as_null = $treat_none_as_null,
                             field_kind = $field_kind,
                         )
-                    ,)+)
+                    ,)+))
                 }
             }
         }

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -38,6 +38,7 @@ mod impls_for_insert_and_query {
     }
 
     impl NotNull for MyType {}
+    impl SingleValue for MyType {}
 
     impl<'a> AsExpression<MyType> for &'a MyEnum {
         type Expression = Bound<MyType, &'a MyEnum>;


### PR DESCRIPTION
This changes our derived implementations of `Insertable` and
`AsChangeset` to be defined in terms of the implementations of those
traits for tuples. This has a few benefits. It "future-proofs" the impls
to a certain extent, since they no longer rely on any internals.
Additionally, this means that passing a struct will always be equivalent
to passing a tuple of the constituent fields, which should help prevent
any regressions or mismatches in capabilities.