### PR TITLE
Change MySQL's number handling to be more permissive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Deprecated specifying a column name as `#[column_name(foo)]`. `#[column_name =
   "foo"]` should be used instead.
 
+### Changed
+
+* The structure used by MySQL for deserialization has changed. Existing
+  `FromSql` implementations may need to ensure they are using `<Mysql as
+  Backend>::RawValue` in their signature.
+
 ## [1.0.0] - 2018-01-02
 
 ### Added

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -5,6 +5,7 @@ use byteorder::NativeEndian;
 use backend::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use super::query_builder::MysqlQueryBuilder;
+use super::MysqlValue;
 
 /// The MySQL backend
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -31,6 +32,8 @@ pub enum MysqlType {
     Float,
     /// Sets `buffer_type` to `MYSQL_TYPE_DOUBLE`
     Double,
+    /// Sets `buffer_type` to `MYSQL_TYPE_NEWDECIMAL`
+    Numeric,
     /// Sets `buffer_type` to `MYSQL_TYPE_TIME`
     Time,
     /// Sets `buffer_type` to `MYSQL_TYPE_DATE`
@@ -48,7 +51,7 @@ pub enum MysqlType {
 impl Backend for Mysql {
     type QueryBuilder = MysqlQueryBuilder;
     type BindCollector = RawBytesBindCollector<Mysql>;
-    type RawValue = [u8];
+    type RawValue = MysqlValue;
     type ByteOrder = NativeEndian;
 }
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -3,7 +3,7 @@ extern crate mysqlclient_sys as ffi;
 use std::mem;
 use std::os::raw as libc;
 
-use mysql::MysqlType;
+use mysql::{MysqlType, MysqlValue};
 use result::QueryResult;
 use super::stmt::Statement;
 
@@ -80,6 +80,12 @@ impl Binds {
 
     pub fn field_data(&self, idx: usize) -> Option<&[u8]> {
         self.data[idx].bytes()
+    }
+
+    pub fn update_value<'a>(&self, value: &'a MysqlValue, idx: usize) -> Option<&'a MysqlValue> {
+        let bytes = self.data[idx].bytes();
+        let tpe = self.data[idx].tpe;
+        bytes.map(|bytes| value.update(bytes, tpe))
     }
 }
 
@@ -211,6 +217,7 @@ fn mysql_type_to_ffi_type(tpe: MysqlType) -> ffi::enum_field_types {
         MysqlType::LongLong => MYSQL_TYPE_LONGLONG,
         MysqlType::Float => MYSQL_TYPE_FLOAT,
         MysqlType::Double => MYSQL_TYPE_DOUBLE,
+        MysqlType::Numeric => MYSQL_TYPE_NEWDECIMAL,
         MysqlType::Time => MYSQL_TYPE_TIME,
         MysqlType::Date => MYSQL_TYPE_DATE,
         MysqlType::DateTime => MYSQL_TYPE_DATETIME,

--- a/diesel/src/mysql/mod.rs
+++ b/diesel/src/mysql/mod.rs
@@ -6,10 +6,12 @@
 
 mod backend;
 mod connection;
-
 mod query_builder;
+mod value;
+
 pub mod types;
 
 pub use self::backend::{Mysql, MysqlType};
 pub use self::connection::MysqlConnection;
 pub use self::query_builder::MysqlQueryBuilder;
+pub use self::value::{MysqlValue, NumericRepresentation};

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -1,11 +1,11 @@
 //! MySQL specific types
 
-#[cfg(feature = "chrono")]
 mod date_and_time;
 mod numeric;
+mod primitives;
 
 use byteorder::WriteBytesExt;
-use mysql::{Mysql, MysqlType};
+use mysql::{Mysql, MysqlType, MysqlValue};
 use std::error::Error as StdError;
 use std::io::Write;
 use types::{FromSql, HasSqlType, IsNull, Tinyint, ToSql, ToSqlOutput};
@@ -24,8 +24,8 @@ impl ToSql<::types::Tinyint, Mysql> for i8 {
 }
 
 impl FromSql<::types::Tinyint, Mysql> for i8 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError + Send + Sync>> {
-        let bytes = not_none!(bytes);
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<StdError + Send + Sync>> {
+        let bytes = not_none!(value).bytes()?;
         Ok(bytes[0] as i8)
     }
 }
@@ -41,8 +41,9 @@ impl ToSql<::types::Bool, Mysql> for bool {
 }
 
 impl FromSql<::types::Bool, Mysql> for bool {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError + Send + Sync>> {
-        Ok(not_none!(bytes).iter().any(|x| *x != 0))
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<StdError + Send + Sync>> {
+        let bytes = not_none!(value).bytes()?;
+        Ok(bytes.iter().any(|x| *x != 0))
     }
 }
 
@@ -72,7 +73,7 @@ impl HasSqlType<Datetime> for Mysql {
 
 impl HasSqlType<::types::Numeric> for Mysql {
     fn metadata(_: &()) -> MysqlType {
-        MysqlType::String
+        MysqlType::Numeric
     }
 }
 

--- a/diesel/src/mysql/types/numeric.rs
+++ b/diesel/src/mysql/types/numeric.rs
@@ -5,11 +5,11 @@ pub mod bigdecimal {
     use std::error::Error;
     use std::io::prelude::*;
 
-    use mysql::{Mysql, MysqlType};
+    use mysql::{Mysql, MysqlValue};
 
     use self::bigdecimal::BigDecimal;
 
-    use types::{self, FromSql, HasSqlType, IsNull, ToSql, ToSqlOutput};
+    use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
 
     impl ToSql<types::Numeric, Mysql> for BigDecimal {
         fn to_sql<W: Write>(
@@ -23,16 +23,20 @@ pub mod bigdecimal {
     }
 
     impl FromSql<types::Numeric, Mysql> for BigDecimal {
-        fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
-            let bytes = not_none!(bytes);
-            BigDecimal::parse_bytes(bytes, 10)
-                .ok_or_else(|| Box::from(format!("{:?} is not valid decimal number ", bytes)))
-        }
-    }
+        fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+            use mysql::NumericRepresentation::*;
 
-    impl HasSqlType<BigDecimal> for Mysql {
-        fn metadata(_: &()) -> MysqlType {
-            MysqlType::String
+            let data = not_none!(value).numeric_value()?;
+            match data {
+                Tiny(x) => Ok(x.into()),
+                Small(x) => Ok(x.into()),
+                Medium(x) => Ok(x.into()),
+                Big(x) => Ok(x.into()),
+                Float(x) => Ok(x.into()),
+                Double(x) => Ok(x.into()),
+                Decimal(bytes) => BigDecimal::parse_bytes(bytes, 10)
+                    .ok_or_else(|| format!("{:?} is not valid decimal number ", bytes).into()),
+            }
         }
     }
 }

--- a/diesel/src/mysql/types/primitives.rs
+++ b/diesel/src/mysql/types/primitives.rs
@@ -1,0 +1,115 @@
+use std::str;
+use std::error::Error;
+
+use mysql::{Mysql, MysqlValue};
+use types::{self, FromSql};
+
+impl FromSql<types::SmallInt, Mysql> for i16 {
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        use mysql::NumericRepresentation::*;
+
+        let data = not_none!(value).numeric_value()?;
+        match data {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x),
+            Medium(x) => Ok(x as Self),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x as Self),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => {
+                let string = str::from_utf8(bytes)?;
+                let integer_portion = string.split('.').nth(0).unwrap_or_default();
+                Ok(integer_portion.parse()?)
+            }
+        }
+    }
+}
+
+impl FromSql<types::Integer, Mysql> for i32 {
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        use mysql::NumericRepresentation::*;
+
+        let data = not_none!(value).numeric_value()?;
+        match data {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x as Self),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => {
+                let string = str::from_utf8(bytes)?;
+                let integer_portion = string.split('.').nth(0).unwrap_or_default();
+                Ok(integer_portion.parse()?)
+            }
+        }
+    }
+}
+
+impl FromSql<types::BigInt, Mysql> for i64 {
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        use mysql::NumericRepresentation::*;
+
+        let data = not_none!(value).numeric_value()?;
+        match data {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x.into()),
+            Big(x) => Ok(x),
+            Float(x) => Ok(x as Self),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => {
+                let string = str::from_utf8(bytes)?;
+                let integer_portion = string.split('.').nth(0).unwrap_or_default();
+                Ok(integer_portion.parse()?)
+            }
+        }
+    }
+}
+
+impl FromSql<types::Float, Mysql> for f32 {
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        use mysql::NumericRepresentation::*;
+
+        let data = not_none!(value).numeric_value()?;
+        match data {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x as Self),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => Ok(str::from_utf8(bytes)?.parse()?),
+        }
+    }
+}
+
+impl FromSql<types::Double, Mysql> for f64 {
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        use mysql::NumericRepresentation::*;
+
+        let data = not_none!(value).numeric_value()?;
+        match data {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x.into()),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x.into()),
+            Double(x) => Ok(x),
+            Decimal(bytes) => Ok(str::from_utf8(bytes)?.parse()?),
+        }
+    }
+}
+
+impl FromSql<types::Text, Mysql> for String {
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        let bytes = not_none!(value).bytes()?;
+        String::from_utf8(bytes.into()).map_err(Into::into)
+    }
+}
+
+impl FromSql<types::Binary, Mysql> for Vec<u8> {
+    fn from_sql(value: Option<&MysqlValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        not_none!(value).bytes().map(Into::into)
+    }
+}

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -1,0 +1,115 @@
+extern crate mysqlclient_sys as ffi;
+
+use byteorder::*;
+use std::cell::Cell;
+use std::error::Error;
+use std::mem;
+
+/// Represents a value returned by a MySQL server.
+///
+/// MySQL is much less strict about keeping types the same than PostgreSQL. For
+/// example, any numeric literal will be interpreted as 64-bit, and there is no
+/// way to shrink that on the server side.
+///
+/// Because of this, numeric deserialization on MySQL always needs to check the
+/// type code of what we got back, and do more permissive coercion than we would
+/// do for a stricter database.
+#[derive(Debug)]
+pub struct MysqlValue {
+    type_code: Cell<ffi::enum_field_types>,
+    /// Even though the data is definitely stored in a valid &[u8], we cannot
+    /// have a lifetime appear on this struct. While it'd be great to have this
+    /// struct just be unsized, it's virtually impossible to construct an
+    /// unsized type in Rust today without boxing.
+    data: Cell<*const [u8]>,
+}
+
+impl Default for MysqlValue {
+    fn default() -> Self {
+        Self {
+            type_code: Cell::new(ffi::enum_field_types::MYSQL_TYPE_NULL),
+            // Can't use ptr::null() here, it requires T: Sized
+            data: Cell::new(unsafe { mem::zeroed() }),
+        }
+    }
+}
+
+impl MysqlValue {
+    pub(crate) fn update(&self, bytes: &[u8], type_code: ffi::enum_field_types) -> &Self {
+        self.data.set(bytes as *const _);
+        self.type_code.set(type_code);
+        self
+    }
+
+    /// Checks that the type code is valid, and interprets the data as a
+    /// `MYSQL_TIME` pointer
+    pub fn time_value(&self) -> Result<ffi::MYSQL_TIME, Box<Error + Send + Sync>> {
+        use self::ffi::enum_field_types as t;
+
+        match self.type_code() {
+            t::MYSQL_TYPE_TIME
+            | t::MYSQL_TYPE_DATE
+            | t::MYSQL_TYPE_DATETIME
+            | t::MYSQL_TYPE_TIMESTAMP => {} // valid type code
+            _ => return Err(self.invalid_type_code("timestamp")),
+        }
+        let bytes_ptr = self.bytes()?.as_ptr() as *const ffi::MYSQL_TIME;
+        unsafe { Ok(*bytes_ptr) }
+    }
+
+    /// Returns the numeric representation of this value, based on the type code.
+    /// Returns an error if the type code is not numeric.
+    pub fn numeric_value(&self) -> Result<NumericRepresentation, Box<Error + Send + Sync>> {
+        use self::ffi::enum_field_types as t;
+        use self::NumericRepresentation::*;
+
+        let mut bytes = self.bytes()?;
+        Ok(match self.type_code() {
+            t::MYSQL_TYPE_TINY => Tiny(bytes[0] as i8),
+            t::MYSQL_TYPE_SHORT => Small(bytes.read_i16::<NativeEndian>()?),
+            t::MYSQL_TYPE_INT24 | t::MYSQL_TYPE_LONG => Medium(bytes.read_i32::<NativeEndian>()?),
+            t::MYSQL_TYPE_LONGLONG => Big(bytes.read_i64::<NativeEndian>()?),
+            t::MYSQL_TYPE_FLOAT => Float(bytes.read_f32::<NativeEndian>()?),
+            t::MYSQL_TYPE_DOUBLE => Double(bytes.read_f64::<NativeEndian>()?),
+            t::MYSQL_TYPE_DECIMAL | t::MYSQL_TYPE_NEWDECIMAL => Decimal(bytes),
+            _ => return Err(self.invalid_type_code("number")),
+        })
+    }
+
+    /// Returns the raw bytes received from the server
+    pub fn bytes(&self) -> Result<&[u8], Box<Error + Send + Sync>> {
+        let bytes = unsafe { self.data.get().as_ref() };
+        Ok(not_none!(bytes))
+    }
+
+    fn type_code(&self) -> ffi::enum_field_types {
+        self.type_code.get()
+    }
+
+    fn invalid_type_code(&self, expected: &str) -> Box<Error + Send + Sync> {
+        format!(
+            "Invalid representation received for {}: {:?}",
+            expected,
+            self.type_code()
+        ).into()
+    }
+}
+
+/// Represents all possible forms MySQL transmits integers
+#[derive(Debug, Clone, Copy)]
+pub enum NumericRepresentation<'a> {
+    /// Correponds to `MYSQL_TYPE_TINY`
+    Tiny(i8),
+    /// Correponds to `MYSQL_TYPE_SHORT`
+    Small(i16),
+    /// Correponds to `MYSQL_TYPE_INT24` and `MYSQL_TYPE_LONG`
+    Medium(i32),
+    /// Correponds to `MYSQL_TYPE_LONGLONG`
+    Big(i64),
+    /// Correponds to `MYSQL_TYPE_FLOAT`
+    Float(f32),
+    /// Correponds to `MYSQL_TYPE_DOUBLE`
+    Double(f64),
+    /// Correponds to `MYSQL_TYPE_DECIMAL` and `MYSQL_TYPE_NEWDECIMAL`
+    Decimal(&'a [u8]),
+}

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -1,22 +1,13 @@
 use diesel::*;
+use diesel::types::Integer;
 
 use test_helpers::connection;
 
-#[cfg(feature = "mysql")]
-type IntSql = ::diesel::types::BigInt;
-#[cfg(feature = "mysql")]
-type IntRust = i64;
-
-#[cfg(not(feature = "mysql"))]
-type IntSql = ::diesel::types::Integer;
-#[cfg(not(feature = "mysql"))]
-type IntRust = i32;
-
 table! {
-    use super::IntSql;
+    use super::Integer;
     my_structs (foo) {
-        foo -> IntSql,
-        bar -> IntSql,
+        foo -> Integer,
+        bar -> Integer,
     }
 }
 
@@ -25,8 +16,8 @@ fn named_struct_definition() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct MyStruct {
-        foo: IntRust,
-        bar: IntRust,
+        foo: i32,
+        bar: i32,
     }
 
     let conn = connection();
@@ -38,7 +29,7 @@ fn named_struct_definition() {
 fn tuple_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
-    struct MyStruct(#[column_name(foo)] IntRust, #[column_name(bar)] IntRust);
+    struct MyStruct(#[column_name(foo)] i32, #[column_name(bar)] i32);
 
     let conn = connection();
     let data = sql_query("SELECT 1 AS foo, 2 AS bar").get_result(&conn);
@@ -51,8 +42,8 @@ fn tuple_struct() {
 fn struct_with_no_table() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     struct MyStructNamedSoYouCantInferIt {
-        #[sql_type = "IntSql"] foo: IntRust,
-        #[sql_type = "IntSql"] bar: IntRust,
+        #[sql_type = "Integer"] foo: i32,
+        #[sql_type = "Integer"] bar: i32,
     }
 
     let conn = connection();
@@ -65,14 +56,14 @@ fn embedded_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct A {
-        foo: IntRust,
+        foo: i32,
         #[diesel(embed)] b: B,
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct B {
-        bar: IntRust,
+        bar: i32,
     }
 
     let conn = connection();
@@ -91,14 +82,14 @@ fn embedded_option() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct A {
-        foo: IntRust,
+        foo: i32,
         #[diesel(embed)] b: Option<B>,
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct B {
-        bar: IntRust,
+        bar: i32,
     }
 
     let conn = connection();


### PR DESCRIPTION
MySQL is a bit more... lax with types than other backends. It's very
easy to accidentally get a 64 bit integer or decimal when other backends
would continue to give you a 32 bit integer. Right now we're relying on
conversion happening in `libmysqlclient` for `query_by_index`. If we
ever want to dump `libmysqlclient`, we will need to move those
conversions into Diesel.

However, I've opted to do this in such a way that it affects `sql_query`
as well. Right now there are many differences between what our query
builder says and what MySQL does. (32 bit addition/subtraction returns
64 bit, 32 bit multiplication/division/sum return decimal). Ideally you
should be able to have a struct that derives both `Queryable` and
`QueryableByName`, and have that work with the same query built using
the query builder or `sql_query`.

In order for that to happen, we can't do the conversions until we hit
`FromSql`, since for `sql_query` that is the first and only time we
learn what the expected type is.

Changing `RawValue` from `[u8]` to a new type is technically a breaking
change. However, I'm going to be a bit liberal with my interpretation of
[RFC 1150] and call it a minor breaking change.

[RFC 1150]: https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md

Keep in mind that MySQL does not have extensions or user defined types
(enums are just strings). That means that there was really no reason for
any `FromSql` impl in the wild to ever inspect the bytes directly. Any
code which is just passing the value to another `FromSql` impl could
have been forwards compatibly written to use `<Mysql as
Backend>::RawValue` instead of `[u8]`. For that reason, I think this can
be considered a minor breaking change, the same way that adding a new
method to a trait is minor even though it can have a naming conflict
with another method implemented for a type.

With all that said, if any member of the core team is uncomfortable with
this change, we can defer this to 2.0.

However, in order to avoid changing the signature of `NamedRow` (which
would be a major breaking change), I had to do some fuckery with `Cell`
in the `MysqlValue` struct. We only ever get immutable access to that
value in `NamedRow`. We can't have `Cell<MysqlValue>` on the row either,
since the signature is `(&self) -> Option<&MysqlValue>`. We can't get an
`Option<&MysqlValue>` from a `Cell<Option<MysqlValue>>`. `RefCell` would
require returning `Option<Ref<'a, MysqlValue>>`