### PR TITLE
Require `Debug` on `Connection::test_transaction` errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `table!`s which use the `Datetime` type with MySQL will now compile correctly,
   even without the `chrono` feature enabled.
 
+### Changed
+
+* `Connection::test_transaction` now requires that the error returned implement
+  `Debug`.
+
 ## [1.0.0-beta1] - 2017-12-04
 
 ### Added

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -1,6 +1,8 @@
 mod statement_cache;
 mod transaction_manager;
 
+use std::fmt::Debug;
+
 use backend::Backend;
 use query_builder::{AsQuery, QueryFragment, QueryId};
 use query_source::{Queryable, QueryableByName};
@@ -122,6 +124,7 @@ pub trait Connection: SimpleConnection + Sized + Send {
     fn test_transaction<T, E, F>(&self, f: F) -> T
     where
         F: FnOnce() -> Result<T, E>,
+        E: Debug,
     {
         let mut user_result = None;
         let _ = self.transaction::<(), _, _>(|| {


### PR DESCRIPTION
I noticed while writing the insert guide that if something inside of
`test_transaction` returns an error, the panic just says "Transaction
did not succeed" but doesn't say why.

I don't want to deal with fixing this right now, but ultimately to do so
we will need either `Display`, `Debug`, or `Error` as a bound, which is
a semver breaking change.

I've opted to use `Debug` as the bound so that we can switch to use
`Result::expect` later on.