### PR TITLE
Add SQLite COLLATE operator support

### DIFF
--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -25,3 +25,7 @@ pub use self::eq_all::EqAll;
 #[cfg(feature = "postgres")]
 #[doc(inline)]
 pub use pg::expression::expression_methods::*;
+
+#[cfg(feature = "sqlite")]
+#[doc(inline)]
+pub use sqlite::expression::expression_methods::*;

--- a/diesel/src/sqlite/expression/collate.rs
+++ b/diesel/src/sqlite/expression/collate.rs
@@ -1,0 +1,101 @@
+use backend::Backend;
+use expression::*;
+use query_builder::*;
+use result::QueryResult;
+
+pub trait Collation {
+    fn get_collation<'a>(&'a self) -> &'a str;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Collate<Lhs: Expression, Coll: Collation> {
+    left: Lhs,
+    collation: Coll,
+}
+
+impl<Lhs: Expression, Coll: Collation> Collate<Lhs, Coll> {
+    pub fn new(left: Lhs, collation: Coll) -> Self {
+        Collate { left, collation }
+    }
+}
+
+impl<Lhs, Coll> QueryId for Collate<Lhs, Coll>
+where
+    Lhs: 'static + Expression + QueryId,
+    Coll: 'static + Collation,
+{
+    type QueryId = Collate<Lhs, Coll>;
+    const HAS_STATIC_QUERY_ID: bool = Lhs::HAS_STATIC_QUERY_ID;
+}
+
+impl<Lhs, Coll, QS> SelectableExpression<QS> for Collate<Lhs, Coll>
+where
+    Collate<Lhs, Coll>: AppearsOnTable<QS>,
+    Lhs: Expression + SelectableExpression<QS>,
+    Coll: Collation,
+{
+}
+
+impl<Lhs, Coll, QS> AppearsOnTable<QS> for Collate<Lhs, Coll>
+where
+    Collate<Lhs, Coll>: Expression,
+    Lhs: Expression + AppearsOnTable<QS>,
+    Coll: Collation,
+{
+}
+
+impl<Lhs, Coll> Expression for Collate<Lhs, Coll>
+where
+    Lhs: Expression,
+    Coll: Collation,
+{
+    type SqlType = Lhs::SqlType;
+}
+
+impl<Lhs, Coll> NonAggregate for Collate<Lhs, Coll>
+where
+    Lhs: Expression + NonAggregate,
+    Coll: Collation,
+{
+}
+
+impl<Lhs, Coll, DB> QueryFragment<DB> for Collate<Lhs, Coll>
+where
+    Lhs: Expression + QueryFragment<DB>,
+    Coll: Collation,
+    DB: Backend,
+{
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        self.left.walk_ast(out.reborrow())?;
+        out.push_sql(" COLLATE ");
+        out.push_sql(self.collation.get_collation());
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CollationBinary;
+
+impl Collation for CollationBinary {
+    fn get_collation<'a>(&'a self) -> &'a str {
+        "BINARY"
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CollationNoCase;
+
+impl Collation for CollationNoCase {
+    fn get_collation<'a>(&'a self) -> &'a str {
+        "NOCASE"
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CollationRTrim;
+
+impl Collation for CollationRTrim {
+    fn get_collation<'a>(&'a self) -> &'a str {
+        "RTRIM"
+    }
+}

