### PR TITLE
Make `#[derive(QueryableByName)]` work without a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* `#[derive(QueryableByName)]` can now handle structs that have no associated
+  table. If the `#[table_name]` annotation is left off, you must annotate each
+  field with `#[sql_type = "Integer"]`
+
+### Changed
+
+* `#[derive(QueryableByName)]` now requires that the table name be explicitly
+  stated.
+
 ### Removed
 
 * All deprecated items have been removed.

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -32,13 +32,15 @@ where
 ///
 /// # Deriving
 ///
-/// To derive this trait, the struct must be associated with a single table.
-/// If the table name is different than `"struct_name" + "s"`, you can
-/// annotate your struct with `#[table_name = "some_table"]`.
+/// To derive this trait, Diesel needs to know the SQL type of each field. You
+/// can do this by either annotating your struct with `#[table_name =
+/// "some_table"]` (in which case the SQL type will be
+/// `diesel::dsl::SqlTypeOf<table_name::column_name>`), or by annotating each
+/// field with `#[sql_type = "SomeType"]`.
 ///
-/// The module for that table must be in scope. For example, to derive this for
-/// a struct called `User`, you will likely need a line such as `use
-/// schema::users;`
+/// If you are using `#[table_name]`, the module for that table must be in
+/// scope. For example, to derive this for a struct called `User`, you will
+/// likely need a line such as `use schema::users;`
 ///
 /// If the name of a field on your struct is different than the column in your
 /// `table!` declaration, or if you are deriving this trait on a tuple struct,

--- a/diesel_compile_tests/tests/compile-fail/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
+++ b/diesel_compile_tests/tests/compile-fail/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
@@ -1,0 +1,9 @@
+#[macro_use] extern crate diesel;
+
+#[derive(QueryableByName)]
+//~^ ERROR Your struct must either be annotated with `#[table_name = "foo"]` or have all of its fields annotated with `#[sql_type = "Integer"]`
+struct Foo {
+    a: i32,
+}
+
+fn main() {}

--- a/diesel_derives/src/attr.rs
+++ b/diesel_derives/src/attr.rs
@@ -7,6 +7,7 @@ use util::*;
 pub struct Attr {
     column_name: Option<syn::Ident>,
     field_name: Option<syn::Ident>,
+    sql_type: Option<syn::Ty>,
     pub ty: syn::Ty,
     pub field_position: syn::Ident,
 }
@@ -18,10 +19,14 @@ impl Attr {
             .cloned()
             .or_else(|| field_name.clone());
         let ty = field.ty.clone();
+        let sql_type = str_value_of_attr_with_name(&field.attrs, "sql_type").map(|st| {
+            syn::parse::ty(st).expect("#[sql_type] did not contain a valid Rust type")
+        });
 
         Attr {
             column_name: column_name,
             field_name: field_name,
+            sql_type: sql_type,
             ty: ty,
             field_position: index.to_string().into(),
         }
@@ -38,6 +43,10 @@ impl Attr {
             .expect(
                 "All fields of tuple structs must be annotated with `#[column_name=\"something\"]`",
             )
+    }
+
+    pub fn sql_type(&self) -> Option<&syn::Ty> {
+        self.sql_type.as_ref()
     }
 
     fn field_kind(&self) -> &str {

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -43,7 +43,7 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
     expand_derive(input, queryable::derive_queryable)
 }
 
-#[proc_macro_derive(QueryableByName, attributes(table_name, column_name))]
+#[proc_macro_derive(QueryableByName, attributes(table_name, column_name, sql_type))]
 pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
     expand_derive(input, queryable_by_name::derive)
 }

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -23,6 +23,7 @@ table! {
 #[test]
 fn named_struct_definition() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    #[table_name = "my_structs"]
     struct MyStruct {
         foo: IntRust,
         bar: IntRust,
@@ -36,6 +37,7 @@ fn named_struct_definition() {
 #[test]
 fn tuple_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    #[table_name = "my_structs"]
     struct MyStruct(#[column_name(foo)] IntRust, #[column_name(bar)] IntRust);
 
     let conn = connection();
@@ -44,3 +46,16 @@ fn tuple_struct() {
 }
 
 // FIXME: Test usage with renamed columns
+
+#[test]
+fn struct_with_no_table() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    struct MyStructNamedSoYouCantInferIt {
+        #[sql_type = "IntSql"] foo: IntRust,
+        #[sql_type = "IntSql"] bar: IntRust,
+    }
+
+    let conn = connection();
+    let data = sql_query("SELECT 1 AS foo, 2 AS bar").get_result(&conn);
+    assert_eq!(Ok(MyStructNamedSoYouCantInferIt { foo: 1, bar: 2 }), data);
+}


### PR DESCRIPTION
crates.io required 5 manual `QueryableByName` implementations. Of those
5, 4 of them were only required because they were for use with a struct
that didn't map to fields on a single table. This change allows use with
those structs by requiring that the SQL type be specified on each field
instead.

Since the default behavior is based on the table name, and forgetting to
annotate the fields is an easy mistake to make, I've changed
`QueryableByName` to no longer use the inferred table name. Instead the
annotation will be required to determine the SQL type based on the
column.