### PR TITLE
Document more items in `query_dsl`

### DIFF
--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -1,9 +1,18 @@
 use query_builder::AsQuery;
 use query_source::Table;
 
+/// The `into_boxed` method
+///
+/// This trait should not be relied on directly by most apps. Its behavior is
+/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
+/// to call `into_boxed` from generic code.
+///
+/// [`QueryDsl`]: ../trait.QueryDsl.html
 pub trait BoxedDsl<'a, DB> {
+    /// The return type of `internal_into_boxed`
     type Output;
 
+    /// See the trait documentation.
     fn internal_into_boxed(self) -> Self::Output;
 }
 

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -10,8 +10,10 @@ use query_source::*;
 ///
 /// [`QueryDsl`]: ../trait.QueryDsl.html
 pub trait FilterDsl<Predicate> {
+    /// The type returned by `.filter`.
     type Output;
 
+    /// See the trait documentation.
     fn filter(self, predicate: Predicate) -> Self::Output;
 }
 
@@ -35,8 +37,10 @@ where
 ///
 /// [`QueryDsl`]: ../trait.QueryDsl.html
 pub trait FindDsl<PK> {
+    /// The type returned by `.find`.
     type Output;
 
+    /// See the trait documentation.
     fn find(self, id: PK) -> Self::Output;
 }
 

--- a/diesel/src/query_dsl/limit_dsl.rs
+++ b/diesel/src/query_dsl/limit_dsl.rs
@@ -8,6 +8,7 @@ use query_source::Table;
 ///
 /// [`QueryDsl`]: ../trait.QueryDsl.html
 pub trait LimitDsl {
+    /// The type returned by `.limit`
     type Output;
 
     /// See the trait documenation

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -6,7 +6,15 @@ use result::QueryResult;
 use super::RunQueryDsl;
 use types::HasSqlType;
 
+/// The `load` method
+///
+/// This trait should not be relied on directly by most apps. Its behavior is
+/// provided by [`RunQueryDsl`]. However, you may need a where clause on this trait
+/// to call `load` from generic code.
+///
+/// [`RunQueryDsl`]: ../trait.RunQueryDsl.html
 pub trait LoadQuery<Conn, U>: RunQueryDsl<Conn> {
+    /// Load this query
     fn internal_load(self, conn: &Conn) -> QueryResult<Vec<U>>;
 }
 
@@ -23,8 +31,16 @@ where
     }
 }
 
+/// The `execute` method
+///
+/// This trait should not be relied on directly by most apps. Its behavior is
+/// provided by [`RunQueryDsl`]. However, you may need a where clause on this trait
+/// to call `execute` from generic code.
+///
+/// [`RunQueryDsl`]: ../trait.RunQueryDsl.html
 pub trait ExecuteDsl<Conn: Connection<Backend = DB>, DB: Backend = <Conn as Connection>::Backend>
     : Sized {
+    /// Execute this command
     fn execute(query: Self, conn: &Conn) -> QueryResult<usize>;
 }
 

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -41,11 +41,11 @@ mod offset_dsl;
 mod order_dsl;
 
 pub use self::belonging_to_dsl::BelongingToDsl;
-pub use self::boxed_dsl::BoxedDsl;
+#[doc(hidden)]
+pub use self::load_dsl::LoadQuery;
 #[doc(hidden)]
 pub use self::group_by_dsl::GroupByDsl;
 pub use self::join_dsl::{InternalJoinDsl, JoinOnDsl, JoinWithImplicitOnClause};
-pub use self::load_dsl::LoadQuery;
 pub use self::save_changes_dsl::SaveChangesDsl;
 
 /// The traits used by `QueryDsl`.
@@ -55,11 +55,12 @@ pub use self::save_changes_dsl::SaveChangesDsl;
 /// However, generic code may need to include a where clause that references
 /// these traits.
 pub mod methods {
+    pub use super::boxed_dsl::BoxedDsl;
     pub use super::distinct_dsl::*;
     #[doc(inline)]
     pub use super::filter_dsl::*;
     pub use super::limit_dsl::LimitDsl;
-    pub use super::load_dsl::ExecuteDsl;
+    pub use super::load_dsl::{ExecuteDsl, LoadQuery};
     pub use super::locking_dsl::ForUpdateDsl;
     pub use super::offset_dsl::OffsetDsl;
     pub use super::order_dsl::OrderDsl;
@@ -749,9 +750,9 @@ pub trait QueryDsl: Sized {
     fn into_boxed<'a, DB>(self) -> IntoBoxed<'a, Self, DB>
     where
         DB: Backend,
-        Self: BoxedDsl<'a, DB>,
+        Self: methods::BoxedDsl<'a, DB>,
     {
-        self.internal_into_boxed()
+        methods::BoxedDsl::internal_into_boxed(self)
     }
 }
 

--- a/diesel/src/query_dsl/select_dsl.rs
+++ b/diesel/src/query_dsl/select_dsl.rs
@@ -12,8 +12,10 @@ pub trait SelectDsl<Selection: Expression> {
     // FIXME: Once we've refactored the `impl Expression` on `SelectStatement`
     // to not conditionally be `types::Array`, it is probably worthwhile to
     // add a `: Expression<SqlType = Selection::SqlType>` bound here.
+    /// The type returned by `.select`
     type Output;
 
+    /// See the trait documentation
     fn select(self, selection: Selection) -> Self::Output;
 }
 


### PR DESCRIPTION
I don't know how this didn't cause our build to fail. The missing_docs
lint should have been triggering.