### PR TITLE
Bump all of the nightly things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: nightly-2018-02-02
+  - rust: nightly-2018-04-19
     env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
     script:
     - (cd diesel && cargo rustc --no-default-features --features "lint sqlite postgres mysql extras" -- -Zno-trans)

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - (cd diesel_migrations && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
     - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
     - (cd diesel_compile_tests && travis-cargo test)
-  - rust: nightly-2018-02-02
+  - rust: nightly-2018-03-15
     env: RUSTFMT=YESPLEASE
     script:
     - cargo install rustfmt-nightly --vers 0.3.7 --force

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["database"]
 byteorder = "1.0"
 diesel_derives = "~1.2.0"
 chrono = { version = "0.4", optional = true }
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.10.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -117,7 +117,7 @@
 #![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
 #![cfg_attr(feature = "clippy",
             allow(option_map_unwrap_or_else, option_map_unwrap_or, match_same_arms,
-                  type_complexity))]
+                  type_complexity, redundant_field_names))]
 #![cfg_attr(feature = "clippy",
             warn(option_unwrap_used, result_unwrap_used, print_stdout,
                  wrong_pub_self_convention, mut_mut, non_ascii_literal, similar_names,

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -25,6 +25,8 @@ macro_rules! mysql_time_impls {
         }
 
         impl FromSql<$ty, Mysql> for ffi::MYSQL_TIME {
+            // ptr::copy_nonoverlapping does not require aligned pointers
+            #[cfg_attr(feature = "clippy", allow(cast_ptr_alignment))]
             fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
                 let bytes = not_none!(bytes);
                 let bytes_ptr = bytes.as_ptr() as *const ffi::MYSQL_TIME;

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -55,12 +55,12 @@ impl Error for InvalidNumericSign {
 impl FromSql<sql_types::Numeric, Pg> for PgNumeric {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let mut bytes = not_none!(bytes);
-        let ndigits = try!(bytes.read_u16::<NetworkEndian>());
-        let mut digits = Vec::with_capacity(ndigits as usize);
+        let digit_count = try!(bytes.read_u16::<NetworkEndian>());
+        let mut digits = Vec::with_capacity(digit_count as usize);
         let weight = try!(bytes.read_i16::<NetworkEndian>());
         let sign = try!(bytes.read_u16::<NetworkEndian>());
         let scale = try!(bytes.read_u16::<NetworkEndian>());
-        for _ in 0..ndigits {
+        for _ in 0..digit_count {
             digits.push(try!(bytes.read_i16::<NetworkEndian>()));
         }
 

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -89,6 +89,8 @@ where
     /// done implicitly for references. For structs with lifetimes it must be
     /// done explicitly. This method matches the semantics of what Rust would do
     /// implicitly if you were passing a mutable reference
+    // Clippy is wrong, this cannot be expressed with pointer casting
+    #[cfg_attr(feature = "clippy", allow(transmute_ptr_to_ptr))]
     pub fn reborrow(&mut self) -> AstPass<DB> {
         use self::AstPassInternals::*;
         let internals = match self.internals {

--- a/diesel/src/query_builder/debug_query.rs
+++ b/diesel/src/query_builder/debug_query.rs
@@ -81,6 +81,8 @@ where
     DB: Backend,
     T: QueryFragment<DB>,
 {
+    // Clippy is wrong, this cannot be expressed with pointer casting
+    #[cfg_attr(feature = "clippy", allow(transmute_ptr_to_ptr))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut list = f.debug_list();
         {

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -44,6 +44,9 @@ impl Statement {
         self.step().map(|_| ())
     }
 
+    // We are always reading potentially misaligned pointers with
+    // `ptr::read_unaligned`
+    #[cfg_attr(feature = "clippy", allow(cast_ptr_alignment))]
     pub fn bind(&mut self, tpe: SqliteType, value: Option<Vec<u8>>) -> QueryResult<()> {
         self.bind_index += 1;
         // This unsafe block assumes the following invariants:
@@ -70,7 +73,7 @@ impl Statement {
                     ffi::SQLITE_TRANSIENT(),
                 ),
                 (SqliteType::Float, Some(bytes)) => {
-                    let value = *(bytes.as_ptr() as *const f32);
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const f32);
                     ffi::sqlite3_bind_double(
                         self.inner_statement.as_ptr(),
                         self.bind_index,
@@ -78,7 +81,7 @@ impl Statement {
                     )
                 }
                 (SqliteType::Double, Some(bytes)) => {
-                    let value = *(bytes.as_ptr() as *const f64);
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const f64);
                     ffi::sqlite3_bind_double(
                         self.inner_statement.as_ptr(),
                         self.bind_index,
@@ -86,7 +89,7 @@ impl Statement {
                     )
                 }
                 (SqliteType::SmallInt, Some(bytes)) => {
-                    let value = *(bytes.as_ptr() as *const i16);
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const i16);
                     ffi::sqlite3_bind_int(
                         self.inner_statement.as_ptr(),
                         self.bind_index,
@@ -94,7 +97,7 @@ impl Statement {
                     )
                 }
                 (SqliteType::Integer, Some(bytes)) => {
-                    let value = *(bytes.as_ptr() as *const i32);
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const i32);
                     ffi::sqlite3_bind_int(
                         self.inner_statement.as_ptr(),
                         self.bind_index,
@@ -102,7 +105,7 @@ impl Statement {
                     )
                 }
                 (SqliteType::Long, Some(bytes)) => {
-                    let value = *(bytes.as_ptr() as *const i64);
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const i64);
                     ffi::sqlite3_bind_int64(self.inner_statement.as_ptr(), self.bind_index, value)
                 }
             }

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -87,7 +87,7 @@ impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
         }
 
         if let Ok(julian_days) = text.parse::<f64>() {
-            let epoch_in_julian_days = 2440587.5;
+            let epoch_in_julian_days = 2_440_587.5;
             let seconds_in_day = 86400.0;
             let timestamp = (julian_days - epoch_in_julian_days) * seconds_in_day;
             let seconds = timestamp as i64;

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -49,4 +49,5 @@ mod polyfill {
 pub(crate) use self::polyfill::*;
 
 #[cfg(feature = "unstable")]
+#[allow(dead_code)]
 pub(crate) type NonNull<T> = ::std::ptr::NonNull<T>;

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4"
 clap = "2.27"
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 diesel = { version = "~1.2.0", default-features = false }
 dotenv = ">=0.8, <0.11"
 infer_schema_internals = { version = "~1.2.0", features = ["serde"] }

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -125,7 +125,7 @@ impl<'a> Display for TableDefinitions<'a> {
             if is_first {
                 is_first = false;
             } else {
-                write!(f, "\n")?;
+                writeln!(f)?;
             }
             writeln!(
                 f,
@@ -139,7 +139,7 @@ impl<'a> Display for TableDefinitions<'a> {
         }
 
         if !self.fk_constraints.is_empty() {
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
 
         for foreign_key in &self.fk_constraints {
@@ -150,7 +150,7 @@ impl<'a> Display for TableDefinitions<'a> {
             write!(f, "\nallow_tables_to_appear_in_same_query!(")?;
             {
                 let mut out = PadAdapter::new(f);
-                write!(out, "\n")?;
+                writeln!(out)?;
                 for table in &self.tables {
                     writeln!(out, "{},", table.name.name)?;
                 }
@@ -173,13 +173,13 @@ impl<'a> Display for TableDefinition<'a> {
         write!(f, "table! {{")?;
         {
             let mut out = PadAdapter::new(f);
-            write!(out, "\n")?;
+            writeln!(out)?;
 
             if let Some(types) = self.import_types {
                 for import in types {
                     writeln!(out, "use {};", import)?;
                 }
-                write!(out, "\n")?;
+                writeln!(out)?;
             }
 
             if self.include_docs {
@@ -260,7 +260,7 @@ struct PadAdapter<'a, 'b: 'a> {
 impl<'a, 'b: 'a> PadAdapter<'a, 'b> {
     fn new(fmt: &'a mut Formatter<'b>) -> PadAdapter<'a, 'b> {
         PadAdapter {
-            fmt: fmt,
+            fmt,
             on_newline: false,
         }
     }

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.2.0", default-features = false, features = ["extras", "sqlite", "postgres", "mysql", "unstable"] }
-compiletest_rs = "=0.3.6"
+compiletest_rs = "=0.3.11"
 
 [replace]
 "diesel:1.2.2" = { path = "../diesel" }

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_column_name.stderr
@@ -34,7 +34,11 @@ error[E0425]: cannot find value `name` in module `users`
 20 | struct UserTuple(#[column_name = "name"] String);
    |                                  ^^^^^^ not found in `users`
 
-error[E0601]: main function not found
+error[E0601]: `main` function not found in crate `as_changeset_bad_column_name`
+  |
+  = note: consider adding a `main` function to `$DIR/as_changeset_bad_column_name.rs`
 
 error: aborting due to 7 previous errors
 
+Some errors occurred: E0412, E0425, E0601.
+For more information about an error, try `rustc --explain E0412`.

--- a/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.stderr
@@ -12,3 +12,4 @@ error[E0433]: failed to resolve. Use of undeclared type or module `users`
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0433`.

--- a/diesel_compile_tests/tests/ui/belongs_to_missing_foreign_key_column.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_missing_foreign_key_column.stderr
@@ -48,3 +48,5 @@ error[E0425]: cannot find value `bar_id` in module `foo`
 
 error: aborting due to 8 previous errors
 
+Some errors occurred: E0412, E0425.
+For more information about an error, try `rustc --explain E0412`.

--- a/diesel_compile_tests/tests/ui/belongs_to_missing_parent_import.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_missing_parent_import.stderr
@@ -6,3 +6,4 @@ error[E0412]: cannot find type `Bar` in this scope
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0412`.

--- a/diesel_compile_tests/tests/ui/insertable_missing_table_or_column.stderr
+++ b/diesel_compile_tests/tests/ui/insertable_missing_table_or_column.stderr
@@ -11,28 +11,30 @@ error[E0433]: failed to resolve. Use of undeclared type or module `posts`
   | ^ Use of undeclared type or module `posts`
 
 error[E0412]: cannot find type `name` in module `users`
-  --> $DIR/insertable_missing_table_or_column.rs:24:5
+  --> $DIR/insertable_missing_table_or_column.rs:21:10
    |
-24 |     name: String
-   |     ^^^^ not found in `users`
+21 | #[derive(Insertable)]
+   |          ^^^^^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
-  --> $DIR/insertable_missing_table_or_column.rs:24:5
+  --> $DIR/insertable_missing_table_or_column.rs:21:10
    |
-24 |     name: String
-   |     ^^^^ not found in `users`
+21 | #[derive(Insertable)]
+   |          ^^^^^^^^^^ not found in `users`
 
 error[E0412]: cannot find type `name` in module `users`
-  --> $DIR/insertable_missing_table_or_column.rs:30:21
+  --> $DIR/insertable_missing_table_or_column.rs:27:10
    |
-30 |     #[column_name = "name"]
-   |                     ^^^^^^ not found in `users`
+27 | #[derive(Insertable)]
+   |          ^^^^^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
-  --> $DIR/insertable_missing_table_or_column.rs:30:21
+  --> $DIR/insertable_missing_table_or_column.rs:27:10
    |
-30 |     #[column_name = "name"]
-   |                     ^^^^^^ not found in `users`
+27 | #[derive(Insertable)]
+   |          ^^^^^^^^^^ not found in `users`
 
 error: aborting due to 6 previous errors
 
+Some errors occurred: E0412, E0425, E0433.
+For more information about an error, try `rustc --explain E0412`.

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -9,10 +9,10 @@ homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_derives"
 
 [dependencies]
-syn = { version = "0.12.11", features = ["full", "fold"] }
-quote = "0.4"
-clippy = { optional = true, version = "=0.0.185" }
-proc-macro2 = "0.2.0"
+syn = { version = "0.13.0", features = ["full", "fold"] }
+quote = "0.5.0"
+clippy = { optional = true, version = "=0.0.195" }
+proc-macro2 = "0.3.0"
 
 [dev-dependencies]
 cfg-if = "0.1.0"

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -105,5 +105,5 @@ impl AssociationOptions {
 
 fn infer_foreign_key(name: syn::Ident) -> syn::Ident {
     let snake_case = camel_to_snake(name.as_ref());
-    syn::Ident::new(&format!("{}_id", snake_case), name.span)
+    syn::Ident::new(&format!("{}_id", snake_case), name.span())
 }

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -22,7 +22,8 @@ impl Field {
         let name = match field.ident {
             Some(mut x) => {
                 // https://github.com/rust-lang/rust/issues/47983#issuecomment-362817105
-                x.span = fix_span(x.span, Span::call_site());
+                let span = x.span();
+                x.set_span(fix_span(span, Span::call_site()));
                 FieldName::Named(x)
             }
             None => FieldName::Unnamed(syn::Index {
@@ -89,7 +90,7 @@ impl FieldName {
 
     pub fn span(&self) -> Span {
         match *self {
-            FieldName::Named(x) => x.span,
+            FieldName::Named(x) => x.span(),
             FieldName::Unnamed(ref x) => x.span,
         }
     }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -24,6 +24,7 @@ mod diagnostic_shim;
 mod field;
 mod meta;
 mod model;
+mod resolved_at_shim;
 mod util;
 
 mod as_changeset;

--- a/diesel_derives/src/meta.rs
+++ b/diesel_derives/src/meta.rs
@@ -137,7 +137,8 @@ impl MetaItem {
 
     pub fn ty_value(&self) -> Result<syn::Type, Diagnostic> {
         let str = self.lit_str_value()?;
-        str.parse().map_err(|_| str.span().error("Invalid Rust type"))
+        str.parse()
+            .map_err(|_| str.span().error("Invalid Rust type"))
     }
 
     pub fn expect_str_value(&self) -> String {

--- a/diesel_derives/src/meta.rs
+++ b/diesel_derives/src/meta.rs
@@ -3,6 +3,7 @@ use syn;
 use syn::spanned::Spanned;
 use syn::fold::Fold;
 
+use resolved_at_shim::*;
 use util::*;
 
 pub struct MetaItem {
@@ -136,7 +137,7 @@ impl MetaItem {
 
     pub fn ty_value(&self) -> Result<syn::Type, Diagnostic> {
         let str = self.lit_str_value()?;
-        str.parse().map_err(|_| str.span.error("Invalid Rust type"))
+        str.parse().map_err(|_| str.span().error("Invalid Rust type"))
     }
 
     pub fn expect_str_value(&self) -> String {
@@ -208,7 +209,7 @@ impl MetaItem {
         use syn::Meta::*;
 
         match self.meta {
-            Word(ident) => ident.span,
+            Word(ident) => ident.span(),
             List(ref meta) => meta.nested.span(),
             NameValue(ref meta) => meta.lit.span(),
         }
@@ -220,7 +221,7 @@ impl MetaItem {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)] // https://github.com/rust-lang-nursery/rustfmt/issues/2392
-pub struct Nested<'a>(syn::punctuated::Iter<'a, syn::NestedMeta, Token![,]>);
+pub struct Nested<'a>(syn::punctuated::Iter<'a, syn::NestedMeta>);
 
 impl<'a> Iterator for Nested<'a> {
     type Item = MetaItem;

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -4,6 +4,7 @@ use proc_macro2::Span;
 use diagnostic_shim::*;
 use field::*;
 use meta::*;
+use resolved_at_shim::*;
 
 pub struct Model {
     pub name: syn::Ident,
@@ -32,7 +33,7 @@ impl Model {
         self.table_name_from_attribute.unwrap_or_else(|| {
             syn::Ident::new(
                 &infer_table_name(self.name.as_ref()),
-                self.name.span.resolved_at(Span::call_site()),
+                self.name.span().resolved_at(Span::call_site()),
             )
         })
     }
@@ -52,7 +53,7 @@ impl Model {
             .find(|f| f.column_name() == column_name)
             .ok_or_else(|| {
                 column_name
-                    .span
+                    .span()
                     .error(format!("No field with column name {}", column_name))
             })
     }

--- a/diesel_derives/src/resolved_at_shim.rs
+++ b/diesel_derives/src/resolved_at_shim.rs
@@ -1,0 +1,21 @@
+use proc_macro2::Span;
+
+pub trait ResolvedAtExt {
+    fn resolved_at(self, span: Span) -> Span;
+}
+
+#[cfg(feature = "nightly")]
+impl ResolvedAtExt for Span {
+    fn resolved_at(self, span: Span) -> Span {
+        self.unstable()
+            .resolved_at(span.unstable())
+            .into()
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+impl ResolvedAtExt for Span {
+    fn resolved_at(self, _: Span) -> Span {
+        self
+    }
+}

--- a/diesel_derives/src/resolved_at_shim.rs
+++ b/diesel_derives/src/resolved_at_shim.rs
@@ -7,9 +7,7 @@ pub trait ResolvedAtExt {
 #[cfg(feature = "nightly")]
 impl ResolvedAtExt for Span {
     fn resolved_at(self, span: Span) -> Span {
-        self.unstable()
-            .resolved_at(span.unstable())
-            .into()
+        self.unstable().resolved_at(span.unstable()).into()
     }
 }
 

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -71,7 +71,7 @@ pub fn ty_for_foreign_derive(item: &DeriveInput, flags: &MetaItem) -> Result<Typ
 }
 
 pub fn fix_span(maybe_bad_span: Span, fallback: Span) -> Span {
-    let bad_span_debug = "Span(Span { lo: BytePos(0), hi: BytePos(0), ctxt: #0 })";
+    let bad_span_debug = "#0 bytes(0..0)";
     if format!("{:?}", maybe_bad_span) == bad_span_debug {
         fallback
     } else {

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["diesel"]
 
 [dependencies]
 infer_schema_macros = { version = "~1.2.0", default-features = false }
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 
 [dev-dependencies]
 diesel = { version = "1.2.0", default-features = false }

--- a/diesel_infer_schema/infer_schema_internals/Cargo.toml
+++ b/diesel_infer_schema/infer_schema_internals/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 
 [dependencies]
 diesel = { version = "~1.2.0", default-features = false }
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 serde = { version = "1.0.0", optional = true }
 
 [dev-dependencies]

--- a/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/data_structures.rs
@@ -68,7 +68,7 @@ impl ColumnInformation {
         ColumnInformation {
             column_name: column_name.into(),
             type_name: type_name.into(),
-            nullable: nullable,
+            nullable,
         }
     }
 }

--- a/diesel_infer_schema/infer_schema_internals/src/pg.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/pg.rs
@@ -29,7 +29,7 @@ pub fn determine_column_type(attr: &ColumnInformation) -> Result<ColumnType, Box
 
     Ok(ColumnType {
         rust_name: capitalize(tpe),
-        is_array: is_array,
+        is_array,
         is_nullable: attr.nullable,
         is_unsigned: false,
     })

--- a/diesel_infer_schema/infer_schema_internals/src/sqlite.rs
+++ b/diesel_infer_schema/infer_schema_internals/src/sqlite.rs
@@ -43,7 +43,7 @@ pub fn load_table_names(
 ) -> Result<Vec<TableName>, Box<Error>> {
     use self::sqlite_master::dsl::*;
 
-    if !schema_name.is_none() {
+    if schema_name.is_some() {
         return Err("sqlite cannot infer schema for databases other than the \
                     main database"
             .into());

--- a/diesel_infer_schema/infer_schema_macros/Cargo.toml
+++ b/diesel_infer_schema/infer_schema_macros/Cargo.toml
@@ -10,7 +10,7 @@ syn = { version = "0.11.4", features = ["aster"] }
 quote = "0.3.12"
 dotenv = { version = ">=0.8, <0.11", optional = true, default-features = false }
 infer_schema_internals = { version = "~1.2.0", default-features = false }
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 
 [dev-dependencies]
 tempdir = "^0.3.4"

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "http://diesel.rs"
 
 
 [dependencies]
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 migrations_internals = "~1.2.0"
 migrations_macros = "~1.2.0"
 

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -7,7 +7,7 @@ description = "Internal implementation of diesels migration mechanism"
 homepage = "http://diesel.rs"
 
 [dependencies]
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 diesel = { version = "~1.2.0", default-features = false }
 barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
 

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -11,9 +11,7 @@ pub struct MigrationName<'a> {
 }
 
 pub fn name(migration: &Migration) -> MigrationName {
-    MigrationName {
-        migration,
-    }
+    MigrationName { migration }
 }
 
 impl<'a> fmt::Display for MigrationName<'a> {

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -12,7 +12,7 @@ pub struct MigrationName<'a> {
 
 pub fn name(migration: &Migration) -> MigrationName {
     MigrationName {
-        migration: migration,
+        migration,
     }
 }
 

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "http://docs.diesel.rs"
 homepage = "http://diesel.rs"
 
 [dependencies]
-clippy = { optional = true, version = "=0.0.185" }
+clippy = { optional = true, version = "=0.0.195" }
 migrations_internals = "~1.2.0"
 syn = { version = "0.11.4", features = ["aster"] }
 quote = "0.3.12"


### PR DESCRIPTION
parking_lot decided to bump their minimum required Rust version in a
patch release, which means that we have to update to a newer nightly.
While this pretty much always means updating our clippy version,
the version of `proc_macro2` we were using stopped working. So we had to
bump syn as well...

It appears that https://github.com/rust-lang/rust/issues/47941 has
gotten worse, so a lot of our error messages have regressed on newer
nightlies.

I also bumped rustfmt because why not.