### PR TITLE
Roll back transactions on panic and report connection status

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -109,6 +109,10 @@ impl Connection for MysqlConnection {
     fn transaction_manager(&self) -> &Self::TransactionManager {
         &self.transaction_manager
     }
+
+    fn is_connected(&self) -> bool {
+        self.raw_connection.is_connected()
+    }
 }
 
 impl MysqlConnection {

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -178,6 +178,17 @@ impl RawConnection {
         self.did_an_error_occur()?;
         Ok(more_results)
     }
+
+    pub fn is_connected(&self) -> bool {
+        const CR_SERVER_GONE_ERROR: u32 = 2006;
+        const CR_SERVER_LOST: u32 = 2013;
+        match unsafe {
+            ffi::mysql_errno(self.0.as_ptr())
+        } {
+            CR_SERVER_GONE_ERROR | CR_SERVER_LOST => false,
+            _ => true
+        }
+    }
 }
 
 impl Drop for RawConnection {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -105,6 +105,10 @@ impl Connection for PgConnection {
     fn transaction_manager(&self) -> &Self::TransactionManager {
         &self.transaction_manager
     }
+
+    fn is_connected(&self) -> bool {
+        self.raw_connection.is_connected()
+    }
 }
 
 impl PgConnection {

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -92,6 +92,12 @@ impl RawConnection {
         );
         RawResult::new(ptr, self)
     }
+
+    pub fn is_connected(&self) -> bool {
+        unsafe {
+            PQstatus(self.internal_connection.as_ptr()) == CONNECTION_OK
+        }
+    }
 }
 
 pub type NoticeProcessor = extern "C" fn(arg: *mut libc::c_void, message: *const libc::c_char);

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -90,8 +90,8 @@ where
             .map_err(Error::QueryError)
     }
 
-    fn has_broken(&self, _conn: &mut T) -> bool {
-        false
+    fn has_broken(&self, conn: &mut T) -> bool {
+        !conn.is_connected()
     }
 }
 


### PR DESCRIPTION
Rolling back transactions on panic is the correct behaviour regardless of whatever else is going on in the system, and is not specific to connection pooling: panics may be unrelated to diesel, in which case diesel should continue to function normally.

See also: scoped thread local storage, which has a similar API, and restores the previous value even in the event that the callback panics.

This is not within the remit of diesel *as an ORM*, but it is within the remit of diesel as a whole because it provides back-end specific implementations of the `Connection` trait.