### PR TITLE
Sqlite custom function

### DIFF
--- a/diesel/src/sqlite/connection/app_defined_fn.rs
+++ b/diesel/src/sqlite/connection/app_defined_fn.rs
@@ -1,0 +1,69 @@
+//! Plumbing for the implementation of the application defined function API
+
+use std::os::raw as libc;
+
+use super::ffi;
+use super::into_sqlite_result::IntoSqliteResult;
+use super::from_sqlite_value::FromSqliteValue;
+
+/// Context is a wrapper for the SQLite function evaluation context.
+#[derive(Debug)]
+pub struct Context<'a> {
+    ctx: *mut ffi::sqlite3_context,
+    args: &'a [*mut ffi::sqlite3_value],
+}
+
+// Context is translated from rusqlite
+impl<'a> Context<'a> {
+    /// Returns the number of arguments to the function.
+    pub fn len(&self) -> usize {
+        self.args.len()
+    }
+
+    /// Returns `true` when there is no argument.
+    pub fn is_empty(&self) -> bool {
+        self.args.is_empty()
+    }
+
+    /// Returns the `idx`th argument as a `T`.
+    ///
+    /// # Failure
+    ///
+    /// Will panic if `idx` is greater than or equal to `self.len()`.
+    pub fn get<T>(&self, idx: usize) -> T
+    where
+        T: FromSqliteValue
+    {
+        let arg = self.args[idx];
+
+        T::from_sqlite_value(arg)
+    }
+}
+
+pub unsafe extern "C" fn free_boxed_value<T>(p: *mut ::std::os::raw::c_void) {
+    let _: Box<T> = Box::from_raw(::std::mem::transmute(p));
+}
+
+pub unsafe extern "C" fn call_boxed_closure<F, T>(
+    ctx: *mut ffi::sqlite3_context,
+    argc: libc::c_int,
+    argv: *mut *mut ffi::sqlite3_value
+)
+where
+    F: FnMut(&Context) -> T,
+    T: IntoSqliteResult
+{
+    use std::{slice, mem};
+
+    let ctx = Context {
+        ctx: ctx,
+        args: slice::from_raw_parts(argv, argc as usize),
+    };
+
+    let boxed_f: *mut F = mem::transmute(ffi::sqlite3_user_data(ctx.ctx));
+    assert!(!boxed_f.is_null(), "Internal error - null function pointer");
+
+    let t = (*boxed_f)(&ctx);
+
+    t.into_sqlite_result(ctx.ctx);
+}

