### PR TITLE
Give diesel.toml the same capabilities as every CLI flag

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -20,7 +20,7 @@ clap = "2.27"
 clippy = { optional = true, version = "=0.0.185" }
 diesel = { version = "~1.2.0", default-features = false }
 dotenv = ">=0.8, <0.11"
-infer_schema_internals = "~1.2.0"
+infer_schema_internals = { version = "~1.2.0", features = ["serde"] }
 migrations_internals = "~1.2.0"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.4.6"

--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -7,8 +7,10 @@ use std::path::PathBuf;
 use toml;
 
 use super::{find_project_root, handle_error};
+use print_schema;
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     pub print_schema: PrintSchema,
@@ -36,6 +38,20 @@ impl Config {
 }
 
 #[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PrintSchema {
+    #[serde(default)]
     pub file: Option<PathBuf>,
+    #[serde(default)]
+    pub with_docs: bool,
+    #[serde(default)]
+    pub filter: print_schema::Filtering,
+    #[serde(default)]
+    pub schema: Option<String>,
+}
+
+impl PrintSchema {
+    pub fn schema_name(&self) -> Option<&str> {
+        self.schema.as_ref().map(|s| &**s)
+    }
 }

--- a/diesel_cli/tests/print_schema/print_schema_blacklist/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_blacklist/diesel.toml
@@ -1,0 +1,4 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true
+filter = { blacklist = ["users1"] }

--- a/diesel_cli/tests/print_schema/print_schema_column_renaming/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_column_renaming/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true

--- a/diesel_cli/tests/print_schema/print_schema_compound_primary_key/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_compound_primary_key/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true

--- a/diesel_cli/tests/print_schema/print_schema_order/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_order/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true

--- a/diesel_cli/tests/print_schema/print_schema_simple/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_simple/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/print_schema/print_schema_specifying_schema_name/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_specifying_schema_name/diesel.toml
@@ -1,0 +1,4 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true
+schema = "custom_schema"

--- a/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/diesel.toml
@@ -1,0 +1,4 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true
+schema = "custom_schema"

--- a/diesel_cli/tests/print_schema/print_schema_whitelist/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_whitelist/diesel.toml
@@ -1,0 +1,4 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true
+filter = { whitelist = ["users1"] }

--- a/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = true

--- a/diesel_infer_schema/infer_schema_internals/Cargo.toml
+++ b/diesel_infer_schema/infer_schema_internals/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 [dependencies]
 diesel = { version = "~1.2.0", default-features = false }
 clippy = { optional = true, version = "=0.0.185" }
+serde = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 dotenv = ">=0.8, <0.11"

--- a/diesel_infer_schema/infer_schema_internals/src/table_data.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/table_data.rs
@@ -82,3 +82,39 @@ pub struct TableData {
     pub column_data: Vec<ColumnDefinition>,
     pub docs: String,
 }
+
+#[cfg(feature = "serde")]
+mod serde_impls {
+    extern crate serde;
+
+    use self::serde::de::Visitor;
+    use self::serde::{de, Deserialize, Deserializer};
+    use std::fmt;
+    use super::TableName;
+
+    impl<'de> Deserialize<'de> for TableName {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct TableNameVisitor;
+
+            impl<'de> Visitor<'de> for TableNameVisitor {
+                type Value = TableName;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("A valid table name")
+                }
+
+                fn visit_str<E>(self, value: &str) -> Result<TableName, E>
+                where
+                    E: de::Error,
+                {
+                    value.parse().map_err(|_| unreachable!())
+                }
+            }
+
+            deserializer.deserialize_string(TableNameVisitor)
+        }
+    }
+}


### PR DESCRIPTION
This gives every existing flag that can be given to `diesel
print-schema` an equivalent entry in `diesel.toml`, with the exception
of `database-url` which should never be in this file.

There are more manual serde impls than I would have liked here.
Particularly, the impl for `Filtering` should have just been derived,
but the derived impl just blows up with "expected string for key
`fields`" -- I have no clue why, and it's really opaque what's going on.