### PR TITLE
The connection module is public API

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -1,4 +1,4 @@
-///! Types related to database connections
+//! Types related to database connections
 
 mod statement_cache;
 mod transaction_manager;

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -1,3 +1,4 @@
+#![doc(hidden)]
 //! A primer on prepared statement caching in Diesel
 //! ------------------------------------------------
 //!

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -134,7 +134,6 @@ pub mod test_helpers;
 
 pub mod associations;
 pub mod backend;
-#[doc(hidden)]
 pub mod connection;
 pub mod data_types;
 pub mod deserialize;


### PR DESCRIPTION
This module got hidden in 61a0302e. I think I meant to write
`#[deny(missing_docs)]`. I am getting false positives from that lint on
`statement_cache`, which is not public API (that said, I should document
everything in that module. I don't remember what any of it does)