### PR TITLE
Our minimum supported Rust version is 1.24.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,11 @@ matrix:
     - SQLITE_DATABASE_URL=/tmp/test.db
     script:
     - (cd diesel_cli && travis-cargo test -- --no-default-features --features "sqlite-bundled")
+  - rust: 1.24.1
+    env:
+    - ENSURE_SUPPORTED_RUST_VERSION=1.24.1
+    script:
+    - cargo check --all
 
 env:
   matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [sql-function-1-3-0]: http://docs.diesel.rs/diesel/macro.sql_function.html
 
+* Diesel's minimum supported Rust version is 1.24.0. This was already true, but
+  it is now tested and enforced. Any future changes to our minimum supported
+  version will be listed in this change log.
+
 ### Fixed
 
 * `diesel print-schema` and `infer_schema!` now properly handle unsigned types


### PR DESCRIPTION
This was already true, as we require
https://github.com/rust-lang/rust/pull/46094 to compile. This commit
ensures that we test for this on CI so we know if this changes in the
future.