### PR TITLE
Enable sqlite/bundle for diesel cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,13 @@ matrix:
         cargo install rustfmt-nightly --vers 0.3.1
       fi
     - cargo fmt --all -- --write-mode=diff
+  - rust: nightly
+    env:
+    - SQLITE_BUNDLED=YESPLEASE
+    - SQLITE_DATABASE_URL=/tmp/test.db
+    script:
+    - (cd diesel_cli && travis-cargo test --no-default-features --features "sqlite-bundled")
+  
 env:
   matrix:
     - BACKEND=sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added support for specifying `ISOLATION LEVEL`, `DEFERRABLE`, and `READ ONLY`
   on PG transactions. See [`PgConnection::build_transaction`] for details.
 
+* Added `sqlite-bundled` feature to `diesel_cli` to make installing on
+  some platforms easier. 
+
 [`PgConnection::build_transaction`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html#method.build_transaction
 
 ### Changed

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -23,6 +23,7 @@ infer_schema_internals = { version = "1.1.0" }
 clippy = { optional = true, version = "=0.0.174" }
 migrations_internals = { version = "1.1.0" }
 url = { version = "1.4.0", optional = true }
+libsqlite3-sys = { version = ">=0.8.0, <0.9.0", default-features = false, optional = true, features = ["bundled"] }
 
 [dev-dependencies]
 difference = "1.0"
@@ -36,6 +37,7 @@ lint = ["clippy"]
 postgres = ["diesel/postgres", "infer_schema_internals/postgres", "url"]
 sqlite = ["diesel/sqlite", "infer_schema_internals/sqlite"]
 mysql = ["diesel/mysql", "infer_schema_internals/mysql", "url"]
+sqlite-bundled = ["sqlite", "libsqlite3-sys/bundled"]
 
 [[test]]
 name = "tests"

--- a/diesel_cli/README.md
+++ b/diesel_cli/README.md
@@ -22,6 +22,13 @@ cargo install diesel_cli --no-default-features --features "postgres sqlite mysql
 [sqlite]: http://www.sqlitetutorial.net/download-install-sqlite/
 [mysql]: https://dev.mysql.com/doc/refman/5.7/en/installing.html
 
+If you are using a system without an easy way to install sqlite (for example Windows),
+you can use a bundled version instead:
+
+```shell
+cargo install diesel_cli --no-default-features --features "sqlite-bundled"
+```
+
 Getting Started
 ---------------
 


### PR DESCRIPTION
Trying to install the CLI on windows can be problematic, when creating a project you can just import the libsqlite3-sys feature but you can't do that when installing the cli tools. With this change you can install on Windows (or other platforms without an easy way of installing sqlite3).

Installation can be achieved using this: `cargo install diesel_cli --no-default-features --features sqlite-bundled`