### PR TITLE
Upload docs to `/edge` instead of the root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,7 @@ env:
 after_success:
 - |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    (cd diesel && travis-cargo doc -- --features "postgres sqlite mysql extras")
-    mkdir diesel/target
-    mv target/doc diesel/target/doc
-    echo "docs.diesel.rs" > diesel/target/doc/CNAME
-    (cd diesel && travis-cargo doc-upload)
+    bin/doc_upload
   fi
 branches:
   only:

--- a/bin/doc_upload
+++ b/bin/doc_upload
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+
+require "fileutils"
+
+def main(token)
+  document_diesel
+  on_gh_pages_branch do |latest_commit|
+    copy_edge_docs
+    doc_commit_message = "Documentation for #{latest_commit}"
+    upload_docs(token, doc_commit_message)
+  end
+end
+
+def run_command(cmd)
+  result = `#{cmd}`
+  if $? != 0
+    raise "#{cmd} failed"
+  end
+  result
+end
+
+def document_diesel
+  Dir.chdir("diesel") do
+    run_command("cargo doc --no-default-features --features docs")
+  end
+  File.open("target/doc/index.html", "w") do |f|
+    f.write("<meta http-equiv=refresh content=0;url=diesel/index.html>")
+  end
+end
+
+def on_gh_pages_branch
+  latest_commit = run_command("git rev-parse --short HEAD").strip
+  run_command("git checkout gh-pages")
+  yield latest_commit
+ensure
+  run_command("git checkout -f #{latest_commit}") if latest_commit
+end
+
+def copy_edge_docs
+  FileUtils.mv("target/doc", "edge")
+end
+
+def upload_docs(token, commit_message)
+  run_command("git add edge")
+  run_command("git commit -m '#{commit_message}'")
+  run_command("git push -fq https://#{token}@github.com/diesel-rs/diesel.git gh-pages")
+end
+
+travis_pr_env_var = ENV.fetch("TRAVIS_PULL_REQUEST", "false")
+branch = ENV["TRAVIS_BRANCH"]
+is_pr = travis_pr_env_var != "false"
+
+if branch == "master" && !is_pr || ENV.key?("FORCE_DOC_UPLOAD")
+  main(ENV["GH_TOKEN"])
+end

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -52,11 +52,12 @@ with-deprecated = []
 deprecated-time = ["time"]
 network-address = ["ipnetwork", "libc"]
 numeric = ["num-bigint", "bigdecimal", "num-traits", "num-integer"]
+docs = ["mysql", "sqlite", "postgres", "extras"]
 
 [badges]
 travis-ci = { repository = "diesel-rs/diesel" }
 appveyor = { repository = "sgrif/diesel" }
 
 [package.metadata.docs.rs]
-features = ["postgres", "mysql", "sqlite", "extras"]
+features = ["docs"]
 no-default-features = true


### PR DESCRIPTION
This moves the documentation off of the root of `docs.diesel.rs`, and
into a subdirectory called `edge`. After this PR is merged,
`docs.diesel.rs` will redirect to the docs for the latest release, and
the docs for the master branch will live at `docs.diesel.rs/edge`.

Before merging this, I will set up the gh-pages branch to contain a
CNAME file, an `index.html` which redirects to 0.99.1, and the docs for
0.99.0 and 0.99.1 in appropriate directories. At the moment I intend to
have updating docs for releases be a manual process, and I don't think
we need to include releases prior to 0.99.0.

This will break *all* existing links to `docs.diesel.rs/stuff`, which is
probably fine. The website should be updated to always link to the docs
for the version it was written against.