### PR TITLE
open SQLite connection with SQLITE_OPEN_URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   They are no longer dependent on the current working directory (for all
   directories in the same project)
 
+* The SQLite backend is now configured to interpret URIs.
+  See [the SQLite URI documentation] for additional details.
+
+[the SQLite URI documentation]: https://www.sqlite.org/uri.html
+
 ### Deprecated
 
 * `diesel_(prefix|postfix|infix)_operator!` have been deprecated. These macros

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -82,3 +82,22 @@ fn strips_sqlite_url_prefix() {
     path.push("diesel_test_sqlite.db");
     assert!(SqliteConnection::establish(&format!("sqlite://{}", path.display())).is_ok());
 }
+
+#[test]
+#[cfg(feature = "sqlite")]
+fn file_uri_created_in_memory() {
+    use std::path::Path;
+
+    assert!(SqliteConnection::establish("file::memory:").is_ok());
+    assert!(!Path::new("file::memory:").exists());
+    assert!(!Path::new(":memory:").exists());
+}
+
+#[test]
+#[cfg(feature = "sqlite")]
+fn sqlite_uri_prefix_interpreted_as_file() {
+    let mut path = std::env::temp_dir();
+    path.push("diesel_test_sqlite_readonly.db");
+    assert!(SqliteConnection::establish(&format!("sqlite://{}?mode=rwc", path.display())).is_ok());
+    assert!(path.exists());
+}


### PR DESCRIPTION
This allows the user to set options such as in-memory caching on the database.

See the documentation here for notes on backwards-compatibility: https://www.sqlite.org/uri.html.