### PR TITLE
Allow bounds on type parameters in `sql_function!`

### DIFF
--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,89 +1,39 @@
-use backend::Backend;
-use expression::Expression;
-use query_builder::*;
-use result::QueryResult;
 use sql_types::{IntoNullable, SqlOrd};
 
-macro_rules! ord_function {
-    ($fn_name:ident, $type_name:ident, $operator:expr, $docs:expr) => {
-        #[doc=$docs]
-        pub fn $fn_name<ST, T>(t: T) -> $type_name<T> where
-            ST: SqlOrd,
-            T: Expression<SqlType=ST>,
-        {
-            $type_name {
-                target: t,
-            }
-        }
-
-        #[derive(Debug, Clone, Copy, QueryId)]
-        #[doc(hidden)]
-        pub struct $type_name<T> {
-            target: T,
-        }
-
-        impl<T: Expression> Expression for $type_name<T> where
-            T::SqlType: IntoNullable,
-        {
-            type SqlType = <T::SqlType as IntoNullable>::Nullable;
-        }
-
-        impl<T, DB> QueryFragment<DB> for $type_name<T> where
-            T: Expression + QueryFragment<DB>,
-            DB: Backend,
-        {
-            fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
-                out.push_sql(concat!($operator, "("));
-                self.target.walk_ast(out.reborrow())?;
-                out.push_sql(")");
-                Ok(())
-            }
-        }
-
-        impl_selectable_expression!($type_name<T>);
-    }
+sql_function! {
+    /// Represents a SQL `MAX` function. This function can only take types which are
+    /// ordered.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = establish_connection();
+    /// assert_eq!(Ok(Some(8)), animals.select(max(legs)).first(&connection));
+    /// # }
+    fn max<ST: SqlOrd + IntoNullable>(expr: ST) -> ST::Nullable;
 }
 
-ord_function!(
-    max,
-    Max,
-    "MAX",
-    "Represents a SQL `MAX` function. This function can only take types which are
-ordered.
-
-# Examples
-
-```rust
-# #[macro_use] extern crate diesel;
-# include!(\"../../doctest_setup.rs\");
-# use diesel::dsl::*;
-#
-# fn main() {
-#     use schema::animals::dsl::*;
-#     let connection = establish_connection();
-assert_eq!(Ok(Some(8)), animals.select(max(legs)).first(&connection));
-# }
-"
-);
-
-ord_function!(
-    min,
-    Min,
-    "MIN",
-    "Represents a SQL `MIN` function. This function can only take types which are
-ordered.
-
-# Examples
-
-```rust
-# #[macro_use] extern crate diesel;
-# include!(\"../../doctest_setup.rs\");
-# use diesel::dsl::*;
-#
-# fn main() {
-#     use schema::animals::dsl::*;
-#     let connection = establish_connection();
-assert_eq!(Ok(Some(4)), animals.select(min(legs)).first(&connection));
-# }
-"
-);
+sql_function! {
+    /// Represents a SQL `MIN` function. This function can only take types which are
+    /// ordered.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = establish_connection();
+    /// assert_eq!(Ok(Some(4)), animals.select(min(legs)).first(&connection));
+    /// # }
+    fn min<ST: SqlOrd + IntoNullable>(expr: ST) -> ST::Nullable;
+}

--- a/diesel/src/expression/functions/helper_types.rs
+++ b/diesel/src/expression/functions/helper_types.rs
@@ -14,10 +14,10 @@ pub type not<Expr> = operators::Not<Grouped<AsExprOf<Expr, Bool>>>;
 pub type Not<Expr> = not<Expr>;
 
 /// The return type of [`max(expr)`](../dsl/fn.max.html)
-pub type max<Expr> = super::aggregate_ordering::Max<Expr>;
+pub type max<Expr> = super::aggregate_ordering::max::HelperType<SqlTypeOf<Expr>, Expr>;
 
 /// The return type of [`min(expr)`](../dsl/fn.min.html)
-pub type min<Expr> = super::aggregate_ordering::Min<Expr>;
+pub type min<Expr> = super::aggregate_ordering::min::HelperType<SqlTypeOf<Expr>, Expr>;
 
 /// The return type of [`sum(expr)`](../dsl/fn.sum.html)
 pub type sum<Expr> = super::aggregate_folding::sum::HelperType<SqlTypeOf<Expr>, Expr>;

