### PR TITLE
Implement `#[sql_name]` for `sql_function!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `NonAggregate` for your function. See [the documentation for
   `sql_function!`][sql-function-1-3-0] for more details.
 
+* `sql_function!` now supports renaming the function by annotating it with
+  `#[sql_name = "SOME_FUNCTION"]`. This can be used to support functions with
+  multiple signatures such as coalesce, by defining multiple rust functions
+  (with different names) that have the same `#[sql_name]`.
+
 * Added `sqlite-bundled` feature to `diesel_cli` to make installing on
   some platforms easier.
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -125,6 +125,8 @@
                  used_underscore_binding))]
 #![cfg_attr(all(test, feature = "clippy"), allow(option_unwrap_used, result_unwrap_used))]
 
+#![recursion_limit = "256"]
+
 #[cfg(feature = "postgres")]
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
The docs for this have already been written, it just hadn't been
implemented. The primary use case is to support variadic functions.

Example:

```rust
sql_function! {
    #[sql_name = "COALESCE"]
    fn coalesce2<T>(x: T, y: T) -> T;
}

sql_function! {
    #[sql_name = "COALESCE"]
    fn coalesce3<T>(x: T, y: T, Z: T) -> T;
}

sql_function! {
    #[sql_name = "COALESCE"]
    fn or_default<T: NotNull>(x: Nullable<T>, y: T) -> T;
}
```