### PR TITLE
Minor cleanup around `InsertValues`

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -68,6 +68,9 @@ pub mod dsl {
 #[doc(inline)]
 pub use self::sql_literal::SqlLiteral;
 
+#[doc(hidden)]
+pub use self::grouped::Grouped;
+
 use backend::Backend;
 use dsl::AsExprOf;
 

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -356,6 +356,7 @@ diesel_postfix_operator!(Desc, " DESC", ());
 
 diesel_prefix_operator!(Not, "NOT ");
 
+use expression::Grouped;
 use insertable::{ColumnInsertValue, Insertable};
 use query_source::Column;
 
@@ -363,10 +364,10 @@ impl<T, U> Insertable<T::Table> for Eq<T, U>
 where
     T: Column,
 {
-    type Values = ColumnInsertValue<T, U>;
+    type Values = Grouped<ColumnInsertValue<T, U>>;
 
     fn values(self) -> Self::Values {
-        ColumnInsertValue::Expression(self.left, self.right)
+        Grouped(ColumnInsertValue::Expression(self.left, self.right))
     }
 }
 

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -209,17 +209,6 @@ where
         Ok(())
     }
 
-    /// FIXME: This method is a temporary shim, and should be removed when
-    /// we are able to merge `InsertValues` into `QueryFragment`
-    #[doc(hidden)]
-    pub fn query_builder(self) -> Option<&'a mut DB::QueryBuilder> {
-        if let AstPassInternals::ToSql(out) = self.internals {
-            Some(out)
-        } else {
-            None
-        }
-    }
-
     #[doc(hidden)]
     pub fn push_bind_param_value_only<T, U>(&mut self, bind: &U) -> QueryResult<()>
     where

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -166,17 +166,9 @@ where
             out.push_sql(" DEFAULT VALUES");
         } else {
             out.push_sql(" (");
-            if let Some(builder) = out.reborrow().query_builder() {
-                self.records.column_names(builder)?;
-            }
+            self.records.column_names(out.reborrow())?;
             out.push_sql(") VALUES ");
-            if self.records.requires_parenthesis() {
-                out.push_sql("(");
-            }
             self.records.walk_ast(out.reborrow())?;
-            if self.records.requires_parenthesis() {
-                out.push_sql(")");
-            }
         }
         self.returning.walk_ast(out.reborrow())?;
         Ok(())
@@ -390,7 +382,7 @@ where
     Tab: Table,
     DB: Backend + Any,
 {
-    fn column_names(&self, _: &mut DB::QueryBuilder) -> QueryResult<()> {
+    fn column_names(&self, _: AstPass<DB>) -> QueryResult<()> {
         Ok(())
     }
 

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -386,7 +386,21 @@ where
         Ok(())
     }
 
+    #[cfg(not(feature = "mysql"))]
     fn walk_ast(&self, _: AstPass<DB>) -> QueryResult<()> {
+        Ok(())
+    }
+
+    #[cfg(feature = "mysql")]
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        // The syntax for this on MySQL is
+        // INSERT INTO table () VALUES ()
+        //
+        // This is hacky, but it's the easiest way to get this done without a
+        // deeper restructuring of this code (which is in progress, but ugly at some mid-points...)
+        if TypeId::of::<DB>() == TypeId::of::<::mysql::Mysql>() {
+            out.push_sql("()");
+        }
         Ok(())
     }
 

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use diesel::deserialize::FromSql;
 use diesel::expression::bound::Bound;
+use diesel::expression::Grouped;
 use diesel::insertable::ColumnInsertValue;
 use diesel::prelude::*;
 use diesel::query_builder::InsertStatement;
@@ -25,7 +26,7 @@ where
     T: Connection,
     String: FromSql<VarChar, T::Backend>,
     // FIXME: HRTB is preventing projecting on any associated types here
-    for<'a> InsertStatement<__diesel_schema_migrations, ColumnInsertValue<version, &'a Bound<VarChar, &'a str>>>: ExecuteDsl<T>,
+    for<'a> InsertStatement<__diesel_schema_migrations, Grouped<ColumnInsertValue<version, &'a Bound<VarChar, &'a str>>>>: ExecuteDsl<T>,
 {
     fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>> {
         __diesel_schema_migrations


### PR DESCRIPTION
This is all in preparation of removing its `is_noop` and `walk_ast`
methods, in favor of using the ones on `QueryFragment`. I can't actually
do what I said we should in the comment about `Grouped`, since
`IncompleteInsertStatement::values` (and thus its return type) are
public API.

Interestingly, though -- I think that we'll be able to get rid of
`UndecoratedInsertRecord`, in favor of `Insertable<Values = Grouped<T>>`
(if it's wrapped in parenthesis, it's by definition valid as a top level
`VALUES` clause).

The `Grouped` change is generally to make handling of parens less hacky. I eventually want to pull out an actual `ValuesClause` struct which is responsible for it (mirroring how literally everything else in Diesel works), but this is an intermediate step. Since we can't change `IncompleteInsertStatement::values` like I had originally intended, we do have to unwrap/re-wrap in `impl Insertable` on tuples to make sure that we only get one outer pair of parenthesis.