### PR TITLE
Provide `FromSql` impls for `*const str` and `*const [u8]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `helper_types` now contains a type for every method defined in
   `expression_methods`, and every function in `dsl`.
 
+* Added `FromSql` impls for `*const str` and `*const [u8]` everywhere that
+  `String` and `Vec` are supported. These impls do not allocate, and are
+  intended for use by other impls which need to parse a string or bytes, and
+  don't want to allocate. These impls should never be used outside of another
+  `FromSql` impl.
+
 ### Deprecated
 
 * *IMPORTANT NOTE* Do to [several][rust-deprecation-bug-1]

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -3,17 +3,18 @@ extern crate chrono;
 use std::io::Write;
 use self::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
+use backend::Backend;
 use deserialize::{self, FromSql};
 use serialize::{self, Output, ToSql};
 use sqlite::Sqlite;
-use sqlite::connection::SqliteValue;
 use sql_types::{Date, Text, Time, Timestamp};
 
 const SQLITE_DATE_FORMAT: &str = "%F";
 
 impl FromSql<Date, Sqlite> for NaiveDate {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
-        let text = not_none!(value).read_text();
+    fn from_sql(value: Option<&<Sqlite as Backend>::RawValue>) -> deserialize::Result<Self> {
+        let text_ptr = <*const str as FromSql<Date, Sqlite>>::from_sql(value)?;
+        let text = unsafe { &*text_ptr };
         Self::parse_from_str(text, SQLITE_DATE_FORMAT).map_err(Into::into)
     }
 }
@@ -26,8 +27,9 @@ impl ToSql<Date, Sqlite> for NaiveDate {
 }
 
 impl FromSql<Time, Sqlite> for NaiveTime {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
-        let text = not_none!(value).read_text();
+    fn from_sql(value: Option<&<Sqlite as Backend>::RawValue>) -> deserialize::Result<Self> {
+        let text_ptr = <*const str as FromSql<Date, Sqlite>>::from_sql(value)?;
+        let text = unsafe { &*text_ptr };
         let valid_time_formats = &[
             // Most likely
             "%T%.f",
@@ -57,8 +59,9 @@ impl ToSql<Time, Sqlite> for NaiveTime {
 }
 
 impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
-        let text = not_none!(value).read_text();
+    fn from_sql(value: Option<&<Sqlite as Backend>::RawValue>) -> deserialize::Result<Self> {
+        let text_ptr = <*const str as FromSql<Date, Sqlite>>::from_sql(value)?;
+        let text = unsafe { &*text_ptr };
 
         let sqlite_datetime_formats = &[
             // Most likely format

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -9,7 +9,12 @@ use sql_types;
 #[cfg(feature = "chrono")]
 mod chrono;
 
-impl FromSql<sql_types::Date, Sqlite> for String {
+/// The returned pointer is *only* valid for the lifetime to the argument of
+/// `from_sql`. This impl is intended for uses where you want to write a new
+/// impl in terms of `String`, but don't want to allocate. We have to return a
+/// raw pointer instead of a reference with a lifetime due to the structure of
+/// `FromSql`
+impl FromSql<sql_types::Date, Sqlite> for *const str {
     fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
@@ -27,7 +32,12 @@ impl ToSql<sql_types::Date, Sqlite> for String {
     }
 }
 
-impl FromSql<sql_types::Time, Sqlite> for String {
+/// The returned pointer is *only* valid for the lifetime to the argument of
+/// `from_sql`. This impl is intended for uses where you want to write a new
+/// impl in terms of `String`, but don't want to allocate. We have to return a
+/// raw pointer instead of a reference with a lifetime due to the structure of
+/// `FromSql`
+impl FromSql<sql_types::Time, Sqlite> for *const str {
     fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
@@ -45,7 +55,12 @@ impl ToSql<sql_types::Time, Sqlite> for String {
     }
 }
 
-impl FromSql<sql_types::Timestamp, Sqlite> for String {
+/// The returned pointer is *only* valid for the lifetime to the argument of
+/// `from_sql`. This impl is intended for uses where you want to write a new
+/// impl in terms of `String`, but don't want to allocate. We have to return a
+/// raw pointer instead of a reference with a lifetime due to the structure of
+/// `FromSql`
+impl FromSql<sql_types::Timestamp, Sqlite> for *const str {
     fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -8,17 +8,27 @@ use super::Sqlite;
 use super::connection::SqliteValue;
 use sql_types;
 
-impl FromSql<sql_types::VarChar, Sqlite> for String {
+/// The returned pointer is *only* valid for the lifetime to the argument of
+/// `from_sql`. This impl is intended for uses where you want to write a new
+/// impl in terms of `String`, but don't want to allocate. We have to return a
+/// raw pointer instead of a reference with a lifetime due to the structure of
+/// `FromSql`
+impl FromSql<sql_types::VarChar, Sqlite> for *const str {
     fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         let text = not_none!(value).read_text();
-        Ok(text.into())
+        Ok(text as *const _)
     }
 }
 
-impl FromSql<sql_types::Binary, Sqlite> for Vec<u8> {
+/// The returned pointer is *only* valid for the lifetime to the argument of
+/// `from_sql`. This impl is intended for uses where you want to write a new
+/// impl in terms of `Vec<u8>`, but don't want to allocate. We have to return a
+/// raw pointer instead of a reference with a lifetime due to the structure of
+/// `FromSql`
+impl FromSql<sql_types::Binary, Sqlite> for *const [u8] {
     fn from_sql(bytes: Option<&SqliteValue>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes).read_blob();
-        Ok(bytes.into())
+        Ok(bytes as *const _)
     }
 }
 

--- a/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_carries_correct_result_type_info.rs
@@ -20,5 +20,5 @@ fn main() {
     let ids = select_name.load::<i32>(&connection);
     //~^ ERROR the trait bound `i32: diesel::deserialize::FromSql<diesel::sql_types::Text, _>` is not satisfied
     let names = select_id.load::<String>(&connection);
-    //~^ ERROR the trait bound `std::string::String: diesel::deserialize::FromSql<diesel::sql_types::Integer, _>` is not satisfied
+    //~^ ERROR the trait bound `*const str: diesel::deserialize::FromSql<diesel::sql_types::Integer, _>` is not satisfied
 }


### PR DESCRIPTION
There are several impls which could be composed on impls for `&str` and
`&[u8]` if they were available. Unfortunately, providing those impls is
impossible in Diesel 1.0. We would need a lifetime on `FromSql`,
changing the signature to this:

```rust
trait FromSql<'a, ST, DB> {
    fn from_sql(bytes: Option<&'a DB::RawValue>) -> ...
}
```

While we can't provide impls for `&str` and `&[u8]`, we can provide
impls for `*const` versions of both. The docs about how long the pointer
is valid for *do* get rendered, and since dereferencing this pointers
requires unsafe code, we can reasonably assume that anyone who uses
these impls has looked at the docs for the assumed invaraints.

I've updated several of our built-in impls that just do string parsing
to use these impls, to demonstrate why they're useful. Keep in mind that
outside of Diesel it is impossible to reference `SqliteValue`. While the
impls I've updated are backend specific, it is also possible to use
these impls to write backend agnostic implementations.

Fixes #1365.