### PR TITLE
Add `insert_or_ignore_into()` "INSERT [OR] IGNORE"

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -267,7 +267,8 @@ pub use prelude::*;
 #[doc(inline)]
 pub use query_builder::debug_query;
 #[doc(inline)]
-pub use query_builder::functions::{delete, insert_into, replace_into, select, sql_query, update};
+pub use query_builder::functions::{delete, insert_into, insert_or_ignore_into, replace_into,
+                                   select, sql_query, update};
 pub use result::Error::NotFound;
 #[doc(inline)]
 pub use types::structs::data_types;

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -283,6 +283,28 @@ impl_query_id!(Insert);
 
 #[derive(Debug, Copy, Clone)]
 #[doc(hidden)]
+pub struct InsertOrIgnore;
+
+#[cfg(feature = "sqlite")]
+impl QueryFragment<Sqlite> for InsertOrIgnore {
+    fn walk_ast(&self, mut out: AstPass<Sqlite>) -> QueryResult<()> {
+        out.push_sql("INSERT OR IGNORE");
+        Ok(())
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl QueryFragment<Mysql> for InsertOrIgnore {
+    fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {
+        out.push_sql("INSERT IGNORE");
+        Ok(())
+    }
+}
+
+impl_query_id!(InsertOrIgnore);
+
+#[derive(Debug, Copy, Clone)]
+#[doc(hidden)]
 pub struct Replace;
 
 #[cfg(feature = "sqlite")]

--- a/diesel_compile_tests/tests/compile-fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.rs
+++ b/diesel_compile_tests/tests/compile-fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.rs
@@ -1,0 +1,24 @@
+#[macro_use] extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+#[derive(Insertable)]
+#[table_name="users"]
+struct User {
+    id: i32,
+}
+
+fn main() {
+    let connection = PgConnection::establish("").unwrap();
+    insert_or_ignore_into(users::table)
+        .values(users::id.eq(1))
+        .execute(&connection)
+        //~^ ERROR E0277
+        .unwrap();
+}


### PR DESCRIPTION
Add `insert_or_ignore_into()` which provides Sqlite's "INSERT OR IGNORE" or
Mysql's "INSERT IGNORE".

When using `insert_or_ignore_into()`, if a constraint violation fails, the
database will ignore the offending row and continue processing any subsequent
rows.

This was implemented as a separate function (as opposed to something like
`insert.or(ignore)`) based on the logic layed out in #297 (0ee8363).

Fixes #1303.