### PR TITLE
Improve the errors generated by `#[derive(AsChangeset)]` when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   inserting from a select statement, as select statements tend to span multiple
   lines.
 
+* Diesel's derives can now produce improved error messages if you are using a
+  nightly compiler, and enable the `unstable` feature. For the best errors, you
+  should also set `RUSTFLAGS="--cfg procmacro2_semver_exempt"`.
+
 * Added support for specifying `ISOLATION LEVEL`, `DEFERRABLE`, and `READ ONLY`
   on PG transactions. See [`PgConnection::build_transaction`] for details.
 

--- a/diesel_compile_tests/tests/compile_tests.rs
+++ b/diesel_compile_tests/tests/compile_tests.rs
@@ -9,13 +9,14 @@ fn run_mode(mode: &'static str) {
 
     let cfg_mode = mode.parse().expect("Invalid mode");
 
-    config.target_rustcflags = Some("-L target/debug/deps/".to_owned());
     if let Ok(name) = var::<&str>("TESTNAME") {
         let s : String = name.to_owned();
         config.filter = Some(s)
     }
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
+    config.link_deps();
+    config.clean_rmeta();
 
     compiletest::run_tests(&config);
 }

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.stderr
@@ -5,10 +5,10 @@ error[E0412]: cannot find type `name` in module `users`
    |     ^^^^ not found in `users`
 
 error[E0412]: cannot find type `hair_color` in module `users`
-  --> $DIR/as_changeset_bad_column_name.rs:14:5
+  --> $DIR/as_changeset_bad_column_name.rs:14:21
    |
 14 |     #[column_name = "hair_color"]
-   |     ^ not found in `users`
+   |                     ^^^^^^^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
   --> $DIR/as_changeset_bad_column_name.rs:13:5
@@ -17,22 +17,22 @@ error[E0425]: cannot find value `name` in module `users`
    |     ^^^^ not found in `users`
 
 error[E0425]: cannot find value `hair_color` in module `users`
-  --> $DIR/as_changeset_bad_column_name.rs:14:5
+  --> $DIR/as_changeset_bad_column_name.rs:14:21
    |
 14 |     #[column_name = "hair_color"]
-   |     ^ not found in `users`
+   |                     ^^^^^^^^^^^^ not found in `users`
 
 error[E0412]: cannot find type `name` in module `users`
