### PR TITLE
Deprecate `#[column_name(foo)]` in favor of `#[column_name = "foo"]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Deprecated `impl_query_id!` in favor of `#[derive(QueryId)]`
 
+* Deprecated specifying a column name as `#[column_name(foo)]`. `#[column_name =
+  "foo"]` should be used instead.
+
 ## [1.0.0] - 2018-01-02
 
 ### Added

--- a/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -33,12 +33,9 @@ impl<DB: Backend> Queryable<(Integer, VarChar), DB> for User where
     }
 }
 
-pub struct NewUser(String);
-
-impl_Insertable! {
-    (users)
-    pub struct NewUser(#[column_name(name)] String,);
-}
+#[derive(Insertable)]
+#[table_name = "users"]
+pub struct NewUser(#[column_name = "name"] String);
 
 fn main() {
     let connection = SqliteConnection::establish(":memory:").unwrap();

--- a/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -18,8 +18,8 @@ table! {
 }
 
 #[derive(Insertable)]
-#[table_name="users"]
-struct NewUser(#[column_name(name)] &'static str);
+#[table_name = "users"]
+pub struct NewUser(#[column_name = "name"] &'static str);
 
 sql_function!(lower, lower_t, (x: diesel::types::Text) -> diesel::types::Text);
 

--- a/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
@@ -15,7 +15,7 @@ sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 
 #[derive(Insertable)]
 #[table_name="users"]
-struct NewUser(#[column_name(name)] &'static str);
+struct NewUser(#[column_name = "name"] &'static str);
 
 // NOTE: This test is meant to be comprehensive, but not exhaustive.
 fn main() {

--- a/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_upsert_do_update_requires_valid_update.rs
@@ -18,8 +18,8 @@ table! {
 }
 
 #[derive(Insertable)]
-#[table_name="users"]
-struct NewUser(#[column_name(name)] &'static str);
+#[table_name = "users"]
+pub struct NewUser(#[column_name = "name"] &'static str);
 
 #[allow(deprecated)]
 fn main() {

--- a/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
+++ b/diesel_compile_tests/tests/compile-fail/returning_cannot_be_called_twice.rs
@@ -9,12 +9,9 @@ table! {
     }
 }
 
-pub struct NewUser(String);
-
-impl_Insertable! {
-    (users)
-    pub struct NewUser(#[column_name(name)] String,);
-}
+#[derive(Insertable)]
+#[table_name = "users"]
+pub struct NewUser(#[column_name = "name"] String);
 
 fn main() {
     use self::users::dsl::*;

--- a/diesel_compile_tests/tests/compile-fail/returning_clause_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/returning_clause_requires_selectable_expression.rs
@@ -10,12 +10,9 @@ table! {
     }
 }
 
-pub struct NewUser(String);
-
-impl_Insertable! {
-    (users)
-    pub struct NewUser(#[column_name(name)] String,);
-}
+#[derive(Insertable)]
+#[table_name = "users"]
+pub struct NewUser(#[column_name = "name"] String);
 
 table! {
     non_users {

--- a/diesel_derives/src/attr.rs
+++ b/diesel_derives/src/attr.rs
@@ -17,7 +17,6 @@ impl Attr {
     pub fn from_struct_field((index, field): (usize, &syn::Field)) -> Self {
         let field_name = field.ident.clone();
         let column_name = ident_value_of_attr_with_name(&field.attrs, "column_name")
-            .cloned()
             .or_else(|| field_name.clone());
         let ty = field.ty.clone();
         let sql_type = str_value_of_attr_with_name(&field.attrs, "sql_type")

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -30,7 +30,7 @@ impl Model {
             .map(|v| v.into_iter().cloned().collect())
             .unwrap_or_else(|| vec![syn::Ident::new("id")]);
         let table_name_from_annotation =
-            str_value_of_attr_with_name(&item.attrs, "table_name").map(syn::Ident::new);
+            ident_value_of_attr_with_name(&item.attrs, "table_name");
 
         Ok(Model {
             ty: ty,

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -29,8 +29,7 @@ impl Model {
         let primary_key_names = list_value_of_attr_with_name(&item.attrs, "primary_key")
             .map(|v| v.into_iter().cloned().collect())
             .unwrap_or_else(|| vec![syn::Ident::new("id")]);
-        let table_name_from_annotation =
-            ident_value_of_attr_with_name(&item.attrs, "table_name");
+        let table_name_from_annotation = ident_value_of_attr_with_name(&item.attrs, "table_name");
 
         Ok(Model {
             ty: ty,

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -38,12 +38,22 @@ pub fn str_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Op
     attr_with_name(attrs, name).map(|attr| str_value_of_attr(attr, name))
 }
 
-pub fn ident_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Option<&'a Ident> {
-    list_value_of_attr_with_name(attrs, name).map(|idents| {
-        if idents.len() != 1 {
-            panic!(r#"`{}` must be in the form `#[{}(something)]`"#, name, name);
+pub fn ident_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Option<Ident> {
+    let error = || panic!(r#"`{}` must be in the form `#[{} = "something"]`"#, name, name);
+    attr_with_name(attrs, name).map(|attr| match attr.value {
+        MetaItem::NameValue(_, Lit::Str(ref value, _)) => Ident::from(&**value),
+        MetaItem::List(_, ref list) => {
+            if list.len() != 1 {
+                error();
+            }
+            println!(r#"The form `#[{}(something)]` is deprecated. Use `#[{} = "something"]` instead"#, name, name);
+            if let NestedMetaItem::MetaItem(MetaItem::Word(ref ident)) = list[0] {
+                ident.clone()
+            } else {
+                error()
+            }
         }
-        idents[0]
+        _ => error(),
     })
 }
 

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -39,14 +39,22 @@ pub fn str_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Op
 }
 
 pub fn ident_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Option<Ident> {
-    let error = || panic!(r#"`{}` must be in the form `#[{} = "something"]`"#, name, name);
+    let error = || {
+        panic!(
+            r#"`{}` must be in the form `#[{} = "something"]`"#,
+            name, name
+        )
+    };
     attr_with_name(attrs, name).map(|attr| match attr.value {
         MetaItem::NameValue(_, Lit::Str(ref value, _)) => Ident::from(&**value),
         MetaItem::List(_, ref list) => {
             if list.len() != 1 {
                 error();
             }
-            println!(r#"The form `#[{}(something)]` is deprecated. Use `#[{} = "something"]` instead"#, name, name);
+            println!(
+                r#"The form `#[{}(something)]` is deprecated. Use `#[{} = "something"]` instead"#,
+                name, name
+            );
             if let NestedMetaItem::MetaItem(MetaItem::Word(ref ident)) = list[0] {
                 ident.clone()
             } else {

--- a/guide_drafts/trait_derives.md
+++ b/guide_drafts/trait_derives.md
@@ -364,7 +364,7 @@ On SQLite, one query will be performed per row.
 For `Insertable` structs, Diesel needs to know the corresponding table name.
 You must add the `#[table_name="some_table_name"]` attribute to your `Insertable` struct.
 If your struct has different field names than the columns they reference,
-they may be annotated with `#[column_name(some_column_name)]`.
+they may be annotated with `#[column_name = "some_column_name"]`.
 
 Typically, you will not use `Queryable` and `Insertable` together.
 Thinking of web forms again, a new record wouldn't have such fields as
@@ -397,7 +397,7 @@ pub struct User {
 pub struct NewUser<'a> {
     pub first_name: &'a str,
     pub last_name: &'a str,
-    #[column_name(email)]
+    #[column_name = "email"]
     pub electronic_mail: &'a str,
  }
 ```


### PR DESCRIPTION
The old form was a relic of the fact that we needed to use a
`macro_rules!` macro to parse the struct at one point in the past, and
there's no way to convert a string to an ident in non-procedural macros.
The parens form is inconsistent with the rest of Diesel, such as
`#[table_name = "foo"]` and `#[sql_type = "Integer"]`.

The only attribute which still uses the parens form is `#[primary_key]`,
since it needs to be able to take multiple values.

Unfortunately there's no way for us to properly deprecate this without just printing to stdout. I also learned while writing this that printing to stderr in proc macros no longer displays its output to the user... We should probably fix that in `infer_schema!` where we print warnings to stderr.