### PR TITLE
Automatically generate a schema file by default

### DIFF
--- a/diesel_cli/src/default_files/diesel.toml
+++ b/diesel_cli/src/default_files/diesel.toml
@@ -1,2 +1,5 @@
 # For documentation on how to configure this file,
 # see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/migration_list.rs
+++ b/diesel_cli/tests/migration_list.rs
@@ -16,7 +16,7 @@ fn migration_list_lists_pending_applied_migrations() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 

--- a/diesel_cli/tests/migration_redo.rs
+++ b/diesel_cli/tests/migration_redo.rs
@@ -5,7 +5,7 @@ fn migration_redo_runs_the_last_migration_down_and_up() {
     let p = project("migration_redo").folder("migrations").build();
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users (id INTEGER);",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY);",
         "DROP TABLE users;",
     );
 
@@ -34,7 +34,7 @@ fn migration_redo_respects_migration_dir_var() {
     p.create_migration_in_directory(
         "foo",
         "12345_create_users_table",
-        "CREATE TABLE users (id INTEGER);",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY);",
         "DROP TABLE users;",
     );
 
@@ -66,7 +66,7 @@ fn migration_redo_respects_migration_dir_env() {
     p.create_migration_in_directory(
         "bar",
         "12345_create_users_table",
-        "CREATE TABLE users (id INTEGER);",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY);",
         "DROP TABLE users;",
     );
 

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -13,7 +13,7 @@ fn migration_run_runs_pending_migrations() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -42,7 +42,7 @@ fn migration_run_inserts_run_on_timestamps() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -117,7 +117,7 @@ fn any_pending_migrations_works() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -136,7 +136,7 @@ fn any_pending_migrations_after_running() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -157,7 +157,7 @@ fn any_pending_migrations_after_running_and_creating() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -165,7 +165,7 @@ fn any_pending_migrations_after_running_and_creating() {
 
     p.create_migration(
         "123456_create_posts_table",
-        "CREATE TABLE posts ( id INTEGER )",
+        "CREATE TABLE posts (id INTEGER PRIMARY KEY)",
         "DROP TABLE posts",
     );
 
@@ -187,7 +187,7 @@ fn migration_run_runs_pending_migrations_custom_database_url_1() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -221,7 +221,7 @@ fn migration_run_runs_pending_migrations_custom_database_url_2() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -256,7 +256,7 @@ fn migration_run_runs_pending_migrations_custom_migration_dir_1() {
     p.create_migration_in_directory(
         "custom_migrations",
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -291,7 +291,7 @@ fn migration_run_runs_pending_migrations_custom_migration_dir_2() {
     p.create_migration_in_directory(
         "custom_migrations",
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 
@@ -358,7 +358,7 @@ fn migrations_can_be_run_with_no_config_file() {
 
     p.create_migration(
         "12345_create_users_table",
-        "CREATE TABLE users ( id INTEGER )",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         "DROP TABLE users",
     );
 


### PR DESCRIPTION
Since we're deprecating `infer_schema!`, we want to generate this file
by default. I think we should eventually change our behavior on tables
with no primary key to warn and skip instead of error, but I want to do
a bigger restructuring once we can get rid of `infer_schema!`.