--- a/diesel/src/sqlite/connection/app_defined_fn.rs
+++ b/diesel/src/sqlite/connection/app_defined_fn.rs
@@ -32,7 +32,7 @@ impl<'a> Context<'a> {
     /// Will panic if `idx` is greater than or equal to `self.len()`.
     pub fn get<T>(&self, idx: usize) -> T
     where
-        T: FromSqliteValue
+        T: FromSqliteValue,
     {
         let arg = self.args[idx];
 
@@ -47,13 +47,12 @@ pub unsafe extern "C" fn free_boxed_value<T>(p: *mut ::std::os::raw::c_void) {
 pub unsafe extern "C" fn call_boxed_closure<F, T>(
     ctx: *mut ffi::sqlite3_context,
     argc: libc::c_int,
-    argv: *mut *mut ffi::sqlite3_value
-)
-where
+    argv: *mut *mut ffi::sqlite3_value,
+) where
     F: FnMut(&Context) -> T,
-    T: IntoSqliteResult
+    T: IntoSqliteResult,
 {
-    use std::{slice, mem};
+    use std::{mem, slice};
 
     let ctx = Context {
         ctx: ctx,

--- a/diesel/src/sqlite/connection/from_sqlite_value.rs
+++ b/diesel/src/sqlite/connection/from_sqlite_value.rs
@@ -1,14 +1,12 @@
-extern crate libsqlite3_sys as ffi;
+use super::ffi;
 
-use std::ffi::CStr;
-use std::os::raw as libc;
-
-// The sqlite3_value_*type*-functions are only safe for so-called "protected" values.
-
-// Per https://www.sqlite.org/c3ref/value.html, values sent to application-defined functions are protected,
-// making it safe to use those values with FromSqliteValue.
-
+/// The sqlite3_value_*type*-functions are only safe for so-called "protected" values.
+///
+/// Per https://www.sqlite.org/c3ref/value.html, values sent to application-defined functions are protected,
+/// making it safe to use those values with FromSqliteValue.
 pub trait FromSqliteValue {
+    /// * `value` must be a valid pointer
+    /// * `value` must be "protected" as defined in the sqlite documentation
     fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self;
 }
 
@@ -50,6 +48,8 @@ impl FromSqliteValue for String {
             // >can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
             // >sqlite3_value_text(), or sqlite3_value_text16().
 
+            // This copy makes this abstraction non-zero cost
+
             let buf = slice::from_raw_parts(ptr, len as usize);
 
             str::from_utf8(buf)
@@ -72,6 +72,8 @@ impl FromSqliteValue for Vec<u8> {
             // >Please pay particular attention to the fact that the pointer returned from ... sqlite3_value_blob(), ...
             // >can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
             // >sqlite3_value_text(), or sqlite3_value_text16().
+
+            // This copy makes this abstraction non-zero cost
 
             let buf = slice::from_raw_parts(ptr as *const u8, len as usize);
 

--- a/diesel/src/sqlite/connection/from_sqlite_value.rs
+++ b/diesel/src/sqlite/connection/from_sqlite_value.rs
@@ -1,0 +1,81 @@
+extern crate libsqlite3_sys as ffi;
+
+use std::ffi::CStr;
+use std::os::raw as libc;
+
+// The sqlite3_value_*type*-functions are only safe for so-called "protected" values.
+
+// Per https://www.sqlite.org/c3ref/value.html, values sent to application-defined functions are protected,
+// making it safe to use those values with FromSqliteValue.
+
+pub trait FromSqliteValue {
+    fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self;
+}
+
+impl FromSqliteValue for i32 {
+    fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
+        unsafe {
+            ffi::sqlite3_value_int(value)
+        }
+    }
+}
+
+impl FromSqliteValue for i64 {
+    fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
+        unsafe {
+            ffi::sqlite3_value_int64(value)
+        }
+    }
+}
+
+impl FromSqliteValue for f64 {
+    fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
+        unsafe {
+            ffi::sqlite3_value_double(value)
+        }
+    }
+}
+
+impl FromSqliteValue for String {
+    fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
+        use std::{slice, str};
+
+        unsafe {
+            let len = ffi::sqlite3_value_bytes(value); // Must not be called after sqlite3_value_text
+            let ptr = ffi::sqlite3_value_text(value);
+            assert!(!ptr.is_null());
+
+            // The buffer must be copied immediately (https://www.sqlite.org/c3ref/value_blob.html):
+            // >Please pay particular attention to the fact that the pointer returned from ... sqlite3_value_text(), ...
+            // >can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
+            // >sqlite3_value_text(), or sqlite3_value_text16().
+
+            let buf = slice::from_raw_parts(ptr, len as usize);
+
+            str::from_utf8(buf)
+                .expect("SQLite guarantees UTF-8 encoding")
+                .to_string()
+        }
+    }
+}
+
+impl FromSqliteValue for Vec<u8> {
+    fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
+        use std::slice;
+
+        unsafe {
+            let len = ffi::sqlite3_value_bytes(value); // Must not be called after sqlite3_value_blob
+            let ptr = ffi::sqlite3_value_blob(value);
+            assert!(!ptr.is_null());
+
+            // The buffer must be copied immediately (https://www.sqlite.org/c3ref/value_blob.html):
+            // >Please pay particular attention to the fact that the pointer returned from ... sqlite3_value_blob(), ...
+            // >can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
+            // >sqlite3_value_text(), or sqlite3_value_text16().
+
+            let buf = slice::from_raw_parts(ptr as *const u8, len as usize);
+
+            buf.into()
+        }
+    }
+}

--- a/diesel/src/sqlite/connection/from_sqlite_value.rs
+++ b/diesel/src/sqlite/connection/from_sqlite_value.rs
@@ -12,25 +12,19 @@ pub trait FromSqliteValue {
 
 impl FromSqliteValue for i32 {
     fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
-        unsafe {
-            ffi::sqlite3_value_int(value)
-        }
+        unsafe { ffi::sqlite3_value_int(value) }
     }
 }
 
 impl FromSqliteValue for i64 {
     fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
-        unsafe {
-            ffi::sqlite3_value_int64(value)
-        }
+        unsafe { ffi::sqlite3_value_int64(value) }
     }
 }
 
 impl FromSqliteValue for f64 {
     fn from_sqlite_value(value: *mut ffi::sqlite3_value) -> Self {
-        unsafe {
-            ffi::sqlite3_value_double(value)
-        }
+        unsafe { ffi::sqlite3_value_double(value) }
     }
 }
 

