### PR TITLE
Add doctests for TextExpression methods

### DIFF
--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -59,11 +59,126 @@ pub trait TextExpressionMethods: Expression + Sized {
     }
 
     /// Returns a SQL `LIKE` expression
+    ///
+    /// This method is case insensitive for SQLite and MySQL backends.
+    /// Postgres `LIKE` is case sensitive. You may use
+    /// [`ilike()`](../expression_methods/trait.PgTextExpressionMethods.html#method.ilike) for case insensitive.
+    ///
+    /// # Examples
+    ///
+    /// ### SQLite and MySQL
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # #[cfg(not(feature = "postgres"))]
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let like_sean = users
+    ///     .select(name)
+    ///     .filter(name.like("sean"))
+    ///     .get_results::<String>(&connection)
+    ///     .expect("Failed");
+    ///
+    /// let expected = vec!["Sean".to_string()];
+    ///
+    /// assert_eq!(expected, like_sean);
+    /// # }
+    /// # #[cfg(feature = "postgres")] fn main() {}
+    /// ```
+    ///
+    /// ### Postgres
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # #[cfg(feature = "postgres")]
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let like_sean = users
+    ///     .select(name)
+    ///     .filter(name.like("sean"))
+    ///     .get_results::<String>(&connection)
+    ///     .expect("Failed");
+    ///
+    /// let expected: Vec<String> = vec![];
+    ///
+    /// assert_eq!(expected, like_sean);
+    /// # }
+    /// # #[cfg(not(feature = "postgres"))] fn main() {}
+    /// ```
     fn like<T: AsExpression<Self::SqlType>>(self, other: T) -> Like<Self, T::Expression> {
         Like::new(self.as_expression(), other.as_expression())
     }
 
     /// Returns a SQL `NOT LIKE` expression
+    ///
+    /// This method is case insensitive for SQLite and MySQL backends.
+    /// Postgres `NOT LIKE` is case sensitive. You may use
+    /// [`not_ilike()`](../expression_methods/trait.PgTextExpressionMethods.html#method.not_ilike) for case insensitive.
+    ///
+    /// # Examples
+    ///
+    /// ### SQLite and MySQL
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # #[cfg(not(feature = "postgres"))]
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let not_like_sean = users
+    ///     .select(name)
+    ///     .filter(name.not_like("sean"))
+    ///     .get_results::<String>(&connection)
+    ///     .expect("Failed");
+    ///
+    /// let expected = vec!["Tess".to_string()];
+    ///
+    /// assert_eq!(expected, not_like_sean);
+    /// # }
+    /// # #[cfg(feature = "postgres")] fn main() {}
+    /// ```
+    ///
+    /// ### Postgres
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # #[cfg(feature = "postgres")]
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let not_like_sean = users
+    ///     .select(name)
+    ///     .filter(name.not_like("sean"))
+    ///     .get_results::<String>(&connection)
+    ///     .expect("Failed");
+    ///
+    /// let expected = vec![
+    ///     "Sean".to_string(),
+    ///     "Tess".to_string()
+    /// ];
+    ///
+    /// assert_eq!(expected, not_like_sean);
+    /// # }
+    /// # #[cfg(not(feature = "postgres"))] fn main() {}
+    /// ```
     fn not_like<T: AsExpression<Self::SqlType>>(self, other: T) -> NotLike<Self, T::Expression> {
         NotLike::new(self.as_expression(), other.as_expression())
     }


### PR DESCRIPTION
Add doctests for `like` & `not_like` text expression methods. 
Show different behavior between SQLite/MySQL & Postgres backends.