### PR TITLE
fixed example

### DIFF
--- a/examples/postgres/getting_started_step_2/src/lib.rs
+++ b/examples/postgres/getting_started_step_2/src/lib.rs
@@ -26,7 +26,7 @@ pub fn create_post(conn: &PgConnection, title: &str, body: &str) -> Post {
         body: body,
     };
 
-    diesel::insert_into(posts::table)
+    diesel::insert_into(posts)
         .values(&new_post)
         .get_result(conn)
         .expect("Error saving new post")


### PR DESCRIPTION
`posts::table` should just be `posts` in insert statements.

`posts::table` fails with `function or associated item not found in 'schema::posts::table'`