### PR TITLE
Refactor our `table!` parsing code

### DIFF
--- a/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_3.rs
+++ b/diesel_compile_tests/tests/compile-fail/table_invalid_syntax_3.rs
@@ -6,6 +6,6 @@ table! {
          id -> Integer,
      }
 }
-// error-pattern: Invalid `table!` syntax. Please see the `table!` macro docs for more info. `https://docs.diesel.rs/diesel/macro.table.html`
+// error-pattern: E0658
 
 fn main() {}


### PR DESCRIPTION
As with most full rewrites, I highly recommend using split diff view to review this.

The old code was a bit of a mess, and was suffering from some serious
bitrot. This is a rewrite that simplifies the flow, and structures it
more in line with how we would write this today. As a side effect, this
will allow attributes other than `#[doc]` to be applied to both tables
and columns. Importantly, this allows `#[allow]` to be applied, so
warnings we haven't considered in the past can be handled by our users.

The new code allows certain "invalid" things to get through (Honestly
the old code was so hard to follow, I'm not sure if this was true before
or not). For example, we permit `use` to come after meta items, and
`foo.bar.baz` is interpreted as `bar.baz`. These seme relatively minor
in the long run though.

I would have loved to have simplified this further by pulling out the
table name super early, but we still can't do that since Rust still
considers `use` ambiguous with `ident` matchers.