### PR TITLE
Merge `ExecuteDsl` and friends into a single trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,18 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   to explicitly do `use diesel::query_dsl::methods::WhateverDsl`. You may also
   need to use UFCS in these cases.
 
+* If you have a type which implemented `QueryFragment` or `Query`, which you
+  intended to be able to call `execute` or `load` on, you will need to manually
+  implement `RunQueryDsl` for that type. The trait should be unconditionally
+  implemented (no where clause beyond what your type requires), and the body
+  should be empty.
+
 ### Removed
 
 * All deprecated items have been removed.
+
+* `LoadDsl` and `FirstDsl` have been removed. Their functionality now lives in
+  `LoadQuery`.
 
 ## [0.99.1] - 2017-12-01
 

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use backend::Backend;
 use expression::*;
 use query_builder::*;
+use query_dsl::RunQueryDsl;
 use result::QueryResult;
 use types::HasSqlType;
 
@@ -49,6 +50,8 @@ impl_query_id!(noop: SqlLiteral<ST>);
 impl<ST> Query for SqlLiteral<ST> {
     type SqlType = ST;
 }
+
+impl<ST, Conn> RunQueryDsl<Conn> for SqlLiteral<ST> {}
 
 impl<QS, ST> SelectableExpression<QS> for SqlLiteral<ST> {}
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -168,8 +168,8 @@ pub mod prelude {
     pub use expression_methods::*;
     #[doc(inline)]
     pub use insertable::Insertable;
-    pub use query_dsl::{BelongingToDsl, ExecuteDsl, FirstDsl, GroupByDsl, JoinOnDsl, LoadDsl,
-                        QueryDsl, SaveChangesDsl};
+    pub use query_dsl::{BelongingToDsl, GroupByDsl, JoinOnDsl, QueryDsl, RunQueryDsl,
+                        SaveChangesDsl};
 
     pub use query_source::{Column, JoinTo, QuerySource, Queryable, Table};
     pub use result::{ConnectionError, ConnectionResult, OptionalExtension, QueryResult};

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -4,6 +4,7 @@ use expression::{AppearsOnTable, SelectableExpression};
 use query_builder::*;
 use query_builder::returning_clause::*;
 use query_builder::where_clause::*;
+use query_dsl::RunQueryDsl;
 use query_dsl::methods::FilterDsl;
 use query_source::Table;
 use result::QueryResult;
@@ -123,6 +124,8 @@ where
 {
     type SqlType = Ret::SqlType;
 }
+
+impl<T, U, Ret, Conn> RunQueryDsl<Conn> for DeleteStatement<T, U, Ret> {}
 
 impl<T, U> DeleteStatement<T, U, NoReturningClause> {
     /// Specify what expression is returned after execution of the `delete`.

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -171,8 +171,8 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// Backends that support the `RETURNING` clause, such as PostgreSQL,
 /// can return the inserted rows by calling [`.get_results`] instead of [`.execute`].
 ///
-/// [`.get_results`]: ../diesel/prelude/trait.LoadDsl.html#method.get_results
-/// [`.execute`]: ../diesel/prelude/trait.ExecuteDsl.html#tymethod.execute
+/// [`.get_results`]: ../diesel/prelude/trait.RunQueryDsl.html#method.get_results
+/// [`.execute`]: ../diesel/prelude/trait.RunQueryDsl.html#tymethod.execute
 ///
 /// # Examples
 ///

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -106,10 +106,10 @@ impl<'a, T: Query> Query for &'a T {
 /// This may be a complete SQL command (such as an update statement without a
 /// `RETURNING` clause), or a subsection (such as our internal types used to
 /// represent a `WHERE` clause). Implementations of [`ExecuteDsl`] and
-/// [`LoadDsl`] will generally require that this trait be implemented.
+/// [`LoadQuery`] will generally require that this trait be implemented.
 ///
-/// [`ExecuteDsl`]: ../prelude/trait.ExecuteDsl.html
-/// [`LoadDsl`]: ../prelude/trait.LoadDsl.html
+/// [`ExecuteDsl`]: ../query_builder/methods/trait.ExecuteDsl.html
+/// [`LoadQuery`]: ../query_builder/trait.LoadQuery.html
 pub trait QueryFragment<DB: Backend> {
     /// Walk over this `QueryFragment` for all passes.
     ///

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -272,3 +272,5 @@ where
 }
 
 impl<'a, ST, QS, DB> QueryDsl for BoxedSelectStatement<'a, ST, QS, DB> {}
+
+impl<'a, ST, QS, DB, Conn> RunQueryDsl<Conn> for BoxedSelectStatement<'a, ST, QS, DB> {}

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -348,3 +348,7 @@ where
 }
 
 impl<F, S, D, W, O, L, Of, G, FU> QueryDsl for SelectStatement<F, S, D, W, O, L, Of, G, FU> {}
+
+impl<F, S, D, W, O, L, Of, G, FU, Conn> RunQueryDsl<Conn>
+    for SelectStatement<F, S, D, W, O, L, Of, G, FU> {
+}

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use backend::Backend;
 use connection::Connection;
 use query_builder::{AstPass, QueryFragment, QueryId};
-use query_dsl::{LoadDsl, LoadQuery};
+use query_dsl::{LoadQuery, RunQueryDsl};
 use query_source::QueryableByName;
 use result::QueryResult;
 use types::{HasSqlType, ToSql};
@@ -100,7 +100,7 @@ where
     }
 }
 
