### PR TITLE
Simplify the internal trait structure of locking select statements

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -206,6 +206,7 @@ pub mod helper_types {
     //! DslName<OtherTypes>>::Output`. So the return type of
     //! `users.filter(first_name.eq("John")).order(last_name.asc()).limit(10)` would
     //! be `Limit<Order<FindBy<users, first_name, &str>, Asc<last_name>>>`
+    use super::query_builder::locking_clause as lock;
     use super::query_dsl::*;
     use super::query_dsl::methods::*;
     use super::query_source::joins;
@@ -223,22 +224,28 @@ pub mod helper_types {
     pub type FindBy<Source, Column, Value> = Filter<Source, Eq<Column, Value>>;
 
     /// Represents the return type of `.for_update()`
+    #[cfg(feature = "with-deprecated")]
+    #[allow(deprecated)]
     pub type ForUpdate<Source> = <Source as ForUpdateDsl>::Output;
 
+    /// Represents the return type of `.for_update()`
+    #[cfg(not(feature = "with-deprecated"))]
+    pub type ForUpdate<Source> = <Source as LockingDsl<lock::ForUpdate>>::Output;
+
     /// Represents the return type of `.for_no_key_update()`
-    pub type ForNoKeyUpdate<Source> = <Source as ForNoKeyUpdateDsl>::Output;
+    pub type ForNoKeyUpdate<Source> = <Source as LockingDsl<lock::ForNoKeyUpdate>>::Output;
 
     /// Represents the return type of `.for_share()`
-    pub type ForShare<Source> = <Source as ForShareDsl>::Output;
+    pub type ForShare<Source> = <Source as LockingDsl<lock::ForShare>>::Output;
 
     /// Represents the return type of `.for_key_share()`
-    pub type ForKeyShare<Source> = <Source as ForKeyShareDsl>::Output;
+    pub type ForKeyShare<Source> = <Source as LockingDsl<lock::ForKeyShare>>::Output;
 
     /// Represents the return type of `.skip_locked()`
-    pub type SkipLocked<Source> = <Source as SkipLockedDsl>::Output;
+    pub type SkipLocked<Source> = <Source as ModifyLockDsl<lock::SkipLocked>>::Output;
 
     /// Represents the return type of `.no_wait()`
-    pub type NoWait<Source> = <Source as NoWaitDsl>::Output;
+    pub type NoWait<Source> = <Source as ModifyLockDsl<lock::NoWait>>::Output;
 
     /// Represents the return type of `.find(pk)`
     pub type Find<Source, PK> = <Source as FindDsl<PK>>::Output;

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -288,124 +288,22 @@ where
     }
 }
 
