### PR TITLE
Ensure PG results always have an error message

### DIFF
--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -132,6 +132,12 @@ impl RawResult {
     pub fn as_ptr(&self) -> *mut PGresult {
         self.0
     }
+
+    pub fn error_message(&self) -> &str {
+        let ptr = unsafe { PQresultErrorMessage(self.0) };
+        let cstr = unsafe { CStr::from_ptr(ptr) };
+        cstr.to_str().unwrap_or_default()
+    }
 }
 
 impl Drop for RawResult {

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -97,10 +97,8 @@ struct PgErrorInformation(RawResult);
 
 impl DatabaseErrorInformation for PgErrorInformation {
     fn message(&self) -> &str {
-        match get_result_field(self.0.as_ptr(), ResultField::MessagePrimary) {
-            Some(e) => e,
-            None => unreachable!("Per PGs documentation, all errors should have a message"),
-        }
+        get_result_field(self.0.as_ptr(), ResultField::MessagePrimary)
+            .unwrap_or_else(|| self.0.error_message())
     }
 
     fn details(&self) -> Option<&str> {


### PR DESCRIPTION
In certain cases (for example, if the database connection unexpectedly
terminated), we will have a `PGResult` pointer which is not null, but
does not have an error response from the server (and therefore no result
error fields). In this case, PG will copy the connection's error message
onto the result. However, this needs to be retrieved with a separate
function, as it is not part of an error response from the server.

I'd like to explore if there are any other cases that can result in
this, and potentially look at providing a specific `DatabaseErrorKind`
variant for this case.

Fixes #1255.