### PR TITLE
Include diesel_compile_tests in the root workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,7 @@ members = [
     "diesel",
     "diesel_cli",
     "diesel_derives",
-    # FIXME: getting "multiple matching crates for `diesel`" because of the shared build directory
-    # "diesel_compile_tests",
+    "diesel_compile_tests",
     "diesel_tests",
     "diesel_infer_schema",
     "diesel_infer_schema/infer_schema_internals",

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -3,8 +3,6 @@ name = "diesel_compile_tests"
 version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
-[workspace]
-
 [dependencies]
 diesel = { version = "1.1.0", default-features = false, features = ["extras", "sqlite", "postgres", "mysql", "unstable"] }
 compiletest_rs = "=0.3.6"


### PR DESCRIPTION
I don't know why it wasn't there in the first place but just removing
the `[workspace]` line from its Cargo.toml and adding it to the
workspace members seems to be working.