### PR TITLE
Merge r2d2-diesel into Diesel itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* `r2d2-diesel` has been merged into Diesel proper. You should no longer rely
+  directly on `r2d2-diesel` or `r2d2`. The functionality of both is exposed from
+  `diesel::r2d2`.
+
+* `r2d2::PooledConnection` now implements `Connection`. This means that you
+  should no longer need to write `&*connection` when using `r2d2`.
+
 * The `BINARY` column type name is now supported for SQLite.
 
 * The `QueryId` trait can now be derived.

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -31,6 +31,7 @@ num-traits = { version = "0.1.35", optional = true }
 num-integer = { version = "0.1.32", optional = true }
 bigdecimal = { version = "0.0.10", optional = true }
 bitflags = { version = "1.0", optional = true }
+r2d2 = { version = ">= 0.7, < 0.9", optional = true }
 
 [dev-dependencies]
 cfg-if = "0.1.0"
@@ -40,7 +41,7 @@ tempdir = "^0.3.4"
 
 [features]
 default = ["with-deprecated"]
-extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address", "numeric"]
+extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address", "numeric", "r2d2"]
 unstable = []
 lint = ["clippy"]
 large-tables = []

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -146,6 +146,8 @@ pub mod insertable;
 pub mod query_builder;
 pub mod query_dsl;
 pub mod query_source;
