### PR TITLE
Allow to select a column as nullable

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -27,6 +27,10 @@ macro_rules! __diesel_column {
         impl SelectableExpression<$($table)::*> for $column_name {
         }
 
+        impl SelectableExpression<$($table)::*> for $crate::expression::nullable::Nullable<$column_name>
+        {
+        }
+
         impl<QS> AppearsOnTable<QS> for $column_name where
             QS: AppearsInFromClause<$($table)::*, Count=Once>,
         {


### PR DESCRIPTION
This makes the following code compile (and work):
```rust
users::table.select(users::name.nullable());
```

This is for example useful to write subselect statements on nullable columns.
(If this is accepted #1547 is not needed anymore.)