-  --> $DIR/as_changeset_bad_column_name.rs:20:18
+  --> $DIR/as_changeset_bad_column_name.rs:20:34
    |
 20 | struct UserTuple(#[column_name = "name"] String);
-   |                  ^ not found in `users`
+   |                                  ^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
-  --> $DIR/as_changeset_bad_column_name.rs:20:18
+  --> $DIR/as_changeset_bad_column_name.rs:20:34
    |
 20 | struct UserTuple(#[column_name = "name"] String);
-   |                  ^ not found in `users`
+   |                                  ^^^^^^ not found in `users`
 
 error[E0601]: main function not found
 

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_column_name_syntax.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_column_name_syntax.rs
@@ -1,0 +1,16 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+struct User {
+    #[column_name]
+    name: String,
+}

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_column_name_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_column_name_syntax.stderr
@@ -1,0 +1,8 @@
+error: `column_name` must be in the form `column_name = "value"`
+  --> $DIR/as_changeset_bad_column_name_syntax.rs:14:7
+   |
+14 |     #[column_name]
+   |       ^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_options.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_options.rs
@@ -1,0 +1,59 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+#[changeset_options(treat_none_as_null("true"))]
+struct UserForm1 {
+    id: i32,
+    name: String,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+#[changeset_options(treat_none_as_null)]
+struct UserForm2 {
+    id: i32,
+    name: String,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+#[changeset_options(treat_none_as_null = "foo")]
+struct UserForm3 {
+    id: i32,
+    name: String,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+#[changeset_options()]
+struct UserForm4 {
+    id: i32,
+    name: String,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+#[changeset_options = "treat_none_as_null"]
+struct UserForm5 {
+    id: i32,
+    name: String,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+#[changeset_options]
+struct UserForm6 {
+    id: i32,
+    name: String,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_options.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_options.stderr
@@ -1,0 +1,38 @@
+error: `treat_none_as_null` must be in the form `treat_none_as_null = "true"`
+ --> <macro expansion>:1:1
+  |
+1 | #[changeset_options(treat_none_as_null("true"))]
+  | ^
+
+error: `treat_none_as_null` must be in the form `treat_none_as_null = "true"`
+ --> <macro expansion>:1:1
+  |
+1 | #[changeset_options(treat_none_as_null)]
+  | ^
+
+error: `treat_none_as_null` must be in the form `treat_none_as_null = "true"`
+ --> <macro expansion>:1:1
+  |
+1 | #[changeset_options(treat_none_as_null = "foo")]
+  | ^
+
+error: Missing required option treat_none_as_null
+ --> <macro expansion>:1:1
+  |
+1 | #[changeset_options()]
+  | ^
+
+error: `changeset_options` must be in the form `changeset_options(...)`
+ --> <macro expansion>:1:1
+  |
+1 | #[changeset_options = "treat_none_as_null"]
+  | ^
+
+error: `changeset_options` must be in the form `changeset_options(...)`
+ --> <macro expansion>:1:1
+  |
+1 | #[changeset_options]
+  | ^
+
+error: aborting due to 6 previous errors
+

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_primary_key_syntax.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_primary_key_syntax.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+#[derive(AsChangeset)]
+#[primary_key(id, bar = "baz", qux(id))]
+struct UserForm {
+    id: i32,
+    name: String,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_primary_key_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_primary_key_syntax.stderr
@@ -1,0 +1,14 @@
+error: Expected `bar` found `bar = "baz"`
+ --> <macro expansion>:1:1
+  |
+1 | #[primary_key(id, bar = "baz", qux(id))]
+  | ^
+
+error: Expected `qux` found `qux ( id )`
+ --> <macro expansion>:1:1
+  |
+1 | #[primary_key(id, bar = "baz", qux(id))]
+  | ^
+
+error: aborting due to 2 previous errors
+

--- a/diesel_compile_tests/tests/ui/as_changeset_deprecated_column_name.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_deprecated_column_name.rs
@@ -1,0 +1,19 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+#[derive(AsChangeset)]
+#[table_name(users)]
+struct UserForm {
+    id: i32,
+    #[column_name(name)]
+    name: String,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/ui/as_changeset_deprecated_column_name.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_deprecated_column_name.stderr
@@ -1,0 +1,12 @@
+warning: The form `table_name(value)` is deprecated. Use `table_name = "value"` instead
+ --> <macro expansion>:1:1
+  |
+1 | #[table_name(users)]
+  | ^
+
+warning: The form `column_name(value)` is deprecated. Use `column_name = "value"` instead
+  --> $DIR/as_changeset_deprecated_column_name.rs:15:7
+   |
+15 |     #[column_name(name)]
+   |       ^^^^^^^^^^^
+

--- a/diesel_compile_tests/tests/ui/as_changeset_missing_column_name_tuple_struct.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_missing_column_name_tuple_struct.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+struct User(i32, #[column_name = "name"] String, String);

--- a/diesel_compile_tests/tests/ui/as_changeset_missing_column_name_tuple_struct.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_missing_column_name_tuple_struct.stderr
@@ -1,0 +1,14 @@
+error: All fields of tuple structs must be annotated with `#[column_name]`
+  --> $DIR/as_changeset_missing_column_name_tuple_struct.rs:14:13
+   |
+14 | struct User(i32, #[column_name = "name"] String, String);
+   |             ^^^
+
+error: All fields of tuple structs must be annotated with `#[column_name]`
+  --> $DIR/as_changeset_missing_column_name_tuple_struct.rs:14:50
+   |
+14 | struct User(i32, #[column_name = "name"] String, String);
+   |                                                  ^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/diesel_compile_tests/tests/ui/as_changeset_on_non_struct.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_on_non_struct.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}
+
+#[derive(AsChangeset)]
+#[table_name = "users"]
+enum User {}

--- a/diesel_compile_tests/tests/ui/as_changeset_on_non_struct.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_on_non_struct.stderr
@@ -1,0 +1,8 @@
+error: This derive can only be used on structs
+  --> $DIR/as_changeset_on_non_struct.rs:12:10
+   |
+12 | #[derive(AsChangeset)]
+   |          ^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/diesel_compile_tests/tests/ui/as_changeset_struct_with_only_primary_key.rs
+++ b/diesel_compile_tests/tests/ui/as_changeset_struct_with_only_primary_key.rs
@@ -1,11 +1,11 @@
 #[macro_use] extern crate diesel;
 
-table!(
+table! {
     foo {
         id -> Integer,
         bar -> Integer,
     }
-);
+}
 
 #[derive(AsChangeset)]
 #[table_name="foo"]
@@ -15,7 +15,6 @@ struct Foo1 {
 }
 
 #[derive(AsChangeset)]
-//~^ ERROR: proc-macro derive panicked
 #[table_name="foo"]
 struct Foo2 {
     id: i32,

--- a/diesel_compile_tests/tests/ui/as_changeset_struct_with_only_primary_key.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_struct_with_only_primary_key.stderr
@@ -1,0 +1,11 @@
+error: Deriving `AsChangeset` on a structure that only contains the primary key isn't supported.
+  --> $DIR/as_changeset_struct_with_only_primary_key.rs:17:10
+   |
+17 | #[derive(AsChangeset)]
+   |          ^^^^^^^^^^^
+   |
+   = help: If you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
+   = note: `#[derive(AsChangeset)]` never changes the primary key of a row.
+
+error: aborting due to previous error
+

--- a/diesel_derives2/src/diagnostic_shim.rs
+++ b/diesel_derives2/src/diagnostic_shim.rs
@@ -1,0 +1,77 @@
+use proc_macro2::Span;
+
+pub trait DiagnosticShim {
+    fn error<T: Into<String>>(self, msg: T) -> Diagnostic;
+    fn warning<T: Into<String>>(self, msg: T) -> Diagnostic;
+}
+
+#[cfg(feature = "nightly")]
+impl DiagnosticShim for Span {
+    fn error<T: Into<String>>(self, msg: T) -> Diagnostic {
+        self.unstable().error(msg)
+    }
+
+    fn warning<T: Into<String>>(self, msg: T) -> Diagnostic {
+        self.unstable().warning(msg)
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+impl DiagnosticShim for Span {
+    fn error<T: Into<String>>(self, msg: T) -> Diagnostic {
+        Diagnostic::error(msg)
+    }
+
+    fn warning<T: Into<String>>(self, msg: T) -> Diagnostic {
+        Diagnostic::warning(msg)
+    }
+}
+
+#[cfg(feature = "nightly")]
+pub use proc_macro::Diagnostic;
+
+#[cfg(not(feature = "nightly"))]
+pub struct Diagnostic {
+    message: String,
+    level: Level,
+}
+
+#[cfg(not(feature = "nightly"))]
+impl Diagnostic {
+    fn error<T: Into<String>>(msg: T) -> Self {
+        Diagnostic {
+            message: msg.into(),
+            level: Level::Error,
+        }
+    }
+
+    fn warning<T: Into<String>>(msg: T) -> Self {
+        Diagnostic {
+            message: msg.into(),
+            level: Level::Warning,
+        }
+    }
+
+    pub fn help(mut self, msg: &str) -> Self {
+        self.message.push_str("\n");
+        self.message.push_str(msg);
+        self
+    }
+
+    pub fn note(self, msg: &str) -> Self {
+        self.help(msg)
+    }
+
+    pub fn emit(self) {
+        match self.level {
+            Level::Error => panic!("{}", self.message),
+            Level::Warning => println!("{}", self.message),
+        }
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+enum Level {
+    Warning,
+    Error,
+}

--- a/diesel_derives2/src/meta.rs
+++ b/diesel_derives2/src/meta.rs
@@ -1,96 +1,115 @@
 use proc_macro2::Span;
 use syn;
+use syn::spanned::Spanned;
+
+use diagnostic_shim::*;
 
 pub struct MetaItem {
     // Due to https://github.com/rust-lang/rust/issues/47941
     // we can only ever get the span of the #, which is better than nothing
-    span: Span,
+    pound_span: Span,
     meta: syn::Meta,
 }
 
 impl MetaItem {
-    pub fn with_name<'a>(
-        attrs: &[syn::Attribute],
-        name: &'a str,
-    ) -> Result<Self, MissingOption<'a>> {
+    pub fn with_name<'a>(attrs: &[syn::Attribute], name: &'a str) -> Option<Self> {
         attrs
             .iter()
             .filter_map(|attr| attr.interpret_meta().map(|m| (attr.pound_token.0[0], m)))
             .find(|&(_, ref m)| m.name() == name)
-            .map(|(span, meta)| Self { span, meta })
-            .ok_or(MissingOption { name })
+            .map(|(pound_span, meta)| Self { pound_span, meta })
     }
 
-    pub fn nested_item<'a>(&self, name: &'a str) -> Result<Self, MissingOption<'a>> {
-        self.expect_nested().nth(0).ok_or(MissingOption { name })
+    pub fn nested_item<'a>(&self, name: &'a str) -> Result<Self, Diagnostic> {
+        self.nested().and_then(|mut i| {
+            i.nth(0).ok_or_else(|| {
+                self.span()
+                    .error(format!("Missing required option {}", name))
+            })
+        })
     }
 
     pub fn expect_bool_value(&self) -> bool {
         match self.str_value().as_ref().map(|s| s.as_str()) {
-            Some("true") => true,
-            Some("false") => false,
-            _ => panic!("`{0}` must be in the form `{0} = \"true\"`", self.name()),
+            Ok("true") => true,
+            Ok("false") => false,
+            _ => {
+                self.span()
+                    .error(format!(
+                        "`{0}` must be in the form `{0} = \"true\"`",
+                        self.name()
+                    ))
+                    .emit();
+                false
+            }
         }
     }
 
     pub fn expect_ident_value(&self) -> syn::Ident {
-        let maybe_attr = self.nested().and_then(|mut n| n.nth(0));
-        let maybe_word = maybe_attr.as_ref().and_then(Self::word);
+        let maybe_attr = self.nested().ok().and_then(|mut n| n.nth(0));
+        let maybe_word = maybe_attr.as_ref().and_then(|m| m.word().ok());
         match maybe_word {
             Some(x) => {
-                println!(
-                    "The form `{0}(value)` is deprecated. Use `{0} = \"value\"` instead",
-                    self.name()
-                );
+                self.span()
+                    .warning(format!(
+                        "The form `{0}(value)` is deprecated. Use `{0} = \"value\"` instead",
+                        self.name(),
+                    ))
+                    .emit();
                 x
             }
             _ => syn::Ident::new(
                 &self.expect_str_value(),
-                self.span.resolved_at(Span::call_site()),
+                self.value_span().resolved_at(Span::call_site()),
             ),
         }
     }
 
     pub fn expect_word(self) -> syn::Ident {
-        self.word().unwrap_or_else(|| {
-            let meta = &self.meta;
-            panic!("Expected `{}` found `{}`", self.name(), quote!(#meta))
+        self.word().unwrap_or_else(|e| {
+            e.emit();
+            self.name()
         })
     }
 
-    pub fn word(&self) -> Option<syn::Ident> {
+    pub fn word(&self) -> Result<syn::Ident, Diagnostic> {
         use syn::Meta::*;
 
         match self.meta {
-            Word(x) => Some(x),
-            _ => None,
+            Word(x) => Ok(x),
+            _ => {
+                let meta = &self.meta;
+                Err(self.span().error(format!(
+                    "Expected `{}` found `{}`",
+                    self.name(),
+                    quote!(#meta)
+                )))
+            }
         }
     }
 
-    pub fn expect_nested(&self) -> Nested {
-        self.nested()
-            .unwrap_or_else(|| panic!("`{0}` must be in the form `{0}(...)`", self.name()))
-    }
-
-    pub fn nested(&self) -> Option<Nested> {
+    pub fn nested(&self) -> Result<Nested, Diagnostic> {
         use syn::Meta::*;
 
         match self.meta {
-            List(ref list) => Some(Nested(list.nested.iter(), self.span)),
-            _ => None,
+            List(ref list) => Ok(Nested(list.nested.iter(), self.pound_span)),
+            _ => Err(self.span()
+                .error(format!("`{0}` must be in the form `{0}(...)`", self.name()))),
         }
     }
 
     fn expect_str_value(&self) -> String {
-        self.str_value()
-            .unwrap_or_else(|| panic!("`{0}` must be in the form `{0} = \"value\"`", self.name()))
+        self.str_value().unwrap_or_else(|e| {
+            e.emit();
+            self.name().to_string()
+        })
     }
 
     fn name(&self) -> syn::Ident {
         self.meta.name()
     }
 
-    fn str_value(&self) -> Option<String> {
+    fn str_value(&self) -> Result<String, Diagnostic> {
         use syn::Meta::*;
         use syn::MetaNameValue;
         use syn::Lit::*;
@@ -98,23 +117,39 @@ impl MetaItem {
         match self.meta {
             NameValue(MetaNameValue {
                 lit: Str(ref s), ..
-            }) => Some(s.value()),
-            _ => None,
+            }) => Ok(s.value()),
+            _ => Err(self.span().error(format!(
+                "`{0}` must be in the form `{0} = \"value\"`",
+                self.name()
+            ))),
         }
     }
-}
 
-pub struct MissingOption<'a> {
-    name: &'a str,
-}
+    fn value_span(&self) -> Span {
+        use syn::Meta::*;
 
-pub trait RequiredOption<T> {
-    fn required(self) -> T;
-}
+        let s = match self.meta {
+            Word(ident) => ident.span,
+            List(ref meta) => meta.nested.span(),
+            NameValue(ref meta) => meta.lit.span(),
+        };
+        self.span_or_pound_token(s)
+    }
 
-impl<'a> RequiredOption<MetaItem> for Result<MetaItem, MissingOption<'a>> {
-    fn required(self) -> MetaItem {
-        self.unwrap_or_else(|e| panic!("Missing required option {}", e.name))
+    fn span(&self) -> Span {
+        self.span_or_pound_token(self.meta.span())
+    }
+
+    /// If the given span is affected by
+    /// https://github.com/rust-lang/rust/issues/47941,
+    /// returns the span of the pound token
+    fn span_or_pound_token(&self, span: Span) -> Span {
+        let bad_span_debug = "Span(Span { lo: BytePos(0), hi: BytePos(0), ctxt: #0 })";
+        if format!("{:?}", span) == bad_span_debug {
+            self.pound_span
+        } else {
+            span
+        }
     }
 }
 
@@ -129,7 +164,7 @@ impl<'a> Iterator for Nested<'a> {
 
         match self.0.next() {
             Some(&Meta(ref item)) => Some(MetaItem {
-                span: self.1,
+                pound_span: self.1,
                 meta: item.clone(),
             }),
             Some(_) => self.next(),

--- a/diesel_derives2/src/util.rs
+++ b/diesel_derives2/src/util.rs
@@ -1,6 +1,8 @@
 use syn::*;
 use quote::Tokens;
 
+pub use diagnostic_shim::*;
+
 pub fn wrap_in_dummy_mod(const_name: Ident, item: Tokens) -> Tokens {
     quote! {
         mod #const_name {


### PR DESCRIPTION
This removes all uses of `panic!` or `println!` from derives2, and
instead using the nightly-only `Diagnostic` API when the nightly feature
is enabled. This does require a change in our structure, as anywhere
that we were relying on `panic!` halting, we either need to return some
"default" value, or use `Result` to halt instead.

Whether we actually want to halt or not for each case is actually not a
simple question. Ideally we only halt if continuing with a dummy would
result in nonsense errors. I've added UI tests for every single place
that previously panicked, and I'm reasonably happy with the error output
of every single one.