### PR TITLE
Adding `barrel` feature

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -168,6 +168,7 @@ pub mod serialize;
 pub mod sql_types;
 pub mod types;
 pub mod row;
+pub mod migration;
 
 #[cfg(feature = "mysql")]
 pub mod mysql;

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -6,9 +6,7 @@ use std::convert::From;
 use std::{fmt, io};
 use std::path::PathBuf;
 use std::error::Error;
-
 use result;
-
 /// Errors that occur while preparing to run migrations
 #[derive(Debug)]
 pub enum MigrationError {
@@ -76,7 +74,7 @@ impl From<io::Error> for MigrationError {
     }
 }
 
-/// Errors that occur while running migrations
+///Errors that occur while running migrations
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "clippy", allow(enum_variant_names))]
 pub enum RunMigrationsError {

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -1,16 +1,27 @@
-use diesel::result;
+//! Error types that represent migration errors.
+//! 
+//! These are split into multiple segments, depending on
+//! where in the migration process an error occurs.
 
 use std::convert::From;
 use std::{fmt, io};
 use std::path::PathBuf;
 use std::error::Error;
 
+use result;
+
+/// Errors that occur while preparing to run migrations
 #[derive(Debug)]
 pub enum MigrationError {
+    /// The migration directory wasn't found
     MigrationDirectoryNotFound,
+    /// Provided migration was in an unknown format
     UnknownMigrationFormat(PathBuf),
+    /// General system IO error
     IoError(io::Error),
+    /// Provided migration had an incompatible version number
     UnknownMigrationVersion(String),
+    /// No migrations had to be/ could be run
     NoMigrationRun,
 }
 
@@ -63,11 +74,15 @@ impl From<io::Error> for MigrationError {
     }
 }
 
+/// Errors that occur while running migrations
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "clippy", allow(enum_variant_names))]
 pub enum RunMigrationsError {
+    /// A general migration error occured
     MigrationError(MigrationError),
+    /// The provided migration included an invalid query
     QueryError(result::Error),
+    /// The provided migration was empty
     EmptyMigration,
 }
 

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -1,5 +1,4 @@
 //! Error types that represent migration errors.
