### PR TITLE
Fix the large tables (and above) features

### DIFF
--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -66,7 +66,7 @@ macro_rules! tuple_impls {
                 DB: Backend,
                 $($T: QueryableByName<DB>,)+
             {
-                fn build<R: NamedRow<DB>>(row: &R) -> Result<Self, Box<Error + Send + Sync>> {
+                fn build<RowT: NamedRow<DB>>(row: &RowT) -> Result<Self, Box<Error + Send + Sync>> {
                     Ok(($($T::build(row)?,)+))
                 }
             }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -12,7 +12,7 @@ dotenv = ">=0.8, <0.11"
 [dependencies]
 assert_matches = "1.0.1"
 chrono = { version = "0.4" }
-diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric", "with-deprecated"] }
+diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric", "with-deprecated", "large-tables"] }
 diesel_codegen = { path = "../diesel_codegen" }
 dotenv = ">=0.8, <0.11"
 quickcheck = { version = "0.4", features = ["unstable"] }


### PR DESCRIPTION
In 6cfafef7f, in the build function, a generic parameter named `R` was
introduced for the build function. It's colliding with the name of our
generic tuple stuff so I just renamed it to `RowT`