### PR TITLE
Enable sqlite/bundle for diesel cli redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
     script:
     - cargo install rustfmt-nightly --vers 0.3.7 --force
     - cargo fmt --all -- --write-mode=diff
-  - rust: nightly
+  - rust: stable
     env:
     - SQLITE_BUNDLED=YESPLEASE
     - SQLITE_DATABASE_URL=/tmp/test.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ matrix:
     - SQLITE_BUNDLED=YESPLEASE
     - SQLITE_DATABASE_URL=/tmp/test.db
     script:
-    - (cd diesel_cli && travis-cargo test --no-default-features --features "sqlite-bundled")
-  
+    - (cd diesel_cli && travis-cargo test -- --no-default-features --features "sqlite-bundled")
+
 env:
   matrix:
     - BACKEND=sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,13 @@ matrix:
     script:
     - cargo install rustfmt-nightly --vers 0.3.7 --force
     - cargo fmt --all -- --write-mode=diff
+  - rust: nightly
+    env:
+    - SQLITE_BUNDLED=YESPLEASE
+    - SQLITE_DATABASE_URL=/tmp/test.db
+    script:
+    - (cd diesel_cli && travis-cargo test --no-default-features --features "sqlite-bundled")
+  
 env:
   matrix:
     - BACKEND=sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added support for specifying `ISOLATION LEVEL`, `DEFERRABLE`, and `READ ONLY`
   on PG transactions. See [`PgConnection::build_transaction`] for details.
 
+* Added `sqlite-bundled` feature to `diesel_cli` to make installing on
+  some platforms easier. 
+
 [`PgConnection::build_transaction`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html#method.build_transaction
 
 * Added support for `BEGIN IMMEDIATE` and `BEGIN EXCLUSIVE` on SQLite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `NonAggregate` for your function. See [the documentation for
   `sql_function!`][sql-function-1-3-0] for more details.
 
+* Added `sqlite-bundled` feature to `diesel_cli` to make installing on
+  some platforms easier.
+
 ### Changed
 
 * `sql_function!` has been redesigned. The syntax is now `sql_function!(fn
@@ -85,9 +88,6 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for specifying `ISOLATION LEVEL`, `DEFERRABLE`, and `READ ONLY`
   on PG transactions. See [`PgConnection::build_transaction`] for details.
-
-* Added `sqlite-bundled` feature to `diesel_cli` to make installing on
-  some platforms easier. 
 
 [`PgConnection::build_transaction`]: http://docs.diesel.rs/diesel/pg/struct.PgConnection.html#method.build_transaction
 

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3.0.0"
 toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
 barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.9.0", default-features = false, optional = true, features = ["bundled"] }
 
 [dev-dependencies]
 difference = "1.0"
@@ -41,6 +42,7 @@ postgres = ["diesel/postgres", "infer_schema_internals/postgres", "url"]
 sqlite = ["diesel/sqlite", "infer_schema_internals/sqlite"]
 mysql = ["diesel/mysql", "infer_schema_internals/mysql", "url"]
 barrel-migrations = ["migrations_internals/barrel", "barrel"]
+sqlite-bundled = ["sqlite", "libsqlite3-sys/bundled"]
 
 [[test]]
 name = "tests"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -27,7 +27,7 @@ tempfile = "3.0.0"
 toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
 barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
-libsqlite3-sys = { version = ">=0.8.0, <0.9.0", default-features = false, optional = true, features = ["bundled"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.10.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 
 [dev-dependencies]
 difference = "1.0"

--- a/diesel_cli/README.md
+++ b/diesel_cli/README.md
@@ -22,6 +22,13 @@ cargo install diesel_cli --no-default-features --features "postgres sqlite mysql
 [sqlite]: http://www.sqlitetutorial.net/download-install-sqlite/
 [mysql]: https://dev.mysql.com/doc/refman/5.7/en/installing.html
 
+If you are using a system without an easy way to install sqlite (for example Windows),
+you can use a bundled version instead:
+
+```shell
+cargo install diesel_cli --no-default-features --features "sqlite-bundled"
+```
+
 Getting Started
 ---------------
 


### PR DESCRIPTION
Rebased #1302 onto master

> Installation can be achieved using this: cargo install diesel_cli --no-default-features --features sqlite-bundled