### PR TITLE
Fix `SelectStatement` being incorrectly allowed in an expression context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `#[derive(Identifiable)]` now correctly associates `#[primary_key]` with the
   column name, not field name.
 
+* Select statements can no longer incorrectly appear in an expression context.
+
+* `exists` can no longer incorrectly receive values other than select
+  statements.
+
 ### Jokes
 
 * Diesel is now powered by the blockchain because it's 2018.

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -43,6 +43,8 @@ pub mod nullable;
 pub mod operators;
 #[doc(hidden)]
 pub mod sql_literal;
+#[doc(hidden)]
+pub mod subselect;
 
 #[doc(hidden)]
 pub mod dsl {

--- a/diesel/src/expression/subselect.rs
+++ b/diesel/src/expression/subselect.rs
@@ -1,0 +1,60 @@
+use std::marker::PhantomData;
+
+use expression::*;
+use expression::array_comparison::MaybeEmpty;
+use query_builder::*;
+use result::QueryResult;
+
+#[derive(Debug, Copy, Clone, QueryId)]
+pub struct Subselect<T, ST> {
+    values: T,
+    _sql_type: PhantomData<ST>,
+}
+
+impl<T, ST> Subselect<T, ST> {
+    pub(crate) fn new(values: T) -> Self {
+        Self {
+            values,
+            _sql_type: PhantomData,
+        }
+    }
+}
+
+impl<T: SelectQuery, ST> Expression for Subselect<T, ST> {
+    type SqlType = ST;
+}
+
+impl<T, ST> MaybeEmpty for Subselect<T, ST> {
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl<T, ST, QS> SelectableExpression<QS> for Subselect<T, ST>
+where
+    Subselect<T, ST>: AppearsOnTable<QS>,
+    T: ValidSubselect<QS>,
+{
+}
+
+impl<T, ST, QS> AppearsOnTable<QS> for Subselect<T, ST>
+where
+    Subselect<T, ST>: Expression,
+    T: ValidSubselect<QS>,
+{
+}
+
+impl<T, ST> NonAggregate for Subselect<T, ST> {}
+
+impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST>
+where
+    DB: Backend,
+    T: QueryFragment<DB>,
+{
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        self.values.walk_ast(out.reborrow())?;
+        Ok(())
+    }
+}
+
+pub trait ValidSubselect<QS> {}

--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -1,8 +1,8 @@
 use pg::Pg;
 use query_dsl::methods::DistinctOnDsl;
-use query_builder::{AstPass, QueryFragment, SelectStatement};
+use query_builder::{AstPass, QueryFragment, SelectQuery, SelectStatement};
 use result::QueryResult;
-use expression::{Expression, SelectableExpression};
+use expression::SelectableExpression;
 
 /// Represents `DISTINCT ON (...)`
 #[derive(Debug, Clone, Copy, QueryId)]
@@ -24,8 +24,8 @@ impl<ST, F, S, D, W, O, L, Of, G, Selection> DistinctOnDsl<Selection>
     for SelectStatement<F, S, D, W, O, L, Of, G>
 where
     Selection: SelectableExpression<F>,
-    Self: Expression<SqlType = ST>,
-    SelectStatement<F, S, DistinctOnClause<Selection>, W, O, L, Of, G>: Expression<SqlType = ST>,
+    Self: SelectQuery<SqlType = ST>,
+    SelectStatement<F, S, DistinctOnClause<Selection>, W, O, L, Of, G>: SelectQuery<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, DistinctOnClause<Selection>, W, O, L, Of, G>;
 

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -108,6 +108,19 @@ impl<'a, T: Query> Query for &'a T {
     type SqlType = T::SqlType;
 }
 
+/// Indicates that a type is a `SELECT` statement.
+///
+/// This trait differs from `Query` in two ways:
+/// - It is implemented only for select statements, rather than all queries
+///   which return a value.
+/// - It has looser constraints. A type implementing `SelectQuery` is known to
+///   be potentially valid if used as a subselect, but it is not necessarily
+///   able to be executed.
+pub trait SelectQuery {
+    /// The SQL type of the `SELECT` clause
+    type SqlType;
+}
+
 /// An untyped fragment of SQL.
 ///
 /// This may be a complete SQL command (such as an update statement without a

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use backend::Backend;
 use dsl::AsExprOf;
 use expression::*;
+use expression::subselect::ValidSubselect;
 use insertable::Insertable;
 use query_builder::*;
 use query_builder::distinct_clause::DistinctClause;
@@ -64,14 +65,14 @@ where
     type SqlType = ST;
 }
 
