### PR TITLE
Implement `EqAll` for all supported tuple sizes

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -125,8 +125,7 @@ macro_rules! __diesel_column {
 /// ```
 ///
 /// You may also specify a primary key if it's called something other than `id`.
-/// Tables with no primary key, or a composite primary key containing more than 5
-/// columns are not supported.
+/// Tables with no primary key are not supported.
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;

--- a/diesel_cli/src/infer_schema_internals/inference.rs
+++ b/diesel_cli/src/infer_schema_internals/inference.rs
@@ -81,16 +81,6 @@ pub(crate) fn get_primary_keys(
              Table {} has no primary key",
             table.to_string()
         ).into())
-    } else if primary_keys.len() > 5 {
-        Err(format!(
-            "Diesel does not currently support tables with \
-             primary keys consisting of more than 5 columns. \
-             Table {} has {} columns in its primary key. \
-             Please open an issue and we will increase the \
-             limit.",
-            table.to_string(),
-            primary_keys.len()
-        ).into())
     } else {
         Ok(primary_keys)
     }


### PR DESCRIPTION
Hello,
I have a table like

```sql
create table abac_policy (
  namespace_id uuid not null,

  subject_namespace_id uuid not null,
  subject_key text not null,
  subject_value text not null,

  object_namespace_id uuid not null,
  object_key text not null,
  object_value text not null,

  action_namespace_id uuid not null,
  action_key text not null,
  action_value text not null,

  issued_at timestamp not null default now(),
  not_before timestamp,
  expired_at timestamp,

  foreign key (namespace_id) references namespace (id) on delete cascade,
  foreign key (subject_namespace_id) references namespace (id) on delete cascade,
  foreign key (object_namespace_id) references namespace (id) on delete cascade,
  foreign key (action_namespace_id) references namespace (id) on delete cascade,
  primary key (namespace_id, subject_namespace_id, subject_key, subject_value, object_namespace_id, object_key, object_value, action_namespace_id, action_key, action_value)
);
```

If you wouldn't mind I would like Diesel to support composite PKs with 10 columns.

This PR is WIP (I will squash commits in the end), opened it to give early feedback.

I am worried about `joinable!` was removed from `schema.rs`.
I guess it should not have happened, should it?
I guess it should have became
```rust
joinable!(abac_policy -> namespace (namespace_id, subject_namespace_id, object_namespace_id, action_namespace_id));
```

```diff
diff --git a/migrations/2018-04-16-123630_create_abac_policy/up.sql b/migrations/2018-04-16-123630_create_abac_policy/up.sql
index d38cf17..6014480 100644
--- a/migrations/2018-04-16-123630_create_abac_policy/up.sql
+++ b/migrations/2018-04-16-123630_create_abac_policy/up.sql
@@ -1,13 +1,21 @@
 create table abac_policy (
-  id uuid default uuid_generate_v4(),
   namespace_id uuid not null,
+  subject_namespace_id uuid not null,
+  subject_key text not null,
   subject_value text not null,
+  object_namespace_id uuid not null,
+  object_key text not null,
   object_value text not null,
+  action_namespace_id uuid not null,
+  action_key text not null,
   action_value text not null,
   issued_at timestamp not null default now(),
   not_before timestamp,
   expired_at timestamp,
 
   foreign key (namespace_id) references namespace (id) on delete cascade,
-  primary key (id)
+  foreign key (subject_namespace_id) references namespace (id) on delete cascade,
+  foreign key (object_namespace_id) references namespace (id) on delete cascade,
+  foreign key (action_namespace_id) references namespace (id) on delete cascade,
+  primary key (namespace_id, subject_namespace_id, subject_key, subject_value, object_namespace_id, object_key, object_value, action_namespace_id, action_key, action_value)
 );

diff --git src/schema.rs src/schema.rs
index 8707262..2ff1bc1 100644
--- src/schema.rs
+++ src/schema.rs
@@ -17,11 +17,16 @@ table! {
 }

 table! {
-    abac_policy (id) {
-        id -> Uuid,
+    abac_policy (namespace_id, subject_namespace_id, subject_key, subject_value, object_namespace_id, object_key, object_value, action_namespace_id, action_key, action_value) {
         namespace_id -> Uuid,
+        subject_namespace_id -> Uuid,
+        subject_key -> Text,
         subject_value -> Text,
+        object_namespace_id -> Uuid,
+        object_key -> Text,
         object_value -> Text,
+        action_namespace_id -> Uuid,
+        action_key -> Text,
         action_value -> Text,
         issued_at -> Timestamp,
         not_before -> Nullable<Timestamp>,
@@ -78,7 +83,6 @@ table! {

 joinable!(abac_action_attr -> namespace (namespace_id));
 joinable!(abac_object_attr -> namespace (namespace_id));
-joinable!(abac_policy -> namespace (namespace_id));
 joinable!(abac_subject_attr -> namespace (namespace_id));
 joinable!(identity -> namespace (provider));
 joinable!(namespace -> account (account_id));
```
