### PR TITLE
Stop recompiling, I have shit to do

### DIFF
--- a/diesel_tests/build.rs
+++ b/diesel_tests/build.rs
@@ -54,7 +54,7 @@ fn main() {
     let migrations_dir = migrations::find_migrations_directory()
         .unwrap()
         .join(MIGRATION_SUBDIR);
-    println!("cargo:rerun-if-changed={}", MIGRATION_SUBDIR);
+    println!("cargo:rerun-if-changed={}", migrations_dir.display());
     migrations::run_pending_migrations_in_directory(
         &connection(),
         &migrations_dir,


### PR DESCRIPTION
I wrote this wrong... It prints `rerun-if-changed=postgresql`, not the
actual directory. Interestingly, this causes Cargo to just
unconditionally recompile the crate, regardless of whether anything has
changed. That is undesirable. Instead, let's only recompile if there is
a new migration. That sounds like a good plan.