### PR TITLE
Abstract away `Option` special handling while deriving `Associations`

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -329,7 +329,7 @@ use std::hash::Hash;
 
 use query_source::Table;
 
-pub use self::belongs_to::{BelongsTo, GroupedBy};
+pub use self::belongs_to::{BelongsTo, GroupedBy, ForeignKey};
 
 /// This trait indicates that a struct is associated with a single database table.
 ///

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -98,6 +98,14 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
                         Bound::new(self)
                     }
                 }
+
+                impl#impl_generics diesel::associations::ForeignKey<#sql_type> for #struct_ty {
+                    type KeyType = #struct_ty;
+
+                    fn key(&self) -> Option<&Self::KeyType> {
+                        Some(self)
+                    }
+                }
             )
         } else {
             tokens


### PR DESCRIPTION
This commit introduces a new trait that abstracts the way foreign keys
are handled. When deriving `Associations` we need a way to extract the
value that is used to compare the foreign key with the referenced
primary key. For not nullable foreign keys this is simply the key
itself, for nullable keys only the not null value, otherwise the key
is skipped. Currently this is handled by some special casing in
`diesel_derives`, after this commit the newly introduced trait will be
used.
There are two reasons for this change:

* This simplifies `diesel_derives`. (In detail it removes the error
  prone detection of the `std::Option` type. This could theoretical
  break if someone uses a other type named `Option` in foreign key
  position, because currently there is no way to detect the origin of some type in
  custom derives.)
* It adds a way for down stream crates to introduce `Option` like
  wrapper types on there own. Using this change it should be possible
  to create a foreign key type wrapper that allows to store the
  referenced values inline later.

This is a more general successor of #1598. 

I really want to have such a thing because otherwise it is not possible for downstream crates to add a new wrapper type that could be used in position of a foreign key and works with the provides derive for `Associations`. For downstream end user crates this may not be that tragic because as Sean pointed out in #1598 this could be worked around by manually implementing `BelongsTo`. For downstream crates that provides additional functionality for other users as library this may be a no go. Currently there are only two bad solutions for this problem: 
1. Provide a own custom derive that implements `BelongsTo` -> Bad because the user needs to remember which custom derive is used in which position. Also this may break anytime as soon as diesel changes the own custom derive.
2. Require the users of that library to manually implement `BelongsTo` for every struct they use the custom type. -> Much repetitive code, therefore the `derive` exists.

The general idea of this PR is to add a third option: Allow that library to `hook` into the custom derive by implementing a trait indicating how to get a foreign key value out of a specific type. As Sean noted in #1598 this is quite similar to use case of `BelongsTo` but works on a other level. `BelongsTo` is meant to define how to get a foreign key out of a "model" type, meaning a type that represents some database entry. `ForeignKey` on the other hand is meant to describe how to get a foreign key value out of some wrapper type, describing a single field of a model type. The easiest type this could be applied to is  `Option<T>`. 

The use case for a custom type that I've in my mind is the following: I want something that could store referenced parent items inside the child type. The mean motivation for this is that this greatly simplifies serialization to json/…. It is quite easy to write some type 
```
enum HasOne<F, I>{
    Id(F),
    Item(I)
}
```
that does exactly this. Implementing support for nearly all operations in diesel is quite easily possible. The only missing bit is that this type won't work with the current `Associations` derive because it would need a similar special casing like `Option<T>`. Because we couldn't add special cases for all possible existing types people will write it seems like a better option to remove the special casing in the custom derive and provide a abstraction point to do this in the type implementation.
