### PR TITLE
Don't wrap `sqlite::RawConnection` in an Rc

### DIFF
--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -9,7 +9,6 @@ mod sqlite_value;
 pub use self::sqlite_value::SqliteValue;
 
 use std::os::raw as libc;
-use std::rc::Rc;
 
 use connection::*;
 use deserialize::{Queryable, QueryableByName};
@@ -27,7 +26,7 @@ use sqlite::Sqlite;
 #[allow(missing_debug_implementations)]
 pub struct SqliteConnection {
     statement_cache: StatementCache<Sqlite, Statement>,
-    raw_connection: Rc<RawConnection>,
+    raw_connection: RawConnection,
     transaction_manager: AnsiTransactionManager,
 }
 
@@ -49,7 +48,7 @@ impl Connection for SqliteConnection {
     fn establish(database_url: &str) -> ConnectionResult<Self> {
         RawConnection::establish(database_url).map(|conn| SqliteConnection {
             statement_cache: StatementCache::new(),
-            raw_connection: Rc::new(conn),
+            raw_connection: conn,
             transaction_manager: AnsiTransactionManager::new(),
         })
     }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -62,16 +62,6 @@ impl RawConnection {
     pub fn rows_affected_by_last_query(&self) -> usize {
         unsafe { ffi::sqlite3_changes(self.internal_connection.as_ptr()) as usize }
     }
-
-    pub fn last_error_message(&self) -> String {
-        let c_str =
-            unsafe { CStr::from_ptr(ffi::sqlite3_errmsg(self.internal_connection.as_ptr())) };
-        c_str.to_string_lossy().into_owned()
-    }
-
-    pub fn last_error_code(&self) -> libc::c_int {
-        unsafe { ffi::sqlite3_extended_errcode(self.internal_connection.as_ptr()) }
-    }
 }
 
 impl Drop for RawConnection {

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -4,7 +4,6 @@ use std::ffi::{CStr, CString};
 use std::io::{stderr, Write};
 use std::os::raw as libc;
 use std::ptr;
-use std::rc::Rc;
 
 use sqlite::SqliteType;
 use result::*;
@@ -14,13 +13,12 @@ use super::sqlite_value::SqliteRow;
 use util::NonNull;
 
 pub struct Statement {
-    raw_connection: Rc<RawConnection>,
     inner_statement: NonNull<ffi::sqlite3_stmt>,
     bind_index: libc::c_int,
 }
 
 impl Statement {
-    pub fn prepare(raw_connection: &Rc<RawConnection>, sql: &str) -> QueryResult<Self> {
+    pub fn prepare(raw_connection: &RawConnection, sql: &str) -> QueryResult<Self> {
         let mut stmt = ptr::null_mut();
         let mut unused_portion = ptr::null();
         let prepare_result = unsafe {
@@ -33,10 +31,11 @@ impl Statement {
             )
         };
 
-        ensure_sqlite_ok(prepare_result, raw_connection).map(|_| Statement {
-            raw_connection: Rc::clone(raw_connection),
-            inner_statement: unsafe { NonNull::new_unchecked(stmt) },
-            bind_index: 0,
+        ensure_sqlite_ok(prepare_result, raw_connection.internal_connection.as_ptr()).map(|_| {
+            Statement {
+                inner_statement: unsafe { NonNull::new_unchecked(stmt) },
+                bind_index: 0,
+            }
         })
     }
 
@@ -111,7 +110,7 @@ impl Statement {
             }
         };
 
-        ensure_sqlite_ok(result, &self.raw_connection)
+        ensure_sqlite_ok(result, self.raw_connection())
     }
 
     fn num_fields(&self) -> usize {
@@ -133,7 +132,7 @@ impl Statement {
         match unsafe { ffi::sqlite3_step(self.inner_statement.as_ptr()) } {
             ffi::SQLITE_DONE => Ok(None),
             ffi::SQLITE_ROW => Ok(Some(SqliteRow::new(self.inner_statement))),
-            _ => Err(last_error(&self.raw_connection)),
+            _ => Err(last_error(self.raw_connection())),
         }
     }
 
@@ -141,9 +140,13 @@ impl Statement {
         self.bind_index = 0;
         unsafe { ffi::sqlite3_reset(self.inner_statement.as_ptr()) };
     }
+
+    fn raw_connection(&self) -> *mut ffi::sqlite3 {
+        unsafe { ffi::sqlite3_db_handle(self.inner_statement.as_ptr()) }
+    }
 }
 
-fn ensure_sqlite_ok(code: libc::c_int, raw_connection: &RawConnection) -> QueryResult<()> {
+fn ensure_sqlite_ok(code: libc::c_int, raw_connection: *mut ffi::sqlite3) -> QueryResult<()> {
     if code == ffi::SQLITE_OK {
         Ok(())
     } else {
@@ -151,10 +154,10 @@ fn ensure_sqlite_ok(code: libc::c_int, raw_connection: &RawConnection) -> QueryR
     }
 }
 
-fn last_error(raw_connection: &RawConnection) -> Error {
-    let error_message = raw_connection.last_error_message();
+fn last_error(raw_connection: *mut ffi::sqlite3) -> Error {
+    let error_message = last_error_message(raw_connection);
     let error_information = Box::new(error_message);
-    let error_kind = match raw_connection.last_error_code() {
+    let error_kind = match last_error_code(raw_connection) {
         ffi::SQLITE_CONSTRAINT_UNIQUE | ffi::SQLITE_CONSTRAINT_PRIMARYKEY => {
             DatabaseErrorKind::UniqueViolation
         }
@@ -164,12 +167,21 @@ fn last_error(raw_connection: &RawConnection) -> Error {
     DatabaseError(error_kind, error_information)
 }
 
+fn last_error_message(conn: *mut ffi::sqlite3) -> String {
+    let c_str = unsafe { CStr::from_ptr(ffi::sqlite3_errmsg(conn)) };
+    c_str.to_string_lossy().into_owned()
+}
+
+fn last_error_code(conn: *mut ffi::sqlite3) -> libc::c_int {
+    unsafe { ffi::sqlite3_extended_errcode(conn) }
+}
+
 impl Drop for Statement {
     fn drop(&mut self) {
         use std::thread::panicking;
 
         let finalize_result = unsafe { ffi::sqlite3_finalize(self.inner_statement.as_ptr()) };
-        if let Err(e) = ensure_sqlite_ok(finalize_result, &self.raw_connection) {
+        if let Err(e) = ensure_sqlite_ok(finalize_result, self.raw_connection()) {
             if panicking() {
                 write!(
                     stderr(),


### PR DESCRIPTION
The reason we originally did the Rc wrapping was to ensure that the
prepared statements were finalized before the connection was closed. If
we don't finalize all prepared statements before closing the connection,
attempting to close the connection will fail, and we will panic.

At the time this code was originally written, the drop order of struct
fields was considered an implementation detail of Rust. However, that
was stabilized in [RFC #1857] last year, so we no longer need to hold an
Rc for that reason. We do now use the DB connection to provide better
error messages, but we can get that from the statement object quite
easily.

[RFC #1857]: https://github.com/rust-lang/rfcs/blob/master/text/1857-stabilize-drop-order.md