### PR TITLE
Refactor handling of special attributes in `sql_function!`

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -125,8 +125,6 @@
                  used_underscore_binding))]
 #![cfg_attr(all(test, feature = "clippy"), allow(option_unwrap_used, result_unwrap_used))]
 
-#![recursion_limit = "256"]
-
 #[cfg(feature = "postgres")]
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
Rather than looping over all the attributes twice, we can just set
default values before searching, and do the whole thing in one loop