### PR TITLE
Re-export query_builder::functions through dsl

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -189,6 +189,10 @@ pub mod dsl {
 
     #[doc(inline)]
     pub use expression::dsl::*;
+
+    #[doc(inline)]
+    pub use query_builder::functions::{delete, insert_into, insert_or_ignore_into, replace_into,
+                                       select, sql_query, update};
 }
 
 pub mod helper_types {


### PR DESCRIPTION
This re-exports all `query_builder::functions` through `dsl`.

I am new to rust and the the diesel project, but hope this helps some! Please let me know if there are incorrect patterns here of if there is anything I need to change.

Addresses #1622