### PR TITLE
Correctly use `NamedTempFile`

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -391,7 +391,8 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), Box<E
         }
 
         let database_url = database::database_url(matches);
-        print_schema::output_schema(&database_url, &config.print_schema, path)?;
+        let mut file = fs::File::create(path)?;
+        print_schema::output_schema(&database_url, &config.print_schema, &mut file, path)?;
     }
     Ok(())
 }

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -392,7 +392,7 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), Box<E
 
         let database_url = database::database_url(matches);
         let mut file = fs::File::create(path)?;
-        print_schema::output_schema(&database_url, &config.print_schema, &mut file, path)?;
+        print_schema::output_schema(&database_url, &config.print_schema, file, path)?;
     }
     Ok(())
 }

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -45,7 +45,7 @@ pub fn run_print_schema(
 
     // patch "replaces" our tempfile, meaning the old handle
     // does not include the patched output.
-    let mut file = tempfile.reopen()?;
+    let mut file = File::open(tempfile.path())?;
     io::copy(&mut file, &mut stdout())?;
     Ok(())
 }


### PR DESCRIPTION
Do not try to open the generated temp file twice. This will fail on
windows.

Fixes #1723