### PR TITLE
Allow embedded structs in `#[derive(QueryableByName)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   table. If the `#[table_name]` annotation is left off, you must annotate each
   field with `#[sql_type = "Integer"]`
 
+* `#[derive(QueryableByName)]` can now handle embedding other structs. To have a
+  field whose type is a struct which implements `QueryableByName`, rather than a
+  single column in the query, add the annotation `#[diesel(embed)]`
+
 ### Changed
 
 * `#[derive(QueryableByName)]` now requires that the table name be explicitly

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -47,6 +47,9 @@ where
 /// you can annotate the field with `#[column_name = "some_column"]`. For tuple
 /// structs, all fields must have this annotation.
 ///
+/// If a field is another struct which implements `QueryableByName`, instead of
+/// a column, you can annotate that struct with `#[diesel(embed)]`
+///
 /// [`sql_query`]: ../fn.sql_query.html
 pub trait QueryableByName<DB>
 where

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -43,7 +43,7 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
     expand_derive(input, queryable::derive_queryable)
 }
 
-#[proc_macro_derive(QueryableByName, attributes(table_name, column_name, sql_type))]
+#[proc_macro_derive(QueryableByName, attributes(table_name, column_name, sql_type, diesel))]
 pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
     expand_derive(input, queryable_by_name::derive)
 }

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -59,3 +59,57 @@ fn struct_with_no_table() {
     let data = sql_query("SELECT 1 AS foo, 2 AS bar").get_result(&conn);
     assert_eq!(Ok(MyStructNamedSoYouCantInferIt { foo: 1, bar: 2 }), data);
 }
+
+#[test]
+fn embedded_struct() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    #[table_name = "my_structs"]
+    struct A {
+        foo: IntRust,
+        #[diesel(embed)] b: B,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    #[table_name = "my_structs"]
+    struct B {
+        bar: IntRust,
+    }
+
+    let conn = connection();
+    let data = sql_query("SELECT 1 AS foo, 2 AS bar").get_result(&conn);
+    assert_eq!(
+        Ok(A {
+            foo: 1,
+            b: B { bar: 2 },
+        }),
+        data
+    );
+}
+
+#[test]
+fn embedded_option() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    #[table_name = "my_structs"]
+    struct A {
+        foo: IntRust,
+        #[diesel(embed)] b: Option<B>,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    #[table_name = "my_structs"]
+    struct B {
+        bar: IntRust,
+    }
+
+    let conn = connection();
+    let data = sql_query("SELECT 1 AS foo, 2 AS bar").get_result(&conn);
+    assert_eq!(
+        Ok(A {
+            foo: 1,
+            b: Some(B { bar: 2 }),
+        }),
+        data
+    );
+    let data = sql_query("SELECT 1 AS foo, NULL AS bar").get_result(&conn);
+    assert_eq!(Ok(A { foo: 1, b: None }), data);
+}


### PR DESCRIPTION
crates.io still has 4 manual `QueryableByName` implementaitons. Of
those, half are because the struct is just "some other struct plus some
extra fields". I've opted to make the flag `#[diesel(embed)]` instead of
just `#[embed]`, as the name is generic enough that I'm concerned about
conflicts with other libraries.