### PR TITLE
Update out of date docs in the `types` module

### DIFF
--- a/diesel/src/types/fold.rs
+++ b/diesel/src/types/fold.rs
@@ -1,6 +1,6 @@
 use types::{self, NotNull};
 
-/// Marker trait for types which can be folded for a sum.
+/// Represents SQL types which can be used with `SUM` and `AVG`
 pub trait Foldable {
     type Sum;
     type Avg;

--- a/diesel/src/types/ord.rs
+++ b/diesel/src/types/ord.rs
@@ -1,6 +1,6 @@
 use types::{self, NotNull};
 
-/// Marker trait for types which can be compared for ordering.
+/// Marker trait for types which can be used with `MAX` and `MIN`
 pub trait SqlOrd {}
 
 impl SqlOrd for types::SmallInt {}


### PR DESCRIPTION
I've gone through the module and read all existing doc comments, and
updated things that have either become out of date, or which needed
additional wording.

A lot of these docs predated MySQL support or even SQLite support, and
said things which made no sense in the context of those backends. Others
were just really badly worded (for example `SqlOrd` implied that it
affected what could be passed to `order_by`)