### PR TITLE
Revise associations and joins documentation

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -65,17 +65,17 @@
 //! custom one to `#[belongs_to]` by adding a `foreign_key` argument to the
 //! attribute like so `#[belongs_to(Foo, foreign_key="mykey")]`.
 //!
-//! `Associations` are separate from joins in Diesel. Please see docs on [`JoinDsl!`]
+//! `Associations` are separate from joins in Diesel. Please see docs on [`JoinDsl`]
 //! to learn more about joining tables.
 //!
-//! [`JoinDsl!`]: ../prelude/trait.JoinDsl.html
+//! [`JoinDsl`]: ../query_dsl/trait.JoinDsl.html
 //!
 //! You can load the children for a single parent or multiple parents (`Vec<ParentType>`) using the
 //! [`belonging_to()`][belonging-to] method.
 //! This amounts to the `SQL` statements `SELECT * FROM posts WHERE posts.user_id = $1`
 //! or `SELECT * FROM posts WHERE posts.user_id IN ($1, $2, etc...)`
 //!
-//! [belonging-to]: ../prelude/trait.BelongingToDsl.html#tymethod.belonging_to
+//! [belonging-to]: ../query_dsl/trait.BelongingToDsl.html#tymethod.belonging_to
 //!
 //! ```rust
 //! # #[macro_use] extern crate diesel;

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -1,14 +1,34 @@
 //! Traits related to relationships between multiple tables.
 //!
-//! Associations in Diesel are bidirectional, but primarily focus on the child-to-parent
-//! relationship. You can declare an association between two records with
-//! `#[belongs_to]`.
+//! **Note: This feature is under active development, and we are seeking feedback on the APIs that
+//! have been released. Please feel free to [open issues][open-issue], or join [our chat][gitter]
+//! to provide feedback.**
+//!
+//! [open-issue]: https://github.com/diesel-rs/diesel/issues/new
+//! [gitter]: https://gitter.im/diesel-rs/diesel
+//!
+//! Associations in Diesel are unidirectional and focus on the child-to-parent
+//! relationship.
+//!
+//! **Child** refers to the *many* part of a *one to many* relationship and has *one parent*.
+//! **Parent** refers to the *one* part of a *one to many* relationship and can *have many
+//! children*.
+//! In the following relationship for our code examples, User has many Posts,
+//! so User is the parent and Posts are children.
+//!
+//! In order to declare this relationship, you must annotate your child struct
+//! with `#[derive(Associations)]` and `#[belongs_to(ParentStructName)]`.
+//! `#[belongs_to]` is given the name of the struct that represents the parent. Both parent and
+//! child types must implement the [`Identifiable`][identifiable] trait.
+//! The struct or table referenced in your association has to be in scope,
+//! so you'll need `use schema::posts` or similar to bring the
+//! table into scope.
 //!
 //! ```rust
-//! // You need to have the table definitions from `infer_schema!` or `table!` in scope to
-//! // derive Identifiable.
 //! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
+//! // Brings User and Post tables into scope.
+//! // Otherwise `table!` definitions would need to be here.
 //! use schema::{posts, users};
 //!
 //! #[derive(Identifiable, Queryable)]
@@ -39,76 +59,21 @@
 //! # }
 //! ```
 //!
-//! Note that in addition to the `#[belongs_to]` annotation, we also need to
-//! `#[derive(Associations)]`
-//!
-//! `#[belongs_to]` is given the name of the struct that represents the parent. Both types
-//! must implement the [`Identifiable`][identifiable] trait. The struct or table referenced in your
-//! association has to be in scope, so you'll need `use schema::posts` or similar to bring the
-//! table into scope, and `use some_module::User` if `User` were in a different module.
-//!
 //! [Identifiable]: trait.Identifiable.html
 //!
 //! If the name of your foreign key doesn't follow the convention `tablename_id`, you can specify a
 //! custom one to `#[belongs_to]` by adding a `foreign_key` argument to the
 //! attribute like so `#[belongs_to(Foo, foreign_key="mykey")]`.
 //!
-//! Once the associations are defined, you can join between the two tables using the
-//! [`inner_join`][inner-join] or [`left_outer_join`][left-outer-join].
+//! `Associations` are separate from joins in Diesel. Please see docs on [`JoinDsl!`]
+//! to learn more about joining tables.
 //!
