### PR TITLE
Deprecate `ne_any` in favor of `ne_all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Deprecated
+
+* `ne_any` has been renamed to `ne_all`.
+
 ## [1.1.0] - 2018-01-15
 
 ### Added

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -76,14 +76,7 @@ pub trait ExpressionMethods: Expression + Sized {
         In::new(self, values.as_in_expression())
     }
 
-    /// Creates a SQL `NOT IN` statement.
-    ///
-    /// Queries using this method will not be
-    /// placed in the prepared statement cache. On PostgreSQL, you should use
-    /// `ne(any())` instead. This method may change in the future to
-    /// automatically perform `!= ANY` on PostgreSQL.
-    ///
-    /// # Example
+    /// Deprecated alias for `ne_all`
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
@@ -105,7 +98,45 @@ pub trait ExpressionMethods: Expression + Sized {
     /// assert_eq!(Ok(vec![1, 2, 3]), data.load(&connection));
     /// # }
     /// ```
+    #[cfg(feature = "with-deprecated")]
+    #[deprecated(since = "1.2.0", note = "use `ne_all` instead")]
     fn ne_any<T>(self, values: T) -> NotIn<Self, T::InExpression>
+    where
+        T: AsInExpression<Self::SqlType>,
+    {
+        NotIn::new(self, values.as_in_expression())
+    }
+
+    /// Creates a SQL `NOT IN` statement.
+    ///
+    /// Queries using this method will not be
+    /// placed in the prepared statement cache. On PostgreSQL, you should use
+    /// `ne(all())` instead. This method may change in the future to
+    /// automatically perform `!= ALL` on PostgreSQL.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = establish_connection();
+    /// #     connection.execute("INSERT INTO users (name) VALUES
+    /// #         ('Jim')").unwrap();
+    /// let data = users.select(id).filter(name.ne_all(vec!["Sean", "Jim"]));
+    /// assert_eq!(Ok(vec![2]), data.load(&connection));
+    ///
+    /// let data = users.select(id).filter(name.ne_all(vec!["Tess"]));
+    /// assert_eq!(Ok(vec![1, 3]), data.load(&connection));
+    ///
+    /// // Calling `ne_any` with an empty array is the same as doing `WHERE 1=1`
+    /// let data = users.select(id).filter(name.ne_all(Vec::<String>::new()));
+    /// assert_eq!(Ok(vec![1, 2, 3]), data.load(&connection));
+    /// # }
+    /// ```
+    fn ne_all<T>(self, values: T) -> NotIn<Self, T::InExpression>
     where
         T: AsInExpression<Self::SqlType>,
     {


### PR DESCRIPTION
This method name is silly and incorrect. The opposite of `eq_any` is
`ne_all`. Doing `foo != ANY(1, 2)` is equivalent to `TRUE`.