### PR TITLE
Add a `nullable` methods for `SelectStatement` and `BoxedSelectStatement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for PG tuples. See [`sql_types::Record`][record-1-3-0] for details.
 
+* Add a `nullable` method on `SelectStatement` and `BoxedSelectStatement` that allows to
+  use those queries in places that except only nullable types
+
 [record-1-3-0]: http://docs.diesel.rs/diesel/pg/types/sql_types/struct.Record.html
 
 ## [1.2.2] - 2018-04-12

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,6 +1,6 @@
 use backend::Backend;
-use expression::*;
 use expression::subselect::Subselect;
+use expression::*;
 use query_builder::*;
 use result::QueryResult;
 use sql_types::Bool;
@@ -129,12 +129,30 @@ pub trait MaybeEmpty {
     fn is_empty(&self) -> bool;
 }
 
-impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<ST> for SelectStatement<S, F, W, O, L, Of, G, FU>
+use query_builder::select_clause::NotNullableSelectClause;
+use sql_types::{Nullable, NotNull};
+use query_builder::select_clause::NullableSelectClause;
+
+impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<ST> for SelectStatement<F, S, W, O, L, Of, G, FU>
 where
     Subselect<Self, ST>: Expression<SqlType = ST>,
     Self: SelectQuery<SqlType = ST>,
+    S: NotNullableSelectClause,
 {
     type InExpression = Subselect<Self, ST>;
+
+    fn as_in_expression(self) -> Self::InExpression {
+        Subselect::new(self)
+    }
+}
+
+impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<Nullable<ST>> for SelectStatement<F, NullableSelectClause<S>, W, O, L, Of, G, FU>
+where
+    Subselect<Self, Nullable<ST>>: Expression<SqlType = Nullable<ST>>,
+    Self: SelectQuery<SqlType = Nullable<ST>>,
+    ST: NotNull,
+{
+    type InExpression = Subselect<Self, Nullable<ST>>;
 
     fn as_in_expression(self) -> Self::InExpression {
         Subselect::new(self)

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -130,7 +130,7 @@ pub trait MaybeEmpty {
 }
 
 use query_builder::select_clause::NotNullableSelectClause;
-use sql_types::{Nullable, NotNull};
+use sql_types::{NotNull, Nullable};
 use query_builder::select_clause::NullableSelectClause;
 
 impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<ST> for SelectStatement<F, S, W, O, L, Of, G, FU>
@@ -146,7 +146,8 @@ where
     }
 }
 
-impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<Nullable<ST>> for SelectStatement<F, NullableSelectClause<S>, W, O, L, Of, G, FU>
+impl<ST, S, F, W, O, L, Of, G, FU> AsInExpression<Nullable<ST>>
+    for SelectStatement<F, NullableSelectClause<S>, W, O, L, Of, G, FU>
 where
     Subselect<Self, Nullable<ST>>: Expression<SqlType = Nullable<ST>>,
     Self: SelectQuery<SqlType = Nullable<ST>>,

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -24,7 +24,7 @@ mod limit_clause;
 mod offset_clause;
 mod order_clause;
 mod returning_clause;
-mod select_clause;
+pub(crate) mod select_clause;
 mod select_statement;
 mod sql_query;
 mod where_clause;

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -2,11 +2,14 @@ use backend::Backend;
 use expression::{Expression, SelectableExpression};
 use query_builder::*;
 use query_source::QuerySource;
+use sql_types::{NotNull, Nullable};
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct DefaultSelectClause;
 #[derive(Debug, Clone, Copy, QueryId)]
-pub struct SelectClause<T>(pub T);
+pub struct SelectClause<T>(pub(crate) T);
+#[derive(Debug, Clone, Copy, QueryId)]
+pub struct NullableSelectClause<T>(pub(crate) T);
 
 pub trait SelectClauseExpression<QS> {
     type SelectClauseSqlType;
@@ -24,6 +27,14 @@ where
     QS: QuerySource,
 {
     type SelectClauseSqlType = <QS::DefaultSelection as Expression>::SqlType;
+}
+
+impl<T, QS> SelectClauseExpression<QS> for NullableSelectClause<T>
+where
+    T: SelectClauseExpression<QS>,
+    T::SelectClauseSqlType: NotNull,
+{
+    type SelectClauseSqlType = Nullable<T::SelectClauseSqlType>;
 }
 
 pub trait SelectClauseQueryFragment<QS, DB: Backend> {
@@ -48,5 +59,52 @@ where
 {
     fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()> {
         source.default_selection().walk_ast(pass)
+    }
+}
+
+impl<T, QS, DB> SelectClauseQueryFragment<QS, DB> for NullableSelectClause<T>
+where
+    DB: Backend,
+    T: SelectClauseQueryFragment<QS, DB>,
+{
+    fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()> {
+        self.0.walk_ast(source, pass)
+    }
+}
+
+pub trait NotNullableSelectClause {}
+
+impl NotNullableSelectClause for DefaultSelectClause {}
+impl<T> NotNullableSelectClause for SelectClause<T> {}
+
+pub trait BoxSelectClause<'a, DB: Backend, F> {
+    fn box_select_clause(self, from: &F) -> Box<QueryFragment<DB> + 'a>;
+}
+
+impl<'a, DB: Backend, F> BoxSelectClause<'a, DB, F> for DefaultSelectClause
+where
+    F: QuerySource,
+    F::DefaultSelection: QueryFragment<DB> + 'a,
+{
+    fn box_select_clause(self, from: &F) -> Box<QueryFragment<DB> + 'a> {
+        Box::new(from.default_selection())
+    }
+}
+
+impl<'a, DB: Backend, T, F> BoxSelectClause<'a, DB, F> for SelectClause<T>
+where
+    T: QueryFragment<DB> + 'a,
+{
+    fn box_select_clause(self, _from: &F) -> Box<QueryFragment<DB> + 'a> {
+        Box::new(self.0)
+    }
+}
+
+impl<'a, DB: Backend, T, F> BoxSelectClause<'a, DB, F> for NullableSelectClause<T>
+where
+    T: BoxSelectClause<'a, DB, F>,
+{
+    fn box_select_clause(self, from: &F) -> Box<QueryFragment<DB> + 'a> {
+        self.0.box_select_clause(from)
     }
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -18,7 +18,7 @@ use query_dsl::methods::*;
 use query_source::joins::*;
 use query_source::{QuerySource, Table};
 use result::QueryResult;
-use sql_types::{BigInt, Bool};
+use sql_types::{BigInt, Bool, NotNull, Nullable};
 
 #[allow(missing_debug_implementations)]
 pub struct BoxedSelectStatement<'a, ST, QS, DB> {
@@ -54,6 +54,22 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
             limit: limit,
             offset: offset,
             group_by: group_by,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> where ST: NotNull{
+    pub fn nullable(self) -> BoxedSelectStatement<'a, Nullable<ST>, QS, DB> {
+        BoxedSelectStatement {
+            select: self.select,
+            from: self.from,
+            distinct: self.distinct,
+            where_clause: self.where_clause,
+            order: self.order,
+            limit: self.limit,
+            offset: self.offset,
+            group_by: self.group_by,
             _marker: PhantomData,
         }
     }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -59,7 +59,10 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
     }
 }
 
-impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> where ST: NotNull{
+impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB>
+where
+    ST: NotNull,
+{
     pub fn nullable(self) -> BoxedSelectStatement<'a, Nullable<ST>, QS, DB> {
         BoxedSelectStatement {
             select: self.select,

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -1,3 +1,4 @@
+use super::BoxedSelectStatement;
 use associations::HasTable;
 use backend::Backend;
 use dsl::AsExprOf;
@@ -14,12 +15,10 @@ use query_builder::select_clause::*;
 use query_builder::update_statement::*;
 use query_builder::where_clause::*;
 use query_builder::{AsQuery, Query, QueryFragment, SelectQuery, SelectStatement};
-use query_dsl::*;
-use query_dsl::methods::*;
 use query_dsl::boxed_dsl::BoxedDsl;
-use query_source::QuerySource;
+use query_dsl::methods::*;
+use query_dsl::*;
 use query_source::joins::{Join, JoinOn, JoinTo};
-use super::BoxedSelectStatement;
 use sql_types::{BigInt, Bool};
 
 impl<F, S, D, W, O, L, Of, G, FU, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On>
@@ -307,12 +306,11 @@ impl<F, S, W, O, L, Of> ForUpdateDsl for SelectStatement<F, S, NoDistinctClause,
     }
 }
 
-impl<'a, F, S, D, W, O, L, Of, G, DB> BoxedDsl<'a, DB>
-    for SelectStatement<F, SelectClause<S>, D, W, O, L, Of, G>
+impl<'a, F, S, D, W, O, L, Of, G, DB> BoxedDsl<'a, DB> for SelectStatement<F, S, D, W, O, L, Of, G>
 where
     Self: AsQuery,
     DB: Backend,
-    S: QueryFragment<DB> + SelectableExpression<F> + 'a,
+    S: BoxSelectClause<'a, DB, F> + SelectClauseExpression<F>,
     D: QueryFragment<DB> + 'a,
     W: Into<BoxedWhereClause<'a, DB>>,
     O: Into<Option<Box<QueryFragment<DB> + 'a>>>,
@@ -320,41 +318,11 @@ where
     Of: QueryFragment<DB> + 'a,
     G: QueryFragment<DB> + 'a,
 {
-    type Output = BoxedSelectStatement<'a, S::SqlType, F, DB>;
+    type Output = BoxedSelectStatement<'a, S::SelectClauseSqlType, F, DB>;
 
     fn internal_into_boxed(self) -> Self::Output {
         BoxedSelectStatement::new(
-            Box::new(self.select.0),
-            self.from,
-            Box::new(self.distinct),
-            self.where_clause.into(),
-            self.order.into(),
-            Box::new(self.limit),
-            Box::new(self.offset),
-            Box::new(self.group_by),
-        )
-    }
-}
-
-impl<'a, F, D, W, O, L, Of, G, DB> BoxedDsl<'a, DB>
-    for SelectStatement<F, DefaultSelectClause, D, W, O, L, Of, G>
-where
-    Self: AsQuery,
-    DB: Backend,
-    F: QuerySource,
-    F::DefaultSelection: QueryFragment<DB> + 'a,
-    D: QueryFragment<DB> + 'a,
-    W: Into<BoxedWhereClause<'a, DB>>,
-    O: Into<Option<Box<QueryFragment<DB> + 'a>>>,
-    L: QueryFragment<DB> + 'a,
-    Of: QueryFragment<DB> + 'a,
-    G: QueryFragment<DB> + 'a,
-{
-    type Output = BoxedSelectStatement<'a, <F::DefaultSelection as Expression>::SqlType, F, DB>;
-
-    fn internal_into_boxed(self) -> Self::Output {
-        BoxedSelectStatement::new(
-            Box::new(self.from.default_selection()),
+            self.select.box_select_clause(&self.from),
             self.from,
             Box::new(self.distinct),
             self.where_clause.into(),

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -101,6 +101,25 @@ impl<F> SelectStatement<F> {
     }
 }
 
+impl<F, S, D, W, O, L, Of, G, FU> SelectStatement<F, S, D, W, O, L, Of, G, FU>
+where
+    S: SelectClauseExpression<F> + NotNullableSelectClause,
+{
+    pub fn nullable(self) -> SelectStatement<F, NullableSelectClause<S>, D, W, O, L, Of, G, FU> {
+        SelectStatement {
+            select: NullableSelectClause(self.select),
+            from: self.from,
+            distinct: self.distinct,
+            where_clause: self.where_clause,
+            order: self.order,
+            limit: self.limit,
+            offset: self.offset,
+            group_by: self.group_by,
+            for_update: self.for_update,
+        }
+    }
+}
+
 impl<F, S, D, W, O, L, Of, G, FU> Query for SelectStatement<F, S, D, W, O, L, Of, G, FU>
 where
     S: SelectClauseExpression<F>,

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -486,11 +486,13 @@ fn filter_subselect_with_nullable_column() {
         )
         .unwrap();
 
-    let expected = vec![Hero {
-        id: 1,
-        name: String::from("Luke Skywalker"),
-        home_world: Some(1),
-    }];
+    let expected = vec![
+        Hero {
+            id: 1,
+            name: String::from("Luke Skywalker"),
+            home_world: Some(1),
+        },
+    ];
 
     let query = heros::table
         .filter(heros::home_world.eq_any(home_worlds::table.select(home_worlds::id).nullable()))


### PR DESCRIPTION
This allows to use a not nullable query in places that only accept
nullable expressions.

A notable use case is passing a subquery that selects a not nullable
primary key column as `IN`/`eq_any` filter to a nullable column.

cc #1547 and #1558