### PR TITLE
Allow Unused External Crates in diesel_derives

### DIFF
--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -9,7 +9,7 @@ pub fn wrap_in_dummy_mod(const_name: Ident, item: Tokens) -> Tokens {
     let call_site = root_span(Span::call_site());
     let use_everything = quote_spanned!(call_site=> __diesel_use_everything!());
     quote! {
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, unused_extern_crates)]
         mod #const_name {
             // https://github.com/rust-lang/rust/issues/47314
             extern crate std;


### PR DESCRIPTION
 ## Problem
With an older version of Rust(`nightly-2017-09-20-x86_64-apple-darwin`), `diesel` does not compile due to `unused
external crate` errors:
```
error: unused extern crate
  --> src/type_impls/primitives.rs:69:14
   |
69 |     #[derive(FromSqlRow)]
   |              ^^^^^^^^^^

error: unused extern crate
 --> src/type_impls/decimal.rs:9:14
  |
9 |     #[derive(FromSqlRow, AsExpression)]
  |              ^^^^^^^^^^
```

 ## Solution
Because it's a simple fix and not worth being a stopper, allow unused
extern crates and allow diesel to compile.