### PR TITLE
Don't panic in `SqliteStatement::step`

### DIFF
--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -94,7 +94,7 @@ impl Connection for SqliteConnection {
         T: QueryFragment<Self::Backend> + QueryId,
     {
         let mut statement = try!(self.prepare_query(source));
-        let statement_use = StatementUse::new(&mut statement);
+        let mut statement_use = StatementUse::new(&mut statement);
         try!(statement_use.run());
         Ok(self.raw_connection.rows_affected_by_last_query())
     }

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -30,7 +30,11 @@ where
     type Item = QueryResult<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.stmt.step().map(|mut row| {
+        let row = match self.stmt.step() {
+            Ok(row) => row,
+            Err(e) => return Some(Err(e)),
+        };
+        row.map(|mut row| {
             T::Row::build_from_row(&mut row)
                 .map(T::build)
                 .map_err(DeserializationError)
@@ -69,7 +73,11 @@ where
     type Item = QueryResult<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.stmt.step().map(|row| {
+        let row = match self.stmt.step() {
+            Ok(row) => row,
+            Err(e) => return Some(Err(e)),
+        };
+        row.map(|row| {
             let row = row.into_named(&self.column_indices);
             T::build(&row).map_err(DeserializationError)
         })


### PR DESCRIPTION
I'm not sure how this ever got in there. Diesel ever panicking is
unacceptable, and we need to just return the error here.

The reason we've never run into this is that this function is only
called from queries with a return value. Previously `.execute` went
through a different code path, which did return an error.

Since SQLite doesn't support a RETURNING keyword, and select statements
should never be able to produce an error in Diesel (I'm not even sure
how we would make a select statement that errors when executed, but
prepares fine), this went unnoticed.

However, there's an additional return value that we *can* get from
select statements: `SQLITE_BUSY`. This is not really an error, but we
have no choice other than to treat it as such. I'm not sure if SQLite
actually gives us an error code here, and I'm not sure how to test it.
Either way we should give this a variant in `DatabaseErrorKind` in 1.1.

Fixes #1357.