### PR TITLE
(derive) Use absolute path to Result in QueryableByName derive

### DIFF
--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -38,7 +38,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
                 __DB: diesel::backend::Backend,
                 #(#attr_where_clause)*
             {
-               fn build<__R: diesel::row::NamedRow<__DB>>(row: &__R) -> Result<Self, Box<::std::error::Error + Send + Sync>> {
+               fn build<__R: diesel::row::NamedRow<__DB>>(row: &__R) -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>> {
                    Ok(#build_expr)
                }
             }


### PR DESCRIPTION
This prevents name collisions when a custom Result type is in scope.

Fixes #1372