### PR TITLE
Implement `or_filter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added support for SQLite's `INSERT OR IGNORE` and MySQL's `INSERT IGNORE`
   via the `insert_or_ignore` function.
 
-* Trait `SqlOrd` is now implemented for `Array`, meaning min/max functions can be used
-  on Array columns (PostgreSQL only).
+* `min` and `max` can now be used with array expressions.
 
 * Added `diesel::dsl::array`, which corresponds to a PG `ARRAY[]` literal.
 
@@ -44,6 +43,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added `result::UnexpectedNullError`, an `Error` type indicating that an
   unexpected `NULL` was received during deserialization.
+
+* Added `.or_filter`, which behaves identically to `.filter`, but using `OR`
+  instead of `AND`.
 
 ### Deprecated
 

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -35,6 +35,9 @@ pub type LtEq<Lhs, Rhs> = super::operators::LtEq<Lhs, AsExpr<Rhs, Lhs>>;
 /// The return type of `lhs.and(rhs)`
 pub type And<Lhs, Rhs> = super::operators::And<Lhs, AsExprOf<Rhs, sql_types::Bool>>;
 
+/// The return type of `lhs.or(rhs)`
+pub type Or<Lhs, Rhs> = Grouped<super::operators::Or<Lhs, AsExprOf<Rhs, types::Bool>>>;
+
 /// The return type of `lhs.like(rhs)`
 pub type Like<Lhs, Rhs> = super::operators::Like<Lhs, AsExprOf<Rhs, sql_types::VarChar>>;
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -209,6 +209,9 @@ pub mod helper_types {
     /// Represents the return type of `.find(pk)`
     pub type Find<Source, PK> = <Source as FindDsl<PK>>::Output;
 
+    /// Represents the return type of `.or_filter(predicate)`
+    pub type OrFilter<Source, Predicate> = <Source as OrFilterDsl<Predicate>>::Output;
+
     /// Represents the return type of `.order(ordering)`
     pub type Order<Source, Ordering> = <Source as OrderDsl<Ordering>>::Output;
 

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -110,6 +110,29 @@ where
     }
 }
 
+impl<F, S, D, W, O, L, Of, G, FU, Predicate> OrFilterDsl<Predicate>
+    for SelectStatement<F, S, D, W, O, L, Of, G, FU>
+where
+    Predicate: Expression<SqlType = Bool> + NonAggregate,
+    W: WhereOr<Predicate>,
+{
+    type Output = SelectStatement<F, S, D, W::Output, O, L, Of, G, FU>;
+
+    fn or_filter(self, predicate: Predicate) -> Self::Output {
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause.or(predicate),
+            self.order,
+            self.limit,
+            self.offset,
+            self.group_by,
+            self.for_update,
+        )
+    }
+}
+
 use dsl::Filter;
 use expression_methods::EqAll;
 use query_source::Table;

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -1,4 +1,4 @@
-use dsl::Filter;
+use dsl::{Filter, OrFilter};
 use expression_methods::*;
 use query_source::*;
 
@@ -54,5 +54,32 @@ where
     fn find(self, id: PK) -> Self::Output {
         let primary_key = self.primary_key();
         self.filter(primary_key.eq_all(id))
+    }
+}
+
+/// The `or_filter` method
+///
+/// This trait should not be relied on directly by most apps. Its behavior is
+/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
+/// to call `or_filter` from generic code.
+///
+/// [`QueryDsl`]: ../trait.QueryDsl.html
+pub trait OrFilterDsl<Predicate> {
+    /// The type returned by `.filter`.
+    type Output;
+
+    /// See the trait documentation.
+    fn or_filter(self, predicate: Predicate) -> Self::Output;
+}
+
+impl<T, Predicate> OrFilterDsl<Predicate> for T
+where
+    T: Table,
+    T::Query: OrFilterDsl<Predicate>,
+{
+    type Output = OrFilter<T::Query, Predicate>;
+
+    fn or_filter(self, predicate: Predicate) -> Self::Output {
+        self.as_query().or_filter(predicate)
     }
 }

--- a/diesel_tests/tests/boxed_queries.rs
+++ b/diesel_tests/tests/boxed_queries.rs
@@ -144,3 +144,18 @@ fn queries_with_borrowed_data_can_be_boxed() {
     let expected_data = vec![find_user_by_name("Tess", &connection)];
     assert_eq!(Ok(expected_data), data);
 }
+
+#[test]
+fn boxed_queries_implement_or_filter() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let data = users::table
+        .into_boxed()
+        .filter(users::name.eq("Sean"))
+        .or_filter(users::name.eq("Tess"))
+        .load(&connection);
+    let expected = vec![
+        find_user_by_name("Sean", &connection),
+        find_user_by_name("Tess", &connection),
+    ];
+    assert_eq!(Ok(expected), data);
+}


### PR DESCRIPTION
I'm still not sold on this method name, but I haven't thought of a
better one. I'm open to any suggestions on better names.

This method behaves identically to `filter`, but it appends to existing
queries using `.or` instead of `.and`. This is useful for cases where
you have a large query being constructed dynamically, but you always
want some other condition to be included. A motivating use case in
crates.io is that we want to be able to do
`.or_filter(has_name(q_string))` in crates::index,
so that crates with an exact match are
always included regardless of what else we've done with the query (the
function itself is over a hundred lines of query construction).

Fixes #1389 