### PR TITLE
Document `query_builder::bind_collector`

### DIFF
--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -1,9 +1,19 @@
+//! Types related to managing bind parameters during query construction.
+
 use backend::{Backend, TypeMetadata};
 use result::Error::SerializationError;
 use result::QueryResult;
 use types::{HasSqlType, IsNull, ToSql, ToSqlOutput};
 
+/// A type which manages serializing bind parameters during query construction.
+///
+/// The only reason you would ever need to interact with this trait is if you
+/// are adding support for a new backend to Diesel. Plugins which are extending
+/// the query builder will use [`AstPass::push_bind_param`] instead.
+///
+/// [`AstPass::push_bind_param`]: struct.AstPass.htmll#method.push_bind_param
 pub trait BindCollector<DB: Backend> {
+    /// Serializes the given bind value, and collects the result.
     fn push_bound_value<T, U>(
         &mut self,
         bind: &U,
@@ -15,13 +25,25 @@ pub trait BindCollector<DB: Backend> {
 }
 
 #[derive(Debug)]
+/// A bind collector used by backends which transmit bind parameters as an
+/// opaque blob of bytes.
+///
+/// For most backends, this is the concrete implementation of `BindCollector`
+/// that should be used.
 pub struct RawBytesBindCollector<DB: Backend + TypeMetadata> {
+    /// The metadata associated with each bind parameter.
+    ///
+    /// This vec is guaranteed to be the same length as `binds`.
     pub metadata: Vec<DB::TypeMetadata>,
+    /// The serialized bytes for each bind parameter.
+    ///
+    /// This vec is guaranteed to be the same length as `metadata`.
     pub binds: Vec<Option<Vec<u8>>>,
 }
 
 impl<DB: Backend + TypeMetadata> RawBytesBindCollector<DB> {
     #[cfg_attr(feature = "clippy", allow(new_without_default_derive))]
+    /// Construct an empty `RawBytesBindCollector`
     pub fn new() -> Self {
         RawBytesBindCollector {
             metadata: Vec::new(),
@@ -41,12 +63,14 @@ impl<DB: Backend + TypeMetadata> BindCollector<DB> for RawBytesBindCollector<DB>
         U: ToSql<T, DB>,
     {
         let mut to_sql_output = ToSqlOutput::new(Vec::new(), metadata_lookup);
-        match bind.to_sql(&mut to_sql_output).map_err(SerializationError)? {
-            IsNull::No => self.binds.push(Some(to_sql_output.into_inner())),
+        let is_null = bind.to_sql(&mut to_sql_output).map_err(SerializationError)?;
+        let bytes = to_sql_output.into_inner();
+        let metadata = <DB as HasSqlType<T>>::metadata(metadata_lookup);
+        match is_null {
+            IsNull::No => self.binds.push(Some(bytes)),
             IsNull::Yes => self.binds.push(None),
         }
-        self.metadata
-            .push(<DB as HasSqlType<T>>::metadata(metadata_lookup));
+        self.metadata.push(metadata);
         Ok(())
     }
 }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -10,6 +10,7 @@ mod query_id;
 mod clause_macro;
 
 mod ast_pass;
+#[deny(missing_docs)]
 pub mod bind_collector;
 mod debug_query;
 mod delete_statement;


### PR DESCRIPTION
While documenting the fields of `RawBytesBindCollector`, I noticed that
my statement about `metadata` being guaranteed to have the same length
as `bytes` is not actually true if something panics. I've moved some
code around to make sure that invariant is upheld, and anything which
can reasonably panic (I'm ignoring allocator failures) is moved before
the vectors are modified.