### PR TITLE
Support specifying details about a PG transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* Added support for specifying `ISOLATION LEVEL`, `DEFERRABLE`, and `READ ONLY`
+  on PG transactions. See [`PgConnection::build_transaction`] for details.
+
+[`PgConnection::build_transaction`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html#method.build_transaction
+
 ### Deprecated
 
 * `ne_any` has been renamed to `ne_all`.

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -9,9 +9,13 @@ cfg_if! {
         #[allow(dead_code)]
         type DB = diesel::pg::Pg;
 
-        fn connection_no_data() -> PgConnection {
+        fn connection_no_transaction() -> PgConnection {
             let connection_url = database_url_from_env("PG_DATABASE_URL");
-            let connection = PgConnection::establish(&connection_url).unwrap();
+            PgConnection::establish(&connection_url).unwrap()
+        }
+
+        fn connection_no_data() -> PgConnection {
+            let connection = connection_no_transaction();
             connection.begin_test_transaction().unwrap();
             connection.execute("DROP TABLE IF EXISTS users CASCADE").unwrap();
             connection.execute("DROP TABLE IF EXISTS animals CASCADE").unwrap();

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -10,7 +10,7 @@ use std::os::raw as libc;
 
 use connection::*;
 use deserialize::{Queryable, QueryableByName};
-use pg::{Pg, PgMetadataLookup};
+use pg::{Pg, PgMetadataLookup, TransactionBuilder};
 use query_builder::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use result::*;
@@ -108,6 +108,34 @@ impl Connection for PgConnection {
 }
 
 impl PgConnection {
+    /// Build a transaction, specifying additional details such as isolation level
+    ///
+    /// See [`TransactionBuilder`] for more examples.
+    ///
+    /// [`TransactionBuilder`]: ../pg/struct.TransactionBuilder.html
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .read_only()
+    ///     .serializable()
+    ///     .deferrable()
+    ///     .run(|| Ok(()))
+    /// # }
+    /// ```
+    pub fn build_transaction(&self) -> TransactionBuilder {
+        TransactionBuilder::new(self)
+    }
+
     #[cfg_attr(feature = "clippy", allow(type_complexity))]
     fn prepare_query<T: QueryFragment<Pg> + QueryId>(
         &self,

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -5,19 +5,21 @@
 //! PostgreSQL, you may need to work with this module directly.
 
 pub mod expression;
-
-mod backend;
-mod metadata_lookup;
-mod query_builder;
-mod connection;
 pub mod types;
 pub mod upsert;
+
+mod backend;
+mod connection;
+mod metadata_lookup;
+mod query_builder;
+mod transaction;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;
 pub use self::metadata_lookup::PgMetadataLookup;
 pub use self::query_builder::PgQueryBuilder;
 pub use self::query_builder::DistinctOnClause;
+pub use self::transaction::TransactionBuilder;
 
 /// Data structures for PG types which have no corresponding Rust type
 ///

--- a/diesel/src/pg/transaction.rs
+++ b/diesel/src/pg/transaction.rs
@@ -1,0 +1,381 @@
+#![allow(dead_code)]
+use backend::Backend;
+use connection::TransactionManager;
+use pg::Pg;
+use prelude::*;
+use query_builder::{AstPass, QueryBuilder, QueryFragment};
+use result::Error;
+
+/// Used to build a transaction, specifying additional details.
+///
+/// This struct is returned by [`.build_transaction`].
+/// See the documentation for methods on this struct for usage examples.
+/// See [the PostgreSQL documentation for `SET TRANSACTION`][pg-docs]
+/// for details on the behavior of each option.
+///
+/// [`.build_transaction`]: struct.PgConnection.html#method.build_transaction
+/// [pg-docs]: https://www.postgresql.org/docs/current/static/sql-set-transaction.html
+#[allow(missing_debug_implementations)] // False positive. Connection isn't Debug.
+#[derive(Clone, Copy)]
+#[must_use = "Transaction builder does nothing unless you call `run` on it"]
+pub struct TransactionBuilder<'a> {
+    connection: &'a PgConnection,
+    isolation_level: Option<IsolationLevel>,
+    read_mode: Option<ReadMode>,
+    deferrable: Option<Deferrable>,
+}
+
+impl<'a> TransactionBuilder<'a> {
+    pub(crate) fn new(connection: &'a PgConnection) -> Self {
+        Self {
+            connection,
+            isolation_level: None,
+            read_mode: None,
+            deferrable: None,
+        }
+    }
+
+    /// Makes the transaction `READ ONLY`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .read_only()
+    ///     .run(|| {
+    ///         let read_attempt = users.select(name).load::<String>(&conn);
+    ///         assert!(read_attempt.is_ok());
+    ///
+    ///         let write_attempt = diesel::insert_into(users)
+    ///             .values(name.eq("Ruby"))
+    ///             .execute(&conn);
+    ///         assert!(write_attempt.is_err());
+    ///
+    ///         Ok(())
+    ///     })
+    /// # }
+    /// ```
+    pub fn read_only(mut self) -> Self {
+        self.read_mode = Some(ReadMode::ReadOnly);
+        self
+    }
+
+    /// Makes the transaction `READ WRITE`
+    ///
+    /// This is the default, unless you've changed the
+    /// `default_transaction_read_only` configuration parameter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// # use diesel::result::Error::RollbackTransaction;
+    /// #
+    /// # fn main() {
+    /// #     assert_eq!(run_test(), Err(RollbackTransaction));
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .read_write()
+    ///     .run(|| {
+    ///         let read_attempt = users.select(name).load::<String>(&conn);
+    ///         assert!(read_attempt.is_ok());
+    ///
+    ///         let write_attempt = diesel::insert_into(users)
+    ///             .values(name.eq("Ruby"))
+    ///             .execute(&conn);
+    ///         assert!(write_attempt.is_ok());
+    ///
+    /// #       Err(RollbackTransaction)
+    /// #       /*
+    ///         Ok(())
+    /// #       */
+    ///     })
+    /// # }
+    /// ```
+    pub fn read_write(mut self) -> Self {
+        self.read_mode = Some(ReadMode::ReadWrite);
+        self
+    }
+
+    /// Makes the transaction `DEFERRABLE`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .deferrable()
+    ///     .run(|| Ok(()))
+    /// # }
+    /// ```
+    pub fn deferrable(mut self) -> Self {
+        self.deferrable = Some(Deferrable::Deferrable);
+        self
+    }
+
+    /// Makes the transaction `NOT DEFERRABLE`
+    ///
+    /// This is the default, unless you've changed the
+    /// `default_transaction_deferrable` configuration parameter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .not_deferrable()
+    ///     .run(|| Ok(()))
+    /// # }
+    /// ```
+    pub fn not_deferrable(mut self) -> Self {
+        self.deferrable = Some(Deferrable::NotDeferrable);
+        self
+    }
+
+    /// Makes the transaction `ISOLATION LEVEL READ COMMITTED`
+    ///
+    /// This is the default, unless you've changed the
+    /// `default_transaction_isolation_level` configuration parameter.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .read_committed()
+    ///     .run(|| Ok(()))
+    /// # }
+    /// ```
+    pub fn read_committed(mut self) -> Self {
+        self.isolation_level = Some(IsolationLevel::ReadCommitted);
+        self
+    }
+
+    /// Makes the transaction `ISOLATION LEVEL REPEATABLE READ`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .repeatable_read()
+    ///     .run(|| Ok(()))
+    /// # }
+    /// ```
+    pub fn repeatable_read(mut self) -> Self {
+        self.isolation_level = Some(IsolationLevel::RepeatableRead);
+        self
+    }
+
+    /// Makes the transaction `ISOLATION LEVEL SERIALIZABLE`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let conn = connection_no_transaction();
+    /// conn.build_transaction()
+    ///     .serializable()
+    ///     .run(|| Ok(()))
+    /// # }
+    /// ```
+    pub fn serializable(mut self) -> Self {
+        self.isolation_level = Some(IsolationLevel::Serializable);
+        self
+    }
+
+    /// Runs the given function inside of the transaction
+    /// with the parameters given to this builder.
+    ///
+    /// Returns an error if the connection is already inside a transaction.
+    pub fn run<T, E, F>(&self, f: F) -> Result<T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+        E: From<Error>,
+    {
+        let mut query_builder = <Pg as Backend>::QueryBuilder::default();
+        self.to_sql(&mut query_builder)?;
+        let sql = query_builder.finish();
+        let transaction_manager = self.connection.transaction_manager();
+
+        transaction_manager.begin_transaction_sql(self.connection, &sql)?;
+        match f() {
+            Ok(value) => {
+                transaction_manager.commit_transaction(self.connection)?;
+                Ok(value)
+            }
+            Err(e) => {
+                transaction_manager.rollback_transaction(self.connection)?;
+                Err(e)
+            }
+        }
+    }
+}
+
+impl<'a> QueryFragment<Pg> for TransactionBuilder<'a> {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("BEGIN TRANSACTION");
+        if let Some(ref isolation_level) = self.isolation_level {
+            isolation_level.walk_ast(out.reborrow())?;
+        }
+        if let Some(ref read_mode) = self.read_mode {
+            read_mode.walk_ast(out.reborrow())?;
+        }
+        if let Some(ref deferrable) = self.deferrable {
+            deferrable.walk_ast(out.reborrow())?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum IsolationLevel {
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+}
+
+impl QueryFragment<Pg> for IsolationLevel {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql(" ISOLATION LEVEL ");
+        match *self {
+            IsolationLevel::ReadCommitted => out.push_sql("READ COMMITTED"),
+            IsolationLevel::RepeatableRead => out.push_sql("REPEATABLE READ"),
+            IsolationLevel::Serializable => out.push_sql("SERIALIZABLE"),
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ReadMode {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl QueryFragment<Pg> for ReadMode {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        match *self {
+            ReadMode::ReadOnly => out.push_sql(" READ ONLY"),
+            ReadMode::ReadWrite => out.push_sql(" READ WRITE"),
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Deferrable {
+    Deferrable,
+    NotDeferrable,
+}
+
+impl QueryFragment<Pg> for Deferrable {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        match *self {
+            Deferrable::Deferrable => out.push_sql(" DEFERRABLE"),
+            Deferrable::NotDeferrable => out.push_sql(" NOT DEFERRABLE"),
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn test_transaction_builder_generates_correct_sql() {
+    extern crate dotenv;
+
+    macro_rules! assert_sql {
+        ($query:expr, $sql:expr) => {
+            let mut query_builder = <Pg as Backend>::QueryBuilder::default();
+            $query.to_sql(&mut query_builder).unwrap();
+            let sql = query_builder.finish();
+            assert_eq!(sql, $sql);
+        }
+    }
+
+    let database_url = dotenv::var("PG_DATABASE_URL")
+        .or_else(|_| dotenv::var("DATABASE_URL"))
+        .expect("DATABASE_URL must be set in order to run tests");
+    let conn = PgConnection::establish(&database_url).unwrap();
+
+    let t = conn.build_transaction();
+    assert_sql!(t, "BEGIN TRANSACTION");
+    assert_sql!(t.read_only(), "BEGIN TRANSACTION READ ONLY");
+    assert_sql!(t.read_write(), "BEGIN TRANSACTION READ WRITE");
+    assert_sql!(t.deferrable(), "BEGIN TRANSACTION DEFERRABLE");
+    assert_sql!(t.not_deferrable(), "BEGIN TRANSACTION NOT DEFERRABLE");
+    assert_sql!(
+        t.read_committed(),
+        "BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED"
+    );
+    assert_sql!(
+        t.repeatable_read(),
+        "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ"
+    );
+    assert_sql!(
+        t.serializable(),
+        "BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE"
+    );
+    assert_sql!(
+        t.serializable().deferrable().read_only(),
+        "BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE"
+    );
+}


### PR DESCRIPTION
This adds support for all options which can be given to `SET
TRANSACTION`. We only expose an API for this when opening the
transaction though, as `SET TRANSACTION` errors unless it's the first
query run after opening the transaction.

Most of the tests are really just there to make sure the code compiles
and generates valid SQL. Seeing *a* usage example is still worth having,
but I don't think we can effectively demonstrate/test the differences
between isolation levels in a reasonable manner.

This lays some groundwork that will also be used by #1356, but I haven't
implemented SQLite support yet. The APIs for this will be backend
specific, not trait based.

Fixes #408.