### PR TITLE
Make clippy happy with the latest num release

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -26,7 +26,7 @@ time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
 uuid = { version = ">=0.2.0, <0.6.0", optional = true, features = ["use_std"] }
 ipnetwork = { version = "0.12.2", optional = true }
-num-bigint = { version = "0.1.37", optional = true }
+num-bigint = { version = "0.1.41", optional = true }
 num-traits = { version = "0.1.35", optional = true }
 num-integer = { version = "0.1.32", optional = true }
 bigdecimal = { version = "0.0.10", optional = true }

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -121,8 +121,8 @@ mod bigdecimal {
             let mut result = BigUint::default();
             let count = digits.len() as i64;
             for digit in digits {
-                result = result * BigUint::from(10_000u64);
-                result = result + BigUint::from(digit as u64);
+                result *= BigUint::from(10_000u64);
+                result += BigUint::from(digit as u64);
             }
             // First digit got factor 10_000^(digits.len() - 1), but should get 10_000^weight
             let correction_exp = 4 * (i64::from(weight) - count + 1);


### PR DESCRIPTION
num-bigint just released 0.1.41, which implements `AddAssign` and
`MulAssign`. This has caused our builds to fail, as clippy does not like
our "manual" implementations