### PR TITLE
Allow (some) subselects to appear in an expression context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `Insertable` (meaning one field can map to more than one column). Add
   `#[diesel(embed)]` to the field to enable this behavior.
 
+* Queries that treat a subselect as a single value (e.g. `foo = (subselect)`)
+  are now supported by calling [`.single_value()`].
+
+[`.single_value()`]: http://docs.diesel.rs/diesel/query_dsl/trait.QueryDsl.html#method.single_value
+
 ### Changed
 
 * The bounds on `impl ToSql for Cow<'a, T>` have been loosened to no longer

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -255,6 +255,9 @@ pub mod helper_types {
     /// Represents the return type of `.distinct_on(expr)`
     #[cfg(feature = "postgres")]
     pub type DistinctOn<Source, Expr> = <Source as DistinctOnDsl<Expr>>::Output;
+
+    /// Represents the return type of `.single_value()`
+    pub type SingleValue<Source> = <Source as SingleValueDsl>::Output;
 }
 
 pub mod prelude {

--- a/diesel/src/query_dsl/single_value_dsl.rs
+++ b/diesel/src/query_dsl/single_value_dsl.rs
@@ -1,0 +1,34 @@
+use dsl::Limit;
+use expression::grouped::Grouped;
+use expression::subselect::Subselect;
+use query_builder::SelectQuery;
+use sql_types::{IntoNullable, SingleValue};
+use super::methods::LimitDsl;
+
+/// The `single_value` method
+///
+/// This trait should not be relied on directly by most apps. Its behavior is
+/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
+/// to call `single_value` from generic code.
+///
+/// [`QueryDsl`]: ../trait.QueryDsl.html
+pub trait SingleValueDsl {
+    /// The type returned by `.single_value`.
+    type Output;
+
+    /// See the trait documentation.
+    fn single_value(self) -> Self::Output;
+}
+
+impl<T, ST> SingleValueDsl for T
+where
+    Self: SelectQuery<SqlType = ST> + LimitDsl,
+    ST: IntoNullable,
+    ST::Nullable: SingleValue,
+{
+    type Output = Grouped<Subselect<Limit<Self>, ST::Nullable>>;
+
+    fn single_value(self) -> Self::Output {
+        Grouped(Subselect::new(self.limit(1)))
+    }
+}


### PR DESCRIPTION
A subselect can be used as an expression by wrapping it in parenthesis
as long as the query returns exactly one column, and exactly zero or one
rows. The first constraint is trivial for us to enforce, but the only
way we can enforce the second is by automatically adding `LIMIT 1` to
the query when this method is called. We also need to make the SQL type
nullable, for the same reasons as max, min, avg, etc. They all return
null if the query returns zero rows.

If disjointness on associated types ever lands, I suspect we can just
implement `AsExpression` directly, and deprecate this method. That
said, given that the SQL type has to become nullable, it may be better
to keep the explicit method, so that we don't get questions on why
`id.eq(subselect)` isn't working.

Fixes #1308.