### PR TITLE
Remove most of `InsertValues`

### DIFF
--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -43,22 +43,24 @@ impl<Tab, Values, Target, Action> InsertValues<Tab, Pg> for OnConflictValues<Val
 where
     Tab: Table,
     Values: InsertValues<Tab, Pg>,
-    Target: QueryFragment<Pg>,
-    Action: QueryFragment<Pg>,
+    Self: QueryFragment<Pg>,
 {
     fn column_names(&self, out: AstPass<Pg>) -> QueryResult<()> {
         self.values.column_names(out)
     }
+}
 
+impl<Values, Target, Action> QueryFragment<Pg> for OnConflictValues<Values, Target, Action>
+where
+    Values: QueryFragment<Pg>,
+    Target: QueryFragment<Pg>,
+    Action: QueryFragment<Pg>,
+{
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         self.values.walk_ast(out.reborrow())?;
         out.push_sql(" ON CONFLICT");
         self.target.walk_ast(out.reborrow())?;
         self.action.walk_ast(out.reborrow())?;
         Ok(())
-    }
-
-    fn is_noop(&self) -> bool {
-        self.values.is_noop()
     }
 }

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -147,7 +147,7 @@ macro_rules! tuple_impls {
                 fn column_names(&self, mut out: AstPass<DB>) -> QueryResult<()> {
                     let mut needs_comma = false;
                     $(
-                        let noop_element = self.$idx.is_noop();
+                        let noop_element = self.$idx.is_noop()?;
                         if !noop_element {
                             if needs_comma {
                                 out.push_sql(", ");
@@ -157,25 +157,6 @@ macro_rules! tuple_impls {
                         }
                     )+
                     Ok(())
-                }
-
-                fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
-                    let mut needs_comma = false;
-                    $(
-                        let noop_element = self.$idx.is_noop();
-                        if !noop_element {
-                            if needs_comma {
-                                out.push_sql(", ");
-                            }
-                            self.$idx.walk_ast(out.reborrow())?;
-                            needs_comma = true;
-                        }
-                    )+
-                    Ok(())
-                }
-
-                fn is_noop(&self) -> bool {
-                    $(self.$idx.is_noop() &&)+ true
                 }
             }
 


### PR DESCRIPTION
This removes every method on `InsertValues` except for `column_names` on
`InsertValues`. These methods were redundant with the versions on
`QueryFragment`, and we can just directly use those instead.

I'd like to actually get rid of this trait completely, but that is
impossible without a breaking change to the API of `Insertable`. As I
suspected, our implementation of `is_noop` doesn't qutie work here. The
issue is that `walk_ast` always outputs at least `()`, which is not
"nothing". I've basically added a hacky workaround to `Grouped` in the
short term (and added a test demonstrating the problem, we didn't
previously have one).

I think this hack and problem both generally go away by introducing a
`ValuesClause` struct which is responsible for both the `VALUES`
keyword, and the parenthesis. (And I guess probably the column list,
too). All of this is required if we don't want to completely
re-implement `InsertStatement` (and more importantly PG upsert,
`insert_or_ignore`, etc) for to insert from a select statement.