+#[cfg(feature = "r2d2")]
+pub mod r2d2;
 pub mod result;
 pub mod serialize;
 #[macro_use]

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -1,0 +1,216 @@
+//! Connection pooling via r2d2
+
+extern crate r2d2;
+
+pub use self::r2d2::*;
+
+use std::convert::Into;
+use std::fmt;
+use std::marker::PhantomData;
+
+use backend::UsesAnsiSavepointSyntax;
+use deserialize::QueryableByName;
+use prelude::*;
+use connection::{AnsiTransactionManager, SimpleConnection};
+use query_builder::{AsQuery, QueryFragment, QueryId};
+use sql_types::HasSqlType;
+
+/// An r2d2 connection manager for use with Diesel.
+///
+/// See the [r2d2 documentation] for usage examples.
+///
+/// [r2d2 documentation]: ../../r2d2
+#[derive(Debug, Clone)]
+pub struct ConnectionManager<T> {
+    database_url: String,
+    _marker: PhantomData<T>,
+}
+
+unsafe impl<T: Send + 'static> Sync for ConnectionManager<T> {}
+
+impl<T> ConnectionManager<T> {
+    /// Returns a new connection manager,
+    /// which establishes connections to the given database URL.
+    pub fn new<S: Into<String>>(database_url: S) -> Self {
+        ConnectionManager {
+            database_url: database_url.into(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// The error used when managing connections with `r2d2`.
+#[derive(Debug)]
+pub enum Error {
+    /// An error occurred establishing the connection
+    ConnectionError(ConnectionError),
+
+    /// An error occurred pinging the database
+    QueryError(::result::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::ConnectionError(ref e) => e.fmt(f),
+            Error::QueryError(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl ::std::error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::ConnectionError(ref e) => e.description(),
+            Error::QueryError(ref e) => e.description(),
+        }
+    }
+}
+
+impl<T> ManageConnection for ConnectionManager<T>
+where
+    T: Connection + Send + 'static,
+{
+    type Connection = T;
+    type Error = Error;
+
+    fn connect(&self) -> Result<T, Error> {
+        T::establish(&self.database_url).map_err(Error::ConnectionError)
+    }
+
+    fn is_valid(&self, conn: &mut T) -> Result<(), Error> {
+        conn.execute("SELECT 1")
+            .map(|_| ())
+            .map_err(Error::QueryError)
+    }
+
+    fn has_broken(&self, _conn: &mut T) -> bool {
+        false
+    }
+}
+
+impl<T> SimpleConnection for PooledConnection<ConnectionManager<T>>
+where
+    T: Connection + Send + 'static,
+{
+    fn batch_execute(&self, query: &str) -> QueryResult<()> {
+        (&**self).batch_execute(query)
+    }
+}
+
+impl<C> Connection for PooledConnection<ConnectionManager<C>>
+where
+    C: Connection<TransactionManager = AnsiTransactionManager> + Send + 'static,
+    C::Backend: UsesAnsiSavepointSyntax,
+{
+    type Backend = C::Backend;
+    type TransactionManager = C::TransactionManager;
+
+    fn establish(_: &str) -> ConnectionResult<Self> {
+        Err(ConnectionError::BadConnection(String::from(
+            "Cannot directly establish a pooled connection",
+        )))
+    }
+
+    fn execute(&self, query: &str) -> QueryResult<usize> {
+        (&**self).execute(query)
+    }
+
+    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>>
+    where
+        T: AsQuery,
+        T::Query: QueryFragment<Self::Backend> + QueryId,
+        Self::Backend: HasSqlType<T::SqlType>,
+        U: Queryable<T::SqlType, Self::Backend>,
+    {
+        (&**self).query_by_index(source)
+    }
+
+    fn query_by_name<T, U>(&self, source: &T) -> QueryResult<Vec<U>>
+    where
+        T: QueryFragment<Self::Backend> + QueryId,
+        U: QueryableByName<Self::Backend>,
+    {
+        (&**self).query_by_name(source)
+    }
+
+    fn execute_returning_count<T>(&self, source: &T) -> QueryResult<usize>
+    where
+        T: QueryFragment<Self::Backend> + QueryId,
+    {
+        (&**self).execute_returning_count(source)
+    }
+
+    fn transaction_manager(&self) -> &Self::TransactionManager {
+        (&**self).transaction_manager()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::thread;
+
+    use r2d2::*;
+    use test_helpers::*;
+
+    #[test]
+    fn establish_basic_connection() {
+        let manager = ConnectionManager::<TestConnection>::new(database_url());
+        let pool = Arc::new(Pool::builder().max_size(2).build(manager).unwrap());
+
+        let (s1, r1) = mpsc::channel();
+        let (s2, r2) = mpsc::channel();
+
+        let pool1 = Arc::clone(&pool);
+        let t1 = thread::spawn(move || {
+            let conn = pool1.get().unwrap();
+            s1.send(()).unwrap();
+            r2.recv().unwrap();
+            drop(conn);
+        });
+
+        let pool2 = Arc::clone(&pool);
+        let t2 = thread::spawn(move || {
+            let conn = pool2.get().unwrap();
+            s2.send(()).unwrap();
+            r1.recv().unwrap();
+            drop(conn);
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        pool.get().unwrap();
+    }
+
+    #[test]
+    fn is_valid() {
+        let manager = ConnectionManager::<TestConnection>::new(database_url());
+        let pool = Pool::builder()
+            .max_size(1)
+            .test_on_check_out(true)
+            .build(manager)
+            .unwrap();
+
+        pool.get().unwrap();
+    }
+
+    #[test]
+    fn pooled_connection_impls_connection() {
+        use select;
+        use sql_types::Text;
+
+        let manager = ConnectionManager::<TestConnection>::new(database_url());
+        let pool = Pool::builder()
+            .max_size(1)
+            .test_on_check_out(true)
+            .build(manager)
+            .unwrap();
+        let conn = pool.get().unwrap();
+
+        let query = select("foo".into_sql::<Text>());
+        assert_eq!("foo", query.get_result::<String>(&conn).unwrap());
+    }
+}


### PR DESCRIPTION
The main benefit of doing this is that we can implement `Connection` for
`PooledConnection`, removing the requirement to do `&*conn` in your
outermost functions. Additionally, we can just re-export r2d2 from
within Diesel itself, so we can hopefully get fewer bug reports saying
"Hey why does it say PgConnection doesn't implement Connection". Instead
people can just `use diesel::r2d2::Pool` instead of explicitly depending
on r2d2.

The code and the tests are both stripped straight from r2d2-diesel.
(Yeah, the tests are a bit... opaque. They come from the initial commit
of that repo, with the commit message "The tests have been pretty much
ripped from r2d2-postgres, as I really don't know what else to do to
test this". So blame r2d2-postgres I guess)

The only changes between this code and what is in r2d2-diesel 1.0 is the
`Connection` impl. This impl has to be a little bit funky. I decided to
just restrict to `AnsiTransactionManager` since that's what all three
backends use at the moment. If we wanted to support anything that
implemented `diesel::Connection`, we would need to add the constraint
`C::TransactionManager: TransactionManager<Self>`. However,
`TransactionManager` has the bound that it's parameter be `Connection`,
so we just recurse infinitely. Maybe on day the language will be smarter
about this. Until then, we just have to do this weird hack.

Fixes #1348.