### PR TITLE
Loosen the bounds on `BoxedDsl`

### DIFF
--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -1,8 +1,7 @@
-use backend::Backend;
 use query_builder::AsQuery;
 use query_source::Table;
 
-pub trait BoxedDsl<'a, DB: Backend> {
+pub trait BoxedDsl<'a, DB> {
     type Output;
 
     fn internal_into_boxed(self) -> Self::Output;
@@ -10,7 +9,6 @@ pub trait BoxedDsl<'a, DB: Backend> {
 
 impl<'a, T, DB> BoxedDsl<'a, DB> for T
 where
-    DB: Backend,
     T: Table + AsQuery,
     T::Query: BoxedDsl<'a, DB>,
 {


### PR DESCRIPTION
The `DB: Backend` constraint was never used by the trait itself. Any
impl that does actual stuff (in this case, only the impl for
`SelectStatement`) will need this constraint for it's
`QueryFragment<DB>` bounds, but we shouldn't force other impls to state
it.