### PR TITLE
Document the SQLite module [ci skip]

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -67,6 +67,7 @@ pub mod mysql;
 #[cfg(feature = "postgres")]
 pub mod pg;
 #[cfg(feature = "sqlite")]
+#[deny(missing_docs)]
 pub mod sqlite;
 
 pub mod query_dsl;

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -1,3 +1,4 @@
+//! The SQLite backend
 use byteorder::NativeEndian;
 
 use backend::*;
@@ -5,18 +6,34 @@ use query_builder::bind_collector::RawBytesBindCollector;
 use super::connection::SqliteValue;
 use super::query_builder::SqliteQueryBuilder;
 
+/// The SQLite backend
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Sqlite;
 
+/// Determines how a bind parameter is given to SQLite
+///
+/// Diesel deals with bind parameters after serialization as opaque blobs of
+/// bytes. However, SQLite instead has several functions where it expects the
+/// relevant C types.
+///
+/// The variants of this struct determine what bytes are expected from
+/// `ToSql` impls.
 #[allow(missing_debug_implementations)]
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub enum SqliteType {
+    /// Bind using `sqlite3_bind_blob`
     Binary,
+    /// Bind using `sqlite3_bind_text`
     Text,
+    /// `bytes` should contain an `f32`
     Float,
+    /// `bytes` should contain an `f64`
     Double,
+    /// `bytes` should contain an `i16`
     SmallInt,
+    /// `bytes` should contain an `i32`
     Integer,
+    /// `bytes` should contain an `i64`
     Long,
 }
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -22,6 +22,8 @@ use self::stmt::{Statement, StatementUse};
 use sqlite::Sqlite;
 use types::HasSqlType;
 
+/// Connections for the SQLite backend. Unlike other backends, "connection URLs"
+/// for SQLite are file paths or special identifiers like `:memory`.
 #[allow(missing_debug_implementations)]
 pub struct SqliteConnection {
     statement_cache: StatementCache<Sqlite, Statement>,

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -1,3 +1,9 @@
+//! Provides types and functions related to working with SQLite
+//!
+//! Much of this module is re-exported from database agnostic locations.
+//! However, if you are writing code specifically to extend Diesel on
+//! SQLite, you may need to work with this module directly.
+
 mod backend;
 mod connection;
 mod types;

--- a/diesel/src/sqlite/query_builder/mod.rs
+++ b/diesel/src/sqlite/query_builder/mod.rs
@@ -1,7 +1,10 @@
+//! The SQLite query builder
+
 use super::backend::Sqlite;
 use query_builder::QueryBuilder;
 use result::QueryResult;
 
+/// Constructs SQL queries for use with the SQLite backend
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct SqliteQueryBuilder {
@@ -9,6 +12,7 @@ pub struct SqliteQueryBuilder {
 }
 
 impl SqliteQueryBuilder {
+    /// Construct a new query builder with an empty query
     pub fn new() -> Self {
         SqliteQueryBuilder::default()
     }


### PR DESCRIPTION
I'm going to start adding `#[deny(missing_docs)]` as I go through these
now. There's not a ton to say about any of these types, and some of
these doc comments are part of why I generally hate
`#[deny(missing_docs)]`, but I still think it will be a net win to have
that on Diesel.