### PR TITLE
Use the scale from postgres to construct our BigDecimal in FromSql

### DIFF
--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -697,6 +697,8 @@ fn pg_numeric_bigdecimal_from_sql() {
         "1.0",
         "141.0",
         "-1.0",
+        // With some more precision
+        "4.2000000",
         // Larger than u64
         "18446744073709551616",
         // Powers of 10k (numeric is represented in base 10k)
@@ -713,6 +715,10 @@ fn pg_numeric_bigdecimal_from_sql() {
         let query = format!("'{}'::numeric", value);
         let expected = value.parse::<BigDecimal>().unwrap();
         assert_eq!(expected, query_single_value::<Numeric, BigDecimal>(&query));
+        assert_eq!(
+            format!("{}", expected),
+            format!("{}", query_single_value::<Numeric, BigDecimal>(&query))
+        );
     }
 }
 


### PR DESCRIPTION
This `with_scale` method didn't exist when we added support for the
bigdecimal crate and it was causing 0.01 to be interpreted as 0.01000.
Now that it exists, use it.