### PR TITLE
Add Cluster Database Connections [WIP]

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -11,9 +11,9 @@ use query_builder::{AsQuery, QueryFragment, QueryId};
 use result::*;
 use sql_types::HasSqlType;
 
-pub use self::transaction_manager::{AnsiTransactionManager, TransactionManager};
 #[doc(hidden)]
 pub use self::statement_cache::{MaybeCached, StatementCache, StatementCacheKey};
+pub use self::transaction_manager::{AnsiTransactionManager, TransactionManager};
 
 /// Perform simple operations on a backend.
 ///
@@ -186,4 +186,14 @@ pub trait Connection: SimpleConnection + Sized + Send {
 
     #[doc(hidden)]
     fn transaction_manager(&self) -> &Self::TransactionManager;
+}
+
+/// A connection to a database
+pub trait ClusteredConnection: Connection {
+    /// Establishes a replica connection to the database cluster
+    ///
+    /// The argument to this method varies by backend.
+    /// See the documentation for that backend's connection class
+    /// for details about what it accepts.
+    fn replica(&mut self, database_url: &str);
 }


### PR DESCRIPTION
This PR is a work in progress and before going too far I'd like to get some feedback. The feature that I'm looking to implement is the ability to use a clustered database connection(s). The idea is that it would be configurable so that reads work on replicas and writes get directed to the master. If this is a feature that sounds reasonable to implement I'd be more than willing to continue on this, but I'd like the blessing of the maintainers first. Thanks!