### PR TITLE
Remove the `HasSqlType` bound everywhere it's not required

### DIFF
--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -2,7 +2,7 @@ use backend::Backend;
 use expression::Expression;
 use query_builder::*;
 use result::QueryResult;
-use types::{Foldable, HasSqlType};
+use types::Foldable;
 
 macro_rules! fold_function {
     ($fn_name:ident, $type_name:ident, $operator:expr, $docs:expr) => {
@@ -31,7 +31,7 @@ macro_rules! fold_function {
 
         impl<T, DB> QueryFragment<DB> for $type_name<T> where
             T: Expression + QueryFragment<DB>,
-            DB: Backend + HasSqlType<T::SqlType>,
+            DB: Backend,
         {
             fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                 out.push_sql(concat!($operator, "("));

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -2,7 +2,7 @@ use backend::Backend;
 use expression::Expression;
 use query_builder::*;
 use result::QueryResult;
-use types::{HasSqlType, IntoNullable, SqlOrd};
+use types::{IntoNullable, SqlOrd};
 
 macro_rules! ord_function {
     ($fn_name:ident, $type_name:ident, $operator:expr, $docs:expr) => {
@@ -30,7 +30,7 @@ macro_rules! ord_function {
 
         impl<T, DB> QueryFragment<DB> for $type_name<T> where
             T: Expression + QueryFragment<DB>,
-            DB: Backend + HasSqlType<T::SqlType>,
+            DB: Backend,
         {
             fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                 out.push_sql(concat!($operator, "("));

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -5,7 +5,6 @@ use expression::*;
 use query_builder::*;
 use query_dsl::RunQueryDsl;
 use result::QueryResult;
-use types::HasSqlType;
 
 #[derive(Debug, Clone)]
 /// Returned by the [`sql()`] function.
@@ -32,7 +31,7 @@ impl<ST> Expression for SqlLiteral<ST> {
 
 impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST>
 where
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();

--- a/diesel/src/mysql/types/numeric.rs
+++ b/diesel/src/mysql/types/numeric.rs
@@ -5,11 +5,11 @@ pub mod bigdecimal {
     use std::error::Error;
     use std::io::prelude::*;
 
-    use mysql::{Mysql, MysqlType};
+    use mysql::Mysql;
 
     use self::bigdecimal::BigDecimal;
 
-    use types::{self, FromSql, HasSqlType, IsNull, ToSql, ToSqlOutput};
+    use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
 
     impl ToSql<types::Numeric, Mysql> for BigDecimal {
         fn to_sql<W: Write>(
@@ -27,12 +27,6 @@ pub mod bigdecimal {
             let bytes = not_none!(bytes);
             BigDecimal::parse_bytes(bytes, 10)
                 .ok_or_else(|| Box::from(format!("{:?} is not valid decimal number ", bytes)))
-        }
-    }
-
-    impl HasSqlType<BigDecimal> for Mysql {
-        fn metadata(_: &()) -> MysqlType {
-            MysqlType::String
         }
     }
 }

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -4,7 +4,7 @@ use result::Error::DeserializationError;
 use result::QueryResult;
 use super::result::PgResult;
 use super::row::PgNamedRow;
-use types::{FromSqlRow, HasSqlType};
+use types::FromSqlRow;
 
 use std::marker::PhantomData;
 
@@ -29,7 +29,6 @@ impl<ST, T> Cursor<ST, T> {
 
 impl<ST, T> Iterator for Cursor<ST, T>
 where
-    Pg: HasSqlType<ST>,
     T: Queryable<ST, Pg>,
 {
     type Item = QueryResult<T>;

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -25,7 +25,6 @@ impl<T> SingleValue for Array<T> {}
 impl<T, ST> FromSql<Array<ST>, Pg> for Vec<T>
 where
     T: FromSql<ST, Pg>,
-    Pg: HasSqlType<ST>,
 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
         let mut bytes = not_none!(bytes);
@@ -67,9 +66,7 @@ use expression::bound::Bound;
 
 macro_rules! array_as_expression {
     ($ty:ty, $sql_type:ty) => {
-        impl<'a, 'b, ST, T> AsExpression<$sql_type> for $ty where
-            Pg: HasSqlType<ST>,
-        {
+        impl<'a, 'b, ST, T> AsExpression<$sql_type> for $ty {
             type Expression = Bound<$sql_type, Self>;
 
             fn as_expression(self) -> Self::Expression {
@@ -128,7 +125,6 @@ where
 
 impl<ST, T> ToSql<Nullable<Array<ST>>, Pg> for [T]
 where
-    Pg: HasSqlType<ST>,
     [T]: ToSql<Array<ST>, Pg>,
 {
     fn to_sql<W: Write>(
@@ -141,7 +137,6 @@ where
 
 impl<ST, T> ToSql<Array<ST>, Pg> for Vec<T>
 where
-    Pg: HasSqlType<ST>,
     [T]: ToSql<Array<ST>, Pg>,
     T: fmt::Debug,
 {
@@ -155,7 +150,6 @@ where
 
 impl<ST, T> ToSql<Nullable<Array<ST>>, Pg> for Vec<T>
 where
-    Pg: HasSqlType<ST>,
     Vec<T>: ToSql<Array<ST>, Pg>,
 {
     fn to_sql<W: Write>(

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -26,7 +26,6 @@ bitflags! {
 impl<T, ST> Queryable<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg> + Queryable<ST, Pg>,
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
 {
     type Row = Self;
     fn build(row: Self) -> Self {
@@ -34,10 +33,7 @@ where
     }
 }
 
-impl<ST, T> AsExpression<Range<ST>> for (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
-{
+impl<ST, T> AsExpression<Range<ST>> for (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Range<ST>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -45,10 +41,7 @@ where
     }
 }
 
-impl<'a, ST, T> AsExpression<Range<ST>> for &'a (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<Range<ST>>,
-{
+impl<'a, ST, T> AsExpression<Range<ST>> for &'a (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Range<ST>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -56,10 +49,7 @@ where
     }
 }
 
-impl<ST, T> AsExpression<Nullable<Range<ST>>> for (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<Range<ST>>,
-{
+impl<ST, T> AsExpression<Nullable<Range<ST>>> for (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Nullable<Range<ST>>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -67,10 +57,7 @@ where
     }
 }
 
-impl<'a, ST, T> AsExpression<Nullable<Range<ST>>> for &'a (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<Range<ST>>,
-{
+impl<'a, ST, T> AsExpression<Nullable<Range<ST>>> for &'a (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Nullable<Range<ST>>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -81,7 +68,6 @@ where
 impl<T, ST> FromSqlRow<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     (Bound<T>, Bound<T>): FromSql<Range<ST>, Pg>,
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
 {
     fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error + Send + Sync>> {
         FromSql::<Range<ST>, Pg>::from_sql(row.take())
@@ -91,7 +77,6 @@ where
 impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg>,
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
         let mut bytes = not_none!(bytes);
@@ -129,7 +114,6 @@ where
 
 impl<ST, T> ToSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
     T: ToSql<ST, Pg>,
 {
     fn to_sql<W: Write>(
@@ -178,7 +162,6 @@ where
 
 impl<ST, T> ToSql<Nullable<Range<ST>>, Pg> for (Bound<T>, Bound<T>)
 where
-    Pg: HasSqlType<Range<ST>>,
     (Bound<T>, Bound<T>): ToSql<Range<ST>, Pg>,
 {
     fn to_sql<W: Write>(

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -14,7 +14,7 @@ use query_dsl::methods::*;
 use query_source::QuerySource;
 use query_source::joins::*;
 use result::QueryResult;
-use types::{BigInt, Bool, HasSqlType};
+use types::{BigInt, Bool};
 
 #[allow(missing_debug_implementations)]
 pub struct BoxedSelectStatement<'a, ST, QS, DB> {
@@ -58,7 +58,6 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
 impl<'a, ST, QS, DB> Query for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    DB: HasSqlType<ST>,
 {
     type SqlType = ST;
 }
@@ -166,7 +165,7 @@ where
 
 impl<'a, ST, QS, DB, Selection> SelectDsl<Selection> for BoxedSelectStatement<'a, ST, QS, DB>
 where
-    DB: Backend + HasSqlType<Selection::SqlType>,
+    DB: Backend,
     Selection: SelectableExpression<QS> + QueryFragment<DB> + 'a,
 {
     type Output = BoxedSelectStatement<'a, Selection::SqlType, QS, DB>;
@@ -187,7 +186,7 @@ where
 
 impl<'a, ST, QS, DB, Predicate> FilterDsl<Predicate> for BoxedSelectStatement<'a, ST, QS, DB>
 where
-    DB: Backend + HasSqlType<ST> + 'a,
+    DB: Backend + 'a,
     Predicate: AppearsOnTable<QS, SqlType = Bool> + NonAggregate,
     Predicate: QueryFragment<DB> + 'a,
 {

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -13,7 +13,7 @@ use backend::Backend;
 use expression::{Expression, NonAggregate, SelectableExpression};
 use query_builder::*;
 use row::NamedRow;
-use types::{FromSqlRow, HasSqlType};
+use types::FromSqlRow;
 
 pub use self::joins::JoinTo;
 pub use self::peano_numbers::*;
@@ -108,7 +108,7 @@ pub use self::peano_numbers::*;
 /// # }
 pub trait Queryable<ST, DB>
 where
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
 {
     /// The Rust type you'd like to map from.
     ///
@@ -123,7 +123,7 @@ where
 //
 // impl<T, ST, DB> Queryable<ST, DB> for T
 // where
-//     DB: Backend + HasSqlType<ST>,
+//     DB: Backend,
 //     T: FromSqlRow<ST, DB>,
 // {
 //     type Row = Self;

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 
 use backend::Backend;
-use types::{FromSql, HasSqlType};
+use types::FromSql;
 
 /// Represents a single database row.
 /// Apps should not need to concern themselves with this trait.
@@ -48,7 +48,6 @@ pub trait NamedRow<DB: Backend> {
     /// this function is undefined.
     fn get<ST, T>(&self, column_name: &str) -> Result<T, Box<Error + Send + Sync>>
     where
-        DB: HasSqlType<ST>,
         T: FromSql<ST, DB>,
     {
         let idx = self.index_of(column_name)

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -6,7 +6,7 @@ use result::Error::DeserializationError;
 use result::QueryResult;
 use sqlite::Sqlite;
 use super::stmt::StatementUse;
-use types::{FromSqlRow, HasSqlType};
+use types::FromSqlRow;
 
 pub struct StatementIterator<'a, ST, T> {
     stmt: StatementUse<'a>,
@@ -24,7 +24,6 @@ impl<'a, ST, T> StatementIterator<'a, ST, T> {
 
 impl<'a, ST, T> Iterator for StatementIterator<'a, ST, T>
 where
-    Sqlite: HasSqlType<ST>,
     T: Queryable<ST, Sqlite>,
 {
     type Item = QueryResult<T>;

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -36,7 +36,7 @@ where
 impl<T, ST, DB> FromSql<Nullable<ST>, DB> for Option<T>
 where
     T: FromSql<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     ST: NotNull,
 {
     fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>> {
@@ -50,7 +50,7 @@ where
 impl<T, ST, DB> Queryable<Nullable<ST>, DB> for Option<T>
 where
     T: Queryable<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     Option<T::Row>: FromSqlRow<Nullable<ST>, DB>,
     ST: NotNull,
 {
@@ -81,7 +81,7 @@ where
 impl<T, ST, DB> FromSqlRow<Nullable<ST>, DB> for Option<T>
 where
     T: FromSqlRow<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     ST: NotNull,
 {
     const FIELDS_NEEDED: usize = T::FIELDS_NEEDED;
@@ -100,7 +100,7 @@ where
 impl<T, ST, DB> ToSql<Nullable<ST>, DB> for Option<T>
 where
     T: ToSql<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     ST: NotNull,
 {
     fn to_sql<W: Write>(

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -2,8 +2,8 @@ use std::error::Error;
 use std::io::Write;
 
 use backend::Backend;
-use types::{self, BigInt, Binary, Bool, Double, Float, FromSql, HasSqlType, Integer, IsNull,
-            NotNull, SmallInt, Text, ToSql, ToSqlOutput};
+use types::{self, BigInt, Binary, Bool, Double, Float, FromSql, Integer, IsNull, NotNull,
+            SmallInt, Text, ToSql, ToSqlOutput};
 
 #[allow(dead_code)]
 mod foreign_impls {
@@ -147,7 +147,7 @@ use std::borrow::{Cow, ToOwned};
 impl<'a, T: ?Sized, ST, DB> ToSql<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned + ToSql<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     T::Owned: ToSql<ST, DB>,
 {
     fn to_sql<W: Write>(
@@ -164,7 +164,7 @@ where
 impl<'a, T: ?Sized, ST, DB> FromSql<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     T::Owned: FromSql<ST, DB>,
 {
     fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>> {
@@ -175,7 +175,7 @@ where
 impl<'a, T: ?Sized, ST, DB> ::types::FromSqlRow<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     Cow<'a, T>: FromSql<ST, DB>,
 {
     fn build_from_row<R: ::row::Row<DB>>(row: &mut R) -> Result<Self, Box<Error + Send + Sync>> {
@@ -186,7 +186,7 @@ where
 impl<'a, T: ?Sized, ST, DB> ::Queryable<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     Self: ::types::FromSqlRow<ST, DB>,
 {
     type Row = Self;

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -37,8 +37,6 @@ macro_rules! tuple_impls {
             impl<$($T),+, $($ST),+, DB> FromSqlRow<($($ST,)+), DB> for ($($T,)+) where
                 DB: Backend,
                 $($T: FromSqlRow<$ST, DB>),+,
-                $(DB: HasSqlType<$ST>),+,
-                DB: HasSqlType<($($ST,)+)>,
             {
                 const FIELDS_NEEDED: usize = $($T::FIELDS_NEEDED +)+ 0;
 
@@ -50,8 +48,6 @@ macro_rules! tuple_impls {
             impl<$($T),+, $($ST),+, DB> Queryable<($($ST,)+), DB> for ($($T,)+) where
                 DB: Backend,
                 $($T: Queryable<$ST, DB>),+,
-                $(DB: HasSqlType<$ST>),+,
-                DB: HasSqlType<($($ST,)+)>,
             {
                 type Row = ($($T::Row,)+);
 

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -498,7 +498,7 @@ impl<T: NotNull + SingleValue> SingleValue for Nullable<T> {}
 /// - For third party backends, consult that backend's documentation.
 ///
 /// [`MysqlType`]: ../mysql/enum.MysqlType.html
-pub trait FromSql<A, DB: Backend + HasSqlType<A>>: Sized {
+pub trait FromSql<A, DB: Backend>: Sized {
     /// See the trait documentation.
     fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>>;
 }
@@ -519,7 +519,7 @@ pub trait FromSql<A, DB: Backend + HasSqlType<A>>: Sized {
 /// for any type which implements `FromSql`.
 /// There are no options or special considerations needed for this derive.
 /// Note that `#[derive(FromSqlRow)]` will also generate a `Queryable` implementation.
-pub trait FromSqlRow<A, DB: Backend + HasSqlType<A>>: Sized {
+pub trait FromSqlRow<A, DB: Backend>: Sized {
     /// The number of fields that this type will consume. Must be equal to
     /// the number of times you would call `row.take()` in `build_from_row`
     const FIELDS_NEEDED: usize = 1;
@@ -704,7 +704,7 @@ where
 /// - For third party backends, consult that backend's documentation.
 ///
 /// [`MysqlType`]: ../mysql/enum.MysqlType.html
-pub trait ToSql<A, DB: Backend + HasSqlType<A>>: fmt::Debug {
+pub trait ToSql<A, DB: Backend>: fmt::Debug {
     /// See the trait documentation.
     fn to_sql<W: Write>(
         &self,
@@ -714,7 +714,7 @@ pub trait ToSql<A, DB: Backend + HasSqlType<A>>: fmt::Debug {
 
 impl<'a, A, T, DB> ToSql<A, DB> for &'a T
 where
-    DB: Backend + HasSqlType<A>,
+    DB: Backend,
     T: ToSql<A, DB> + ?Sized,
 {
     fn to_sql<W: Write>(

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -24,7 +24,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
         quote!(
             impl#generics diesel::types::FromSqlRow<__ST, __DB> for #struct_ty
             where
-                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                __DB: diesel::backend::Backend,
                 Self: diesel::types::FromSql<__ST, __DB>,
             {
                 fn build_from_row<R: diesel::row::Row<__DB>>(row: &mut R)
@@ -36,7 +36,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
 
             impl#generics diesel::query_source::Queryable<__ST, __DB> for #struct_ty
             where
-                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                __DB: diesel::backend::Backend,
                 Self: diesel::types::FromSqlRow<__ST, __DB>,
             {
                 type Row = Self;

--- a/diesel_derives/src/queryable.rs
+++ b/diesel_derives/src/queryable.rs
@@ -22,7 +22,7 @@ pub fn derive_queryable(item: syn::DeriveInput) -> Tokens {
         model.dummy_const_name("QUERYABLE"),
         quote!(
             impl#generics diesel::Queryable<__ST, __DB> for #struct_ty where
-                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                __DB: diesel::backend::Backend,
                 #row_ty: diesel::Queryable<__ST, __DB>,
             {
                type Row = <#row_ty as diesel::Queryable<__ST, __DB>>::Row;

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -20,7 +20,6 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
         } else {
             let st = sql_type(attr, &model);
             quote!(
-                __DB: diesel::types::HasSqlType<#st>,
                 #attr_ty: diesel::types::FromSql<#st, __DB>,
             )
         }

--- a/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
@@ -3,7 +3,7 @@ use diesel::*;
 use diesel::backend::Backend;
 #[cfg(feature = "sqlite")]
 use diesel::sqlite::Sqlite;
-use diesel::types::{FromSqlRow, HasSqlType};
+use diesel::types::FromSqlRow;
 
 #[cfg(feature = "uses_information_schema")]
 use super::information_schema::UsesInformationSchema;
@@ -69,7 +69,7 @@ impl ColumnInformation {
 #[cfg(feature = "uses_information_schema")]
 impl<ST, DB> Queryable<ST, DB> for ColumnInformation
 where
-    DB: Backend + UsesInformationSchema + HasSqlType<ST>,
+    DB: Backend + UsesInformationSchema,
     (String, String, String): FromSqlRow<ST, DB>,
 {
     type Row = (String, String, String);
@@ -82,7 +82,6 @@ where
 #[cfg(feature = "sqlite")]
 impl<ST> Queryable<ST, Sqlite> for ColumnInformation
 where
-    Sqlite: HasSqlType<ST>,
     (i32, String, String, bool, Option<String>, bool): FromSqlRow<ST, Sqlite>,
 {
     type Row = (i32, String, String, bool, Option<String>, bool);

--- a/diesel_infer_schema/infer_schema_internals/src/table_data.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/table_data.rs
@@ -1,6 +1,6 @@
 use diesel::*;
 use diesel::backend::Backend;
-use diesel::types::{FromSqlRow, HasSqlType};
+use diesel::types::FromSqlRow;
 use std::fmt;
 use std::str::FromStr;
 
@@ -40,7 +40,7 @@ impl TableName {
 
 impl<ST, DB> Queryable<ST, DB> for TableName
 where
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     (String, String): FromSqlRow<ST, DB>,
 {
     type Row = (String, String);

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1019,7 +1019,6 @@ use diesel::query_builder::{QueryFragment, QueryId};
 
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool
 where
-    TestBackend: HasSqlType<T>,
     U: AsExpression<T> + Debug + Clone,
     U::Expression: SelectableExpression<(), SqlType = T>,
     U::Expression: QueryFragment<TestBackend> + QueryId,


### PR DESCRIPTION
Back in 0.4, this was a trait called `NativeSqlType`. I stuck it as a
bound on virtually every place a SQL type was expected, since it served
as nice documentation for "the set of types you can use here". It lived
on things like `Query` and `Expression` as well.

In 0.5 we added support for SQLite, and things got considerably more
complex. This trait could no longer appear in places that the backend
doesn't, and the "implementors" section is much more noisy and no longer
useful documentation of "what are the SQL types".

Ultimately this trait has a single concrete use, and that is to get the
metadata associated with bind parameters. So `BindCollector` needs it,
`AstPass` needs it on the methods that interact there, and `Bound` will
need it in its `QueryFragment` impl. Virtually every other place that
has that bound doesn't need it, and requiring it usually just means "oh
I have to stick this additional useless bound here that I don't know or
understand". Really the annoyance that made me want this is that you
usually wouldn't even import the trait otherwise.

One point to note here is that I was unable to remove this bound from
the `Connection` trait. This is because the MySQL connection is actually
using this bound to tell the C API what type we expect the results to
be. If I change the code to do the same thing we do for `sql_query`,
where we simply ask the database for the result types, we learn that
MySQL does a lot of things differently than we expected:

- 32 bit addition/subtraction returns a 64 bit integer
- 32 bit multiplication/division returns numeric
- 32 bit sum returns numeric
- 32 bit bind parameters are converted to 64 bit

So it turns out that we're relying on the client library to do implicit
coercion in more places than we should be. Ultimately we're going to
need to start doing those conversions ourselves if we ever want to dump
the C API. Once we start doing that, we can remove `HasSqlType` from
`Connection` (and thus also from `LoadQuery`), and then we can deprecate
the `row_metadata` method from that trait.