### PR TITLE
Support retrieving error codes for database errors

### DIFF
--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -129,6 +129,10 @@ impl DatabaseErrorInformation for PgErrorInformation {
     fn constraint_name(&self) -> Option<&str> {
         get_result_field(self.0.as_ptr(), ResultField::ConstraintName)
     }
+
+    fn code(&self) -> Option<i64> {
+        get_result_field(self.0.as_ptr(), ResultField::SqlState).and_then(|code| code.parse().ok())
+    }
 }
 
 /// Represents valid options to

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -120,6 +120,15 @@ pub trait DatabaseErrorInformation {
     /// Currently this method will return `None` for all backends other than
     /// PostgreSQL.
     fn constraint_name(&self) -> Option<&str>;
+
+    /// The numeric error code that was returned by the database if the backend
+    /// supports retrieving that information.
+    ///
+    /// Currently this method will return `None` for all backends other than
+    /// PostgreSQL.
+    fn code(&self) -> Option<i64> {
+        None
+    }
 }
 
 impl fmt::Debug for DatabaseErrorInformation + Send + Sync {
@@ -146,6 +155,9 @@ impl DatabaseErrorInformation for String {
         None
     }
     fn constraint_name(&self) -> Option<&str> {
+        None
+    }
+    fn code(&self) -> Option<i64> {
         None
     }
 }


### PR DESCRIPTION
Most databases have error codes for errors they return [1] [2] [3].
This patch extends the DatabaseErrorInformation trait to make those
codes available. The only implementation is for Postgres right now,
because the other backends don't define their own error types.

[1]: https://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
[2]: https://sqlite.org/rescode.html
[3]: https://dev.mysql.com/doc/en/error-messages-server.html