### PR TITLE
Add Support for Unsigned Types in Mysql

### DIFF
--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -5,36 +5,228 @@ mod date_and_time;
 mod numeric;
 
 use std::io::Write;
-use byteorder::WriteBytesExt;
+use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use deserialize::{self, FromSql};
-use mysql::Mysql;
+use row::Row;
+use deserialize::{self, FromSql, FromSqlRow, Queryable};
+use backend::Backend;
+use mysql::{Mysql, MysqlType};
 use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use expression::{AppearsOnTable, Expression, SelectableExpression};
+use query_builder::{AstPass, QueryFragment, QueryId};
+use result::QueryResult;
+use sql_types::*;
 
-impl ToSql<sql_types::Tinyint, Mysql> for i8 {
+impl ToSql<Tinyint, Mysql> for i8 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
         out.write_i8(*self).map(|_| IsNull::No).map_err(Into::into)
     }
 }
 
-impl FromSql<sql_types::Tinyint, Mysql> for i8 {
+impl FromSql<Tinyint, Mysql> for i8 {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes);
         Ok(bytes[0] as i8)
     }
 }
 
-impl ToSql<sql_types::Bool, Mysql> for bool {
+/// Represents the MySQL unsigned type.
+#[derive(Debug, Clone, Copy, Default, SqlType)]
+pub struct Unsigned<ST: NotNull + SingleValue + QueryId>(ST);
+
+impl ToSql<Unsigned<Integer>, Mysql> for u16 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
-        let int_value = if *self { 1 } else { 0 };
-        <i32 as ToSql<sql_types::Integer, Mysql>>::to_sql(&int_value, out)
+        out.write_u16::<<Mysql as Backend>::ByteOrder>(*self)
+            .map(|_| IsNull::No)
+            .map_err(Into::into)
     }
 }
 