-impl<Conn> LoadDsl<Conn> for SqlQuery {}
+impl<Conn> RunQueryDsl<Conn> for SqlQuery {}
 
 #[derive(Debug, Clone, Copy)]
 #[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
@@ -158,4 +158,4 @@ where
     }
 }
 
-impl<Conn, Query, Value, ST> LoadDsl<Conn> for UncheckedBind<Query, Value, ST> {}
+impl<Conn, Query, Value, ST> RunQueryDsl<Conn> for UncheckedBind<Query, Value, ST> {}

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -7,10 +7,11 @@ pub use self::target::{IntoUpdateTarget, UpdateTarget};
 use backend::Backend;
 use dsl::Filter;
 use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
-use query_dsl::methods::FilterDsl;
 use query_builder::*;
 use query_builder::returning_clause::*;
 use query_builder::where_clause::*;
+use query_dsl::RunQueryDsl;
+use query_dsl::methods::FilterDsl;
 use query_source::Table;
 use result::Error::QueryBuilderError;
 use result::QueryResult;
@@ -228,6 +229,8 @@ where
 {
     type SqlType = Ret::SqlType;
 }
+
+impl<T, U, V, Ret, Conn> RunQueryDsl<Conn> for UpdateStatement<T, U, V, Ret> {}
 
 impl<T, U, V> UpdateStatement<T, U, V, NoReturningClause> {
     /// Specify what expression is returned after execution of the `update`.

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,13 +1,12 @@
 use backend::Backend;
 use connection::Connection;
-use dsl::Limit;
 use query_builder::{AsQuery, QueryFragment, QueryId};
 use query_source::Queryable;
-use result::{first_or_not_found, QueryResult};
-use super::methods::LimitDsl;
+use result::QueryResult;
+use super::RunQueryDsl;
 use types::HasSqlType;
 
-pub trait LoadQuery<Conn, U>: LoadDsl<Conn> {
+pub trait LoadQuery<Conn, U>: RunQueryDsl<Conn> {
     fn internal_load(self, conn: &Conn) -> QueryResult<Vec<U>>;
 }
 
@@ -15,7 +14,7 @@ impl<Conn, T, U> LoadQuery<Conn, U> for T
 where
     Conn: Connection,
     Conn::Backend: HasSqlType<T::SqlType>,
-    T: AsQuery,
+    T: AsQuery + RunQueryDsl<Conn>,
     T::Query: QueryFragment<Conn::Backend> + QueryId,
     U: Queryable<T::SqlType, Conn::Backend>,
 {
@@ -24,105 +23,9 @@ where
     }
 }
 
-/// Methods to execute a query given a connection. These are automatically implemented for the
-/// various query types.
-pub trait LoadDsl<Conn>: Sized {
-    /// Executes the given query, returning a `Vec` with the returned rows.
-    fn load<U>(self, conn: &Conn) -> QueryResult<Vec<U>>
-    where
-        Self: LoadQuery<Conn, U>,
-    {
-        self.internal_load(conn)
-    }
-
-    /// Runs the command, and returns the affected row. `Err(NotFound)` will be
-    /// returned if the query affected 0 rows. You can call `.optional()` on the
-    /// result of this if the command was optional to get back a
-    /// `Result<Option<U>>`
-    fn get_result<U>(self, conn: &Conn) -> QueryResult<U>
-    where
-        Self: LoadQuery<Conn, U>,
-    {
-        first_or_not_found(self.load(conn))
-    }
-
-    /// Runs the command, returning an `Vec` with the affected rows.
-    fn get_results<U>(self, conn: &Conn) -> QueryResult<Vec<U>>
-    where
-        Self: LoadQuery<Conn, U>,
-    {
-        self.load(conn)
-    }
-}
-
-impl<Conn, T> LoadDsl<Conn> for T
-where
-    // These constraints are fairly redundant with `Self: LoadQuery`,
-    // But since `LoadQuery` has a second type parameter, it can't be
-    // used to prove impls on things like `SupportsReturningClause` are disjoint.
-    // If disjointness on associated types ever lands, we can drop all of these
-    // except `T: AsQuery`
-    Conn: Connection,
-    Conn::Backend: HasSqlType<T::SqlType>,
-    T: AsQuery,
-    T::Query: QueryFragment<Conn::Backend> + QueryId,
-{
-}
-
-pub trait FirstDsl<Conn>: LimitDsl + LoadDsl<Conn> {
-    /// Attempts to load a single record. Returns `Ok(record)` if found, and
-    /// `Err(NotFound)` if no results are returned. If the query truly is
-    /// optional, you can call `.optional()` on the result of this to get a
-    /// `Result<Option<U>>`.
-    ///
-    /// # Example:
-    ///
-    /// ```rust
-    /// # #[macro_use] extern crate diesel;
-    /// # include!("../doctest_setup.rs");
-    /// # use diesel::NotFound;
-    /// table! {
-    ///     users {
-    ///         id -> Integer,
-    ///         name -> VarChar,
-    ///     }
-    /// }
-    ///
-    /// #[derive(Queryable, PartialEq, Debug)]
-    /// struct User {
-    ///     id: i32,
-    ///     name: String,
-    /// }
-    ///
-    /// # fn main() {
-    /// #   let connection = establish_connection();
-    /// let user1 = NewUser { name: "Sean".into() };
-    /// let user2 = NewUser { name: "Pascal".into() };
-    /// diesel::insert_into(users::table).values(&vec![user1, user2]).execute(&connection).unwrap();
-    ///
-    /// let user = users::table.order(users::id.asc()).first(&connection);
-    /// assert_eq!(Ok(User { id: 1, name: "Sean".into() }), user);
-    /// let user = users::table.filter(users::name.eq("Foo")).first::<User>(&connection);
-    /// assert_eq!(Err(NotFound), user);
-    /// # }
-    /// ```
-    fn first<U>(self, conn: &Conn) -> QueryResult<U>
-    where
-        Limit<Self>: LoadQuery<Conn, U>,
-    {
-        self.limit(1).get_result(conn)
-    }
-}
-
-impl<Conn, T: LimitDsl + LoadDsl<Conn>> FirstDsl<Conn> for T {}
-
 pub trait ExecuteDsl<Conn: Connection<Backend = DB>, DB: Backend = <Conn as Connection>::Backend>
     : Sized {
-    /// Executes the given command, returning the number of rows affected. Used
-    /// in conjunction with
-    /// [`update`](/diesel/fn.update.html) and
-    /// [`delete`](/diesel/fn.delete.html)
-    fn execute(self, conn: &Conn) -> QueryResult<usize>;
+    fn execute(query: Self, conn: &Conn) -> QueryResult<usize>;
 }
 
 impl<Conn, DB, T> ExecuteDsl<Conn, DB> for T
@@ -131,7 +34,7 @@ where
     DB: Backend,
     T: QueryFragment<DB> + QueryId,
 {
-    fn execute(self, conn: &Conn) -> QueryResult<usize> {
-        conn.execute_returning_count(&self)
+    fn execute(query: Self, conn: &Conn) -> QueryResult<usize> {
+        conn.execute_returning_count(&query)
     }
 }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -30,9 +30,9 @@ pub enum Error {
     /// does not treat 0 rows as an error. If you would like to allow either 0
     /// or 1 rows, call [`optional`] on the result.
     ///
-    /// [`get_result`]: ../prelude/trait.LoadDsl.html#method.get_result
-    /// [`first`]: ../prelude/trait.FirstDsl.html#method.first
-    /// [`load`]: ../prelude/trait.LoadDsl.html#method.load
+    /// [`get_result`]: ../query_dsl/trait.RunQueryDsl.html#method.get_result
+    /// [`first`]: ../query_dsl/trait.RunQueryDsl.html#method.first
+    /// [`load`]: ../query_dsl/trait.RunQueryDsl.html#method.load
     /// [`optional`]: trait.OptionalExtension.html#tymethod.optional
     NotFound,
     /// The query could not be constructed
@@ -190,8 +190,8 @@ pub trait OptionalExtension<T> {
     /// row as an error (e.g. the return value of [`get_result`] or [`first`]). This method will
     /// handle that error, and give you back an `Option<T>` instead.
     ///
-    /// [`get_result`]: ../prelude/trait.LoadDsl.html#method.get_result
-    /// [`first`]: ../prelude/trait.FirstDsl.html#method.first
+    /// [`get_result`]: ../query_dsl/trait.RunQueryDsl.html#method.get_result
+    /// [`first`]: ../query_dsl/trait.RunQueryDsl.html#method.first
     ///
     /// # Example
     ///

--- a/diesel_cli/src/query_helper.rs
+++ b/diesel_cli/src/query_helper.rs
@@ -1,6 +1,7 @@
 use diesel::backend::Backend;
 use diesel::query_builder::*;
 use diesel::result::QueryResult;
+use diesel::RunQueryDsl;
 
 #[derive(Debug, Clone)]
 pub struct DropDatabaseStatement {
@@ -35,6 +36,8 @@ impl<DB: Backend> QueryFragment<DB> for DropDatabaseStatement {
     }
 }
 
+impl<Conn> RunQueryDsl<Conn> for DropDatabaseStatement {}
+
 impl_query_id!(noop: DropDatabaseStatement);
 
 #[derive(Debug, Clone)]
@@ -57,6 +60,8 @@ impl<DB: Backend> QueryFragment<DB> for CreateDatabaseStatement {
         Ok(())
     }
 }
+
+impl<Conn> RunQueryDsl<Conn> for CreateDatabaseStatement {}
 
 impl_query_id!(noop: CreateDatabaseStatement);
 

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -1,5 +1,5 @@
 use support::{database, project};
-use diesel::{select, LoadDsl};
+use diesel::{select, RunQueryDsl};
 use diesel::dsl::sql;
 use diesel::types::Bool;
 

--- a/diesel_cli/tests/support/postgres_database.rs
+++ b/diesel_cli/tests/support/postgres_database.rs
@@ -1,7 +1,7 @@
 use diesel::connection::SimpleConnection;
 use diesel::dsl::sql;
 use diesel::types::Bool;
-use diesel::{select, Connection, LoadDsl, PgConnection};
+use diesel::{select, Connection, PgConnection, RunQueryDsl};
 
 pub struct Database {
     url: String,

--- a/diesel_cli/tests/support/sqlite_database.rs
+++ b/diesel_cli/tests/support/sqlite_database.rs
@@ -2,7 +2,7 @@ use diesel::connection::SimpleConnection;
 use diesel::dsl::sql;
 use diesel::sqlite::SqliteConnection;
 use diesel::types::Bool;
-use diesel::{select, Connection, LoadDsl};
+use diesel::{select, Connection, RunQueryDsl};
 
 use std::fs;
 

--- a/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -27,9 +27,7 @@ fn main() {
 
     let conn = PgConnection::establish("").unwrap();
 
-    let _ = LoadDsl::load::<Stuff>(
-    //~^ ERROR E0277
-        stuff.filter(name.eq(any(more_stuff::names))),
-        &conn,
-    );
+    let _ = stuff.filter(name.eq(any(more_stuff::names)))
+        .load(&conn);
+        //~^ ERROR AppearsInFromClause
 }

--- a/diesel_compile_tests/tests/compile-fail/columns_cannot_be_rhs_of_insert.rs
+++ b/diesel_compile_tests/tests/compile-fail/columns_cannot_be_rhs_of_insert.rs
@@ -19,6 +19,6 @@ fn main() {
     insert_into(users)
         .values(&name.eq(hair_color))
         .execute(&conn)
-        //~^ ERROR E0599
+        //~^ ERROR ColumnInsertValue
         .unwrap();
 }

--- a/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -28,11 +28,9 @@ struct User {
 fn main() {
     let conn = PgConnection::establish("").unwrap();
 
-    let _ = LoadDsl::load::<User>(
-    //~^ ERROR type mismatch resolving `<users::table as diesel::query_source::AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
-        users::table.filter(posts::id.eq(1)),
-        &conn,
-    );
+    let _ = users::table.filter(posts::id.eq(1))
+        .load::<User>(&conn);
+        //~^ ERROR type mismatch resolving `<users::table as diesel::query_source::AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
 
     let _ = users::table
         .into_boxed::<Pg>()
@@ -44,11 +42,9 @@ fn main() {
         //~^ ERROR BoxedDsl
         // FIXME: It'd be great if this mentioned `AppearsInFromClause` instead...
 
-    let _ = LoadDsl::load::<User>(
-    //~^ ERROR AppearsInFromClause
-        users::table.filter(users::name.eq(posts::title)),
-        &conn,
-    );
+    let _ = users::table.filter(users::name.eq(posts::title))
+        .load::<User>(&conn);
+        //~^ ERROR AppearsInFromClause
 
     let _ = users::table.into_boxed::<Pg>()
         .filter(users::name.eq(posts::title));

--- a/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -17,12 +17,12 @@ table! {
 
 fn main() {
     let connection = PgConnection::establish("").unwrap();
-    int_primary_key::table.find("1").first(&connection).unwrap();
-    //~^ ERROR no method named `first`
+    // FIXME: It'd be nice if this mentioned `AsExpression`
+    int_primary_key::table.find("1");
+    //~^ ERROR Expression
     //~| ERROR E0277
-    //~| ERROR E0277
-    string_primary_key::table.find(1).first(&connection).unwrap();
-    //~^ ERROR no method named `first`
-    //~| ERROR E0277
+    // FIXME: It'd be nice if this mentioned `AsExpression`
+    string_primary_key::table.find(1);
+    //~^ ERROR Expression
     //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/subselect_cannot_reference_random_tables.rs
+++ b/diesel_compile_tests/tests/compile-fail/subselect_cannot_reference_random_tables.rs
@@ -21,33 +21,27 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(users, posts);
-allow_tables_to_appear_in_same_query!(users, comments);
-allow_tables_to_appear_in_same_query!(posts, comments);
+allow_tables_to_appear_in_same_query!(users, posts, comments);
 
 fn main() {
     use diesel::dsl::{any, exists};
 
     let conn = PgConnection::establish("").unwrap();
 
-    let _ = LoadDsl::load::<(i32,)>(
-    //~^ ERROR E0271
-        users::table
-            .filter(users::id.eq_any(posts::table.select(posts::id).filter(comments::id.eq(1)))),
-        &conn,
-    );
+    let _ = users::table
+        .filter(users::id.eq_any(posts::table.select(posts::id).filter(comments::id.eq(1))))
+        .load::<(i32,)>(&conn);
+        //~^ ERROR AppearsInFromClause
 
-    let _ = LoadDsl::load::<(i32,)>(
-    //~^ ERROR E0271
-        users::table.filter(users::id.eq(any(
+    let _ = users::table
+        .filter(users::id.eq(any(
             posts::table.select(posts::id).filter(comments::id.eq(1)),
-        ))),
-        &conn,
-    );
+        )))
+        .load::<(i32,)>(&conn);
+        //~^ ERROR AppearsInFromClause
 
-    let _ = LoadDsl::load::<(i32,)>(
-    //~^ ERROR E0271
-        users::table.filter(exists(posts::table.filter(comments::id.eq(1)))),
-        &conn,
-    );
+    let _ = users::table
+        .filter(exists(posts::table.filter(comments::id.eq(1))))
+        .load::<(i32,)>(&conn);
+        //~^ ERROR AppearsInFromClause
 }

--- a/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
+++ b/diesel_compile_tests/tests/compile-fail/user_defined_functions_follow_same_selection_rules.rs
@@ -35,9 +35,7 @@ fn main() {
     let _ = users::table.filter(name.eq(foo(1)));
     //~^ ERROR type mismatch
 
-    let _ = LoadDsl::load::<User>(
-    //~^ ERROR E0277
-        users::table.filter(name.eq(bar(title))),
-        &conn,
-    );
+    let _ = users::table.filter(name.eq(bar(title)))
+        .load::<User>(&conn);
+        //~^ ERROR AppearsInFromClause
 }

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
 use std::iter::FromIterator;
-
 use diesel::expression::bound::Bound;
-use diesel::prelude::*;
 use diesel::insertable::ColumnInsertValue;
+use diesel::prelude::*;
 use diesel::query_builder::insert_statement::InsertStatement;
-use super::schema::__diesel_schema_migrations::dsl::*;
+use diesel::query_dsl::methods::ExecuteDsl;
 use diesel::types::{FromSql, VarChar};
+
+use super::schema::__diesel_schema_migrations::dsl::*;
 
 /// A connection which can be passed to the migration methods. This exists only
 /// to wrap up some constraints which are meant to hold for *all* connections.

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -94,7 +94,7 @@ use std::fs::DirEntry;
 use std::io::{stdout, Write};
 
 use diesel::expression_methods::*;
-use diesel::{Connection, ExecuteDsl, QueryDsl, QueryResult};
+use diesel::{Connection, QueryDsl, QueryResult, RunQueryDsl};
 use self::schema::__diesel_schema_migrations::dsl::*;
 
 use std::env;
@@ -216,7 +216,7 @@ pub fn revert_migration_with_version<Conn: Connection>(
 ) -> Result<(), RunMigrationsError> {
     migration_with_version(migrations_dir, ver)
         .map_err(|e| e.into())
-        .and_then(|m| revert_migration(conn, m, output))
+        .and_then(|m| revert_migration(conn, &m, output))
 }
 
 #[doc(hidden)]
@@ -336,7 +336,7 @@ where
 
 fn revert_migration<Conn: Connection>(
     conn: &Conn,
-    migration: Box<Migration>,
+    migration: &Migration,
     output: &mut Write,
 ) -> Result<(), RunMigrationsError> {
     conn.transaction(|| {

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -1,3 +1,4 @@
+use diesel::RunQueryDsl;
 use std::marker::PhantomData;
 
 pub struct CreateTable<'a, Cols> {
@@ -13,6 +14,8 @@ impl<'a, Cols> CreateTable<'a, Cols> {
         }
     }
 }
+
+impl<'a, Cols, Conn> RunQueryDsl<Conn> for CreateTable<'a, Cols> {}
 
 pub struct Column<'a, T> {
     name: &'a str,

--- a/guide_drafts/model-derives.md
+++ b/guide_drafts/model-derives.md
@@ -33,12 +33,12 @@ a subset of columns.
 For this reason, it may be helpful to view `Queryable` structs as the *result* of your query.
 It is acceptable and often desirable to have multiple `Queryable` structs for the same database table.
 
-Annotating your struct with [`#[derive(Queryable)]`][queryable_doc] enables you to use Diesel's 
-`LoadDsl` and `FirstDsl` to assist in retrieving data.
+Annotating your struct with [`#[derive(Queryable)]`][queryable_doc] enables you to use Diesel's
+`RunQueryDsl` to assist in retrieving data.
 A few of the methods you may use are `load()`, `get_result()`, `get_results()`, and `first()`.
 Should you make a query that doesn't return the same columns and values (in the order specified) on your `Queryable` struct,
 you will get a compile-time error.
-The only thing `Queryable` cares about is that the data returned from the query 
+The only thing `Queryable` cares about is that the data returned from the query
 maps exactly to your data structure.
 
 [queryable_doc]: https://docs.diesel.rs/diesel/query_source/trait.Queryable.html


### PR DESCRIPTION
This applies the same strategy as #1343 to `ExecuteDsl`, `LoadDsl`, and
`FirstDsl`. Ultimately I didn't think that `LoadDsl` and `FirstDsl` were
pulling their weight enough to continue to exist.

This will dramatically improve our error messages in some cases, since
we should never see `no method named "first" for <INSERT PAGE LONG TYPE
HERE OMG THIS IS PROOF DIESEL IS THE MOST COMPLEX THING EVER RUN FOR
YOUR LIFE>` again. Users should see the actual issue that caused
the query to be invalid. Many of those errors still need to be improved,
but it's a step in the right direction. This ends up killing the UFCS
trick.

There was one unfortunate side effect, which is that I had to convert an
impl which previously applied to all backends which support the
returning keyword to one that is PG specific. This will go away with
either specialization (maybe) or disjointness on associated types.

I've opted to change `ExecuteDsl` to not take a `self` parameter here,
as it seemed like most code using it with a where clause was also
imporitng `RunQueryDsl`.

This also forces an explicit impl of `RunQueryDsl` on types which we
want to be able to execute as a full query. Previously `Query` did this
for cases where we were using `get_result`, but it's actually possible
to do `id.eq(1).execute(&conn)` before this commit (which would of
course error).