### PR TITLE
Update documentation for all items in `expression_methods`

### DIFF
--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -3,8 +3,40 @@ use expression::operators::{And, Or};
 use expression::{AsExpression, Expression};
 use types::Bool;
 
+/// Methods present on boolean expressions
 pub trait BoolExpressionMethods: Expression<SqlType = Bool> + Sized {
     /// Creates a SQL `AND` expression
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// diesel::insert_into(animals)
+    ///     .values(&vec![
+    ///         (species.eq("ferret"), legs.eq(4), name.eq("Freddy")),
+    ///         (species.eq("ferret"), legs.eq(4), name.eq("Jack")),
+    ///     ])
+    ///     .execute(&connection)?;
+    ///
+    /// let data = animals.select((species, name))
+    ///     .filter(species.eq("ferret").and(name.eq("Jack")))
+    ///     .load(&connection)?;
+    /// let expected = vec![
+    ///     (String::from("ferret"), Some(String::from("Jack"))),
+    /// ];
+    /// assert_eq!(expected, data);
+    /// #     Ok(())
+    /// # }
     fn and<T: AsExpression<Bool>>(self, other: T) -> And<Self, T::Expression> {
         And::new(self.as_expression(), other.as_expression())
     }
@@ -12,8 +44,41 @@ pub trait BoolExpressionMethods: Expression<SqlType = Bool> + Sized {
     /// Creates a SQL `OR` expression
     ///
     /// The result will be wrapped in parenthesis, so that precedence matches
-    /// that of your function calls. For example, `false.and(true.or(false))`
-    /// will return `false`
+    /// that of your function calls. For example, `false.and(false.or(true))`
+    /// will generate the SQL `FALSE AND (FALSE OR TRUE)`, which returns `false`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// diesel::insert_into(animals)
+    ///     .values(&vec![
+    ///         (species.eq("ferret"), legs.eq(4), name.eq("Freddy")),
+    ///         (species.eq("ferret"), legs.eq(4), name.eq("Jack")),
+    ///     ])
+    ///     .execute(&connection)?;
+    ///
+    /// let data = animals.select((species, name))
+    ///     .filter(species.eq("ferret").or(name.eq("Jack")))
+    ///     .load(&connection)?;
+    /// let expected = vec![
+    ///     (String::from("dog"), Some(String::from("Jack"))),
+    ///     (String::from("ferret"), Some(String::from("Freddy"))),
+    ///     (String::from("ferret"), Some(String::from("Jack"))),
+    /// ];
+    /// assert_eq!(expected, data);
+    /// #     Ok(())
+    /// # }
     fn or<T: AsExpression<Bool>>(self, other: T) -> Grouped<Or<Self, T::Expression>> {
         Grouped(Or::new(self, other.as_expression()))
     }

--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -5,6 +5,9 @@ use types::VarChar;
 /// Adds the `escape` method to `LIKE` and `NOT LIKE`. This is used to specify
 /// the escape character for the pattern.
 ///
+/// By default, the escape character is `\` on most backends. On SQLite,
+/// there is no default escape character.
+///
 /// # Example
 ///
 /// ```rust
@@ -28,6 +31,7 @@ use types::VarChar;
 /// # }
 /// ```
 pub trait EscapeExpressionMethods: Sized {
+    /// See the trait documentation.
     fn escape(self, character: char) -> Escape<Self, AsExprOf<String, VarChar>> {
         Escape::new(self, character.to_string().into_sql::<VarChar>())
     }

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -3,6 +3,7 @@ use expression::array_comparison::{AsInExpression, In, NotIn};
 use expression::operators::*;
 use types::SingleValue;
 
+/// Methods present on all expressions, except tuples
 pub trait ExpressionMethods: Expression + Sized {
     /// Creates a SQL `=` expression.
     ///
@@ -118,18 +119,21 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::animals;
     /// #
     /// # fn main() {
-    /// #     use animals::dsl::*;
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
     ///     .select(species)
     ///     .filter(name.is_null())
-    ///     .first(&connection);
-    /// #
-    /// assert_eq!(Ok("spider".to_string()), data);
+    ///     .first::<String>(&connection)?;
+    /// assert_eq!("spider", data);
+    /// #     Ok(())
     /// # }
     fn is_null(self) -> IsNull<Self> {
         IsNull::new(self)
@@ -142,18 +146,21 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::animals;
     /// #
     /// # fn main() {
-    /// #     use animals::dsl::*;
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
     ///     .select(species)
     ///     .filter(name.is_not_null())
-    ///     .first(&connection);
-    /// #
-    /// assert_eq!(Ok("dog".to_string()), data);
+    ///     .first::<String>(&connection)?;
+    /// assert_eq!("dog", data);
+    /// #     Ok(())
     /// # }
     fn is_not_null(self) -> IsNotNull<Self> {
         IsNotNull::new(self)
@@ -168,10 +175,18 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// let data = users.select(name).filter(id.gt(1));
-    /// assert_eq!(Ok("Tess".to_string()), data.first(&connection));
+    /// let data = users
+    ///     .select(name)
+    ///     .filter(id.gt(1))
+    ///     .first::<String>(&connection)?;
+    /// assert_eq!("Tess", data);
+    /// #     Ok(())
     /// # }
     /// ```
     fn gt<T: AsExpression<Self::SqlType>>(self, other: T) -> Gt<Self, T::Expression> {
@@ -187,10 +202,18 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// let data = users.select(name).filter(id.ge(2));
-    /// assert_eq!(Ok("Tess".to_string()), data.first(&connection));
+    /// let data = users
+    ///     .select(name)
+    ///     .filter(id.ge(2))
+    ///     .first::<String>(&connection)?;
+    /// assert_eq!("Tess", data);
+    /// #     Ok(())
     /// # }
     /// ```
     fn ge<T: AsExpression<Self::SqlType>>(self, other: T) -> GtEq<Self, T::Expression> {
@@ -206,10 +229,18 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// let data = users.select(name).filter(id.lt(2));
-    /// assert_eq!(Ok("Sean".to_string()), data.first(&connection));
+    /// let data = users
+    ///     .select(name)
+    ///     .filter(id.lt(2))
+    ///     .first::<String>(&connection)?;
+    /// assert_eq!("Sean", data);
+    /// #     Ok(())
     /// # }
     /// ```
     fn lt<T: AsExpression<Self::SqlType>>(self, other: T) -> Lt<Self, T::Expression> {
@@ -225,10 +256,18 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// let data = users.select(name).filter(id.le(2));
-    /// assert_eq!(Ok("Sean".to_string()), data.first(&connection));
+    /// let data = users
+    ///     .select(name)
+    ///     .filter(id.le(2))
+    ///     .first::<String>(&connection)?;
+    /// assert_eq!("Sean", data);
+    /// #     Ok(())
     /// # }
     fn le<T: AsExpression<Self::SqlType>>(self, other: T) -> LtEq<Self, T::Expression> {
         LtEq::new(self, other.as_expression())
@@ -242,10 +281,9 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::animals;
     /// #
     /// # fn main() {
-    /// #     use animals::dsl::*;
+    /// #     use schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
@@ -272,18 +310,21 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::animals;
     /// #
     /// # fn main() {
-    /// #     use animals::dsl::*;
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
     ///     .select(species)
     ///     .filter(legs.not_between(2, 6))
-    ///     .first(&connection);
-    /// #
-    /// assert_eq!(Ok("spider".to_string()), data);
+    ///     .first::<String>(&connection)?;
+    /// assert_eq!("spider", data);
+    /// #     Ok(())
     /// # }
     fn not_between<T, U>(
         self,
@@ -299,6 +340,29 @@ pub trait ExpressionMethods: Expression + Sized {
 
     /// Creates a SQL `DESC` expression, representing this expression in
     /// descending order.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #
+    /// let names = users
+    ///     .select(name)
+    ///     .order(name.desc())
+    ///     .load::<String>(&connection)?;
+    /// assert_eq!(vec!["Tess", "Sean"], names);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn desc(self) -> Desc<Self> {
         Desc::new(self)
     }
@@ -339,6 +403,7 @@ where
 {
 }
 
+/// Methods present on all expressions
 pub trait NullableExpressionMethods: Expression + Sized {
     /// Converts this potentially non-null expression into one which is treated
     /// as nullable. This method has no impact on the generated SQL, and is only
@@ -374,6 +439,7 @@ pub trait NullableExpressionMethods: Expression + Sized {
     ///         .load::<String>(&connection);
     ///     println!("{:?}", data);
     /// }
+    /// ```
     fn nullable(self) -> nullable::Nullable<Self> {
         nullable::Nullable::new(self)
     }

--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -4,12 +4,11 @@
 //! You can rely on the methods provided by this trait existing on any
 //! `Expression` of the appropriate type. You should not rely on the specific
 //! traits existing, their names, or their organization.
-pub mod bool_expression_methods;
-pub mod escape_expression_methods;
-pub mod global_expression_methods;
-pub mod text_expression_methods;
-#[doc(hidden)]
-pub mod eq_all;
+mod bool_expression_methods;
+mod escape_expression_methods;
+mod global_expression_methods;
+mod text_expression_methods;
+mod eq_all;
 
 #[doc(inline)]
 pub use self::bool_expression_methods::BoolExpressionMethods;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -55,6 +55,7 @@ pub mod backend;
 pub mod connection;
 #[macro_use]
 pub mod expression;
+#[deny(missing_docs)]
 pub mod expression_methods;
 #[doc(hidden)]
 pub mod insertable;

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -4,13 +4,12 @@ use expression::{AsExpression, Expression};
 use super::operators::*;
 use types::{Array, Text};
 
-/// PostgreSQL expression methods which are not type specific.
-///
-/// This trait is implemented for all types that implement `Expression`.
+/// PostgreSQL specific methods which are present on all expressions.
 pub trait PgExpressionMethods: Expression + Sized {
-    /// Creates a PostgreSQL `IS NOT DISTINCT FROM` expression. This behaves
-    /// identically to the `=` operator, except that `NULL` is treated as a
-    /// normal value.
+    /// Creates a PostgreSQL `IS NOT DISTINCT FROM` expression.
+    ///
+    /// This behaves identically to the `=` operator, except that `NULL` is
+    /// treated as a normal value.
     ///
     /// # Example
     ///
@@ -34,9 +33,10 @@ pub trait PgExpressionMethods: Expression + Sized {
         IsNotDistinctFrom::new(self, other.as_expression())
     }
 
-    /// Creates a PostgreSQL `IS DISTINCT FROM` expression. This behaves
-    /// identically to the `!=` operator, except that `NULL` is treated as a
-    /// normal value.
+    /// Creates a PostgreSQL `IS DISTINCT FROM` expression.
+    ///
+    /// This behaves identically to the `!=` operator, except that `NULL` is
+    /// treated as a normal value.
     ///
     /// # Example
     ///
@@ -66,12 +66,67 @@ impl<T: Expression> PgExpressionMethods for T {}
 use super::date_and_time::{AtTimeZone, DateTimeLike};
 use types::VarChar;
 
-/// PostgreSQL expression methods related to timestamps.
-///
-/// This trait is implemented for all types that implement `Expression` where
-/// the `SqlType` is either `Timestamp` or `Timestamptz`
+/// PostgreSQL specific methods present on timestamp expressions.
 pub trait PgTimestampExpressionMethods: Expression + Sized {
-    /// Returns a PostgreSQL "AT TIME ZONE" expression
+    /// Creates a PostgreSQL "AT TIME ZONE" expression.
+    ///
+    /// When this is called on a `TIMESTAMP WITHOUT TIME ZONE` column,
+    /// the value will be treated as if were in the given time zone,
+    /// and then converted to UTC.
+    ///
+    /// When this is called on a `TIMESTAMP WITH TIME ZONE` column,
+    /// the value will be converted to the given time zone,
+    /// and then have its time zone information removed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # #[cfg(feature = "chrono")]
+    /// # extern crate chrono;
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     timestamps (timestamp) {
+    /// #         timestamp -> Timestamp,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(all(feature = "postgres", feature = "chrono"))]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use timestamps::dsl::*;
+    /// #     use chrono::*;
+    /// #     let connection = establish_connection();
+    /// #     connection.execute("CREATE TABLE timestamps (\"timestamp\"
+    /// #         timestamp NOT NULL)")?;
+    /// let christmas_morning = NaiveDate::from_ymd(2017, 12, 25)
+    ///     .and_hms(8, 0, 0);
+    /// diesel::insert_into(timestamps)
+    ///     .values(timestamp.eq(christmas_morning))
+    ///     .execute(&connection)?;
+    ///
+    /// let utc_time = timestamps
+    ///     .select(timestamp.at_time_zone("UTC"))
+    ///     .first(&connection)?;
+    /// assert_eq!(christmas_morning, utc_time);
+    ///
+    /// let eastern_time = timestamps
+    ///     .select(timestamp.at_time_zone("EST"))
+    ///     .first(&connection)?;
+    /// let five_hours_later = christmas_morning + Duration::hours(5);
+    /// assert_eq!(five_hours_later, eastern_time);
+    /// #     Ok(())
+    /// # }
+    /// #
+    /// # #[cfg(not(all(feature = "postgres", feature = "chrono")))]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn at_time_zone<T>(self, timezone: T) -> AtTimeZone<Self, T::Expression>
     where
         T: AsExpression<VarChar>,
@@ -86,20 +141,17 @@ where
 {
 }
 
-/// PostgreSQL expression methods related to arrays.
-///
-/// This trait is implemented for all types that implement `Expression` where
-/// the `SqlType` is `Array`.
-pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
-    /// Compares two arrays for common elements, using the `&&` operator in
-    /// the final SQL
+/// PostgreSQL specific methods present on array expressions.
+pub trait PgArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
+    /// Creates a PostgreSQL `&&` expression.
+    ///
+    /// This operator returns whether two arrays have common elements.
     ///
     /// # Example
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../../doctest_setup.rs");
-    /// # use schema::users;
     /// #
     /// # table! {
     /// #     posts {
@@ -109,6 +161,10 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// # }
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use self::posts::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("DROP TABLE IF EXISTS posts").unwrap();
@@ -120,17 +176,23 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     ///         tags.eq(vec!["awesome", "great"]),
     ///         tags.eq(vec!["cool", "great"]),
     ///     ])
-    ///     .execute(&conn)
-    ///     .unwrap();
+    ///     .execute(&conn)?;
     ///
-    /// let query = posts.select(id).filter(tags.overlaps_with(vec!["horrid", "cool"]));
-    /// assert_eq!(Ok(vec![1, 3]), query.load(&conn));
+    /// let data = posts.select(id)
+    ///     .filter(tags.overlaps_with(vec!["horrid", "cool"]))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 3], data);
     ///
-    /// let query = posts.select(id).filter(tags.overlaps_with(vec!["cool", "great"]));
-    /// assert_eq!(Ok(vec![1, 2, 3]), query.load(&conn));
+    /// let data = posts.select(id)
+    ///     .filter(tags.overlaps_with(vec!["cool", "great"]))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2, 3], data);
     ///
-    /// let query = posts.select(id).filter(tags.overlaps_with(vec!["horrid"]));
-    /// assert_eq!(Ok(Vec::new()), query.load::<i32>(&conn));
+    /// let data = posts.select(id)
+    ///     .filter(tags.overlaps_with(vec!["horrid"]))
+    ///     .load::<i32>(&conn)?;
+    /// assert!(data.is_empty());
+    /// #     Ok(())
     /// # }
     /// ```
     fn overlaps_with<T>(self, other: T) -> OverlapsWith<Self, T::Expression>
@@ -140,14 +202,15 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
         OverlapsWith::new(self, other.as_expression())
     }
 
-    /// Compares whether an array contains another array, using the `@>` operator.
+    /// Creates a PostgreSQL `@>` expression.
+    ///
+    /// This operator returns whether an array contains another array.
     ///
     /// # Example
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../../doctest_setup.rs");
-    /// # use schema::users;
     /// #
     /// # table! {
     /// #     posts {
@@ -157,6 +220,10 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// # }
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use self::posts::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("DROP TABLE IF EXISTS posts").unwrap();
@@ -164,14 +231,18 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// #
     /// diesel::insert_into(posts)
     ///     .values(tags.eq(vec!["cool", "awesome"]))
-    ///     .execute(&conn)
-    ///     .unwrap();
+    ///     .execute(&conn)?;
     ///
-    /// let query = posts.select(id).filter(tags.contains(vec!["cool"]));
-    /// assert_eq!(Ok(vec![1]), query.load(&conn));
+    /// let cool_posts = posts.select(id)
+    ///     .filter(tags.contains(vec!["cool"]))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1], cool_posts);
     ///
-    /// let query = posts.select(id).filter(tags.contains(vec!["cool", "amazing"]));
-    /// assert_eq!(Ok(Vec::new()), query.load::<i32>(&conn));
+    /// let amazing_posts = posts.select(id)
+    ///     .filter(tags.contains(vec!["cool", "amazing"]))
+    ///     .load::<i32>(&conn)?;
+    /// assert!(amazing_posts.is_empty());
+    /// #     Ok(())
     /// # }
     /// ```
     fn contains<T>(self, other: T) -> Contains<Self, T::Expression>
@@ -181,15 +252,16 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
         Contains::new(self, other.as_expression())
     }
 
-    /// Compares whether an array is contained by another array, using the `<@` operator.
-    /// This is the opposite of `contains`
+    /// Creates a PostgreSQL `<@` expression.
+    ///
+    /// This operator returns whether an array is contained by another array.
+    /// `foo.contains(bar)` is the same as `bar.is_contained_by(foo)`
     ///
     /// # Example
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../../doctest_setup.rs");
-    /// # use schema::users;
     /// #
     /// # table! {
     /// #     posts {
@@ -199,6 +271,10 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// # }
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use self::posts::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("DROP TABLE IF EXISTS posts").unwrap();
@@ -206,14 +282,18 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     /// #
     /// diesel::insert_into(posts)
     ///     .values(tags.eq(vec!["cool", "awesome"]))
-    ///     .execute(&conn)
-    ///     .unwrap();
+    ///     .execute(&conn)?;
     ///
-    /// let query = posts.select(id).filter(tags.is_contained_by(vec!["cool", "awesome", "amazing"]));
-    /// assert_eq!(Ok(vec![1]), query.load(&conn));
+    /// let data = posts.select(id)
+    ///     .filter(tags.is_contained_by(vec!["cool", "awesome", "amazing"]))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1], data);
     ///
-    /// let query = posts.select(id).filter(tags.is_contained_by(vec!["cool"]));
-    /// assert_eq!(Ok(Vec::new()), query.load::<i32>(&conn));
+    /// let data = posts.select(id)
+    ///     .filter(tags.is_contained_by(vec!["cool"]))
+    ///     .load::<i32>(&conn)?;
+    /// assert!(data.is_empty());
+    /// #     Ok(())
     /// # }
     /// ```
     fn is_contained_by<T>(self, other: T) -> IsContainedBy<Self, T::Expression>
@@ -224,7 +304,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
     }
 }
 
-impl<T, ST> ArrayExpressionMethods<ST> for T
+impl<T, ST> PgArrayExpressionMethods<ST> for T
 where
     T: Expression<SqlType = Array<ST>>,
 {
@@ -237,8 +317,9 @@ use expression::operators::{Asc, Desc};
 /// This trait is only implemented for `Asc` and `Desc`. Although `.asc` is
 /// implicit if no order is given, you will need to call `.asc()` explicitly in
 /// order to call these methods.
-pub trait SortExpressionMethods: Sized {
+pub trait PgSortExpressionMethods: Sized {
     /// Specify that nulls should come before other values in this ordering.
+    ///
     /// Normally, nulls come last when sorting in ascending order and first
     /// when sorting in descending order.
     ///
@@ -249,24 +330,37 @@ pub trait SortExpressionMethods: Sized {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
-    /// #     foos {
-    /// #         id -> Integer,
-    /// #         foo -> Nullable<Integer>,
+    /// #     nullable_numbers (nullable_number) {
+    /// #         nullable_number -> Nullable<Integer>,
     /// #     }
     /// # }
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::nullable_numbers::dsl::*;
     /// #     let connection = connection_no_data();
-    /// #     connection.execute("DROP TABLE IF EXISTS foos").unwrap();
-    /// connection.execute("CREATE TABLE foos (id SERIAL PRIMARY KEY, foo INTEGER)").unwrap();
-    /// connection.execute("INSERT INTO foos (foo) VALUES (NULL), (1), (2)").unwrap();
+    /// #     connection.execute("CREATE TABLE nullable_numbers (nullable_number INTEGER)")?;
+    /// diesel::insert_into(nullable_numbers)
+    ///     .values(&vec![
+    ///         nullable_number.eq(None),
+    ///         nullable_number.eq(Some(1)),
+    ///         nullable_number.eq(Some(2)),
+    ///     ])
+    ///     .execute(&connection)?;
     ///
-    /// #     use self::foos::dsl::*;
-    /// assert_eq!(Ok(vec![Some(1), Some(2), None]),
-    ///            foos.select(foo).order(foo.asc()).load(&connection));
-    /// assert_eq!(Ok(vec![None, Some(1), Some(2)]),
-    ///            foos.select(foo).order(foo.asc().nulls_first()).load(&connection));
-    /// #     connection.execute("DROP TABLE foos").unwrap();
+    /// let asc_default_nulls = nullable_numbers.select(nullable_number)
+    ///     .order(nullable_number.asc())
+    ///     .load(&connection)?;
+    /// assert_eq!(vec![Some(1), Some(2), None], asc_default_nulls);
+    ///
+    /// let asc_nulls_first = nullable_numbers.select(nullable_number)
+    ///     .order(nullable_number.asc().nulls_first())
+    ///     .load(&connection)?;
+    /// assert_eq!(vec![None, Some(1), Some(2)], asc_nulls_first);
+    /// #     Ok(())
     /// # }
     /// ```
     fn nulls_first(self) -> NullsFirst<Self> {
@@ -274,6 +368,7 @@ pub trait SortExpressionMethods: Sized {
     }
 
     /// Specify that nulls should come after other values in this ordering.
+    ///
     /// Normally, nulls come last when sorting in ascending order and first
     /// when sorting in descending order.
     ///
@@ -284,24 +379,37 @@ pub trait SortExpressionMethods: Sized {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
-    /// #     foos {
-    /// #         id -> Integer,
-    /// #         foo -> Nullable<Integer>,
+    /// #     nullable_numbers (nullable_number) {
+    /// #         nullable_number -> Nullable<Integer>,
     /// #     }
     /// # }
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::nullable_numbers::dsl::*;
     /// #     let connection = connection_no_data();
-    /// #     connection.execute("DROP TABLE IF EXISTS foos").unwrap();
-    /// connection.execute("CREATE TABLE foos (id SERIAL PRIMARY KEY, foo INTEGER)").unwrap();
-    /// connection.execute("INSERT INTO foos (foo) VALUES (NULL), (1), (2)").unwrap();
+    /// #     connection.execute("CREATE TABLE nullable_numbers (nullable_number INTEGER)")?;
+    /// diesel::insert_into(nullable_numbers)
+    ///     .values(&vec![
+    ///         nullable_number.eq(None),
+    ///         nullable_number.eq(Some(1)),
+    ///         nullable_number.eq(Some(2)),
+    ///     ])
+    ///     .execute(&connection)?;
     ///
-    /// #     use self::foos::dsl::*;
-    /// assert_eq!(Ok(vec![None, Some(2), Some(1)]),
-    ///            foos.select(foo).order(foo.desc()).load(&connection));
-    /// assert_eq!(Ok(vec![Some(2), Some(1), None]),
-    ///            foos.select(foo).order(foo.desc().nulls_last()).load(&connection));
-    /// #     connection.execute("DROP TABLE foos").unwrap();
+    /// let desc_default_nulls = nullable_numbers.select(nullable_number)
+    ///     .order(nullable_number.desc())
+    ///     .load(&connection)?;
+    /// assert_eq!(vec![None, Some(2), Some(1)], desc_default_nulls);
+    ///
+    /// let desc_nulls_last = nullable_numbers.select(nullable_number)
+    ///     .order(nullable_number.desc().nulls_last())
+    ///     .load(&connection)?;
+    /// assert_eq!(vec![Some(2), Some(1), None], desc_nulls_last);
+    /// #     Ok(())
     /// # }
     /// ```
     fn nulls_last(self) -> NullsLast<Self> {
@@ -309,65 +417,59 @@ pub trait SortExpressionMethods: Sized {
     }
 }
 
-impl<T> SortExpressionMethods for Asc<T> {}
+impl<T> PgSortExpressionMethods for Asc<T> {}
+impl<T> PgSortExpressionMethods for Desc<T> {}
 
-impl<T> SortExpressionMethods for Desc<T> {}
-
-/// PostgreSQL expression methods related to text.
-///
-/// This trait is implemented for all types that implement `Expression` where
-/// the `SqlType` is `Text`
+/// PostgreSQL specific methods present on text expressions.
 pub trait PgTextExpressionMethods: Expression<SqlType = Text> + Sized {
-    /// Returns a SQL `ILIKE` expression
+    /// Creates a  PostgreSQL `ILIKE` expression
     ///
     /// # Example
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../../doctest_setup.rs");
-    /// # use schema::users;
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// #
-    /// let like_sean = users
+    /// let starts_with_s = users
     ///     .select(name)
-    ///     .filter(name.ilike("sean"))
-    ///     .get_results::<String>(&connection)
-    ///     .expect("Failed");
-    ///
-    /// let expected = vec!["Sean".to_string()];
-    ///
-    /// assert_eq!(expected, like_sean);
+    ///     .filter(name.ilike("s%"))
+    ///     .get_results::<String>(&connection)?;
+    /// assert_eq!(vec!["Sean"], starts_with_s);
+    /// #     Ok(())
     /// # }
     /// ```
     fn ilike<T: AsExpression<Text>>(self, other: T) -> ILike<Self, T::Expression> {
         ILike::new(self.as_expression(), other.as_expression())
     }
 
-    /// Returns a SQL `NOT ILIKE` expression
+    /// Creates a PostgreSQL `NOT ILIKE` expression
     ///
     /// # Example
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../../doctest_setup.rs");
-    /// # use schema::users;
     /// #
     /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
     /// #     let connection = establish_connection();
-    /// #
-    /// let not_like_sean = users
+    /// let doesnt_start_with_s = users
     ///     .select(name)
-    ///     .filter(name.not_ilike("sean"))
-    ///     .get_results::<String>(&connection)
-    ///     .expect("Failed");
-    ///
-    /// let expected = vec!["Tess".to_string()];
-    ///
-    /// assert_eq!(expected, not_like_sean);
+    ///     .filter(name.not_ilike("s%"))
+    ///     .get_results::<String>(&connection)?;
+    /// assert_eq!(vec!["Tess"], doesnt_start_with_s);
+    /// #     Ok(())
     /// # }
     /// ```
     fn not_ilike<T: AsExpression<Text>>(self, other: T) -> NotILike<Self, T::Expression> {

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -6,7 +6,7 @@
 
 #[doc(hidden)]
 pub mod array_comparison;
-pub mod expression_methods;
+pub(crate) mod expression_methods;
 pub mod extensions;
 #[doc(hidden)]
 pub mod operators;


### PR DESCRIPTION
In addition to normal doc cleanup, I've hidden the submodules of
`expression_methods`, as well as `pg::expression_methods`. I've also
made sure that we consistently prefix the PG expression methods with
`Pg`.