### PR TITLE
Add a trait to abstract away the access to foreign key fields in belongs_to

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -329,7 +329,7 @@ use std::hash::Hash;
 
 use query_source::Table;
 
-pub use self::belongs_to::{BelongsTo, GroupedBy};
+pub use self::belongs_to::{BelongsTo, ForeignKey, GroupedBy};
 
 /// This trait indicates that a struct is associated with a single database table.
 ///


### PR DESCRIPTION
This allows to use wrapper constructs as foreign key fields. Without
this change a foreign key is required to have "the same" type as the
primary key of the parent struct. After this change it is possible to
do some kind of transformation to get a compatible type out of the
wrapper struct