### PR TITLE
Get diesel_derives2 working with hygiene turned on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,10 @@ script:
   (cd diesel && travis-cargo test -- --no-default-features --features "extras with-deprecated $BACKEND") &&
   (cd diesel_derives && travis-cargo test -- --features "diesel/$BACKEND") &&
   (cd diesel_derives2 && travis-cargo test -- --features "$BACKEND") &&
-  if [[ "$BACKEND" == postgres ]]; then
-    (cd examples/postgres && ./test_all)
+  if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
+    (cd diesel_derives2 && travis-cargo test -- --features "nightly $BACKEND")
   fi &&
-  if [[ "$BACKEND" == mysql ]]; then
-    (cd examples/mysql && ./test_all)
-  fi &&
-  if [[ "$BACKEND" == sqlite ]]; then
-    (cd examples/sqlite && ./test_all)
-  fi &&
+  (cd "examples/$BACKEND" && ./test_all) &&
   (cd diesel_cli && travis-cargo test -- --no-default-features --features "$BACKEND") &&
   (cd diesel_infer_schema/infer_schema_internals && travis-cargo test -- --no-default-features --features "$BACKEND") &&
   (cd diesel_infer_schema/infer_schema_macros && travis-cargo test -- --no-default-features --features "$BACKEND") &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
     - rust: nightly
     - rust: beta
   include:
-  - rust: nightly-2017-11-28
+  - rust: nightly-2018-02-02
     env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
     script:
     - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans)

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.0"
 diesel_derives = { version = "1.1.0" }
 diesel_derives2 = { path = "../diesel_derives2" }
 chrono = { version = "0.4", optional = true }
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.10.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -43,7 +43,7 @@ tempdir = "^0.3.4"
 [features]
 default = ["with-deprecated"]
 extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address", "numeric", "r2d2"]
-unstable = []
+unstable = ["diesel_derives2/nightly"]
 lint = ["clippy"]
 large-tables = []
 huge-tables = ["large-tables"]

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -108,7 +108,7 @@ pub struct StatementCache<DB: Backend, Statement> {
     pub cache: RefCell<HashMap<StatementCacheKey<DB>, Statement>>,
 }
 
-#[cfg_attr(feature = "clippy", allow(len_without_is_empty))]
+#[cfg_attr(feature = "clippy", allow(len_without_is_empty, new_without_default_derive))]
 impl<DB, Statement> StatementCache<DB, Statement>
 where
     DB: Backend,