-impl FromSql<sql_types::Bool, Mysql> for bool {
+impl FromSql<Unsigned<SmallInt>, Mysql> for u16 {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        let mut bytes = not_none!(bytes);
+        debug_assert!(
+            bytes.len() <= 2,
+            "Received more than 2 bytes decoding u16. \
+             Was a Integer expression accidentally identified as SmallInt?"
+        );
+        debug_assert!(
+            bytes.len() >= 2,
+            "Received fewer than 2 bytes decoding u16. \
+             Was the expression accidentally identified as SmallInt?"
+        );
+        bytes
+            .read_u16::<<Mysql as Backend>::ByteOrder>()
+            .map_err(Into::into)
+    }
+}
+
+impl ToSql<Unsigned<Integer>, Mysql> for u32 {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
+        out.write_u32::<<Mysql as Backend>::ByteOrder>(*self)
+            .map(|_| IsNull::No)
+            .map_err(Into::into)
+    }
+}
+
+impl FromSql<Unsigned<Integer>, Mysql> for u32 {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        let mut bytes = not_none!(bytes);
+        debug_assert!(
+            bytes.len() <= 4,
+            "Received more than 4 bytes decoding u32. \
+             Was a BigInteger expression accidentally identified as Integer?"
+        );
+        debug_assert!(
+            bytes.len() >= 4,
+            "Received fewer than 4 bytes decoding u32. \
+             Was a SmallInteger expression accidentally identified as Integer?"
+        );
+        bytes
+            .read_u32::<<Mysql as Backend>::ByteOrder>()
+            .map_err(Into::into)
+    }
+}
+
+impl ToSql<Unsigned<Integer>, Mysql> for u64 {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
+        out.write_u64::<<Mysql as Backend>::ByteOrder>(*self)
+            .map(|_| IsNull::No)
+            .map_err(Into::into)
+    }
+}
+
+impl FromSql<Unsigned<BigInt>, Mysql> for u64 {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        let mut bytes = not_none!(bytes);
+        debug_assert!(
+            bytes.len() <= 8,
+            "Received more than 8 bytes decoding u64. \
+             Was the expression accidentally identified as BigInt?"
+        );
+        debug_assert!(
+            bytes.len() >= 8,
+            "Received fewer than 8 bytes decoding u64. \
+             Was a Integer expression accidentally identified as BigInt?"
+        );
+        bytes
+            .read_u64::<<Mysql as Backend>::ByteOrder>()
+            .map_err(Into::into)
+    }
+}
+
+impl ToSql<Bool, Mysql> for bool {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
+        let int_value = if *self { 1 } else { 0 };
+        <i32 as ToSql<Integer, Mysql>>::to_sql(&int_value, out)
+    }
+}
+
+impl FromSql<Bool, Mysql> for bool {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         Ok(not_none!(bytes).iter().any(|x| *x != 0))
+    }
+}
+
+impl<ST> HasSqlType<Unsigned<ST>> for Mysql
+where
+    ST: NotNull + SingleValue + QueryId,
+    Mysql: HasSqlType<ST>,
+{
+    fn metadata(lookup: &()) -> MysqlType {
+        <Mysql as HasSqlType<ST>>::metadata(lookup)
+    }
+}
+
+impl<ST> QueryId for Unsigned<ST>
+where
+    ST: NotNull + SingleValue + QueryId,
+    <ST as QueryId>::QueryId: SingleValue + NotNull + QueryId,
+{
+    type QueryId = Unsigned<<ST as QueryId>::QueryId>;
+}
+
+impl QueryFragment<Mysql> for u16 {
+    fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {
+        let value = *self as i16;
+        out.push_sql(&value.to_string());
+        Ok(())
+    }
+}
+
+impl QueryFragment<Mysql> for u32 {
+    fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {
+        let value = *self as i32;
+        out.push_sql(&value.to_string());
+        Ok(())
+    }
+}
+
+impl QueryFragment<Mysql> for u64 {
+    fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {
+        let value = *self as i64;
+        out.push_sql(&value.to_string());
+        Ok(())
+    }
+}
+
+impl Expression for u16 {
+    type SqlType = Unsigned<SmallInt>;
+}
+
+impl Expression for u32 {
+    type SqlType = Unsigned<Integer>;
+}
+
+impl Expression for u64 {
+    type SqlType = Unsigned<BigInt>;
+}
+
+impl SelectableExpression<()> for u16 {}
+impl SelectableExpression<()> for u32 {}
+impl SelectableExpression<()> for u64 {}
+
+impl AppearsOnTable<()> for u16 {}
+impl AppearsOnTable<()> for u32 {}
+impl AppearsOnTable<()> for u64 {}
+
+impl QueryId for u16 {
+    type QueryId = ();
+}
+
+impl QueryId for u32 {
+    type QueryId = ();
+}
+
+impl QueryId for u64 {
+    type QueryId = ();
+}
+
+impl Queryable<Unsigned<SmallInt>, Mysql> for u16 {
+    type Row = u16;
+
+    fn build(row: Self::Row) -> Self {
+        row
+    }
+}
+
+impl Queryable<Unsigned<BigInt>, Mysql> for u64 {
+    type Row = u64;
+
+    fn build(row: Self::Row) -> Self {
+        row
+    }
+}
+
+impl FromSqlRow<Unsigned<SmallInt>, Mysql> for u16 {
+    fn build_from_row<T: Row<Mysql>>(row: &mut T) -> deserialize::Result<Self> {
+        Self::from_sql(row.take())
+    }
+}
+
+impl FromSqlRow<Unsigned<BigInt>, Mysql> for u64 {
+    fn build_from_row<T: Row<Mysql>>(row: &mut T) -> deserialize::Result<Self> {
+        Self::from_sql(row.take())
     }
 }
 

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -7,8 +7,7 @@ mod numeric;
 use std::io::Write;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use row::Row;
-use deserialize::{self, FromSql, FromSqlRow, Queryable};
+use deserialize::{self, FromSql};
 use backend::Backend;
 use mysql::{Mysql, MysqlType};
 use serialize::{self, IsNull, Output, ToSql};
