### PR TITLE
Unify the PG interval DSLs into a single trait

### DIFF
--- a/diesel/src/pg/expression/extensions/mod.rs
+++ b/diesel/src/pg/expression/extensions/mod.rs
@@ -3,4 +3,4 @@
 //! re-exported in `diesel::dsl`
 mod interval_dsl;
 
-pub use self::interval_dsl::{DayAndMonthIntervalDsl, MicroIntervalDsl};
+pub use self::interval_dsl::IntervalDsl;


### PR DESCRIPTION
These were originally split for correctness. I wanted to avoid
implementing `days` and `months` on `i64`, since they can't represent
any value larger than an `i32`. Additionally, I wanted to avoid
implementing `MicroIntervalDsl` on `i32` because calculating some of the
larger units could easily overflow (1 hour in microseconds is greater
than a 32 bit integer can store).

Both of these concerns are invalid. `f64` already represents plenty of
values that can't fit into `days` and `months`, and doing
`i64::MAX.weeks()` would overflow as well. It's no less correct to allow
`i32` here. We can also fix the overflow issues on the smaller units by
just implementing all the methods to cast immediately.

I've opted to stop at `i32` and not implement this for smaller/larger
types however. `i32` is the "default" integer type in Rust, so it makes
sense to implement these traits for that type specifically, but the same
argument doesn't really hold for `i16`. While the same argument could be
made for implementing this trait on `f32`, I've opted to avoid that for
now. When PG parses an interval, it will always treat floats as 64 bit,
so major precision issues will occur if we do the calculation with a 32
bit float (at the very least, it would be impossible to test).

Additionally, I noticed that these tests were extremely slow as they
establish a ton of database connections all at once. Since none of them
modify any state (there's no transaction), I've switched them to use a
thread local connection.

We still have some float precision issues that I'd like to address at
some point. We're ending up being off by 1 microsecond in the
implementations of `weeks` and `months` that I'm still unsure exactly
why.