### PR TITLE
Add a helper trait for writing `ToSql` impls for PG tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `embed_migrations!` will no longer emit an unused import warning
 
+### Added
+
+* A helper trait has been added for implementing `ToSql` for PG composite types.
+  See [`WriteTuple`][write-tuple-1-4-0] for details.
+
+[write-tuple-1-4-0]: docs.diesel.rs/diesel/serialize/trait.WriteTuple.html
+
 ## [1.3.1] - 2018-05-23
 
 ### Fixed

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -12,6 +12,7 @@ mod backend;
 mod connection;
 mod metadata_lookup;
 mod query_builder;
+pub(crate) mod serialize;
 mod transaction;
 
 pub use self::backend::{Pg, PgTypeMetadata};

--- a/diesel/src/pg/serialize/mod.rs
+++ b/diesel/src/pg/serialize/mod.rs
@@ -1,0 +1,3 @@
+mod write_tuple;
+
+pub use self::write_tuple::WriteTuple;

--- a/diesel/src/pg/serialize/write_tuple.rs
+++ b/diesel/src/pg/serialize/write_tuple.rs
@@ -1,0 +1,49 @@
+use std::io::Write;
+
+use pg::Pg;
+use serialize::{self, Output};
+
+/// Helper trait for writing tuples as named composite types
+///
+/// This trait is essentially `ToSql<Record<ST>>` for tuples.
+/// While we can provide a valid body of `to_sql`,
+/// PostgreSQL doesn't allow the use of bind parameters for unnamed composite types.
+/// For this reason, we avoid implementing `ToSql` directly.
+///
+/// This trait can be used by `ToSql` impls of named composite types.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[macro_use]
+/// # extern crate diesel;
+/// #
+/// # #[cfg(feature = "postgres")]
+/// # mod the_impl {
+/// #     use diesel::pg::Pg;
+/// #     use diesel::serialize::{self, ToSql, Output, WriteTuple};
+/// #     use diesel::sql_types::{Integer, Text};
+/// #     use std::io::Write;
+/// #
+///     #[derive(SqlType)]
+///     #[postgres(type_name = "my_type")]
+///     struct MyType;
+///
+///     #[derive(Debug)]
+///     struct MyStruct<'a>(i32, &'a str);
+///
+///     impl<'a> ToSql<MyType, Pg> for MyStruct<'a> {
+///         fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+///             WriteTuple::<(Integer, Text)>::write_tuple(
+///                 &(self.0, self.1),
+///                 out,
+///             )
+///         }
+///     }
+/// # }
+/// # fn main() {}
+/// ```
+pub trait WriteTuple<ST> {
+    /// See trait documentation.
+    fn write_tuple<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result;
+}

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -150,9 +150,10 @@ pub mod sql_types {
     /// Your code would not compile in that case, as the `ToSql` trait itself is
     /// not implemented.
     ///
-    /// We do intend to provide an impl that can be used as a basis for named
-    /// composite types in the future, but there is no way for Diesel to
-    /// actually support a `ToSql` impl for anonymous record types.
+    /// You can implement `ToSql` for named composite types. See [`WriteTuple`]
+    /// for details.
+    ///
+    /// [`WriteTuple`]: ../../../serialize/trait.WriteTuple.html
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
     #[postgres(oid = "2249", array_oid = "2287")]
     pub struct Record<ST>(ST);

--- a/diesel/src/serialize.rs
+++ b/diesel/src/serialize.rs
@@ -9,6 +9,9 @@ use std::result;
 use backend::Backend;
 use sql_types::TypeMetadata;
 
+#[cfg(feature = "postgres")]
+pub use pg::serialize::*;
+
 /// A specialized result type representing the result of serializing
 /// a value for the database.
 pub type Result = result::Result<IsNull, Box<Error + Send + Sync>>;


### PR DESCRIPTION
I had meant to do this when adding support for `Record`, but didn't get
around to it. However, @ebkalderon needed this today, so now is as
good a time as any.

We avoid implementing `ToSql` directly, because we don't want
`Bound<Record<(Integer, Text)>, (i32, String)>` to become valid.