### PR TITLE
Handle query strings in database url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `ne_any` has been renamed to `ne_all`.
 
+### Fixed
+
+* The CLI now handles query strings in the database URL to properly infer the
+  name of the database.
+
 ## [1.1.1] - 2018-01-16
 
 ### Added

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -22,6 +22,7 @@ dotenv = ">=0.8, <0.11"
 infer_schema_internals = { version = "1.1.0" }
 clippy = { optional = true, version = "=0.0.174" }
 migrations_internals = { version = "1.1.0" }
+url = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 difference = "1.0"
@@ -32,9 +33,9 @@ url = { version = "1.4.0" }
 [features]
 default = ["postgres", "sqlite", "mysql"]
 lint = ["clippy"]
-postgres = ["diesel/postgres", "infer_schema_internals/postgres"]
+postgres = ["diesel/postgres", "infer_schema_internals/postgres", "url"]
 sqlite = ["diesel/sqlite", "infer_schema_internals/sqlite"]
-mysql = ["diesel/mysql", "infer_schema_internals/mysql"]
+mysql = ["diesel/mysql", "infer_schema_internals/mysql", "url"]
 
 [[test]]
 name = "tests"

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -17,6 +17,8 @@ extern crate diesel;
 extern crate dotenv;
 extern crate infer_schema_internals;
 extern crate migrations_internals;
+#[cfg(feature = "url")]
+extern crate url;
 
 mod database_error;
 #[macro_use]


### PR DESCRIPTION
Fixes #1480 

If the DATABASE_URL is set to has a query string, for example:

`postgres://postgres@localhost/example?sslmode=disable`

Then database is parsed to be `example?sslmode=disable` rather than `example`.

I added a test which fails without the additional code in this change. The test ensures that `change_database_of_url` returns the proper database name along with the full DSN including the query string as the second return value.

I used the url crate to handle the parsing, but followed the style of the function that current exists and just used unwrap instead of more friendly error handling.