--- a/diesel/src/sqlite/connection/from_sqlite_value.rs
+++ b/diesel/src/sqlite/connection/from_sqlite_value.rs
@@ -39,8 +39,9 @@ impl FromSqliteValue for String {
         use std::{slice, str};
 
         unsafe {
-            let len = ffi::sqlite3_value_bytes(value); // Must not be called after sqlite3_value_text
+            // Call sqlite3_value_text(), then _bytes(), as per https://www.sqlite.org/c3ref/column_blob.html
             let ptr = ffi::sqlite3_value_text(value);
+            let len = ffi::sqlite3_value_bytes(value);
             assert!(!ptr.is_null());
 
             // The buffer must be copied immediately (https://www.sqlite.org/c3ref/value_blob.html):
@@ -64,8 +65,9 @@ impl FromSqliteValue for Vec<u8> {
         use std::slice;
 
         unsafe {
-            let len = ffi::sqlite3_value_bytes(value); // Must not be called after sqlite3_value_blob
+            // Call sqlite3_value_blob(), then _bytes(), as per https://www.sqlite.org/c3ref/column_blob.html
             let ptr = ffi::sqlite3_value_blob(value);
+            let len = ffi::sqlite3_value_bytes(value);
             assert!(!ptr.is_null());
 
             // The buffer must be copied immediately (https://www.sqlite.org/c3ref/value_blob.html):

--- a/diesel/src/sqlite/connection/into_sqlite_result.rs
+++ b/diesel/src/sqlite/connection/into_sqlite_result.rs
@@ -55,14 +55,6 @@ impl IntoSqliteResult for CString {
     }
 }
 
-impl IntoSqliteResult for String {
-    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
-        CString::new(self)
-            .expect("TODO Missing error propagation")
-            .into_sqlite_result(ctx)
-    }
-}
-
 impl IntoSqliteResult for &'static CStr {
     fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
         // See note in CString-implementation above about cast

--- a/diesel/src/sqlite/connection/into_sqlite_result.rs
+++ b/diesel/src/sqlite/connection/into_sqlite_result.rs
@@ -1,14 +1,17 @@
-extern crate libsqlite3_sys as ffi;
-
 use std::ffi::{CString, CStr};
 use std::os::raw as libc;
 
+use super::ffi;
+
+// TODO: Support BLOB values
 
 pub trait IntoSqliteResult {
+    /// `ctx` must be a valid pointer
     fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context);
 }
 
 pub trait IntoSqliteResultError {
+    /// `ctx` must be a valid pointer
     fn into_sqlite_result_error(self, ctx: *mut ffi::sqlite3_context);
 }
 

--- a/diesel/src/sqlite/connection/into_sqlite_result.rs
+++ b/diesel/src/sqlite/connection/into_sqlite_result.rs
@@ -1,5 +1,7 @@
 extern crate libsqlite3_sys as ffi;
 
+use std::os::raw as libc;
+
 pub trait IntoSqliteResult {
     fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context);
 }