-impl<'a, ST, QS, DB> Expression for BoxedSelectStatement<'a, ST, QS, DB>
+impl<'a, ST, QS, DB> SelectQuery for BoxedSelectStatement<'a, ST, QS, DB>
 where
-    Self: Query<SqlType = ST>,
+    DB: Backend,
 {
     type SqlType = ST;
 }
 
-impl<'a, ST, QS, QS2, DB> AppearsOnTable<QS2> for BoxedSelectStatement<'a, ST, QS, DB>
+impl<'a, ST, QS, QS2, DB> ValidSubselect<QS2> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     Self: Query<SqlType = ST>,
 {

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -13,7 +13,7 @@ use query_builder::order_clause::*;
 use query_builder::select_clause::*;
 use query_builder::update_statement::*;
 use query_builder::where_clause::*;
-use query_builder::{AsQuery, Query, QueryFragment, SelectStatement};
+use query_builder::{AsQuery, Query, QueryFragment, SelectQuery, SelectStatement};
 use query_dsl::*;
 use query_dsl::methods::*;
 use query_dsl::boxed_dsl::BoxedDsl;
@@ -47,8 +47,8 @@ where
 impl<F, S, D, W, O, L, Of, G, FU, Selection> SelectDsl<Selection>
     for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
-    Selection: Expression,
-    SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G, FU>: Expression,
+    Selection: SelectableExpression<F>,
+    SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G, FU>: SelectQuery,
 {
     type Output = SelectStatement<F, SelectClause<Selection>, D, W, O, L, Of, G, FU>;
 
@@ -69,8 +69,8 @@ where
 
 impl<ST, F, S, D, W, O, L, Of, G> DistinctDsl for SelectStatement<F, S, D, W, O, L, Of, G>
 where
-    Self: Expression<SqlType = ST>,
-    SelectStatement<F, S, DistinctClause, W, O, L, Of, G>: Expression<SqlType = ST>,
+    Self: SelectQuery<SqlType = ST>,
+    SelectStatement<F, S, DistinctClause, W, O, L, Of, G>: SelectQuery<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, DistinctClause, W, O, L, Of, G>;
 
@@ -157,8 +157,8 @@ impl<ST, F, S, D, W, O, L, Of, G, FU, Expr> OrderDsl<Expr>
     for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
     Expr: AppearsOnTable<F>,
-    Self: Expression<SqlType = ST>,
-    SelectStatement<F, S, D, W, OrderClause<Expr>, L, Of, G, FU>: Expression<SqlType = ST>,
+    Self: SelectQuery<SqlType = ST>,
+    SelectStatement<F, S, D, W, OrderClause<Expr>, L, Of, G, FU>: SelectQuery<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, D, W, OrderClause<Expr>, L, Of, G, FU>;
 
@@ -218,8 +218,8 @@ pub type Limit = AsExprOf<i64, BigInt>;
 
 impl<ST, F, S, D, W, O, L, Of, G, FU> LimitDsl for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
-    Self: Expression<SqlType = ST>,
-    SelectStatement<F, S, D, W, O, LimitClause<Limit>, Of, G, FU>: Expression<SqlType = ST>,
+    Self: SelectQuery<SqlType = ST>,
+    SelectStatement<F, S, D, W, O, LimitClause<Limit>, Of, G, FU>: SelectQuery<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, D, W, O, LimitClause<Limit>, Of, G, FU>;
 
@@ -244,8 +244,8 @@ pub type Offset = Limit;
 
 impl<ST, F, S, D, W, O, L, Of, G, FU> OffsetDsl for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
-    Self: Expression<SqlType = ST>,
-    SelectStatement<F, S, D, W, O, L, OffsetClause<Offset>, G, FU>: Expression<SqlType = ST>,
+    Self: SelectQuery<SqlType = ST>,
+    SelectStatement<F, S, D, W, O, L, OffsetClause<Offset>, G, FU>: SelectQuery<SqlType = ST>,
 {
     type Output = SelectStatement<F, S, D, W, O, L, OffsetClause<Offset>, G, FU>;
 

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -18,6 +18,8 @@ pub use self::boxed::BoxedSelectStatement;
 
 use backend::Backend;
 use expression::*;
+use expression::subselect::ValidSubselect;
+use query_builder::SelectQuery;
 use query_source::*;
 use query_source::joins::{AppendSelection, Inner, Join};
 use result::QueryResult;
@@ -107,16 +109,7 @@ where
     type SqlType = S::SelectClauseSqlType;
 }
 
-#[cfg(feature = "postgres")]
-impl<F, S, D, W, O, L, Of, G, FU> Expression for SelectStatement<F, S, D, W, O, L, Of, G, FU>
-where
-    S: SelectClauseExpression<F>,
-{
-    type SqlType = ::sql_types::Array<S::SelectClauseSqlType>;
-}
-
-#[cfg(not(feature = "postgres"))]
-impl<F, S, D, W, O, L, Of, G, FU> Expression for SelectStatement<F, S, D, W, O, L, Of, G, FU>
+impl<F, S, D, W, O, L, Of, G, FU> SelectQuery for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
     S: SelectClauseExpression<F>,
 {
@@ -181,24 +174,11 @@ where
     }
 }
 
-impl<F, S, D, W, O, L, Of, G, FU, QS> SelectableExpression<QS>
-    for SelectStatement<F, S, D, W, O, L, Of, G, FU>
-where
-    Self: AppearsOnTable<QS>,
-{
-}
-
-impl<S, F, D, W, O, L, Of, G, FU, QS> AppearsOnTable<QS>
+impl<S, F, D, W, O, L, Of, G, FU, QS> ValidSubselect<QS>
     for SelectStatement<F, S, D, W, O, L, Of, FU, G>
 where
-    Self: Expression,
+    Self: SelectQuery,
     W: ValidWhereClause<Join<F, QS, Inner>>,
-{
-}
-
-impl<F, S, D, W, O, L, Of, G, FU> NonAggregate for SelectStatement<F, S, D, W, O, L, Of, G, FU>
-where
-    Self: Expression,
 {
 }
 

--- a/diesel_compile_tests/tests/compile-fail/exists_can_only_take_subselects.rs
+++ b/diesel_compile_tests/tests/compile-fail/exists_can_only_take_subselects.rs
@@ -1,0 +1,27 @@
+#[macro_use] extern crate diesel;
+
+use diesel::*;
+use diesel::dsl::exists;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    let conn = SqliteConnection::establish(":memory:").unwrap();
+    // Sanity check, no error
+    users::table.filter(exists(posts::table.select(posts::id))).execute(&conn).unwrap();
+
+    users::table.filter(exists(true));
+    //~^ ERROR SelectQuery
+    users::table.filter(exists(users::id));
+    //~^ ERROR SelectQuery
+}


### PR DESCRIPTION
This unfortunately requires a breaking change, but it is in order to fix
a bug. Any code that was relying on this impl would have generated an
invalid query, or be subject to other bugs. Additionally, all types
affected by this are internal API. Finally, the SQL types are no longer
changed by enabling the "postgres" feature, and we can start relying on
`SelectStatement` always doing what we want (there are some hacks
working around that which I have not removed in this commit).

In order to continue to be able to at least somewhat abstract over how
to get the SQL type of a select clause, I've introduced `SelectQuery`
into the public API. This trait is basically `Expression`, but only
implemented for select statements.