### PR TITLE
Fix a ton of broken links

### DIFF
--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -30,7 +30,7 @@ pub fn count<T: Expression>(t: T) -> Count<T> {
 /// Creates a SQL `COUNT(*)` expression
 ///
 /// For selecting the count of a query, and nothing else, you can just call
-/// [`count`](../query_dsl/trait.CountDsl.html#method.count)
+/// [`count`](../query_dsl/trait.QueryDsl.html#method.count)
 /// on the query instead.
 ///
 /// As with most bare functions, this is not exported by default. You can import

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -6,8 +6,10 @@
 //! The most common expression to work with is a
 //! [`Column`](../query_source/trait.Column.html). There are various methods
 //! that you can call on these, found in
-//! [`expression_methods`](expression_methods/index.html). You can also call
+//! [`expression_methods`]. You can also call
 //! numeric operators on expressions of the appropriate type.
+//!
+//! [`expression_methods`]: ../expression_methods
 //!
 //! Any primitive which implements [`ToSql`](../types/trait.ToSql.html) will
 //! also implement [`AsExpression`](trait.AsExpression.html), allowing it to be
@@ -103,9 +105,9 @@ impl<'a, T: Expression + ?Sized> Expression for &'a T {
 ///   implement [`ToSql`] will generally implement `AsExpression` this way.
 ///
 ///   [`IntoSql`]: trait.IntoSql.html
-///   [`now`]: ../dsl/fn.now.html
+///   [`now`]: ../dsl/struct.now.html
 ///   [`Timestamp`]: ../types/struct.Timestamp.html
-///   [`Timestamptz`]: ../types/struct.Timestamptz.html
+///   [`Timestamptz`]: ../../pg/types/sql_types/struct.Timestamptz.html
 ///   [`ToSql`]: ../types/trait.ToSql.html
 pub trait AsExpression<T> {
     /// The expression being returned

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -1,8 +1,7 @@
 use backend::{Backend, SupportsDefaultKeyword};
 use expression::{AppearsOnTable, Expression};
 use result::QueryResult;
-use query_builder::{AstPass, QueryBuilder, QueryFragment};
-use query_builder::insert_statement::UndecoratedInsertRecord;
+use query_builder::{AstPass, QueryBuilder, QueryFragment, UndecoratedInsertRecord};
 use query_source::{Column, Table};
 #[cfg(feature = "sqlite")]
 use sqlite::Sqlite;

--- a/diesel/src/macros/insertable.rs
+++ b/diesel/src/macros/insertable.rs
@@ -118,7 +118,7 @@ macro_rules! impl_Insertable {
             }
         }
 
-        impl<$($lifetime,)*> $crate::query_builder::insert_statement::UndecoratedInsertRecord<$table_name::table>
+        impl<$($lifetime,)*> $crate::query_builder::UndecoratedInsertRecord<$table_name::table>
             for $struct_ty
         {
         }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -249,7 +249,7 @@ macro_rules! __diesel_column {
 /// `all_columns`. The SQL type is needed for things like [returning boxed
 /// queries][boxed_queries].
 ///
-/// [boxed_queries]: prelude/trait.BoxedDsl.html#example-1
+/// [boxed_queries]: query_dsl/trait.QueryDsl.html#method.into_boxed
 ///
 /// `BoxedQuery`
 /// ----------

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -16,7 +16,7 @@ pub mod helper_types;
 mod date_and_time;
 
 /// PostgreSQL specific expression DSL methods. This module will be glob
-/// imported by [`diesel::dsl`](../../dsl/index.html) when
+/// imported by [`diesel::dsl`](../../../dsl/index.html) when
 /// compiled with the `feature = "postgres"` flag.
 pub mod dsl {
     #[doc(inline)]

--- a/diesel/src/pg/upsert/mod.rs
+++ b/diesel/src/pg/upsert/mod.rs
@@ -1,6 +1,6 @@
 //! Types and functions related to PG's `ON CONFLICT` clause
 //!
-//! See [the methods on `InsertStatement`](../../query_builder/insert_statement/struct.InsertStatement.html#impl-1)
+//! See [the methods on `InsertStatement`](../../query_builder/struct.InsertStatement.html#impl-1)
 //! for usage examples.
 
 mod on_conflict_actions;

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -1,5 +1,4 @@
-use query_builder::AsChangeset;
-use query_builder::insert_statement::{InsertStatement, UndecoratedInsertRecord};
+use query_builder::{AsChangeset, InsertStatement, UndecoratedInsertRecord};
 use query_source::QuerySource;
 use super::on_conflict_actions::*;
 use super::on_conflict_clause::*;
@@ -194,8 +193,8 @@ impl<T, U, Op, Ret, Target> IncompleteOnConflict<InsertStatement<T, U, Op, Ret>,
     /// [`on_conflict_do_nothing`] instead. See [`on_conflict`] for usage
     /// examples.
     ///
-    /// [`on_conflict_do_nothing`]: ../../query_builder/insert_statement/struct.InsertStatement.html#method.on_conflict_do_nothing
-    /// [`on_conflict`]: ../../query_builder/insert_statement/struct.InsertStatement.html#method.on_conflict
+    /// [`on_conflict_do_nothing`]: ../../query_builder/struct.InsertStatement.html#method.on_conflict_do_nothing
+    /// [`on_conflict`]: ../../query_builder/struct.InsertStatement.html#method.on_conflict
     pub fn do_nothing(self) -> InsertStatement<T, OnConflictValues<U, Target, DoNothing>, Op, Ret> {
         let target = self.target;
         self.stmt

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -11,7 +11,7 @@ use types::{HasSqlType, IsNull, ToSql, ToSqlOutput};
 /// are adding support for a new backend to Diesel. Plugins which are extending
 /// the query builder will use [`AstPass::push_bind_param`] instead.
 ///
-/// [`AstPass::push_bind_param`]: struct.AstPass.htmll#method.push_bind_param
+/// [`AstPass::push_bind_param`]: ../struct.AstPass.htmll#method.push_bind_param
 pub trait BindCollector<DB: Backend> {
     /// Serializes the given bind value, and collects the result.
     fn push_bound_value<T, U>(

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -144,8 +144,8 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// You may add data by calling [`values()`] or [`default_values()`]
 /// as shown in the examples.
 ///
-/// [`values()`]: query_builder/insert_statement/struct.IncompleteInsertStatement.html#method.values
-/// [`default_values()`]: query_builder/insert_statement/struct.IncompleteInsertStatement.html#method.default_values
+/// [`values()`]: query_builder/struct.IncompleteInsertStatement.html#method.values
+/// [`default_values()`]: query_builder/struct.IncompleteInsertStatement.html#method.default_values
 ///
 /// Backends that support the `RETURNING` clause, such as PostgreSQL,
 /// can return the inserted rows by calling [`.get_results`] instead of [`.execute`].

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -1,5 +1,3 @@
-//! Types related to the construction of an `INSERT` statement.
-
 use std::any::*;
 
 use backend::Backend;
@@ -23,7 +21,7 @@ use super::returning_clause::*;
 /// The provided methods [`values`] and [`default_values`] will insert
 /// data into the targeted table.
 ///
-/// [`insert_into`]: ../../fn.insert_into.html
+/// [`insert_into`]: ../fn.insert_into.html
 /// [`values`]: #method.values
 /// [`default_values`]: #method.default_values
 #[derive(Debug, Clone, Copy)]
@@ -89,7 +87,7 @@ impl<T, Op> IncompleteInsertStatement<T, Op> {
     /// "overflow evaluating requirement" as a result of calling this method,
     /// you may need an `&` in front of the argument to this method.
     ///
-    /// [`insert_into`]: ../../fn.insert_into.html
+    /// [`insert_into`]: ../fn.insert_into.html
     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
     where
         U: Insertable<T>,

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -28,7 +28,7 @@ mod select_clause;
 mod select_statement;
 mod sql_query;
 mod where_clause;
-pub mod insert_statement;
+mod insert_statement;
 mod update_statement;
 
 pub use self::ast_pass::AstPass;
@@ -36,7 +36,8 @@ pub use self::bind_collector::BindCollector;
 pub use self::debug_query::DebugQuery;
 pub use self::delete_statement::DeleteStatement;
 #[doc(inline)]
-pub use self::insert_statement::IncompleteInsertStatement;
+pub use self::insert_statement::{IncompleteInsertStatement, InsertStatement,
+                                 UndecoratedInsertRecord};
 pub use self::query_id::QueryId;
 #[doc(hidden)]
 pub use self::select_statement::{BoxedSelectStatement, SelectStatement};
@@ -111,7 +112,7 @@ impl<'a, T: Query> Query for &'a T {
 /// [`LoadQuery`] will generally require that this trait be implemented.
 ///
 /// [`ExecuteDsl`]: ../query_dsl/methods/trait.ExecuteDsl.html
-/// [`LoadQuery`]: ../query_dsl/trait.LoadQuery.html
+/// [`LoadQuery`]: ../query_dsl/methods/trait.LoadQuery.html
 pub trait QueryFragment<DB: Backend> {
     /// Walk over this `QueryFragment` for all passes.
     ///

--- a/diesel/src/query_dsl/locking_dsl.rs
+++ b/diesel/src/query_dsl/locking_dsl.rs
@@ -9,10 +9,10 @@ use query_source::Table;
 ///
 /// [`QueryDsl`]: ../trait.QueryDsl.html
 pub trait ForUpdateDsl {
-    /// The query returned by `for_update`. See [`dsl::ForUpdate`] for
+    /// The type returned by `for_update`. See [`dsl::ForUpdate`] for
     /// convenient access to this type.
     ///
-    /// [`dsl::ForUpdate`]: ../dsl/type.ForUpdate.html
+    /// [`dsl::ForUpdate`]: ../../dsl/type.ForUpdate.html
     type Output;
 
     /// See the trait level documentation

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -5,7 +5,6 @@ use backend::Backend;
 use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
 use insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
 use query_builder::*;
-use query_builder::insert_statement::UndecoratedInsertRecord;
 use query_source::*;
 use result::QueryResult;
 use row::*;

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 use diesel::expression::bound::Bound;
 use diesel::insertable::ColumnInsertValue;
 use diesel::prelude::*;
-use diesel::query_builder::insert_statement::InsertStatement;
+use diesel::query_builder::InsertStatement;
 use diesel::query_dsl::methods::ExecuteDsl;
 use diesel::types::{FromSql, VarChar};
 


### PR DESCRIPTION
Some broken links on the docs for `IncompleteInsertStatement` were
because it's rendered in two different places. Since we inline
everything in `update_statement` to only be visible from the
`query_builder` module, I've done the same for `InsertStatement`.