### PR TITLE
Pg text expression doctests

### DIFF
--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -102,19 +102,12 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("../../doctest_setup.rs");
+    /// # use schema::users;
     /// #
     /// # table! {
     /// #     posts {
     /// #         id -> Integer,
     /// #         tags -> Array<VarChar>,
-    /// #     }
-    /// # }
-    /// #
-    /// # // FIXME: We shouldn't need to define a users table here
-    /// # table! {
-    /// #     users {
-    /// #         id -> Integer,
-    /// #         name -> VarChar,
     /// #     }
     /// # }
     /// #
@@ -162,19 +155,12 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("../../doctest_setup.rs");
+    /// # use schema::users;
     /// #
     /// # table! {
     /// #     posts {
     /// #         id -> Integer,
     /// #         tags -> Array<VarChar>,
-    /// #     }
-    /// # }
-    /// #
-    /// # // FIXME: We shouldn't need to define a users table here
-    /// # table! {
-    /// #     users {
-    /// #         id -> Integer,
-    /// #         name -> VarChar,
     /// #     }
     /// # }
     /// #
@@ -218,19 +204,12 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
     /// # include!("../../doctest_setup.rs");
+    /// # use schema::users;
     /// #
     /// # table! {
     /// #     posts {
     /// #         id -> Integer,
     /// #         tags -> Array<VarChar>,
-    /// #     }
-    /// # }
-    /// #
-    /// # // FIXME: We shouldn't need to define a users table here
-    /// # table! {
-    /// #     users {
-    /// #         id -> Integer,
-    /// #         name -> VarChar,
     /// #     }
     /// # }
     /// #

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -368,11 +368,59 @@ impl<T> SortExpressionMethods for Desc<T> {}
 
 pub trait PgTextExpressionMethods: Expression<SqlType = Text> + Sized {
     /// Returns a SQL `ILIKE` expression
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("../../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let like_sean = users
+    ///     .select(name)
+    ///     .filter(name.ilike("sean"))
+    ///     .get_results::<String>(&connection)
+    ///     .expect("Failed");
+    ///
+    /// let expected = vec!["Sean".to_string()];
+    ///
+    /// assert_eq!(expected, like_sean);
+    /// # }
+    /// ```
     fn ilike<T: AsExpression<Text>>(self, other: T) -> ILike<Self, T::Expression> {
         ILike::new(self.as_expression(), other.as_expression())
     }
 
     /// Returns a SQL `NOT ILIKE` expression
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[macro_use] extern crate diesel_codegen;
+    /// # include!("../../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let not_like_sean = users
+    ///     .select(name)
+    ///     .filter(name.not_ilike("sean"))
+    ///     .get_results::<String>(&connection)
+    ///     .expect("Failed");
+    ///
+    /// let expected = vec!["Tess".to_string()];
+    ///
+    /// assert_eq!(expected, not_like_sean);
+    /// # }
+    /// ```
     fn not_ilike<T: AsExpression<Text>>(self, other: T) -> NotILike<Self, T::Expression> {
         NotILike::new(self.as_expression(), other.as_expression())
     }


### PR DESCRIPTION
Add doctests for Pg Text Expression methods `ilike` and `not_ilike`.
Update the FIXME for `table!` macros in expression_methods file.