@@ -8,6 +10,59 @@ impl IntoSqliteResult for i32 {
     fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
         unsafe {
             ffi::sqlite3_result_int(ctx, self);
+        }
+    }
+}
+
+impl IntoSqliteResult for i64 {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
+        unsafe {
+            ffi::sqlite3_result_int64(ctx, self);
+        }
+    }
+}
+
+impl IntoSqliteResult for f64 {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
+        unsafe {
+            ffi::sqlite3_result_double(ctx, self);
+        }
+    }
+}
+
+impl IntoSqliteResult for String {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
+        // Inefficient. Assumes ownership of the String, and also tells SQLite
+        // to copy it (SQLITE_TRANSIENT). We could send a destructor as the
+        // last argument to sqlite3_result_text and give ownership of the
+        // string to SQLite.
+
+        // BUG: Will allow sending strings with embedded NUL characters into
+        // SQLite. Working with strings with embedded NUL characters causes
+        // undefined behavior in SQLite.
+        unsafe {
+            ffi::sqlite3_result_text(
+                ctx,
+                self.as_ptr() as *const libc::c_char,
+                self.len() as libc::c_int,
+                ffi::SQLITE_TRANSIENT(),
+            )
+        }
+    }
+}
+
+impl IntoSqliteResult for &'static str {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
+        // BUG: Will allow sending strings with embedded NUL characters into
+        // SQLite. Working with strings with embedded NUL characters causes
+        // undefined behavior in SQLite.
+        unsafe {
+            ffi::sqlite3_result_text(
+                ctx,
+                self.as_ptr() as *const libc::c_char,
+                self.len() as libc::c_int,
+                ffi::SQLITE_STATIC(),
+            )
         }
     }
 }

--- a/diesel/src/sqlite/connection/into_sqlite_result.rs
+++ b/diesel/src/sqlite/connection/into_sqlite_result.rs
@@ -1,5 +1,6 @@
 extern crate libsqlite3_sys as ffi;
 
+use std::ffi::CString;
 use std::os::raw as libc;
 
 pub trait IntoSqliteResult {
@@ -30,24 +31,34 @@ impl IntoSqliteResult for f64 {
     }
 }
 
-impl IntoSqliteResult for String {
-    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
-        // Inefficient. Assumes ownership of the String, and also tells SQLite
-        // to copy it (SQLITE_TRANSIENT). We could send a destructor as the
-        // last argument to sqlite3_result_text and give ownership of the
-        // string to SQLite.
+unsafe extern "C" fn free_cstring(p: *mut ::std::os::raw::c_void) {
+    let _: CString = CString::from_raw(::std::mem::transmute(p));
+}
 
-        // BUG: Will allow sending strings with embedded NUL characters into
-        // SQLite. Working with strings with embedded NUL characters causes
-        // undefined behavior in SQLite.
+impl IntoSqliteResult for CString {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
+        // TODO Narrowing typecast, could overflow.
+        //  * sqlite3_result_text64 accepts 64 bit len, but is not exposed
+        //    by ffi library
+        //  * Never the less, the cast should be checked for overflow
+        let len = self.as_bytes().len() as i32;
+
         unsafe {
             ffi::sqlite3_result_text(
                 ctx,
-                self.as_ptr() as *const libc::c_char,
-                self.len() as libc::c_int,
-                ffi::SQLITE_TRANSIENT(),
+                self.into_raw(),
+                len,
+                Some(free_cstring),
             )
         }
+    }
+}
+
+impl IntoSqliteResult for String {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
+        CString::new(self)
+            .expect("TODO Missing error propagation")
+            .into_sqlite_result(ctx)
     }
 }
 

--- a/diesel/src/sqlite/connection/into_sqlite_result.rs
+++ b/diesel/src/sqlite/connection/into_sqlite_result.rs
@@ -1,0 +1,13 @@
+extern crate libsqlite3_sys as ffi;
+
+pub trait IntoSqliteResult {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context);
+}
+
+impl IntoSqliteResult for i32 {
+    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
+        unsafe {
+            ffi::sqlite3_result_int(ctx, self);
+        }
+    }
+}

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -198,12 +198,8 @@ mod tests {
     use dsl::sql;
     use prelude::*;
     use super::*;
-<<<<<<< HEAD
-    use sql_types::Integer;
-=======
     use super::app_defined_fn::Context;
-    use types::Integer;
->>>>>>> Cleanup. Module structure and documentation
+    use sql_types::{Integer, Nullable, Text};
 
     #[test]
     fn prepared_statements_are_cached_when_run() {
@@ -291,8 +287,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Text>("SELECT f()");
+        let query = sql::<Text>("SELECT f()");
         assert_eq!(Ok("Meaning of life".to_string()), query.get_result(&connection));
     }
 
@@ -308,8 +303,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Text>("SELECT f()");
+        let query = sql::<Text>("SELECT f()");
         assert_eq!(Ok("Meaning of life".to_string()), query.get_result(&connection));
     }
 
