### PR TITLE
Add partial support for `Numeric` on SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * `#[derive(AsChangeset)]` now implements `AsChangeset` on the struct itself,
   and not only on a reference to the struct
 
+* Added support for deserializing `Numeric` into `BigDecimal` on SQLite. SQLite
+  has no arbitrary precision type, so the result will still have floating point
+  rounding issues. This is primarily to support things like `avg(int_col)`,
+  which we define as returning `Numeric`
+
 ### Changed
 
 * The bounds on `impl ToSql for Cow<'a, T>` have been loosened to no longer

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -175,6 +175,7 @@ pub type Float8 = Double;
 #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
 #[postgres(oid = "1700", array_oid = "1231")]
 #[mysql_type = "String"]
+#[sqlite_type = "Double"]
 pub struct Numeric;
 
 /// Alias for `Numeric`

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -1,4 +1,5 @@
 mod date_and_time;
+mod numeric;
 
 use std::io::prelude::*;
 

--- a/diesel/src/sqlite/types/numeric.rs
+++ b/diesel/src/sqlite/types/numeric.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "bigdecimal")]
+
+extern crate bigdecimal;
+
+use self::bigdecimal::BigDecimal;
+
+use deserialize::{self, FromSql};
+use sqlite::Sqlite;
+use sqlite::connection::SqliteValue;
+use sql_types::{Double, Numeric};
+
+impl FromSql<Numeric, Sqlite> for BigDecimal {
+    fn from_sql(bytes: Option<&SqliteValue>) -> deserialize::Result<Self> {
+        let data = <f64 as FromSql<Double, Sqlite>>::from_sql(bytes)?;
+        Ok(data.into())
+    }
+}

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -1,7 +1,11 @@
+extern crate bigdecimal;
+
 mod date_and_time;
 mod ops;
 
-use schema::{connection, DropTable, NewUser, TestBackend};
+use self::bigdecimal::BigDecimal;
+use schema::{connection, connection_with_sean_and_tess_in_users_table, DropTable, NewUser,
+             TestBackend};
 use schema::users::dsl::*;
 use diesel::*;
 use diesel::backend::Backend;
@@ -325,6 +329,14 @@ fn test_avg() {
     assert_eq!(Ok(Some(3.5f64)), source.first(&connection));
     connection.execute("DELETE FROM precision_numbers").unwrap();
     assert_eq!(Ok(None::<f64>), source.first(&connection));
+}
+
+#[test]
+fn test_avg_integer() {
+    let conn = connection_with_sean_and_tess_in_users_table();
+    let avg_id = users.select(avg(id)).get_result(&conn);
+    let expected = "1.5".parse::<BigDecimal>().unwrap();
+    assert_eq!(Ok(Some(expected)), avg_id);
 }
 
 #[test]


### PR DESCRIPTION
Even though we can't support it as a proper type on that backend (there
is no native type to represent it), we still need this `FromSql` impl.
The way our query builder is structured, we can't vary the return type
of functions like `avg` based on the backend being used.

Even though this is subject to 64 bit precision, I opted to implement
support for `BigDecimal` instead of `f64` for consistency with the other
backends.

Fixes #1409.