### PR TITLE
Revamp the docs in `expression::helper_types`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added `.or_filter`, which behaves identically to `.filter`, but using `OR`
   instead of `AND`.
 
+* `helper_types` now contains a type for every method defined in
+  `expression_methods`, and every function in `dsl`.
+
 ### Deprecated
 
 * *IMPORTANT NOTE* Do to [several][rust-deprecation-bug-1]
@@ -74,6 +77,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `types::ToSqlOutput` has been deprecated. It has been renamed to
   `serialize::Output`.
+
+* `helper_types::Not` is now `helper_types::not`
 
 ### Fixed
 

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,5 +1,4 @@
 use backend::Backend;
-use dsl::SqlTypeOf;
 use expression::*;
 use query_builder::*;
 use result::QueryResult;
@@ -16,11 +15,6 @@ pub struct NotIn<T, U> {
     left: T,
     values: U,
 }
-
-/// The return type of `lhs.eq_any(rhs)`
-pub type EqAny<Lhs, Rhs> = In<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>;
-/// The return type of `lhs.ne_any(rhs)`
-pub type NeAny<Lhs, Rhs> = NotIn<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>;
 
 impl<T, U> In<T, U> {
     pub fn new(left: T, values: U) -> Self {

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -27,7 +27,7 @@ impl_selectable_expression!(now);
 
 operator_allowed!(now, Add, add);
 operator_allowed!(now, Sub, sub);
-sql_function!(date, date_t, (x: Timestamp) -> Date,
+sql_function!(date, date_t, (expr: Timestamp) -> Date,
 "Represents the SQL `DATE` function. The argument should be a Timestamp
 expression, and the return value will be an expression of type Date.
 
@@ -43,7 +43,8 @@ expression, and the return value will be an expression of type Date.
 #     let connection = establish_connection();
 let today: chrono::NaiveDate = diesel::select(date(now)).first(&connection).unwrap();
 # }
-");
+",
+"The return type of [`date(expr)`](../dsl/fn.date.html)");
 
 #[cfg(feature = "postgres")]
 use expression::AsExpression;

--- a/diesel/src/expression/functions/helper_types.rs
+++ b/diesel/src/expression/functions/helper_types.rs
@@ -1,0 +1,26 @@
+#![allow(non_camel_case_types)]
+
+use dsl::AsExprOf;
+use expression::grouped::Grouped;
+use expression::operators;
+use sql_types::Bool;
+
+/// The return type of [`not(expr)`](../dsl/fn.not.html)
+pub type not<Expr> = operators::Not<Grouped<AsExprOf<Expr, Bool>>>;
+
+/// The return type of `not(expr)`
+#[deprecated(since = "1.1.0", note = "use `not` instead")]
+#[cfg(feature = "with-deprecated")]
+pub type Not<Expr> = not<Expr>;
+
+/// The return type of [`max(expr)`](../dsl/fn.max.html)
+pub type max<Expr> = super::aggregate_ordering::Max<Expr>;
+
+/// The return type of [`min(expr)`](../dsl/fn.min.html)
+pub type min<Expr> = super::aggregate_ordering::Min<Expr>;
+
+/// The return type of [`sum(expr)`](../dsl/fn.sum.html)
+pub type sum<Expr> = super::aggregate_folding::Sum<Expr>;
+
+/// The return type of [`avg(expr)`](../dsl/fn.avg.html)
+pub type avg<Expr> = super::aggregate_folding::Avg<Expr>;

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -1,8 +1,13 @@
 #[macro_export]
 #[doc(hidden)]
 macro_rules! sql_function_body {
-    ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*) -> $return_type:ty,
-    $docs: expr) => {
+    (
+        $fn_name:ident,
+        $struct_name:ident,
+        ($($arg_name:ident: $arg_type:ty),*) -> $return_type:ty,
+        $docs:expr,
+        $helper_ty_docs:expr
+    ) => {
         #[allow(non_camel_case_types)]
         #[derive(Debug, Clone, Copy, QueryId)]
         #[doc(hidden)]
@@ -11,6 +16,7 @@ macro_rules! sql_function_body {
         }
 
         #[allow(non_camel_case_types)]
+        #[doc=$helper_ty_docs]
         pub type $fn_name<$($arg_name),*> = $struct_name<$(
             <$arg_name as $crate::expression::AsExpression<$arg_type>>::Expression
         ),*>;
@@ -100,17 +106,26 @@ macro_rules! sql_function_body {
 /// # }
 /// ```
 macro_rules! sql_function {
-    ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*) -> $return_type:ty) => {
-        sql_function!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> $return_type, "");
+    ($fn_name:ident, $struct_name:ident, $args:tt -> $return_type:ty) => {
+        sql_function!($fn_name, $struct_name, $args -> $return_type, "");
     };
 
-    ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*) -> $return_type:ty,
-    $docs: expr) => {
-        sql_function_body!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> $return_type, $docs);
+    ($fn_name:ident, $struct_name:ident, $args:tt -> $return_type:ty, $docs:expr) => {
+        sql_function!($fn_name, $struct_name, $args -> $return_type, $docs, "");
     };
 
     ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
         sql_function!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> ());
+    };
+
+    (
+        $fn_name:ident,
+        $struct_name:ident,
+        $args:tt -> $return_type:ty,
+        $docs:expr,
+        $helper_ty_docs:expr
+    ) => {
+        sql_function_body!($fn_name, $struct_name, $args -> $return_type, $docs, $helper_ty_docs);
     };
 }
 