@@ -200,34 +199,6 @@ impl QueryId for u32 {
 
 impl QueryId for u64 {
     type QueryId = ();
-}
-
-impl Queryable<Unsigned<SmallInt>, Mysql> for u16 {
-    type Row = u16;
-
-    fn build(row: Self::Row) -> Self {
-        row
-    }
-}
-
-impl Queryable<Unsigned<BigInt>, Mysql> for u64 {
-    type Row = u64;
-
-    fn build(row: Self::Row) -> Self {
-        row
-    }
-}
-
-impl FromSqlRow<Unsigned<SmallInt>, Mysql> for u16 {
-    fn build_from_row<T: Row<Mysql>>(row: &mut T) -> deserialize::Result<Self> {
-        Self::from_sql(row.take())
-    }
-}
-
-impl FromSqlRow<Unsigned<BigInt>, Mysql> for u64 {
-    fn build_from_row<T: Row<Mysql>>(row: &mut T) -> deserialize::Result<Self> {
-        Self::from_sql(row.take())
-    }
 }
 
 /// Represents the MySQL datetime type.

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -38,7 +38,17 @@ mod foreign_impls {
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
     #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Oid")]
+    struct U16Proxy(u16);
+
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(foreign_derive)]
+    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Oid")]
     struct U32Proxy(u32);
+
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(foreign_derive)]
+    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Oid")]
+    struct U64Proxy(u64);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]

--- a/diesel_compile_tests/tests/compile-fail/array_expressions_must_be_same_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/array_expressions_must_be_same_type.rs
@@ -17,13 +17,4 @@ fn main() {
     //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
-
-    select(array((1, 3f64))).get_result::<Vec<f64>>(&connection).unwrap();
-    //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -21,8 +21,4 @@ fn main() {
     int_primary_key::table.find("1");
     //~^ ERROR Expression
     //~| ERROR E0277
-    // FIXME: It'd be nice if this mentioned `AsExpression`
-    string_primary_key::table.find(1);
-    //~^ ERROR Expression
-    //~| ERROR E0277
 }

--- a/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
@@ -21,6 +21,7 @@ pub struct ColumnType {
     pub rust_name: String,
     pub is_array: bool,
     pub is_nullable: bool,
+    pub is_unsigned: bool,
 }
 
 use std::fmt;

--- a/diesel_infer_schema/infer_schema_internals/src/mysql.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/mysql.rs
@@ -81,15 +81,17 @@ pub fn load_foreign_key_constraints(
 
 pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box<Error>> {
     let tpe = determine_type_name(&attr.type_name)?;
+    let unsigned = determine_unsigned(&attr.type_name);
 
     Ok(ColumnType {
-        rust_name: capitalize(tpe),
+        rust_name: capitalize(tpe.trim()),
         is_array: false,
         is_nullable: attr.nullable,
+        is_unsigned: unsigned,
     })
 }
 
-fn determine_type_name(sql_type_name: &str) -> Result<&str, Box<Error>> {
+fn determine_type_name(sql_type_name: &str) -> Result<String, Box<Error>> {
     let result = if sql_type_name == "tinyint(1)" {
         "bool"
     } else if sql_type_name.starts_with("int") {
@@ -101,12 +103,20 @@ fn determine_type_name(sql_type_name: &str) -> Result<&str, Box<Error>> {
     };
 
     if result.to_lowercase().contains("unsigned") {
-        Err("unsigned types are not yet supported".into())
+        Ok(result
+            .to_lowercase()
+            .replace("unsigned", "")
+            .trim()
+            .to_owned())
     } else if result.contains(' ') {
         Err(format!("unrecognized type {:?}", result).into())
     } else {
-        Ok(result)
+        Ok(result.to_owned())
     }
+}
+
+fn determine_unsigned(sql_type_name: &str) -> bool {
+    sql_type_name.to_lowercase().contains("unsigned")
 }
 
 fn capitalize(name: &str) -> String {
@@ -140,10 +150,15 @@ fn int_is_treated_as_integer() {
 }
 
 #[test]
-fn unsigned_types_are_not_supported() {
-    assert!(determine_type_name("float unsigned").is_err());
-    assert!(determine_type_name("UNSIGNED INT").is_err());
-    assert!(determine_type_name("unsigned bigint").is_err())
+fn unsigned_types_are_supported() {
+    assert!(determine_unsigned("float unsigned"));
+    assert!(determine_unsigned("UNSIGNED INT"));
+    assert!(determine_unsigned("unsigned bigint"));
+    assert!(!determine_unsigned("bigint"));
+    assert!(!determine_unsigned("FLOAT"));
+    assert_eq!("float", determine_type_name("float unsigned").unwrap());
+    assert_eq!("int", determine_type_name("UNSIGNED INT").unwrap());
+    assert_eq!("bigint", determine_type_name("unsigned bigint").unwrap());
 }
 
 #[test]

--- a/diesel_infer_schema/infer_schema_internals/src/pg.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/pg.rs
@@ -31,6 +31,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
         rust_name: capitalize(tpe),
         is_array: is_array,
         is_nullable: attr.nullable,
+        is_unsigned: false,
     })
 }
 

--- a/diesel_infer_schema/infer_schema_internals/src/sqlite.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/sqlite.rs
@@ -189,6 +189,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
         rust_name: path,
         is_array: false,
         is_nullable: attr.nullable,
+        is_unsigned: false,
     })
 }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -196,6 +196,120 @@ fn i32_to_sql_integer() {
 }
 
 #[test]
