### PR TITLE
Use `diesel print-schema` in our tests

### DIFF
--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["mysql"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["mysql"] }
 dotenv = "0.10"

--- a/examples/mysql/getting_started_step_1/src/lib.rs
+++ b/examples/mysql/getting_started_step_1/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/mysql/getting_started_step_1/src/schema.rs
+++ b/examples/mysql/getting_started_step_1/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> Varchar,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["mysql"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["mysql"] }
 dotenv = "0.10"

--- a/examples/mysql/getting_started_step_2/src/lib.rs
+++ b/examples/mysql/getting_started_step_2/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/mysql/getting_started_step_2/src/schema.rs
+++ b/examples/mysql/getting_started_step_2/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> Varchar,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["mysql"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["mysql"] }
 dotenv = "0.10"

--- a/examples/mysql/getting_started_step_3/src/lib.rs
+++ b/examples/mysql/getting_started_step_3/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/mysql/getting_started_step_3/src/schema.rs
+++ b/examples/mysql/getting_started_step_3/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> Varchar,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["postgres"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["postgres"] }
 dotenv = "0.10"

--- a/examples/postgres/getting_started_step_1/src/lib.rs
+++ b/examples/postgres/getting_started_step_1/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/postgres/getting_started_step_1/src/schema.rs
+++ b/examples/postgres/getting_started_step_1/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Int4,
+        title -> Varchar,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["postgres"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["postgres"] }
 dotenv = "0.10"

--- a/examples/postgres/getting_started_step_2/src/lib.rs
+++ b/examples/postgres/getting_started_step_2/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/postgres/getting_started_step_2/src/schema.rs
+++ b/examples/postgres/getting_started_step_2/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Int4,
+        title -> Varchar,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["postgres"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["postgres"] }
 dotenv = "0.10"

--- a/examples/postgres/getting_started_step_3/src/lib.rs
+++ b/examples/postgres/getting_started_step_3/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/postgres/getting_started_step_3/src/schema.rs
+++ b/examples/postgres/getting_started_step_3/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Int4,
+        title -> Varchar,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -6,5 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["sqlite"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["sqlite"] }
 dotenv = "0.10"

--- a/examples/sqlite/getting_started_step_1/src/lib.rs
+++ b/examples/sqlite/getting_started_step_1/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/sqlite/getting_started_step_1/src/schema.rs
+++ b/examples/sqlite/getting_started_step_1/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> Text,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -6,5 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["sqlite"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["sqlite"] }
 dotenv = "0.10"

--- a/examples/sqlite/getting_started_step_2/src/lib.rs
+++ b/examples/sqlite/getting_started_step_2/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 extern crate dotenv;
 
 pub mod schema;

--- a/examples/sqlite/getting_started_step_2/src/schema.rs
+++ b/examples/sqlite/getting_started_step_2/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> Text,
+        body -> Text,
+        published -> Bool,
+    }
+}

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -6,5 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.0.0-beta1", features = ["sqlite"] }
-diesel_infer_schema = { version = "1.0.0-beta1", features = ["sqlite"] }
 dotenv = "0.10"

--- a/examples/sqlite/getting_started_step_3/src/lib.rs
+++ b/examples/sqlite/getting_started_step_3/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_infer_schema;
 
 extern crate dotenv;
 

--- a/examples/sqlite/getting_started_step_3/src/schema.rs
+++ b/examples/sqlite/getting_started_step_3/src/schema.rs
@@ -1,1 +1,8 @@
-infer_schema!("dotenv:DATABASE_URL");
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> Text,
+        body -> Text,
+        published -> Bool,
+    }
+}


### PR DESCRIPTION
`infer_schema!` is meant to be a useful tool for when you're just
getting started on a project. Most projects should eventually migrate to
using `diesel print-schema`, once their schema is being modified less
often.

Even though the hypothetical project in the guide would be using
`infer_schema!` at this point in time, I think that for teaching
purposes, we should use show the generated code.