### PR TITLE
Fix our SQLite chrono implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * References to types other than `str` and slice can now appear on structs which
   derive `Insertable` or `AsChangeset`.
 
+* Deserializing a date/time/timestamp column into a chrono type on SQLite will
+  now handle any value that is in a format documented as valid for SQLite's
+  `strftime` function except for the string `'now'`.
+
 ## [0.16.0] - 2017-08-24
 
 ### Added


### PR DESCRIPTION
The previous implementation would only handle the specific output format
of the `datetime` function. However, it is incorrect for us to assume
that we would get that specific function, as times may not have been
created by that function (which is why the range of input it accepts is
wider than the output it can give).

While values that were stored by using Diesel with chrono will be in the
expected format, we need to work with databases that have data from
other sources. The value in the column will just be whatever string was
given.

This implementation is updated to take every value that is defined as
valid input to the `strftime` function in SQLite, with the exception of
`'now'`. I've updated the tests to exercise all possible values. I've
also changed/removed tests which were testing for values that SQLite
does not handle. It documents its range as being from midnight of Jan 1
0000 to Dec 31 9999 23:59:59.999999. I explicitly opted not to test the
behavior of out of range values, as SQLite defines it as undefined.