@@ -116,7 +116,6 @@ where
     DB::QueryBuilder: Default,
     StatementCacheKey<DB>: Hash + Eq,
 {
-    #[cfg_attr(feature = "clippy", allow(new_without_default_derive))]
     pub fn new() -> Self {
         StatementCache {
             cache: RefCell::new(HashMap::new()),

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -31,14 +31,14 @@ impl ToSql<Uuid, Pg> for uuid::Uuid {
 #[test]
 fn uuid_to_sql() {
     let mut bytes = Output::test();
-    let test_uuid = uuid::Uuid::from_fields(4_294_967_295, 65_535, 65_535, b"abcdef12").unwrap();
+    let test_uuid = uuid::Uuid::from_fields(0xFFFF_FFFF, 0xFFFF, 0xFFFF, b"abcdef12").unwrap();
     ToSql::<Uuid, Pg>::to_sql(&test_uuid, &mut bytes).unwrap();
     assert_eq!(bytes, test_uuid.as_bytes());
 }
 
 #[test]
 fn some_uuid_from_sql() {
-    let input_uuid = uuid::Uuid::from_fields(4_294_967_295, 65_535, 65_535, b"abcdef12").unwrap();
+    let input_uuid = uuid::Uuid::from_fields(0xFFFF_FFFF, 0xFFFF, 0xFFFF, b"abcdef12").unwrap();
     let output_uuid = FromSql::<Uuid, Pg>::from_sql(Some(input_uuid.as_bytes())).unwrap();
     assert_eq!(input_uuid, output_uuid);
 }

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -42,8 +42,8 @@ pub struct RawBytesBindCollector<DB: Backend + TypeMetadata> {
     pub binds: Vec<Option<Vec<u8>>>,
 }
 
+#[cfg_attr(feature = "clippy", allow(new_without_default_derive))]
 impl<DB: Backend + TypeMetadata> RawBytesBindCollector<DB> {
-    #[cfg_attr(feature = "clippy", allow(new_without_default_derive))]
     /// Construct an empty `RawBytesBindCollector`
     pub fn new() -> Self {
         RawBytesBindCollector {

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -20,7 +20,7 @@ clap = "2.27"
 diesel = { version = "1.1.0", default-features = false }
 dotenv = ">=0.8, <0.11"
 infer_schema_internals = { version = "1.1.0" }
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 migrations_internals = { version = "1.1.0" }
 url = { version = "1.4.0", optional = true }
 

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [workspace]
 
 [dependencies]
-diesel = { version = "1.1.0", features = ["extras", "sqlite", "postgres", "mysql"] }
-compiletest_rs = "=0.3.3"
+diesel = { version = "1.1.0", features = ["extras", "sqlite", "postgres", "mysql", "unstable"] }
+compiletest_rs = "=0.3.6"
 
 [replace]
 "diesel:1.1.1" = { path = "../diesel" }

--- a/diesel_compile_tests/tests/compile_tests.rs
+++ b/diesel_compile_tests/tests/compile_tests.rs
@@ -21,6 +21,11 @@ fn run_mode(mode: &'static str) {
 }
 
 #[test]
-fn compile_test() {
+fn compile_fail() {
     run_mode("compile-fail");
+}
+
+#[test]
+fn ui() {
+    run_mode("ui")
 }

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.rs
@@ -1,0 +1,20 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+struct UserStruct {
+    name: String,
+    #[column_name = "hair_color"]
+    color_de_pelo: String,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+struct UserTuple(#[column_name = "name"] String);

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.stderr
@@ -1,0 +1,40 @@
+error[E0412]: cannot find type `name` in module `users`
+  --> $DIR/as_changeset_bad_column_name.rs:13:5
+   |
+13 |     name: String,
+   |     ^^^^ not found in `users`
+
+error[E0412]: cannot find type `hair_color` in module `users`
+  --> $DIR/as_changeset_bad_column_name.rs:14:5
+   |
+14 |     #[column_name = "hair_color"]
+   |     ^ not found in `users`
+
+error[E0425]: cannot find value `name` in module `users`
+  --> $DIR/as_changeset_bad_column_name.rs:13:5
+   |
+13 |     name: String,
+   |     ^^^^ not found in `users`
+
+error[E0425]: cannot find value `hair_color` in module `users`
+  --> $DIR/as_changeset_bad_column_name.rs:14:5
+   |
+14 |     #[column_name = "hair_color"]
+   |     ^ not found in `users`
+
+error[E0412]: cannot find type `name` in module `users`
+  --> $DIR/as_changeset_bad_column_name.rs:20:18
+   |
+20 | struct UserTuple(#[column_name = "name"] String);
+   |                  ^ not found in `users`
+
+error[E0425]: cannot find value `name` in module `users`
+  --> $DIR/as_changeset_bad_column_name.rs:20:18
+   |
+20 | struct UserTuple(#[column_name = "name"] String);
+   |                  ^ not found in `users`
+
+error[E0601]: main function not found
+
+error: aborting due to 7 previous errors
+

--- a/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate diesel;
+
+#[derive(AsChangeset)]
+struct User {
+    id: i32,
+    name: String,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+struct UserForm {
+    id: i32,
+    name: String,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve. Use of undeclared type or module `users`
+ --> $DIR/as_changeset_missing_table_import.rs:5:8
+  |
+5 | struct User {
+  |        ^^^^ Use of undeclared type or module `users`
+
+error[E0433]: failed to resolve. Use of undeclared type or module `users`
+ --> <macro expansion>:1:1
+  |
+1 | #[table_name = "users"]
+  | ^ Use of undeclared type or module `users`
+
+error: aborting due to 2 previous errors
+

--- a/diesel_compile_tests/tests/ui/update-references.sh
+++ b/diesel_compile_tests/tests/ui/update-references.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# A script to update the references for particular tests. The idea is
+# that you do a run, which will generate files in the build directory
+# containing the (normalized) actual output of the compiler. This
+# script will then copy that output and replace the "expected output"
+# files. You can then commit the changes.
+#
+# If you find yourself manually editing a foo.stderr file, you're
+# doing it wrong.
+
+if [[ "$1" == "--help" || "$1" == "-h" || "$1" == "" || "$2" == "" ]]; then
+    echo "usage: $0 <build-directory> <relative-path-to-rs-files>"
+    echo ""
+    echo "For example:"
+    echo "   $0 ../../../build/x86_64-apple-darwin/test/ui *.rs */*.rs"
+fi
+
+MYDIR=$(dirname $0)
+
+BUILD_DIR="$1"
+shift
+
+while [[ "$1" != "" ]]; do
+    STDERR_NAME="${1/%.rs/.stderr}"
+    STDOUT_NAME="${1/%.rs/.stdout}"
+    shift
+    if [ -f $BUILD_DIR/$STDOUT_NAME ] && \
+           ! (diff $BUILD_DIR/$STDOUT_NAME $MYDIR/$STDOUT_NAME >& /dev/null); then
+        echo updating $MYDIR/$STDOUT_NAME
+        cp $BUILD_DIR/$STDOUT_NAME $MYDIR/$STDOUT_NAME
+    fi
+    if [ -f $BUILD_DIR/$STDERR_NAME ] && \
+           ! (diff $BUILD_DIR/$STDERR_NAME $MYDIR/$STDERR_NAME >& /dev/null); then
+        echo updating $MYDIR/$STDERR_NAME
+        cp $BUILD_DIR/$STDERR_NAME $MYDIR/$STDERR_NAME
+    fi
+done

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_derives"
 [dependencies]
 syn = { version = "0.11.4", features = ["aster"] }
 quote = "0.3.12"
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 
 [dev-dependencies]
 dotenv = { version = ">=0.8, <0.11", default-features = false }

--- a/diesel_derives2/Cargo.toml
+++ b/diesel_derives2/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_derives"
 syn = { version = "0.12.0", features = ["full"] }
 quote = "0.4"
 clippy = { optional = true, version = "=0.0.174" }
+proc-macro2 = "0.2.0"
 
 [dev-dependencies]
 cfg-if = "0.1.0"
@@ -28,6 +29,7 @@ name = "tests"
 [features]
 default = []
 lint = ["clippy"]
+nightly = ["proc-macro2/nightly"]
 postgres = ["diesel/postgres", "diesel_migrations/postgres"]
 sqlite = ["diesel/sqlite", "diesel_migrations/sqlite"]
 mysql = ["diesel/mysql", "diesel_migrations/mysql"]

--- a/diesel_derives2/Cargo.toml
+++ b/diesel_derives2/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_derives"
 [dependencies]
 syn = { version = "0.12.0", features = ["full"] }
 quote = "0.4"
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 proc-macro2 = "0.2.0"
 
 [dev-dependencies]

--- a/diesel_derives2/src/as_changeset.rs
+++ b/diesel_derives2/src/as_changeset.rs
@@ -43,10 +43,10 @@ pub fn derive(item: syn::DeriveInput) -> quote::Tokens {
         );
     }
 
-    wrap_in_dummy_const(
-        model.dummy_const_name("AS_CHANGESET"),
+    wrap_in_dummy_mod(
+        model.dummy_mod_name("as_changeset"),
         quote!(
-            use diesel::query_builder::AsChangeset;
+            use self::diesel::query_builder::AsChangeset;
 
             impl #impl_generics AsChangeset for &'update #struct_name #ty_generics
             #where_clause
@@ -70,7 +70,7 @@ fn field_changeset_ty(
     let column_name = field.column_name();
     if !treat_none_as_null && is_option_ty(&field.ty) {
         let field_ty = inner_of_option_ty(&field.ty);
-        parse_quote!(::std::option::Option<diesel::dsl::Eq<#table_name::#column_name, &'update #field_ty>>)
+        parse_quote!(std::option::Option<diesel::dsl::Eq<#table_name::#column_name, &'update #field_ty>>)
     } else {
         let field_ty = &field.ty;
         parse_quote!(diesel::dsl::Eq<#table_name::#column_name, &'update #field_ty>)
@@ -82,11 +82,11 @@ fn field_changeset_expr(
     table_name: syn::Ident,
     treat_none_as_null: bool,
 ) -> syn::Expr {
-    let field_name = &field.name;
+    let field_access = &field.name;
     let column_name = field.column_name();
     if !treat_none_as_null && is_option_ty(&field.ty) {
-        parse_quote!(self.#field_name.as_ref().map(|x| #table_name::#column_name.eq(x)))
+        parse_quote!(self#field_access.as_ref().map(|x| #table_name::#column_name.eq(x)))
     } else {
-        parse_quote!(#table_name::#column_name.eq(&self.#field_name))
+        parse_quote!(#table_name::#column_name.eq(&self#field_access))
     }
 }

--- a/diesel_derives2/src/lib.rs
+++ b/diesel_derives2/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "1024"]
 // Built-in Lints
 #![deny(warnings, missing_copy_implementations)]
 // Clippy lints
@@ -9,6 +10,7 @@
             warn(wrong_pub_self_convention, mut_mut, non_ascii_literal, similar_names,
                  unicode_not_nfc, if_not_else, items_after_statements, used_underscore_binding))]
 
+extern crate proc_macro2;
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;

--- a/diesel_derives2/src/meta.rs
+++ b/diesel_derives2/src/meta.rs
@@ -44,7 +44,10 @@ impl MetaItem {
                 );
                 x
             }
-            _ => syn::Ident::new(&self.expect_str_value(), self.span.resolved_at(Span::call_site())),
+            _ => syn::Ident::new(
+                &self.expect_str_value(),
+                self.span.resolved_at(Span::call_site()),
+            ),
         }
     }
 
@@ -125,7 +128,10 @@ impl<'a> Iterator for Nested<'a> {
         use syn::NestedMeta::*;
 
         match self.0.next() {
-            Some(&Meta(ref item)) => Some(MetaItem { span: self.1, meta: item.clone() }),
+            Some(&Meta(ref item)) => Some(MetaItem {
+                span: self.1,
+                meta: item.clone(),
+            }),
             Some(_) => self.next(),
             None => None,
         }

--- a/diesel_derives2/src/model.rs
+++ b/diesel_derives2/src/model.rs
@@ -1,4 +1,5 @@
 use syn;
+use proc_macro2::Span;
 
 use field::*;
 use meta::*;
@@ -28,13 +29,17 @@ impl Model {
     }
 
     pub fn table_name(&self) -> syn::Ident {
-        self.table_name_from_attribute
-            .unwrap_or_else(|| infer_table_name(self.name.as_ref()).into())
+        self.table_name_from_attribute.unwrap_or_else(|| {
+            syn::Ident::new(
+                &infer_table_name(self.name.as_ref()),
+                self.name.span.resolved_at(Span::call_site()),
+            )
+        })
     }
 
-    pub fn dummy_const_name(&self, trait_name: &str) -> syn::Ident {
-        let name = self.name.as_ref().to_uppercase();
-        format!("_IMPL_{}_FOR_{}", trait_name, name).into()
+    pub fn dummy_mod_name(&self, trait_name: &str) -> syn::Ident {
+        let name = self.name.as_ref().to_lowercase();
+        format!("_impl_{}_for_{}", trait_name, name).into()
     }
 
     pub fn fields(&self) -> &[Field] {

--- a/diesel_derives2/src/util.rs
+++ b/diesel_derives2/src/util.rs
@@ -1,14 +1,18 @@
 use syn::*;
 use quote::Tokens;
 
-pub fn wrap_in_dummy_const(const_name: Ident, item: Tokens) -> Tokens {
+pub fn wrap_in_dummy_mod(const_name: Ident, item: Tokens) -> Tokens {
     quote! {
-        const #const_name: () = {
+        mod #const_name {
+            // https://github.com/rust-lang/rust/issues/47314
+            extern crate std;
+
             mod diesel {
                 __diesel_use_everything!();
             }
+            use self::diesel::prelude::*;
             #item
-        };
+        }
     }
 }
 

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["diesel"]
 
 [dependencies]
 infer_schema_macros = { version = "1.1.0" }
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 
 [dev-dependencies]
 diesel = "1.1.0"

--- a/diesel_infer_schema/infer_schema_internals/Cargo.toml
+++ b/diesel_infer_schema/infer_schema_internals/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 
 [dependencies]
 diesel = { version = "1.1.0", default-features = false }
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 
 [dev-dependencies]
 dotenv = ">=0.8, <0.11"

--- a/diesel_infer_schema/infer_schema_macros/Cargo.toml
+++ b/diesel_infer_schema/infer_schema_macros/Cargo.toml
@@ -10,7 +10,7 @@ syn = { version = "0.11.4", features = ["aster"] }
 quote = "0.3.12"
 dotenv = { version = ">=0.8, <0.11", optional = true, default-features = false }
 infer_schema_internals = { version = "1.1.0", default-features = false }
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 
 [dev-dependencies]
 tempdir = "^0.3.4"

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "http://diesel.rs"
 
 
 [dependencies]
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 migrations_internals = { version = "1.1.0" }
 migrations_macros = { version = "1.1.0" }
 

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -7,7 +7,7 @@ description = "Internal implementation of diesels migration mechanism"
 homepage = "http://diesel.rs"
 
 [dependencies]
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 diesel = "1.1.0"
 
 [dev-dependencies]

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "http://docs.diesel.rs"
 homepage = "http://diesel.rs"
 
 [dependencies]
-clippy = { optional = true, version = "=0.0.174" }
+clippy = { optional = true, version = "=0.0.185" }
 migrations_internals = { version = "1.1.0" }
 syn = { version = "0.11.4", features = ["aster"] }
 quote = "0.3.12"


### PR DESCRIPTION
When `proc_macro2` has the nightly feature enabled, a lot of the rules
around hygiene change. Most of the changes needed appear to be due to
bugs in Rust (e.g. to access a tuple struct field, the span of the dot has to
be resolved specially, but not for a named struct field), but the span
changes for table names in particular is definitely required.

The change to hygiene rules randomly broke our const workaround (the
ability to `use` items defined in an expression like that was
potentially unintended to begin with). However, there's no reason it
needs to be a const, we can just have it be a module with no additional
problems.

I've added a few UI tests for the failure cases that are actually
affected by this change (there is more work to be done on this, of
course). Note that we can't actually run those tests yet, as they
require a nightly compiler, and we won't build on nightly until
tomorrow. However, I've left the tests in place so that the changes in
output can be seen.

The error for `table_name` isn't quite there, but due to a bug in Rust
it's the best we can do. Right now it looks like this:

```
1 | #[table_name = "users"]
  | ^ Use of undeclared type or module `users`
```

instead of like this:

```
1 | #[table_name = "users"]
  |                ^^^^^^^ Use of undeclared type or module `users`
```