### PR TITLE
Support generic and aggregate `sql_function!`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,22 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [record-1-3-0]: http://docs.diesel.rs/diesel/pg/types/sql_types/struct.Record.html
 
+* `sql_function!` now supports generic functions. See [the documentation for
+  `sql_function!`][sql-function-1-3-0] for more details.
+
+* `sql_function!` now supports aggregate functions like `sum` and `max`, by
+  annotating them with `#[aggregate]`. This skips the implementation of
+  `NonAggregate` for your function. See [the documentation for
+  `sql_function!`][sql-function-1-3-0] for more details.
+
 ### Changed
 
 * `sql_function!` has been redesigned. The syntax is now `sql_function!(fn
   lower(x: Text) -> Text);`. The output of the new syntax is slightly different
   than what was generated in the past. See [the documentation for
   `sql_function!`][sql-function-1-3-0] for more details.
+
+[sql-function-1-3-0]: http://docs.diesel.rs/diesel/macro.sql_function.html
 
 ### Fixed
 

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,118 +1,69 @@
-use backend::Backend;
-use expression::Expression;
-use query_builder::*;
-use result::QueryResult;
 use sql_types::Foldable;
 
-macro_rules! fold_function {
-    ($fn_name:ident, $type_name:ident, $operator:expr, $docs:expr) => {
-        #[doc=$docs]
-        pub fn $fn_name<ST, T>(t: T) -> $type_name<T> where
-            ST: Foldable,
-            T: Expression<SqlType=ST>,
-        {
-            $type_name {
-                target: t,
-            }
-        }
-
-        #[derive(Debug, Clone, Copy, QueryId)]
-        #[doc(hidden)]
-        pub struct $type_name<T> {
-            target: T,
-        }
-
-        impl<ST, T> Expression for $type_name<T> where
-            ST: Foldable,
-            T: Expression<SqlType=ST>
-        {
-            type SqlType = <<T as Expression>::SqlType as Foldable>::$type_name;
-        }
-
-        impl<T, DB> QueryFragment<DB> for $type_name<T> where
-            T: Expression + QueryFragment<DB>,
-            DB: Backend,
-        {
-            fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
-                out.push_sql(concat!($operator, "("));
-                self.target.walk_ast(out.reborrow())?;
-                out.push_sql(")");
-                Ok(())
-            }
-        }
-
-        impl_selectable_expression!($type_name<T>);
-    }
+sql_function! {
+    /// Represents a SQL `SUM` function. This function can only take types which are
+    /// Foldable.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = establish_connection();
+    /// assert_eq!(Ok(Some(12i64)), animals.select(sum(legs)).first(&connection));
+    /// # }
+    /// ```
+    #[aggregate]
+    fn sum<ST: Foldable>(expr: ST) -> ST::Sum;
 }
 
