### PR TITLE
Allow `BoxableExpression` to be used with lifetimes other than `'static`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `#[derive(QueryableByName)]` will now compile correctly when there is a shadowed `Result` type in scope.
 
+* `BoxableExpression` can now be used with types that are not `'static`
+
 ### Changed
 
 * `Connection::test_transaction` now requires that the error returned implement

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -312,7 +312,7 @@ where
 {
 }
 
-impl<QS, ST, DB> QueryId for BoxableExpression<QS, DB, SqlType = ST> {
+impl<'a, QS, ST, DB> QueryId for BoxableExpression<QS, DB, SqlType = ST> + 'a {
     type QueryId = ();
 
     const HAS_STATIC_QUERY_ID: bool = false;


### PR DESCRIPTION
When using this function in a guide, I noticed that using lifetimes
other than `'static` failed. This is because in our `QueryId` impl, we
reference `BoxableExpression` which is sugar in Rust for
`BoxableExpression + 'static`.

We don't need a static lifetime here, since boxed trait objects have no
query id, and thus don't need to satisfy the bounds of `Any`.