-//! [inner-join]: ../prelude/trait.JoinDsl.html#method.inner_join
-//! [left-outer-join]: ../prelude/trait.JoinDsl.html#method.left_outer_join
+//! [`JoinDsl!`]: ../prelude/trait.JoinDsl.html
 //!
-//! ```rust
-//! # #[macro_use] extern crate diesel;
-//! # include!("../doctest_setup.rs");
-//! # use schema::users;
-//! # use schema::posts;
-//! #
-//! # #[derive(Debug, PartialEq, Identifiable, Queryable)]
-//! # pub struct User {
-//! #     id: i32,
-//! #     name: String,
-//! # }
-//! #
-//! # #[derive(Debug, PartialEq, Identifiable, Queryable, Associations)]
-//! # #[belongs_to(User)]
-//! # pub struct Post {
-//! #     id: i32,
-//! #     user_id: i32,
-//! #     title: String,
-//! # }
-//! #
-//! # fn main() {
-//! #   use users::dsl::*;
-//! #   use posts::dsl::*;
-//! #   let connection = establish_connection();
-//! #
-//! let data: Vec<(User, Post)> = users.inner_join(posts)
-//!     .load(&connection)
-//!     .expect("Couldn't load query");
-//! let expected = vec![
-//!     (
-//!         User { id: 1, name: "Sean".to_string() },
-//!         Post { id: 1, user_id: 1, title: "My first post".to_string() }
-//!     ),
-//!     (
-//!         User { id: 1, name: "Sean".to_string() },
-//!         Post { id: 2, user_id: 1, title: "About Rust".to_string() }
-//!     ),
-//!     (
-//!         User { id: 2, name: "Tess".to_string() },
-//!         Post { id: 3, user_id: 2, title: "My first post too".to_string() }
-//!     ),
-//! ];
-//!
-//! assert_eq!(data, expected);
-//! # }
-//! ```
-//! Typically however, queries are loaded in multiple queries. For most datasets, the reduced
-//! amount of duplicated information sent over the wire saves more time than the extra round trip
-//! costs us. You can load the children for a single parent using the
-//! [`belonging_to`][belonging-to]
+//! You can load the children for a single parent or multiple parents (`Vec<ParentType>`) using the
+//! [`belonging_to()`][belonging-to] method.
+//! This amounts to the `SQL` statements `SELECT * FROM posts WHERE posts.user_id = $1`
+//! or `SELECT * FROM posts WHERE posts.user_id IN ($1, $2, etc...)`
 //!
 //! [belonging-to]: ../prelude/trait.BelongingToDsl.html#tymethod.belonging_to
 //!
@@ -136,13 +101,15 @@
 //! #   use users::dsl::*;
 //! #   let connection = establish_connection();
 //! #
-//! let user = users.find(1).first::<User>(&connection).expect("Error loading user");
+//! // Loading the posts for a single parent user.
+//! let user = users.load::<User>(&connection).expect("Error loading user");
 //! let post_list = Post::belonging_to(&user)
 //!     .load::<Post>(&connection)
 //!     .expect("Error loading posts");
 //! let expected = vec![
 //!     Post { id: 1, user_id: 1, title: "My first post".to_string() },
 //!     Post { id: 2, user_id: 1, title: "About Rust".to_string() },
+//!     Post { id: 3, user_id: 2, title: "My first post too".to_string() }
 //! ];
 //!
 //! assert_eq!(post_list, expected);
@@ -161,8 +128,9 @@
 //! a user and all of its posts, that type is `(User, Vec<Post>)`.
 //!
 //! Next lets look at how to load the children for more than one parent record.
-//! [`belonging_to`][belonging-to] can be used to load the data, but we'll also need to group it
-//! with its parents. For this we use an additional method [`grouped_by`][grouped-by]
+//! [`belonging_to`][belonging-to] can be used to load all of the child data, but we'll also need to group the
+//! child records with their parents.
+//! For this we use an additional method [`grouped_by`][grouped-by]
 //!
 //! [grouped-by]: trait.GroupedBy.html#tymethod.grouped_by
 //!
@@ -307,11 +275,6 @@
 //!
 //!
 //! ```