-//! 
 //! These are split into multiple segments, depending on
 //! where in the migration process an error occurs.
 

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -22,6 +22,9 @@ pub enum MigrationError {
     UnknownMigrationVersion(String),
     /// No migrations had to be/ could be run
     NoMigrationRun,
+    /// 
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 impl Error for MigrationError {
@@ -83,6 +86,9 @@ pub enum RunMigrationsError {
     QueryError(result::Error),
     /// The provided migration was empty
     EmptyMigration,
+    /// 
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 impl Error for RunMigrationsError {

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -12,19 +12,19 @@ use result;
 /// Errors that occur while preparing to run migrations
 #[derive(Debug)]
 pub enum MigrationError {
-/// The migration directory wasn't found
-MigrationDirectoryNotFound,
-/// Provided migration was in an unknown format
-UnknownMigrationFormat(PathBuf),
-/// General system IO error
-IoError(io::Error),
-/// Provided migration had an incompatible version number
-UnknownMigrationVersion(String),
-/// No migrations had to be/ could be run
-NoMigrationRun,
-/// 
-#[doc(hidden)]
-__NonExhaustive,
+    /// The migration directory wasn't found
+    MigrationDirectoryNotFound,
+    /// Provided migration was in an unknown format
+    UnknownMigrationFormat(PathBuf),
+    /// General system IO error
+    IoError(io::Error),
+    /// Provided migration had an incompatible version number
+    UnknownMigrationVersion(String),
+    /// No migrations had to be/ could be run
+    NoMigrationRun,
+    ///
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 impl Error for MigrationError {
@@ -80,15 +80,15 @@ impl From<io::Error> for MigrationError {
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "clippy", allow(enum_variant_names))]
 pub enum RunMigrationsError {
-/// A general migration error occured
-MigrationError(MigrationError),
-/// The provided migration included an invalid query
-QueryError(result::Error),
-/// The provided migration was empty
-EmptyMigration,
-/// 
-#[doc(hidden)]
-__NonExhaustive,
+    /// A general migration error occured
+    MigrationError(MigrationError),
+    /// The provided migration included an invalid query
+    QueryError(result::Error),
+    /// The provided migration was empty
+    EmptyMigration,
+    ///
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 impl Error for RunMigrationsError {

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -44,6 +44,7 @@ impl Error for MigrationError {
             MigrationError::NoMigrationRun => {
                 "No migrations have been run. Did you forget `diesel migration run`?"
             }
+            MigrationError::__NonExhaustive => unreachable!()
         }
     }
 }
@@ -97,6 +98,7 @@ impl Error for RunMigrationsError {
             RunMigrationsError::MigrationError(ref error) => error.description(),
             RunMigrationsError::QueryError(ref error) => error.description(),
             RunMigrationsError::EmptyMigration => "Attempted to run an empty migration.",
+            RunMigrationsError::__NonExhaustive => unreachable!()
         }
     }
 }

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -12,19 +12,19 @@ use result;
 /// Errors that occur while preparing to run migrations
 #[derive(Debug)]
 pub enum MigrationError {
-    /// The migration directory wasn't found
-    MigrationDirectoryNotFound,
-    /// Provided migration was in an unknown format
-    UnknownMigrationFormat(PathBuf),
-    /// General system IO error
-    IoError(io::Error),
-    /// Provided migration had an incompatible version number
-    UnknownMigrationVersion(String),
-    /// No migrations had to be/ could be run
-    NoMigrationRun,
-    /// 
-    #[doc(hidden)]
-    __NonExhaustive,
+/// The migration directory wasn't found
+MigrationDirectoryNotFound,
+/// Provided migration was in an unknown format
+UnknownMigrationFormat(PathBuf),
+/// General system IO error
+IoError(io::Error),
+/// Provided migration had an incompatible version number
+UnknownMigrationVersion(String),
+/// No migrations had to be/ could be run
+NoMigrationRun,
+/// 
+#[doc(hidden)]
+__NonExhaustive,
 }
 
 impl Error for MigrationError {
@@ -80,15 +80,15 @@ impl From<io::Error> for MigrationError {
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "clippy", allow(enum_variant_names))]
 pub enum RunMigrationsError {
-    /// A general migration error occured
-    MigrationError(MigrationError),
-    /// The provided migration included an invalid query
-    QueryError(result::Error),
-    /// The provided migration was empty
-    EmptyMigration,
-    /// 
-    #[doc(hidden)]
-    __NonExhaustive,
+/// A general migration error occured
+MigrationError(MigrationError),
+/// The provided migration included an invalid query
+QueryError(result::Error),
+/// The provided migration was empty
+EmptyMigration,
+/// 
+#[doc(hidden)]
+__NonExhaustive,
 }
 
 impl Error for RunMigrationsError {

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -44,7 +44,7 @@ impl Error for MigrationError {
             MigrationError::NoMigrationRun => {
                 "No migrations have been run. Did you forget `diesel migration run`?"
             }
-            MigrationError::__NonExhaustive => unreachable!()
+            MigrationError::__NonExhaustive => unreachable!(),
         }
     }
 }
@@ -98,7 +98,7 @@ impl Error for RunMigrationsError {
             RunMigrationsError::MigrationError(ref error) => error.description(),
             RunMigrationsError::QueryError(ref error) => error.description(),
             RunMigrationsError::EmptyMigration => "Attempted to run an empty migration.",
-            RunMigrationsError::__NonExhaustive => unreachable!()
+            RunMigrationsError::__NonExhaustive => unreachable!(),
         }
     }
 }

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -6,7 +6,9 @@ use std::convert::From;
 use std::{fmt, io};
 use std::path::PathBuf;
 use std::error::Error;
+
 use result;
+
 /// Errors that occur while preparing to run migrations
 #[derive(Debug)]
 pub enum MigrationError {
@@ -74,7 +76,7 @@ impl From<io::Error> for MigrationError {
     }
 }
 