@@ -324,8 +318,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Nullable<types::Integer>>("SELECT f()");
+        let query = sql::<Nullable<Integer>>("SELECT f()");
         assert_eq!(Ok(Some(42)), query.get_result(&connection));
     }
 
@@ -340,8 +333,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Nullable<types::Integer>>("SELECT f()");
+        let query = sql::<Nullable<Integer>>("SELECT f()");
         assert_eq!(Ok(None as Option<i32>), query.get_result(&connection));
     }
 
@@ -357,8 +349,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Integer>("SELECT f()");
+        let query = sql::<Integer>("SELECT f()");
         assert_eq!(Ok(42), query.get_result(&connection));
     }
 
@@ -375,8 +366,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Integer>("SELECT f()");
+        let query = sql::<Integer>("SELECT f()");
         match query.get_result::<i32>(&connection) {
             Err(DatabaseError(..)) => (),
             _ => panic!("Expected Err result"),
@@ -397,8 +387,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Integer>("SELECT f()");
+        let query = sql::<Integer>("SELECT f()");
         match query.get_result::<i32>(&connection) {
             Err(DatabaseError(_kind, info)) => {
                 assert_eq!("My custom error", info.message());
@@ -434,8 +423,7 @@ mod tests {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.create_scalar_function("f", 1, true, f).unwrap();
 
-        use types;
-        let query = sql::<types::Text>("SELECT f('Fun!')");
+        let query = sql::<Text>("SELECT f('Fun!')");
         assert_eq!(Ok("FUN!".to_string()), query.get_result(&connection));
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -343,22 +343,6 @@ mod tests {
     }
 
     #[test]
-    fn create_scalar_function_return_string() {
-        use expression::sql_literal::sql;
-
-        fn f(_: &Context) -> String {
-            "Meaning of life".into()
-        }
-
-        let mut connection = SqliteConnection::establish(":memory:").unwrap();
-        connection.create_scalar_function("f", 0, true, f).unwrap();
-
-        use types;
-        let query = sql::<types::Text>("SELECT f()");
-        assert_eq!(Ok("Meaning of life".to_string()), query.get_result(&connection));
-    }
-
-    #[test]
     fn create_scalar_function_return_cstring() {
         use std::ffi::CString;
         use expression::sql_literal::sql;

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -359,11 +359,12 @@ mod tests {
     }
 
     #[test]
-    fn create_scalar_function_return_str() {
+    fn create_scalar_function_return_cstring() {
+        use std::ffi::CString;
         use expression::sql_literal::sql;
 
-        fn f(_: &Context) -> &'static str {
-            "Meaning of life"
+        fn f(_: &Context) -> CString {
+            CString::new("Meaning of life").unwrap()
         }
 
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
@@ -375,12 +376,12 @@ mod tests {
     }
 
     #[test]
-    fn create_scalar_function_return_cstring() {
-        use std::ffi::CString;
+    fn create_scalar_function_return_cstr() {
+        use std::ffi::CStr;
         use expression::sql_literal::sql;
 
-        fn f(_: &Context) -> CString {
-            CString::new("Meaning of life").unwrap()
+        fn f(_: &Context) -> &'static CStr {
+            CStr::from_bytes_with_nul(b"Meaning of life\0").unwrap()
         }
 
         let mut connection = SqliteConnection::establish(":memory:").unwrap();

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -2,9 +2,10 @@ extern crate libsqlite3_sys as ffi;
 
 #[doc(hidden)]
 pub mod raw;
-mod stmt;
-mod statement_iterator;
+mod into_sqlite_result;
 mod sqlite_value;
+mod statement_iterator;
+mod stmt;
 
 pub use self::sqlite_value::SqliteValue;
 
@@ -16,6 +17,7 @@ use deserialize::{Queryable, QueryableByName};
 use query_builder::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use result::*;
+use self::into_sqlite_result::IntoSqliteResult;
 use self::raw::RawConnection;
 use self::statement_iterator::*;
 use self::stmt::{Statement, StatementUse};
@@ -157,18 +159,6 @@ impl<'a> Context<'a> {
 
 unsafe extern "C" fn free_boxed_value<T>(p: *mut ::std::os::raw::c_void) {
     let _: Box<T> = Box::from_raw(::std::mem::transmute(p));
-}
-
-pub trait IntoSqliteResult {
-    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context);
-}
-
-impl IntoSqliteResult for i32 {
-    fn into_sqlite_result(self, ctx: *mut ffi::sqlite3_context) {
-        unsafe {
-            ffi::sqlite3_result_int(ctx, self);
-        }
-    }
 }
 
 impl SqliteConnection {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -11,6 +11,7 @@ mod stmt;
 
 pub use self::sqlite_value::SqliteValue;
 pub use self::into_sqlite_result::error;
+pub use self::app_defined_fn::Context;
 
 use std::os::raw as libc;
 use std::rc::Rc;
@@ -144,7 +145,7 @@ impl SqliteConnection {
         x_func: F
     ) -> QueryResult<()>
     where
-        F: FnMut(&app_defined_fn::Context) -> T,
+        F: FnMut(&Context) -> T,
         T: IntoSqliteResult
     {
         // create_scalar_function is translated from rusqlite

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -142,11 +142,11 @@ impl SqliteConnection {
         fn_name: &str,
         n_arg: libc::c_int,
         deterministic: bool,
-        x_func: F
+        x_func: F,
     ) -> QueryResult<()>
     where
         F: FnMut(&Context) -> T,
-        T: IntoSqliteResult
+        T: IntoSqliteResult,
     {
         // create_scalar_function is translated from rusqlite
 
@@ -176,7 +176,7 @@ impl SqliteConnection {
                 Some(call_boxed_closure::<F, T>),
                 None,
                 None,
-                Some(free_boxed_value::<F>)
+                Some(free_boxed_value::<F>),
             )
         };
 
@@ -253,7 +253,9 @@ mod tests {
 
     #[test]
     fn create_scalar_function() {
-        fn f(_: &Context) -> i32 { panic!(); }
+        fn f(_: &Context) -> i32 {
+            panic!();
+        }
 
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
 
@@ -289,7 +291,10 @@ mod tests {
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
         let query = sql::<Text>("SELECT f()");
-        assert_eq!(Ok("Meaning of life".to_string()), query.get_result(&connection));
+        assert_eq!(
+            Ok("Meaning of life".to_string()),
+            query.get_result(&connection)
+        );
     }
 
     #[test]
@@ -305,7 +310,10 @@ mod tests {
         connection.create_scalar_function("f", 0, true, f).unwrap();
 
         let query = sql::<Text>("SELECT f()");
-        assert_eq!(Ok("Meaning of life".to_string()), query.get_result(&connection));
+        assert_eq!(
+            Ok("Meaning of life".to_string()),
+            query.get_result(&connection)
+        );
     }
 
     #[test]
@@ -392,7 +400,7 @@ mod tests {
         match query.get_result::<i32>(&connection) {
             Err(DatabaseError(_kind, info)) => {
                 assert_eq!("My custom error", info.message());
-            },
+            }
             _ => panic!("Expected Err result"),
         }
     }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -373,4 +373,21 @@ mod tests {
         let query = sql::<types::Text>("SELECT f()");
         assert_eq!(Ok("Meaning of life".to_string()), query.get_result(&connection));
     }
+
+    #[test]
+    fn create_scalar_function_return_cstring() {
+        use std::ffi::CString;
+        use expression::sql_literal::sql;
+
+        fn f(_: &Context) -> CString {
+            CString::new("Meaning of life").unwrap()
+        }
+
+        let mut connection = SqliteConnection::establish(":memory:").unwrap();
+        connection.create_scalar_function("f", 0, true, f).unwrap();
+
+        use types;
+        let query = sql::<types::Text>("SELECT f()");
+        assert_eq!(Ok("Meaning of life".to_string()), query.get_result(&connection));
+    }
 }

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -13,5 +13,5 @@ mod types;
 pub mod query_builder;
 
 pub use self::backend::{Sqlite, SqliteType};
-pub use self::connection::{SqliteConnection, error};
+pub use self::connection::{Context, SqliteConnection, error};
 pub use self::query_builder::SqliteQueryBuilder;

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -4,6 +4,8 @@
 //! However, if you are writing code specifically to extend Diesel on
 //! SQLite, you may need to work with this module directly.
 
+#![warn(warnings)] //FIXME
+
 mod backend;
 mod connection;
 mod types;
@@ -11,5 +13,5 @@ mod types;
 pub mod query_builder;
 
 pub use self::backend::{Sqlite, SqliteType};
-pub use self::connection::SqliteConnection;
+pub use self::connection::{SqliteConnection, error};
 pub use self::query_builder::SqliteQueryBuilder;

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -13,5 +13,5 @@ mod types;
 pub mod query_builder;
 
 pub use self::backend::{Sqlite, SqliteType};
-pub use self::connection::{Context, SqliteConnection, error};
+pub use self::connection::{error, Context, SqliteConnection};
 pub use self::query_builder::SqliteQueryBuilder;


### PR DESCRIPTION
This is a work in progress, for issue #1103.

The goal here is to support exposing application defined functions to SQL with SQLite, and this is currently implemented. See [the tests](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/mod.rs#L253-L436) for examples.

There are problems I want to address still, but I'd like some input/discussion for what's a good way to do that.

1. The [`create_scalar_function`](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/mod.rs#L139-L148) API is a bit clunky. It is especially round-about how the arguments to the application-defined function must be queried from the context-object. It would be nice to have an API that would let you stuff in a function, and the argument count and necessary conversions would be discovered automatically. Can we do this?
2. In [FromSqliteValue](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/mod.rs#L139-L148) and [into_sqlite_result](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/into_sqlite_result.rs#L8-L16) I'm passing raw pointers. This is my first foray into `unsafe` code, so I am a bit uncertain. I suppose I should really create types that semantically convey guarantees such as "this is a valid sqlite3_context pointer" and "this is a valid sqlite3_value pointer that is 'protected' in the sqlite3-sense". I am not sure how I would go about doing this without introducing some inadvertent cost, for example when [converting a raw array of `sqlite3_value` pointers](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/app_defined_fn.rs#L60). (Maybe do it one at a time in [fn get(..)](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/app_defined_fn.rs#L37)?)
3. `FromSqliteValue` for `String` and `Vec<u8>` is [not zero cost](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/from_sqlite_value.rs#L46-L51). I think it is impossible to create a safe zero-cost abstraction here. Maybe the ideal API would offer two options: unsafe zero-cost and safe non-zero-cost.
4. `IntoSqliteResult` [should support blob](https://github.com/maghoff/diesel/blob/d200a6344fda92445a3776c0538ad1bda0f9431f/diesel/src/sqlite/connection/into_sqlite_result.rs#L6). I'd like this to be zero-cost, like the CString-impl, but I don't know how to go about it. (I can only pass a (non-fat) pointer into the FFI, and I have to properly drop the value based on this later, but `slice::as_ptr` gives me a fat pointer)
5. I'm not entirely sure that `IntoSqliteResult` is ideal because of the recursive `impl`s of `Option` and `Result`. Not only is it possible to convert an `Option<i32>` into a nullable sqlite result, it is also possible to convert `Option<Option<Option<i32>>>` into one. This doesn't actually make any sense. Is it worth it to add additional types so that while `Option<i32>` works, `Option<Option<i32>>` would fail to compile?

I'm hoping for some input/discussion to help me focus on what's most important going forward. Thanks :)

(CC @killercup )