### PR TITLE
Allow use of uuid 0.6.0

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -24,7 +24,7 @@ quickcheck = { version = "0.4", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }
 time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
-uuid = { version = ">=0.2.0, <0.6.0", optional = true, features = ["use_std"] }
+uuid = { version = ">=0.2.0, <0.7.0", optional = true, features = ["use_std"] }
 ipnetwork = { version = "0.12.2", optional = true }
 num-bigint = { version = "0.1.41", optional = true }
 num-traits = { version = "0.1.35", optional = true }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -18,7 +18,7 @@ diesel_infer_schema = { version = "1.1.0" }
 diesel_migrations = { version = "1.1.0" }
 dotenv = ">=0.8, <0.11"
 quickcheck = { version = "0.4", features = ["unstable"] }
-uuid = { version = ">=0.2.0, <0.6.0" }
+uuid = { version = ">=0.2.0, <0.7.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = "0.12.2"
 bigdecimal = "0.0.10"


### PR DESCRIPTION
There is a new version of uuid. This is similar to #878, however version 0.6.0 of the uuid crates has renamed the `use_std` feature to `std` and turned it on by default.

As far as I can tell, it is not possible to support all versions in one Cargo.toml file, without either adding the `use_std` flag back into uuid as compatibility or getting them to use the semver-trick.