--- a/diesel/src/macros/internal.rs
+++ b/diesel/src/macros/internal.rs
@@ -34,3 +34,433 @@ macro_rules! impl_selectable_expression {
         }
     };
 }
+
+/// Parses a sequence of type parameters and their bounds.
+///
+/// Ideally we would just be able to write this as
+/// `$($param:ident $(: $bound:ty)*),* $(,)*`, but Rust doesn't allow a `ty`
+/// fragment in a trait bound position.
+///
+/// Assuming we don't care about lifetimes or existentials, we could also
+/// possibly write `$($param:ident $(: $bound:path)+*),* $(,)*` but Rust doesn't
+/// allow `+` as a separator. In fact, we can't even use the `path` fragment
+/// at all, as Rust does not allow it to be followed by `+` or `tt`.
+///
+/// This macro takes three arguments.
+///
+/// - `data`: Any arbitrary token tree you'd like given back to you when parsing
+///   is complete.
+/// - `callback`: The name of the macro to call when parsing is complete
+/// - `tokens`: The tokens to be parsed.
+///
+/// This macro will consume tokens until it reaches a `>` that was not
+/// preceded by a `<`. It will then invoke `callback` with 4 arguments:
+///
+/// - `data`: Whatever you gave this macro.
+/// - `type_args`: The names of the type parameters. Always contains a trailing
+///   comma if non-empty.
+/// - `type_args_with_bounds`: The arguments and their bounds. Always contains
+///   a trailing comma if non-empty
+/// - `unparsed_tokens`: Any tokens that were not consumed by this macro.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __diesel_parse_type_args {
+    // ENTRYPOINT
+    //
+    // Set up our lists.
+    // Continues to NEXT_ARG, NEXT_ARG_NO_BOUNDS, or EXIT
+    (
+        data = $data:tt,
+        callback = $callback:ident,
+        tokens = $tokens:tt,
+    ) => {
+        __diesel_parse_type_args! {
+            data = $data,
+            callback = $callback,
+            args = (),
+            bounds = (),
+            tokens = $tokens,
+        }
+    };
+
+    // NEXT_ARG
+    //
+    // No arg currently being parsed, next token is an argument with a `:`.
+    // From here we set up a stack of `<` to track,
+    // and start putting tokens into the bounds.
+    //
+    // Continues to BOUNDS or OPENING_BRACKET
+    (
+        data = $data:tt,
+        callback = $callback:ident,
+        args = ($($args:tt)*),
+        bounds = ($($bounds:tt)*),
+        tokens = ($next_arg:ident : $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            brackets = (),
+            data = $data,
+            callback = $callback,
+            args = ($($args)* $next_arg,),
+            bounds = ($($bounds)* $next_arg:),
+            tokens = ($($tokens)*),
+        }
+    };
+
+    // NEXT_ARG_NO_BOUNDS
+    //
+    // No arg currently being parsed, next token is an argument without a :.
+    //
+    // Continues to NEXT_ARG, NEXT_ARG_NO_BOUNDS, NO_ARG_COMMA, or EXIT
+    (
+        data = $data:tt,
+        callback = $callback:ident,
+        args = ($($args:tt)*),
+        bounds = ($($bounds:tt)*),
+        tokens = ($next_arg:ident $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            data = $data,
+            callback = $callback,
+            args = ($($args)* $next_arg,),
+            bounds = ($($bounds)* $next_arg,),
+            tokens = ($($tokens)*),
+        }
+    };
+
+    // FINAL_CLOSING_BRACKET
+    //
+    // > encountered, no bracket on the stack. We're done.
+    //
+    // Continues to EXIT
+    (
+        brackets = (),
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = ($($bounds:tt)*),
+        tokens = (> $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            data = $data,
+            callback = $callback,
+            args = $args,
+            bounds = ($($bounds)*,),
+            tokens = (> $($tokens)*),
+        }
+    };
+
+    // END_OF_BOUND
+    //
+    // , encountered, no bracket on the stack. We're done.
+    //
+    // Continues to NEXT_ARG, NEXT_ARG_NO_BOUNDS, or EXIT
+    (
+        brackets = (),
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = ($($bounds:tt)*),
+        tokens = (, $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            data = $data,
+            callback = $callback,
+            args = $args,
+            bounds = ($($bounds)* ,),
+            tokens = ($($tokens)*),
+        }
+    };
+
+    // OPENING_BRACKET
+    //
+    // Token is <, push it on the stack.
+    //
+    // Continues to BOUNDS, OPENING_BRACKET, CLOSING_BRACKET, or
+    // DOUBLE_CLOSING_BRACKET.
+    (
+        brackets = ($($brackets:tt)*),
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = ($($bounds:tt)*),
+        tokens = (< $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            brackets = (< $($brackets)*),
+            data = $data,
+            callback = $callback,
+            args = $args,
+            bounds = ($($bounds)* <),
+            tokens = ($($tokens)*),
+        }
+    };
+
+    // DOUBLE_CLOSING_BRACKET
+    //
+    // Rust treats >> as a single token, so we have to special case it.
+    //
+    // Continues to CLOSING_BRACKET or FINAL_CLOSING_BRACKET.
+    (
+        brackets = (< $($brackets:tt)*),
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = ($($bounds:tt)*),
+        tokens = (>> $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            brackets = ($($brackets)*),
+            data = $data,
+            callback = $callback,
+            args = $args,
+            bounds = ($($bounds)* >),
+            tokens = (> $($tokens)*),
+        }
+    };
+
+    // CLOSING_BRACKET
+    //
+    // Token is >, and we have a non-empty bracket stack.
+    // Pop it and continue.
+    //
+    // Continues to BOUNDS, OPENING_BRACKET, CLOSING_BRACKET,
+    // DOUBLE_CLOSING_BRACKET, FINAL_CLOSING_BRACKET, or END_OF_BOUND
+    (
+        brackets = (< $($brackets:tt)*),
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = ($($bounds:tt)*),
+        tokens = (> $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            brackets = ($($brackets)*),
+            data = $data,
+            callback = $callback,
+            args = $args,
+            bounds = ($($bounds)* >),
+            tokens = ($($tokens)*),
+        }
+    };
+
+    // BOUNDS
+    //
+    // Token is not a , or >. It's part of the trait bounds.
+    //
+    // Continues to BOUNDS, OPENING_BRACKET, CLOSING_BRACKET,
+    // DOUBLE_CLOSING_BRACKET, FINAL_CLOSING_BRACKET, or END_OF_BOUND.
+    (
+        brackets = $brackets:tt,
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = ($($bounds:tt)*),
+        tokens = ($token:tt $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            brackets = $brackets,
+            data = $data,
+            callback = $callback,
+            args = $args,
+            bounds = ($($bounds)* $token),
+            tokens = ($($tokens)*),
+        }
+    };
+
+    // NO_ARG_COMMA
+    //
+    // No arg currently being parsed, , encountered. Skip.
+    //
+    // Continues to NEXT_ARG, NEXT_ARG_NO_BOUNDS, or EXIT
+    (
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = $bounds:tt,
+        tokens = (, $($tokens:tt)*),
+    ) => {
+        __diesel_parse_type_args! {
+            data = $data,
+            callback = $callback,
+            args = $args,
+            bounds = $bounds,
+            tokens = ($($tokens)*),
+        }
+    };
+
+    // EXIT
+    //
+    // No arg currently being parsed, > encountered.
+    (
+        data = $data:tt,
+        callback = $callback:ident,
+        args = $args:tt,
+        bounds = $bounds:tt,
+        tokens = (> $($tokens:tt)*),
+    ) => {
+        $callback! {
+            data = $data,
+            type_args = $args,
+            type_args_with_bounds = $bounds,
+            unparsed_tokens = ($($tokens)*),
+        }
+    };
+}
+
+#[test]
+fn parse_type_args_empty() {
+    let expected = stringify!(
+        data = (),
+        type_args = (),
+        type_args_with_bounds = (),
+        unparsed_tokens = (),
+    );
+    let actual = __diesel_parse_type_args! {
+        data = (),
+        callback = stringify,
+        tokens = (>),
+    };
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn parse_type_args_simple() {
+    let expected = stringify!(
+        data = (foo),
+        type_args = (T,),
+        type_args_with_bounds = (T,),
+        unparsed_tokens = (),
+    );
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T>),
+    };
+
+    assert_eq!(expected, actual);
+
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T,>),
+    };
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn parse_type_args_multiple() {
+    let expected = stringify!(
+        data = (foo),
+        type_args = (T, U,),
+        type_args_with_bounds = (T, U,),
+        unparsed_tokens = (),
+    );
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T,U>),
+    };
+
+    assert_eq!(expected, actual);
+
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T,U,>),
+    };
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn parse_type_args_with_bounds() {
+    let expected = stringify!(
+        data = (foo),
+        type_args = (T, U,),
+        type_args_with_bounds = (T: Foo + Bar, U: Baz,),
+        unparsed_tokens = (),
+    );
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T: Foo + Bar, U: Baz>),
+    };
+
+    assert_eq!(expected, actual);
+
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T: Foo + Bar, U: Baz,>),
+    };
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn parse_type_args_with_bounds_containing_braces_and_commas() {
+    let expected = stringify!(
+        data = (foo),
+        type_args = (T,U,),
+        type_args_with_bounds = (T: Foo<X> + Bar<U, V>,U: Baz<Vec<i32>, String>,),
+        unparsed_tokens = (),
+    );
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T: Foo<X> + Bar<U, V>,U: Baz<Vec<i32>, String>>),
+    };
+
+    assert_eq!(expected, actual);
+
+    let actual = __diesel_parse_type_args! {
+        data = (foo),
+        callback = stringify,
+        tokens = (T: Foo<X> + Bar<U, V>,U: Baz<Vec<i32>, String>,>),
+    };
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn parse_type_args_with_trailer() {
+    let expected = stringify!(
+        data = (
+            meta = (#[aggregate]),
+            fn_name = max,
+        ),
+        type_args = (ST,),
+        type_args_with_bounds = (ST: SqlOrd + IntoNullable,),
+        unparsed_tokens = ((expr: ST) -> ST::Nullable),
+    );
+    let actual = __diesel_parse_type_args! {
+        data = (
+            meta = (#[aggregate]),
+            fn_name = max,
+        ),
+        callback = stringify,
+        tokens = (ST: SqlOrd + IntoNullable>(expr: ST) -> ST::Nullable),
+    };
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn parse_type_args_with_existentials_and_lifetimes() {
+    let expected = stringify! (
+        data = (),
+        type_args = (ST,U,),
+        type_args_with_bounds = (ST: for<'a> Foo<'a, U> + 'static, U,),
+        unparsed_tokens = (),
+    );
+    let actual = __diesel_parse_type_args! {
+        data = (),
+        callback = stringify,
+        tokens = (ST: for<'a> Foo<'a, U> + 'static, U>),
+    };
+
+    assert_eq!(expected, actual);
+}

--- a/diesel_compile_tests/tests/compile-fail/ordering_functions_require_ord.rs
+++ b/diesel_compile_tests/tests/compile-fail/ordering_functions_require_ord.rs
@@ -12,7 +12,9 @@ table! {
 
 fn main() {
     let source = stuff::table.select(max(stuff::b));
-    //~^ ERROR E0277
+    //~^ ERROR SqlOrd
+    //~| ERROR E0277
     let source = stuff::table.select(min(stuff::b));
-    //~^ ERROR E0277
+    //~^ ERROR SqlOrd
+    //~| ERROR E0277
 }


### PR DESCRIPTION
This was... harder than it should be. What I really want to do is this:
`<$($type_arg $(: $bound:ty)*),* $(,)*>`. However, this will fail, since
doing: `$type_arg: $bound` complains that we can't use a `ty` token
there.

We can use `path`, but we can't capture the separater. We can't do `$(:
$($bound:path)+*)*`, since `+` means something special and can't be used
as a separator. We also can't do anything like `$(: $($bound:path)
$(+)*)` either, since Rust doesn't allow `path` fragments to be followed
by `+`.

Hell, we can't even do a token munching macro where we match something
like `$type_arg:ident : $bound:path $(rest:tt)*`, since Rust won't let
us have a `path` fragment followed by `tt` either! We can't even just
capture the tokens we care about since `<>` is not an individual token
tree, so `<$($tokens:tt)*>` is ambiguous.

So we have to implement a manual parser for this... We set up a state
machine that goes through and parses the whole thing one token a time.
I've tried to at least make it somewhat easier to follow than this has
been in the past by labeling each state, and the expected flow between
them.

It's way more code than it should be, but at least it's easy to test in
isolation.