### PR TITLE
bugfix: Eliminate shadowing of r2d2 public rexports by diesel types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## [1.1.1] - 2018-01-15
+
+### Added
+
+* Added `diesel::r2d2::PoolError` as an alias for `r2d2::Error`. Previously this
+  type was inaccessible due to `diesel::r2d2::Error`.
+
 ## [1.1.0] - 2018-01-15
 
 ### Added

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -3,6 +3,8 @@
 extern crate r2d2;
 
 pub use self::r2d2::*;
+/// A re-export of r2d2::Error, which is only used by methods on r2d2::Pool.
+pub type PoolError = self::r2d2::Error;
 
 use std::convert::Into;
 use std::fmt;


### PR DESCRIPTION
bug: Alias `r2d2::Error` as `diesel::r2d2::PoolError` to prevent shadowing of public rexports from r2d2 crate by diesel types.