-///Errors that occur while running migrations
+/// Errors that occur while running migrations
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "clippy", allow(enum_variant_names))]
 pub enum RunMigrationsError {

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -1,11 +1,10 @@
-//!
+//! Representation of migrations
 
 pub mod errors;
 pub use self::errors::*;
 
 use connection::SimpleConnection;
 use std::path::Path;
-use std::fmt;
 
 /// Represents a migration that interacts with diesel
 pub trait Migration {
@@ -18,36 +17,6 @@ pub trait Migration {
     /// Get the migration file path
     fn file_path(&self) -> Option<&Path> {
         None
-    }
-}
-
-/// A migration name
-#[allow(missing_debug_implementations)]
-#[derive(Clone, Copy)]
-pub struct MigrationName<'a> {
-    /// Wraps around a migration
-    pub migration: &'a Migration,
-}
-
-/// Get the name of a migration
-pub fn name(migration: &Migration) -> MigrationName {
-    MigrationName {
-        migration: migration,
-    }
-}
-
-impl<'a> fmt::Display for MigrationName<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let file_name = self.migration
-            .file_path()
-            .and_then(|file_path| file_path.file_name())
-            .and_then(|file| file.to_str());
-        if let Some(name) = file_name {
-            f.write_str(name)?;
-        } else {
-            f.write_str(self.migration.version())?;
-        }
-        Ok(())
     }
 }
 

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -1,6 +1,6 @@
 //! Representation of migrations
 
-pub mod errors;
+mod errors;
 pub use self::errors::{MigrationError, RunMigrationsError};
 
 use connection::SimpleConnection;

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -1,0 +1,21 @@
+//!
+
+pub mod errors;
+pub use self::errors::*;
+
+use connection::SimpleConnection;
+use std::path::Path;
+
+/// Represents a migration that interacts with diesel
+pub trait Migration {
+    /// Get the migration version
+    fn version(&self) -> &str;
+    /// Apply this migration
+    fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError>;
+    /// Revert this migration
+    fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError>;
+    /// Get the migration file path
+    fn file_path(&self) -> Option<&Path> {
+        None
+    }
+}

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -1,7 +1,7 @@
 //! Representation of migrations
 
 pub mod errors;
-pub use self::errors::*;
+pub use self::errors::{MigrationError, RunMigrationsError};
 
 use connection::SimpleConnection;
 use std::path::Path;

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -5,6 +5,7 @@ pub use self::errors::*;
 
 use connection::SimpleConnection;
 use std::path::Path;
+use std::fmt;
 
 /// Represents a migration that interacts with diesel
 pub trait Migration {
@@ -17,5 +18,69 @@ pub trait Migration {
     /// Get the migration file path
     fn file_path(&self) -> Option<&Path> {
         None
+    }
+}
+
+/// A migration name
+#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy)]
+pub struct MigrationName<'a> {
+    /// Wraps around a migration
+    pub migration: &'a Migration,
+}
+
+/// Get the name of a migration
+pub fn name(migration: &Migration) -> MigrationName {
+    MigrationName {
+        migration: migration,
+    }
+}
+
+impl<'a> fmt::Display for MigrationName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let file_name = self.migration
+            .file_path()
+            .and_then(|file_path| file_path.file_name())
+            .and_then(|file| file.to_str());
+        if let Some(name) = file_name {
+            f.write_str(name)?;
+        } else {
+            f.write_str(self.migration.version())?;
+        }
+        Ok(())
+    }
+}
+
+impl Migration for Box<Migration> {
+    fn version(&self) -> &str {
+        (&**self).version()
+    }
+
+    fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).run(conn)
+    }
+
+    fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).revert(conn)
+    }
+    fn file_path(&self) -> Option<&Path> {
+        (&**self).file_path()
+    }
+}
+
+impl<'a> Migration for &'a Migration {
+    fn version(&self) -> &str {
+        (&**self).version()
+    }
+
+    fn run(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).run(conn)
+    }
+
+    fn revert(&self, conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
+        (&**self).revert(conn)
+    }
+    fn file_path(&self) -> Option<&Path> {
+        (&**self).file_path()
     }
 }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -39,6 +39,7 @@ lint = ["clippy"]
 postgres = ["diesel/postgres", "infer_schema_internals/postgres", "url"]
 sqlite = ["diesel/sqlite", "infer_schema_internals/sqlite"]
 mysql = ["diesel/mysql", "infer_schema_internals/mysql", "url"]
