### PR TITLE
Disallow registering custom impls for aggregate functions on SQLite

### DIFF
--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -263,6 +263,7 @@ macro_rules! __diesel_sql_function_body {
 
             __diesel_sqlite_register_fn! {
                 type_args = ($($type_args)*),
+                aggregate = $aggregate,
                 fn_name = $fn_name,
                 args = ($($arg_name,)+),
                 sql_args = ($($arg_type,)+),
@@ -283,8 +284,17 @@ macro_rules! __diesel_sqlite_register_fn {
     ) => {
     };
 
+    // We don't currently support aggregate functions for SQLite
+    (
+        type_args = $ignored:tt,
+        aggregate = yes,
+        $($rest:tt)*
+    ) => {
+    };
+
     (
         type_args = (),
+        aggregate = no,
         fn_name = $fn_name:ident,
         args = ($($args:ident,)+),
         sql_args = $sql_args:ty,


### PR DESCRIPTION
We may allow this in the future, but it will require a separate API. I'd
like to see concrete examples of user defined aggregate functions in the
wild before working on this. For now we can just disallow it entirely.