@@ -200,3 +215,4 @@ macro_rules! no_arg_sql_function {
 pub mod aggregate_ordering;
 pub mod aggregate_folding;
 pub mod date_and_time;
+pub mod helper_types;

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -1,9 +1,10 @@
 //! The types in this module are all shorthand for `PredicateType<Lhs,
 //! AsExpr<Rhs, Lhs>>`. Since we often need to return concrete types, instead of
 //! a boxed trait object, these can be useful for writing concise return types.
-use super::{AsExpression, Expression};
-use super::grouped::Grouped;
 use sql_types;
+use super::array_comparison::{AsInExpression, In, NotIn};
+use super::grouped::Grouped;
+use super::{AsExpression, Expression};
 
 /// The SQL type of an expression
 pub type SqlTypeOf<Expr> = <Expr as Expression>::SqlType;
@@ -14,50 +15,91 @@ pub type AsExpr<Item, TargetExpr> = AsExprOf<Item, SqlTypeOf<TargetExpr>>;
 /// The type of `Item` when converted to an expression of `Type`
 pub type AsExprOf<Item, Type> = <Item as AsExpression<Type>>::Expression;
 
-/// The return type of `lhs.eq(rhs)`
+/// The return type of
+/// [`lhs.eq(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.eq)
 pub type Eq<Lhs, Rhs> = super::operators::Eq<Lhs, AsExpr<Rhs, Lhs>>;
 
-/// The return type of `lhs.ne(rhs)`
+/// The return type of
+/// [`lhs.ne(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.ne)
 pub type NotEq<Lhs, Rhs> = super::operators::NotEq<Lhs, AsExpr<Rhs, Lhs>>;
 
-/// The return type of `lhs.gt(rhs)`
+/// The return type of
+/// [`lhs.eq_any(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.eq_any)
+pub type EqAny<Lhs, Rhs> = In<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>;
+
+/// The return type of
+/// [`lhs.ne_any(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.ne_any)
+pub type NeAny<Lhs, Rhs> = NotIn<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>;
+
+/// The return type of
+/// [`expr.is_null()`](../expression_methods/trait.ExpressionMethods.html#method.is_null)
+pub type IsNull<Expr> = super::operators::IsNull<Expr>;
+
+/// The return type of
+/// [`expr.is_not_null()`](../expression_methods/trait.ExpressionMethods.html#method.is_not_null)
+pub type IsNotNull<Expr> = super::operators::IsNotNull<Expr>;
+
+/// The return type of
+/// [`lhs.gt(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.gt)
 pub type Gt<Lhs, Rhs> = super::operators::Gt<Lhs, AsExpr<Rhs, Lhs>>;
 
-/// The return type of `lhs.ge(rhs)`
+/// The return type of
+/// [`lhs.ge(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.ge)
 pub type GtEq<Lhs, Rhs> = super::operators::GtEq<Lhs, AsExpr<Rhs, Lhs>>;
 
-/// The return type of `lhs.lt(rhs)`
+/// The return type of
+/// [`lhs.lt(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.lt)
 pub type Lt<Lhs, Rhs> = super::operators::Lt<Lhs, AsExpr<Rhs, Lhs>>;
 
-/// The return type of `lhs.le(rhs)`
+/// The return type of
+/// [`lhs.le(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.le)
 pub type LtEq<Lhs, Rhs> = super::operators::LtEq<Lhs, AsExpr<Rhs, Lhs>>;
 
-/// The return type of `lhs.and(rhs)`
-pub type And<Lhs, Rhs> = super::operators::And<Lhs, AsExprOf<Rhs, sql_types::Bool>>;
-
-/// The return type of `lhs.or(rhs)`
-pub type Or<Lhs, Rhs> = Grouped<super::operators::Or<Lhs, AsExprOf<Rhs, sql_types::Bool>>>;
-
-/// The return type of `lhs.like(rhs)`
-pub type Like<Lhs, Rhs> = super::operators::Like<Lhs, AsExprOf<Rhs, sql_types::VarChar>>;
-
-/// The return type of `lhs.not_like(rhs)`
-pub type NotLike<Lhs, Rhs> = super::operators::NotLike<Lhs, AsExprOf<Rhs, sql_types::VarChar>>;
-
-/// The return type of `lhs.between(lower, upper)`
+/// The return type of
+/// [`lhs.between(lower, upper)`](../expression_methods/trait.ExpressionMethods.html#method.between)
 pub type Between<Lhs, Lower, Upper> = super::operators::Between<
     Lhs,
     super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>,
 >;
-/// The return type of `lhs.not_between(lower, upper)`
+
+/// The return type of
+/// [`lhs.not_between(lower, upper)`](../expression_methods/trait.ExpressionMethods.html#method.not_between)
 pub type NotBetween<Lhs, Lower, Upper> = super::operators::NotBetween<
     Lhs,
     super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>,
 >;
-/// The return type of `not(expr)`
-pub type Not<Expr> = super::operators::Not<Grouped<AsExprOf<Expr, sql_types::Bool>>>;
+
+/// The return type of
+/// [`expr.desc()`](../expression_methods/trait.ExpressionMethods.html#method.desc)
+pub type Desc<Expr> = super::operators::Desc<Expr>;
+
+/// The return type of
+/// [`expr.asc()`](../expression_methods/trait.ExpressionMethods.html#method.asc)
+pub type Asc<Expr> = super::operators::Asc<Expr>;
+
+/// The return type of
+/// [`expr.nullable()`](../expression_methods/trait.NullableExpressionMethods.html#method.nullable)
+pub type Nullable<Expr> = super::nullable::Nullable<Expr>;
+
+/// The return type of
+/// [`lhs.and(rhs)`](../expression_methods/trait.BoolExpressionMethods.html#method.and)
+pub type And<Lhs, Rhs> = super::operators::And<Lhs, AsExprOf<Rhs, sql_types::Bool>>;
+
+/// The return type of
+/// [`lhs.or(rhs)`](../expression_methods/trait.BoolExpressionMethods.html#method.or)
+pub type Or<Lhs, Rhs> = Grouped<super::operators::Or<Lhs, AsExprOf<Rhs, sql_types::Bool>>>;
+
+/// The return type of
+/// [`lhs.escape('x')`](../expression_methods/trait.EscapeExpressionMethods.html#method.escape)
+pub type Escape<Lhs> = super::operators::Escape<Lhs, AsExprOf<String, sql_types::VarChar>>;
+
+/// The return type of
+/// [`lhs.like(rhs)`](../expression_methods/trait.TextExpressionMethods.html#method.like)
+pub type Like<Lhs, Rhs> = super::operators::Like<Lhs, AsExprOf<Rhs, sql_types::VarChar>>;
+
+/// The return type of
+/// [`lhs.not_like(rhs)`](../expression_methods/trait.TextExpressionMethods.html#method.not_like)
+pub type NotLike<Lhs, Rhs> = super::operators::NotLike<Lhs, AsExprOf<Rhs, sql_types::VarChar>>;
 
 #[doc(inline)]
-pub use super::operators::{Asc, Desc, IsNotNull, IsNull};
-#[doc(inline)]
-pub use super::array_comparison::EqAny;
+pub use super::functions::helper_types::*;

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -6,10 +6,10 @@
 //! The most common expression to work with is a
 //! [`Column`](../query_source/trait.Column.html). There are various methods
 //! that you can call on these, found in
-//! [`expression_methods`]. You can also call
-//! numeric operators on expressions of the appropriate type.
+//! [`expression_methods`](../expression_methods).
 //!
-//! [`expression_methods`]: ../expression_methods
+//! You can also use numeric operators such as `+` on expressions of the
+//! appropriate type.
 //!
 //! Any primitive which implements [`ToSql`](../serialize/trait.ToSql.html) will
 //! also implement [`AsExpression`](trait.AsExpression.html), allowing it to be
@@ -33,7 +33,7 @@ pub mod exists;
 pub mod functions;
 #[doc(hidden)]
 pub mod grouped;
-#[macro_use]
+#[doc(hidden)]
 pub mod helper_types;
 mod not;
 #[doc(hidden)]

--- a/diesel/src/expression/not.rs
+++ b/diesel/src/expression/not.rs
@@ -1,4 +1,4 @@
-use dsl::Not;
+use helper_types::not;
 use expression::AsExpression;
 use expression::grouped::Grouped;
 use sql_types::Bool;
@@ -24,6 +24,6 @@ use sql_types::Bool;
 /// assert_eq!(Ok(2), users_not_with_name.first(&connection));
 /// # }
 /// ```
-pub fn not<T: AsExpression<Bool>>(expr: T) -> Not<T> {
+pub fn not<T: AsExpression<Bool>>(expr: T) -> not<T> {
     super::operators::Not::new(Grouped(expr.as_expression()))
 }


### PR DESCRIPTION
I've converted everything to links. The function links are `../dsl/fn`
instead of just `fn`, because these types are rendered both in the `dsl`
module and the `helper_types` module.

I've added a bunch of missing helper types, restructured the module so
that everything is ordered the same as they're defined on the traits
involved, to make it easier for me to ensure we have a helper type for
every method in `expression_methods`.

I've also added a bunch of helper types for the various bare functions,
and converted `not` to use our convention for function helper types.