### PR TITLE
Support custom functions on SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added `sqlite-bundled` feature to `diesel_cli` to make installing on
   some platforms easier.
 
+* Custom SQL functions can now be used with SQLite. See [the
+  docs][sql-function-sqlite-1-3-0] for details.
+
+[sql-function-sqlite-1-3-0]: http://docs.diesel.rs/diesel/macro.sql_function.html#use-with-sqlite
+
 ### Changed
 
 * `sql_function!` has been redesigned. The syntax is now `sql_function!(fn

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -1,0 +1,73 @@
+extern crate libsqlite3_sys as ffi;
+
+use deserialize::{FromSqlRow, Queryable};
+use result::{DatabaseErrorKind, Error, QueryResult};
+use row::Row;
+use serialize::{IsNull, Output, ToSql};
+use sql_types::HasSqlType;
+use super::raw::RawConnection;
+use super::serialized_value::SerializedValue;
+use super::{Sqlite, SqliteValue};
+
+pub fn register<ArgsSqlType, RetSqlType, Args, Ret, F>(
+    conn: &RawConnection,
+    fn_name: &str,
+    deterministic: bool,
+    mut f: F,
+) -> QueryResult<()>
+where
+    F: FnMut(Args) -> Ret + Send + 'static,
+    Args: Queryable<ArgsSqlType, Sqlite>,
+    Ret: ToSql<RetSqlType, Sqlite>,
+    Sqlite: HasSqlType<RetSqlType>,
+{
+    let fields_needed = Args::Row::FIELDS_NEEDED;
+    if fields_needed > 127 {
+        return Err(Error::DatabaseError(
+            DatabaseErrorKind::UnableToSendCommand,
+            Box::new("SQLite functions cannot take more than 127 parameters".to_string()),
+        ));
+    }
+
+    conn.register_sql_function(fn_name, fields_needed, deterministic, move |args| {
+        let mut row = FunctionRow { args };
+        let args_row = Args::Row::build_from_row(&mut row).map_err(Error::DeserializationError)?;
+        let args = Args::build(args_row);
+
+        let result = f(args);
+
+        let mut buf = Output::new(Vec::new(), &());
+        let is_null = result.to_sql(&mut buf).map_err(Error::SerializationError)?;
+
+        let bytes = if let IsNull::Yes = is_null {
+            None
+        } else {
+            Some(buf.into_inner())
+        };
+
+        Ok(SerializedValue {
+            ty: Sqlite::metadata(&()),
+            data: bytes,
+        })
+    })?;
+    Ok(())
+}
+
+struct FunctionRow<'a> {
+    args: &'a [*mut ffi::sqlite3_value],
+}
+
+impl<'a> Row<Sqlite> for FunctionRow<'a> {
+    fn take(&mut self) -> Option<&SqliteValue> {
+        self.args.split_first().and_then(|(&first, rest)| {
+            self.args = rest;
+            unsafe { SqliteValue::new(first) }
+        })
+    }
+
+    fn next_is_null(&self, count: usize) -> bool {
+        self.args[..count]
+            .iter()
+            .all(|&p| unsafe { SqliteValue::new(p) }.is_none())
+    }
+}

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -319,12 +319,9 @@ mod tests {
     #[test]
     fn register_multiarg_function() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
-        my_add::register_impl(&connection, |x: i32, y: i32| {
-            x + y
-        }).unwrap();
+        my_add::register_impl(&connection, |x: i32, y: i32| x + y).unwrap();
 
-        let added = ::select(my_add(1, 2))
-            .get_result::<i32>(&connection);
+        let added = ::select(my_add(1, 2)).get_result::<i32>(&connection);
         assert_eq!(Ok(3), added);
     }
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -2,6 +2,7 @@ extern crate libsqlite3_sys as ffi;
 
 #[doc(hidden)]
 pub mod raw;
+mod serialized_value;
 mod stmt;
 mod statement_iterator;
 mod sqlite_value;

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1,5 +1,6 @@
 extern crate libsqlite3_sys as ffi;
 
+mod functions;
 #[doc(hidden)]
 pub mod raw;
 mod serialized_value;
@@ -19,6 +20,7 @@ use result::*;
 use self::raw::RawConnection;
 use self::statement_iterator::*;
 use self::stmt::{Statement, StatementUse};
+use serialize::ToSql;
 use sql_types::HasSqlType;
 use sqlite::Sqlite;
 
@@ -209,6 +211,22 @@ impl SqliteConnection {
             Statement::prepare(&self.raw_connection, sql)
         })
     }
+
+    #[doc(hidden)]
+    pub fn register_sql_function<ArgsSqlType, RetSqlType, Args, Ret, F>(
+        &self,
+        fn_name: &str,
+        deterministic: bool,
+        f: F,
+    ) -> QueryResult<()>
+    where
+        F: FnMut(Args) -> Ret + Send + 'static,
+        Args: Queryable<ArgsSqlType, Sqlite>,
+        Ret: ToSql<RetSqlType, Sqlite>,
+        Sqlite: HasSqlType<RetSqlType>,
+    {
+        functions::register(&self.raw_connection, fn_name, deterministic, f)
+    }
 }
 
 fn error_message(err_code: libc::c_int) -> &'static str {
@@ -269,5 +287,60 @@ mod tests {
 
         assert_eq!(Ok(true), query.get_result(&connection));
         assert_eq!(1, connection.statement_cache.len());
+    }
+
+    use sql_types::Text;
+    sql_function!(fn fun_case(x: Text) -> Text);
+
+    #[test]
+    fn register_custom_function() {
+        let connection = SqliteConnection::establish(":memory:").unwrap();
+        fun_case::register_impl(&connection, |x: String| {
+            x.chars()
+                .enumerate()
+                .map(|(i, c)| {
+                    if i % 2 == 0 {
+                        c.to_lowercase().to_string()
+                    } else {
+                        c.to_uppercase().to_string()
+                    }
+                })
+                .collect::<String>()
+        }).unwrap();
+
+        let mapped_string = ::select(fun_case("foobar"))
+            .get_result::<String>(&connection)
+            .unwrap();
+        assert_eq!("fOoBaR", mapped_string);
+    }
+
+    sql_function!(fn my_add(x: Integer, y: Integer) -> Integer);
+
+    #[test]
+    fn register_multiarg_function() {
+        let connection = SqliteConnection::establish(":memory:").unwrap();
+        my_add::register_impl(&connection, |x: i32, y: i32| {
+            x + y
+        }).unwrap();
+
+        let added = ::select(my_add(1, 2))
+            .get_result::<i32>(&connection);
+        assert_eq!(Ok(3), added);
+    }
+
+    sql_function!(fn add_counter(x: Integer) -> Integer);
+
+    #[test]
+    fn register_nondeterministic_function() {
+        let connection = SqliteConnection::establish(":memory:").unwrap();
+        let mut y = 0;
+        add_counter::register_nondeterministic_impl(&connection, move |x: i32| {
+            y += 1;
+            x + y
+        }).unwrap();
+
+        let added = ::select((add_counter(1), add_counter(1), add_counter(1)))
+            .get_result::<(i32, i32, i32)>(&connection);
+        assert_eq!(Ok((2, 3, 4)), added);
     }
 }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -3,10 +3,11 @@ extern crate libsqlite3_sys as ffi;
 use std::ffi::{CStr, CString};
 use std::io::{stderr, Write};
 use std::os::raw as libc;
-use std::{ptr, str};
+use std::{ptr, slice, str};
 
 use result::*;
 use result::Error::DatabaseError;
+use super::serialized_value::SerializedValue;
 use util::NonNull;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
@@ -62,6 +63,48 @@ impl RawConnection {
     pub fn rows_affected_by_last_query(&self) -> usize {
         unsafe { ffi::sqlite3_changes(self.internal_connection.as_ptr()) as usize }
     }
+
+    pub fn register_sql_function<F>(
+        &self,
+        fn_name: &str,
+        num_args: usize,
+        deterministic: bool,
+        f: F,
+    ) -> QueryResult<()>
+    where
+        F: FnMut(&[*mut ffi::sqlite3_value]) -> QueryResult<SerializedValue> + Send + 'static,
+    {
+        let fn_name = CString::new(fn_name)?;
+        let mut flags = ffi::SQLITE_UTF8;
+        if deterministic {
+            flags |= ffi::SQLITE_DETERMINISTIC;
+        }
+        let callback_fn = Box::into_raw(Box::new(f));
+
+        let result = unsafe {
+            ffi::sqlite3_create_function_v2(
+                self.internal_connection.as_ptr(),
+                fn_name.as_ptr(),
+                num_args as _,
+                flags,
+                callback_fn as *mut _,
+                Some(run_custom_function::<F>),
+                None,
+                None,
+                Some(destroy_boxed_fn::<F>),
+            )
+        };
+
+        if result == ffi::SQLITE_OK {
+            Ok(())
+        } else {
+            let error_message = super::error_message(result);
+            Err(DatabaseError(
+                DatabaseErrorKind::__Unknown,
+                Box::new(error_message.to_string()),
+            ))
+        }
+    }
 }
 
 impl Drop for RawConnection {
@@ -91,4 +134,47 @@ fn convert_to_string_and_free(err_msg: *const libc::c_char) -> String {
     };
     unsafe { ffi::sqlite3_free(err_msg as *mut libc::c_void) };
     msg
+}
+
+#[allow(warnings)]
+extern "C" fn run_custom_function<F>(
+    ctx: *mut ffi::sqlite3_context,
+    num_args: libc::c_int,
+    value_ptr: *mut *mut ffi::sqlite3_value,
+) where
+    F: FnMut(&[*mut ffi::sqlite3_value]) -> QueryResult<SerializedValue> + Send + 'static,
+{
+    const NULL_DATA_ERR: &str = "An unknown error occurred. sqlite3_user_data returned a null pointer. This should never happen.";
+    unsafe {
+        let data_ptr = ffi::sqlite3_user_data(ctx);
+        let data_ptr = data_ptr as *mut F;
+        let f = match data_ptr.as_mut() {
+            Some(f) => f,
+            None => {
+                ffi::sqlite3_result_error(
+                    ctx,
+                    NULL_DATA_ERR.as_ptr() as *const _ as *const _,
+                    NULL_DATA_ERR.len() as _,
+                );
+                return;
+            }
+        };
+
+        let args = slice::from_raw_parts(value_ptr, num_args as _);
+        match f(args) {
+            Ok(value) => value.result_of(ctx),
+            Err(e) => {
+                let msg = e.to_string();
+                ffi::sqlite3_result_error(ctx, msg.as_ptr() as *const _, msg.len() as _);
+            }
+        }
+    }
+}
+
+extern "C" fn destroy_boxed_fn<F>(data: *mut libc::c_void)
+where
+    F: FnMut(&[*mut ffi::sqlite3_value]) -> QueryResult<SerializedValue> + Send + 'static,
+{
+    let ptr = data as *mut F;
+    unsafe { Box::from_raw(ptr) };
 }

--- a/diesel/src/sqlite/connection/serialized_value.rs
+++ b/diesel/src/sqlite/connection/serialized_value.rs
@@ -1,0 +1,81 @@
+extern crate libsqlite3_sys as ffi;
+
+use std::os::raw as libc;
+use std::ptr;
+
+use sqlite::SqliteType;
+use util::NonNull;
+
+pub struct SerializedValue {
+    pub ty: SqliteType,
+    pub data: Option<Vec<u8>>,
+}
+
+impl SerializedValue {
+    // We are always reading potentially misaligned pointers with
+    // `ptr::read_unaligned`
+    #[cfg_attr(feature = "clippy", allow(cast_ptr_alignment))]
+    pub(crate) fn bind_to(self, stmt: NonNull<ffi::sqlite3_stmt>, idx: libc::c_int) -> libc::c_int {
+        // This unsafe block assumes the following invariants:
+        //
+        // - `stmt` points to valid memory
+        // - If `self.ty` is anything other than `Binary` or `Text`, the appropriate
+        //   number of bytes were written to `value` for an integer of the
+        //   corresponding size.
+        unsafe {
+            match (self.ty, self.data) {
+                (_, None) => ffi::sqlite3_bind_null(stmt.as_ptr(), idx),
+                (SqliteType::Binary, Some(bytes)) => ffi::sqlite3_bind_blob(
+                    stmt.as_ptr(),
+                    idx,
+                    bytes.as_ptr() as *const libc::c_void,
+                    bytes.len() as libc::c_int,
+                    ffi::SQLITE_TRANSIENT(),
+                ),
+                (SqliteType::Text, Some(bytes)) => ffi::sqlite3_bind_text(
+                    stmt.as_ptr(),
+                    idx,
+                    bytes.as_ptr() as *const libc::c_char,
+                    bytes.len() as libc::c_int,
+                    ffi::SQLITE_TRANSIENT(),
+                ),
+                (SqliteType::Float, Some(bytes)) => {
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const f32);
+                    ffi::sqlite3_bind_double(
+                        stmt.as_ptr(),
+                        idx,
+                        libc::c_double::from(value),
+                    )
+                }
+                (SqliteType::Double, Some(bytes)) => {
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const f64);
+                    ffi::sqlite3_bind_double(
+                        stmt.as_ptr(),
+                        idx,
+                        value as libc::c_double,
+                    )
+                }
+                (SqliteType::SmallInt, Some(bytes)) => {
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const i16);
+                    ffi::sqlite3_bind_int(
+                        stmt.as_ptr(),
+                        idx,
+                        libc::c_int::from(value),
+                    )
+                }
+                (SqliteType::Integer, Some(bytes)) => {
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const i32);
+                    ffi::sqlite3_bind_int(
+                        stmt.as_ptr(),
+                        idx,
+                        value as libc::c_int,
+                    )
+                }
+                (SqliteType::Long, Some(bytes)) => {
+                    let value = ptr::read_unaligned(bytes.as_ptr() as *const i64);
+                    ffi::sqlite3_bind_int64(stmt.as_ptr(), idx, value)
+                }
+            }
+        }
+    }
+}

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -19,22 +19,20 @@ pub struct SqliteRow {
 }
 
 impl SqliteValue {
-    pub(crate) unsafe fn new<'a>(inner: *mut ffi::sqlite3_value) -> Option<&'a Self>  {
-        (inner as *const _ as *const Self).as_ref()
-            .and_then(|v| {
-                if v.is_null() {
-                    None
-                } else {
-                    Some(v)
-                }
-            })
+    pub(crate) unsafe fn new<'a>(inner: *mut ffi::sqlite3_value) -> Option<&'a Self> {
+        (inner as *const _ as *const Self).as_ref().and_then(|v| {
+            if v.is_null() {
+                None
+            } else {
+                Some(v)
+            }
+        })
     }
 
     pub fn read_text(&self) -> &str {
         unsafe {
             let ptr = ffi::sqlite3_value_text(self.value());
-            let len =
-                ffi::sqlite3_value_bytes(self.value());
+            let len = ffi::sqlite3_value_bytes(self.value());
             let bytes = slice::from_raw_parts(ptr as *const u8, len as usize);
             str::from_utf8_unchecked(bytes)
         }
@@ -43,34 +41,25 @@ impl SqliteValue {
     pub fn read_blob(&self) -> &[u8] {
         unsafe {
             let ptr = ffi::sqlite3_value_blob(self.value());
-            let len =
-                ffi::sqlite3_value_bytes(self.value());
+            let len = ffi::sqlite3_value_bytes(self.value());
             slice::from_raw_parts(ptr as *const u8, len as usize)
         }
     }
 
     pub fn read_integer(&self) -> i32 {
-        unsafe {
-            ffi::sqlite3_value_int(self.value()) as i32
-        }
+        unsafe { ffi::sqlite3_value_int(self.value()) as i32 }
     }
 
     pub fn read_long(&self) -> i64 {
-        unsafe {
-            ffi::sqlite3_value_int64(self.value()) as i64
-        }
+        unsafe { ffi::sqlite3_value_int64(self.value()) as i64 }
     }
 
     pub fn read_double(&self) -> f64 {
-        unsafe {
-            ffi::sqlite3_value_double(self.value()) as f64
-        }
+        unsafe { ffi::sqlite3_value_double(self.value()) as f64 }
     }
 
     pub fn is_null(&self) -> bool {
-        let tpe = unsafe {
-            ffi::sqlite3_value_type(self.value())
-        };
+        let tpe = unsafe { ffi::sqlite3_value_type(self.value()) };
         tpe == ffi::SQLITE_NULL
     }
 


### PR DESCRIPTION
When the sqlite feature is enabled, we add an additional function to the module generated by `sql_function!` called `register_impl` (we also have `register_nondeterministic_impl`, for nondeterminitstic functions). I've attempted to make it at least slightly difficult to register a nondeterministic function as deterministic by taking `Fn` instead of `FnMut`, but anything that's using internal mutability can still break this (and you can still call rand).

For now I've restricted the closure to be `'static`, which means that you can't, for example close over the connection. I'm not sure how I want to handle this yet, so I've just been as restrictive as possible. The more I think about this the more I expect this bound will just stick around forever, and we'll need a separate API to provide the connection if we want that. I don't think there's any use case that can't be made `'static` other than accessing the connection.

If we ever provide access to the connection in this API, se'll also need to change the prepared statement cache to handle concurrent access. Allowing access to the connection in one of these functions potentially breaks our invariant that prepared statements are always given exclusive access (we'd panic right now if you tried to run a cacheable query inside a SQL function). I think this will be easy to handle if/when we want to do so, we just need to change from `borrow_mut` to `try_borrow_mut`, and return a `CannotCache` newly prepared statement if we fail to borrow.

The implementation is a bit messy (due to the nature of how we handle serialization on SQLite), but I'm overall pretty happy with the API. It meets my main criteria that I was looking for:

- Gets the type information from `sql_function!`
- Works with closures
- Uses `ToSql` and `Queryable`, users don't have to care about the plumbing.
- Allows multiple arguments without manual tuple unpacking