### PR TITLE
Bump dotenv to 0.10 in every example

### DIFF
--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["mysql"] }
 diesel_codegen = { version = "0.16.0", features = ["mysql"] }
-dotenv = "0.8.0"
+dotenv = "0.10"

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["mysql"] }
 diesel_codegen = { version = "0.16.0", features = ["mysql"] }
-dotenv = "0.8.0"
+dotenv = "0.10"

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["mysql"] }
 diesel_codegen = { version = "0.16.0", features = ["mysql"] }
-dotenv = "0.8.0"
+dotenv = "0.10"

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["postgres"] }
 diesel_codegen = { version = "0.16.0", features = ["postgres"] }
-dotenv = "0.8.0"
+dotenv = "0.10"

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["postgres"] }
 diesel_codegen = { version = "0.16.0", features = ["postgres"] }
-dotenv = "0.8.0"
+dotenv = "0.10"

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["postgres"] }
 diesel_codegen = { version = "0.16.0", features = ["postgres"] }
-dotenv = "0.8.0"
+dotenv = "0.10"

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["sqlite"] }
 diesel_codegen = { version = "0.16.0", features = ["sqlite"] }
-dotenv = "0.8"
+dotenv = "0.10"

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["sqlite"] }
 diesel_codegen = { version = "0.16.0", features = ["sqlite"] }
-dotenv = "0.8"
+dotenv = "0.10"

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["sqlite"] }
 diesel_codegen = { version = "0.16.0", features = ["sqlite"] }
-dotenv = "0.8"
+dotenv = "0.10"


### PR DESCRIPTION
It removes the dotenv 0.8 dependency in the workspace's Cargo.lock