+barrels = ["migrations_internals/barrel", "barrel"]
 
 [[test]]
 name = "tests"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -39,7 +39,7 @@ lint = ["clippy"]
 postgres = ["diesel/postgres", "infer_schema_internals/postgres", "url"]
 sqlite = ["diesel/sqlite", "infer_schema_internals/sqlite"]
 mysql = ["diesel/mysql", "infer_schema_internals/mysql", "url"]
-barrels = ["migrations_internals/barrel", "barrel"]
+rust-migrations = ["migrations_internals/barrel", "barrel"]
 
 [[test]]
 name = "tests"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -25,7 +25,7 @@ migrations_internals = "~1.2.0"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
-barrel = { git = "https://github.com/spacekookie/barrel", optional = true, features = ["diesel"] }
+barrel = { version = "<= 0.2.0", optional = true, features = ["diesel_filled"] }
 
 [dev-dependencies]
 difference = "1.0"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -25,7 +25,7 @@ migrations_internals = "~1.2.0"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
-barrel = { version = "<= 0.2.0", optional = true, features = ["diesel_filled"] }
+barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
 
 [dev-dependencies]
 difference = "1.0"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -25,6 +25,7 @@ migrations_internals = "~1.2.0"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
+barrel = { git = "https://github.com/spacekookie/barrel", optional = true, features = ["diesel"] }
 
 [dev-dependencies]
 difference = "1.0"

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -51,6 +51,13 @@ pub fn build_cli() -> App<'static, 'static> {
                              for most use cases.",
                         )
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("type")
+                        .long("type")
+                        .short("t")
+                        .takes_value(true)
+                        .help("Specify the migration type."),
                 ),
         )
         .setting(AppSettings::SubcommandRequiredElseHelp);

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -56,7 +56,7 @@ pub fn build_cli() -> App<'static, 'static> {
                     Arg::with_name("TYPE")
                         .long("type")
                         .short("t")
-                        .possible_values(&["sql", "barrel"])
+                        .possible_values(&["sql", "rust"])
                         .default_value("sql")
                         .takes_value(true)
                         .help("Specify the migration type."),

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -53,9 +53,11 @@ pub fn build_cli() -> App<'static, 'static> {
                         .takes_value(true),
                 )
                 .arg(
-                    Arg::with_name("type")
+                    Arg::with_name("TYPE")
                         .long("type")
                         .short("t")
+                        .possible_values(&["sql", "barrel"])
+                        .default_value("sql")
                         .takes_value(true)
                         .help("Specify the migration type."),
                 ),

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -137,13 +137,13 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<Error>> {
                     let mut barrel_migr = fs::File::create(migr_path).unwrap();
                     barrel_migr.write(b"/// Handle up migrations \n").unwrap();
                     barrel_migr
-                        .write(b"fn up(migr: &mut Migration) -> String {} \n\n")
+                        .write(b"fn up(migr: &mut Migration) {} \n\n")
                         .unwrap();
                     barrel_migr.write(b"/// Handle down migrations \n").unwrap();
                     barrel_migr
-                        .write(b"fn down(migr: &mut Migration) -> String {} \n")
+                        .write(b"fn down(migr: &mut Migration) {} \n")
                         .unwrap();
-                },
+                }
                 _ => {
                     let up_path = migration_dir.join("up.sql");
                     println!(

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -132,7 +132,7 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<Error>> {
             match migration_type {
                 #[cfg(feature = "barrel")]
                 Some("barrel") => barrel::diesel::generate_initial(migration_dir),
-                _ => generate_sql_migration(migration_dir),
+                _ => generate_sql_migration(&migration_dir),
             }
         }
         _ => unreachable!("The cli parser should prevent reaching here"),
@@ -141,7 +141,7 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<Error>> {
     Ok(())
 }
 
-fn generate_sql_migration(path: PathBuf) {
+fn generate_sql_migration(path: &PathBuf) {
     use std::io::Write;
 
     let migration_dir_relative =

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -23,13 +23,11 @@ extern crate toml;
 #[cfg(feature = "url")]
 extern crate url;
 
-<<<<<<< HEAD
 mod config;
-=======
-#[cfg(feature = "barrel")]
+
+#[cfg(feature = "rust-migrations")]
 extern crate barrel;
 
->>>>>>> Implementing requested changes in diesel_cli
 mod database_error;
 #[macro_use]
 mod database;
@@ -130,8 +128,8 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<Error>> {
                 convert_absolute_path_to_relative(&migration_dir, &env::current_dir()?);
 
             match migration_type {
-                #[cfg(feature = "barrel")]
-                Some("barrel") => ::barrel::integrations::diesel::generate_initial(&migration_dir),
+                #[cfg(feature = "rust-migrations")]
+                Some("rust") => ::barrel::integrations::diesel::generate_initial(&migration_dir),
                 _ => generate_sql_migration(&migration_dir),
             }
         }

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -124,9 +124,6 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<Error>> {
             let migration_type: Option<&str> = args.value_of("TYPE");
             fs::create_dir(&migration_dir).unwrap();
 
-            let migration_dir_relative =
-                convert_absolute_path_to_relative(&migration_dir, &env::current_dir()?);
-
             match migration_type {
                 #[cfg(feature = "rust-migrations")]
                 Some("rust") => ::barrel::integrations::diesel::generate_initial(&migration_dir),

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -131,7 +131,7 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<Error>> {
 
             match migration_type {
                 #[cfg(feature = "barrel")]
-                Some("barrel") => barrel::diesel::generate_initial(migration_dir),
+                Some("barrel") => ::barrel::integrations::diesel::generate_initial(&migration_dir),
                 _ => generate_sql_migration(&migration_dir),
             }
         }

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -23,6 +23,8 @@ extern crate toml;
 #[cfg(feature = "url")]
 extern crate url;
 
+mod config;
+
 #[cfg(feature = "rust-migrations")]
 extern crate barrel;
 
@@ -132,30 +134,6 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<Error>> {
     };
 
     Ok(())
-}
-
-fn generate_sql_migration(path: &PathBuf) {
-    use std::io::Write;
-
-    let migration_dir_relative =
-        convert_absolute_path_to_relative(path, &env::current_dir().unwrap());
-
-    let up_path = path.join("up.sql");
-    println!(
-        "Creating {}",
-        migration_dir_relative.join("up.sql").display()
-    );
-    let mut up = fs::File::create(up_path).unwrap();
-    up.write_all(b"-- Your SQL goes here").unwrap();
-
-    let down_path = path.join("down.sql");
-    println!(
-        "Creating {}",
-        migration_dir_relative.join("down.sql").display()
-    );
-    let mut down = fs::File::create(down_path).unwrap();
-    down.write_all(b"-- This file should undo anything in `up.sql`")
-        .unwrap();
 }
 
 fn generate_sql_migration(path: &PathBuf) {

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -145,7 +145,7 @@ fn generate_sql_migration(path: &PathBuf) {
     use std::io::Write;
 
     let migration_dir_relative =
-        convert_absolute_path_to_relative(&path, &env::current_dir().unwrap());
+        convert_absolute_path_to_relative(path, &env::current_dir().unwrap());
 
     let up_path = path.join("up.sql");
     println!(

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -8,8 +8,13 @@ homepage = "http://diesel.rs"
 
 [dependencies]
 clippy = { optional = true, version = "=0.0.185" }
+<<<<<<< HEAD
 diesel = { version = "~1.2.0", default-features = false }
 barrel = { version = "0.2.0", optional = true }
+=======
+diesel = { version = "1.1.0", default-features = false }
+barrel = { path = "/home/spacekookie/Projects/code/barrel", optional = true, features = ["diesel"] }
+>>>>>>> Changing barrel call signature to build Migration on diesel side
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -8,8 +8,13 @@ homepage = "http://diesel.rs"
 
 [dependencies]
 clippy = { optional = true, version = "=0.0.185" }
+<<<<<<< HEAD
 diesel = { version = "~1.2.0", default-features = false }
 barrel = { version = "0.2.0", optional = true }
+=======
+diesel = { version = "1.1.0", default-features = false }
+barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
+>>>>>>> Adjust the diesel feature flag on barrel
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -8,13 +8,8 @@ homepage = "http://diesel.rs"
 
 [dependencies]
 clippy = { optional = true, version = "=0.0.185" }
-<<<<<<< HEAD
 diesel = { version = "~1.2.0", default-features = false }
 barrel = { version = "0.2.0", optional = true }
-=======
-diesel = { version = "1.1.0", default-features = false }
-barrel = { path = "/home/spacekookie/Projects/code/barrel", optional = true, features = ["diesel"] }
->>>>>>> Changing barrel call signature to build Migration on diesel side
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "http://diesel.rs"
 [dependencies]
 clippy = { optional = true, version = "=0.0.185" }
 diesel = { version = "~1.2.0", default-features = false }
+barrel = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -8,8 +8,13 @@ homepage = "http://diesel.rs"
 
 [dependencies]
 clippy = { optional = true, version = "=0.0.185" }
+<<<<<<< HEAD
 diesel = { version = "~1.2.0", default-features = false }
 barrel = { version = "0.2.0", optional = true }
+=======
+diesel = { version = "1.1.0", default-features = false }
+barrel = { git = "https://github.com/spacekookie/barrel", optional = true, features = ["diesel_filled"] }
+>>>>>>> Preliminarily commiting refactoring changes
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -8,13 +8,8 @@ homepage = "http://diesel.rs"
 
 [dependencies]
 clippy = { optional = true, version = "=0.0.185" }
-<<<<<<< HEAD
 diesel = { version = "~1.2.0", default-features = false }
 barrel = { version = "0.2.0", optional = true }
-=======
-diesel = { version = "1.1.0", default-features = false }
-barrel = { git = "https://github.com/spacekookie/barrel", optional = true, features = ["diesel_filled"] }
->>>>>>> Preliminarily commiting refactoring changes
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -8,13 +8,8 @@ homepage = "http://diesel.rs"
 
 [dependencies]
 clippy = { optional = true, version = "=0.0.185" }
-<<<<<<< HEAD
 diesel = { version = "~1.2.0", default-features = false }
 barrel = { version = "0.2.0", optional = true }
-=======
-diesel = { version = "1.1.0", default-features = false }
-barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
->>>>>>> Adjust the diesel feature flag on barrel
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -90,12 +90,11 @@ pub mod schema;
 pub use self::connection::MigrationConnection;
 #[doc(inline)]
 pub use self::migration::*;
-// pub use self::migration_error::*;
+pub use diesel::migration::*;
 
 use std::fs::DirEntry;
 use std::io::{stdout, Write};
 
-use diesel::migration::*;
 use diesel::expression_methods::*;
 use diesel::{Connection, QueryDsl, QueryResult, RunQueryDsl};
 use self::schema::__diesel_schema_migrations::dsl::*;

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -77,6 +77,9 @@
 #[macro_use]
 extern crate diesel;
 
+#[cfg(feature = "barrel")]
+extern crate barrel;
+
 mod migration;
 #[doc(hidden)]
 pub mod connection;

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -80,10 +80,9 @@ extern crate diesel;
 #[cfg(feature = "barrel")]
 extern crate barrel;
 
-mod migration;
+pub mod migration;
 #[doc(hidden)]
 pub mod connection;
-mod migration_error;
 #[doc(hidden)]
 pub mod schema;
 
@@ -91,14 +90,16 @@ pub mod schema;
 pub use self::connection::MigrationConnection;
 #[doc(inline)]
 pub use self::migration::*;
-pub use self::migration_error::*;
+// pub use self::migration_error::*;
 
 use std::fs::DirEntry;
 use std::io::{stdout, Write};
 
+use diesel::migration::errors::*;
 use diesel::expression_methods::*;
 use diesel::{Connection, QueryDsl, QueryResult, RunQueryDsl};
 use self::schema::__diesel_schema_migrations::dsl::*;
+use self::migration::Migration;
 
 use std::env;
 use std::path::{Path, PathBuf};

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -95,11 +95,10 @@ pub use self::migration::*;
 use std::fs::DirEntry;
 use std::io::{stdout, Write};
 
-use diesel::migration::errors::*;
+use diesel::migration::*;
 use diesel::expression_methods::*;
 use diesel::{Connection, QueryDsl, QueryResult, RunQueryDsl};
 use self::schema::__diesel_schema_migrations::dsl::*;
-use self::migration::Migration;
 
 use std::env;
 use std::path::{Path, PathBuf};

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -1,5 +1,5 @@
 use diesel::connection::SimpleConnection;
-use super::{MigrationError, RunMigrationsError};
+use diesel::migration::errors::*;
 
 use std::path::{Path, PathBuf};
 use std::fmt;
@@ -90,6 +90,7 @@ fn barrel_to_migration(
 ) -> Result<Box<Migration>, MigrationError> {
     Ok(Box::new(BarrelMigration(path, version, sql.0, sql.1)))
 }
+
 
 impl Migration for Box<Migration> {
     fn version(&self) -> &str {

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -59,7 +59,6 @@ pub fn migration_from(path: PathBuf) -> Result<Box<Migration>, MigrationError> {
 }
 
 #[cfg(feature = "barrel")]
-/// Include the path, version, up and down sql strings 
 struct BarrelMigration(PathBuf, String, String, String);
 
 #[cfg(feature = "barrel")]
@@ -84,7 +83,11 @@ impl Migration for BarrelMigration {
 }
 
 #[cfg(feature = "barrel")]
-fn barrel_to_migration(path: PathBuf, version: String, sql: (String, String)) -> Result<Box<Migration>, MigrationError> {
+fn barrel_to_migration(
+    path: PathBuf,
+    version: String,
+    sql: (String, String),
+) -> Result<Box<Migration>, MigrationError> {
     println!("Converting migration: {:?}", sql);
     Ok(Box::new(BarrelMigration(path, version, sql.0, sql.1)))
 }

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -33,7 +33,7 @@ impl<'a> fmt::Display for MigrationName<'a> {
 
 pub fn migration_from(path: PathBuf) -> Result<Box<Migration>, MigrationError> {
     #[cfg(feature = "barrel")]
-    match ::barrel::diesel::migration_from(&path) {
+    match ::barrel::integrations::diesel::migration_from(&path) {
         Some(migration) => return Ok(migration),
         None => {}
     }

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -41,6 +41,11 @@ impl<'a> fmt::Display for MigrationName<'a> {
 }
 
 pub fn migration_from(path: PathBuf) -> Result<Box<Migration>, MigrationError> {
+    #[cfg(feature = "barrel")]
+    if let Some(migration) = ::barrel::migration_from(&path) {
+        return Ok(migration);
+    }
+
     if valid_sql_migration_directory(&path) {
         let version = try!(version_from_path(&path));
         Ok(Box::new(SqlFileMigration(path, version)))

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -2,6 +2,34 @@ use diesel::connection::SimpleConnection;
 use diesel::migration::*;
 
 use std::path::{Path, PathBuf};
+use std::fmt;
+
+#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy)]
+pub struct MigrationName<'a> {
+    pub migration: &'a Migration,
+}
+
+pub fn name(migration: &Migration) -> MigrationName {
+    MigrationName {
+        migration: migration,
+    }
+}
+
+impl<'a> fmt::Display for MigrationName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let file_name = self.migration
+            .file_path()
+            .and_then(|file_path| file_path.file_name())
+            .and_then(|file| file.to_str());
+        if let Some(name) = file_name {
+            f.write_str(name)?;
+        } else {
+            f.write_str(self.migration.version())?;
+        }
+        Ok(())
+    }
+}
 
 pub fn migration_from(path: PathBuf) -> Result<Box<Migration>, MigrationError> {
     #[cfg(feature = "barrel")]

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -88,7 +88,6 @@ fn barrel_to_migration(
     version: String,
     sql: (String, String),
 ) -> Result<Box<Migration>, MigrationError> {
-    println!("Converting migration: {:?}", sql);
     Ok(Box::new(BarrelMigration(path, version, sql.0, sql.1)))
 }
 

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -66,6 +66,7 @@ pub fn derive_embed_migrations(input: &syn::DeriveInput) -> quote::Tokens {
         extern crate diesel_migrations;
 
         use self::diesel_migrations::*;
+        use self::diesel::migration::*;
         use self::diesel::connection::SimpleConnection;
         use std::io;
 

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -79,10 +79,10 @@ extern crate migrations_macros;
 pub use migrations_macros::*;
 #[doc(inline)]
 pub use migrations_internals::MigrationConnection;
-// #[doc(inline)]
-// pub use migrations_internals::MigrationError;
-// #[doc(inline)]
-// pub use migrations_internals::RunMigrationsError;
+#[doc(inline)]
+pub use migrations_internals::MigrationError;
+#[doc(inline)]
+pub use migrations_internals::RunMigrationsError;
 #[doc(inline)]
 pub use migrations_internals::run_migration_with_version;
 #[doc(inline)]

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -78,6 +78,10 @@ extern crate migrations_macros;
 #[doc(hidden)]
 pub use migrations_macros::*;
 #[doc(inline)]
+pub use migrations_internals::Migration;
+#[doc(inline)]
+pub use migrations_internals::MigrationName;
+#[doc(inline)]
 pub use migrations_internals::MigrationConnection;
 #[doc(inline)]
 pub use migrations_internals::MigrationError;
@@ -113,8 +117,8 @@ pub use migrations_internals::find_migrations_directory;
 pub use migrations_internals::search_for_migrations_directory;
 #[doc(inline)]
 pub use migrations_internals::version_from_path;
-// #[doc(inline)]
-// pub use migrations_internals::name;
+#[doc(inline)]
+pub use migrations_internals::name;
 
 pub mod connection {
     #[doc(inline)]

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -78,15 +78,15 @@ extern crate migrations_macros;
 #[doc(hidden)]
 pub use migrations_macros::*;
 #[doc(inline)]
-pub use migrations_internals::Migration;
+pub use migrations_internals::migration::Migration;
 #[doc(inline)]
 pub use migrations_internals::MigrationName;
 #[doc(inline)]
 pub use migrations_internals::MigrationConnection;
-#[doc(inline)]
-pub use migrations_internals::MigrationError;
-#[doc(inline)]
-pub use migrations_internals::RunMigrationsError;
+// #[doc(inline)]
+// pub use migrations_internals::MigrationError;
+// #[doc(inline)]
+// pub use migrations_internals::RunMigrationsError;
 #[doc(inline)]
 pub use migrations_internals::run_migration_with_version;
 #[doc(inline)]

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -78,10 +78,6 @@ extern crate migrations_macros;
 #[doc(hidden)]
 pub use migrations_macros::*;
 #[doc(inline)]
-pub use migrations_internals::migration::Migration;
-#[doc(inline)]
-pub use migrations_internals::MigrationName;
-#[doc(inline)]
 pub use migrations_internals::MigrationConnection;
 // #[doc(inline)]
 // pub use migrations_internals::MigrationError;
@@ -117,8 +113,8 @@ pub use migrations_internals::find_migrations_directory;
 pub use migrations_internals::search_for_migrations_directory;
 #[doc(inline)]
 pub use migrations_internals::version_from_path;
-#[doc(inline)]
-pub use migrations_internals::name;
+// #[doc(inline)]
+// pub use migrations_internals::name;
 
 pub mod connection {
     #[doc(inline)]


### PR DESCRIPTION
This is the initial version of integrating `barrel` into diesel. A few things are still not optimal and I'd like to get some feedback regarding that.

1. There are some barrel specific functions and structs in the `migrations_internal` module which are only compiled when using barrel. I would love to keep those parts in the barrel crate but can't because of cyclic dependencies. Is there a different way to solve this? If so, how?

2. Currently (for testing) the `barrel` feature is always enabled on diesel. How would I add `features = [ "barrel"]` to the `migration_internals` crate, depending on the external flag? Is there a more elegant way of doing this?

3. Should the code added to `diesel_cli` be conditionally added with a `barrel` feature flag too?

Additionally the barrel dependency currently points to `git` which should be changed once `barrel 0.2` is released