### PR TITLE
Allow disable sub-dependencies default-features

### DIFF
--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/diesel-rs/diesel"
 keywords = ["diesel"]
 
 [dependencies]
-infer_schema_macros = { version = "1.1.0" }
+infer_schema_macros = { version = "1.1.0", default-features = false }
 clippy = { optional = true, version = "=0.0.185" }
 
 [dev-dependencies]


### PR DESCRIPTION
I find [a blocking issue in the compilation of dotenv](https://github.com/purpliminal/rust-dotenv/issues/69), I decided to remove the `dotenv` feature (that I didn't use in fact) and fix the compilation of `infer_schema_macros` but the problem persist and this is because `dotenv` is specified in the `default` feature of `infer_schema_macros` and hasn't been deactivated by the parent crate (i.e. `diesel_infer_schema`).

So I decided, in this PR, [to force the deactivation](https://github.com/rust-lang/cargo/issues/1886) of the `dotenv` feature by default but the `default-feature` of `diesel_infer_schema` will active `dotenv_macro` (i.e. `infer_schema_macros/dotenv`) so it works like before, allow users to do more accurate settings over features activations and by the way permit a complete compilation 😃.

## Alternative
Don't make `dotenv` a default feature of `infer_schema_macros`.