### PR TITLE
Add `.then_order_by`, which appends rather than replaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Tables with more than 56 columns are now supported by enabling the
   `128-column-tables` feature.
 
+* Added `order_by` as an alias for `order`.
+
+* Added `then_order_by`, which appends to an `ORDER BY` clause rather than
+  replacing it. This is useful with boxed queries to dynamically construct an
+  order by clause containing an unknown number of columns.
+
 ### Changed
 
 * The bounds on `impl ToSql for Cow<'a, T>` have been loosened to no longer

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -220,6 +220,9 @@ pub mod helper_types {
     /// Represents the return type of `.order(ordering)`
     pub type Order<Source, Ordering> = <Source as OrderDsl<Ordering>>::Output;
 
+    /// Represents the return type of `.then_order_by(ordering)`
+    pub type ThenOrderBy<Source, Ordering> = <Source as ThenOrderDsl<Ordering>>::Output;
+
     /// Represents the return type of `.limit()`
     pub type Limit<Source> = <Source as LimitDsl>::Output;
 

--- a/diesel/src/query_builder/order_clause.rs
+++ b/diesel/src/query_builder/order_clause.rs
@@ -1,1 +1,20 @@
 simple_clause!(NoOrderClause, OrderClause, " ORDER BY ");
+
+impl<'a, DB, Expr> Into<Option<Box<QueryFragment<DB> + 'a>>> for OrderClause<Expr>
+where
+    DB: Backend,
+    Expr: QueryFragment<DB> + 'a,
+{
+    fn into(self) -> Option<Box<QueryFragment<DB> + 'a>> {
+        Some(Box::new(self.0))
+    }
+}
+
+impl<'a, DB> Into<Option<Box<QueryFragment<DB> + 'a>>> for NoOrderClause
+where
+    DB: Backend,
+{
+    fn into(self) -> Option<Box<QueryFragment<DB> + 'a>> {
+        None
+    }
+}

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -24,7 +24,7 @@ pub struct BoxedSelectStatement<'a, ST, QS, DB> {
     from: QS,
     distinct: Box<QueryFragment<DB> + 'a>,
     where_clause: Option<Box<QueryFragment<DB> + 'a>>,
-    order: Box<QueryFragment<DB> + 'a>,
+    order: Option<Box<QueryFragment<DB> + 'a>>,
     limit: Box<QueryFragment<DB> + 'a>,
     offset: Box<QueryFragment<DB> + 'a>,
     group_by: Box<QueryFragment<DB> + 'a>,
@@ -38,7 +38,7 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
         from: QS,
         distinct: Box<QueryFragment<DB> + 'a>,
         where_clause: Option<Box<QueryFragment<DB> + 'a>>,
-        order: Box<QueryFragment<DB> + 'a>,
+        order: Option<Box<QueryFragment<DB> + 'a>>,
         limit: Box<QueryFragment<DB> + 'a>,
         offset: Box<QueryFragment<DB> + 'a>,
         group_by: Box<QueryFragment<DB> + 'a>,
@@ -96,7 +96,12 @@ where
         }
 
         self.group_by.walk_ast(out.reborrow())?;
-        self.order.walk_ast(out.reborrow())?;
+
+        if let Some(ref order) = self.order {
+            out.push_sql(" ORDER BY ");
+            order.walk_ast(out.reborrow())?;
+        }
+
         self.limit.walk_ast(out.reborrow())?;
         self.offset.walk_ast(out.reborrow())?;
         Ok(())
@@ -257,7 +262,23 @@ where
     type Output = Self;
 
     fn order(mut self, order: Order) -> Self::Output {
-        self.order = Box::new(OrderClause(order));
+        self.order = OrderClause(order).into();
+        self
+    }
+}
+
+impl<'a, ST, QS, DB, Order> ThenOrderDsl<Order> for BoxedSelectStatement<'a, ST, QS, DB>
+where
+    DB: Backend + 'a,
+    Order: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
+{
+    type Output = Self;
+
+    fn then_order_by(mut self, order: Order) -> Self::Output {
+        self.order = match self.order {
+            Some(old) => Some(Box::new((old, order))),
+            None => Some(Box::new(order)),
+        };
         self
     }
 }

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -28,3 +28,31 @@ where
         self.as_query().order(expr)
     }
 }
+
+/// The `then_order_by` method
+///
+/// This trait should not be relied on directly by most apps. Its behavior is
+/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
+/// to call `then_order_by` from generic code.
+///
+/// [`QueryDsl`]: ../trait.QueryDsl.html
+pub trait ThenOrderDsl<Expr> {
+    /// The type returned by `.then_order_by`.
+    type Output;
+
+    /// See the trait documentation.
+    fn then_order_by(self, expr: Expr) -> Self::Output;
+}
+
+impl<T, Expr> ThenOrderDsl<Expr> for T
+where
+    Expr: Expression,
+    T: Table,
+    T::Query: ThenOrderDsl<Expr>,
+{
+    type Output = <T::Query as ThenOrderDsl<Expr>>::Output;
+
+    fn then_order_by(self, expr: Expr) -> Self::Output {
+        self.as_query().then_order_by(expr)
+    }
+}


### PR DESCRIPTION
I was originally only going to implement this for boxed queries, but I
don't think there's any reason we need to do that here. My original
reasoning was I didn't want to write code that appended tuples, but
there's actually no difference in behavior between `.order((foo, bar,
baz))` and `.order(((foo, bar), baz))` (which is the type we get from
this).

Fixes #1311.