### PR TITLE
Remove `queryable_impls!` in favor of `#[derive(FromSqlRow)]`

### DIFF
--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -42,7 +42,6 @@ macro_rules! mysql_time_impls {
 }
 
 mysql_time_impls!(Datetime);
-queryable_impls!(Datetime -> NaiveDateTime);
 expression_impls!(Datetime -> NaiveDateTime);
 mysql_time_impls!(Timestamp);
 mysql_time_impls!(Time);

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::io::Write;
 
 use pg::{Pg, PgMetadataLookup, PgTypeMetadata};
-use query_source::Queryable;
 use types::*;
 
 impl<T> HasSqlType<Array<T>> for Pg
@@ -60,27 +59,6 @@ where
                 }
             })
             .collect()
-    }
-}
-
-impl<T, ST> FromSqlRow<Array<ST>, Pg> for Vec<T>
-where
-    Pg: HasSqlType<ST>,
-    Vec<T>: FromSql<Array<ST>, Pg>,
-{
-    fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error + Send + Sync>> {
-        FromSql::<Array<ST>, Pg>::from_sql(row.take())
-    }
-}
-
-impl<T, ST> Queryable<Array<ST>, Pg> for Vec<T>
-where
-    T: FromSql<ST, Pg> + Queryable<ST, Pg>,
-    Pg: HasSqlType<ST>,
-{
-    type Row = Self;
-    fn build(row: Self) -> Self {
-        row
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -18,9 +18,6 @@ expression_impls!(Timestamptz -> DateTime<Utc>);
 expression_impls!(Timestamptz -> DateTime<FixedOffset>);
 expression_impls!(Timestamptz -> DateTime<Local>);
 
-queryable_impls!(Timestamptz -> NaiveDateTime);
-queryable_impls!(Timestamptz -> DateTime<Utc>);
-
 // Postgres timestamps start from January 1st 2000.
 fn pg_epoch() -> NaiveDateTime {
     NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0)

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -9,7 +9,11 @@ use pg::Pg;
 use types::{self, FromSql, IsNull, Timestamp, ToSql, ToSqlOutput};
 
 expression_impls!(Timestamp -> Timespec);
-queryable_impls!(Timestamp -> Timespec);
+
+#[derive(FromSqlRow)]
+#[diesel(foreign_derive)]
+#[allow(dead_code)]
+struct TimespecProxy(Timespec);
 
 const TIME_SEC_CONV: i64 = 946_684_800;
 

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -20,13 +20,13 @@ mod chrono;
 #[cfg(feature = "deprecated-time")]
 mod deprecated_time;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
 /// Timestamps are represented in Postgres as a 64 bit signed integer representing the number of
 /// microseconds since January 1st 2000. This struct is a dumb wrapper type, meant only to indicate
 /// the integer's meaning.
 pub struct PgTimestamp(pub i64);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
 /// Dates are represented in Postgres as a 32 bit signed integer representing the number of julian
 /// days since January 1st 2000. This struct is a dumb wrapper type, meant only to indicate the
 /// integer's meaning.
@@ -35,14 +35,14 @@ pub struct PgDate(pub i32);
 /// Time is represented in Postgres as a 64 bit signed integer representing the number of
 /// microseconds since midnight. This struct is a dumb wrapper type, meant only to indicate the
 /// integer's meaning.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
 pub struct PgTime(pub i64);
 
 /// Intervals in Postgres are separated into 3 parts. A 64 bit integer representing time in
 /// microseconds, a 32 bit integer representing number of days, and a 32 bit integer
 /// representing number of months. This struct is a dumb wrapper type, meant only to indicate the
 /// meaning of these parts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromSqlRow)]
 pub struct PgInterval {
     /// The number of whole microseconds
     pub microseconds: i64,
@@ -83,10 +83,6 @@ impl PgInterval {
     }
 }
 
-queryable_impls!(Date -> PgDate);
-queryable_impls!(Time -> PgTime);
-queryable_impls!(Timestamp -> PgTimestamp);
-queryable_impls!(Timestamptz -> PgTimestamp);
 expression_impls!(Date -> PgDate);
 expression_impls!(Time -> PgTime);
 expression_impls!(Timestamp -> PgTimestamp);

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -6,7 +6,6 @@ use pg::Pg;
 use types::{self, FromSql, IsNull, Timestamp, ToSql, ToSqlOutput};
 
 expression_impls!(Timestamp -> SystemTime);
-queryable_impls!(Timestamp -> SystemTime);
 
 fn pg_epoch() -> SystemTime {
     let thirty_years = Duration::from_secs(946_684_800);

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -8,7 +8,7 @@ use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, FromSqlRow)]
 /// Represents a NUMERIC value, closely mirroring the PG wire protocol
 /// representation
 pub enum PgNumeric {

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -17,6 +17,15 @@ use types::{self, FromSql, IsNull, Json, Jsonb, ToSql, ToSqlOutput};
 primitive_impls!(Json -> (serde_json::Value, pg: (114, 199)));
 primitive_impls!(Jsonb -> (serde_json::Value, pg: (3802, 3807)));
 
+#[allow(dead_code)]
+mod foreign_derives {
+    use super::serde_json;
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct SerdeJsonValueProxy(serde_json::Value);
+}
+
 impl FromSql<types::Json, Pg> for serde_json::Value {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
         let bytes = not_none!(bytes);

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -16,7 +16,7 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 /// use diesel::data_types::PgMoney as Pence; // 1/100th unit of Pound
 /// use diesel::data_types::PgMoney as Fils;  // 1/1000th unit of Dinar
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
 pub struct PgMoney(pub i64);
 
 use pg::Pg;

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -25,6 +25,19 @@ primitive_impls!(MacAddr -> ([u8; 6], pg: (829, 1040)));
 primitive_impls!(Inet -> (IpNetwork, pg: (869, 1041)));
 primitive_impls!(Cidr -> (IpNetwork, pg: (650, 651)));
 
+#[allow(dead_code)]
+mod foreign_derives {
+    use super::IpNetwork;
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct ByteArrayProxy([u8; 6]);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct IpNetworkProxy(IpNetwork);
+}
+
 macro_rules! err {
     () => (Err("invalid network address format".into()));
     ($msg: expr) => (Err(format!("invalid network address format. {}", $msg).into()));

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -8,6 +8,11 @@ use types::{self, FromSql, IsNull, ToSql, ToSqlOutput, Uuid};
 
 primitive_impls!(Uuid -> (uuid::Uuid, pg: (2950, 2951)));
 
+#[derive(FromSqlRow)]
+#[diesel(foreign_derive)]
+#[allow(dead_code)]
+struct UuidProxy(uuid::Uuid);
+
 impl FromSql<types::Uuid, Pg> for uuid::Uuid {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
         let bytes = not_none!(bytes);

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -26,10 +26,6 @@ impl HasSqlType<types::Timestamp> for Sqlite {
     }
 }
 
-queryable_impls!(Date -> String);
-queryable_impls!(Time -> String);
-queryable_impls!(Timestamp -> String);
-
 expression_impls!(Date -> String);
 expression_impls!(Date -> str, unsized);
 expression_impls!(Time -> String);

--- a/diesel/src/types/impls/date_and_time.rs
+++ b/diesel/src/types/impls/date_and_time.rs
@@ -1,3 +1,11 @@
+#![allow(dead_code)]
+
+use std::time::SystemTime;
+
+#[derive(FromSqlRow)]
+#[diesel(foreign_derive)]
+struct SystemTimeProxy(SystemTime);
+
 #[cfg(feature = "chrono")]
 mod chrono {
     extern crate chrono;
@@ -8,7 +16,19 @@ mod chrono {
     expression_impls!(Time -> NaiveTime);
     expression_impls!(Timestamp -> NaiveDateTime);
 
-    queryable_impls!(Date -> NaiveDate);
-    queryable_impls!(Time -> NaiveTime);
-    queryable_impls!(Timestamp -> NaiveDateTime);
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct NaiveDateProxy(NaiveDate);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct NaiveTimeProxy(NaiveTime);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct NaiveDateTimeProxy(NaiveDateTime);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct DateTimeProxy<Tz: TimeZone>(DateTime<Tz>);
 }

--- a/diesel/src/types/impls/decimal.rs
+++ b/diesel/src/types/impls/decimal.rs
@@ -1,8 +1,14 @@
+#![allow(dead_code)]
+
 #[cfg(feature = "bigdecimal")]
 mod bigdecimal {
     extern crate bigdecimal;
+    use self::bigdecimal::BigDecimal;
     use types::Numeric;
 
-    expression_impls!(Numeric -> bigdecimal::BigDecimal);
-    queryable_impls!(Numeric -> bigdecimal::BigDecimal);
+    expression_impls!(Numeric -> BigDecimal);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct BigDecimalProxy(BigDecimal);
 }

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -1,3 +1,7 @@
+/// Gets the value out of an option, or returns an error.
+///
+/// This is used by `FromSql` implementations.
+#[macro_export]
 macro_rules! not_none {
     ($bytes:expr) => {
         match $bytes {
@@ -78,32 +82,6 @@ macro_rules! expression_impls {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! queryable_impls {
-    ($Source:ident -> $Target:ty) => {
-        impl<DB> $crate::types::FromSqlRow<$Source, DB> for $Target where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<$Source>,
-            $Target: $crate::types::FromSql<$Source, DB>,
-        {
-            fn build_from_row<R: $crate::row::Row<DB>>(row: &mut R) -> ::std::result::Result<Self, Box<::std::error::Error+Send+Sync>> {
-                $crate::types::FromSql::<$Source, DB>::from_sql(row.take())
-            }
-        }
-
-        impl<DB> $crate::query_source::Queryable<$Source, DB> for $Target where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<$Source>,
-            $Target: $crate::types::FromSqlRow<$Source, DB>,
-        {
-            type Row = Self;
-
-            fn build(row: Self::Row) -> Self {
-                row
-            }
-        }
-    }
-}
-
-#[doc(hidden)]
-#[macro_export]
 macro_rules! primitive_impls {
     ($Source:ident -> (, $($rest:tt)*)) => {
         primitive_impls!($Source -> ($($rest)*));
@@ -156,7 +134,6 @@ macro_rules! primitive_impls {
 
     ($Source:ident -> $Target:ty) => {
         primitive_impls!($Source);
-        queryable_impls!($Source -> $Target);
         expression_impls!($Source -> $Target);
     };
 

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -22,6 +22,45 @@ primitive_impls!(Date);
 primitive_impls!(Time);
 primitive_impls!(Timestamp);
 
+#[allow(dead_code)]
+mod foreign_impls {
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct BoolProxy(bool);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct I16Proxy(i16);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct I32Proxy(i32);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct I64Proxy(i64);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct U32Proxy(u32);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct F32Proxy(f32);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct F64Proxy(f64);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct StringProxy(String);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
+    struct VecProxy<T>(Vec<T>);
+}
+
 expression_impls!(Text -> str, unsized);
 expression_impls!(Binary -> [u8], unsized);
 

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -30,6 +30,10 @@ mod foreign_impls {
 
     #[derive(FromSqlRow)]
     #[diesel(foreign_derive)]
+    struct I8Proxy(i8);
+
+    #[derive(FromSqlRow)]
+    #[diesel(foreign_derive)]
     struct I16Proxy(i16);
 
     #[derive(FromSqlRow)]

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -415,6 +415,8 @@ impl<T: NotNull + SingleValue> SingleValue for Nullable<T> {}
 /// the database, prefer `i32::from_sql(bytes)` over reading from `bytes`
 /// directly)
 ///
+/// Types which implement this trait should also have `#[derive(FromSqlRow)]`
+///
 /// ### Backend specific details
 ///
 /// - For PostgreSQL, the bytes will be sent using the binary protocol, not text.
@@ -435,10 +437,18 @@ pub trait FromSql<A, DB: Backend + HasSqlType<A>>: Sized {
 ///
 /// All types which implement `FromSql` should also implement this trait. This
 /// trait differs from `FromSql` in that it is also implemented by tuples.
+/// Implementations of this trait are usually derived.
 ///
 /// In the future, we hope to be able to provide a blanket impl of this trait
 /// for all types which implement `FromSql`. However, as of Diesel 1.0, such an
 /// impl would conflict with our impl for tuples.
+///
+/// ## Deriving
+///
+/// This trait can be automatically derived by Diesel
+/// for any type which implements `FromSql`.
+/// There are no options or special considerations needed for this derive.
+/// Note that `#[derive(FromSqlRow)]` will also generate a `Queryable` implementation.
 pub trait FromSqlRow<A, DB: Backend + HasSqlType<A>>: Sized {
     /// The number of fields that this type will consume. Must be equal to
     /// the number of times you would call `row.take()` in `build_from_row`

--- a/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
@@ -18,7 +18,7 @@ fn main() {
     let select_name = users.select(name);
 
     let ids = select_name.load::<i32>(&connection);
-    //~^ ERROR the trait bound `i32: diesel::Queryable<diesel::types::Text, _>` is not satisfied
+    //~^ ERROR the trait bound `i32: diesel::types::FromSql<diesel::types::Text, _>` is not satisfied
     let names = select_id.load::<String>(&connection);
-    //~^ ERROR the trait bound `std::string::String: diesel::Queryable<diesel::types::Integer, _>` is not satisfied
+    //~^ ERROR the trait bound `std::string::String: diesel::types::FromSql<diesel::types::Integer, _>` is not satisfied
 }

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -45,6 +45,6 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
                     row
                 }
             }
-        )
+        ),
     )
 }

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -1,0 +1,50 @@
+use quote::Tokens;
+use syn;
+
+use util::*;
+
+pub fn derive(item: syn::DeriveInput) -> Tokens {
+    let struct_ty = if flag_present(&item.attrs, "foreign_derive") {
+        match item.body {
+            syn::Body::Struct(ref body) => body.fields()[0].ty.clone(),
+            _ => panic!("foreign_derive cannot be used on enums"),
+        }
+    } else {
+        struct_ty(item.ident.clone(), &item.generics)
+    };
+
+    let item_name = item.ident.as_ref().to_uppercase();
+    let generics = syn::aster::from_generics(item.generics)
+        .ty_param_id("__ST")
+        .ty_param_id("__DB")
+        .build();
+
+    wrap_item_in_const(
+        format!("_IMPL_FROM_SQL_ROW_FOR_{}", item_name).into(),
+        quote!(
+            impl#generics diesel::types::FromSqlRow<__ST, __DB> for #struct_ty
+            where
+                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                Self: diesel::types::FromSql<__ST, __DB>,
+            {
+                fn build_from_row<R: diesel::row::Row<__DB>>(row: &mut R)
+                    -> Result<Self, Box<::std::error::Error + Send + Sync>>
+                {
+                    diesel::types::FromSql::<__ST, __DB>::from_sql(row.take())
+                }
+            }
+
+            impl#generics diesel::query_source::Queryable<__ST, __DB> for #struct_ty
+            where
+                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                Self: diesel::types::FromSqlRow<__ST, __DB>,
+            {
+                type Row = Self;
+
+                fn build(row: Self::Row) -> Self {
+                    row
+                }
+            }
+        )
+    )
+}

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -28,6 +28,7 @@ mod as_changeset;
 mod associations;
 mod ast_builder;
 mod attr;
+mod from_sql_row;
 mod identifiable;
 mod insertable;
 mod model;
@@ -73,6 +74,11 @@ pub fn derive_associations(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(QueryId)]
 pub fn derive_query_id(input: TokenStream) -> TokenStream {
     expand_derive(input, query_id::derive)
+}
+
+#[proc_macro_derive(FromSqlRow, attributes(diesel))]
+pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
+    expand_derive(input, from_sql_row::derive)
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::DeriveInput) -> quote::Tokens) -> TokenStream {

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -122,3 +122,10 @@ pub fn wrap_item_in_const(const_name: Ident, item: Tokens) -> Tokens {
         };
     }
 }
+
+pub fn flag_present(attrs: &[Attribute], flag: &str) -> bool {
+    list_value_of_attr_with_name(attrs, "diesel")
+        .unwrap_or_else(Vec::new)
+        .into_iter()
+        .any(|f| f == flag)
+}

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1000,22 +1000,6 @@ fn third_party_crates_can_add_new_types() {
         }
     }
 
-    impl FromSqlRow<MyInt, Pg> for i32 {
-        fn build_from_row<R: ::diesel::row::Row<Pg>>(
-            row: &mut R,
-        ) -> Result<Self, Box<Error + Send + Sync>> {
-            FromSql::<MyInt, Pg>::from_sql(row.take())
-        }
-    }
-
-    impl Queryable<MyInt, Pg> for i32 {
-        type Row = Self;
-
-        fn build(row: Self) -> Self {
-            row
-        }
-    }
-
     assert_eq!(0, query_single_value::<MyInt, i32>("0"));
     assert_eq!(-1, query_single_value::<MyInt, i32>("-1"));
     assert_eq!(70_000, query_single_value::<MyInt, i32>("70000"));


### PR DESCRIPTION
This generates a slightly different impl than we had before.
Rather than explicitly stating the SQL type,
the generated impl is now generic for any SQL type
as long as there is a `FromSql` impl.
This is basically the blanket impl that I want to write,
but can't for various reasons.

This means that certain `queryable_impl!` invocations were redundant.
Some impls will now be present regardless of enabled features.

This derive will also generate a `Queryable` impl,
which you always want when implementing `FromSqlRow`.

Since the majority of impls in Diesel are for types located outside of Diesel, I've added an undocumented `foreign_derive` flag. The error handling around it is light, since it's intended to only be used by Diesel