### PR TITLE
Move the responsibility of the `VALUES` keyword off of `InsertStatement`

### DIFF
--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -1,8 +1,6 @@
 use backend::Backend;
 use expression::{Expression, NonAggregate};
-use insertable::InsertValues;
 use query_builder::*;
-use query_source::Table;
 use result::QueryResult;
 
 #[derive(Debug, Copy, Clone, QueryId, Default)]
@@ -14,14 +12,9 @@ impl<T: Expression> Expression for Grouped<T> {
 
 impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
-        let is_noop = self.0.is_noop()?;
-        if !is_noop {
-            out.push_sql("(");
-        }
+        out.push_sql("(");
         self.0.walk_ast(out.reborrow())?;
-        if !is_noop {
-            out.push_sql(")");
-        }
+        out.push_sql(")");
         Ok(())
     }
 }
@@ -31,22 +24,5 @@ impl_selectable_expression!(Grouped<T>);
 impl<T: NonAggregate> NonAggregate for Grouped<T>
 where
     Grouped<T>: Expression,
-{
-}
-
-impl<T, U, DB> InsertValues<T, DB> for Grouped<U>
-where
-    T: Table,
-    DB: Backend,
-    U: InsertValues<T, DB>,
-{
-    fn column_names(&self, out: AstPass<DB>) -> QueryResult<()> {
-        self.0.column_names(out)
-    }
-}
-
-impl<T, U> UndecoratedInsertRecord<T> for Grouped<U>
-where
-    U: UndecoratedInsertRecord<T>,
 {
 }

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -68,9 +68,6 @@ pub mod dsl {
 #[doc(inline)]
 pub use self::sql_literal::SqlLiteral;
 
-#[doc(hidden)]
-pub use self::grouped::Grouped;
-
 use backend::Backend;
 use dsl::AsExprOf;
 

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -356,18 +356,18 @@ diesel_postfix_operator!(Desc, " DESC", ());
 
 diesel_prefix_operator!(Not, "NOT ");
 
-use expression::Grouped;
 use insertable::{ColumnInsertValue, Insertable};
+use query_builder::ValuesClause;
 use query_source::Column;
 
 impl<T, U> Insertable<T::Table> for Eq<T, U>
 where
     T: Column,
 {
-    type Values = Grouped<ColumnInsertValue<T, U>>;
+    type Values = ValuesClause<ColumnInsertValue<T, U>, T::Table>;
 
     fn values(self) -> Self::Values {
-        Grouped(ColumnInsertValue::Expression(self.left, self.right))
+        ValuesClause::new(ColumnInsertValue::Expression(self.left, self.right))
     }
 }
 

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -1,7 +1,6 @@
 use insertable::*;
 use pg::Pg;
 use query_builder::*;
-use query_source::Table;
 use result::QueryResult;
 use super::on_conflict_actions::*;
 use super::on_conflict_target::*;
@@ -36,17 +35,6 @@ where
 {
     fn rows_to_insert(&self) -> usize {
         self.values.rows_to_insert()
-    }
-}
-
-impl<Tab, Values, Target, Action> InsertValues<Tab, Pg> for OnConflictValues<Values, Target, Action>
-where
-    Tab: Table,
-    Values: InsertValues<Tab, Pg>,
-    Self: QueryFragment<Pg>,
-{
-    fn column_names(&self, out: AstPass<Pg>) -> QueryResult<()> {
-        self.values.column_names(out)
     }
 }
 

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -163,6 +163,7 @@ where
         self.operator.walk_ast(out.reborrow())?;
         out.push_sql(" INTO ");
         self.target.from_clause().walk_ast(out.reborrow())?;
+        out.push_sql(" ");
         self.records.walk_ast(out.reborrow())?;
         self.returning.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -37,7 +37,7 @@ pub use self::debug_query::DebugQuery;
 pub use self::delete_statement::DeleteStatement;
 #[doc(inline)]
 pub use self::insert_statement::{IncompleteInsertStatement, InsertStatement,
-                                 UndecoratedInsertRecord};
+                                 UndecoratedInsertRecord, ValuesClause};
 pub use self::query_id::QueryId;
 #[doc(hidden)]
 pub use self::select_statement::{BoxedSelectStatement, SelectStatement};

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 use associations::BelongsTo;
 use backend::Backend;
 use deserialize::{self, FromSqlRow, Queryable, QueryableByName};
-use expression::{AppearsOnTable, AsExpression, AsExpressionList, Expression, Grouped,
-                 NonAggregate, SelectableExpression};
+use expression::{AppearsOnTable, AsExpression, AsExpressionList, Expression, NonAggregate,
+                 SelectableExpression};
 use insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
 use query_builder::*;
 use query_source::*;
@@ -117,12 +117,12 @@ macro_rules! tuple_impls {
 
             impl<$($T,)+ $($ST,)+ Tab> Insertable<Tab> for ($($T,)+)
             where
-                $($T: Insertable<Tab, Values = Grouped<$ST>>,)+
+                $($T: Insertable<Tab, Values = ValuesClause<$ST, Tab>>,)+
             {
-                type Values = Grouped<($($ST,)+)>;
+                type Values = ValuesClause<($($ST,)+), Tab>;
 
                 fn values(self) -> Self::Values {
-                    Grouped(($(self.$idx.values().0,)+))
+                    ValuesClause::new(($(self.$idx.values().values,)+))
                 }
             }
 

--- a/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_cannot_reference_columns_from_other_table.rs
@@ -26,4 +26,6 @@ fn main() {
     insert_into(users::table)
         .values(&(posts::id.eq(1), users::id.eq(2)));
         //~^ ERROR type mismatch resolving `<posts::columns::id as diesel::Column>::Table == users::table`
+        //~| ERROR E0271
+        //FIXME: Bad error on the second one
 }

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -2,10 +2,9 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use diesel::deserialize::FromSql;
 use diesel::expression::bound::Bound;
-use diesel::expression::Grouped;
 use diesel::insertable::ColumnInsertValue;
 use diesel::prelude::*;
-use diesel::query_builder::InsertStatement;
+use diesel::query_builder::{InsertStatement, ValuesClause};
 use diesel::query_dsl::methods::ExecuteDsl;
 use diesel::sql_types::VarChar;
 
@@ -26,7 +25,7 @@ where
     T: Connection,
     String: FromSql<VarChar, T::Backend>,
     // FIXME: HRTB is preventing projecting on any associated types here
-    for<'a> InsertStatement<__diesel_schema_migrations, Grouped<ColumnInsertValue<version, &'a Bound<VarChar, &'a str>>>>: ExecuteDsl<T>,
+    for<'a> InsertStatement<__diesel_schema_migrations, ValuesClause<ColumnInsertValue<version, &'a Bound<VarChar, &'a str>>, __diesel_schema_migrations>>: ExecuteDsl<T>,
 {
     fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>> {
         __diesel_schema_migrations


### PR DESCRIPTION
This change is in order to allow a select statement to be used instead.
There's a little bit of duplication between this and batch insert, but
I'm relatively comfortable with it overall. This should be the last
structural change required to support insert from select

We can safely make the change to this impl, since it has bounds on
traits that are not public API. The only types which could have been
used here are types defined by Diesel.