### PR TITLE
Do not depend on r2d2 < 0.8 because this causes compile errors

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -31,7 +31,7 @@ num-traits = { version = "0.1.35", optional = true }
 num-integer = { version = "0.1.32", optional = true }
 bigdecimal = { version = "0.0.10", optional = true }
 bitflags = { version = "1.0", optional = true }
-r2d2 = { version = ">= 0.7, < 0.9", optional = true }
+r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 
 [dev-dependencies]
 cfg-if = "0.1.0"


### PR DESCRIPTION
Fix #1508 
I think this should also be backported to 1.1.