### PR TITLE
Add a more "advanced" example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "examples/mysql/getting_started_step_1",
     "examples/mysql/getting_started_step_2",
     "examples/mysql/getting_started_step_3",
+    "examples/postgres/advanced-blog-cli",
     "examples/postgres/all_about_inserts",
     "examples/postgres/all_about_updates",
     "examples/postgres/getting_started_step_1",

--- a/examples/postgres/advanced-blog-cli/.env.sample
+++ b/examples/postgres/advanced-blog-cli/.env.sample
@@ -1,0 +1,3 @@
+BLOG_USERNAME=sgrif
+BLOG_PASSWORD=hunter2
+DATABASE_URL=postgres://localhost/diesel_example

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -6,10 +6,11 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 bcrypt = "0.1.0"
 chrono = "0.4.0"
-clap = "2.29.0"
 diesel = { version = "1.0.0-beta1", features = ["postgres", "chrono"] }
 dotenv = "0.10.0"
 tempfile = "2.2.0"
+structopt = "0.1.6"
+structopt-derive = "0.1.6"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "advanced-blog-cli"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+
+[dependencies]
+bcrypt = "0.1.0"
+chrono = "0.4.0"
+clap = "2.29.0"
+diesel = { version = "1.0.0-beta1", features = ["postgres", "chrono"] }
+dotenv = "0.10.0"
+tempfile = "2.2.0"
+
+[dev-dependencies]
+assert_matches = "1.1"
+diesel_migrations = { version = "1.0.0-beta1", features = ["postgres"] }
+lazy_static = "1.0"

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -8,9 +8,9 @@ bcrypt = "0.1.0"
 chrono = "0.4.0"
 diesel = { version = "1.0.0-beta1", features = ["postgres", "chrono"] }
 dotenv = "0.10.0"
-tempfile = "2.2.0"
 structopt = "0.1.6"
 structopt-derive = "0.1.6"
