### PR TITLE
add statement position to error info

### DIFF
--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -129,6 +129,10 @@ impl DatabaseErrorInformation for PgErrorInformation {
     fn constraint_name(&self) -> Option<&str> {
         get_result_field(self.0.as_ptr(), ResultField::ConstraintName)
     }
+
+    fn statement_position(&self) -> Option<&str> {
+        get_result_field(self.0.as_ptr(), ResultField::StatementPosition)
+    }
 }
 
 /// Represents valid options to
@@ -144,6 +148,7 @@ enum ResultField {
     TableName = 't' as i32,
     ColumnName = 'c' as i32,
     ConstraintName = 'n' as i32,
+    StatementPosition = 'P' as i32,
 }
 
 fn get_result_field<'a>(res: *mut PGresult, field: ResultField) -> Option<&'a str> {

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -120,6 +120,13 @@ pub trait DatabaseErrorInformation {
     /// Currently this method will return `None` for all backends other than
     /// PostgreSQL.
     fn constraint_name(&self) -> Option<&str>;
+
+    /// An optional integer indicating an error cursor position as an index into
+    /// the original statement string.
+    ///
+    /// Currently this method will return `None` for all backends other than
+    /// PostgreSQL.
+    fn statement_position(&self) -> Option<&str>;
 }
 
 impl fmt::Debug for DatabaseErrorInformation + Send + Sync {
@@ -146,6 +153,9 @@ impl DatabaseErrorInformation for String {
         None
     }
     fn constraint_name(&self) -> Option<&str> {
+        None
+    }
+    fn statement_position(&self) -> Option<&str> {
         None
     }
 }


### PR DESCRIPTION
PostgreSQL can return the position of an error which is useful when
executing arbitrary SQL statements. Include this position in the
DatabaseErrorInformation implementation for PG.