### PR TITLE
Add support for serializing `std::time::Duration` and

### DIFF
--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -286,6 +286,10 @@ pub struct Date;
 /// ### [`ToSql`](../serialize/trait.ToSql.html) impls
 ///
 /// - [`PgInterval`] which can be constructed using [`IntervalDsl`]
+/// - [`std::time::Duration`](https://doc.rust-lang.org/std/time/struct.Duration.html)
+///   [^microseconds]
+/// - [`chrono::Duration`](/chrono/struct.Duration.html)
+///   [^microseconds] with `feature = "chrono"`
 ///
 /// ### [`FromSql`](../deserialize/trait.FromSql.html) impls
 ///
@@ -293,6 +297,10 @@ pub struct Date;
 ///
 /// [`PgInterval`]: ../pg/data_types/struct.PgInterval.html
 /// [`IntervalDsl`]: ../pg/expression/extensions/trait.IntervalDsl.html
+/// [^microseconds]:  Note: The conversion is done on microseconds basis,
+///   that means any timeshift (like leepseconds, daylaight saving,
+///   …) is ignored. Also this conversion will drop the microseconds fraction on
+///  if there is an overflow
 #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
 #[postgres(oid = "1186", array_oid = "1187")]
 pub struct Interval;

--- a/diesel/src/type_impls/date_and_time.rs
+++ b/diesel/src/type_impls/date_and_time.rs
@@ -1,11 +1,16 @@
 #![allow(dead_code)]
 
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 #[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
 #[sql_type = "::sql_types::Timestamp"]
 struct SystemTimeProxy(SystemTime);
+
+#[derive(FromSqlRow, AsExpression)]
+#[diesel(foreign_derive)]
+#[cfg_attr(feature = "postgres", sql_type = "::sql_types::Interval")]
+struct SystemDurationProxy(Duration);
 
 #[cfg(feature = "chrono")]
 mod chrono {
@@ -34,4 +39,9 @@ mod chrono {
     #[diesel(foreign_derive)]
     #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Timestamptz")]
     struct DateTimeProxy<Tz: TimeZone>(DateTime<Tz>);
+
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(foreign_derive)]
+    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Interval")]
+    struct DurationProxy(Duration);
 }


### PR DESCRIPTION
`chrono::Duration` to `Interval`

We add only a `ToSql` implementation because it is possible to map
every instance to a `Interval`. `FromSql` is not added because it is
not possible to represent every instance of as on of this two
`Duration` types.
Normally we only support types that allows us to implement `ToSql` and
`FromSql`, but in this case we make a exception to make it possible to
use the `Duration` types in a context like `now() - Duration::minutes(42)`