+tempfile = "2.2.0"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/examples/postgres/advanced-blog-cli/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/examples/postgres/advanced-blog-cli/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-144812_create_users/down.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-144812_create_users/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE users;

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-144812_create_users/up.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-144812_create_users/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  username TEXT NOT NULL,
+  hashed_password TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+SELECT diesel_manage_updated_at('users');

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-163829_create_posts/down.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-163829_create_posts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE posts;

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-163829_create_posts/up.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-163829_create_posts/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE posts (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users (id),
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+SELECT diesel_manage_updated_at('posts');

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-164453_make_username_unique/down.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-164453_make_username_unique/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX users_username;

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-164453_make_username_unique/up.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-164453_make_username_unique/up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX users_username ON users (username);

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-171042_add_published_at_to_posts/down.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-171042_add_published_at_to_posts/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts DROP COLUMN published_at;

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-171042_add_published_at_to_posts/up.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-171042_add_published_at_to_posts/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ADD COLUMN published_at TIMESTAMP;

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-183155_create_comments/down.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-183155_create_comments/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE comments;

--- a/examples/postgres/advanced-blog-cli/migrations/2017-12-20-183155_create_comments/up.sql
+++ b/examples/postgres/advanced-blog-cli/migrations/2017-12-20-183155_create_comments/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users (id),
+  post_id INTEGER NOT NULL REFERENCES posts (id),
+  body TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+SELECT diesel_manage_updated_at('comments');

--- a/examples/postgres/advanced-blog-cli/src/auth.rs
+++ b/examples/postgres/advanced-blog-cli/src/auth.rs
@@ -1,0 +1,164 @@
+use bcrypt::*;
+use diesel::prelude::*;
+use diesel::{self, insert_into};
+use dotenv;
+
+use schema::users;
+
+#[derive(Debug)]
+pub enum AuthenticationError {
+    IncorrectPassword,
+    NoUsernameSet,
+    NoPasswordSet,
+    EnvironmentError(dotenv::Error),
+    BcryptError(BcryptError),
+    DatabaseError(diesel::result::Error),
+}
+
+impl From<BcryptError> for AuthenticationError {
+    fn from(e: BcryptError) -> Self {
+        AuthenticationError::BcryptError(e)
+    }
+}
+
+pub use self::AuthenticationError::{IncorrectPassword, NoPasswordSet, NoUsernameSet};
+
+#[derive(Queryable, Identifiable, Debug, PartialEq)]
+pub struct User {
+    pub id: i32,
+    pub username: String,
+}
+
+#[derive(Queryable)]
+pub struct UserWithPassword {
+    user: User,
+    password: String,
+}
+
+pub fn current_user_from_env(conn: &PgConnection) -> Result<Option<User>, AuthenticationError> {
+    let username = get_username()?;
+    let password = get_password()?;
+    find_user(conn, &username, &password)
+}
+
+pub fn register_user_from_env(conn: &PgConnection) -> Result<User, AuthenticationError> {
+    let username = get_username()?;
+    let password = get_password()?;
+    register_user(conn, &username, &password)
+}
+
+fn find_user(
+    conn: &PgConnection,
+    username: &str,
+    password: &str,
+) -> Result<Option<User>, AuthenticationError> {
+    let user_and_password = users::table
+        .filter(users::username.eq(username))
+        .select(((users::id, users::username), users::hashed_password))
+        .first::<UserWithPassword>(conn)
+        .optional()
+        .map_err(AuthenticationError::DatabaseError)?;
+
+    if let Some(user_and_password) = user_and_password {
+        if verify(password, &user_and_password.password)? {
+            Ok(Some(user_and_password.user))
+        } else {
+            Err(IncorrectPassword)
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+fn register_user(
+    conn: &PgConnection,
+    username: &str,
+    password: &str,
+) -> Result<User, AuthenticationError> {
+    let hashed_password = hash(password, DEFAULT_COST)?;
+    insert_into(users::table)
+        .values((
+            users::username.eq(username),
+            users::hashed_password.eq(hashed_password),
+        ))
+        .returning((users::id, users::username))
+        .get_result(conn)
+        .map_err(AuthenticationError::DatabaseError)
+}
+
+fn get_username() -> Result<String, AuthenticationError> {
+    if_not_present(dotenv::var("BLOG_USERNAME"), NoUsernameSet)
+}
+
+fn get_password() -> Result<String, AuthenticationError> {
+    if_not_present(dotenv::var("BLOG_PASSWORD"), NoPasswordSet)
+}
+
+fn if_not_present<T>(
+    res: Result<T, dotenv::Error>,
+    on_not_present: AuthenticationError,
+) -> Result<T, AuthenticationError> {
+    use dotenv::ErrorKind::EnvVar;
+    use std::env::VarError::NotPresent;
+
+    res.map_err(|e| match e {
+        dotenv::Error(EnvVar(NotPresent), _) => on_not_present,
+        e => AuthenticationError::EnvironmentError(e),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_helpers::*;
+
+    use std::env;
+
+    #[test]
+    fn current_user_from_env_fails_when_no_username_set() {
+        let _guard = this_test_modifies_env();
+        env::remove_var("BLOG_USERNAME");
+
+        let conn = connection();
+
+        assert_matches!(current_user_from_env(&conn), Err(NoUsernameSet));
+    }
+
+    #[test]
+    fn current_user_from_env_fails_when_no_password_set() {
+        let _guard = this_test_modifies_env();
+        env::remove_var("BLOG_PASSWORD");
+        env::set_var("BLOG_USERNAME", "sgrif");
+
+        let conn = connection();
+
+        assert_matches!(current_user_from_env(&conn), Err(NoPasswordSet));
+    }
+
+    #[test]
+    fn current_user_returns_none_when_no_user_exists_with_username() {
+        let conn = connection();
+
+        assert_matches!(find_user(&conn, "sgrif", "hunter2"), Ok(None));
+    }
+
+    #[test]
+    fn current_user_returns_the_user_if_it_has_the_same_password() {
+        let conn = connection();
+
+        let expected_user = register_user(&conn, "sgrif", "hunter2").unwrap();
+        let user = find_user(&conn, "sgrif", "hunter2").unwrap();
+
+        assert_eq!(Some(expected_user), user);
+    }
+
+    #[test]
+    fn current_user_fails_if_password_does_not_match() {
+        let conn = connection();
+
+        register_user(&conn, "sgrif", "letmein").unwrap();
+        let result = find_user(&conn, "sgrif", "hunter2");
+
+        assert_matches!(result, Err(IncorrectPassword));
+    }
+}

--- a/examples/postgres/advanced-blog-cli/src/cli.rs
+++ b/examples/postgres/advanced-blog-cli/src/cli.rs
@@ -16,6 +16,7 @@ pub enum Cli {
     EditPost {
         /// The id of the post to edit
         post_id: i32,
+        /// Announce this piece of literary perfectionims to the world?
         #[structopt(short = "i", default_value = "false")]
         publish: bool,
     },

--- a/examples/postgres/advanced-blog-cli/src/cli.rs
+++ b/examples/postgres/advanced-blog-cli/src/cli.rs
@@ -1,0 +1,59 @@
+use clap::{App, AppSettings, Arg, SubCommand};
+
+pub fn build_cli() -> App<'static, 'static> {
+    let post_id_arg = Arg::with_name("POST_ID")
+        .help("The id of the post to edit")
+        .takes_value(true)
+        .required(true);
+    let page_arg = Arg::with_name("PAGE")
+        .long("page")
+        .takes_value(true)
+        .help("The page to display");
+    let per_page_arg = Arg::with_name("PER_PAGE")
+        .long("per-page")
+        .takes_value(true)
+        .help("The number of posts to display per page (cannot be larger than 25)");
+
+    let create_post = SubCommand::with_name("create_post").arg(
+        Arg::with_name("TITLE")
+            .long("title")
+            .help("The title of your post")
+            .takes_value(true)
+            .required(true),
+    );
+    let edit_post = SubCommand::with_name("edit_post")
+        .arg(post_id_arg.clone())
+        .arg(
+            Arg::with_name("PUBLISH")
+                .long("publish")
+                .help("Publish the post after editing"),
+        );
+    let all_posts = SubCommand::with_name("all_posts")
+        .arg(page_arg.clone())
+        .arg(per_page_arg.clone());
+    let add_comment = SubCommand::with_name("add_comment").arg(post_id_arg.clone());
+    let edit_comment = SubCommand::with_name("edit_comment").arg(
+        Arg::with_name("COMMENT_ID")
+            .help("The id of the comment to edit")
+            .takes_value(true)
+            .required(true),
+    );
+    let my_comments = SubCommand::with_name("my_comments")
+        .arg(page_arg.clone())
+        .arg(per_page_arg.clone());
+
+    App::new("blog")
+        .version(env!("CARGO_PKG_VERSION"))
+        .setting(AppSettings::VersionlessSubcommands)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(create_post)
+        .subcommand(all_posts)
+        .subcommand(edit_post)
+        .subcommand(add_comment)
+        .subcommand(edit_comment)
+        .subcommand(my_comments)
+        .subcommand(SubCommand::with_name("register"))
+        .after_help(
+            "You can also run `blog SUBCOMMAND -h` to get more information about that subcommand.",
+        )
+}

--- a/examples/postgres/advanced-blog-cli/src/cli.rs
+++ b/examples/postgres/advanced-blog-cli/src/cli.rs
@@ -1,59 +1,57 @@
-use clap::{App, AppSettings, Arg, SubCommand};
-
-pub fn build_cli() -> App<'static, 'static> {
-    let post_id_arg = Arg::with_name("POST_ID")
-        .help("The id of the post to edit")
-        .takes_value(true)
-        .required(true);
-    let page_arg = Arg::with_name("PAGE")
-        .long("page")
-        .takes_value(true)
-        .help("The page to display");
-    let per_page_arg = Arg::with_name("PER_PAGE")
-        .long("per-page")
-        .takes_value(true)
-        .help("The number of posts to display per page (cannot be larger than 25)");
-
-    let create_post = SubCommand::with_name("create_post").arg(
-        Arg::with_name("TITLE")
-            .long("title")
-            .help("The title of your post")
-            .takes_value(true)
-            .required(true),
-    );
-    let edit_post = SubCommand::with_name("edit_post")
-        .arg(post_id_arg.clone())
-        .arg(
-            Arg::with_name("PUBLISH")
-                .long("publish")
-                .help("Publish the post after editing"),
-        );
-    let all_posts = SubCommand::with_name("all_posts")
-        .arg(page_arg.clone())
-        .arg(per_page_arg.clone());
-    let add_comment = SubCommand::with_name("add_comment").arg(post_id_arg.clone());
-    let edit_comment = SubCommand::with_name("edit_comment").arg(
-        Arg::with_name("COMMENT_ID")
-            .help("The id of the comment to edit")
-            .takes_value(true)
-            .required(true),
-    );
-    let my_comments = SubCommand::with_name("my_comments")
-        .arg(page_arg.clone())
-        .arg(per_page_arg.clone());
-
-    App::new("blog")
-        .version(env!("CARGO_PKG_VERSION"))
-        .setting(AppSettings::VersionlessSubcommands)
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(create_post)
-        .subcommand(all_posts)
-        .subcommand(edit_post)
-        .subcommand(add_comment)
-        .subcommand(edit_comment)
-        .subcommand(my_comments)
-        .subcommand(SubCommand::with_name("register"))
-        .after_help(
-            "You can also run `blog SUBCOMMAND -h` to get more information about that subcommand.",
-        )
+#[derive(StructOpt)]
+#[structopt(
+    name = "blog",
+    after_help = "You can also run `blog SUBCOMMAND -h` to get more information about that subcommand.",
+)]
+pub enum Cli {
+    /// Create a new wonderfully delighting blog post
+    #[structopt(name = "create_post")]
+    CreatePost {
+        /// The title of your post
+        #[structopt(long = "title")]
+        title: String,
+    },
+    /// Fine-tune an existing post to reach 100% reader delight
+    #[structopt(name = "edit_post")]
+    EditPost {
+        /// The id of the post to edit
+        post_id: i32,
+        #[structopt(short = "i", default_value = "false")]
+        publish: bool,
+    },
+    /// Get an overview of all your literary accomplishments
+    #[structopt(name = "all_posts")]
+    AllPosts {
+        /// The page to display
+        #[structopt(long = "page", default_value = "1")]
+        page: i64,
+        /// The number of posts to display per page (cannot be larger than 25)
+        #[structopt(long = "per-page", default_value = "1")]
+        per_page: Option<i64>,
+    },
+    /// Quickly add an important remark to a post
+    #[structopt(name = "add_comment")]
+    AddComment {
+        /// The id of the post to comment on
+        post_id: i32,
+    },
+    /// Edit a comment, e.g. to citate the sources of your facts
+    #[structopt(name = "edit_comment")]
+    EditComment {
+        /// The id of the comment to edit
+        comment_id: i32,
+    },
+    /// See all the instances where you were able to improve a post by adding a comment
+    #[structopt(name = "my_comments")]
+    MyComments {
+        /// The page to display
+        #[structopt(long = "page", default_value = "1")]
+        page: i64,
+        /// The number of comments to display per page (cannot be larger than 25)
+        #[structopt(long = "per-page", default_value = "1")]
+        per_page: Option<i64>,
+    },
+    /// Register as the newest member of this slightly elitist community
+    #[structopt(name = "register")]
+    Register,
 }

--- a/examples/postgres/advanced-blog-cli/src/comment.rs
+++ b/examples/postgres/advanced-blog-cli/src/comment.rs
@@ -1,0 +1,30 @@
+use chrono::NaiveDateTime;
+
+use auth::User;
+use post::Post;
+use schema::comments;
+
+#[derive(Queryable, Identifiable, Associations)]
+#[belongs_to(User)]
+#[belongs_to(Post)]
+pub struct Comment {
+    pub id: i32,
+    pub user_id: i32,
+    pub post_id: i32,
+    pub body: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+pub fn render(comments_and_post_title: &[(Comment, String)]) {
+    for &(ref comment, ref post_title) in comments_and_post_title {
+        println!("On post {}", post_title);
+        println!(
+            "At {} (id: {})",
+            comment.updated_at.format("%F %T"),
+            comment.id
+        );
+        println!("{}", comment.body);
+        print!("===============\n\n");
+    }
+}

--- a/examples/postgres/advanced-blog-cli/src/editor.rs
+++ b/examples/postgres/advanced-blog-cli/src/editor.rs
@@ -1,0 +1,39 @@
+extern crate tempfile;
+
+use std::error::Error;
+use std::ffi::OsString;
+use std::io::prelude::*;
+use self::tempfile::NamedTempFile;
+use std::process::Command;
+
+pub fn edit_string(s: &str) -> Result<String, Box<Error>> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(s.as_bytes())?;
+    editor_output(&mut file)
+}
+
+fn editor_output(file: &mut NamedTempFile) -> Result<String, Box<Error>> {
+    use std::io::SeekFrom::Start;
+
+    let status = Command::new(editor_command()?)
+        .arg(file.path().as_os_str())
+        .spawn()?
+        .wait()?;
+
+    if !status.success() {
+        return Err("Editor did not exit successfully. Aborting".into());
+    }
+
+    let mut buffer = String::new();
+    file.seek(Start(0))?;
+    file.read_to_string(&mut buffer)?;
+    Ok(buffer)
+}
+
+fn editor_command() -> Result<OsString, Box<Error>> {
+    use std::env;
+
+    env::var_os("VISUAL")
+        .or_else(|| env::var_os("EDITOR"))
+        .ok_or_else(|| "Either $VISUAL or $EDITOR must be set to edit files".into())
+}

--- a/examples/postgres/advanced-blog-cli/src/main.rs
+++ b/examples/postgres/advanced-blog-cli/src/main.rs
@@ -2,12 +2,12 @@
 
 extern crate bcrypt;
 extern crate chrono;
-extern crate structopt;
-#[macro_use]
-extern crate structopt_derive;
 #[macro_use]
 extern crate diesel;
 extern crate dotenv;
+extern crate structopt;
+#[macro_use]
+extern crate structopt_derive;
 
 #[cfg(test)]
 #[macro_use]
@@ -113,7 +113,9 @@ fn run_cli(database_url: &str, cli: Cli) -> Result<(), Box<Error>> {
                 .set((body.eq(new_body), updated_status))
                 .execute(&conn)?;
         }
-        Cli::AddComment { post_id: given_post_id } => {
+        Cli::AddComment {
+            post_id: given_post_id,
+        } => {
             use schema::comments::dsl::*;
 
             let inserted = diesel::insert_into(comments)

--- a/examples/postgres/advanced-blog-cli/src/main.rs
+++ b/examples/postgres/advanced-blog-cli/src/main.rs
@@ -1,0 +1,239 @@
+#![deny(warnings)]
+
+extern crate bcrypt;
+extern crate chrono;
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate diesel;
+extern crate dotenv;
+
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
+#[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
+mod auth;
+mod cli;
+mod comment;
+mod editor;
+mod pagination;
+mod post;
+mod schema;
+
+#[cfg(test)]
+mod test_helpers;
+
+use clap::ArgMatches;
+use diesel::prelude::*;
+use std::error::Error;
+
+use self::schema::*;
+use self::post::*;
+use self::pagination::*;
+
+fn main() {
+    let matches = cli::build_cli().get_matches();
+    let database_url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+
+    handle_error(run_cli(&database_url, &matches));
+}
+
+fn run_cli(database_url: &str, matches: &ArgMatches) -> Result<(), Box<Error>> {
+    let conn = PgConnection::establish(database_url)?;
+
+    match matches.subcommand() {
+        ("all_posts", Some(args)) => {
+            use comment::*;
+            use auth::User;
+
+            let (page, per_page) = pagination_args(args)?;
+            let mut query = posts::table
+                .order(posts::published_at.desc())
+                .filter(posts::published_at.is_not_null())
+                .inner_join(users::table)
+                .select((posts::all_columns, (users::id, users::username)))
+                .paginate(page);
+
+            if let Some(per_page) = per_page {
+                query = query.per_page(per_page);
+            }
+
+            let (posts_with_user, total_pages) = query.load_and_count_pages::<(Post, User)>(&conn)?;
+            let (posts, post_users): (Vec<_>, Vec<_>) = posts_with_user.into_iter().unzip();
+
+            let comments = Comment::belonging_to(&posts)
+                .inner_join(users::table)
+                .select((comments::all_columns, (users::id, users::username)))
+                .load::<(Comment, User)>(&conn)?
+                .grouped_by(&posts);
+
+            let to_display = posts.into_iter().zip(post_users).zip(comments);
+            for ((post, user), comments) in to_display {
+                post::render(&post, &user, &comments);
+            }
+
+            println!("Page {} of {}", page, total_pages);
+        }
+
+        ("create_post", Some(args)) => {
+            let title = args.value_of("TITLE").unwrap();
+            let user = current_user(&conn)?;
+            let body = editor::edit_string("")?;
+            let id = diesel::insert_into(posts::table)
+                .values((
+                    posts::user_id.eq(user.id),
+                    posts::title.eq(title),
+                    posts::body.eq(body),
+                ))
+                .returning(posts::id)
+                .get_result::<i32>(&conn)?;
+            println!("Successfully created post with id {}", id);
+        }
+
+        ("edit_post", Some(args)) => {
+            use schema::posts::dsl::*;
+            use post::Status::*;
+            use diesel::dsl::now;
+
+            let post_id = value_t!(args, "POST_ID", i32)?;
+            let user = current_user(&conn)?;
+            let post = Post::belonging_to(&user)
+                .find(post_id)
+                .first::<Post>(&conn)?;
+            let new_body = editor::edit_string(&post.body)?;
+
+            let updated_status = match post.status {
+                Draft if args.is_present("PUBLISH") => Some(published_at.eq(now.nullable())),
+                _ => None,
+            };
+
+            diesel::update(&post)
+                .set((body.eq(new_body), updated_status))
+                .execute(&conn)?;
+        }
+
+        ("add_comment", Some(args)) => {
+            use schema::comments::dsl::*;
+
+            let inserted = diesel::insert_into(comments)
+                .values((
+                    user_id.eq(current_user(&conn)?.id),
+                    post_id.eq(value_t!(args, "POST_ID", i32)?),
+                    body.eq(editor::edit_string("")?),
+                ))
+                .returning(id)
+                .get_result::<i32>(&conn)?;
+            println!("Created comment with ID {}", inserted);
+        }
+
+        ("edit_comment", Some(args)) => {
+            use schema::comments::dsl::*;
+            use comment::Comment;
+
+            let user = current_user(&conn)?;
+
+            let comment = Comment::belonging_to(&user)
+                .find(value_t!(args, "COMMENT_ID", i32)?)
+                .first::<Comment>(&conn)?;
+
+            diesel::update(comments)
+                .set(body.eq(editor::edit_string(&comment.body)?))
+                .execute(&conn)?;
+        }
+
+        ("my_comments", Some(args)) => {
+            use comment::Comment;
+
+            let (page, per_page) = pagination_args(args)?;
+            let user = current_user(&conn)?;
+
+            let mut query = Comment::belonging_to(&user)
+                .order(comments::created_at.desc())
+                .inner_join(posts::table)
+                .select((comments::all_columns, posts::title))
+                .paginate(page);
+
+            if let Some(per_page) = per_page {
+                query = query.per_page(per_page);
+            }
+
+            let (comments_and_post_title, total_pages) =
+                query.load_and_count_pages::<(Comment, String)>(&conn)?;
+            comment::render(&comments_and_post_title);
+            println!("Page {} of {}", page, total_pages);
+        }
+
+        ("register", Some(_)) => register_user(&conn)?,
+
+        _ => unreachable!(),
+    }
+    Ok(())
+}
+
+fn pagination_args(args: &ArgMatches) -> Result<(i64, Option<i64>), Box<Error>> {
+    use std::cmp::min;
+
+    let page = args.value_of("PAGE").unwrap_or("1").parse()?;
+
+    if let Some(per_page) = args.value_of("PER_PAGE") {
+        let per_page = min(per_page.parse()?, 25);
+        Ok((page, Some(per_page)))
+    } else {
+        Ok((page, None))
+    }
+}
+
+fn current_user(conn: &PgConnection) -> Result<auth::User, Box<Error>> {
+    match auth::current_user_from_env(conn) {
+        Ok(Some(user)) => Ok(user),
+        Ok(None) => Err("No user found with the given username".into()),
+        Err(e) => Err(convert_auth_error(e)),
+    }
+}
+
+fn register_user(conn: &PgConnection) -> Result<(), Box<Error>> {
+    use auth::AuthenticationError as Auth;
+    use diesel::result::Error::DatabaseError;
+    use diesel::result::DatabaseErrorKind::UniqueViolation;
+
+    match auth::register_user_from_env(conn) {
+        Ok(_) => Ok(()),
+        Err(Auth::DatabaseError(DatabaseError(UniqueViolation, _))) => {
+            Err("A user with that name already exists".into())
+        }
+        Err(e) => Err(convert_auth_error(e)),
+    }
+}
+
+fn convert_auth_error(err: auth::AuthenticationError) -> Box<Error> {
+    use auth::AuthenticationError::*;
+
+    match err {
+        IncorrectPassword => "The password given does not match our records".into(),
+        NoUsernameSet => {
+            "No username given. You need to set the BLOG_USERNAME environment variable.".into()
+        }
+        NoPasswordSet => {
+            "No password given. You need to set the BLOG_PASSWORD environment variable.".into()
+        }
+        EnvironmentError(e) => e.into(),
+        BcryptError(e) => e.into(),
+        DatabaseError(e) => e.into(),
+    }
+}
+
+fn handle_error<T>(res: Result<T, Box<Error>>) -> T {
+    match res {
+        Ok(x) => x,
+        Err(e) => print_error_and_exit(&*e),
+    }
+}
+
+fn print_error_and_exit(err: &Error) -> ! {
+    use std::process::exit;
+    eprintln!("An unexpected error occurred: {}", err);
+    exit(1);
+}

--- a/examples/postgres/advanced-blog-cli/src/pagination.rs
+++ b/examples/postgres/advanced-blog-cli/src/pagination.rs
@@ -1,0 +1,69 @@
+use diesel::prelude::*;
+use diesel::query_dsl::methods::LoadQuery;
+use diesel::query_builder::*;
+use diesel::pg::Pg;
+use diesel::types::BigInt;
+
+pub trait Paginate: Sized {
+    fn paginate(self, page: i64) -> Paginated<Self>;
+}
+
+impl<T> Paginate for T {
+    fn paginate(self, page: i64) -> Paginated<Self> {
+        Paginated {
+            query: self,
+            per_page: DEFAULT_PER_PAGE,
+            page,
+        }
+    }
+}
+
+const DEFAULT_PER_PAGE: i64 = 10;
+
+pub struct Paginated<T> {
+    query: T,
+    page: i64,
+    per_page: i64,
+}
+
+impl<T> Paginated<T> {
+    pub fn per_page(self, per_page: i64) -> Self {
+        Paginated { per_page, ..self }
+    }
+
+    pub fn load_and_count_pages<U>(self, conn: &PgConnection) -> QueryResult<(Vec<U>, i64)>
+    where
+        Self: LoadQuery<PgConnection, (U, i64)>,
+    {
+        let per_page = self.per_page;
+        let results = self.load::<(U, i64)>(conn)?;
+        let total = results.get(0).map(|x| x.1).unwrap_or(0);
+        let records = results.into_iter().map(|x| x.0).collect();
+        let total_pages = (total as f64 / per_page as f64).ceil() as i64;
+        Ok((records, total_pages))
+    }
+}
+
+impl_query_id!(Paginated<T>);
+
+impl<T: Query> Query for Paginated<T> {
+    type SqlType = (T::SqlType, BigInt);
+}
+
+impl<T> RunQueryDsl<PgConnection> for Paginated<T> {}
+
+impl<T> QueryFragment<Pg> for Paginated<T>
+where
+    T: QueryFragment<Pg>,
+{
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(") t LIMIT ");
+        out.push_bind_param::<BigInt, _>(&self.per_page)?;
+        out.push_sql(" OFFSET ");
+        let offset = (self.page - 1) * self.per_page;
+        out.push_bind_param::<BigInt, _>(&offset)?;
+        Ok(())
+    }
+}

--- a/examples/postgres/advanced-blog-cli/src/post.rs
+++ b/examples/postgres/advanced-blog-cli/src/post.rs
@@ -1,0 +1,74 @@
+use chrono::NaiveDateTime;
+use auth::User;
+use comment::Comment;
+
+use schema::posts;
+
+#[derive(Queryable, Associations, Identifiable)]
+#[belongs_to(User)]
+pub struct Post {
+    pub id: i32,
+    pub user_id: i32,
+    pub title: String,
+    pub body: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+    pub status: Status,
+}
+
+pub enum Status {
+    Draft,
+    Published { at: NaiveDateTime },
+}
+
+use diesel::query_source::Queryable;
+use diesel::types::{Nullable, Timestamp};
+use diesel::pg::Pg;
+
+impl Queryable<Nullable<Timestamp>, Pg> for Status {
+    type Row = Option<NaiveDateTime>;
+
+    fn build(row: Self::Row) -> Self {
+        match row {
+            Some(at) => Status::Published { at },
+            None => Status::Draft,
+        }
+    }
+}
+
+pub fn render(post: &Post, user: &User, comments: &[(Comment, User)]) {
+    use self::Status::*;
+
+    println!("{} (id: {})", post.title, post.id);
+    println!("By {}", user.username);
+    let edited_at = post.updated_at.format("%F %T");
+    match post.status {
+        Draft => println!("DRAFT (last edited at {})", edited_at),
+        Published { at } if at != post.updated_at => {
+            let published_at = at.format("%F %T");
+            println!(
+                "Published at {} (lasted edited at {})",
+                published_at, edited_at
+            );
+        }
+        Published { at } => println!("Published at {}", at.format("%F %T")),
+    }
+    print!("\n");
+    println!("{}", post.body);
+
+    if !comments.is_empty() {
+        println!("---------------\n");
+        println!("{} Comments\n", comments.len());
+        for &(ref comment, ref user) in comments {
+            let at = comment.created_at.format("%F %T");
+            print!("{} at {}", user.username, at);
+            if comment.updated_at != comment.created_at {
+                let edited = comment.updated_at.format("%F %T");
+                print!(" (last edited {})", edited);
+            }
+            print!("\n{}\n", comment.body);
+        }
+    }
+
+    print!("===============\n\n");
+}

--- a/examples/postgres/advanced-blog-cli/src/schema.rs
+++ b/examples/postgres/advanced-blog-cli/src/schema.rs
@@ -1,0 +1,38 @@
+table! {
+    comments (id) {
+        id -> Int4,
+        user_id -> Int4,
+        post_id -> Int4,
+        body -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    posts (id) {
+        id -> Int4,
+        user_id -> Int4,
+        title -> Text,
+        body -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        published_at -> Nullable<Timestamp>,
+    }
+}
+
+table! {
+    users (id) {
+        id -> Int4,
+        username -> Text,
+        hashed_password -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+joinable!(comments -> posts (post_id));
+joinable!(comments -> users (user_id));
+joinable!(posts -> users (user_id));
+
+allow_tables_to_appear_in_same_query!(comments, posts, users,);

--- a/examples/postgres/advanced-blog-cli/src/test_helpers.rs
+++ b/examples/postgres/advanced-blog-cli/src/test_helpers.rs
@@ -1,0 +1,22 @@
+extern crate diesel_migrations;
+
+use diesel::prelude::*;
+use dotenv;
+use self::diesel_migrations::run_pending_migrations;
+use std::sync::{Mutex, MutexGuard};
+
+pub fn connection() -> PgConnection {
+    let url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let conn = PgConnection::establish(&url).unwrap();
+    run_pending_migrations(&conn).unwrap();
+    conn.begin_test_transaction().unwrap();
+    conn
+}
+
+pub fn this_test_modifies_env() -> MutexGuard<'static, ()> {
+    let _ = dotenv::var("FORCING_DOTENV_LOAD");
+    lazy_static! {
+        static ref ENV_LOCK: Mutex<()> = Mutex::new(());
+    }
+    ENV_LOCK.lock().unwrap()
+}


### PR DESCRIPTION
This app is eventually going to be used as part of the advanced querying
guide. Unlike the getting started guide, that guide will not be a step
by step "building this app" style guide, but will instead refer to some
of the code in this example for its code examples, as I want to have
them presented with broader context if the reader wants it.

Since this example is meant to be separate from the guide, I figured it
made sense to submit it on its own.

Originally I chose a CLI blog for the getting started guide because I
wanted the example purely focused on Diesel, with little to no noise
from CLI stuff or a web framework. Clearly that is not the case here. In
fact, a web app probably would be a better example. However, I'm so
amused by the idea of a "CLI blog" that I decided to double down on it
and make a multi-tenant blog wiht commenting functionality and
pagination. Of course this is a pointless exercise, since having auth
logic makes no sense when the client requires a direct database
connection...

Anyway, this example is meant to provide some examples for the following
more complex use cases:

- Various types of joins and associations. Demonstrating data with
  multiple associations that go to the same table multiple times, and is
  difficult to describe unambiguously
- When to use joins vs `belonging_to`
- Nesting queryables (see the structs used in auth)
- Dealing with structs that don't contain all fields from a table
- Demonstrating that `Queryable` represents the results of a query, not
  a single table
  - I want to restructure how `all_posts` works. I really want to have
    a struct that is used for "comment with username" and "comment
    with post title" but that doesn't work well today. I'm going to
    revisit for 1.1
- Real world use of `returning`
- Real world constraint error handling (I may change this to be
  `.on_conflict(username).do_nothing()` and handle it there so this maps
  more easily to SQLite and MySQL. If we're being pedantic I should be
  checking the constraint name in that match arm)
- Showing how to deal with "sometimes update this field" without using
  `AsChangeset`.
- Showing that various query builder methods compose together
- Generally just having more examples of non-trivial queries.