### PR TITLE
Use qualified name in `#[derive(QueryableByName)]`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `table!`s which use the `Datetime` type with MySQL will now compile correctly,
   even without the `chrono` feature enabled.
 
+* `#[derive(QueryableByName)]` will now compile correctly when there is a shadowed `Result` type in scope.
+
 ### Changed
 
 * `Connection::test_transaction` now requires that the error returned implement

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -38,7 +38,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
                 __DB: diesel::backend::Backend,
                 #(#attr_where_clause)*
             {
-               fn build<__R: diesel::row::NamedRow<__DB>>(row: &__R) -> Result<Self, Box<::std::error::Error + Send + Sync>> {
+               fn build<__R: diesel::row::NamedRow<__DB>>(row: &__R) -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>> {
                    Ok(#build_expr)
                }
             }


### PR DESCRIPTION
_I cannot commit to https://github.com/diesel-rs/diesel/pull/1415 (it says `from unknown repository`)  so I have to create this new pull request. Sorry._

The following code fails to compile
`E0244: wrong number of type arguments: expected 1, found 2`

```rust
#[macro_use]
extern crate diesel;

use diesel::types::*;

type Result<T> = ::std::result::Result<T, ()>;

#[derive(Debug, QueryableByName)]
pub struct Row {
  #[sql_type = "Text"]
  pub column: String,
}
```

Related issue:
https://github.com/diesel-rs/diesel/issues/1372