-//!
-//! And that's it. This module will be expanded in the future with more complex joins, and the
-//! ability to define "through" associations (e.g. load all the comments left on any posts written
-//! by a user in a single query). However, the goal is to provide simple building blocks which can
-//! be used to construct the complex behavior applications need.
 mod belongs_to;
 
 use std::hash::Hash;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -958,8 +958,8 @@ macro_rules! __diesel_table_query_source_impl {
 /// be able to use the resulting query, unless you are using `infer_schema!` or
 /// `diesel print-schema` which will generate it for you.
 ///
-/// [`.on`]: ./prelude/trait.JoinOnDsl.html#method.on
-///
+/// [`.on`]: ./query_dsl/trait.JoinOnDsl.html#method.on
+/// [`allow_tables_to_appear_in_same_query!`]: macro.allow_tables_to_appear_in_same_query.html
 /// If you are using `infer_schema!` or `diesel print-schema`, an invocation of
 /// this macro will be generated for every foreign key in your database unless
 /// one of the following is true:
@@ -1197,8 +1197,7 @@ mod tests {
     #[cfg(feature = "postgres")]
     fn table_with_column_renaming_postgres() {
         use pg::Pg;
-        let expected_sql =
-            r#"SELECT "foo"."id", "foo"."type", "foo"."bleh" FROM "foo" WHERE "foo"."type" = $1 -- binds: [1]"#;
+        let expected_sql = r#"SELECT "foo"."id", "foo"."type", "foo"."bleh" FROM "foo" WHERE "foo"."type" = $1 -- binds: [1]"#;
         assert_eq!(
             expected_sql,
             ::debug_query::<Pg, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
@@ -1209,8 +1208,7 @@ mod tests {
     #[cfg(feature = "mysql")]
     fn table_with_column_renaming_mysql() {
         use mysql::Mysql;
-        let expected_sql =
-            r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
+        let expected_sql = r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
         assert_eq!(
             expected_sql,
             ::debug_query::<Mysql, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
@@ -1221,8 +1219,7 @@ mod tests {
     #[cfg(feature = "sqlite")]
     fn table_with_column_renaming_sqlite() {
         use sqlite::Sqlite;
-        let expected_sql =
-            r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
+        let expected_sql = r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
         assert_eq!(
             expected_sql,
             ::debug_query::<Sqlite, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -958,6 +958,8 @@ macro_rules! __diesel_table_query_source_impl {
 /// be able to use the resulting query, unless you are using `infer_schema!` or
 /// `diesel print-schema` which will generate it for you.
 ///
+/// [`.on`]: ./prelude/trait.JoinOnDsl.html#method.on
+///
 /// If you are using `infer_schema!` or `diesel print-schema`, an invocation of
 /// this macro will be generated for every foreign key in your database unless
 /// one of the following is true:

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -114,7 +114,7 @@ impl PgConnection {
         source: &T,
     ) -> QueryResult<(MaybeCached<Statement>, Vec<Option<Vec<u8>>>)> {
         let mut bind_collector = RawBytesBindCollector::<Pg>::new();
-        try!(source.collect_binds(&mut bind_collector, PgMetadataLookup::new(self)));
+        try!(source.collect_binds(&mut bind_collector, PgMetadataLookup::new(self),));
         let binds = bind_collector.binds;
         let metadata = bind_collector.metadata;
 

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -173,7 +173,7 @@ impl FromSql<types::Interval, Pg> for PgInterval {
             microseconds: try!(FromSql::<types::BigInt, Pg>::from_sql(Some(&bytes[..8]))),
             days: try!(FromSql::<types::Integer, Pg>::from_sql(Some(&bytes[8..12]))),
             months: try!(FromSql::<types::Integer, Pg>::from_sql(
-                Some(&bytes[12..16])
+                Some(&bytes[12..16]),
             )),
         })
     }

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -44,6 +44,84 @@ where
     }
 }
 
+/// Methods allowing various joins between two or more tables.
+///
+/// If you have invoked [`joinable!`] for the two tables, you can pass that
+/// table directly.  Otherwise you will need to use [`.on`] to specify the `ON`
+/// clause.
+///
+/// [`joinable!`]: ../macro.joinable.html
+/// [`.on`]: trait.JoinOnDsl.html#method.on
+///
+/// You can join to as many tables as you'd like in a query, with the
+/// restriction that no table can appear in the query more than once. The reason
+/// for this restriction is that one of the appearances would require aliasing,
+/// and we do not currently have a fleshed out story for dealing with table
+/// aliases.
+///
+/// You may also need to call [`allow_tables_to_appear_in_same_query!`][] (particularly if
+/// you see an unexpected error about `AppearsInFromClause`). See the
+/// documentation for [`allow_tables_to_appear_in_same_query!`][] for details.
+///
+/// Diesel expects multi-table joins to be semantically grouped based on the
+/// relationships. For example, `users.inner_join(posts.inner_join(comments))`
+/// is not the same as `users.inner_join(posts).inner_join(comments)`. The first
+/// would deserialize into `(User, (Post, Comment))` and generate the following
+/// SQL:
+///
+/// ```sql
+/// SELECT * FROM users
+///     INNER JOIN posts ON posts.user_id = users.id
+///     INNER JOIN comments ON comments.post_id = posts.id
+/// ```
+///
+/// While the second query would deserialize into `(User, Post, Comment)` and
+/// generate the following SQL:
+///
+/// ```sql
+/// SELECT * FROM users
+///     INNER JOIN posts ON posts.user_id = users.id
+///     INNER JOIN comments ON comments.user_id = users.id
+/// ```
+///
+/// [associations]: ../associations/index.html
+/// [`allow_tables_to_appear_in_same_query!`]: ../macro.allow_tables_to_appear_in_same_query.html
+pub trait JoinDsl: Sized {
+    /// Join two tables using a SQL `INNER JOIN`.
+    /// The implicit `ON` clause is defined
+    /// via the [JoinDsl](./trait.JoinOnDsl.html). 
+    /// Use [`.on`](./trait.JoinOnDsl.html#method.on) 
+    /// to override the implicit `ON` clause.
+    fn inner_join<Rhs>(self, rhs: Rhs) -> Self::Output
+    where
+        Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    {
+        self.join_with_implicit_on_clause(rhs, joins::Inner)
+    }
+
+    /// Join two tables using a SQL `LEFT OUTER JOIN`.
+    /// The implicit `ON` clause is defined
+    /// via the [JoinDsl](./trait.JoinOnDsl.html). 
+    /// Use [`.on`](./trait.JoinOnDsl.html#method.on) 
+    /// to override the implicit `ON` clause.
+    fn left_outer_join<Rhs>(self, rhs: Rhs) -> Self::Output
+    where
+        Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    {
+        self.join_with_implicit_on_clause(rhs, joins::LeftOuter)
+    }
+
+    /// Alias for `left_outer_join`
+    fn left_join<Rhs>(self, rhs: Rhs) -> Self::Output
+    where
+        Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    {
+        self.left_outer_join(rhs)
+    }
+}
+
+impl<T: AsQuery> JoinDsl for T {}
+
 pub trait JoinOnDsl: Sized {
     /// Specify the `ON` clause for a join statement. This will override
     /// any implicit `ON` clause that would come from [`joinable!`]

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -89,8 +89,8 @@ where
 pub trait JoinDsl: Sized {
     /// Join two tables using a SQL `INNER JOIN`.
     /// The implicit `ON` clause is defined
-    /// via the [JoinDsl](./trait.JoinOnDsl.html). 
-    /// Use [`.on`](./trait.JoinOnDsl.html#method.on) 
+    /// via the [JoinDsl](./trait.JoinOnDsl.html).
+    /// Use [`.on`](./trait.JoinOnDsl.html#method.on)
     /// to override the implicit `ON` clause.
     fn inner_join<Rhs>(self, rhs: Rhs) -> Self::Output
     where
@@ -101,8 +101,8 @@ pub trait JoinDsl: Sized {
 
     /// Join two tables using a SQL `LEFT OUTER JOIN`.
     /// The implicit `ON` clause is defined
-    /// via the [JoinDsl](./trait.JoinOnDsl.html). 
-    /// Use [`.on`](./trait.JoinOnDsl.html#method.on) 
+    /// via the [JoinDsl](./trait.JoinOnDsl.html).
+    /// Use [`.on`](./trait.JoinOnDsl.html#method.on)
     /// to override the implicit `ON` clause.
     fn left_outer_join<Rhs>(self, rhs: Rhs) -> Self::Output
     where

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -23,6 +23,93 @@ where
     }
 }
 
+/// Methods to execute a query given a connection. These are automatically implemented for the
+/// various query types.
+pub trait LoadDsl<Conn>: Sized {
+    /// Executes the given query, returning a `Vec` with the returned rows.
+    fn load<U>(self, conn: &Conn) -> QueryResult<Vec<U>>
+    where
+        Self: LoadQuery<Conn, U>,
+    {
+        self.internal_load(conn)
+    }
+
+    /// Runs the command, and returns the affected row. `Err(NotFound)` will be
+    /// returned if the query affected 0 rows. You can call `.optional()` on the
+    /// result of this if the command was optional to get back a
+    /// `Result<Option<U>>`
+    fn get_result<U>(self, conn: &Conn) -> QueryResult<U>
+    where
+        Self: LoadQuery<Conn, U>,
+    {
+        first_or_not_found(self.load(conn))
+    }
+
+    /// Runs the command, returning an `Vec` with the affected rows.
+    fn get_results<U>(self, conn: &Conn) -> QueryResult<Vec<U>>
+    where
+        Self: LoadQuery<Conn, U>,
+    {
+        self.load(conn)
+    }
+}
+
+impl<Conn, T> LoadDsl<Conn> for T
+where
+    Conn: Connection,
+    Conn::Backend: HasSqlType<T::SqlType>,
+    T: AsQuery,
+    T::Query: QueryFragment<Conn::Backend> + QueryId,
+{
+}
+
+pub trait FirstDsl<Conn>: LimitDsl + LoadDsl<Conn> {
+    /// Attempts to load a single record. Returns `Ok(record)` if found, and
+    /// `Err(NotFound)` if no results are returned. If the query truly is
+    /// optional, you can call `.optional()` on the result of this to get a
+    /// `Result<Option<U>>`.
+    ///
+    /// # Example:
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// # use diesel::NotFound;
+    /// table! {
+    ///     users {
+    ///         id -> Integer,
+    ///         name -> VarChar,
+    ///     }
+    /// }
+    ///
+    /// #[derive(Queryable, PartialEq, Debug)]
+    /// struct User {
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// # fn main() {
+    /// #   let connection = establish_connection();
+    /// let user1 = NewUser { name: "Sean".into() };
+    /// let user2 = NewUser { name: "Pascal".into() };
+    /// diesel::insert_into(users::table).values(&vec![user1, user2]).execute(&connection).unwrap();
+    ///
+    /// let user = users::table.order(users::id.asc()).first(&connection);
+    /// assert_eq!(Ok(User { id: 1, name: "Sean".into() }), user);
+    /// let user = users::table.filter(users::name.eq("Foo")).first::<User>(&connection);
+    /// assert_eq!(Err(NotFound), user);
+    /// # }
+    /// ```
+    fn first<U>(self, conn: &Conn) -> QueryResult<U>
+    where
+        Limit<Self>: LoadQuery<Conn, U>,
+    {
+        self.limit(1).get_result(conn)
+    }
+}
+
+impl<Conn, T: LimitDsl + LoadDsl<Conn>> FirstDsl<Conn> for T {}
+
 pub trait ExecuteDsl<Conn: Connection<Backend = DB>, DB: Backend = <Conn as Connection>::Backend>
     : Sized {
     fn execute(query: Self, conn: &Conn) -> QueryResult<usize>;

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -154,8 +154,12 @@ where
 // }
 
 /// Indicates that two tables can be used together in a JOIN clause.
-/// Implementations of this trait will be generated for you automatically by
-/// the [association annotations](../associations/index.html) from codegen.
+/// Implementations of this trait will be generated for you when using
+/// the [`joinable!`](../macro.joinable.html) or
+/// [`allow_tables_to_appear_in_same_query!`](../macro.allow_tables_to_appear_in_same_query.html) macros.
+/// When using [`infer_schema!`](../macro.infer_schema.html),
+/// `joinable!` will automatically be generated if you have foreign key constraints
+/// on the child table.
 pub trait JoinTo<T> {
     #[doc(hidden)]
     type FromClause;

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -23,7 +23,7 @@ impl<T> MigrationConnection for T
 where
     T: Connection,
     String: FromSql<VarChar, T::Backend>,
-    // FIXME: HRTB is preventing projecting on any associated types here
+// FIXME: HRTB is preventing projecting on any associated types here
     for<'a> InsertStatement<__diesel_schema_migrations, ColumnInsertValue<version, &'a Bound<VarChar, &'a str>>>: ExecuteDsl<T>,
 {
     fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>> {


### PR DESCRIPTION
`Associations` docs currently portray a role in the `JoinDsl`. Updates documentation where they reference each other to make a clear distinction in use-cases and responsibilities.