-fold_function!(
-    sum,
-    Sum,
-    "SUM",
-    "Represents a SQL `SUM` function. This function can only take types which are
-Foldable.
-
-# Examples
-
-```rust
-# #[macro_use] extern crate diesel;
-# include!(\"../../doctest_setup.rs\");
-# use diesel::dsl::*;
-#
-# fn main() {
-#     use schema::animals::dsl::*;
-#     let connection = establish_connection();
-assert_eq!(Ok(Some(12i64)), animals.select(sum(legs)).first(&connection));
-# }
-"
-);
-
-fold_function!(
-    avg,
-    Avg,
-    "AVG",
-    r#"Represents a SQL `AVG` function. This function can only take types which are
-Foldable.
-
-# Examples
-
-```rust
-# #[macro_use] extern crate diesel;
-# include!("../../doctest_setup.rs");
-# use diesel::dsl::*;
-# #[cfg(feature = "bigdecimal")]
-# extern crate bigdecimal;
-#
-# fn main() {
-#     run_test().unwrap();
-# }
-#
-# table! {
-#     numbers (number) {
-#         number -> Integer,
-#     }
-# }
-#
-# #[cfg(all(feature = "numeric", any(feature = "postgres", not(feature = "sqlite"))))]
-# fn run_test() -> QueryResult<()> {
-#     use bigdecimal::BigDecimal;
-#     use numbers::dsl::*;
-#     let conn = establish_connection();
-#     conn.execute("DROP TABLE IF EXISTS numbers")?;
-#     conn.execute("CREATE TABLE numbers (number INTEGER)")?;
-diesel::insert_into(numbers)
-    .values(&vec![number.eq(1), number.eq(2)])
-    .execute(&conn)?;
-let average = numbers.select(avg(number)).get_result(&conn)?;
-let expected = "1.5".parse::<BigDecimal>().unwrap();
-assert_eq!(Some(expected), average);
-#     Ok(())
-# }
-#
-# #[cfg(not(all(feature = "numeric", any(feature = "postgres", not(feature = "sqlite")))))]
-# fn run_test() -> QueryResult<()> {
-#     Ok(())
-# }
-```
-"#
-);
+sql_function! {
+    /// Represents a SQL `AVG` function. This function can only take types which are
+    /// Foldable.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// # #[cfg(feature = "bigdecimal")]
+    /// # extern crate bigdecimal;
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # table! {
+    /// #     numbers (number) {
+    /// #         number -> Integer,
+    /// #     }
+    /// # }
+    /// #
+    /// # #[cfg(all(feature = "numeric", any(feature = "postgres", not(feature = "sqlite"))))]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use bigdecimal::BigDecimal;
+    /// #     use numbers::dsl::*;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS numbers")?;
+    /// #     conn.execute("CREATE TABLE numbers (number INTEGER)")?;
+    /// diesel::insert_into(numbers)
+    ///     .values(&vec![number.eq(1), number.eq(2)])
+    ///     .execute(&conn)?;
+    /// let average = numbers.select(avg(number)).get_result(&conn)?;
+    /// let expected = "1.5".parse::<BigDecimal>().unwrap();
+    /// assert_eq!(Some(expected), average);
+    /// #     Ok(())
+    /// # }
+    /// #
+    /// # #[cfg(not(all(feature = "numeric", any(feature = "postgres", not(feature = "sqlite")))))]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     Ok(())
+    /// # }
+    #[aggregate]
+    fn avg<ST: Foldable>(expr: ST) -> ST::Avg;
+}

--- a/diesel/src/expression/functions/helper_types.rs
+++ b/diesel/src/expression/functions/helper_types.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use dsl::AsExprOf;
+use dsl::{AsExprOf, SqlTypeOf};
 use expression::grouped::Grouped;
 use expression::operators;
 use sql_types::Bool;
@@ -20,7 +20,7 @@ pub type max<Expr> = super::aggregate_ordering::Max<Expr>;
 pub type min<Expr> = super::aggregate_ordering::Min<Expr>;
 
 /// The return type of [`sum(expr)`](../dsl/fn.sum.html)
-pub type sum<Expr> = super::aggregate_folding::Sum<Expr>;
+pub type sum<Expr> = super::aggregate_folding::sum::HelperType<SqlTypeOf<Expr>, Expr>;
 
 /// The return type of [`avg(expr)`](../dsl/fn.avg.html)
-pub type avg<Expr> = super::aggregate_folding::Avg<Expr>;
+pub type avg<Expr> = super::aggregate_folding::avg::HelperType<SqlTypeOf<Expr>, Expr>;


### PR DESCRIPTION
This extends the new syntax of `sql_function!` to allow generics. To
test this, I wanted to use it internally by replacing some of our
"special" function macros with normal `sql_function!`.

To do this for our aggregate functions, I also needed to add a way to
skip the `NonAggregate` impl. Generic functions were easier than
expected, though capturing the type parameters and their bounds was
annoying as all hell since `<>` isn't a token tree...

Right now we don't support multiple bounds on a type either, which
prevents me from moving `max` and `min` over to this. I'm not sure how
I'm going to handle that, since you can't capture a sequence separated
by `+`... Ideally I'd just be able to do `$($param:ident $(:
$bound:ty)*),*` since `Foo + Bar` parses as a valid type. However, Rust
doesn't allow a type token in the bounds position, only `path` and
`lifetime`. I think we'll probably just have to support where clauses,
and say "if you need more than one bound, put it in a where clause".

Dealing with `#[aggregate]` was a bit more annoying, but it's something
we will need to eventually do in order to support `#[sql_name]` anyway.
We just do our typical token munching strategy, going through one meta
item at a time and letting `macro_rules!` branching do the work for us
as we recursively call ourselves.

The main thing that makes this annoying is that we can never capture
anything as a `meta` token, since once you do that it no longer can be
matched against, ever. Luckily for attributes in particular this is not
a huge annoyance, as the attribute itself is surrounded by `[]` making
it a single token tree.