### PR TITLE
Remove `expression_impls!` in favor of a derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * The `QueryId` trait can now be derived.
 
+* `AsExpression` can now be derived for types which implement `FromSql`.
+
 ### Deprecated
 
 * Deprecated `impl_query_id!` in favor of `#[derive(QueryId)]`

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -109,6 +109,26 @@ impl<'a, T: Expression + ?Sized> Expression for &'a T {
 ///   [`Timestamp`]: ../types/struct.Timestamp.html
 ///   [`Timestamptz`]: ../../pg/types/sql_types/struct.Timestamptz.html
 ///   [`ToSql`]: ../types/trait.ToSql.html
+///
+/// ## Deriving
+///
+/// This trait can be automatically derived for any type which implements `ToSql`.
+/// The type must be annotated with `#[sql_type = "SomeType"]`.
+/// If that annotation appears multiple times,
+/// implementations will be generated for each one of them.
+///
+/// This will generate the following impls:
+///
+/// - `impl AsExpression<SqlType> for YourType`
+/// - `impl AsExpression<Nullable<SqlType>> for YourType`
+/// - `impl AsExpression<SqlType> for &'a YourType`
+/// - `impl AsExpression<Nullable<SqlType>> for &'a YourType`
+/// - `impl AsExpression<SqlType> for &'a &'b YourType`
+/// - `impl AsExpression<Nullable<SqlType>> for &'a &'b YourType`
+///
+/// If your type is unsized,
+/// you can specify this by adding the annotation `#[diesel(not_sized)]`.
+/// This will skip the impls for non-reference types.
 pub trait AsExpression<T> {
     /// The expression being returned
     type Expression: Expression<SqlType = T>;

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -42,7 +42,6 @@ macro_rules! mysql_time_impls {
 }
 
 mysql_time_impls!(Datetime);
-expression_impls!(Datetime -> NaiveDateTime);
 mysql_time_impls!(Timestamp);
 mysql_time_impls!(Time);
 mysql_time_impls!(Date);

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -10,7 +10,7 @@ use std::error::Error as StdError;
 use std::io::Write;
 use types::{FromSql, HasSqlType, IsNull, Tinyint, ToSql, ToSqlOutput};
 
-primitive_impls!(Tinyint -> (i8, mysql: (Tiny)));
+primitive_impls!(Tinyint -> (mysql: (Tiny)));
 
 impl ToSql<::types::Tinyint, Mysql> for i8 {
     fn to_sql<W: Write>(

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -5,18 +5,12 @@ extern crate chrono;
 
 use std::error::Error;
 use std::io::Write;
-use self::chrono::{DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime,
-                   TimeZone, Utc};
+use self::chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use self::chrono::naive::MAX_DATE;
 
 use pg::Pg;
 use super::{PgDate, PgTime, PgTimestamp};
 use types::{Date, FromSql, IsNull, Time, Timestamp, Timestamptz, ToSql, ToSqlOutput};
-
-expression_impls!(Timestamptz -> NaiveDateTime);
-expression_impls!(Timestamptz -> DateTime<Utc>);
-expression_impls!(Timestamptz -> DateTime<FixedOffset>);
-expression_impls!(Timestamptz -> DateTime<Local>);
 
 // Postgres timestamps start from January 1st 2000.
 fn pg_epoch() -> NaiveDateTime {

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -8,10 +8,9 @@ use self::time::{Duration, Timespec};
 use pg::Pg;
 use types::{self, FromSql, IsNull, Timestamp, ToSql, ToSqlOutput};
 
-expression_impls!(Timestamp -> Timespec);
-
-#[derive(FromSqlRow)]
+#[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
+#[sql_type = "Timestamp"]
 #[allow(dead_code)]
 struct TimespecProxy(Timespec);
 

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -6,11 +6,7 @@ use pg::Pg;
 use types::{self, Date, FromSql, Interval, IsNull, Time, Timestamp, Timestamptz, ToSql,
             ToSqlOutput};
 
-primitive_impls!(Date -> (pg: (1082, 1182)));
-primitive_impls!(Time -> (pg: (1083, 1183)));
-primitive_impls!(Timestamp -> (pg: (1114, 1115)));
 primitive_impls!(Timestamptz -> (pg: (1184, 1185)));
-primitive_impls!(Timestamptz);
 
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
@@ -20,13 +16,16 @@ mod chrono;
 #[cfg(feature = "deprecated-time")]
 mod deprecated_time;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[sql_type = "Timestamp"]
+#[sql_type = "Timestamptz"]
 /// Timestamps are represented in Postgres as a 64 bit signed integer representing the number of
 /// microseconds since January 1st 2000. This struct is a dumb wrapper type, meant only to indicate
 /// the integer's meaning.
 pub struct PgTimestamp(pub i64);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[sql_type = "Date"]
 /// Dates are represented in Postgres as a 32 bit signed integer representing the number of julian
 /// days since January 1st 2000. This struct is a dumb wrapper type, meant only to indicate the
 /// integer's meaning.
@@ -35,14 +34,16 @@ pub struct PgDate(pub i32);
 /// Time is represented in Postgres as a 64 bit signed integer representing the number of
 /// microseconds since midnight. This struct is a dumb wrapper type, meant only to indicate the
 /// integer's meaning.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[sql_type = "Time"]
 pub struct PgTime(pub i64);
 
 /// Intervals in Postgres are separated into 3 parts. A 64 bit integer representing time in
 /// microseconds, a 32 bit integer representing number of days, and a 32 bit integer
 /// representing number of months. This struct is a dumb wrapper type, meant only to indicate the
 /// meaning of these parts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromSqlRow)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromSqlRow, AsExpression)]
+#[sql_type = "Interval"]
 pub struct PgInterval {
     /// The number of whole microseconds
     pub microseconds: i64,
@@ -83,12 +84,7 @@ impl PgInterval {
     }
 }
 
-expression_impls!(Date -> PgDate);
-expression_impls!(Time -> PgTime);
-expression_impls!(Timestamp -> PgTimestamp);
-expression_impls!(Timestamptz -> PgTimestamp);
-
-primitive_impls!(Interval -> (PgInterval, pg: (1186, 1187)));
+primitive_impls!(Interval -> (pg: (1186, 1187)));
 
 impl ToSql<types::Timestamp, Pg> for PgTimestamp {
     fn to_sql<W: Write>(

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -3,9 +3,7 @@ use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use pg::Pg;
-use types::{self, FromSql, IsNull, Timestamp, ToSql, ToSqlOutput};
-
-expression_impls!(Timestamp -> SystemTime);
+use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
 
 fn pg_epoch() -> SystemTime {
     let thirty_years = Duration::from_secs(946_684_800);

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -8,7 +8,8 @@ use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
 
-#[derive(Debug, Clone, PartialEq, Eq, FromSqlRow)]
+#[derive(Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression)]
+#[sql_type = "types::Numeric"]
 /// Represents a NUMERIC value, closely mirroring the PG wire protocol
 /// representation
 pub enum PgNumeric {

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 use pg::Pg;
 use types::{self, FromSql, IsNull, Oid, ToSql, ToSqlOutput};
 
-primitive_impls!(Oid -> (u32, pg: (26, 1018)));
+primitive_impls!(Oid -> (pg: (26, 1018)));
 
 impl FromSql<types::Oid, Pg> for u32 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -14,15 +14,18 @@ use types::{self, FromSql, IsNull, Json, Jsonb, ToSql, ToSqlOutput};
 //
 // https://www.postgresql.org/message-id/CA+mi_8Yv2SVOdhAtx-4CbpzoDtaJGkf8QvnushdF8bMgySAbYg@mail.gmail.com
 // https://www.postgresql.org/message-id/CA+mi_8bd_g-MDPMwa88w0HXfjysaLFcrCza90+KL9zpRGbxKWg@mail.gmail.com
-primitive_impls!(Json -> (serde_json::Value, pg: (114, 199)));
-primitive_impls!(Jsonb -> (serde_json::Value, pg: (3802, 3807)));
+primitive_impls!(Json -> (pg: (114, 199)));
+primitive_impls!(Jsonb -> (pg: (3802, 3807)));
 
 #[allow(dead_code)]
 mod foreign_derives {
     use super::serde_json;
+    use types::{Json, Jsonb};
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Json"]
+    #[sql_type = "Jsonb"]
     struct SerdeJsonValueProxy(serde_json::Value);
 }
 

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -16,14 +16,15 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 /// use diesel::data_types::PgMoney as Pence; // 1/100th unit of Pound
 /// use diesel::data_types::PgMoney as Fils;  // 1/1000th unit of Dinar
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[sql_type = "Money"]
 pub struct PgMoney(pub i64);
 
 use pg::Pg;
 use types::{self, FromSql, IsNull, Money, ToSql, ToSqlOutput};
 
 // https://github.com/postgres/postgres/blob/502a3832cc54c7115dacb8a2dae06f0620995ac6/src/include/catalog/pg_type.h#L429-L432
-primitive_impls!(Money -> (PgMoney, pg: (790, 791)));
+primitive_impls!(Money -> (pg: (790, 791)));
 
 impl FromSql<types::Money, Pg> for PgMoney {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -21,20 +21,23 @@ const PGSQL_AF_INET: u8 = AF_INET;
 const PGSQL_AF_INET6: u8 = AF_INET + 1;
 
 // https://github.com/postgres/postgres/blob/502a3832cc54c7115dacb8a2dae06f0620995ac6/src/include/catalog/pg_type.h#L435-L443
-primitive_impls!(MacAddr -> ([u8; 6], pg: (829, 1040)));
-primitive_impls!(Inet -> (IpNetwork, pg: (869, 1041)));
-primitive_impls!(Cidr -> (IpNetwork, pg: (650, 651)));
+primitive_impls!(MacAddr -> (pg: (829, 1040)));
+primitive_impls!(Inet -> (pg: (869, 1041)));
+primitive_impls!(Cidr -> (pg: (650, 651)));
 
 #[allow(dead_code)]
 mod foreign_derives {
-    use super::IpNetwork;
+    use super::*;
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "MacAddr"]
     struct ByteArrayProxy([u8; 6]);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Inet"]
+    #[sql_type = "Cidr"]
     struct IpNetworkProxy(IpNetwork);
 }
 

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -2,10 +2,9 @@ use std::io::prelude::*;
 use std::error::Error;
 
 use pg::Pg;
-use pg::data_types::PgNumeric;
 use types::{self, FromSql, IsNull, Numeric, ToSql, ToSqlOutput};
 
-primitive_impls!(Numeric -> (PgNumeric, pg: (1700, 1231)));
+primitive_impls!(Numeric -> (pg: (1700, 1231)));
 
 impl FromSql<types::Bool, Pg> for bool {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -3,7 +3,7 @@ use std::collections::Bound;
 use std::error::Error;
 use std::io::Write;
 
-use expression::{AsExpression, NonAggregate};
+use expression::AsExpression;
 use expression::bound::Bound as SqlBound;
 use pg::Pg;
 use query_source::Queryable;
@@ -22,10 +22,6 @@ bitflags! {
         const CONTAIN_EMPTY = 0x80;
     }
 }
-
-impl<T> NotNull for Range<T> {}
-impl<T> SingleValue for Range<T> {}
-impl<T> NonAggregate for Range<T> {}
 
 impl<T, ST> Queryable<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
@@ -51,7 +47,7 @@ where
 
 impl<'a, ST, T> AsExpression<Range<ST>> for &'a (Bound<T>, Bound<T>)
 where
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
+    Pg: HasSqlType<Range<ST>>,
 {
     type Expression = SqlBound<Range<ST>, Self>;
 
@@ -62,7 +58,8 @@ where
 
 impl<ST, T> AsExpression<Nullable<Range<ST>>> for (Bound<T>, Bound<T>)
 where
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
+    Pg: HasSqlType<Range<ST>>,
+    Range<ST>: NotNull,
 {
     type Expression = SqlBound<Nullable<Range<ST>>, Self>;
 
@@ -73,7 +70,8 @@ where
 
 impl<'a, ST, T> AsExpression<Nullable<Range<ST>>> for &'a (Bound<T>, Bound<T>)
 where
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
+    Pg: HasSqlType<Range<ST>>,
+    Range<ST>: NotNull,
 {
     type Expression = SqlBound<Nullable<Range<ST>>, Self>;
 
@@ -184,6 +182,7 @@ impl<ST, T> ToSql<Nullable<Range<ST>>, Pg> for (Bound<T>, Bound<T>)
 where
     Pg: HasSqlType<Range<ST>>,
     (Bound<T>, Bound<T>): ToSql<Range<ST>, Pg>,
+    Range<ST>: NotNull,
 {
     fn to_sql<W: Write>(
         &self,

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -6,10 +6,11 @@ use std::error::Error;
 use pg::Pg;
 use types::{self, FromSql, IsNull, ToSql, ToSqlOutput, Uuid};
 
-primitive_impls!(Uuid -> (uuid::Uuid, pg: (2950, 2951)));
+primitive_impls!(Uuid -> (pg: (2950, 2951)));
 
-#[derive(FromSqlRow)]
+#[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
+#[sql_type = "Uuid"]
 #[allow(dead_code)]
 struct UuidProxy(uuid::Uuid);
 

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use sqlite::{Sqlite, SqliteType};
 use sqlite::connection::SqliteValue;
-use types::{self, Date, FromSql, HasSqlType, IsNull, Time, Timestamp, ToSql, ToSqlOutput};
+use types::{self, FromSql, HasSqlType, IsNull, ToSql, ToSqlOutput};
 
 #[cfg(feature = "chrono")]
 mod chrono;
@@ -25,13 +25,6 @@ impl HasSqlType<types::Timestamp> for Sqlite {
         SqliteType::Text
     }
 }
-
-expression_impls!(Date -> String);
-expression_impls!(Date -> str, unsized);
-expression_impls!(Time -> String);
-expression_impls!(Time -> str, unsized);
-expression_impls!(Timestamp -> String);
-expression_impls!(Timestamp -> str, unsized);
 
 impl FromSql<types::Date, Sqlite> for String {
     fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {

--- a/diesel/src/types/impls/date_and_time.rs
+++ b/diesel/src/types/impls/date_and_time.rs
@@ -2,8 +2,9 @@
 
 use std::time::SystemTime;
 
-#[derive(FromSqlRow)]
+#[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
+#[sql_type = "::types::Timestamp"]
 struct SystemTimeProxy(SystemTime);
 
 #[cfg(feature = "chrono")]
@@ -12,23 +13,25 @@ mod chrono {
     use self::chrono::*;
     use types::{Date, Time, Timestamp};
 
-    expression_impls!(Date -> NaiveDate);
-    expression_impls!(Time -> NaiveTime);
-    expression_impls!(Timestamp -> NaiveDateTime);
-
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Date"]
     struct NaiveDateProxy(NaiveDate);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Time"]
     struct NaiveTimeProxy(NaiveTime);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Timestamp"]
+    #[cfg_attr(feature = "postgres", sql_type = "::types::Timestamptz")]
+    #[cfg_attr(feature = "mysql", sql_type = "::types::Datetime")]
     struct NaiveDateTimeProxy(NaiveDateTime);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[cfg_attr(feature = "postgres", sql_type = "::types::Timestamptz")]
     struct DateTimeProxy<Tz: TimeZone>(DateTime<Tz>);
 }

--- a/diesel/src/types/impls/decimal.rs
+++ b/diesel/src/types/impls/decimal.rs
@@ -6,9 +6,8 @@ mod bigdecimal {
     use self::bigdecimal::BigDecimal;
     use types::Numeric;
 
-    expression_impls!(Numeric -> BigDecimal);
-
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Numeric"]
     struct BigDecimalProxy(BigDecimal);
 }

--- a/diesel/src/types/impls/mod.rs
+++ b/diesel/src/types/impls/mod.rs
@@ -15,73 +15,6 @@ macro_rules! not_none {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! expression_impls {
-    ($Source:ident -> $Target:ty) => {
-        expression_impls!($Source -> $Target, unsized);
-
-        impl $crate::expression::AsExpression<$Source> for $Target {
-            type Expression = $crate::expression::bound::Bound<$Source, Self>;
-
-            fn as_expression(self) -> Self::Expression {
-                $crate::expression::bound::Bound::new(self)
-            }
-        }
-
-        impl $crate::expression::AsExpression<$crate::types::Nullable<$Source>> for $Target {
-            type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$Source>, Self>;
-
-            fn as_expression(self) -> Self::Expression {
-                $crate::expression::bound::Bound::new(self)
-            }
-        }
-    };
-
-    ($Source:ident -> $Target:ty, unsized) => {
-        impl<'expr> $crate::expression::AsExpression<$Source> for &'expr $Target {
-            type Expression = $crate::expression::bound::Bound<$Source, Self>;
-
-            fn as_expression(self) -> Self::Expression {
-                $crate::expression::bound::Bound::new(self)
-            }
-        }
-
-        impl<'expr, 'expr2> $crate::expression::AsExpression<$Source> for &'expr2 &'expr $Target {
-            type Expression = $crate::expression::bound::Bound<$Source, Self>;
-
-            fn as_expression(self) -> Self::Expression {
-                $crate::expression::bound::Bound::new(self)
-            }
-        }
-
-        impl<'expr> $crate::expression::AsExpression<$crate::types::Nullable<$Source>> for &'expr $Target {
-            type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$Source>, Self>;
-
-            fn as_expression(self) -> Self::Expression {
-                $crate::expression::bound::Bound::new(self)
-            }
-        }
-
-        impl<'expr, 'expr2> $crate::expression::AsExpression<$crate::types::Nullable<$Source>> for &'expr2 &'expr $Target {
-            type Expression = $crate::expression::bound::Bound<$crate::types::Nullable<$Source>, Self>;
-
-            fn as_expression(self) -> Self::Expression {
-                $crate::expression::bound::Bound::new(self)
-            }
-        }
-
-        impl<DB> $crate::types::ToSql<$crate::types::Nullable<$Source>, DB> for $Target where
-            DB: $crate::backend::Backend + $crate::types::HasSqlType<$Source>,
-            $Target: $crate::types::ToSql<$Source, DB>,
-        {
-            fn to_sql<W: ::std::io::Write>(&self, out: &mut $crate::types::ToSqlOutput<W, DB>) -> ::std::result::Result<$crate::types::IsNull, Box<::std::error::Error+Send+Sync>> {
-                $crate::types::ToSql::<$Source, DB>::to_sql(self, out)
-            }
-        }
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
 macro_rules! primitive_impls {
     ($Source:ident -> (, $($rest:tt)*)) => {
         primitive_impls!($Source -> ($($rest)*));
@@ -125,16 +58,7 @@ macro_rules! primitive_impls {
 
     // Done implementing type metadata, no body
     ($Source:ident -> ()) => {
-    };
-
-    ($Source:ident -> ($Target:ty, $($rest:tt)+)) => {
-        primitive_impls!($Source -> $Target);
-        primitive_impls!($Source -> ($($rest)+));
-    };
-
-    ($Source:ident -> $Target:ty) => {
         primitive_impls!($Source);
-        expression_impls!($Source -> $Target);
     };
 
     ($Source:ident) => {

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -5,68 +5,97 @@ use backend::Backend;
 use types::{self, BigInt, Binary, Bool, Date, Double, Float, FromSql, HasSqlType, Integer, IsNull,
             NotNull, SmallInt, Text, Time, Timestamp, ToSql, ToSqlOutput};
 
-primitive_impls!(Bool -> (bool, pg: (16, 1000), sqlite: (Integer), mysql: (Tiny)));
+primitive_impls!(Bool -> (pg: (16, 1000), sqlite: (Integer), mysql: (Tiny)));
 
-primitive_impls!(SmallInt -> (i16, pg: (21, 1005), sqlite: (SmallInt), mysql: (Short)));
-primitive_impls!(Integer -> (i32, pg: (23, 1007), sqlite: (Integer), mysql: (Long)));
-primitive_impls!(BigInt -> (i64, pg: (20, 1016), sqlite: (Long), mysql: (LongLong)));
+primitive_impls!(SmallInt -> (pg: (21, 1005), sqlite: (SmallInt), mysql: (Short)));
+primitive_impls!(Integer -> (pg: (23, 1007), sqlite: (Integer), mysql: (Long)));
+primitive_impls!(BigInt -> (pg: (20, 1016), sqlite: (Long), mysql: (LongLong)));
 
-primitive_impls!(Float -> (f32, pg: (700, 1021), sqlite: (Float), mysql: (Float)));
-primitive_impls!(Double -> (f64, pg: (701, 1022), sqlite: (Double), mysql: (Double)));
+primitive_impls!(Float -> (pg: (700, 1021), sqlite: (Float), mysql: (Float)));
+primitive_impls!(Double -> (pg: (701, 1022), sqlite: (Double), mysql: (Double)));
 
-primitive_impls!(Text -> (String, pg: (25, 1009), sqlite: (Text), mysql: (String)));
+primitive_impls!(Text -> (pg: (25, 1009), sqlite: (Text), mysql: (String)));
 
-primitive_impls!(Binary -> (Vec<u8>, pg: (17, 1001), sqlite: (Binary), mysql: (Blob)));
+primitive_impls!(Binary -> (pg: (17, 1001), sqlite: (Binary), mysql: (Blob)));
 
-primitive_impls!(Date);
-primitive_impls!(Time);
-primitive_impls!(Timestamp);
+primitive_impls!(Date -> (pg: (1082, 1182)));
+primitive_impls!(Time -> (pg: (1083, 1183)));
+primitive_impls!(Timestamp -> (pg: (1114, 1115)));
 
 #[allow(dead_code)]
 mod foreign_impls {
-    #[derive(FromSqlRow)]
+    use super::*;
+
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Bool"]
     struct BoolProxy(bool);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[cfg_attr(feature = "mysql", sql_type = "types::Tinyint")]
     struct I8Proxy(i8);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "SmallInt"]
     struct I16Proxy(i16);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Integer"]
     struct I32Proxy(i32);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "BigInt"]
     struct I64Proxy(i64);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[cfg_attr(feature = "postgres", sql_type = "::types::Oid")]
     struct U32Proxy(u32);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Float"]
     struct F32Proxy(f32);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Double"]
     struct F64Proxy(f64);
 
-    #[derive(FromSqlRow)]
+    #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[sql_type = "Text"]
+    #[cfg_attr(feature = "sqlite", sql_type = "Date")]
+    #[cfg_attr(feature = "sqlite", sql_type = "Time")]
+    #[cfg_attr(feature = "sqlite", sql_type = "Timestamp")]
     struct StringProxy(String);
+
+    #[derive(AsExpression)]
+    #[diesel(foreign_derive, not_sized)]
+    #[sql_type = "Text"]
+    #[cfg_attr(feature = "sqlite", sql_type = "Date")]
+    #[cfg_attr(feature = "sqlite", sql_type = "Time")]
+    #[cfg_attr(feature = "sqlite", sql_type = "Timestamp")]
+    struct StrProxy(str);
 
     #[derive(FromSqlRow)]
     #[diesel(foreign_derive)]
     struct VecProxy<T>(Vec<T>);
-}
 
-expression_impls!(Text -> str, unsized);
-expression_impls!(Binary -> [u8], unsized);
+    #[derive(AsExpression)]
+    #[diesel(foreign_derive)]
+    #[sql_type = "Binary"]
+    struct BinaryVecProxy(Vec<u8>);
+
+    #[derive(AsExpression)]
+    #[diesel(foreign_derive, not_sized)]
+    #[sql_type = "Binary"]
+    struct BinarySliceProxy([u8]);
+}
 
 impl NotNull for () {}
 

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -622,6 +622,8 @@ where
 /// database, you should use `i32::to_sql(x, out)` instead of writing to `out`
 /// yourself.
 ///
+/// Any types which implement this trait should also `#[derive(AsExpression)]`.
+///
 /// ### Backend specific details
 ///
 /// - For PostgreSQL, the bytes will be sent using the binary protocol, not text.

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -1,0 +1,112 @@
+use quote::Tokens;
+use syn;
+
+use util::*;
+
+pub fn derive(item: syn::DeriveInput) -> Tokens {
+    let item_name = item.ident.as_ref().to_uppercase();
+    let is_sized = !flag_present(&item.attrs, "not_sized");
+    let sql_types = item.attrs
+        .iter()
+        .filter(|attr| attr.name() == "sql_type")
+        .map(|attr| ty_value_of_attr(attr, "sql_type"));
+
+    let struct_ty = if flag_present(&item.attrs, "foreign_derive") {
+        match item.body {
+            syn::Body::Struct(ref body) => body.fields()[0].ty.clone(),
+            _ => panic!("foreign_derive cannot be used on enums"),
+        }
+    } else {
+        struct_ty(item.ident.clone(), &item.generics)
+    };
+
+    let generics = &item.generics;
+    let syn::Generics {
+        ref lifetimes,
+        ref ty_params,
+        ..
+    } = *generics;
+
+    let tokens = sql_types.map(|sql_type| {
+        let tokens = quote!(
+            impl<'expr, #(#lifetimes,)* #(#ty_params,)*> diesel::expression::AsExpression<#sql_type>
+                for &'expr #struct_ty
+            {
+                type Expression = diesel::expression::bound::Bound<#sql_type, Self>;
+
+                fn as_expression(self) -> Self::Expression {
+                    diesel::expression::bound::Bound::new(self)
+                }
+            }
+
+            impl<'expr, #(#lifetimes,)* #(#ty_params,)*> diesel::expression::AsExpression<diesel::types::Nullable<#sql_type>>
+                for &'expr #struct_ty
+            {
+                type Expression = diesel::expression::bound::Bound<diesel::types::Nullable<#sql_type>, Self>;
+
+                fn as_expression(self) -> Self::Expression {
+                    diesel::expression::bound::Bound::new(self)
+                }
+            }
+
+            impl<'expr2, 'expr, #(#lifetimes,)* #(#ty_params,)*> diesel::expression::AsExpression<#sql_type>
+                for &'expr2 &'expr #struct_ty
+            {
+                type Expression = diesel::expression::bound::Bound<#sql_type, Self>;
+
+                fn as_expression(self) -> Self::Expression {
+                    diesel::expression::bound::Bound::new(self)
+                }
+            }
+
+            impl<'expr2, 'expr, #(#lifetimes,)* #(#ty_params,)*> diesel::expression::AsExpression<diesel::types::Nullable<#sql_type>>
+                for &'expr2 &'expr #struct_ty
+            {
+                type Expression = diesel::expression::bound::Bound<diesel::types::Nullable<#sql_type>, Self>;
+
+                fn as_expression(self) -> Self::Expression {
+                    diesel::expression::bound::Bound::new(self)
+                }
+            }
+
+            impl<#(#lifetimes,)* #(#ty_params,)* __DB> diesel::types::ToSql<diesel::types::Nullable<#sql_type>, __DB>
+                for #struct_ty
+            where
+                __DB: diesel::backend::Backend + diesel::types::HasSqlType<#sql_type>,
+                Self: diesel::types::ToSql<#sql_type, __DB>,
+            {
+                fn to_sql<W: ::std::io::Write>(&self, out: &mut diesel::types::ToSqlOutput<W, __DB>) -> ::std::result::Result<diesel::types::IsNull, Box<::std::error::Error + Send + Sync>> {
+                    diesel::types::ToSql::<#sql_type, __DB>::to_sql(self, out)
+                }
+            }
+        );
+        if is_sized {
+            quote!(
+                #tokens
+
+                impl#generics diesel::expression::AsExpression<#sql_type> for #struct_ty {
+                    type Expression = diesel::expression::bound::Bound<#sql_type, Self>;
+
+                    fn as_expression(self) -> Self::Expression {
+                        diesel::expression::bound::Bound::new(self)
+                    }
+                }
+
+                impl#generics diesel::expression::AsExpression<diesel::types::Nullable<#sql_type>> for #struct_ty {
+                    type Expression = diesel::expression::bound::Bound<diesel::types::Nullable<#sql_type>, Self>;
+
+                    fn as_expression(self) -> Self::Expression {
+                        diesel::expression::bound::Bound::new(self)
+                    }
+                }
+            )
+        } else {
+            tokens
+        }
+    });
+
+    wrap_item_in_const(
+        format!("_IMPL_AS_EXPRESSION_FOR_{}", item_name).into(),
+        quote!(#(#tokens)*),
+    )
+}

--- a/diesel_derives/src/attr.rs
+++ b/diesel_derives/src/attr.rs
@@ -19,8 +19,7 @@ impl Attr {
         let column_name = ident_value_of_attr_with_name(&field.attrs, "column_name")
             .or_else(|| field_name.clone());
         let ty = field.ty.clone();
-        let sql_type = str_value_of_attr_with_name(&field.attrs, "sql_type")
-            .map(|st| syn::parse::ty(st).expect("#[sql_type] did not contain a valid Rust type"));
+        let sql_type = ty_value_of_attr_with_name(&field.attrs, "sql_type");
         let flags = list_value_of_attr_with_name(&field.attrs, "diesel")
             .unwrap_or_else(Vec::new)
             .into_iter()

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -25,6 +25,7 @@ extern crate quote;
 extern crate syn;
 
 mod as_changeset;
+mod as_expression;
 mod associations;
 mod ast_builder;
 mod attr;
@@ -79,6 +80,11 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(FromSqlRow, attributes(diesel))]
 pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
     expand_derive(input, from_sql_row::derive)
+}
+
+#[proc_macro_derive(AsExpression, attributes(diesel, sql_type))]
+pub fn derive_from_as_expression(input: TokenStream) -> TokenStream {
+    expand_derive(input, as_expression::derive)
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::DeriveInput) -> quote::Tokens) -> TokenStream {

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -34,8 +34,8 @@ pub fn struct_ty(name: Ident, generics: &Generics) -> Ty {
     )
 }
 
-pub fn str_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Option<&'a str> {
-    attr_with_name(attrs, name).map(|attr| str_value_of_attr(attr, name))
+pub fn ty_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Option<Ty> {
+    attr_with_name(attrs, name).map(|attr| ty_value_of_attr(attr, name))
 }
 
 pub fn ident_value_of_attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Option<Ident> {
@@ -78,6 +78,11 @@ pub fn attr_with_name<'a>(attrs: &'a [Attribute], name: &str) -> Option<&'a Attr
 
 fn str_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> &'a str {
     str_value_of_meta_item(&attr.value, name)
+}
+
+pub fn ty_value_of_attr<'a>(attr: &'a Attribute, name: &str) -> Ty {
+    parse::ty(str_value_of_attr(attr, name))
+        .expect(&format!("#[{}] did not contain a valid Rust type", name))
 }
 
 pub fn str_value_of_meta_item<'a>(item: &'a MetaItem, name: &str) -> &'a str {

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -13,15 +13,14 @@ table! {
 
 pub struct MyType;
 
-#[derive(Debug, PartialEq, FromSqlRow)]
+#[derive(Debug, PartialEq, FromSqlRow, AsExpression)]
+#[sql_type = "MyType"]
 pub enum MyEnum {
     Foo,
     Bar,
 }
 
 mod impls_for_insert_and_query {
-    use diesel::expression::AsExpression;
-    use diesel::expression::bound::Bound;
     use diesel::pg::Pg;
     use diesel::types::*;
     use std::error::Error;
@@ -37,14 +36,6 @@ mod impls_for_insert_and_query {
 
     impl NotNull for MyType {}
     impl SingleValue for MyType {}
-
-    impl<'a> AsExpression<MyType> for &'a MyEnum {
-        type Expression = Bound<MyType, &'a MyEnum>;
-
-        fn as_expression(self) -> Self::Expression {
-            Bound::new(self)
-        }
-    }
 
     impl ToSql<MyType, Pg> for MyEnum {
         fn to_sql<W: Write>(


### PR DESCRIPTION
The nullable `ToSql` impl feels funky here,
but I've left it there to keep parity with the old macro.
Similar to `FromSqlRow`, there is an undocumented `foreign_derive` flag.
Any external crates attempting to use that flag would actually fail to
compile,
since `impl AsExpression<Nullable<Type>, DB> for NotLocal` is a
coherence violation.

This derive does not work for types which need to be generic on the SQL
type, so `Option`, arrays, and ranges can't use it.