--- a/diesel/src/sqlite/expression/expression_methods.rs
+++ b/diesel/src/sqlite/expression/expression_methods.rs
@@ -2,17 +2,20 @@ use expression::Expression;
 use super::operators::*;
 
 pub trait SqliteExpressionMethods: Sized {
-    /// Creates SQLite `COLLATE BINARY` expression
+    /// Creates SQLite `COLLATE BINARY` expression.
+    /// https://sqlite.org/datatype3.html#collating_sequences
     fn collate_binary(self) -> CollateBinary<Self> {
         CollateBinary::new(self)
     }
 
-    /// Creates SQLite `COLLATE NOCASE` expression
+    /// Creates SQLite `COLLATE NOCASE` expression.
+    /// https://sqlite.org/datatype3.html#collating_sequences
     fn collate_nocase(self) -> CollateNoCase<Self> {
         CollateNoCase::new(self)
     }
 
-    /// Creates SQLite `COLLATE RTRIM` expression
+    /// Creates SQLite `COLLATE RTRIM` expression.
+    /// https://sqlite.org/datatype3.html#collating_sequences
     fn collate_rtrim(self) -> CollateRTrim<Self> {
         CollateRTrim::new(self)
     }

--- a/diesel/src/sqlite/expression/expression_methods.rs
+++ b/diesel/src/sqlite/expression/expression_methods.rs
@@ -1,0 +1,21 @@
+use expression::Expression;
+use super::operators::*;
+
+pub trait SqliteExpressionMethods: Sized {
+    /// Creates SQLite `COLLATE BINARY` expression
+    fn collate_binary(self) -> CollateBinary<Self> {
+        CollateBinary::new(self)
+    }
+
+    /// Creates SQLite `COLLATE NOCASE` expression
+    fn collate_nocase(self) -> CollateNoCase<Self> {
+        CollateNoCase::new(self)
+    }
+
+    /// Creates SQLite `COLLATE RTRIM` expression
+    fn collate_rtrim(self) -> CollateRTrim<Self> {
+        CollateRTrim::new(self)
+    }
+}
+
+impl<T: Expression> SqliteExpressionMethods for T {}

--- a/diesel/src/sqlite/expression/expression_methods.rs
+++ b/diesel/src/sqlite/expression/expression_methods.rs
@@ -1,23 +1,11 @@
 use expression::Expression;
-use super::operators::*;
+use super::collate::{Collate, Collation};
 
-pub trait SqliteExpressionMethods: Sized {
-    /// Creates SQLite `COLLATE BINARY` expression.
+pub trait SqliteExpressionMethods: Expression + Sized {
+    /// Creates SQLite `COLLATE` expression.
     /// https://sqlite.org/datatype3.html#collating_sequences
-    fn collate_binary(self) -> CollateBinary<Self> {
-        CollateBinary::new(self)
-    }
-
-    /// Creates SQLite `COLLATE NOCASE` expression.
-    /// https://sqlite.org/datatype3.html#collating_sequences
-    fn collate_nocase(self) -> CollateNoCase<Self> {
-        CollateNoCase::new(self)
-    }
-
-    /// Creates SQLite `COLLATE RTRIM` expression.
-    /// https://sqlite.org/datatype3.html#collating_sequences
-    fn collate_rtrim(self) -> CollateRTrim<Self> {
-        CollateRTrim::new(self)
+    fn collate<Coll: Collation>(self, collation: Coll) -> Collate<Self, Coll> {
+        Collate::new(self, collation)
     }
 }
 

--- a/diesel/src/sqlite/expression/mod.rs
+++ b/diesel/src/sqlite/expression/mod.rs
@@ -1,3 +1,5 @@
 #[doc(hidden)]
-pub mod operators;
 pub mod expression_methods;
+pub mod collate;
+
+pub use self::collate::*;

--- a/diesel/src/sqlite/expression/mod.rs
+++ b/diesel/src/sqlite/expression/mod.rs
@@ -1,0 +1,3 @@
+#[doc(hidden)]
+pub mod operators;
+pub mod expression_methods;

--- a/diesel/src/sqlite/expression/operators.rs
+++ b/diesel/src/sqlite/expression/operators.rs
@@ -1,5 +1,0 @@
-use sqlite::Sqlite;
-
-diesel_postfix_operator!(CollateBinary, " COLLATE BINARY", backend: Sqlite);
-diesel_postfix_operator!(CollateNoCase, " COLLATE NOCASE", backend: Sqlite);
-diesel_postfix_operator!(CollateRTrim, " COLLATE RTRIM", backend: Sqlite);

--- a/diesel/src/sqlite/expression/operators.rs
+++ b/diesel/src/sqlite/expression/operators.rs
@@ -1,0 +1,5 @@
+use sqlite::Sqlite;
+
+diesel_postfix_operator!(CollateBinary, " COLLATE BINARY", backend: Sqlite);
+diesel_postfix_operator!(CollateNoCase, " COLLATE NOCASE", backend: Sqlite);
+diesel_postfix_operator!(CollateRTrim, " COLLATE RTRIM", backend: Sqlite);

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -1,4 +1,3 @@
-
 mod backend;
 mod connection;
 mod types;

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -1,8 +1,10 @@
+
 mod backend;
 mod connection;
 mod types;
 
 pub mod query_builder;
+pub mod expression;
 
 pub use self::backend::{Sqlite, SqliteType};
 pub use self::connection::SqliteConnection;

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -465,6 +465,7 @@ fn filter_subselect_with_pg_any() {
 #[cfg(feature = "sqlite")]
 fn filter_by_string_equality_case_insensitive() {
     use schema::users::dsl::*;
+    use diesel::sqlite::expression::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -473,13 +474,13 @@ fn filter_by_string_equality_case_insensitive() {
     assert_eq!(
         Ok(sean),
         users
-            .filter(name.eq("sean").collate_nocase())
+            .filter(name.eq("sean").collate(CollationNoCase))
             .first(&connection)
     );
     assert_eq!(
         Ok(tess),
         users
-            .filter(name.eq("Tess ").collate_rtrim())
+            .filter(name.collate(CollationRTrim).eq("Tess "))
             .first(&connection)
     );
 }

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -460,3 +460,16 @@ fn filter_subselect_with_pg_any() {
         .load(&conn);
     assert_eq!(Ok(vec![sean]), users_with_published_posts);
 }
+
+#[test]
+#[cfg(feature = "sqlite")]
+fn filter_by_string_equality_case_insensitive() {
+    use schema::users::dsl::*;
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    let sean = User::new(1, "Sean");
+    let tess = User::new(2, "Tess");
+    assert_eq!(Ok(sean), users.filter(name.eq("sean").collate_nocase()).first(&connection));
+    assert_eq!(Ok(tess), users.filter(name.eq("Tess ").collate_rtrim()).first(&connection));
+}

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -470,6 +470,16 @@ fn filter_by_string_equality_case_insensitive() {
 
     let sean = User::new(1, "Sean");
     let tess = User::new(2, "Tess");
-    assert_eq!(Ok(sean), users.filter(name.eq("sean").collate_nocase()).first(&connection));
-    assert_eq!(Ok(tess), users.filter(name.eq("Tess ").collate_rtrim()).first(&connection));
+    assert_eq!(
+        Ok(sean),
+        users
+            .filter(name.eq("sean").collate_nocase())
+            .first(&connection)
+    );
+    assert_eq!(
+        Ok(tess),
+        users
+            .filter(name.eq("Tess ").collate_rtrim())
+            .first(&connection)
+    );
 }

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -83,6 +83,7 @@ fn order_by_descending_column() {
 #[cfg(feature = "sqlite")]
 fn order_collate() {
     use schema::users::dsl::*;
+    use diesel::sqlite::expression::*;
 
     let conn = connection();
     let data = vec![
@@ -101,7 +102,10 @@ fn order_collate() {
         User::new(jim.id, "jim"),
         User::new(tess.id, "tess"),
     ];
-    let data: Vec<_> = users.order(name.collate_binary()).load(&conn).unwrap();
+    let data: Vec<_> = users
+        .order(name.collate(CollationBinary))
+        .load(&conn)
+        .unwrap();
     assert_eq!(expected_data_binary, data);
 
     let expected_data_nocase = vec![
@@ -109,6 +113,9 @@ fn order_collate() {
         User::new(sean.id, "SEAN"),
         User::new(tess.id, "tess"),
     ];
-    let data: Vec<_> = users.order(name.collate_nocase()).load(&conn).unwrap();
+    let data: Vec<_> = users
+        .order(name.collate(CollationNoCase))
+        .load(&conn)
+        .unwrap();
     assert_eq!(expected_data_nocase, data);
 }

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -78,3 +78,37 @@ fn order_by_descending_column() {
     let data: Vec<_> = users.order(name.desc()).load(&conn).unwrap();
     assert_eq!(expected_data, data);
 }
+
+#[test]
+#[cfg(feature = "sqlite")]
+fn order_collate() {
+    use schema::users::dsl::*;
+
+    let conn = connection();
+    let data = vec![
+        NewUser::new("SEAN", None),
+        NewUser::new("tess", None),
+        NewUser::new("jim", None),
+    ];
+    insert_into(users).values(&data).execute(&conn).unwrap();
+    let data = users.load::<User>(&conn).unwrap();
+    let sean = &data[0];
+    let tess = &data[1];
+    let jim = &data[2];
+
+    let expected_data_binary = vec![
+        User::new(sean.id, "SEAN"),
+        User::new(jim.id, "jim"),
+        User::new(tess.id, "tess"),
+    ];
+    let data: Vec<_> = users.order(name.collate_binary()).load(&conn).unwrap();
+    assert_eq!(expected_data_binary, data);
+
+    let expected_data_nocase = vec![
+        User::new(jim.id, "jim"),
+        User::new(sean.id, "SEAN"),
+        User::new(tess.id, "tess"),
+    ];
+    let data: Vec<_> = users.order(name.collate_nocase()).load(&conn).unwrap();
+    assert_eq!(expected_data_nocase, data);
+}


### PR DESCRIPTION
> When SQLite compares two strings, it uses a collating sequence or collating function (two words for the same thing) to determine which string is greater or if the two strings are equal. SQLite has three built-in collating functions: `BINARY`, `NOCASE`, and `RTRIM`.
> 
> * `BINARY` - Compares string data using `memcmp()`, regardless of text encoding.
> * `NOCASE` - The same as binary, except the 26 upper case characters of ASCII are folded to their lower case equivalents before the comparison is performed. Note that only ASCII characters are case folded. SQLite does not attempt to do full UTF case folding due to the size of the tables required.
> * `RTRIM` - The same as binary, except that trailing space characters are ignored.
>
https://sqlite.org/datatype3.html#collating_sequences
