### PR TITLE
Partially fix our test suite on beta/nightly

### DIFF
--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -77,9 +77,8 @@ const BACKEND: &str = "postgres";
 const BACKEND: &str = "mysql";
 
 fn test_print_schema(test_name: &str, args: Vec<&str>) {
-    let test_path = Path::new(file!())
-        .parent()
-        .unwrap()
+    let test_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
         .join("print_schema")
         .join(test_name)
         .join(BACKEND);


### PR DESCRIPTION
Right now on beta the behavior of `file!` (or more specifically, the
cwd when compiling the crate) has changed when running `cargo test`.
It's unclear whether that change will be reverted or not, but it does
point out how brittle these tests are. We want an absolute path, not a
relative one, so using `CARGO_MANIFEST_DIR` instead seems like the way
to go.