### PR TITLE
Add a config file for Diesel CLI, autorun `print-schema`

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -17,11 +17,13 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4"
 clap = "2.27"
+clippy = { optional = true, version = "=0.0.185" }
 diesel = { version = "~1.2.0", default-features = false }
 dotenv = ">=0.8, <0.11"
 infer_schema_internals = "~1.2.0"
-clippy = { optional = true, version = "=0.0.185" }
 migrations_internals = "~1.2.0"
+serde = { version = "1.0.0", features = ["derive"] }
+toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
 
 [dev-dependencies]

--- a/diesel_cli/build.rs
+++ b/diesel_cli/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    if env::var("CARGO_PKG_VERSION").unwrap() == "1.3.0" {
+        panic!(
+            "Did you remember to publish documentation on the config file? \
+             If not go do it. And then delete this build script."
+        );
+    }
+}

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -122,6 +122,17 @@ pub fn build_cli() -> App<'static, 'static> {
                 .help("Render documentation comments for tables and columns"),
         );
 
+    let config_arg = Arg::with_name("CONFIG_FILE")
+        .long("config-file")
+        .help(
+            "The location of the configuration file to use. Falls back to the \
+             `DIESEL_CONFIG_FILE` environment variable if unspecified. Defaults \
+             to `diesel.toml` in your project root. See \
+             diesel.rs/guides/configuring-diesel-cli for documentation on this file.",
+        )
+        .global(true)
+        .takes_value(true);
+
     App::new("diesel")
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::VersionlessSubcommands)
@@ -129,6 +140,7 @@ pub fn build_cli() -> App<'static, 'static> {
             "You can also run `diesel SUBCOMMAND -h` to get more information about that subcommand.",
         )
         .arg(database_arg)
+        .arg(config_arg)
         .subcommand(migration_subcommand)
         .subcommand(setup_subcommand)
         .subcommand(database_subcommand)

--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -1,0 +1,41 @@
+use clap::ArgMatches;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use toml;
+
+use super::{find_project_root, handle_error};
+
+#[derive(Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub print_schema: PrintSchema,
+}
+
+impl Config {
+    pub fn file_path(matches: &ArgMatches) -> PathBuf {
+        matches
+            .value_of("CONFIG_FILE")
+            .map(PathBuf::from)
+            .or_else(|| env::var_os("DIESEL_CONFIG_FILE").map(PathBuf::from))
+            .unwrap_or_else(|| {
+                find_project_root()
+                    .unwrap_or_else(handle_error)
+                    .join("diesel.toml")
+            })
+    }
+
+    pub fn read(matches: &ArgMatches) -> Result<Self, Box<Error>> {
+        let path = Self::file_path(matches);
+        let mut bytes = Vec::new();
+        fs::File::open(path)?.read_to_end(&mut bytes)?;
+        toml::from_slice(&bytes).map_err(Into::into)
+    }
+}
+
+#[derive(Default, Deserialize)]
+pub struct PrintSchema {
+    pub file: Option<PathBuf>,
+}

--- a/diesel_cli/src/default_files/diesel.toml
+++ b/diesel_cli/src/default_files/diesel.toml
@@ -1,0 +1,2 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli

--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -182,3 +182,63 @@ fn setup_works_with_migration_dir_by_env() {
     assert!(!p.has_file("migrations"));
     assert!(p.has_file("bar"));
 }
+
+#[test]
+fn setup_creates_config_file() {
+    let p = project("setup_creates_config_file").build();
+
+    // Make sure the project builder didn't create the file
+    assert!(!p.has_file("diesel.toml"));
+
+    let result = p.command("setup").run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(p.has_file("diesel.toml"));
+    assert!(
+        p.file_contents("diesel.toml")
+            .contains("diesel.rs/guides/configuring-diesel-cli")
+    );
+}
+
+#[test]
+fn setup_can_take_config_file_by_env() {
+    let p = project("setup_can_take_config_file_by_env").build();
+
+    // Make sure the project builder didn't create the file
+    assert!(!p.has_file("diesel.toml"));
+    assert!(!p.has_file("foo"));
+
+    let result = p.command("setup").env("DIESEL_CONFIG_FILE", "foo").run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(!p.has_file("diesel.toml"));
+    assert!(p.has_file("foo"));
+    assert!(
+        p.file_contents("foo")
+            .contains("diesel.rs/guides/configuring-diesel-cli")
+    );
+}
+
+#[test]
+fn setup_can_take_config_file_by_param() {
+    let p = project("setup_can_take_config_file_by_param").build();
+
+    // Make sure the project builder didn't create the file
+    assert!(!p.has_file("diesel.toml"));
+    assert!(!p.has_file("foo"));
+    assert!(!p.has_file("bar"));
+
+    let result = p.command("setup")
+        .env("DIESEL_CONFIG_FILE", "foo")
+        .arg("--config-file=bar")
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(!p.has_file("diesel.toml"));
+    assert!(!p.has_file("foo"));
+    assert!(p.has_file("bar"));
+    assert!(
+        p.file_contents("bar")
+            .contains("diesel.rs/guides/configuring-diesel-cli")
+    );
+}


### PR DESCRIPTION
As discussed in #1629 and elsewhere, we'd like to replace
`infer_schema!` with a config file that re-writes your schema file
automatically when it changes.

This file will eventually be expanded to support most of the CLI args to
`print-schema`, and gain additional options to further customize the
output. However, this is the minimal first step.

I would like to change the default file generated by `diesel setup` to
include `file = "src/schema.rs"`, but before we do that I think we
should change the behavior on tables with no PK to print a warning that
it's being skipped instead of panicking.