### PR TITLE
Add type aliases for the return types of `ToSql` and `FromSql`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `HasSqlType`, `NotNull`, and `SingleValue` can now be derived with
   `#[derive(SqlType)]`. See the docs for those traits for more information.
 
+* The return type of `FromSql`, `FromSqlRow`, and `QueryableByName` can now be
+  written as `deserialize::Result<Self>`.
+
+* The return type of `ToSql` can now be written as `serialize::Result`.
+
 ### Deprecated
 
 * Deprecated `impl_query_id!` in favor of `#[derive(QueryId)]`

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -1,0 +1,8 @@
+//! Types and traits related to deserializing values from the database
+
+use std::error::Error;
+use std::result;
+
+/// A specialized result type representing the result of deserializing
+/// a value from the database.
+pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -2,7 +2,7 @@ use backend::Backend;
 use expression::Expression;
 use query_builder::*;
 use result::QueryResult;
-use types::{Foldable, HasSqlType};
+use types::Foldable;
 
 macro_rules! fold_function {
     ($fn_name:ident, $type_name:ident, $operator:expr, $docs:expr) => {
@@ -31,7 +31,7 @@ macro_rules! fold_function {
 
         impl<T, DB> QueryFragment<DB> for $type_name<T> where
             T: Expression + QueryFragment<DB>,
-            DB: Backend + HasSqlType<T::SqlType>,
+            DB: Backend,
         {
             fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                 out.push_sql(concat!($operator, "("));

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -2,7 +2,7 @@ use backend::Backend;
 use expression::Expression;
 use query_builder::*;
 use result::QueryResult;
-use types::{HasSqlType, IntoNullable, SqlOrd};
+use types::{IntoNullable, SqlOrd};
 
 macro_rules! ord_function {
     ($fn_name:ident, $type_name:ident, $operator:expr, $docs:expr) => {
@@ -30,7 +30,7 @@ macro_rules! ord_function {
 
         impl<T, DB> QueryFragment<DB> for $type_name<T> where
             T: Expression + QueryFragment<DB>,
-            DB: Backend + HasSqlType<T::SqlType>,
+            DB: Backend,
         {
             fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                 out.push_sql(concat!($operator, "("));

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -5,7 +5,6 @@ use expression::*;
 use query_builder::*;
 use query_dsl::RunQueryDsl;
 use result::QueryResult;
-use types::HasSqlType;
 
 #[derive(Debug, Clone)]
 /// Returned by the [`sql()`] function.
@@ -32,7 +31,7 @@ impl<ST> Expression for SqlLiteral<ST> {
 
 impl<ST, DB> QueryFragment<DB> for SqlLiteral<ST>
 where
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -136,12 +136,14 @@ pub mod associations;
 pub mod backend;
 #[doc(hidden)]
 pub mod connection;
+pub mod deserialize;
 #[macro_use]
 pub mod expression;
 pub mod expression_methods;
 #[doc(hidden)]
 pub mod insertable;
 pub mod query_builder;
+pub mod serialize;
 #[macro_use]
 pub mod types;
 

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -6,40 +6,32 @@ mod numeric;
 
 use byteorder::WriteBytesExt;
 use mysql::Mysql;
-use std::error::Error as StdError;
 use std::io::Write;
 use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 impl ToSql<types::Tinyint, Mysql> for i8 {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Mysql>,
-    ) -> Result<IsNull, Box<StdError + Send + Sync>> {
-        out.write_i8(*self)
-            .map(|_| IsNull::No)
-            .map_err(|e| Box::new(e) as Box<StdError + Send + Sync>)
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> serialize::Result {
+        out.write_i8(*self).map(|_| IsNull::No).map_err(Into::into)
     }
 }
 
 impl FromSql<types::Tinyint, Mysql> for i8 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes);
         Ok(bytes[0] as i8)
     }
 }
 
 impl ToSql<types::Bool, Mysql> for bool {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Mysql>,
-    ) -> Result<IsNull, Box<StdError + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> serialize::Result {
         let int_value = if *self { 1 } else { 0 };
         <i32 as ToSql<types::Integer, Mysql>>::to_sql(&int_value, out)
     }
 }
 
 impl FromSql<types::Bool, Mysql> for bool {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<StdError + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         Ok(not_none!(bytes).iter().any(|x| *x != 0))
     }
 }

--- a/diesel/src/mysql/types/numeric.rs
+++ b/diesel/src/mysql/types/numeric.rs
@@ -2,20 +2,15 @@
 pub mod bigdecimal {
     extern crate bigdecimal;
 
-    use std::error::Error;
+    use self::bigdecimal::BigDecimal;
     use std::io::prelude::*;
 
     use mysql::Mysql;
-
-    use self::bigdecimal::BigDecimal;
-
     use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+    use {deserialize, serialize};
 
     impl ToSql<types::Numeric, Mysql> for BigDecimal {
-        fn to_sql<W: Write>(
-            &self,
-            out: &mut ToSqlOutput<W, Mysql>,
-        ) -> Result<IsNull, Box<Error + Send + Sync>> {
+        fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Mysql>) -> serialize::Result {
             write!(out, "{}", *self)
                 .map(|_| IsNull::No)
                 .map_err(|e| e.into())
@@ -23,7 +18,7 @@ pub mod bigdecimal {
     }
 
     impl FromSql<types::Numeric, Mysql> for BigDecimal {
-        fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+        fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
             let bytes = not_none!(bytes);
             BigDecimal::parse_bytes(bytes, 10)
                 .ok_or_else(|| Box::from(format!("{:?} is not valid decimal number ", bytes)))

--- a/diesel/src/mysql/types/numeric.rs
+++ b/diesel/src/mysql/types/numeric.rs
@@ -5,11 +5,11 @@ pub mod bigdecimal {
     use std::error::Error;
     use std::io::prelude::*;
 
-    use mysql::{Mysql, MysqlType};
+    use mysql::Mysql;
 
     use self::bigdecimal::BigDecimal;
 
-    use types::{self, FromSql, HasSqlType, IsNull, ToSql, ToSqlOutput};
+    use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
 
     impl ToSql<types::Numeric, Mysql> for BigDecimal {
         fn to_sql<W: Write>(
@@ -27,12 +27,6 @@ pub mod bigdecimal {
             let bytes = not_none!(bytes);
             BigDecimal::parse_bytes(bytes, 10)
                 .ok_or_else(|| Box::from(format!("{:?} is not valid decimal number ", bytes)))
-        }
-    }
-
-    impl HasSqlType<BigDecimal> for Mysql {
-        fn metadata(_: &()) -> MysqlType {
-            MysqlType::String
         }
     }
 }

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -4,7 +4,7 @@ use result::Error::DeserializationError;
 use result::QueryResult;
 use super::result::PgResult;
 use super::row::PgNamedRow;
-use types::{FromSqlRow, HasSqlType};
+use types::FromSqlRow;
 
 use std::marker::PhantomData;
 
@@ -29,7 +29,6 @@ impl<ST, T> Cursor<ST, T> {
 
 impl<ST, T> Iterator for Cursor<ST, T>
 where
-    Pg: HasSqlType<ST>,
     T: Queryable<ST, Pg>,
 {
     type Item = QueryResult<T>;

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -25,7 +25,6 @@ impl<T> SingleValue for Array<T> {}
 impl<T, ST> FromSql<Array<ST>, Pg> for Vec<T>
 where
     T: FromSql<ST, Pg>,
-    Pg: HasSqlType<ST>,
 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
         let mut bytes = not_none!(bytes);
@@ -67,9 +66,7 @@ use expression::bound::Bound;
 
 macro_rules! array_as_expression {
     ($ty:ty, $sql_type:ty) => {
-        impl<'a, 'b, ST, T> AsExpression<$sql_type> for $ty where
-            Pg: HasSqlType<ST>,
-        {
+        impl<'a, 'b, ST, T> AsExpression<$sql_type> for $ty {
             type Expression = Bound<$sql_type, Self>;
 
             fn as_expression(self) -> Self::Expression {
@@ -128,7 +125,6 @@ where
 
 impl<ST, T> ToSql<Nullable<Array<ST>>, Pg> for [T]
 where
-    Pg: HasSqlType<ST>,
     [T]: ToSql<Array<ST>, Pg>,
 {
     fn to_sql<W: Write>(
@@ -141,7 +137,6 @@ where
 
 impl<ST, T> ToSql<Array<ST>, Pg> for Vec<T>
 where
-    Pg: HasSqlType<ST>,
     [T]: ToSql<Array<ST>, Pg>,
     T: fmt::Debug,
 {
@@ -155,7 +150,6 @@ where
 
 impl<ST, T> ToSql<Nullable<Array<ST>>, Pg> for Vec<T>
 where
-    Pg: HasSqlType<ST>,
     Vec<T>: ToSql<Array<ST>, Pg>,
 {
     fn to_sql<W: Write>(

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -1,10 +1,10 @@
-use std::error::Error;
 use std::io::Write;
 use std::ops::Add;
 
 use pg::Pg;
 use types::{self, Date, FromSql, Interval, IsNull, Time, Timestamp, Timestamptz, ToSql,
             ToSqlOutput};
+use {deserialize, serialize};
 
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
@@ -83,70 +83,55 @@ impl PgInterval {
 }
 
 impl ToSql<types::Timestamp, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
         ToSql::<types::BigInt, Pg>::to_sql(&self.0, out)
     }
 }
 
 impl FromSql<types::Timestamp, Pg> for PgTimestamp {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         FromSql::<types::BigInt, Pg>::from_sql(bytes).map(PgTimestamp)
     }
 }
 
 impl ToSql<types::Timestamptz, Pg> for PgTimestamp {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
         ToSql::<types::Timestamp, Pg>::to_sql(self, out)
     }
 }
 
 impl FromSql<types::Timestamptz, Pg> for PgTimestamp {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         FromSql::<types::Timestamp, Pg>::from_sql(bytes)
     }
 }
 
 impl ToSql<types::Date, Pg> for PgDate {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
         ToSql::<types::Integer, Pg>::to_sql(&self.0, out)
     }
 }
 
 impl FromSql<types::Date, Pg> for PgDate {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         FromSql::<types::Integer, Pg>::from_sql(bytes).map(PgDate)
     }
 }
 
 impl ToSql<types::Time, Pg> for PgTime {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
         ToSql::<types::BigInt, Pg>::to_sql(&self.0, out)
     }
 }
 
 impl FromSql<types::Time, Pg> for PgTime {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         FromSql::<types::BigInt, Pg>::from_sql(bytes).map(PgTime)
     }
 }
 
 impl ToSql<types::Interval, Pg> for PgInterval {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
         try!(ToSql::<types::BigInt, Pg>::to_sql(&self.microseconds, out));
         try!(ToSql::<types::Integer, Pg>::to_sql(&self.days, out));
         try!(ToSql::<types::Integer, Pg>::to_sql(&self.months, out));
@@ -155,7 +140,7 @@ impl ToSql<types::Interval, Pg> for PgInterval {
 }
 
 impl FromSql<types::Interval, Pg> for PgInterval {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes);
         Ok(PgInterval {
             microseconds: try!(FromSql::<types::BigInt, Pg>::from_sql(Some(&bytes[..8]))),

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -1,22 +1,19 @@
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
-use std::error::Error;
 use std::io::prelude::*;
 
 use pg::Pg;
 use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 impl FromSql<types::Oid, Pg> for u32 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let mut bytes = not_none!(bytes);
         bytes.read_u32::<NetworkEndian>().map_err(|e| e.into())
     }
 }
 
 impl ToSql<types::Oid, Pg> for u32 {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
         out.write_u32::<NetworkEndian>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| e.into())

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -1,11 +1,11 @@
 use std::io::prelude::*;
-use std::error::Error;
 
 use pg::Pg;
 use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 impl FromSql<types::Bool, Pg> for bool {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         match bytes {
             Some(bytes) => Ok(bytes[0] != 0),
             None => Ok(false),
@@ -14,13 +14,8 @@ impl FromSql<types::Bool, Pg> for bool {
 }
 
 impl ToSql<types::Bool, Pg> for bool {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
-        out.write_all(&[*self as u8])
-            .map(|_| IsNull::No)
-            .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
+        out.write_all(&[*self as u8]).map(|_| IsNull::No).map_err(Into::into)
     }
 }
 

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -26,7 +26,6 @@ bitflags! {
 impl<T, ST> Queryable<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg> + Queryable<ST, Pg>,
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
 {
     type Row = Self;
     fn build(row: Self) -> Self {
@@ -34,10 +33,7 @@ where
     }
 }
 
-impl<ST, T> AsExpression<Range<ST>> for (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
-{
+impl<ST, T> AsExpression<Range<ST>> for (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Range<ST>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -45,10 +41,7 @@ where
     }
 }
 
-impl<'a, ST, T> AsExpression<Range<ST>> for &'a (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<Range<ST>>,
-{
+impl<'a, ST, T> AsExpression<Range<ST>> for &'a (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Range<ST>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -56,10 +49,7 @@ where
     }
 }
 
-impl<ST, T> AsExpression<Nullable<Range<ST>>> for (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<Range<ST>>,
-{
+impl<ST, T> AsExpression<Nullable<Range<ST>>> for (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Nullable<Range<ST>>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -67,10 +57,7 @@ where
     }
 }
 
-impl<'a, ST, T> AsExpression<Nullable<Range<ST>>> for &'a (Bound<T>, Bound<T>)
-where
-    Pg: HasSqlType<Range<ST>>,
-{
+impl<'a, ST, T> AsExpression<Nullable<Range<ST>>> for &'a (Bound<T>, Bound<T>) {
     type Expression = SqlBound<Nullable<Range<ST>>, Self>;
 
     fn as_expression(self) -> Self::Expression {
@@ -81,7 +68,6 @@ where
 impl<T, ST> FromSqlRow<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     (Bound<T>, Bound<T>): FromSql<Range<ST>, Pg>,
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
 {
     fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> Result<Self, Box<Error + Send + Sync>> {
         FromSql::<Range<ST>, Pg>::from_sql(row.take())
@@ -91,7 +77,6 @@ where
 impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg>,
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
 {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
         let mut bytes = not_none!(bytes);
@@ -129,7 +114,6 @@ where
 
 impl<ST, T> ToSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
-    Pg: HasSqlType<ST> + HasSqlType<Range<ST>>,
     T: ToSql<ST, Pg>,
 {
     fn to_sql<W: Write>(
@@ -178,7 +162,6 @@ where
 
 impl<ST, T> ToSql<Nullable<Range<ST>>, Pg> for (Bound<T>, Bound<T>)
 where
-    Pg: HasSqlType<Range<ST>>,
     (Bound<T>, Bound<T>): ToSql<Range<ST>, Pg>,
 {
     fn to_sql<W: Write>(

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -14,7 +14,7 @@ use query_dsl::methods::*;
 use query_source::QuerySource;
 use query_source::joins::*;
 use result::QueryResult;
-use types::{BigInt, Bool, HasSqlType};
+use types::{BigInt, Bool};
 
 #[allow(missing_debug_implementations)]
 pub struct BoxedSelectStatement<'a, ST, QS, DB> {
@@ -58,7 +58,6 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
 impl<'a, ST, QS, DB> Query for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    DB: HasSqlType<ST>,
 {
     type SqlType = ST;
 }
@@ -166,7 +165,7 @@ where
 
 impl<'a, ST, QS, DB, Selection> SelectDsl<Selection> for BoxedSelectStatement<'a, ST, QS, DB>
 where
-    DB: Backend + HasSqlType<Selection::SqlType>,
+    DB: Backend,
     Selection: SelectableExpression<QS> + QueryFragment<DB> + 'a,
 {
     type Output = BoxedSelectStatement<'a, Selection::SqlType, QS, DB>;
@@ -187,7 +186,7 @@ where
 
 impl<'a, ST, QS, DB, Predicate> FilterDsl<Predicate> for BoxedSelectStatement<'a, ST, QS, DB>
 where
-    DB: Backend + HasSqlType<ST> + 'a,
+    DB: Backend + 'a,
     Predicate: AppearsOnTable<QS, SqlType = Bool> + NonAggregate,
     Predicate: QueryFragment<DB> + 'a,
 {

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -7,9 +7,8 @@
 pub mod joins;
 mod peano_numbers;
 
-use std::error::Error;
-
 use backend::Backend;
+use deserialize;
 use expression::{Expression, NonAggregate, SelectableExpression};
 use query_builder::*;
 use row::NamedRow;
@@ -177,7 +176,7 @@ where
     DB: Backend,
 {
     /// Construct an instance of `Self` from the database row
-    fn build<R: NamedRow<DB>>(row: &R) -> Result<Self, Box<Error + Send + Sync>>;
+    fn build<R: NamedRow<DB>>(row: &R) -> deserialize::Result<Self>;
 }
 
 /// Represents a type which can appear in the `FROM` clause. Apps should not

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -13,7 +13,7 @@ use backend::Backend;
 use expression::{Expression, NonAggregate, SelectableExpression};
 use query_builder::*;
 use row::NamedRow;
-use types::{FromSqlRow, HasSqlType};
+use types::FromSqlRow;
 
 pub use self::joins::JoinTo;
 pub use self::peano_numbers::*;
@@ -108,7 +108,7 @@ pub use self::peano_numbers::*;
 /// # }
 pub trait Queryable<ST, DB>
 where
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
 {
     /// The Rust type you'd like to map from.
     ///
@@ -123,7 +123,7 @@ where
 //
 // impl<T, ST, DB> Queryable<ST, DB> for T
 // where
-//     DB: Backend + HasSqlType<ST>,
+//     DB: Backend,
 //     T: FromSqlRow<ST, DB>,
 // {
 //     type Row = Self;

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -1,8 +1,7 @@
 //! Contains the `Row` trait
 
-use std::error::Error;
-
 use backend::Backend;
+use deserialize;
 use types::FromSql;
 
 /// Represents a single database row.
@@ -46,7 +45,7 @@ pub trait NamedRow<DB: Backend> {
     ///
     /// If two or more fields in the query have the given name, the result of
     /// this function is undefined.
-    fn get<ST, T>(&self, column_name: &str) -> Result<T, Box<Error + Send + Sync>>
+    fn get<ST, T>(&self, column_name: &str) -> deserialize::Result<T>
     where
         T: FromSql<ST, DB>,
     {

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 
 use backend::Backend;
-use types::{FromSql, HasSqlType};
+use types::FromSql;
 
 /// Represents a single database row.
 /// Apps should not need to concern themselves with this trait.
@@ -48,7 +48,6 @@ pub trait NamedRow<DB: Backend> {
     /// this function is undefined.
     fn get<ST, T>(&self, column_name: &str) -> Result<T, Box<Error + Send + Sync>>
     where
-        DB: HasSqlType<ST>,
         T: FromSql<ST, DB>,
     {
         let idx = self.index_of(column_name)

--- a/diesel/src/serialize.rs
+++ b/diesel/src/serialize.rs
@@ -1,0 +1,10 @@
+//! Types and traits related to serializing values for the database
+
+use std::error::Error;
+use std::result;
+
+use types::IsNull;
+
+/// A specialized result type representing the result of serializing
+/// a value for the database.
+pub type Result = result::Result<IsNull, Box<Error + Send + Sync>>;

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -6,7 +6,7 @@ use result::Error::DeserializationError;
 use result::QueryResult;
 use sqlite::Sqlite;
 use super::stmt::StatementUse;
-use types::{FromSqlRow, HasSqlType};
+use types::FromSqlRow;
 
 pub struct StatementIterator<'a, ST, T> {
     stmt: StatementUse<'a>,
@@ -24,7 +24,6 @@ impl<'a, ST, T> StatementIterator<'a, ST, T> {
 
 impl<'a, ST, T> Iterator for StatementIterator<'a, ST, T>
 where
-    Sqlite: HasSqlType<ST>,
     T: Queryable<ST, Sqlite>,
 {
     type Item = QueryResult<T>;

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -1,34 +1,31 @@
 extern crate chrono;
 
-use std::error::Error;
 use std::io::Write;
 use self::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
 use sqlite::Sqlite;
 use sqlite::connection::SqliteValue;
-use types::{Date, FromSql, IsNull, Text, Time, Timestamp, ToSql, ToSqlOutput};
+use types::{Date, FromSql, Text, Time, Timestamp, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 const SQLITE_DATE_FORMAT: &str = "%F";
 
 impl FromSql<Date, Sqlite> for NaiveDate {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         let text = not_none!(value).read_text();
         Self::parse_from_str(text, SQLITE_DATE_FORMAT).map_err(Into::into)
     }
 }
 
 impl ToSql<Date, Sqlite> for NaiveDate {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         let s = self.format(SQLITE_DATE_FORMAT).to_string();
         ToSql::<Text, Sqlite>::to_sql(&s, out)
     }
 }
 
 impl FromSql<Time, Sqlite> for NaiveTime {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         let text = not_none!(value).read_text();
         let valid_time_formats = &[
             // Most likely
@@ -52,17 +49,14 @@ impl FromSql<Time, Sqlite> for NaiveTime {
 }
 
 impl ToSql<Time, Sqlite> for NaiveTime {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         let s = self.format("%T%.f").to_string();
         ToSql::<Text, Sqlite>::to_sql(&s, out)
     }
 }
 
 impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         let text = not_none!(value).read_text();
 
         let sqlite_datetime_formats = &[
@@ -104,10 +98,7 @@ impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
 }
 
 impl ToSql<Timestamp, Sqlite> for NaiveDateTime {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         let s = self.format("%F %T%.f").to_string();
         ToSql::<Text, Sqlite>::to_sql(&s, out)
     }

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -1,81 +1,63 @@
-use std::error::Error;
 use std::io::Write;
 
 use sqlite::Sqlite;
 use sqlite::connection::SqliteValue;
-use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+use types::{self, FromSql, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 #[cfg(feature = "chrono")]
 mod chrono;
 
 impl FromSql<types::Date, Sqlite> for String {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         FromSql::<types::Text, Sqlite>::from_sql(value)
     }
 }
 
 impl ToSql<types::Date, Sqlite> for str {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         ToSql::<types::Text, Sqlite>::to_sql(self, out)
     }
 }
 
 impl ToSql<types::Date, Sqlite> for String {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         <&str as ToSql<types::Date, Sqlite>>::to_sql(&&**self, out)
     }
 }
 
 impl FromSql<types::Time, Sqlite> for String {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         FromSql::<types::Text, Sqlite>::from_sql(value)
     }
 }
 
 impl ToSql<types::Time, Sqlite> for str {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         ToSql::<types::Text, Sqlite>::to_sql(self, out)
     }
 }
 
 impl ToSql<types::Time, Sqlite> for String {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         <&str as ToSql<types::Time, Sqlite>>::to_sql(&&**self, out)
     }
 }
 
 impl FromSql<types::Timestamp, Sqlite> for String {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         FromSql::<types::Text, Sqlite>::from_sql(value)
     }
 }
 
 impl ToSql<types::Timestamp, Sqlite> for str {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         ToSql::<types::Text, Sqlite>::to_sql(self, out)
     }
 }
 
 impl ToSql<types::Timestamp, Sqlite> for String {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         <&str as ToSql<types::Timestamp, Sqlite>>::to_sql(&&**self, out)
     }
 }

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -1,67 +1,64 @@
 mod date_and_time;
 
 use std::io::prelude::*;
-use std::error::Error;
 
 use super::Sqlite;
 use super::connection::SqliteValue;
-use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+use types::{self, FromSql, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 impl FromSql<types::VarChar, Sqlite> for String {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         let text = not_none!(value).read_text();
         Ok(text.into())
     }
 }
 
 impl FromSql<types::Binary, Sqlite> for Vec<u8> {
-    fn from_sql(bytes: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&SqliteValue>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes).read_blob();
         Ok(bytes.into())
     }
 }
 
 impl FromSql<types::SmallInt, Sqlite> for i16 {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_integer() as i16)
     }
 }
 
 impl FromSql<types::Integer, Sqlite> for i32 {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_integer())
     }
 }
 
 impl FromSql<types::Bool, Sqlite> for bool {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_integer() != 0)
     }
 }
 
 impl FromSql<types::BigInt, Sqlite> for i64 {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_long())
     }
 }
 
 impl FromSql<types::Float, Sqlite> for f32 {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_double() as f32)
     }
 }
 
 impl FromSql<types::Double, Sqlite> for f64 {
-    fn from_sql(value: Option<&SqliteValue>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_double())
     }
 }
 
 impl ToSql<types::Bool, Sqlite> for bool {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Sqlite>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Sqlite>) -> serialize::Result {
         let int_value = if *self { 1 } else { 0 };
         <i32 as ToSql<types::Integer, Sqlite>>::to_sql(&int_value, out)
     }

--- a/diesel/src/types/impls/floats.rs
+++ b/diesel/src/types/impls/floats.rs
@@ -4,9 +4,10 @@ use std::io::prelude::*;
 
 use backend::Backend;
 use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 impl<DB: Backend<RawValue = [u8]>> FromSql<types::Float, DB> for f32 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let mut bytes = not_none!(bytes);
         debug_assert!(
             bytes.len() <= 4,
@@ -20,10 +21,7 @@ impl<DB: Backend<RawValue = [u8]>> FromSql<types::Float, DB> for f32 {
 }
 
 impl<DB: Backend> ToSql<types::Float, DB> for f32 {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, DB>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> serialize::Result {
         out.write_f32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
@@ -31,7 +29,7 @@ impl<DB: Backend> ToSql<types::Float, DB> for f32 {
 }
 
 impl<DB: Backend<RawValue = [u8]>> FromSql<types::Double, DB> for f64 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let mut bytes = not_none!(bytes);
         debug_assert!(
             bytes.len() <= 8,
@@ -45,10 +43,7 @@ impl<DB: Backend<RawValue = [u8]>> FromSql<types::Double, DB> for f64 {
 }
 
 impl<DB: Backend> ToSql<types::Double, DB> for f64 {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, DB>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> serialize::Result {
         out.write_f64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)

--- a/diesel/src/types/impls/integers.rs
+++ b/diesel/src/types/impls/integers.rs
@@ -4,9 +4,10 @@ use std::io::prelude::*;
 
 use backend::Backend;
 use types::{self, FromSql, IsNull, ToSql, ToSqlOutput};
+use {deserialize, serialize};
 
 impl<DB: Backend<RawValue = [u8]>> FromSql<types::SmallInt, DB> for i16 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let mut bytes = not_none!(bytes);
         debug_assert!(
             bytes.len() <= 2,
@@ -26,10 +27,7 @@ impl<DB: Backend<RawValue = [u8]>> FromSql<types::SmallInt, DB> for i16 {
 }
 
 impl<DB: Backend> ToSql<types::SmallInt, DB> for i16 {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, DB>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> serialize::Result {
         out.write_i16::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
@@ -37,7 +35,7 @@ impl<DB: Backend> ToSql<types::SmallInt, DB> for i16 {
 }
 
 impl<DB: Backend<RawValue = [u8]>> FromSql<types::Integer, DB> for i32 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let mut bytes = not_none!(bytes);
         debug_assert!(
             bytes.len() <= 4,
@@ -56,10 +54,7 @@ impl<DB: Backend<RawValue = [u8]>> FromSql<types::Integer, DB> for i32 {
 }
 
 impl<DB: Backend> ToSql<types::Integer, DB> for i32 {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, DB>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> serialize::Result {
         out.write_i32::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
@@ -67,7 +62,7 @@ impl<DB: Backend> ToSql<types::Integer, DB> for i32 {
 }
 
 impl<DB: Backend<RawValue = [u8]>> FromSql<types::BigInt, DB> for i64 {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let mut bytes = not_none!(bytes);
         debug_assert!(
             bytes.len() <= 8,
@@ -86,10 +81,7 @@ impl<DB: Backend<RawValue = [u8]>> FromSql<types::BigInt, DB> for i64 {
 }
 
 impl<DB: Backend> ToSql<types::BigInt, DB> for i64 {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, DB>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> serialize::Result {
         out.write_i64::<DB::ByteOrder>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)

--- a/diesel/src/types/impls/option.rs
+++ b/diesel/src/types/impls/option.rs
@@ -36,7 +36,7 @@ where
 impl<T, ST, DB> FromSql<Nullable<ST>, DB> for Option<T>
 where
     T: FromSql<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     ST: NotNull,
 {
     fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>> {
@@ -50,7 +50,7 @@ where
 impl<T, ST, DB> Queryable<Nullable<ST>, DB> for Option<T>
 where
     T: Queryable<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     Option<T::Row>: FromSqlRow<Nullable<ST>, DB>,
     ST: NotNull,
 {
@@ -81,7 +81,7 @@ where
 impl<T, ST, DB> FromSqlRow<Nullable<ST>, DB> for Option<T>
 where
     T: FromSqlRow<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     ST: NotNull,
 {
     const FIELDS_NEEDED: usize = T::FIELDS_NEEDED;
@@ -100,7 +100,7 @@ where
 impl<T, ST, DB> ToSql<Nullable<ST>, DB> for Option<T>
 where
     T: ToSql<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     ST: NotNull,
 {
     fn to_sql<W: Write>(

--- a/diesel/src/types/impls/primitives.rs
+++ b/diesel/src/types/impls/primitives.rs
@@ -2,8 +2,8 @@ use std::error::Error;
 use std::io::Write;
 
 use backend::Backend;
-use types::{self, BigInt, Binary, Bool, Double, Float, FromSql, HasSqlType, Integer, IsNull,
-            NotNull, SmallInt, Text, ToSql, ToSqlOutput};
+use types::{self, BigInt, Binary, Bool, Double, Float, FromSql, Integer, IsNull, NotNull,
+            SmallInt, Text, ToSql, ToSqlOutput};
 
 #[allow(dead_code)]
 mod foreign_impls {
@@ -147,7 +147,7 @@ use std::borrow::{Cow, ToOwned};
 impl<'a, T: ?Sized, ST, DB> ToSql<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned + ToSql<ST, DB>,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     T::Owned: ToSql<ST, DB>,
 {
     fn to_sql<W: Write>(
@@ -164,7 +164,7 @@ where
 impl<'a, T: ?Sized, ST, DB> FromSql<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     T::Owned: FromSql<ST, DB>,
 {
     fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>> {
@@ -175,7 +175,7 @@ where
 impl<'a, T: ?Sized, ST, DB> ::types::FromSqlRow<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     Cow<'a, T>: FromSql<ST, DB>,
 {
     fn build_from_row<R: ::row::Row<DB>>(row: &mut R) -> Result<Self, Box<Error + Send + Sync>> {
@@ -186,7 +186,7 @@ where
 impl<'a, T: ?Sized, ST, DB> ::Queryable<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned,
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     Self: ::types::FromSqlRow<ST, DB>,
 {
     type Row = Self;

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -37,8 +37,6 @@ macro_rules! tuple_impls {
             impl<$($T),+, $($ST),+, DB> FromSqlRow<($($ST,)+), DB> for ($($T,)+) where
                 DB: Backend,
                 $($T: FromSqlRow<$ST, DB>),+,
-                $(DB: HasSqlType<$ST>),+,
-                DB: HasSqlType<($($ST,)+)>,
             {
                 const FIELDS_NEEDED: usize = $($T::FIELDS_NEEDED +)+ 0;
 
@@ -50,8 +48,6 @@ macro_rules! tuple_impls {
             impl<$($T),+, $($ST),+, DB> Queryable<($($ST,)+), DB> for ($($T,)+) where
                 DB: Backend,
                 $($T: Queryable<$ST, DB>),+,
-                $(DB: HasSqlType<$ST>),+,
-                DB: HasSqlType<($($ST,)+)>,
             {
                 type Row = ($($T::Row,)+);
 

--- a/diesel/src/types/impls/tuples.rs
+++ b/diesel/src/types/impls/tuples.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 
 use associations::BelongsTo;
 use backend::Backend;
+use deserialize;
 use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
 use insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
 use query_builder::*;
@@ -61,7 +62,7 @@ macro_rules! tuple_impls {
                 DB: Backend,
                 $($T: QueryableByName<DB>,)+
             {
-                fn build<RowT: NamedRow<DB>>(row: &RowT) -> Result<Self, Box<Error + Send + Sync>> {
+                fn build<RowT: NamedRow<DB>>(row: &RowT) -> deserialize::Result<Self> {
                     Ok(($($T::build(row)?,)+))
                 }
             }

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -498,7 +498,7 @@ impl<T: NotNull + SingleValue> SingleValue for Nullable<T> {}
 /// - For third party backends, consult that backend's documentation.
 ///
 /// [`MysqlType`]: ../mysql/enum.MysqlType.html
-pub trait FromSql<A, DB: Backend + HasSqlType<A>>: Sized {
+pub trait FromSql<A, DB: Backend>: Sized {
     /// See the trait documentation.
     fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>>;
 }
@@ -519,7 +519,7 @@ pub trait FromSql<A, DB: Backend + HasSqlType<A>>: Sized {
 /// for any type which implements `FromSql`.
 /// There are no options or special considerations needed for this derive.
 /// Note that `#[derive(FromSqlRow)]` will also generate a `Queryable` implementation.
-pub trait FromSqlRow<A, DB: Backend + HasSqlType<A>>: Sized {
+pub trait FromSqlRow<A, DB: Backend>: Sized {
     /// The number of fields that this type will consume. Must be equal to
     /// the number of times you would call `row.take()` in `build_from_row`
     const FIELDS_NEEDED: usize = 1;
@@ -704,7 +704,7 @@ where
 /// - For third party backends, consult that backend's documentation.
 ///
 /// [`MysqlType`]: ../mysql/enum.MysqlType.html
-pub trait ToSql<A, DB: Backend + HasSqlType<A>>: fmt::Debug {
+pub trait ToSql<A, DB: Backend>: fmt::Debug {
     /// See the trait documentation.
     fn to_sql<W: Write>(
         &self,
@@ -714,7 +714,7 @@ pub trait ToSql<A, DB: Backend + HasSqlType<A>>: fmt::Debug {
 
 impl<'a, A, T, DB> ToSql<A, DB> for &'a T
 where
-    DB: Backend + HasSqlType<A>,
+    DB: Backend,
     T: ToSql<A, DB> + ?Sized,
 {
     fn to_sql<W: Write>(

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -75,7 +75,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
                 __DB: diesel::backend::Backend + diesel::types::HasSqlType<#sql_type>,
                 Self: diesel::types::ToSql<#sql_type, __DB>,
             {
-                fn to_sql<W: ::std::io::Write>(&self, out: &mut diesel::types::ToSqlOutput<W, __DB>) -> ::std::result::Result<diesel::types::IsNull, Box<::std::error::Error + Send + Sync>> {
+                fn to_sql<W: ::std::io::Write>(&self, out: &mut diesel::types::ToSqlOutput<W, __DB>) -> diesel::serialize::Result {
                     diesel::types::ToSql::<#sql_type, __DB>::to_sql(self, out)
                 }
             }

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -28,7 +28,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
                 Self: diesel::types::FromSql<__ST, __DB>,
             {
                 fn build_from_row<R: diesel::row::Row<__DB>>(row: &mut R)
-                    -> Result<Self, Box<::std::error::Error + Send + Sync>>
+                    -> diesel::deserialize::Result<Self>
                 {
                     diesel::types::FromSql::<__ST, __DB>::from_sql(row.take())
                 }

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -24,7 +24,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
         quote!(
             impl#generics diesel::types::FromSqlRow<__ST, __DB> for #struct_ty
             where
-                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                __DB: diesel::backend::Backend,
                 Self: diesel::types::FromSql<__ST, __DB>,
             {
                 fn build_from_row<R: diesel::row::Row<__DB>>(row: &mut R)
@@ -36,7 +36,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
 
             impl#generics diesel::query_source::Queryable<__ST, __DB> for #struct_ty
             where
-                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                __DB: diesel::backend::Backend,
                 Self: diesel::types::FromSqlRow<__ST, __DB>,
             {
                 type Row = Self;

--- a/diesel_derives/src/queryable.rs
+++ b/diesel_derives/src/queryable.rs
@@ -22,7 +22,7 @@ pub fn derive_queryable(item: syn::DeriveInput) -> Tokens {
         model.dummy_const_name("QUERYABLE"),
         quote!(
             impl#generics diesel::Queryable<__ST, __DB> for #struct_ty where
-                __DB: diesel::backend::Backend + diesel::types::HasSqlType<__ST>,
+                __DB: diesel::backend::Backend,
                 #row_ty: diesel::Queryable<__ST, __DB>,
             {
                type Row = <#row_ty as diesel::Queryable<__ST, __DB>>::Row;

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -34,7 +34,7 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
                 __DB: diesel::backend::Backend,
                 #(#attr_where_clause)*
             {
-               fn build<__R: diesel::row::NamedRow<__DB>>(row: &__R) -> ::std::result::Result<Self, Box<::std::error::Error + Send + Sync>> {
+               fn build<__R: diesel::row::NamedRow<__DB>>(row: &__R) -> diesel::deserialize::Result<Self> {
                    Ok(#build_expr)
                }
             }

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -20,7 +20,6 @@ pub fn derive(item: syn::DeriveInput) -> Tokens {
         } else {
             let st = sql_type(attr, &model);
             quote!(
-                __DB: diesel::types::HasSqlType<#st>,
                 #attr_ty: diesel::types::FromSql<#st, __DB>,
             )
         }

--- a/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
@@ -3,7 +3,7 @@ use diesel::*;
 use diesel::backend::Backend;
 #[cfg(feature = "sqlite")]
 use diesel::sqlite::Sqlite;
-use diesel::types::{FromSqlRow, HasSqlType};
+use diesel::types::FromSqlRow;
 
 #[cfg(feature = "uses_information_schema")]
 use super::information_schema::UsesInformationSchema;
@@ -69,7 +69,7 @@ impl ColumnInformation {
 #[cfg(feature = "uses_information_schema")]
 impl<ST, DB> Queryable<ST, DB> for ColumnInformation
 where
-    DB: Backend + UsesInformationSchema + HasSqlType<ST>,
+    DB: Backend + UsesInformationSchema,
     (String, String, String): FromSqlRow<ST, DB>,
 {
     type Row = (String, String, String);
@@ -82,7 +82,6 @@ where
 #[cfg(feature = "sqlite")]
 impl<ST> Queryable<ST, Sqlite> for ColumnInformation
 where
-    Sqlite: HasSqlType<ST>,
     (i32, String, String, bool, Option<String>, bool): FromSqlRow<ST, Sqlite>,
 {
     type Row = (i32, String, String, bool, Option<String>, bool);

--- a/diesel_infer_schema/infer_schema_internals/src/table_data.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/table_data.rs
@@ -1,6 +1,6 @@
 use diesel::*;
 use diesel::backend::Backend;
-use diesel::types::{FromSqlRow, HasSqlType};
+use diesel::types::FromSqlRow;
 use std::fmt;
 use std::str::FromStr;
 
@@ -40,7 +40,7 @@ impl TableName {
 
 impl<ST, DB> Queryable<ST, DB> for TableName
 where
-    DB: Backend + HasSqlType<ST>,
+    DB: Backend,
     (String, String): FromSqlRow<ST, DB>,
 {
     type Row = (String, String);

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -3,7 +3,6 @@ use diesel::connection::SimpleConnection;
 use diesel::pg::Pg;
 use diesel::types::*;
 use schema::*;
-use std::error::Error;
 use std::io::Write;
 
 table! {
@@ -27,10 +26,7 @@ pub enum MyEnum {
 }
 
 impl ToSql<MyType, Pg> for MyEnum {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> serialize::Result {
         match *self {
             MyEnum::Foo => out.write_all(b"foo")?,
             MyEnum::Bar => out.write_all(b"bar")?,
@@ -40,7 +36,7 @@ impl ToSql<MyType, Pg> for MyEnum {
 }
 
 impl FromSql<MyType, Pg> for MyEnum {
-    fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         match not_none!(bytes) {
             b"foo" => Ok(MyEnum::Foo),
             b"bar" => Ok(MyEnum::Bar),

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1019,7 +1019,6 @@ use diesel::query_builder::{QueryFragment, QueryId};
 
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool
 where
-    TestBackend: HasSqlType<T>,
     U: AsExpression<T> + Debug + Clone,
     U::Expression: SelectableExpression<(), SqlType = T>,
     U::Expression: QueryFragment<TestBackend> + QueryId,

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -981,8 +981,6 @@ fn text_array_can_be_assigned_to_varchar_array_column() {
 #[test]
 #[cfg(feature = "postgres")]
 fn third_party_crates_can_add_new_types() {
-    use std::error::Error;
-
     #[derive(Debug, Clone, Copy, QueryId, SqlType)]
     struct MyInt;
 
@@ -993,7 +991,7 @@ fn third_party_crates_can_add_new_types() {
     }
 
     impl FromSql<MyInt, Pg> for i32 {
-        fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error + Send + Sync>> {
+        fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
             FromSql::<Integer, Pg>::from_sql(bytes)
         }
     }


### PR DESCRIPTION
These types were annoying to write out, and often involved importing
several types you wouldn't otherwise need to import.

These aliases are `serialize::Result` and `deserialize::Result`. I
intend to eventually move the relevant traits into these modules, but
this felt like a good standalone change.