### PR TITLE
Support `#[diesel(embed)]` on `Insertable` structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   replacing it. This is useful with boxed queries to dynamically construct an
   order by clause containing an unknown number of columns.
 
+* `#[derive(Insertable)]` can now work on structs with fields that implement
+  `Insertable` (meaning one field can map to more than one column). Add
+  `#[diesel(embed)]` to the field to enable this behavior.
+
 ### Changed
 
 * The bounds on `impl ToSql for Cow<'a, T>` have been loosened to no longer

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -19,6 +19,11 @@ use sqlite::Sqlite;
 /// with `#[table_name = "some_table_name"]`. If the field name of your
 /// struct differs from the name of the column, you can annotate the field
 /// with `#[column_name = "some_column_name"]`.
+///
+/// Your struct can also contain fields which implement `Insertable`. This is
+/// useful when you want to have one field map to more than one column (for
+/// example, an enum that maps to a label and a value column). Add
+/// `#[diesel(embed)]` to any such fields.
 pub trait Insertable<T> {
     /// The `VALUES` clause to insert these records
     ///

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -60,23 +60,32 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
 }
 
 fn field_ty(field: &Field, table_name: syn::Ident) -> syn::Type {
-    let inner_ty = inner_of_option_ty(&field.ty);
-    let column_name = field.column_name();
-    parse_quote!(
-        std::option::Option<diesel::dsl::Eq<
-            #table_name::#column_name,
-            &'insert #inner_ty,
-        >>
-    )
+    if field.has_flag("embed") {
+        let field_ty = &field.ty;
+        parse_quote!(&'insert #field_ty)
+    } else {
+        let inner_ty = inner_of_option_ty(&field.ty);
+        let column_name = field.column_name();
+        parse_quote!(
+            std::option::Option<diesel::dsl::Eq<
+                #table_name::#column_name,
+                &'insert #inner_ty,
+            >>
+        )
+    }
 }
 
 fn field_expr(field: &Field, table_name: syn::Ident) -> syn::Expr {
     let field_access = field.name.access();
-    let column_name = field.column_name();
-    let column: syn::Expr = parse_quote!(#table_name::#column_name);
-    if is_option_ty(&field.ty) {
-        parse_quote!(self#field_access.as_ref().map(|x| #column.eq(x)))
+    if field.has_flag("embed") {
+        parse_quote!(&self#field_access)
     } else {
-        parse_quote!(std::option::Option::Some(#column.eq(&self#field_access)))
+        let column_name = field.column_name();
+        let column: syn::Expr = parse_quote!(#table_name::#column_name);
+        if is_option_ty(&field.ty) {
+            parse_quote!(self#field_access.as_ref().map(|x| #column.eq(x)))
+        } else {
+            parse_quote!(std::option::Option::Some(#column.eq(&self#field_access)))
+        }
     }
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -65,14 +65,14 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
     expand_derive(input, identifiable::derive)
 }
 
+#[proc_macro_derive(Insertable, attributes(table_name, column_name, diesel))]
+pub fn derive_insertable(input: TokenStream) -> TokenStream {
+    expand_derive(input, insertable::derive)
+}
+
 #[proc_macro_derive(QueryId)]
 pub fn derive_query_id(input: TokenStream) -> TokenStream {
     expand_derive(input, query_id::derive)
-}
-
-#[proc_macro_derive(Insertable, attributes(table_name, column_name))]
-pub fn derive_insertable(input: TokenStream) -> TokenStream {
-    expand_derive(input, insertable::derive)
 }
 
 #[proc_macro_derive(Queryable, attributes(column_name))]


### PR DESCRIPTION
There have been a few people asking about how to implement `Insertable`
for enums which map to more than one column. This would allow those
people to only have to implement `Insertable` for that enum, as opposed
to the type which contains it.