### PR TITLE
Document all items in the `types` module

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -59,6 +59,7 @@ pub mod expression_methods;
 #[doc(hidden)]
 pub mod insertable;
 pub mod query_builder;
+#[deny(missing_docs)]
 #[macro_use]
 pub mod types;
 

--- a/diesel/src/types/fold.rs
+++ b/diesel/src/types/fold.rs
@@ -2,7 +2,9 @@ use types::{self, NotNull};
 
 /// Represents SQL types which can be used with `SUM` and `AVG`
 pub trait Foldable {
+    /// The SQL type of `sum(this_type)`
     type Sum;
+    /// The SQL type of `avg(this_type)`
     type Avg;
 }
 


### PR DESCRIPTION
I'm actually surprised this was it. I expected there to be many more
undocumented items in here than this.