### PR TITLE
Remove `Changeset`

### DIFF
--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -64,7 +64,7 @@ macro_rules! __diesel_operator_body {
         #[derive(Debug, Clone, Copy, QueryId)]
         #[doc(hidden)]
         pub struct $name<$($ty_param,)+> {
-            $($field_name: $ty_param,)+
+            $(pub(crate) $field_name: $ty_param,)+
         }
 
         impl<$($ty_param,)+> $name<$($ty_param,)+> {
@@ -356,42 +356,8 @@ diesel_postfix_operator!(Desc, " DESC", ());
 
 diesel_prefix_operator!(Not, "NOT ");
 
-use backend::Backend;
 use insertable::{ColumnInsertValue, Insertable};
 use query_source::Column;
-use query_builder::*;
-use result::QueryResult;
-use super::AppearsOnTable;
-
-impl<T, U, DB> Changeset<DB> for Eq<T, U>
-where
-    DB: Backend,
-    T: Column,
-    U: AppearsOnTable<T::Table> + QueryFragment<DB>,
-{
-    fn is_noop(&self) -> bool {
-        false
-    }
-
-    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
-        try!(out.push_identifier(T::NAME));
-        out.push_sql(" = ");
-        QueryFragment::walk_ast(&self.right, out)
-    }
-}
-
-impl<T, U> AsChangeset for Eq<T, U>
-where
-    T: Column,
-    U: AppearsOnTable<T::Table>,
-{
-    type Target = T::Table;
-    type Changeset = Self;
-
-    fn as_changeset(self) -> Self {
-        self
-    }
-}
 
 impl<T, U> Insertable<T::Table> for Eq<T, U>
 where

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -34,11 +34,11 @@ impl<T> DoUpdate<T> {
 
 impl<T> QueryFragment<Pg> for DoUpdate<T>
 where
-    T: Changeset<Pg>,
+    T: QueryFragment<Pg>,
 {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
-        if self.changeset.is_noop() {
+        if self.changeset.is_noop()? {
             out.push_sql(" DO NOTHING");
         } else {
             out.push_sql(" DO UPDATE SET ");

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -1,7 +1,7 @@
 pub mod changeset;
 pub mod target;
 
-pub use self::changeset::{AsChangeset, Changeset};
+pub use self::changeset::AsChangeset;
 pub use self::target::{IntoUpdateTarget, UpdateTarget};
 
 use backend::Backend;
@@ -172,11 +172,11 @@ where
     T: Table,
     T::FromClause: QueryFragment<DB>,
     U: QueryFragment<DB>,
-    V: changeset::Changeset<DB>,
+    V: QueryFragment<DB>,
     Ret: QueryFragment<DB>,
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
-        if self.values.is_noop() {
+        if self.values.is_noop()? {
             return Err(QueryBuilderError(
                 "There are no changes to save. This query cannot be built".into(),
             ));


### PR DESCRIPTION
This is a long overdue refactoring. I'm going to do a similar
refactoring for `InsertValues` as part of #1106, but this shares a lot
of groundwork for that and is much smaller in scope. `Changeset` has
always been entirely redundant with `QueryFragment`, but we had to keep
it as a separate trait for two places where the implementation changed:

- `Eq` doesn't qualify the column name
- tuples skip commas when `is_noop` returned true (for `Changeset` this
  was only the case for `None` or a tuple where all elements were `None`)

The first one is easy to solve, we just return a type other than `Eq` in
`AsChangeset` (there was very little reason to use `Eq` in the first
place. We weren't able to re-use any of its code.)

The second one is a bit trickier, since we need to replicate the
`is_noop` method in `QueryFragment`. I'm fine with doing this, since
`InsertValues` has the same method (and tuples implement `walk_ast`
identically for `InsertValues` and `Changeset`), so it makes sense to
share them.

Originally I added an explicit `noop` method to `AstPass` which we would
call. However, it felt weird that the impl for `()` which literally just
does `Ok(())` didn't call `noop`. At that point I realized I could just
generalize this to "did a method that generates SQL get called?" This
works fine for updates. I'm not 100% sure if it'll work for inserts, but
it's worth a shot.

I should note that the semantics of the new `is_noop` are slightly
different than the one on `InsertValues`, which explicitly states that
an empty array will return `false`. This will make it return `true` when
we switch inserts to use this. Since we already have to explicitly
handle empty arrays long before we start checking `is_noop`, I think
that's fine.