-impl<F, S, W, O, L, Of> ForUpdateDsl for SelectStatement<F, S, NoDistinctClause, W, O, L, Of> {
-    type Output = SelectStatement<
-        F,
-        S,
-        NoDistinctClause,
-        W,
-        O,
-        L,
-        Of,
-        NoGroupByClause,
-        LockingClause<ForUpdate, NoModifier>,
-    >;
-
-    fn for_update(self) -> Self::Output {
-        SelectStatement::new(
-            self.select,
-            self.from,
-            self.distinct,
-            self.where_clause,
-            self.order,
-            self.limit,
-            self.offset,
-            self.group_by,
-            LockingClause::new(ForUpdate, NoModifier),
-        )
-    }
-}
-
-impl<F, S, W, O, L, Of> ForNoKeyUpdateDsl for SelectStatement<F, S, NoDistinctClause, W, O, L, Of> {
-    type Output = SelectStatement<
-        F,
-        S,
-        NoDistinctClause,
-        W,
-        O,
-        L,
-        Of,
-        NoGroupByClause,
-        LockingClause<ForNoKeyUpdate, NoModifier>,
-    >;
-
-    fn for_no_key_update(self) -> Self::Output {
-        SelectStatement::new(
-            self.select,
-            self.from,
-            self.distinct,
-            self.where_clause,
-            self.order,
-            self.limit,
-            self.offset,
-            self.group_by,
-            LockingClause::new(ForNoKeyUpdate, NoModifier),
-        )
-    }
-}
-
-impl<F, S, W, O, L, Of> ForShareDsl for SelectStatement<F, S, NoDistinctClause, W, O, L, Of> {
-    type Output = SelectStatement<
-        F,
-        S,
-        NoDistinctClause,
-        W,
-        O,
-        L,
-        Of,
-        NoGroupByClause,
-        LockingClause<ForShare, NoModifier>,
-    >;
-
-    fn for_share(self) -> Self::Output {
-        SelectStatement::new(
-            self.select,
-            self.from,
-            self.distinct,
-            self.where_clause,
-            self.order,
-            self.limit,
-            self.offset,
-            self.group_by,
-            LockingClause::new(ForShare, NoModifier),
-        )
-    }
-}
-
-impl<F, S, W, O, L, Of> ForKeyShareDsl for SelectStatement<F, S, NoDistinctClause, W, O, L, Of> {
-    type Output = SelectStatement<
-        F,
-        S,
-        NoDistinctClause,
-        W,
-        O,
-        L,
-        Of,
-        NoGroupByClause,
-        LockingClause<ForKeyShare, NoModifier>,
-    >;
-
-    fn for_key_share(self) -> Self::Output {
-        SelectStatement::new(
-            self.select,
-            self.from,
-            self.distinct,
-            self.where_clause,
-            self.order,
-            self.limit,
-            self.offset,
-            self.group_by,
-            LockingClause::new(ForKeyShare, NoModifier),
-        )
-    }
-}
-
-impl<F, S, D, W, O, L, Of, G, LM> SkipLockedDsl
-    for SelectStatement<F, S, D, W, O, L, Of, G, LockingClause<LM, NoModifier>>
+impl<F, S, W, O, L, Of, Lock> LockingDsl<Lock>
+    for SelectStatement<F, S, NoDistinctClause, W, O, L, Of>
 {
-    type Output = SelectStatement<F, S, D, W, O, L, Of, G, LockingClause<LM, SkipLocked>>;
+    type Output = SelectStatement<
+        F,
+        S,
+        NoDistinctClause,
+        W,
+        O,
+        L,
+        Of,
+        NoGroupByClause,
+        LockingClause<Lock, NoModifier>,
+    >;
 
-    fn skip_locked(self) -> Self::Output {
+    fn with_lock(self, lock: Lock) -> Self::Output {
         SelectStatement::new(
             self.select,
             self.from,
@@ -415,17 +313,17 @@ impl<F, S, D, W, O, L, Of, G, LM> SkipLockedDsl
             self.limit,
             self.offset,
             self.group_by,
-            LockingClause::new(self.locking.lock_mode, SkipLocked),
+            LockingClause::new(lock, NoModifier),
         )
     }
 }
 
-impl<F, S, D, W, O, L, Of, G, LM> NoWaitDsl
-    for SelectStatement<F, S, D, W, O, L, Of, G, LockingClause<LM, NoModifier>>
+impl<F, S, D, W, O, L, Of, G, LC, LM, Modifier> ModifyLockDsl<Modifier>
+    for SelectStatement<F, S, D, W, O, L, Of, G, LockingClause<LC, LM>>
 {
-    type Output = SelectStatement<F, S, D, W, O, L, Of, G, LockingClause<LM, NoWait>>;
+    type Output = SelectStatement<F, S, D, W, O, L, Of, G, LockingClause<LC, Modifier>>;
 
-    fn no_wait(self) -> Self::Output {
+    fn modify_lock(self, modifier: Modifier) -> Self::Output {
         SelectStatement::new(
             self.select,
             self.from,
@@ -435,7 +333,7 @@ impl<F, S, D, W, O, L, Of, G, LM> NoWaitDsl
             self.limit,
             self.offset,
             self.group_by,
-            LockingClause::new(self.locking.lock_mode, NoWait),
+            LockingClause::new(self.locking.lock_mode, modifier),
         )
     }
 }

--- a/diesel/src/query_dsl/locking_dsl.rs
+++ b/diesel/src/query_dsl/locking_dsl.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "with-deprecated")]
+use query_builder::locking_clause::ForUpdate;
 use query_builder::AsQuery;
 use query_source::Table;
 
@@ -8,6 +10,8 @@ use query_source::Table;
 /// to call `for_update` from generic code.
 ///
 /// [`QueryDsl`]: ../trait.QueryDsl.html
