### PR TITLE
Make query_dsl more discoverable

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -68,7 +68,7 @@ pub mod pg;
 pub mod sqlite;
 
 pub mod migrations;
-mod query_dsl;
+pub mod query_dsl;
 pub mod query_source;
 pub mod result;
 pub mod row;

--- a/diesel/src/query_dsl/belonging_to_dsl.rs
+++ b/diesel/src/query_dsl/belonging_to_dsl.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 /// Constructs a query that finds record(s) based on directional association with other record(s).
 ///
 /// # Example

--- a/diesel/src/query_dsl/belonging_to_dsl.rs
+++ b/diesel/src/query_dsl/belonging_to_dsl.rs
@@ -1,5 +1,44 @@
+/// Constructs a query that finds record(s) based on directional association with other record(s).
+///
+/// # Example
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # #[macro_use] extern crate diesel_codegen;
+/// # include!("../doctest_setup.rs");
+/// # use schema::{posts, users};
+/// #
+/// # #[derive(Identifiable, Queryable)]
+/// # pub struct User {
+/// #     id: i32,
+/// #     name: String,
+/// # }
+/// #
+/// # #[derive(Debug, PartialEq)]
+/// # #[derive(Identifiable, Queryable, Associations)]
+/// # #[belongs_to(User)]
+/// # pub struct Post {
+/// #     id: i32,
+/// #     user_id: i32,
+/// #     title: String,
+/// # }
+/// #
+/// # fn main() {
+/// # let connection = establish_connection();
+/// # use users::dsl::*;
+/// # let user = users.find(2).get_result::<User>(&connection).unwrap();
+/// let posts = Post::belonging_to(&user)
+/// #    .load::<Post>(&connection);
+/// #
+/// # assert_eq!(posts,
+/// #     Ok(vec![Post { id: 3, user_id: 2, title: "My first post too".to_owned() }])
+/// # );
+/// # }
+/// ```
 pub trait BelongingToDsl<T> {
+    /// The query returned by `belonging_to`
     type Output;
 
+    /// Get the record(s) belonging to record(s) `other`
     fn belonging_to(other: T) -> Self::Output;
 }

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use query_source::Table;
 
 /// Adds the `DISTINCT` keyword to a query.
@@ -31,7 +32,10 @@ use query_source::Table;
 /// # }
 /// ```
 pub trait DistinctDsl {
+    /// Query with DISTINCT added
     type Output;
+
+    /// Should return query with DISTINCT added
     fn distinct(self) -> Self::Output;
 }
 
@@ -42,6 +46,7 @@ where
 {
     type Output = <T::Query as DistinctDsl>::Output;
 
+    /// Returns query with DISTINCT added
     fn distinct(self) -> Self::Output {
         self.as_query().distinct()
     }

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -1,3 +1,12 @@
+//! Traits that construct SELECT statements
+//!
+//! Traits in this module have methods that generally map to the keyword for the corresponding clause in SQL,
+//! unless it conflicts with a Rust keyword (such as `WHERE`/`where`).
+//!
+//! See also [`expression_methods`][expression_methods] and [`dsl`][dsl].
+//!
+//! [expression_methods]: ../expression_methods/index.html
+//! [dsl]: ../dsl/index.html
 mod belonging_to_dsl;
 #[doc(hidden)]
 pub mod boxed_dsl;


### PR DESCRIPTION
Previously in docs, query_dsl attributes were doced on the prelude page
this makes the mod public so it has its own doc page.