### PR TITLE
Rename a few things related to barrel support

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -39,7 +39,7 @@ lint = ["clippy"]
 postgres = ["diesel/postgres", "infer_schema_internals/postgres", "url"]
 sqlite = ["diesel/sqlite", "infer_schema_internals/sqlite"]
 mysql = ["diesel/mysql", "infer_schema_internals/mysql", "url"]
-rust-migrations = ["migrations_internals/barrel", "barrel"]
+barrel-migrations = ["migrations_internals/barrel", "barrel"]
 
 [[test]]
 name = "tests"

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -53,13 +53,12 @@ pub fn build_cli() -> App<'static, 'static> {
                         .takes_value(true),
                 )
                 .arg(
-                    Arg::with_name("TYPE")
-                        .long("type")
-                        .short("t")
-                        .possible_values(&["sql", "rust"])
+                    Arg::with_name("MIGRATION_FORMAT")
+                        .long("format")
+                        .possible_values(&["sql", "barrel"])
                         .default_value("sql")
                         .takes_value(true)
-                        .help("Specify the migration type."),
+                        .help("The format of the migration to be generated."),
                 ),
         )
         .setting(AppSettings::SubcommandRequiredElseHelp);


### PR DESCRIPTION
"type" is an overloaded term. "format" makes more sense with regards to
migration generation. I'm also not a fan of short form args in general,
and `-f` implies force instead of format, so I just removed the short
form version. Finally, I renamed the "rust" part of both the argument
and feature to "barrel", both to make it clear what library is being
used, and to leave room for other rust migration libraries to appear in
the future.

Unfortunately, we couldn't just name the feature "barrel", since Cargo
doesn't allow dependencies and features to share a name. We really
should submit an RFC to fix this. In the mean time, the feature is now
`barrel-migrations`.