### PR TITLE
Tighten bounds on select statements used as a subselect

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -132,6 +132,7 @@ pub trait MaybeEmpty {
 impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<ST> for SelectStatement<S, F, W, O, L, Of, G, FU>
 where
     Subselect<Self, ST>: Expression<SqlType = ST>,
+    Self: SelectQuery<SqlType = ST>,
 {
     type InExpression = Subselect<Self, ST>;
 

--- a/diesel_compile_tests/tests/compile-fail/subselect_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/subselect_requires_correct_type.rs
@@ -1,0 +1,24 @@
+#[macro_use] extern crate diesel;
+
+use diesel::*;
+
+table!{
+    users{
+       id -> Integer,
+       name -> Text,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        user_id -> Integer,
+    }
+}
+
+fn main() {
+    let conn = PgConnection::establish("").unwrap();
+    let subquery = users::table.filter(users::id.eq(1));
+    let query = posts::table.filter(posts::user_id.eq_any(subquery));
+    //~^ ERROR E0277
+}


### PR DESCRIPTION
We were accidentally allowing them to coerce to any SQL type.
Fixes #1587.