### PR TITLE
Support `BINARY` type name for SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Added
+
+* The `BINARY` column type name is now supported for SQLite.
+
 ## [1.0.0-rc1] - 2017-12-23
 
 ### Fixed

--- a/diesel_infer_schema/infer_schema_internals/src/sqlite.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/sqlite.rs
@@ -169,7 +169,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
         String::from("Integer")
     } else if is_text(&type_name) {
         String::from("Text")
-    } else if type_name.contains("blob") || type_name.is_empty() {
+    } else if is_binary(&type_name) {
         String::from("Binary")
     } else if is_float(&type_name) {
         String::from("Float")
@@ -194,6 +194,10 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
 
 fn is_text(type_name: &str) -> bool {
     type_name.contains("char") || type_name.contains("clob") || type_name.contains("text")
+}
+
+fn is_binary(type_name: &str) -> bool {
+    type_name.contains("blob") || type_name.contains("binary") || type_name.is_empty()
 }
 
 fn is_bool(type_name: &str) -> bool {


### PR DESCRIPTION
I believe this fixes #1355.

My understanding is that this issue is a matter of taking columns labeled `BINARY` and fitting them under [Diesel's `Binary` type](https://docs.diesel.rs/diesel/types/struct.Binary.html). I've just been getting into the source code for diesel and I'm slowly gaining more context for how `determine_column_type` fits into everything, so feel to correct and provide more context if I have the wrong idea!

Let me know if this is something we should add to the changelog. I'm happy to do that with some guidance.