### PR TITLE
Make raw connection handles available

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -153,3 +153,12 @@ pub trait Connection: SimpleConnection + Sized + Send {
     #[doc(hidden)]
     fn transaction_manager(&self) -> &Self::TransactionManager;
 }
+
+/// Get access to the underlying connection
+pub trait AsRawHandle {
+    type Target;
+
+    /// Get a copy of raw handle of the underlying database library. You are
+    /// responsible for tracking ownership and synchronizing access.
+    fn as_raw(&self) -> Self::Target;
+}

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -98,6 +98,14 @@ impl Connection for MysqlConnection {
     }
 }
 
+impl AsRawHandle for MysqlConnection {
+    type Target = <RawConnection as AsRawHandle>::Target;
+
+    fn as_raw(&self) -> Self::Target {
+        self.raw_connection.as_raw()
+    }
+}
+
 impl MysqlConnection {
     fn prepare_query<T>(&self, source: &T) -> QueryResult<MaybeCached<Statement>>
     where

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -8,6 +8,7 @@ use std::sync::{Once, ONCE_INIT};
 use result::{ConnectionError, ConnectionResult, QueryResult};
 use super::url::ConnectionOptions;
 use super::stmt::Statement;
+use connection::AsRawHandle;
 
 pub struct RawConnection(*mut ffi::MYSQL);
 
@@ -178,6 +179,14 @@ impl RawConnection {
         let more_results = unsafe { ffi::mysql_next_result(self.0) == 0 };
         self.did_an_error_occur()?;
         Ok(more_results)
+    }
+}
+
+impl AsRawHandle for RawConnection {
+    type Target = *mut ffi::MYSQL;
+
+    fn as_raw(&self) -> *mut ffi::MYSQL {
+        self.0
     }
 }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -94,6 +94,14 @@ impl Connection for PgConnection {
     }
 }
 
+impl AsRawHandle for PgConnection {
+    type Target = <RawConnection as AsRawHandle>::Target;
+
+    fn as_raw(&self) -> Self::Target {
+        self.raw_connection.as_raw()
+    }
+}
+
 impl PgConnection {
     #[cfg_attr(feature = "clippy", allow(type_complexity))]
     fn prepare_query<T: QueryFragment<Pg> + QueryId>(

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -8,6 +8,7 @@ use std::os::raw as libc;
 use std::{ptr, str};
 
 use result::*;
+use connection::AsRawHandle;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct RawConnection {
@@ -87,6 +88,14 @@ impl RawConnection {
             param_types,
         );
         RawResult::new(ptr, self)
+    }
+}
+
+impl AsRawHandle for RawConnection {
+    type Target = *mut PGconn;
+
+    fn as_raw(&self) -> *mut PGconn {
+        self.internal_connection
     }
 }
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -91,6 +91,14 @@ impl Connection for SqliteConnection {
     }
 }
 
+impl AsRawHandle for SqliteConnection {
+    type Target = <RawConnection as AsRawHandle>::Target;
+
+    fn as_raw(&self) -> Self::Target {
+        self.raw_connection.as_raw()
+    }
+}
+
 impl SqliteConnection {
     fn prepare_query<T: QueryFragment<Sqlite> + QueryId>(
         &self,

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -7,6 +7,7 @@ use std::{ptr, str};
 
 use result::*;
 use result::Error::DatabaseError;
+use connection::AsRawHandle;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct RawConnection {
@@ -66,6 +67,14 @@ impl RawConnection {
 
     pub fn last_error_code(&self) -> libc::c_int {
         unsafe { ffi::sqlite3_extended_errcode(self.internal_connection) }
+    }
+}
+
+impl AsRawHandle for RawConnection {
+    type Target = *mut ffi::sqlite3;
+
+    fn as_raw(&self) -> *mut ffi::sqlite3 {
+        self.internal_connection
     }
 }
 


### PR DESCRIPTION
Sometimes, you need to access specialized DB functionality that is not available through Diesel directly. This PR makes the raw connection handles available for that purpose.

This is a pretty common practice:
* https://doc.rust-lang.org/std/os/unix/io/trait.AsRawFd.html
* https://docs.rs/native-tls/0.1.4/native_tls/backend/openssl/trait.TlsStreamExt.html
* https://docs.rs/curl/0.4.8/curl/easy/struct.Easy2.html#method.raw
* etc.