+#[cfg(feature = "mysql")]
+fn u16_to_sql_integer() {
+    assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>(
+        "-1",
+        65535
+    ));
+    assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>("0", 0));
+    assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>("1", 1));
+    assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>(
+        "7000",
+        7000
+    ));
+    assert!(!query_to_sql_equality::<Unsigned<SmallInt>, u16>("0", 1));
+    assert!(!query_to_sql_equality::<Unsigned<SmallInt>, u16>(
+        "50000",
+        49999
+    ));
+    assert!(!query_to_sql_equality::<Unsigned<SmallInt>, u16>(
+        "-1",
+        64434
+    ));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn u16_from_sql() {
+    assert_eq!(0, query_single_value::<Unsigned<SmallInt>, u16>("0"));
+    assert_eq!(65535, query_single_value::<Unsigned<SmallInt>, u16>("-1"));
+    assert_ne!(65534, query_single_value::<Unsigned<SmallInt>, u16>("-1"));
+    assert_eq!(7000, query_single_value::<Unsigned<SmallInt>, u16>("7000"));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn u32_to_sql_integer() {
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>(
+        "-1",
+        4294967295
+    ));
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("0", 0));
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("1", 1));
+    assert!(query_to_sql_equality::<Unsigned<Integer>, u32>(
+        "70000",
+        70000
+    ));
+    assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>("0", 1));
+    assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>(
+        "70000",
+        69999
+    ));
+    assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>(
+        "-1",
+        4294967294
+    ));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn u32_from_sql() {
+    assert_eq!(0, query_single_value::<Unsigned<Integer>, u32>("0"));
+    assert_eq!(
+        4294967295,
+        query_single_value::<Unsigned<Integer>, u32>("-1")
+    );
+    assert_ne!(
+        4294967294,
+        query_single_value::<Unsigned<Integer>, u32>("-1")
+    );
+    assert_eq!(70000, query_single_value::<Unsigned<Integer>, u32>("70000"));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn u64_to_sql_integer() {
+    assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>(
+        "-1",
+        18446744073709551615
+    ));
+    assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>("0", 0));
+    assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>("1", 1));
+    assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>(
+        "700000",
+        700000
+    ));
+    assert!(!query_to_sql_equality::<Unsigned<BigInt>, u64>("0", 1));
+    assert!(!query_to_sql_equality::<Unsigned<BigInt>, u64>(
+        "70000",
+        69999
+    ));
+    assert!(!query_to_sql_equality::<Unsigned<BigInt>, u64>(
+        "-1",
+        18446744073709551614
+    ));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn u64_from_sql() {
+    assert_eq!(0, query_single_value::<Unsigned<BigInt>, u64>("0"));
+    assert_eq!(
+        18446744073709551615,
+        query_single_value::<Unsigned<BigInt>, u64>("-1")
+    );
+    assert_ne!(
+        18446744073709551614,
+        query_single_value::<Unsigned<BigInt>, u64>("-1")
+    );
+    assert_eq!(
+        700000,
+        query_single_value::<Unsigned<BigInt>, u64>("700000")
+    );
+}
+
+#[test]
 #[cfg(feature = "postgres")]
 fn i64_from_sql() {
     assert_eq!(0, query_single_value::<BigInt, i64>("0::int8"));


### PR DESCRIPTION
Ref. Handling unsigned integer types from MySQL #1181

This functionality was originally added in #782 and then reverted in #912. 