### PR TITLE
feat: add run_with_callback for embedded_migration

### DIFF
--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -133,7 +133,7 @@ where
     Conn: MigrationConnection,
 {
     let all_migrations = try!(migrations_in_directory(migrations_dir));
-    run_migrations(conn, all_migrations, output)
+    run_migrations(conn, all_migrations, output, None)
 }
 
 /// Compares migrations found in `migrations_dir` to those that have been applied.
@@ -284,12 +284,15 @@ fn migrations_in_directory(path: &Path) -> Result<Vec<Box<Migration>>, Migration
         .collect()
 }
 
+pub type RunMigrationCallback = Box<Fn(&Migration)>;
+
 /// Run all pending migrations in the given list. Apps should likely be calling
 /// `run_pending_migrations` or `run_pending_migrations_in_directory` instead.
 pub fn run_migrations<Conn, List>(
     conn: &Conn,
     migrations: List,
     output: &mut Write,
+    callback: Option<RunMigrationCallback>,
 ) -> Result<(), RunMigrationsError>
 where
     Conn: MigrationConnection,
@@ -306,6 +309,9 @@ where
     pending_migrations.sort_by(|a, b| a.version().cmp(b.version()));
     for migration in pending_migrations {
         try!(run_migration(conn, &migration, output));
+        if let Some(ref callback) = callback.as_ref() {
+            callback(&migration);
+        }
     }
     Ok(())
 }

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -57,9 +57,17 @@ pub fn derive_embed_migrations(input: &syn::DeriveInput) -> quote::Tokens {
         pub fn run_with_output<C: MigrationConnection>(conn: &C, out: &mut io::Write)
             -> Result<(), RunMigrationsError>
         {
-            run_migrations(conn, ALL_MIGRATIONS.iter().map(|v| *v), out)
+            run_migrations(conn, ALL_MIGRATIONS.iter().map(|v| *v), out, None)
         }
-    );
+
+        pub fn run_with_callback<C: MigrationConnection>(
+            conn: &C,
+            callback: RunMigrationCallback
+        ) -> Result<(), RunMigrationsError>
+        {
+            run_migrations(conn, ALL_MIGRATIONS.iter().map(|v| *v), &mut io::sink(), Some(callback))
+        }
+     );
 
     quote! {
         extern crate diesel;

--- a/diesel_migrations/migrations_macros/src/lib.rs
+++ b/diesel_migrations/migrations_macros/src/lib.rs
@@ -12,6 +12,7 @@
                  non_ascii_literal, similar_names, unicode_not_nfc, enum_glob_use, if_not_else,
                  items_after_statements, used_underscore_binding))]
 #![cfg_attr(all(test, feature = "clippy"), allow(option_unwrap_used, result_unwrap_used))]
+#![recursion_limit="128"]
 extern crate migrations_internals;
 extern crate proc_macro;
 #[macro_use]

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -88,6 +88,8 @@ pub use migrations_internals::MigrationError;
 #[doc(inline)]
 pub use migrations_internals::RunMigrationsError;
 #[doc(inline)]
+pub use migrations_internals::RunMigrationCallback;
+#[doc(inline)]
 pub use migrations_internals::run_migration_with_version;
 #[doc(inline)]
 pub use migrations_internals::run_migrations;
@@ -166,6 +168,12 @@ pub mod connection {
 ///     // By default the output is thrown out. If you want to redirect it to stdout, you
 ///     // should call embedded_migrations::run_with_output.
 ///     embedded_migrations::run_with_output(&connection, &mut std::io::stdout());
+///
+///     // You can do something in the callback after each migration runs successfully
+///     let c = |migration: &Migration| {
+///         println!("Run migration {} success", migration.version());
+///     }
+///     embedded_migrations::run_with_callback(&conn, Box::new(c));
 /// }
 /// ```
 macro_rules! embed_migrations {


### PR DESCRIPTION
My Application meets a problem that some data is saved in the form of BLOB in SQLite, and I want to transfer them to a new struct after some migrations run successfully. This transformation can not be done only by sql query,  so a callback is needed for each successfully ran migration.
Change-Id: I7b24bf53afbec227c6b9ed927fc25f1452687ee4