### PR TITLE
Replace most raw pointer usage with `NonNull`

### DIFF
--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -131,7 +131,7 @@ fn execute_statement(stmt: &mut Statement, binds: &mut Binds) -> QueryResult<()>
 }
 
 fn populate_row_buffers(stmt: &Statement, binds: &mut Binds) -> QueryResult<Option<()>> {
-    let next_row_result = unsafe { ffi::mysql_stmt_fetch(stmt.stmt) };
+    let next_row_result = unsafe { ffi::mysql_stmt_fetch(stmt.stmt.as_ptr()) };
     match next_row_result as libc::c_uint {
         ffi::MYSQL_NO_DATA => Ok(None),
         ffi::MYSQL_DATA_TRUNCATED => binds.populate_dynamic_buffers(stmt).map(Some),

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -5,3 +5,46 @@ pub trait TupleAppend<T> {
 
     fn tuple_append(self, right: T) -> Self::Output;
 }
+
+#[cfg(not(feature = "unstable"))]
+mod polyfill {
+    /// A polyfill for `std::ptr::NonNull`, which was stabilized in Rust 1.25.
+    /// When our minimum supported version of Rust is >= 1.25, this should be
+    /// removed. However, we should not bump our minimum version of Rust just
+    /// to remove this polyfill.
+    pub(crate) struct NonNull<T: ?Sized> {
+        ptr: *mut T,
+    }
+
+    impl<T: ?Sized> Clone for NonNull<T> {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
+
+    impl<T: ?Sized> Copy for NonNull<T> {}
+
+    impl<T: ?Sized> NonNull<T> {
+        pub(crate) unsafe fn new_unchecked(ptr: *mut T) -> Self {
+            Self { ptr }
+        }
+
+        pub(crate) fn new(ptr: *mut T) -> Option<Self> {
+            if ptr.is_null() {
+                None
+            } else {
+                Some(unsafe { Self::new_unchecked(ptr) })
+            }
+        }
+
+        pub(crate) fn as_ptr(self) -> *mut T {
+            self.ptr
+        }
+    }
+}
+
+#[cfg(not(feature = "unstable"))]
+pub(crate) use self::polyfill::*;
+
+#[cfg(feature = "unstable")]
+pub(crate) type NonNull<T> = ::std::ptr::NonNull<T>;

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -7,6 +7,7 @@ pub trait TupleAppend<T> {
 }
 
 #[cfg(not(feature = "unstable"))]
+#[allow(dead_code)]
 mod polyfill {
     /// A polyfill for `std::ptr::NonNull`, which was stabilized in Rust 1.25.
     /// When our minimum supported version of Rust is >= 1.25, this should be
@@ -44,6 +45,7 @@ mod polyfill {
 }
 
 #[cfg(not(feature = "unstable"))]
+#[allow(unused_imports)]
 pub(crate) use self::polyfill::*;
 
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
This newly stabilized feature indicates that a pointer cannot be null.
This allows certain compiler optimizations, including but not limited to
the "null pointer optimization", which means that `Option<NonNull<T>>`
has the same size as `NonNull<T>`.

Using `NonNull` over raw pointers as much as possible in our code
potentially enables additional compiler optimizations, and better
expresses intent in several places.

Since this type was only stabilized in Rust 1.25, I have stuck the use
of the real thing behind the unstable flag, and provided a polyfill
by default. This keeps with our policy of "only bump the minimum Rust
version if you have a good reason". I don't think this is a good enough
reason to bump on its own. The polyfill lets us structure our code the
same regardless, and it should be trivial to switch to always using the
real thing once we no longer support Rust 1.24 and earlier.