### PR TITLE
Remove some keywords from CLI and Infer Schema

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://diesel.rs/guides/getting-started"
 homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel"
-keywords = ["orm", "database", "postgres", "postgresql", "sql"]
+keywords = ["diesel", "migrations", "cli"]
 
 [[bin]]
 name = "diesel"

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -7,7 +7,7 @@ description = "Provides functionality to infer the schema of a database"
 documentation = "https://docs.rs/diesel_infer_schema"
 homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel"
-keywords = ["orm", "database", "postgres", "postgresql", "sql"]
+keywords = ["diesel"]
 
 [dependencies]
 infer_schema_macros = { version = "0.99.0" }


### PR DESCRIPTION
If people are browsing the "database" keyword on crates.io, these are
not the crates that they're looking for. I'm going to encourage some
other libs that have this keyword unneccessarily to do the same.