### PR TITLE
Compile successfully when `infer_schema!` is used with an empty database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Deprecated specifying a column name as `#[column_name(foo)]`. `#[column_name =
   "foo"]` should be used instead.
 
+### Fixed
+
+* `infer_schema!` generates valid code when run against a database with no
+  tables.
+
 ## [1.0.0] - 2018-01-02
 
 ### Added

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -1079,6 +1079,8 @@ macro_rules! allow_tables_to_appear_in_same_query {
     };
 
     ($last_table:ident,) => {};
+
+    () => {};
 }
 
 #[macro_export]

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -11,6 +11,11 @@ infer_schema!("dotenv:MYSQL_DATABASE_URL");
 #[cfg(not(feature = "backend_specific_database_url"))]
 infer_schema!("dotenv:DATABASE_URL");
 
+#[cfg(feature = "sqlite")]
+mod test_infer_schema_works_on_empty_database {
+    infer_schema!(":memory:");
+}
+
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset,
          Associations, QueryableByName)]
 #[table_name = "users"]


### PR DESCRIPTION
If you run `infer_schema!` on an empty database, we generate this code:

    allow_tables_to_appear_in_same_query!();

That macro doesn't allow an empty token list, so we get the error
"unexpected end of macro invocation" with no indication to the user of
how to fix it.

We could just skip generating that macro in `infer_schema!`, but this is
less code.