### PR TITLE
Implement various "primitive" traits for `Datetime`

### DIFF
--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -42,7 +42,8 @@ macro_rules! mysql_time_impls {
 }
 
 mysql_time_impls!(Datetime);
-primitive_impls!(Datetime -> NaiveDateTime);
+queryable_impls!(Datetime -> NaiveDateTime);
+expression_impls!(Datetime -> NaiveDateTime);
 mysql_time_impls!(Timestamp);
 mysql_time_impls!(Time);
 mysql_time_impls!(Date);

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -97,3 +97,5 @@ impl QueryId for ::types::Numeric {
 /// [NaiveDateTime]: https://lifthrasiir.github.io/rust-chrono/chrono/naive/datetime/struct.NaiveDateTime.html
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Datetime;
+
+primitive_impls!(Datetime);


### PR DESCRIPTION
Prior to this commit, it was impossible to have any columns of the type
`Nullable<Datetime>`, call any methods from `ExpressionMethods` on
expressions of that type, or use a bind parameter of that type. This
implements the required traits to enable all of those things.