### PR TITLE
Adding a way to provide a backend specific create table statement for

### DIFF
--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -3,7 +3,7 @@
 mod errors;
 pub use self::errors::{MigrationError, RunMigrationsError};
 
-use connection::SimpleConnection;
+use connection::{Connection, SimpleConnection};
 use std::path::Path;
 
 /// Represents a migration that interacts with diesel
@@ -52,4 +52,27 @@ impl<'a> Migration for &'a Migration {
     fn file_path(&self) -> Option<&Path> {
         (&**self).file_path()
     }
+}
+
+/// A trait indicating that a connection could be used to run migrations
+///
+/// Normal users of diesel should not use/see this trait.
+/// This trait is only relevant when you are implementing a new connection type
+/// that could be used with diesel.
+pub trait MigrationConnection: Connection {
+    /// The create table statement used to create the internal table used to
+    /// track which migrations were already run
+    ///
+    /// This constant should contain a `CREATE TABLE` statement that
+    /// creates a new table called `__diesel_schema_migrations` containing
+    /// two columns named `version` and `run_on`. The `version` column must have a
+    /// datatype compatible with diesels `Text` sql type and must be the primary key
+    /// of the table. The `run_on` column must have a datatype compatible with diesels
+    /// `Timestamp` sql type, have a `NOT NULL` annotation and a default value
+    /// corresponding to the actual insert time (`CURRENT_TIMESTAMP` in ISO sql).
+    const CREATE_MIGRATIONS_TABLE: &'static str =
+        "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (\
+         version VARCHAR(50) PRIMARY KEY NOT NULL,\
+         run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
+         )";
 }

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -10,6 +10,7 @@ use super::backend::Mysql;
 use super::bind_collector::MysqlBindCollector;
 use connection::*;
 use deserialize::{Queryable, QueryableByName};
+use migration::MigrationConnection;
 use query_builder::*;
 use result::*;
 use sql_types::HasSqlType;
@@ -31,6 +32,8 @@ impl SimpleConnection for MysqlConnection {
             .enable_multi_statements(|| self.raw_connection.execute(query))
     }
 }
+
+impl MigrationConnection for MysqlConnection {}
 
 impl Connection for MysqlConnection {
     type Backend = Mysql;

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -14,6 +14,7 @@ use self::result::PgResult;
 use self::stmt::Statement;
 use connection::*;
 use deserialize::{Queryable, QueryableByName};
+use migration::MigrationConnection;
 use pg::{Pg, PgMetadataLookup, TransactionBuilder};
 use query_builder::bind_collector::RawBytesBindCollector;
 use query_builder::*;
@@ -106,6 +107,8 @@ impl Connection for PgConnection {
         &self.transaction_manager
     }
 }
+
+impl MigrationConnection for PgConnection {}
 
 impl PgConnection {
     /// Build a transaction, specifying additional details such as isolation level

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -17,6 +17,7 @@ use self::statement_iterator::*;
 use self::stmt::{Statement, StatementUse};
 use connection::*;
 use deserialize::{Queryable, QueryableByName};
+use migration::MigrationConnection;
 use query_builder::bind_collector::RawBytesBindCollector;
 use query_builder::*;
 use result::*;
@@ -44,6 +45,8 @@ impl SimpleConnection for SqliteConnection {
         self.raw_connection.exec(query)
     }
 }
+
+impl MigrationConnection for SqliteConnection {}
 
 impl Connection for SqliteConnection {
     type Backend = Sqlite;

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -14,7 +14,7 @@ use super::schema::__diesel_schema_migrations::dsl::*;
 /// to wrap up some constraints which are meant to hold for *all* connections.
 /// This trait will go away at some point in the future. Any Diesel connection
 /// should be useable where this trait is required.
-pub trait MigrationConnection: Connection {
+pub trait MigrationConnection: ::diesel::migration::MigrationConnection {
     fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>>;
     fn latest_run_migration_version(&self) -> QueryResult<Option<String>>;
     fn insert_new_migration(&self, version: &str) -> QueryResult<()>;
@@ -22,7 +22,7 @@ pub trait MigrationConnection: Connection {
 
 impl<T> MigrationConnection for T
 where
-    T: Connection,
+    T: ::diesel::migration::MigrationConnection,
     String: FromSql<VarChar, T::Backend>,
     // FIXME: HRTB is preventing projecting on any associated types here
     for<'a> InsertStatement<

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -257,17 +257,14 @@ fn migration_with_version(
 }
 
 #[doc(hidden)]
-pub fn setup_database<Conn: Connection>(conn: &Conn) -> QueryResult<usize> {
+pub fn setup_database<Conn: MigrationConnection>(conn: &Conn) -> QueryResult<usize> {
     create_schema_migrations_table_if_needed(conn)
 }
 
-fn create_schema_migrations_table_if_needed<Conn: Connection>(conn: &Conn) -> QueryResult<usize> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (\
-         version VARCHAR(50) PRIMARY KEY NOT NULL,\
-         run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
-         )",
-    )
+fn create_schema_migrations_table_if_needed<Conn: MigrationConnection>(
+    conn: &Conn,
+) -> QueryResult<usize> {
+    conn.execute(<Conn as ::diesel::migration::MigrationConnection>::CREATE_MIGRATIONS_TABLE)
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
the migration table

Different databases uses different sql dialects. While the current
table statement for the migration table works on all supported
backends it is a show stopper while implementing a new backend for
supporting a oracle database.

Technically this commit is a breaking change. This may affect only
custom backend implementation. We are not aware of any such
implementation. (Because of that I've requested a review from the other @diesel-rs/core members)

cc @pgab 
