### PR TITLE
Change 'keep' from .gitkeep to .keep

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -222,7 +222,7 @@ fn generate_bash_completion_command(_: &ArgMatches) {
 fn create_migrations_directory(path: &Path) -> DatabaseResult<PathBuf> {
     println!("Creating migrations directory at: {}", path.display());
     fs::create_dir(path)?;
-    fs::File::create(path.join(".gitkeep"))?;
+    fs::File::create(path.join(".keep"))?;
     Ok(path.to_owned())
 }
 


### PR DESCRIPTION
connect #1399 

Just generates a `.keep` instead of `.gitkeep`

I've typed 'keep' so much I'm questioning it's spelling.