### PR TITLE
rm `IncompleteUpdateStatement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * The `huge-tables` feature has been renamed to `64-column-tables`.
 
+* `IncompleteUpdateStatement` has been removed. Use `UpdateStatement` instead.
+
 ### Fixed
 
 * `diesel database setup` now correctly handles database URLs containing query

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -3,8 +3,8 @@ use expression::Expression;
 use query_dsl::methods::SelectDsl;
 use super::delete_statement::DeleteStatement;
 use super::insert_statement::{Insert, InsertOrIgnore, Replace};
-use super::{IncompleteInsertStatement, IncompleteUpdateStatement, IntoUpdateTarget,
-            SelectStatement, SqlQuery};
+use super::{IncompleteInsertStatement, IntoUpdateTarget, SelectStatement, SqlQuery,
+            UpdateStatement};
 
 /// Creates an `UPDATE` statement.
 ///
@@ -15,7 +15,7 @@ use super::{IncompleteInsertStatement, IncompleteUpdateStatement, IntoUpdateTarg
 /// Passing a type which implements `Identifiable` is the same as passing
 /// `some_table.find(some_struct.id())`.
 ///
-/// [`filter`]: query_builder/update_statement/struct.IncompleteUpdateStatement.html#method.filter
+/// [`filter`]: query_builder/struct.UpdateStatement.html#method.filter
 ///
 /// # Examples
 ///
@@ -42,7 +42,7 @@ use super::{IncompleteInsertStatement, IncompleteUpdateStatement, IntoUpdateTarg
 ///
 /// To update multiple columns, give [`set`] a tuple argument:
 ///
-/// [`set`]: query_builder/struct.IncompleteUpdateStatement.html#method.set
+/// [`set`]: query_builder/struct.UpdateStatement.html#method.set
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
@@ -76,10 +76,8 @@ use super::{IncompleteInsertStatement, IncompleteUpdateStatement, IntoUpdateTarg
 /// # #[cfg(not(feature = "postgres"))]
 /// # fn main() {}
 /// ```
-pub fn update<T: IntoUpdateTarget>(
-    source: T,
-) -> IncompleteUpdateStatement<T::Table, T::WhereClause> {
-    IncompleteUpdateStatement::new(source.into_update_target())
+pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {
+    UpdateStatement::new(source.into_update_target())
 }
 
 /// Creates a `DELETE` statement.

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -43,8 +43,10 @@ pub use self::query_id::QueryId;
 pub use self::select_statement::{BoxedSelectStatement, SelectStatement};
 pub use self::sql_query::SqlQuery;
 #[doc(inline)]
-pub use self::update_statement::{AsChangeset, IncompleteUpdateStatement, IntoUpdateTarget,
-                                 UpdateStatement, UpdateTarget};
+pub use self::update_statement::{AsChangeset, IntoUpdateTarget, UpdateStatement, UpdateTarget};
+#[cfg(feature = "with-deprecated")]
+#[allow(deprecated)]
+pub use self::update_statement::IncompleteUpdateStatement;
 
 pub(crate) use self::insert_statement::ColumnList;
 

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -6,7 +6,7 @@ use query_source::{Column, QuerySource};
 use result::QueryResult;
 
 /// Types which can be passed to
-/// [`update.set`](struct.IncompleteUpdateStatement.html#method.set).
+/// [`update.set`](struct.UpdateStatement.html#method.set).
 ///
 /// ### Deriving
 ///

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -24,7 +24,7 @@ pub struct UpdateTarget<Table, WhereClause> {
 ///
 /// [`update`]: ../fn.update.html
 /// [`delete`]: ../fn.delete.html
-/// [`filter`]: struct.IncompleteUpdateStatement.html#method.filter
+/// [`filter`]: struct.UpdateStatement.html#method.filter
 pub trait IntoUpdateTarget: HasTable {
     /// What is the `WHERE` clause of this target?
     type WhereClause;

--- a/diesel_compile_tests/tests/compile-fail/update_requires_set.rs
+++ b/diesel_compile_tests/tests/compile-fail/update_requires_set.rs
@@ -1,0 +1,16 @@
+#[macro_use] extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    let conn = SqliteConnection::establish(":memory:").unwrap();
+    update(users::table)
+        .execute(&conn);
+        //~^ ERROR diesel::query_builder::update_statement::SetNotCalled: diesel::query_builder::QueryFragment<_>
+}


### PR DESCRIPTION
This type is redundant and can be replaced with a session type in the
third parameter of `UpdateStatement`. Otherwise I'll end up needing
`IncompleteBoxedUpdateStatement` too. I've left a deprecated type alias
in place for backwards compatibility.