### PR TITLE
Check if there is a newer version of diesel in the dependency graph.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ script:
 matrix:
   allow_failures:
     - rust: nightly
-    - rust: beta
   include:
-  - rust: nightly-2017-06-06
+  - rust: nightly-2017-08-31
     env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
     script:
     - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,15 @@ script:
 matrix:
   allow_failures:
     - rust: nightly
-  include:
-  - rust: nightly-2017-08-31
-    env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
-    script:
-    - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans)
-    - (cd diesel_cli && cargo rustc --no-default-features --features "lint sqlite postgres mysql" -- -Zno-trans)
-    - (cd diesel_codegen && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
-    - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
-    - (cd diesel_compile_tests && travis-cargo test)
+      #  include:
+      #  - rust: nightly-2017-08-31
+      #    env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
+      #    script:
+      #    - (cd diesel && cargo rustc --no-default-features --features "lint unstable sqlite postgres mysql extras" -- -Zno-trans)
+      #    - (cd diesel_cli && cargo rustc --no-default-features --features "lint sqlite postgres mysql" -- -Zno-trans)
+      #    - (cd diesel_codegen && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
+      #    - (cd diesel_infer_schema && cargo rustc --no-default-features --features "lint dotenv sqlite postgres mysql" -- -Zno-trans)
+      #    - (cd diesel_compile_tests && travis-cargo test)
 env:
   # TODO: why is there no database specified for Postgres?
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ after_success:
 branches:
   only:
     - master
+    - 0.16.x
     - ಠ_ಠ
 notifications:
   webhooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -992,4 +992,3 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 [0.15.0]: https://github.com/diesel-rs/diesel/compare/v0.14.1...v0.15.0
 [0.15.1]: https://github.com/diesel-rs/diesel/compare/v0.15.0...v0.15.1
 [0.15.2]: https://github.com/diesel-rs/diesel/compare/v0.15.1...v0.15.2
-[0.16.0]: https://github.com/diesel-rs/diesel/compare/v0.15.2...v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## [0.16.1] - 2018-05-27
+
+### Changed
+
+* Report an error if someone tries to use `diesel_codegen` with a newer version of diesel.
+  0.16.0 is the last version that is supported by `diesel_codegen`. See the changelog
+  of diesel 0.99 for details.
+
 ## [0.16.0] - 2017-08-24
 
 ### Added

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 [dependencies]
 byteorder = "1.0"
 chrono = { version = "0.4", optional = true }
-clippy = { optional = true, version = "=0.0.138" }
+clippy = { optional = true, version = "=0.0.155" }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.9.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -20,7 +20,7 @@
 //! // derive Identifiable.
 //! # #[macro_use] extern crate diesel;
 //! # #[macro_use] extern crate diesel_codegen;
-//! # include!("src/doctest_setup.rs");
+//! # include!("../doctest_setup.rs");
 //! use schema::{posts, users};
 //!
 //! #[derive(Identifiable, Queryable)]

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -44,7 +44,7 @@ pub trait Connection: SimpleConnection + Sized + Send {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// # table!(
     /// #    users(id) {
     /// #        id -> Integer,

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -14,7 +14,7 @@ use types::BigInt;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// # use diesel::expression::dsl::*;
 /// #
 /// # table! {
@@ -50,7 +50,7 @@ pub fn count<T: Expression>(t: T) -> Count<T> {
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// # use diesel::expression::dsl::*;
 /// #
 /// # table! {

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -14,7 +14,7 @@ use types::Bool;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -53,7 +53,7 @@ Foldable.
 
 ```rust
 # #[macro_use] extern crate diesel;
-# include!(\"src/doctest_setup.rs\");
+# include!(\"../../doctest_setup.rs\");
 # use diesel::expression::dsl::*;
 #
 # table! {
@@ -78,7 +78,7 @@ Foldable.
 
 ```rust
 # #[macro_use] extern crate diesel;
-# include!(\"src/doctest_setup.rs\");
+# include!(\"../../doctest_setup.rs\");
 # use diesel::expression::dsl::*;
 #
 # table! {

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -52,7 +52,7 @@ ordered.
 
 ```rust
 # #[macro_use] extern crate diesel;
-# include!(\"src/doctest_setup.rs\");
+# include!(\"../../doctest_setup.rs\");
 # use diesel::expression::dsl::*;
 #
 # table! {
@@ -77,7 +77,7 @@ ordered.
 
 ```rust
 # #[macro_use] extern crate diesel;
-# include!(\"src/doctest_setup.rs\");
+# include!(\"../../doctest_setup.rs\");
 # use diesel::expression::dsl::*;
 #
 # table! {

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -38,7 +38,7 @@ expression, and the return value will be an expression of type Date.
 ```ignore
 # #[macro_use] extern crate diesel;
 # extern crate chrono;
-# include!(\"src/doctest_setup.rs\");
+# include!(\"../../doctest_setup.rs\");
 # use diesel::expression::dsl::*;
 #
 # table! {

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -175,7 +175,7 @@ use query_builder::{QueryFragment, QueryId};
 /// # #[macro_use] extern crate diesel_codegen;
 /// # #[macro_use] extern crate diesel;
 /// # use diesel::types;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/expression/not.rs
+++ b/diesel/src/expression/not.rs
@@ -9,7 +9,7 @@ use types::Bool;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -135,7 +135,7 @@ macro_rules! __diesel_operator_to_sql {
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -41,7 +41,7 @@ impl<ST> SqlLiteral<ST> {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -72,7 +72,7 @@ impl<ST> SqlLiteral<ST> {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -158,7 +158,7 @@ impl<ST> NonAggregate for SqlLiteral<ST> {
 /// # #[macro_use] extern crate diesel_codegen;
 /// use diesel::expression::sql;
 /// use diesel::types::{Bool, Integer, Text};
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// # table! {
 /// #   users {
 /// #       id -> Integer,

--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -9,7 +9,7 @@ use types::VarChar;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -10,7 +10,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -36,7 +36,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -65,7 +65,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -102,7 +102,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -149,7 +149,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -175,7 +175,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -201,7 +201,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -227,7 +227,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -275,7 +275,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -316,7 +316,7 @@ pub trait NullableExpressionMethods: Expression + Sized {
     /// ```no_run
     /// # #![allow(dead_code)]
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// # use self::diesel::types::*;
     /// #
     /// table! {

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -9,7 +9,7 @@ pub trait TextExpressionMethods: Expression<SqlType=Text> + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/macros/as_changeset.rs
+++ b/diesel/src/macros/as_changeset.rs
@@ -19,7 +19,7 @@
 /// # #[macro_use] extern crate diesel_codegen;
 /// # #[macro_use] extern crate diesel;
 /// # table! { users { id -> Integer, name -> VarChar, } }
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 ///
 /// #[derive(PartialEq, Debug, Queryable)]
 /// struct User {

--- a/diesel/src/macros/macros_from_codegen.rs
+++ b/diesel/src/macros/macros_from_codegen.rs
@@ -82,7 +82,7 @@ macro_rules! infer_table_from_schema {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_codegen;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// # table! {
 /// #   users {
 /// #       id -> Integer,

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -50,7 +50,7 @@ impl RawConnection {
                 user.as_ptr(),
                 password.map(CStr::as_ptr).unwrap_or_else(|| ptr::null_mut()),
                 database.map(CStr::as_ptr).unwrap_or_else(|| ptr::null_mut()),
-                port.unwrap_or(0) as u32,
+                u32::from(port.unwrap_or(0)),
                 ptr::null_mut(),
                 0,
             )

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -69,7 +69,7 @@ impl ToSql<Timestamp, Mysql> for NaiveDateTime {
         mysql_time.hour = self.hour() as libc::c_uint;
         mysql_time.minute = self.minute() as libc::c_uint;
         mysql_time.second = self.second() as libc::c_uint;
-        mysql_time.second_part = self.timestamp_subsec_micros() as libc::c_ulong;
+        mysql_time.second_part = libc::c_ulong::from(self.timestamp_subsec_micros());
 
         <ffi::MYSQL_TIME as ToSql<Timestamp, Mysql>>::to_sql(&mysql_time, out)
     }

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -14,7 +14,7 @@ use types::Array;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../../doctest_setup.rs");
 /// # use diesel::expression::dsl::*;
 /// #
 /// # table! {
@@ -50,7 +50,7 @@ pub fn any<ST, T>(vals: T) -> Any<T::Expression> where
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../../doctest_setup.rs");
 /// # use diesel::expression::dsl::*;
 /// #
 /// # table! {

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -11,7 +11,7 @@ pub trait PgExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -44,7 +44,7 @@ pub trait PgExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -98,7 +98,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     posts {
@@ -154,7 +154,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     posts {
@@ -206,7 +206,7 @@ pub trait ArrayExpressionMethods<ST>: Expression<SqlType=Array<ST>> + Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     posts {
@@ -268,7 +268,7 @@ pub trait SortExpressionMethods : Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -311,7 +311,7 @@ pub trait SortExpressionMethods : Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -12,7 +12,7 @@ use data_types::PgInterval;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../../../doctest_setup.rs");
 /// # use diesel::expression::dsl::*;
 /// #
 /// # table! {
@@ -103,7 +103,7 @@ pub trait MicroIntervalDsl: Sized + Mul<Self, Output=Self> {
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../../../doctest_setup.rs");
 /// # use diesel::expression::dsl::*;
 /// #
 /// # table! {
@@ -191,7 +191,7 @@ impl MicroIntervalDsl for i64 {
     }
 
     fn times(self, x: i32) -> i64 {
-        self * x as i64
+        self * i64::from(x)
     }
 }
 
@@ -201,7 +201,7 @@ impl MicroIntervalDsl for f64 {
     }
 
     fn times(self, x: i32) -> f64 {
-        self * x as f64
+        self * f64::from(x)
     }
 }
 
@@ -235,7 +235,7 @@ impl DayAndMonthIntervalDsl for f64 {
     }
 
     fn times(self, x: i32) -> f64 {
-        self * x as f64
+        self * f64::from(x)
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -111,7 +111,7 @@ impl ToSql<Date, Pg> for NaiveDate {
 impl FromSql<Date, Pg> for NaiveDate {
     fn from_sql(bytes: Option<&[u8]>) -> Result<Self, Box<Error+Send+Sync>> {
         let PgDate(offset) = try!(FromSql::<Date, Pg>::from_sql(bytes));
-        match pg_epoch_date().checked_add_signed(Duration::days(offset as i64)) {
+        match pg_epoch_date().checked_add_signed(Duration::days(i64::from(offset))) {
             Some(date) => Ok(date),
             None => {
                 let error_message = format!("Chrono can only represent dates up to {:?}",

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -11,7 +11,7 @@ use types::{self, ToSql, ToSqlOutput, FromSql, IsNull, Timestamp};
 expression_impls!(Timestamp -> Timespec);
 queryable_impls!(Timestamp -> Timespec);
 
-const TIME_SEC_CONV: i64 = 946684800;
+const TIME_SEC_CONV: i64 = 946_684_800;
 
 impl ToSql<types::Timestamp, Pg> for Timespec {
     fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, Pg>) -> Result<IsNull, Box<Error+Send+Sync>> {

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -9,7 +9,7 @@ expression_impls!(Timestamp -> SystemTime);
 queryable_impls!(Timestamp -> SystemTime);
 
 fn pg_epoch() -> SystemTime {
-    let thirty_years = Duration::from_secs(946684800);
+    let thirty_years = Duration::from_secs(946_684_800);
     UNIX_EPOCH + thirty_years
 }
 
@@ -56,7 +56,7 @@ fn usecs_to_duration(usecs_passed: u64) -> Duration {
 fn duration_to_usecs(duration: Duration) -> u64 {
     let seconds = duration.as_secs() * USEC_PER_SEC;
     let subseconds = duration.subsec_nanos() / NANO_PER_USEC;
-    seconds + subseconds as u64
+    seconds + u64::from(subseconds)
 }
 
 #[cfg(test)]

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -177,7 +177,7 @@ pub mod sql_types {
     /// extern crate serde_json;
     /// # #[macro_use] extern crate diesel_codegen;
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -252,7 +252,7 @@ pub mod sql_types {
     /// # #![allow(dead_code)]
     /// # #[macro_use] extern crate diesel_codegen;
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -323,7 +323,7 @@ pub mod sql_types {
     /// # #![allow(dead_code)]
     /// # #[macro_use] extern crate diesel_codegen;
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -395,7 +395,7 @@ pub mod sql_types {
     /// # #![allow(dead_code)]
     /// # #[macro_use] extern crate diesel_codegen;
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -465,7 +465,7 @@ pub mod sql_types {
     /// # #![allow(dead_code)]
     /// # #[macro_use] extern crate diesel_codegen;
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -25,7 +25,7 @@ mod bigdecimal {
 
         fn next(&mut self) -> Option<Self::Item> {
             self.0.take().map(|v| {
-                let (div, rem) = v.div_rem(&BigUint::from(10000u16));
+                let (div, rem) = v.div_rem(&BigUint::from(10_000u16));
                 if !div.is_zero() {
                     self.0 = Some(div);
                 }
@@ -109,7 +109,7 @@ mod bigdecimal {
                 result = result + BigUint::from(digit as u64);
             }
             // First digit got factor 10_000^(digits.len() - 1), but should get 10_000^weight
-            let correction_exp = 4 * ( (weight as i64) - count + 1);
+            let correction_exp = 4 * (i64::from(weight) - count + 1);
             // FIXME: `scale` allows to drop some insignificant figures, which is currently unimplemented.
             // This means that e.g. PostgreSQL 0.01 will be interpreted as 0.0100
             let result = BigDecimal::new(BigInt::from_biguint(sign, result), -correction_exp);

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -30,7 +30,7 @@ pub fn do_nothing() -> DoNothing {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_codegen;
-/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// # include!("on_conflict_docs_setup.rs");
 /// #
 /// # fn main() {
 /// #     use self::users::dsl::*;
@@ -58,7 +58,7 @@ pub fn do_nothing() -> DoNothing {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_codegen;
-/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// # include!("on_conflict_docs_setup.rs");
 /// #
 /// # fn main() {
 /// #     use self::users::dsl::*;
@@ -86,7 +86,7 @@ pub fn do_nothing() -> DoNothing {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_codegen;
-/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// # include!("on_conflict_docs_setup.rs");
 /// #
 /// # fn main() {
 /// #     use self::users::dsl::*;

--- a/diesel/src/pg/upsert/on_conflict_docs_setup.rs
+++ b/diesel/src/pg/upsert/on_conflict_docs_setup.rs
@@ -1,4 +1,4 @@
-include!("src/doctest_setup.rs");
+include!("../../doctest_setup.rs");
 
 table! {
     users {

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -13,7 +13,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+    /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
@@ -38,7 +38,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+    /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
@@ -59,7 +59,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+    /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
@@ -100,7 +100,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+    /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
     /// #     use self::users::dsl::*;
@@ -132,7 +132,7 @@ pub trait OnConflictExtension {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # #[macro_use] extern crate diesel_codegen;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -13,7 +13,7 @@ use result::QueryResult;
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_codegen;
-/// # include!("src/pg/upsert/on_conflict_docs_setup.rs");
+/// # include!("on_conflict_docs_setup.rs");
 /// #
 /// # fn main() {
 /// #     use self::users::dsl::*;

--- a/diesel/src/query_builder/delete_statement.rs
+++ b/diesel/src/query_builder/delete_statement.rs
@@ -70,7 +70,7 @@ impl<T, U> DeleteStatement<T, U, NoReturningClause> {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -12,7 +12,7 @@ use super::{IntoUpdateTarget, IncompleteUpdateStatement, IncompleteInsertStateme
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {
@@ -42,7 +42,7 @@ use super::{IntoUpdateTarget, IncompleteUpdateStatement, IncompleteInsertStateme
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {
@@ -86,7 +86,7 @@ pub fn update<T: IntoUpdateTarget>(source: T) -> IncompleteUpdateStatement<T::Ta
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {
@@ -114,7 +114,7 @@ pub fn update<T: IntoUpdateTarget>(source: T) -> IncompleteUpdateStatement<T::Ta
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {
@@ -149,7 +149,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {
@@ -188,7 +188,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/query_builder/insert_statement.rs
+++ b/diesel/src/query_builder/insert_statement.rs
@@ -149,7 +149,7 @@ impl<T, U, Op> InsertStatement<T, U, Op, NoReturningClause> {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {
@@ -221,7 +221,7 @@ impl<T, U, Op> BatchInsertStatement<T, U, Op> {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -163,7 +163,7 @@ impl<T: Query> AsQuery for T {
 /// ### Returning SQL from a count statement:
 ///
 /// ```rust
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # #[macro_use] extern crate diesel;
 /// # use diesel::*;

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -102,7 +102,7 @@ impl<T, U, V> UpdateStatement<T, U, V, NoReturningClause> {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -33,7 +33,7 @@ impl<'a, T, DB> InternalBoxedDsl<'a, DB> for T where
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {
@@ -70,7 +70,7 @@ impl<'a, T, DB> InternalBoxedDsl<'a, DB> for T where
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/query_dsl/count_dsl.rs
+++ b/diesel/src/query_dsl/count_dsl.rs
@@ -8,7 +8,7 @@ use super::SelectDsl;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -8,7 +8,7 @@ use query_source::Table;
 /// ```rust
 ///
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -11,7 +11,7 @@ use query_source::*;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {
@@ -54,7 +54,7 @@ impl<T, U, Predicate> FilterDsl<Predicate> for T where
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -116,7 +116,7 @@ pub trait JoinOnDsl: Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("src/doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// #
     /// # table! {
     /// #     users {

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -17,7 +17,7 @@ use query_source::Table;
 ///
 /// ```rust
 /// # #[macro_use] extern crate diesel;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -79,7 +79,7 @@ impl Statement {
                 ffi::sqlite3_bind_double(
                     self.inner_statement,
                     self.bind_index,
-                    value as libc::c_double,
+                    libc::c_double::from(value),
                 )
             }
             (SqliteType::Double, Some(bytes)) => {
@@ -95,7 +95,7 @@ impl Statement {
                 ffi::sqlite3_bind_int(
                     self.inner_statement,
                     self.bind_index,
-                    value as libc::c_int,
+                    libc::c_int::from(value),
                 )
             }
             (SqliteType::Integer, Some(bytes)) => {

--- a/diesel/src/sqlite/query_builder/functions.rs
+++ b/diesel/src/sqlite/query_builder/functions.rs
@@ -9,7 +9,7 @@ use super::nodes::Replace;
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_codegen;
-/// # include!("src/doctest_setup.rs");
+/// # include!("../../doctest_setup.rs");
 /// #
 /// # table! {
 /// #     users {

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -20,7 +20,7 @@ clap = "2.20.3"
 diesel = { version = "0.16.0", default-features = false }
 dotenv = ">=0.8, <0.11"
 diesel_infer_schema = "0.16.0"
-clippy = { optional = true, version = "=0.0.138" }
+clippy = { optional = true, version = "=0.0.155" }
 
 [dev-dependencies]
 difference = "1.0"

--- a/diesel_cli/tests/database_reset.rs
+++ b/diesel_cli/tests/database_reset.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "postgres")]
 extern crate url;
 
 use support::{database, project};

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -5,40 +5,45 @@ use std::path::Path;
 use support::{database, project};
 
 #[test]
+fn run_infer_schema_without_docs() {
+    test_print_schema("print_schema_simple_without_docs", vec![]);
+}
+
+#[test]
 fn run_infer_schema() {
-    test_print_schema("print_schema_simple", vec![]);
+    test_print_schema("print_schema_simple", vec!["--with-docs"]);
 }
 
 #[test]
 fn run_infer_schema_whitelist() {
-    test_print_schema("print_schema_whitelist", vec!["-w", "users1"]);
+    test_print_schema("print_schema_whitelist", vec!["--with-docs", "-w", "users1"]);
 }
 
 #[test]
 fn run_infer_schema_blacklist() {
-    test_print_schema("print_schema_blacklist", vec!["-b", "users1"]);
+    test_print_schema("print_schema_blacklist", vec!["--with-docs", "-b", "users1"]);
 }
 
 #[test]
 fn run_infer_schema_order() {
-    test_print_schema("print_schema_order", vec![]);
+    test_print_schema("print_schema_order", vec!["--with-docs"]);
 }
 
 #[test]
 fn run_infer_schema_compound_primary_key() {
-    test_print_schema("print_schema_compound_primary_key", vec![]);
+    test_print_schema("print_schema_compound_primary_key", vec!["--with-docs"]);
 }
 
 #[test]
 #[cfg(feature = "postgres")]
 fn print_schema_specifying_schema_name() {
-    test_print_schema("print_schema_specifying_schema_name", vec!["--schema", "custom_schema"])
+    test_print_schema("print_schema_specifying_schema_name", vec!["--with-docs", "--schema", "custom_schema"])
 }
 
 #[test]
 #[cfg(feature = "postgres")]
 fn print_schema_with_foreign_keys() {
-    test_print_schema("print_schema_with_foreign_keys", vec![]);
+    test_print_schema("print_schema_with_foreign_keys", vec!["--with-docs"]);
 }
 
 #[cfg(feature = "sqlite")]

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -54,9 +54,8 @@ const BACKEND: &str = "postgres";
 const BACKEND: &str = "mysql";
 
 fn test_print_schema(test_name: &str, args: Vec<&str>) {
-    let test_path = Path::new(file!())
-        .parent()
-        .unwrap()
+    let test_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
         .join("print_schema")
         .join(test_name)
         .join(BACKEND);

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -5,50 +5,40 @@ use std::path::Path;
 use support::{database, project};
 
 #[test]
-fn run_infer_schema_without_docs() {
-    test_print_schema("print_schema_simple_without_docs", vec![]);
-}
-
-#[test]
 fn run_infer_schema() {
-    test_print_schema("print_schema_simple", vec!["--with-docs"]);
+    test_print_schema("print_schema_simple", vec![]);
 }
 
 #[test]
 fn run_infer_schema_whitelist() {
-    test_print_schema("print_schema_whitelist", vec!["--with-docs", "-w", "users1"]);
+    test_print_schema("print_schema_whitelist", vec!["-w", "users1"]);
 }
 
 #[test]
 fn run_infer_schema_blacklist() {
-    test_print_schema("print_schema_blacklist", vec!["--with-docs", "-b", "users1"]);
+    test_print_schema("print_schema_blacklist", vec!["-b", "users1"]);
 }
 
 #[test]
 fn run_infer_schema_order() {
-    test_print_schema("print_schema_order", vec!["--with-docs"]);
+    test_print_schema("print_schema_order", vec![]);
 }
 
 #[test]
 fn run_infer_schema_compound_primary_key() {
-    test_print_schema("print_schema_compound_primary_key", vec!["--with-docs"]);
+    test_print_schema("print_schema_compound_primary_key", vec![]);
 }
 
 #[test]
 #[cfg(feature = "postgres")]
 fn print_schema_specifying_schema_name() {
-    test_print_schema("print_schema_specifying_schema_name", vec!["--with-docs", "--schema", "custom_schema"])
+    test_print_schema("print_schema_specifying_schema_name", vec!["--schema", "custom_schema"])
 }
 
 #[test]
 #[cfg(feature = "postgres")]
 fn print_schema_with_foreign_keys() {
-    test_print_schema("print_schema_with_foreign_keys", vec!["--with-docs"]);
-}
-
-#[test]
-fn print_schema_column_renaming() {
-    test_print_schema("print_schema_column_renaming", vec!["--with-docs"]);
+    test_print_schema("print_schema_with_foreign_keys", vec![]);
 }
 
 #[cfg(feature = "sqlite")]

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -1,4 +1,6 @@
+#[cfg(not(feature = "sqlite"))]
 extern crate url;
+#[cfg(not(feature = "sqlite"))]
 extern crate dotenv;
 
 use std::fs::{self, File};

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -17,6 +17,9 @@ dotenv = { version = ">=0.8, <0.11", optional = true, default-features = false }
 diesel = { version = "0.16.0", default-features = false }
 diesel_infer_schema = { version = "0.16.0", default-features = false, optional = true }
 clippy = { optional = true, version = "=0.0.138" }
+serde_json = "1"
+serde = "1"
+serde_derive = "1"
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_codegen/Cargo.toml
+++ b/diesel_codegen/Cargo.toml
@@ -17,9 +17,8 @@ dotenv = { version = ">=0.8, <0.11", optional = true, default-features = false }
 diesel = { version = "0.16.0", default-features = false }
 diesel_infer_schema = { version = "0.16.0", default-features = false, optional = true }
 clippy = { optional = true, version = "=0.0.138" }
-serde_json = "1"
-serde = "1"
-serde_derive = "1"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/diesel_codegen/src/check_version.rs
+++ b/diesel_codegen/src/check_version.rs
@@ -1,0 +1,42 @@
+
+use std::process::Command;
+
+#[derive(Deserialize)]
+struct Metadata {
+    packages: Vec<Package>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Package {
+    name: String,
+    version: String,
+}
+#[allow(warnings)]
+pub fn check_version() {
+    let contents = String::from_utf8(
+        Command::new("cargo")
+            .arg("metadata")
+            .output()
+            .unwrap()
+            .stdout,
+    ).unwrap();
+
+    let data: Metadata = ::serde_json::from_str(&contents).unwrap();
+
+    let diesel = data.packages
+        .into_iter()
+        .filter(|p| p.name == "diesel")
+        .collect::<Vec<_>>();
+    for d in diesel {
+        if d.version.starts_with("1.") || d.version.starts_with("0.99") {
+            panic!(
+                "diesel_codegen was deprecated and removed with\
+                 version 0.99. You are trying to use the old codegen with \
+                 diesel {}. See the Changelog \
+                 (https://github.com/diesel-rs/diesel/blob/master/CHANGELOG.md#changed-6)\
+                 for details.",
+                d.version
+            );
+        }
+    }
+}

--- a/diesel_codegen/src/check_version.rs
+++ b/diesel_codegen/src/check_version.rs
@@ -1,4 +1,3 @@
-
 use std::process::Command;
 
 #[derive(Deserialize)]
@@ -11,22 +10,23 @@ struct Package {
     name: String,
     version: String,
 }
+
 #[allow(warnings)]
-pub fn check_version() {
+pub fn check_version() -> Result<(), ()> {
     let contents = String::from_utf8(
         Command::new("cargo")
             .arg("metadata")
             .output()
-            .unwrap()
+            .map_err(|_| ())?
             .stdout,
-    ).unwrap();
+    ).map_err(|_| ())?;
 
-    let data: Metadata = ::serde_json::from_str(&contents).unwrap();
+    let data: Metadata = ::serde_json::from_str(&contents).map_err(|_| ())?;
 
     let diesel = data.packages
         .into_iter()
-        .filter(|p| p.name == "diesel")
-        .collect::<Vec<_>>();
+        .filter(|p| p.name == "diesel");
+
     for d in diesel {
         if d.version.starts_with("1.") || d.version.starts_with("0.99") {
             panic!(
@@ -39,4 +39,5 @@ pub fn check_version() {
             );
         }
     }
+    Ok(())
 }

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -22,7 +22,7 @@ macro_rules! t {
     };
 }
 
-#[cfg(feature = "dotenv")]
+#[cfg(all(feature = "dotenv", feature = "diesel_infer_schema"))]
 extern crate dotenv;
 #[cfg(feature = "diesel_infer_schema")]
 extern crate diesel_infer_schema;

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -31,6 +31,10 @@ extern crate diesel;
 extern crate quote;
 extern crate proc_macro;
 extern crate syn;
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
 mod as_changeset;
 mod associations;
@@ -47,6 +51,7 @@ mod schema_inference;
 mod database_url;
 mod util;
 mod migrations;
+mod check_version;
 
 use proc_macro::TokenStream;
 use syn::parse_derive_input;
@@ -94,6 +99,7 @@ pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::DeriveInput) -> quote::Tokens) -> TokenStream {
+    self::check_version::check_version();
     let item = parse_derive_input(&input.to_string()).unwrap();
     f(item).to_string().parse().unwrap()
 }

--- a/diesel_codegen/src/lib.rs
+++ b/diesel_codegen/src/lib.rs
@@ -31,10 +31,9 @@ extern crate diesel;
 extern crate quote;
 extern crate proc_macro;
 extern crate syn;
+#[macro_use]
 extern crate serde;
 extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
 
 mod as_changeset;
 mod associations;
@@ -99,7 +98,7 @@ pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
 }
 
 fn expand_derive(input: TokenStream, f: fn(syn::DeriveInput) -> quote::Tokens) -> TokenStream {
-    self::check_version::check_version();
+    let _ = self::check_version::check_version();
     let item = parse_derive_input(&input.to_string()).unwrap();
     f(item).to_string().parse().unwrap()
 }

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 [dependencies]
 diesel = { version = "0.16.0", features = ["extras", "sqlite", "postgres", "mysql"] }
 diesel_codegen = { version = "0.16.0" }
-compiletest_rs = "=0.2.7"
+compiletest_rs = "=0.2.9"
 
 [replace]
 "diesel:0.16.0" = { path = "../diesel" }

--- a/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/compile-fail/find_requires_correct_type.rs
@@ -21,10 +21,8 @@ fn main() {
     //~^ ERROR no method named `first`
     //~| ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
     string_primary_key::table.find(1).first(&connection).unwrap();
     //~^ ERROR no method named `first`
-    //~| ERROR E0277
     //~| ERROR E0277
     //~| ERROR E0277
 }

--- a/diesel_compile_tests/tests/compile-fail/insert_default_values_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_default_values_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::sqlite::{Sqlite, SqliteQueryBuilder, SqliteConnection};
+use diesel::sqlite::SqliteConnection;
 use diesel::backend::Backend;
 use diesel::types::{Integer, VarChar};
 

--- a/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::sqlite::{Sqlite, SqliteQueryBuilder, SqliteConnection};
+use diesel::sqlite::SqliteConnection;
 use diesel::backend::Backend;
 use diesel::types::{Integer, VarChar};
 

--- a/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
+++ b/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
@@ -16,15 +16,15 @@ fn main() {
     use stuff::table as st;
     use stuff::b;
 
-    st.select(b); //~ ERROR unused result
-    st.select(b).distinct(); //~ ERROR unused result
-    st.count(); //~ ERROR unused result
-    st.order(b); //~ ERROR unused result
-    st.limit(1); //~ ERROR unused result
-    st.offset(1); //~ ERROR unused result
+    st.select(b); //~ ERROR unused `diesel::query_builder::SelectStatement`
+    st.select(b).distinct(); //~ ERROR unused `diesel::query_builder::SelectStatement`
+    st.count(); //~ ERROR unused `diesel::query_builder::SelectStatement`
+    st.order(b); //~ ERROR unused `diesel::query_builder::SelectStatement`
+    st.limit(1); //~ ERROR unused `diesel::query_builder::SelectStatement`
+    st.offset(1); //~ ERROR unused `diesel::query_builder::SelectStatement`
 
-    st.filter(b.eq(true)); //~ ERROR unused result
-    st.filter(b.eq(true)).limit(1); //~ ERROR unused result
+    st.filter(b.eq(true)); //~ ERROR unused `diesel::query_builder::SelectStatement`
+    st.filter(b.eq(true)).limit(1); //~ ERROR unused `diesel::query_builder::SelectStatement`
 
     let _thingies = st.filter(b.eq(true)); // No ERROR
 }

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -38,5 +38,7 @@ fn main() {
     //~^ ERROR E0271
     //~| ERROR E0271
     // Invalid, Nullable<title> is selectable, but lower expects not-null
-    let _ = join.select(lower(posts::title.nullable())); //~ ERROR E0271
+    let _ = join.select(lower(posts::title.nullable()));
+    //~^ ERROR E0271
+    //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_1.rs
+++ b/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_1.rs
@@ -2,7 +2,7 @@
 
 table! {
     12
-    //~^ ERROR expected ident
 }
+// error-pattern: invalid table! syntax
 
 fn main() {}

--- a/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_3.rs
+++ b/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_3.rs
@@ -2,10 +2,10 @@
 
 table! {
      #[foobar]
-     //~^ ERROR expected ident, found #
      posts {
          id -> Integer,
      }
 }
+// error-pattern: invalid table! syntax
 
 fn main() {}

--- a/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
+++ b/diesel_compile_tests/tests/compile-fail/upsert_cannot_be_nested.rs
@@ -28,17 +28,9 @@ fn main() {
     insert(&NewUser("Sean").on_conflict(id, do_nothing()).on_conflict(id, do_nothing())).into(users).execute(&connection);
     //~^ ERROR no method named `execute`
     insert(&vec![NewUser("Sean").on_conflict_do_nothing()]).into(users).execute(&connection);
-    //~^ ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
+    //~^ ERROR E0061
     insert(&vec![&NewUser("Sean").on_conflict_do_nothing()]).into(users).execute(&connection);
-    //~^ ERROR no method named `execute`
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
+    //~^ ERROR E0061
     insert(&vec![&NewUser("Sean").on_conflict(id, do_nothing())]).into(users).execute(&connection);
-    //~^ ERROR no method named `execute`
-    //~| ERROR E0277
-    //~| ERROR E0277
-    //~| ERROR E0277
+    //~^ ERROR E0061
 }

--- a/diesel_infer_schema/Cargo.toml
+++ b/diesel_infer_schema/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["orm", "database", "postgres", "postgresql", "sql"]
 
 [dependencies]
 diesel = { version = "0.16.0", default-features = false }
-clippy = { optional = true, version = "=0.0.138" }
+clippy = { optional = true, version = "=0.0.155" }
 
 [dev-dependencies]
 dotenv = ">=0.8, <0.11"

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -96,7 +96,7 @@ fn selecting_expression_with_bind_param() {
 
     let source = users.select(name.eq("Sean".to_string()));
     let expected_data = vec![true, false];
-    let actual_data: Vec<_> = source.load(&connection).unwrap();
+    let actual_data = source.load::<bool>(&connection).unwrap();
 
     assert_eq!(expected_data, actual_data);
 }


### PR DESCRIPTION
This means most likely that the build will break because of a changed codegen.

Fixes #1704 

@sgrif The 0.16.x branch is missing. Could you crate one?