### PR TITLE
Set order for distinct integration tests

### DIFF
--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -10,7 +10,7 @@ fn simple_distinct() {
         .execute("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Tess')")
         .unwrap();
 
-    let source = users.select(name).distinct();
+    let source = users.select(name).distinct().order(name);
     let expected_data = vec!["Sean".to_string(), "Tess".to_string()];
     let data: Vec<String> = source.load(&connection).unwrap();
 
@@ -29,7 +29,7 @@ fn distinct_on() {
         )
         .unwrap();
 
-    let source = users.select((name, hair_color)).distinct_on(name);
+    let source = users.select((name, hair_color)).order(name).distinct_on(name);
     let expected_data = vec![
         ("Sean".to_string(), Some("black".to_string())),
         ("Tess".to_string(), None),

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -29,7 +29,10 @@ fn distinct_on() {
         )
         .unwrap();
 
-    let source = users.select((name, hair_color)).order(name).distinct_on(name);
+    let source = users
+        .select((name, hair_color))
+        .order(name)
+        .distinct_on(name);
     let expected_data = vec![
         ("Sean".to_string(), Some("black".to_string())),
         ("Tess".to_string(), None),


### PR DESCRIPTION
Explicitly set the order for the integration tests in
'diesel_tests/tests/distinct.rs'.

Previously, the tests could fail with an error like the following:

    $ bin/test integration postgres -- distinct::simple_distinct
    ...
    ---- distinct::simple_distinct stdout ----
        thread 'distinct::simple_distinct' panicked at 'assertion failed: `(left == right)`
      left: `["Sean", "Tess"]`,
     right: `["Tess", "Sean"]`', tests/distinct.rs:17:4
    note: Run with `RUST_BACKTRACE=1` for a backtrace.
    ...