### PR TITLE
Update the documentation for `associations`

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -50,6 +50,7 @@ extern crate cfg_if;
 #[cfg(test)]
 pub mod test_helpers;
 
+#[deny(missing_docs)]
 pub mod associations;
 pub mod backend;
 pub mod connection;

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -60,32 +60,15 @@ impl Comment {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Associations)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Associations, Identifiable)]
 #[belongs_to(User)]
 #[belongs_to(Post)]
 #[table_name = "followings"]
+#[primary_key(user_id, post_id)]
 pub struct Following {
     pub user_id: i32,
     pub post_id: i32,
     pub email_notifications: bool,
-}
-
-impl ::diesel::associations::HasTable for Following {
-    type Table = followings::table;
-
-    fn table() -> Self::Table {
-        followings::table
-    }
-}
-
-// Test to ensure a proper implementation of `Identifiable` can be written for composite types.
-// This will eventually be replaced with a derive.
-impl<'a> ::diesel::associations::Identifiable for &'a Following {
-    type Id = (&'a i32, &'a i32);
-
-    fn id(self) -> Self::Id {
-        (&self.user_id, &self.post_id)
-    }
 }
 
 #[cfg_attr(feature = "postgres", path = "postgres_specific_schema.rs")]


### PR DESCRIPTION
Wow, this really hasn't been touched since 0.7...

I'm still not super happy with these docs. Specifically I don't think
I've made it clear enough exactly what `grouped_by` does. I wish there
were a way for me to demonstrate it that is a bit less visually noisy...

I think having the smaller first example will help at least. If nothing
else, these docs are now all up to date, and at least are factually
correct.