### PR TITLE
implement arithmetics to timestamptz

### DIFF
--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -80,5 +80,6 @@ macro_rules! __diesel_generate_ops_impls_if_date_time {
     ($column_name:ident, Time) => { date_time_expr!($column_name); };
     ($column_name:ident, Date) => { date_time_expr!($column_name); };
     ($column_name:ident, Timestamp) => { date_time_expr!($column_name); };
+    ($column_name:ident, Timestamptz) => { date_time_expr!($column_name); };
     ($column_name:ident, $non_date_time_type:ty) => {};
 }

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -1,23 +1,23 @@
 //! PostgreSQL specific types
 
 mod array;
-mod ranges;
 #[doc(hidden)]
 pub mod date_and_time;
 #[doc(hidden)]
 pub mod floats;
-#[cfg(feature = "network-address")]
-mod network_address;
 mod integers;
-mod numeric;
-mod primitives;
-mod record;
-#[cfg(feature = "uuid")]
-mod uuid;
 #[cfg(feature = "serde_json")]
 mod json;
 #[doc(hidden)]
 pub mod money;
+#[cfg(feature = "network-address")]
+mod network_address;
+mod numeric;
+mod primitives;
+mod ranges;
+mod record;
+#[cfg(feature = "uuid")]
+mod uuid;
 
 /// PostgreSQL specific SQL types
 ///
@@ -487,4 +487,31 @@ pub mod sql_types {
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
     #[postgres(oid = "650", array_oid = "651")]
     pub struct Cidr;
+}
+
+mod ops {
+    use super::sql_types::*;
+    use sql_types::ops::*;
+    use sql_types::{Interval, Nullable};
+
+    impl Add for Timestamptz {
+        type Rhs = Interval;
+        type Output = Timestamptz;
+    }
+
+    impl Add for Nullable<Timestamptz> {
+        type Rhs = Nullable<Interval>;
+        type Output = Nullable<Timestamptz>;
+    }
+
+    impl Sub for Timestamptz {
+        type Rhs = Interval;
+        type Output = Timestamptz;
+    }
+
+    impl Sub for Nullable<Timestamptz> {
+        type Rhs = Nullable<Interval>;
+        type Output = Nullable<Timestamptz>;
+    }
+
 }

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -513,5 +513,4 @@ mod ops {
         type Rhs = Nullable<Interval>;
         type Output = Nullable<Timestamptz>;
     }
-
 }

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -342,9 +342,7 @@ fn now_can_be_operated_as_timestamptz() {
     assert_eq!(Ok(vec![1]), before_now);
 }
 
