### PR TITLE
Implement `PartialEq` for `ConnectionError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [`.single_value()`]: http://docs.diesel.rs/diesel/query_dsl/trait.QueryDsl.html#method.single_value
 
+* `ConnectionError` now implements `PartialEq`.
+
 ### Changed
 
 * The bounds on `impl ToSql for Cow<'a, T>` have been loosened to no longer

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -166,7 +166,7 @@ impl DatabaseErrorInformation for String {
 /// Errors which can occur during [`Connection::establish`]
 ///
 /// [`Connection::establish`]: ../connection/trait.Connection.html#tymethod.establish
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ConnectionError {
     /// The connection URL contained a `NUL` byte.
     InvalidCString(NulError),


### PR DESCRIPTION
We do this for other error types, and it's trivial to do here.

Fixes #1562.