+#[cfg(feature = "with-deprecated")]
+#[deprecated(since = "1.3.0", note = "use `LockingDsl<ForUpdate>` instead")]
 pub trait ForUpdateDsl {
     /// The type returned by `for_update`. See [`dsl::ForUpdate`] for
     /// convenient access to this type.
@@ -19,140 +23,63 @@ pub trait ForUpdateDsl {
     fn for_update(self) -> Self::Output;
 }
 
+#[cfg(feature = "with-deprecated")]
+#[allow(deprecated)]
 impl<T> ForUpdateDsl for T
 where
-    T: Table + AsQuery,
-    T::Query: ForUpdateDsl,
+    T: LockingDsl<ForUpdate>,
 {
-    type Output = <T::Query as ForUpdateDsl>::Output;
+    type Output = <T as LockingDsl<ForUpdate>>::Output;
 
     fn for_update(self) -> Self::Output {
-        self.as_query().for_update()
+        self.with_lock(ForUpdate)
     }
 }
 
-/// The `for_no_key_update` method
+/// Methods related to locking select statements
 ///
 /// This trait should not be relied on directly by most apps. Its behavior is
 /// provided by [`QueryDsl`]. However, you may need a where clause on this trait
-/// to call `for_no_key_update` from generic code.
+/// to call `for_update` from generic code.
 ///
 /// [`QueryDsl`]: ../trait.QueryDsl.html
-pub trait ForNoKeyUpdateDsl {
-    /// The type returned by `for_no_key_update`. See [`dsl::ForNoKeyUpdate`] for
+pub trait LockingDsl<Lock> {
+    /// The type returned by `set_lock`. See [`dsl::ForUpdate`] and friends for
     /// convenient access to this type.
     ///
-    /// [`dsl::ForNoKeyUpdate`]: ../../dsl/type.ForNoKeyUpdate.html
+    /// [`dsl::ForUpdate`]: ../../dsl/type.ForUpdate.html
     type Output;
 
     /// See the trait level documentation
-    fn for_no_key_update(self) -> Self::Output;
+    fn with_lock(self, lock: Lock) -> Self::Output;
 }
 
-impl<T> ForNoKeyUpdateDsl for T
+impl<T, Lock> LockingDsl<Lock> for T
 where
     T: Table + AsQuery,
-    T::Query: ForNoKeyUpdateDsl,
+    T::Query: LockingDsl<Lock>,
 {
-    type Output = <T::Query as ForNoKeyUpdateDsl>::Output;
+    type Output = <T::Query as LockingDsl<Lock>>::Output;
 
-    fn for_no_key_update(self) -> Self::Output {
-        self.as_query().for_no_key_update()
+    fn with_lock(self, lock: Lock) -> Self::Output {
+        self.as_query().with_lock(lock)
     }
 }
 
-/// The `for_share` method
-///
-/// This trait should not be relied on directly by most apps. Its behavior is
-/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
-/// to call `for_share` from generic code.
-///
-/// [`QueryDsl`]: ../trait.QueryDsl.html
-pub trait ForShareDsl {
-    /// The type returned by `for_share`. See [`dsl::ForShare`] for
-    /// convenient access to this type.
-    ///
-    /// [`dsl::ForShare`]: ../../dsl/type.ForShare.html
-    type Output;
-
-    /// See the trait level documentation
-    fn for_share(self) -> Self::Output;
-}
-
-impl<T> ForShareDsl for T
-where
-    T: Table + AsQuery,
-    T::Query: ForShareDsl,
-{
-    type Output = <T::Query as ForShareDsl>::Output;
-
-    fn for_share(self) -> Self::Output {
-        self.as_query().for_share()
-    }
-}
-
-/// The `for_key_share` method
-///
-/// This trait should not be relied on directly by most apps. Its behavior is
-/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
-/// to call `for_key_share` from generic code.
-///
-/// [`QueryDsl`]: ../trait.QueryDsl.html
-pub trait ForKeyShareDsl {
-    /// The type returned by `for_key_share`. See [`dsl::ForKeyShare`] for
-    /// convenient access to this type.
-    ///
-    /// [`dsl::ForKeyShare`]: ../../dsl/type.ForKeyShare.html
-    type Output;
-
-    /// See the trait level documentation
-    fn for_key_share(self) -> Self::Output;
-}
-
-impl<T> ForKeyShareDsl for T
-where
-    T: Table + AsQuery,
-    T::Query: ForKeyShareDsl,
-{
-    type Output = <T::Query as ForKeyShareDsl>::Output;
-
-    fn for_key_share(self) -> Self::Output {
-        self.as_query().for_key_share()
-    }
-}
-
-/// The `skip_locked` method
+/// Methods related to modifiers on locking select statements
 ///
 /// This trait should not be relied on directly by most apps. Its behavior is
 /// provided by [`QueryDsl`]. However, you may need a where clause on this trait
 /// to call `skip_locked` from generic code.
 ///
 /// [`QueryDsl`]: ../trait.QueryDsl.html
-pub trait SkipLockedDsl {
-    /// The type returned by `skip_locked`. See [`dsl::SkipLocked`] for
-    /// convenient access to this type.
+pub trait ModifyLockDsl<Modifier> {
+    /// The type returned by `modify_lock`. See [`dsl::SkipLocked`] and friends
+    /// for convenient access to this type.
     ///
     /// [`dsl::SkipLocked`]: ../../dsl/type.SkipLocked.html
     type Output;
 
     /// See the trait level documentation
-    fn skip_locked(self) -> Self::Output;
-}
-
-/// The `no_wait` method
-///
-/// This trait should not be relied on directly by most apps. Its behavior is
-/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
-/// to call `no_wait` from generic code.
-///
-/// [`QueryDsl`]: ../trait.QueryDsl.html
-pub trait NoWaitDsl {
-    /// The type returned by `no_wait`. See [`dsl::NoWait`] for
-    /// convenient access to this type.
-    ///
-    /// [`dsl::NoWait`]: ../../dsl/type.NoWait.html
-    type Output;
-
-    /// See the trait level documentation
-    fn no_wait(self) -> Self::Output;
+    fn modify_lock(self, modifier: Modifier) -> Self::Output;
 }


### PR DESCRIPTION
The public API for these features remains the same, but we don't need
this many traits to support it. Similar to joins, we can represent this
with a single trait that has many methods accessing it.

Since `ForUpdateDsl` is part of the public API, we cannot directly
remove it.