### PR TITLE
Add support for `BEGIN IMMEDIATE` and `BEGIN EXCLUSIVE` on SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [`PgConnection::build_transaction`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html#method.build_transaction
 
+* Added support for `BEGIN IMMEDIATE` and `BEGIN EXCLUSIVE` on SQLite.
+  See [`SqliteConnection::immediate_transaction`] and
+  [`SqliteConnection::exclusive_transaction`] for details
+
+[`SqliteConnection::immediate_transaction`]: http://docs.diesel.rs/diesel/sqlite/struct.SqliteConnection.html#method.immediate_transaction
+[`SqliteConnection::exclusive_transaction`]: http://docs.diesel.rs/diesel/sqlite/struct.SqliteConnection.html#method.exclusive_transaction
+
 ### Changed
 
 * The bounds on `impl ToSql for Cow<'a, T>` have been loosened to no longer


### PR DESCRIPTION
Much like the tests for the most of the PG modifiers, I don't think we
can reasonably demonstrate their behavior in the doc example. It's still
worth having an example to show some amount of usage though, and to test
that we are generating a syntactically valid query.

Fixes #1356.