-}
-
-#[cfg(not(or(feature = "mysql", feature = "postgres")))] // FIXME: Figure out how to handle tests that modify schema
+#[cfg(not(any(feature = "mysql", feature = "postgres")))] // FIXME: Figure out how to handle tests that modify schema
 fn setup_test_table(conn: &TestConnection) {
     use schema_dsl::*;
 

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -318,30 +318,6 @@ fn adding_interval_to_nullable_things() {
     assert_eq!(expected_data, actual_data);
 }
 
-#[test]
-#[cfg(feature = "postgres")]
-// FIXME: Replace this with an actual timestamptz expression
-fn now_can_be_operated_as_timestamptz() {
-    use self::has_timestamps::dsl::*;
-    use diesel::sql_types::Timestamptz;
-
-    let connection = connection();
-    setup_test_table(&connection);
-    connection
-        .execute(
-            "INSERT INTO has_timestamps (created_at) VALUES \
-             (NOW())",
-        )
-        .unwrap();
-
-    let created_at_tz = sql::<Timestamptz>("created_at");
-    let before_now = has_timestamps
-        .select(id)
-        .filter(created_at_tz.gt(now - 1.day()))
-        .load::<i32>(&connection);
-    assert_eq!(Ok(vec![1]), before_now);
-}
-
 #[cfg(not(any(feature = "mysql", feature = "postgres")))] // FIXME: Figure out how to handle tests that modify schema
 fn setup_test_table(conn: &TestConnection) {
     use schema_dsl::*;

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -282,11 +282,11 @@ fn adding_interval_to_nullable_things() {
         .first::<Option<PgTimestamp>>(&connection);
     assert_eq!(expected_data, actual_data);
 
-    let expected_data = select(sql::<Nullable<sql_types::Timestampyz>>(
+    let expected_data = select(sql::<Nullable<sql_types::Timestamptz>>(
         "'2017-08-21 18:13:37+0000'::timestamp",
     )).get_result::<Option<PgTimestamp>>(&connection);
     let actual_data = nullable_date_and_time
-        .select(timestampyz + 1.day())
+        .select(timestamptz + 1.day())
         .first::<Option<PgTimestamp>>(&connection);
     assert_eq!(expected_data, actual_data);
 

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -250,7 +250,7 @@ fn adding_interval_to_timestamp() {
 #[test]
 #[cfg(feature = "postgres")]
 fn adding_interval_to_timestamptz() {
-    use self::has_timestamps::dsl::*;
+    use self::has_timestamptzs::dsl::*;
     use diesel::dsl::sql;
 
     let connection = connection();
@@ -265,7 +265,7 @@ fn adding_interval_to_timestamptz() {
     let expected_data = select(sql::<sql_types::Timestamptz>(
         "'2015-11-16 06:07:41+0000'::timestamp",
     )).get_result::<PgTimestamp>(&connection);
-    let actual_data = has_timestamps
+    let actual_data = has_timestamptzs
         .select(created_at + 1.day())
         .first::<PgTimestamp>(&connection);
     assert_eq!(expected_data, actual_data);

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -323,6 +323,18 @@ fn setup_test_table(conn: &TestConnection) {
         .unwrap();
 
     create_table(
+        "has_timestampstz",
+        (
+            integer("id").primary_key().auto_increment(),
+            timestamptz("created_at").not_null(),
+            timestamptz("updated_at")
+                .not_null()
+                .default("CURRENT_TIMESTAMP"),
+        ),
+    ).execute(conn)
+        .unwrap();
+
+    create_table(
         "has_time",
         (
             integer("id").primary_key().auto_increment(),
@@ -336,6 +348,7 @@ fn setup_test_table(conn: &TestConnection) {
         (
             integer("id").primary_key().auto_increment(),
             timestamp("timestamp"),
+            timestamptz("timestamptz"),
             time("time"),
             date("date"),
         ),

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -398,7 +398,7 @@ fn setup_test_table(conn: &TestConnection) {
         .unwrap();
 
     create_table(
-        "has_timestampstz",
+        "has_timestamptzs",
         (
             integer("id").primary_key().auto_increment(),
             timestamptz("created_at").not_null(),

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -258,12 +258,12 @@ fn adding_interval_to_timestamptz() {
     connection
         .execute(
             "INSERT INTO has_timestamptzs (created_at, updated_at) VALUES
-                       ('2015-11-15 06:07:41+0000', '2015-11-15 20:07:41+0000')",
+                       ('2015-11-15 06:07:41+0100', '2015-11-15 20:07:41+0100')",
         )
         .unwrap();
 
     let expected_data = select(sql::<sql_types::Timestamptz>(
-        "'2015-11-16 06:07:41+0000'::timestamp",
+        "'2015-11-16 06:07:41+0100'::timestamptz",
     )).get_result::<PgTimestamp>(&connection);
     let actual_data = has_timestamptzs
         .select(created_at + 1.day())
@@ -282,7 +282,7 @@ fn adding_interval_to_nullable_things() {
     connection
         .execute(
             "INSERT INTO nullable_date_and_time (timestamp, timestamptz, date, time) VALUES
-                       ('2017-08-20 18:13:37', '2017-08-20 18:13:37+0000', '2017-08-20', '18:13:37')",
+                       ('2017-08-20 18:13:37', '2017-08-20 18:13:37+0100', '2017-08-20', '18:13:37')",
         )
         .unwrap();
 
@@ -295,7 +295,7 @@ fn adding_interval_to_nullable_things() {
     assert_eq!(expected_data, actual_data);
 
     let expected_data = select(sql::<Nullable<sql_types::Timestamptz>>(
-        "'2017-08-21 18:13:37+0000'::timestamp",
+        "'2017-08-21 18:13:37+0100'::timestamptz",
     )).get_result::<Option<PgTimestamp>>(&connection);
     let actual_data = nullable_date_and_time
         .select(timestamptz + 1.day())

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -318,7 +318,7 @@ fn adding_interval_to_nullable_things() {
     assert_eq!(expected_data, actual_data);
 }
 
-#[cfg(not(any(feature = "mysql", feature = "postgres")))] // FIXME: Figure out how to handle tests that modify schema
+#[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 fn setup_test_table(conn: &TestConnection) {
     use schema_dsl::*;
 
@@ -334,43 +334,7 @@ fn setup_test_table(conn: &TestConnection) {
     ).execute(conn)
         .unwrap();
 
-    create_table(
-        "has_time",
-        (
-            integer("id").primary_key().auto_increment(),
-            time("time").not_null(),
-        ),
-    ).execute(conn)
-        .unwrap();
-
-    create_table(
-        "nullable_date_and_time",
-        (
-            integer("id").primary_key().auto_increment(),
-            timestamp("timestamp"),
-            time("time"),
-            date("date"),
-        ),
-    ).execute(conn)
-        .unwrap();
-}
-
-#[cfg(feature = "postgres")]
-fn setup_test_table(conn: &TestConnection) {
-    use schema_dsl::*;
-
-    create_table(
-        "has_timestamps",
-        (
-            integer("id").primary_key().auto_increment(),
-            timestamp("created_at").not_null(),
-            timestamp("updated_at")
-                .not_null()
-                .default("CURRENT_TIMESTAMP"),
-        ),
-    ).execute(conn)
-        .unwrap();
-
+    #[cfg(feature = "postgres")]
     create_table(
         "has_timestamptzs",
         (
@@ -397,6 +361,7 @@ fn setup_test_table(conn: &TestConnection) {
         (
             integer("id").primary_key().auto_increment(),
             timestamp("timestamp"),
+            #[cfg(feature = "postgres")]
             timestamptz("timestamptz"),
             time("time"),
             date("date"),

--- a/diesel_tests/tests/schema_dsl/functions.rs
+++ b/diesel_tests/tests/schema_dsl/functions.rs
@@ -18,6 +18,10 @@ pub fn timestamp<'a>(name: &'a str) -> Column<'a, sql_types::VarChar> {
     Column::new(name, "TIMESTAMP")
 }
 
+pub fn timestamptz<'a>(name: &'a str) -> Column<'a, sql_types::VarChar> {
+    Column::new(name, "TIMESTAMPTZ")
+}
+
 pub fn time<'a>(name: &'a str) -> Column<'a, sql_types::VarChar> {
     Column::new(name, "TIME")
 }

--- a/diesel_tests/tests/schema_dsl/functions.rs
+++ b/diesel_tests/tests/schema_dsl/functions.rs
@@ -18,6 +18,7 @@ pub fn timestamp<'a>(name: &'a str) -> Column<'a, sql_types::VarChar> {
     Column::new(name, "TIMESTAMP")
 }
 
+#[cfg(feature = "postgres")]
 pub fn timestamptz<'a>(name: &'a str) -> Column<'a, sql_types::VarChar> {
     Column::new(name, "TIMESTAMPTZ")
 }


### PR DESCRIPTION
Implement #1656 . 
* implement `Add` and `Sub` for `Timestamptz`

Note that still you cannot operate on `now` as `Timestamptz`; like `updated_ad.gt(now - 1.day())` or even `updated_at.gt(now.to_sql::<Timestamptz>() - 1.day())`. To do so in a consistent way, (as Postgres returns `timestamptz` for `now()`)  some breaking change may be needed (and the same as `date`.)