### PR TITLE
Move various `AsChangeset` tests into derives2, more exhaustively test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   fi &&
   (cd diesel && travis-cargo test -- --no-default-features --features "extras with-deprecated $BACKEND") &&
   (cd diesel_derives && travis-cargo test -- --features "diesel/$BACKEND") &&
+  (cd diesel_derives2 && travis-cargo test -- --features "$BACKEND") &&
   if [[ "$BACKEND" == postgres ]]; then
     (cd examples/postgres && ./test_all)
   fi &&
@@ -53,6 +54,7 @@ matrix:
     - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans)
     - (cd diesel_cli && cargo rustc --no-default-features --features "lint sqlite postgres mysql" -- -Zno-trans)
     - (cd diesel_derives && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
+    - (cd diesel_derives2 && cargo rustc --no-default-features --features "lint" -- -Zno-trans)
     - (cd diesel_migrations && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
     - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
     - (cd diesel_compile_tests && travis-cargo test)

--- a/bin/check
+++ b/bin/check
@@ -11,6 +11,10 @@ check() {
     check &&
     echo "✔ derives crate looks good!")
 
+(cd diesel_derives2 &&
+    check &&
+    echo "✔ derives2 crate looks good!")
+
 (cd diesel &&
     check "unstable extras" &&
     echo "✔ diesel core crate looks good!")

--- a/bin/test
+++ b/bin/test
@@ -27,6 +27,7 @@ else
   (cd diesel_infer_schema && cargo test --features "$CLIPPY sqlite" $*)
   (cd diesel_migrations && cargo test --features "$CLIPPY sqlite" $*)
   (cd diesel_derives && cargo test --features "$CLIPPY diesel/sqlite" $*)
+  (cd diesel_derives2 && cargo test --features "$CLIPPY sqlite" $*)
   (cd diesel_tests && cargo test --features "$CLIPPY sqlite" --no-default-features $*)
 
   (cd diesel_infer_schema/infer_schema_internals && cargo test --features "$CLIPPY postgres" $*)
@@ -34,6 +35,7 @@ else
   (cd diesel_infer_schema && cargo test --features "$CLIPPY postgres" $*)
   (cd diesel_migrations && cargo test --features "$CLIPPY postgres" $*)
   (cd diesel_derives && cargo test --features "$CLIPPY diesel/postgres" $*)
+  (cd diesel_derives2 && cargo test --features "$CLIPPY postgres" $*)
   (cd diesel_cli && cargo test --features "$CLIPPY postgres" --no-default-features $*)
   (cd diesel_tests && cargo test --features "$CLIPPY postgres" --no-default-features $*)
 
@@ -43,6 +45,7 @@ else
   (cd diesel_infer_schema && cargo test --features "$CLIPPY mysql" $*)
   (cd diesel_migrations && cargo test --features "$CLIPPY mysql" $*)
   (cd diesel_derives && cargo test --features "$CLIPPY diesel/mysql" $*)
+  (cd diesel_derives2 && cargo test --features "$CLIPPY mysql" $*)
   (cd diesel_cli && cargo test --features "$CLIPPY mysql" --no-default-features $*)
   (cd diesel_tests && cargo test --features "$CLIPPY mysql" --no-default-features $*)
   unset RUST_TEST_THREADS

--- a/diesel_derives2/Cargo.toml
+++ b/diesel_derives2/Cargo.toml
@@ -13,12 +13,24 @@ syn = { version = "0.12.0", features = ["full"] }
 quote = "0.4"
 clippy = { optional = true, version = "=0.0.174" }
 
+[dev-dependencies]
+cfg-if = "0.1.0"
+diesel = "1.1.0"
+diesel_migrations = "1.1.0"
+dotenv = "0.10.0"
+
 [lib]
 proc-macro = true
+
+[[test]]
+name = "tests"
 
 [features]
 default = []
 lint = ["clippy"]
+postgres = ["diesel/postgres", "diesel_migrations/postgres"]
+sqlite = ["diesel/sqlite", "diesel_migrations/sqlite"]
+mysql = ["diesel/mysql", "diesel_migrations/mysql"]
 
 [badges]
 travis-ci = { repository = "diesel-rs/diesel" }

--- a/diesel_derives2/src/as_changeset.rs
+++ b/diesel_derives2/src/as_changeset.rs
@@ -82,7 +82,7 @@ fn field_changeset_expr(
     table_name: syn::Ident,
     treat_none_as_null: bool,
 ) -> syn::Expr {
-    let field_name = field.field_name();
+    let field_name = &field.name;
     let column_name = field.column_name();
     if !treat_none_as_null && is_option_ty(&field.ty) {
         parse_quote!(self.#field_name.as_ref().map(|x| #table_name::#column_name.eq(x)))

--- a/diesel_derives2/src/field.rs
+++ b/diesel_derives2/src/field.rs
@@ -1,11 +1,12 @@
 use syn;
+use quote;
 
 use meta::*;
 
 pub struct Field {
     pub ty: syn::Type,
+    pub name: FieldName,
     column_name_from_attribute: Option<syn::Ident>,
-    identifier: Identifier,
 }
 
 impl Field {
@@ -13,43 +14,37 @@ impl Field {
         let column_name_from_attribute = MetaItem::with_name(&field.attrs, "column_name")
             .ok()
             .map(|m| m.expect_ident_value());
-        let identifier = match field.ident {
-            Some(x) => Identifier::Named(x),
-            None => Identifier::Unnamed(index.to_string().into()),
+        let name = match field.ident {
+            Some(x) => FieldName::Named(x),
+            None => FieldName::Unnamed(index.into()),
         };
 
         Self {
             ty: field.ty.clone(),
             column_name_from_attribute,
-            identifier,
+            name,
         }
     }
 
     pub fn column_name(&self) -> syn::Ident {
         self.column_name_from_attribute
-            .unwrap_or_else(|| match self.identifier {
-                Identifier::Named(x) => x,
+            .unwrap_or_else(|| match self.name {
+                FieldName::Named(x) => x,
                 _ => panic!("All fields of tuple structs must be annotated with `#[column_name]`"),
             })
     }
-
-    pub fn field_name(&self) -> syn::Ident {
-        self.identifier.ident()
-    }
 }
 
-#[derive(Debug)]
-enum Identifier {
+pub enum FieldName {
     Named(syn::Ident),
-    Unnamed(syn::Ident),
+    Unnamed(syn::Index),
 }
 
-impl Identifier {
-    fn ident(&self) -> syn::Ident {
-        use self::Identifier::*;
-
+impl quote::ToTokens for FieldName {
+    fn to_tokens(&self, tokens: &mut quote::Tokens) {
         match *self {
-            Named(x) | Unnamed(x) => x,
+            FieldName::Named(x) => x.to_tokens(tokens),
+            FieldName::Unnamed(ref x) => x.to_tokens(tokens),
         }
     }
 }

--- a/diesel_derives2/tests/as_changeset.rs
+++ b/diesel_derives2/tests/as_changeset.rs
@@ -1,0 +1,418 @@
+use diesel::*;
+use helpers::*;
+use schema::*;
+
+#[test]
+fn named_struct() {
+    #[derive(AsChangeset)]
+    struct User {
+        name: String,
+        hair_color: String,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&User {
+            name: String::from("Jim"),
+            hair_color: String::from("blue"),
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn with_explicit_table_name() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm {
+        name: String,
+        hair_color: String,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: String::from("Jim"),
+            hair_color: String::from("blue"),
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn with_lifetime() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a> {
+        name: &'a str,
+        hair_color: &'a str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: "Jim",
+            hair_color: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn with_multiple_lifetimes() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a, 'b> {
+        name: &'a str,
+        hair_color: &'b str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: "Jim",
+            hair_color: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn with_lifetime_constraints() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a, 'b: 'a> {
+        name: &'a str,
+        hair_color: &'b str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: "Jim",
+            hair_color: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn with_explicit_column_names() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a> {
+        #[column_name = "name"] nombre: &'a str,
+        #[column_name = "hair_color"] color_de_pelo: &'a str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            nombre: "Jim",
+            color_de_pelo: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn tuple_struct() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a>(
+        #[column_name = "name"] &'a str,
+        #[column_name = "hair_color"] &'a str,
+    );
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm("Jim", "blue"))
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn struct_containing_single_field() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a> {
+        name: &'a str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm { name: "Jim" })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("black"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn tuple_struct_containing_single_field() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a>(#[column_name = "name"] &'a str);
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm("Jim"))
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("black"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn primary_key_is_not_updated() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a> {
+        #[allow(dead_code)] id: i32,
+        name: &'a str,
+        hair_color: &'a str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            id: 3,
+            name: "Jim",
+            hair_color: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn primary_key_is_based_on_column_name() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a> {
+        #[column_name = "id"] _id: i32,
+        name: &'a str,
+        hair_color: &'a str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            _id: 3,
+            name: "Jim",
+            hair_color: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn primary_key_is_not_updated_with_custom_pk() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    #[primary_key(name)]
+    struct UserForm<'a> {
+        #[allow(dead_code)] name: &'a str,
+        hair_color: &'a str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: "Jim",
+            hair_color: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Sean"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn primary_key_is_not_updated_with_custom_composite_pk() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    #[primary_key(id, name)]
+    #[allow(dead_code)]
+    struct UserForm<'a> {
+        id: i32,
+        name: &'a str,
+        hair_color: &'a str,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            id: 3,
+            name: "Jim",
+            hair_color: "blue",
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Sean"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn option_fields_are_skipped() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    struct UserForm<'a> {
+        name: &'a str,
+        hair_color: Option<&'a str>,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: "Jim",
+            hair_color: Some("blue"),
+        })
+        .execute(&connection)
+        .unwrap();
+    update(users::table.find(2))
+        .set(&UserForm {
+            name: "Ruby",
+            hair_color: None,
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Ruby"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
+fn option_fields_are_assigned_null_when_specified() {
+    #[derive(AsChangeset)]
+    #[table_name = "users"]
+    #[changeset_options(treat_none_as_null = "true")]
+    struct UserForm<'a> {
+        name: &'a str,
+        hair_color: Option<&'a str>,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: "Jim",
+            hair_color: Some("blue"),
+        })
+        .execute(&connection)
+        .unwrap();
+    update(users::table.find(2))
+        .set(&UserForm {
+            name: "Ruby",
+            hair_color: None,
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Ruby"), None),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}

--- a/diesel_derives2/tests/helpers.rs
+++ b/diesel_derives2/tests/helpers.rs
@@ -1,0 +1,76 @@
+use diesel::prelude::*;
+use std::sync::{Once, ONCE_INIT};
+
+cfg_if! {
+    if #[cfg(feature = "sqlite")] {
+        embed_migrations!("../migrations/sqlite");
+
+        pub type TestConnection = SqliteConnection;
+
+        fn connection_no_transaction() -> TestConnection {
+            SqliteConnection::establish(":memory:").unwrap()
+        }
+    } else if #[cfg(feature = "postgres")] {
+        extern crate dotenv;
+
+        embed_migrations!("../migrations/postgresql");
+
+        pub type TestConnection = PgConnection;
+
+        fn connection_no_transaction() -> TestConnection {
+            let database_url = dotenv::var("PG_DATABASE_URL")
+                .or_else(|_| dotenv::var("DATABASE_URL"))
+                .expect("DATABASE_URL must be set in order to run tests");
+            PgConnection::establish(&database_url).unwrap()
+        }
+    } else if #[cfg(feature = "mysql")] {
+        extern crate dotenv;
+
+        embed_migrations!("../migrations/mysql");
+
+        pub type TestConnection = MysqlConnection;
+
+        fn connection_no_transaction() -> TestConnection {
+            let database_url = dotenv::var("MYSQL_DATABASE_URL")
+                .or_else(|_| dotenv::var("DATABASE_URL"))
+                .expect("DATABASE_URL must be set in order to run tests");
+            MysqlConnection::establish(&database_url).unwrap()
+        }
+    } else {
+        compile_error!(
+            "At least one backend must be used to test this crate.\n \
+            Pass argument `--features \"<backend>\"` with one or more of the following backends, \
+            'mysql', 'postgres', or 'sqlite'. \n\n \
+            ex. cargo test --features \"mysql postgres sqlite\"\n"
+        );
+     }
+}
+
+static RUN_MIGRATIONS: Once = ONCE_INIT;
+
+pub fn connection() -> TestConnection {
+    let connection = connection_no_transaction();
+    if cfg!(feature = "sqlite") {
+        embedded_migrations::run(&connection).unwrap();
+    } else {
+        RUN_MIGRATIONS.call_once(|| {
+            embedded_migrations::run(&connection).unwrap();
+        })
+    }
+    connection.begin_test_transaction().unwrap();
+    connection
+}
+
+pub fn connection_with_sean_and_tess_in_users_table() -> TestConnection {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    ::diesel::insert_into(users)
+        .values(&vec![
+            (id.eq(1), name.eq("Sean"), hair_color.eq("black")),
+            (id.eq(2), name.eq("Tess"), hair_color.eq("brown")),
+        ])
+        .execute(&connection)
+        .unwrap();
+    connection
+}

--- a/diesel_derives2/tests/schema.rs
+++ b/diesel_derives2/tests/schema.rs
@@ -1,0 +1,7 @@
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}

--- a/diesel_derives2/tests/tests.rs
+++ b/diesel_derives2/tests/tests.rs
@@ -1,0 +1,13 @@
+#![deny(warnings)]
+
+#[macro_use]
+extern crate cfg_if;
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_migrations;
+
+mod helpers;
+mod schema;
+
+mod as_changeset;


### PR DESCRIPTION
The tests for `AsChangeset` mostly lived in the integration suite (there
is still at least one test that is redundant there, but I do want the
integration suite to have at least one "AsChangeset works" test).

I have not moved the tests that are specific to `save_changes` over,
since those have nothing to do with codegen. I specifically structured
the tests so that the *only* derive used is `AsChangeset`, since these
are meant to be unit tests for that derive.

I've added a few tests that weren't covered before (like a tuple
struct), and in the process learned that tuple structs were broken. I
haven't tested anything that we don't explicitly support yet or that we
know is broken, like generic structs or structs with where clauses.