### PR TITLE
Feature: expose raw sqlite connection

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -175,6 +175,8 @@ pub mod mysql;
 pub mod pg;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
+#[cfg(feature = "sqlite")]
+pub extern crate libsqlite3_sys;
 
 mod type_impls;
 mod util;


### PR DESCRIPTION
Related: #150, #1103, #1492

This is a simple change that allows diesel applications to hook directly into sqlite's API. This PR exposes diesel's version for libsqlite3_sys bindings, and an `SqliteConnection::get_raw_conn` method. In particular, this allows query tracing/profiling, as well as custom functions via SQLite's API (see also #1103).

Thanks for considering!