### PR TITLE
Simplify advanced blog CLI using `structopt`

### DIFF
--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -6,10 +6,11 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 bcrypt = "0.1.0"
 chrono = "0.4.0"
-clap = "2.29.0"
 diesel = { version = "1.0.0-beta1", features = ["postgres", "chrono"] }
 dotenv = "0.10.0"
 tempfile = "2.2.0"
+structopt = "0.1.6"
+structopt-derive = "0.1.6"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/examples/postgres/advanced-blog-cli/src/cli.rs
+++ b/examples/postgres/advanced-blog-cli/src/cli.rs
@@ -1,59 +1,57 @@
-use clap::{App, AppSettings, Arg, SubCommand};
-
-pub fn build_cli() -> App<'static, 'static> {
-    let post_id_arg = Arg::with_name("POST_ID")
-        .help("The id of the post to edit")
-        .takes_value(true)
-        .required(true);
-    let page_arg = Arg::with_name("PAGE")
-        .long("page")
-        .takes_value(true)
-        .help("The page to display");
-    let per_page_arg = Arg::with_name("PER_PAGE")
-        .long("per-page")
-        .takes_value(true)
-        .help("The number of posts to display per page (cannot be larger than 25)");
-
-    let create_post = SubCommand::with_name("create_post").arg(
-        Arg::with_name("TITLE")
-            .long("title")
-            .help("The title of your post")
-            .takes_value(true)
-            .required(true),
-    );
-    let edit_post = SubCommand::with_name("edit_post")
-        .arg(post_id_arg.clone())
-        .arg(
-            Arg::with_name("PUBLISH")
-                .long("publish")
-                .help("Publish the post after editing"),
-        );
-    let all_posts = SubCommand::with_name("all_posts")
-        .arg(page_arg.clone())
-        .arg(per_page_arg.clone());
-    let add_comment = SubCommand::with_name("add_comment").arg(post_id_arg.clone());
-    let edit_comment = SubCommand::with_name("edit_comment").arg(
-        Arg::with_name("COMMENT_ID")
-            .help("The id of the comment to edit")
-            .takes_value(true)
-            .required(true),
-    );
-    let my_comments = SubCommand::with_name("my_comments")
-        .arg(page_arg.clone())
-        .arg(per_page_arg.clone());
-
-    App::new("blog")
-        .version(env!("CARGO_PKG_VERSION"))
-        .setting(AppSettings::VersionlessSubcommands)
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(create_post)
-        .subcommand(all_posts)
-        .subcommand(edit_post)
-        .subcommand(add_comment)
-        .subcommand(edit_comment)
-        .subcommand(my_comments)
-        .subcommand(SubCommand::with_name("register"))
-        .after_help(
-            "You can also run `blog SUBCOMMAND -h` to get more information about that subcommand.",
-        )
+#[derive(StructOpt)]
+#[structopt(
+    name = "blog",
+    after_help = "You can also run `blog SUBCOMMAND -h` to get more information about that subcommand.",
+)]
+pub enum Cli {
+    /// Create a new wonderfully delighting blog post
+    #[structopt(name = "create_post")]
+    CreatePost {
+        /// The title of your post
+        #[structopt(long = "title")]
+        title: String,
+    },
+    /// Fine-tune an existing post to reach 100% reader delight
+    #[structopt(name = "edit_post")]
+    EditPost {
+        /// The id of the post to edit
+        post_id: i32,
+        #[structopt(short = "i", default_value = "false")]
+        publish: bool,
+    },
+    /// Get an overview of all your literary accomplishments
+    #[structopt(name = "all_posts")]
+    AllPosts {
+        /// The page to display
+        #[structopt(long = "page", default_value = "1")]
+        page: i64,
+        /// The number of posts to display per page (cannot be larger than 25)
+        #[structopt(long = "per-page", default_value = "1")]
+        per_page: Option<i64>,
+    },
+    /// Quickly add an important remark to a post
+    #[structopt(name = "add_comment")]
+    AddComment {
+        /// The id of the post to comment on
+        post_id: i32,
+    },
+    /// Edit a comment, e.g. to citate the sources of your facts
+    #[structopt(name = "edit_comment")]
+    EditComment {
+        /// The id of the comment to edit
+        comment_id: i32,
+    },
+    /// See all the instances where you were able to improve a post by adding a comment
+    #[structopt(name = "my_comments")]
+    MyComments {
+        /// The page to display
+        #[structopt(long = "page", default_value = "1")]
+        page: i64,
+        /// The number of comments to display per page (cannot be larger than 25)
+        #[structopt(long = "per-page", default_value = "1")]
+        per_page: Option<i64>,
+    },
+    /// Register as the newest member of this slightly elitist community
+    #[structopt(name = "register")]
+    Register,
 }


### PR DESCRIPTION
Structopt allows generating clap-based CLI arg parsers by using derives
on structs/enums. Crucially, it also handles converting arguments to
their expected types.

My goal here was to reduce the CLI parsing boilerplate (this code lives
in Diesel's example directory and should thus focus on Diesel) while
also switching to a style that will most likely be used by the next
version of clap itself.

There still is more boilerplate[^1] than I'd like to have, but at least
it's now a well-typed enum, and we can skip all the type conversion
steps. Also note that the line count is slightly skewed by my additional
help texts.

[^1]: For example: If there was a "convert enum variant name to
      kebab-case[^2] option I'd love to use it instead of all these
      `name = "foo_bar"` attributes.
[^2]: Yes we should totally use kebab-case and not snake_case here.