### PR TITLE
Allow function overloading in Postgres via variant_sql_function macro

### DIFF
--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -131,7 +131,7 @@ macro_rules! sql_function {
 }
 
 #[macro_export]
-#[cfg(feature = "postgres")]
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
 /// Declare a variant of an already defined sql function for use in your code. Useful if you have
 /// your own SQL functions that you'd like to use that are overloaded. You can optionally provide a
 /// doc string as well. `$struct_name` and `$fn_name` should be unique names. You will not need to

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -131,7 +131,7 @@ macro_rules! sql_function {
 }
 
 #[macro_export]
-#[cfg(feature= "postgres" )]
+#[cfg(feature = "postgres")]
 /// Declare a variant of an already defined sql function for use in your code. Useful if you have
 /// your own SQL functions that you'd like to use that are overloaded. You can optionally provide a
 /// doc string as well. `$struct_name` and `$fn_name` should be unique names. You will not need to
@@ -142,15 +142,15 @@ macro_rules! sql_function {
 /// its arguments to expressions.
 macro_rules! variant_sql_function {
     ($fn_name:ident, $struct_name:ident, $sql_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
-        sql_function_variant!($fn_name, $struct_name, $sql_name, ($($arg_name $arg_type),*) -> ());
+        variant_sql_function!($fn_name, $struct_name, $sql_name, ($($arg_name $arg_type),*) -> ());
     };
 
     ($fn_name:ident, $struct_name:ident, $sql_name:ident, $args:tt -> $return_type:ty) => {
-        sql_function_variant!($fn_name, $struct_name, $sql_name, $args -> $return_type, "");
+        variant_sql_function!($fn_name, $struct_name, $sql_name, $args -> $return_type, "");
     };
 
     ($fn_name:ident, $struct_name:ident, $sql_name:ident, $args:tt -> $return_type:ty, $docs:expr) => {
-        sql_function_variant!($fn_name, $struct_name, $sql_name, $args -> $return_type, $docs, "");
+        variant_sql_function!($fn_name, $struct_name, $sql_name, $args -> $return_type, $docs, "");
     };
 
     ($fn_name:ident,

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -4,6 +4,7 @@ macro_rules! sql_function_body {
     (
         $fn_name:ident,
         $struct_name:ident,
+        $sql_name:ident,
         ($($arg_name:ident: $arg_type:ty),*) -> $return_type:ty,
         $docs:expr,
         $helper_ty_docs:expr
@@ -45,7 +46,7 @@ macro_rules! sql_function_body {
             for <'a> ($(&'a $arg_name),*): $crate::query_builder::QueryFragment<DB>,
         {
             fn walk_ast(&self, mut out: $crate::query_builder::AstPass<DB>) -> $crate::result::QueryResult<()> {
-                out.push_sql(concat!(stringify!($fn_name), "("));
+                out.push_sql(concat!(stringify!($sql_name), "("));
                 $crate::query_builder::QueryFragment::walk_ast(
                     &($(&self.$arg_name),*), out.reborrow())?;
                 out.push_sql(")");
@@ -106,16 +107,16 @@ macro_rules! sql_function_body {
 /// # }
 /// ```
 macro_rules! sql_function {
+    ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
+        sql_function!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> ());
+    };
+
     ($fn_name:ident, $struct_name:ident, $args:tt -> $return_type:ty) => {
         sql_function!($fn_name, $struct_name, $args -> $return_type, "");
     };
 
     ($fn_name:ident, $struct_name:ident, $args:tt -> $return_type:ty, $docs:expr) => {
         sql_function!($fn_name, $struct_name, $args -> $return_type, $docs, "");
-    };
-
-    ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
-        sql_function!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> ());
     };
 
     (
@@ -125,7 +126,40 @@ macro_rules! sql_function {
         $docs:expr,
         $helper_ty_docs:expr
     ) => {
-        sql_function_body!($fn_name, $struct_name, $args -> $return_type, $docs, $helper_ty_docs);
+        sql_function_body!($fn_name, $fn_name, $struct_name, $args -> $return_type, $docs, $helper_ty_docs);
+    };
+}
+
+#[macro_export]
+#[cfg(feature= "postgres" )]
+/// Declare a variant of an already defined sql function for use in your code. Useful if you have
+/// your own SQL functions that you'd like to use that are overloaded. You can optionally provide a
+/// doc string as well. `$struct_name` and `$fn_name` should be unique names. You will not need to
+/// reference `$struct_name` in your code.
+///
+/// This will generate a rust function with the same name to construct the expression, and a helper
+/// type which represents the return type of that function. The function will automatically convert
+/// its arguments to expressions.
+macro_rules! variant_sql_function {
+    ($fn_name:ident, $struct_name:ident, $sql_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
+        sql_function_variant!($fn_name, $struct_name, $sql_name, ($($arg_name $arg_type),*) -> ());
+    };
+
+    ($fn_name:ident, $struct_name:ident, $sql_name:ident, $args:tt -> $return_type:ty) => {
+        sql_function_variant!($fn_name, $struct_name, $sql_name, $args -> $return_type, "");
+    };
+
+    ($fn_name:ident, $struct_name:ident, $sql_name:ident, $args:tt -> $return_type:ty, $docs:expr) => {
+        sql_function_variant!($fn_name, $struct_name, $sql_name, $args -> $return_type, $docs, "");
+    };
+
+    ($fn_name:ident,
+     $struct_name:ident,
+     $sql_name:ident,
+     $args:tt -> $return_type:ty,
+     $docs:expr,
+     $helper_ty_docs:expr) => {
+        sql_function_body!($fn_name, $struct_name, $sql_name, $args -> $return_type, $docs, $helper_ty_docs);
     };
 }
 

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -126,7 +126,7 @@ macro_rules! sql_function {
         $docs:expr,
         $helper_ty_docs:expr
     ) => {
-        sql_function_body!($fn_name, $fn_name, $struct_name, $args -> $return_type, $docs, $helper_ty_docs);
+        sql_function_body!($fn_name, $struct_name, $fn_name, $args -> $return_type, $docs, $helper_ty_docs);
     };
 }
 

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -140,6 +140,25 @@ macro_rules! sql_function {
 /// This will generate a rust function with the same name to construct the expression, and a helper
 /// type which represents the return type of that function. The function will automatically convert
 /// its arguments to expressions.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[macro_use] extern crate diesel;
+/// # use diesel::*;
+/// # use diesel::sql_types::Text;
+/// #
+/// # table! { crates { id -> Integer, name -> VarChar, } }
+/// #
+/// sql_function!(btrim, btrim_t, (t: Text) -> Text);
+/// variant_sql_function!(btrim_custom, btrim_t2, btrim, (t: Text, s: Text) -> Text);
+///
+/// # fn main() {
+/// # use self::crates::dsl::*;
+/// let target_name = "diesel";
+/// crates.filter(btrim_custom(name, "_derives").eq("diesel"));
+/// # }
+/// ```
 macro_rules! variant_sql_function {
     ($fn_name:ident, $struct_name:ident, $sql_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
         variant_sql_function!($fn_name, $struct_name, $sql_name, ($($arg_name $arg_type),*) -> ());

--- a/diesel_tests/tests/macros.rs
+++ b/diesel_tests/tests/macros.rs
@@ -5,7 +5,7 @@
 #![cfg(feature = "postgres")]
 use schema::*;
 use diesel::*;
-use diesel::sql_types::{BigInt, VarChar, Int4};
+use diesel::sql_types::{BigInt, Int4, VarChar};
 
 sql_function!(my_lower, my_lower_t, (x: VarChar) -> VarChar);
 variant_sql_function!(my_lower_id, my_lower_t2, my_lower, (x: VarChar, y: Int4) -> VarChar);
@@ -48,10 +48,7 @@ fn test_sql_function() {
     );
     assert_eq!(
         vec![sean],
-        users
-            .filter(my_lower(name,1))
-            .load(&connection)
-            .unwrap()
+        users.filter(my_lower(name,1)).load(&connection).unwrap()
     );
 }
 

--- a/diesel_tests/tests/macros.rs
+++ b/diesel_tests/tests/macros.rs
@@ -48,7 +48,7 @@ fn test_sql_function() {
     );
     assert_eq!(
         vec![sean],
-        users.filter(my_lower(name,1)).load(&connection).unwrap()
+        users.filter(my_lower_id(name, 1)).load(&connection).unwrap()
     );
 }
 


### PR DESCRIPTION
## Summary

This pull request adds another macro for extending diesel, `variant_sql_function`. This macro is only available to Postgres, and provides a way to overload SQL functions (MySQL doesn't provide function overloading). The format is: `variant_sql_function(rust_function_name, struct_name, sql_name, type signature)`.

`sql_function_body` has been modified to take a sql function name so `variant_sql_function` can use it too.

`sql_function` patterns were reordered to flow more logically (the third pattern doesn't call the first).

## Does this break backwards combatibility at all?

Nope!

## What needs improving?

Just like `sql_function`, it would be nice to need less arguments. Unfortunately, `concat_idents` isn't that useful. Luckily, macros 2.0 seems to be moving and would allow less arguments.