### PR TITLE
Don't recommend installing a server to get libpq

### DIFF
--- a/guide_drafts/backend_installation.md
+++ b/guide_drafts/backend_installation.md
@@ -40,7 +40,7 @@ with various package managers.
 
 ### PostgreSQL
 
-`sudo apt-get install postgresql-server-dev-all`
+`sudo apt-get install libpq-dev`
 
 ### MySQL
 


### PR DESCRIPTION
This is a dependency of `postgresql-server-dev-all`, and I suspect it's the only bit we actually need.