### PR TITLE
Restructure `InternalSaveChangesDsl`

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -15,8 +15,8 @@
 
 use backend::Backend;
 use connection::Connection;
-use expression::Expression;
 use expression::count::CountStar;
+use expression::Expression;
 use helper_types::*;
 use query_builder::locking_clause as lock;
 use query_source::{joins, Table};

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -15,8 +15,8 @@
 
 use backend::Backend;
 use connection::Connection;
-use expression::count::CountStar;
 use expression::Expression;
+use expression::count::CountStar;
 use helper_types::*;
 use query_builder::locking_clause as lock;
 use query_source::{joins, Table};
@@ -48,9 +48,7 @@ pub use self::group_by_dsl::GroupByDsl;
 pub use self::join_dsl::{InternalJoinDsl, JoinOnDsl, JoinWithImplicitOnClause};
 #[doc(hidden)]
 pub use self::load_dsl::LoadQuery;
-pub use self::save_changes_dsl::SaveChangesDsl;
-#[doc(hidden)]
-pub use self::save_changes_dsl::InternalSaveChangesDsl;
+pub use self::save_changes_dsl::{SaveChangesDsl, UpdateAndFetchResults};
 
 /// The traits used by `QueryDsl`.
 ///

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -49,6 +49,8 @@ pub use self::join_dsl::{InternalJoinDsl, JoinOnDsl, JoinWithImplicitOnClause};
 #[doc(hidden)]
 pub use self::load_dsl::LoadQuery;
 pub use self::save_changes_dsl::SaveChangesDsl;
+#[doc(hidden)]
+pub use self::save_changes_dsl::InternalSaveChangesDsl;
 
 /// The traits used by `QueryDsl`.
 ///

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -115,10 +115,11 @@ where
 /// #     Ok(())
 /// # }
 /// ```
-pub trait SaveChangesDsl<Conn>: Sized {
+pub trait SaveChangesDsl<Conn> {
     /// See the trait documentation.
     fn save_changes<T>(self, connection: &Conn) -> QueryResult<T>
     where
+        Self: Sized,
         Conn: InternalSaveChangesDsl<Self, T>,
     {
         connection.internal_save_changes(self)

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -12,21 +12,22 @@ use query_dsl::methods::{ExecuteDsl, FindDsl};
 use query_dsl::{LoadQuery, RunQueryDsl};
 use result::QueryResult;
 
-pub trait InternalSaveChangesDsl<Conn, T>: Sized {
-    fn internal_save_changes(self, connection: &Conn) -> QueryResult<T>;
+#[doc(hidden)]
+pub trait InternalSaveChangesDsl<T, U> {
+    fn internal_save_changes(&self, changeset: T) -> QueryResult<U>;
 }
 
 #[cfg(feature = "postgres")]
 use pg::PgConnection;
 
 #[cfg(feature = "postgres")]
-impl<T, U> InternalSaveChangesDsl<PgConnection, U> for T
+impl<T, U> InternalSaveChangesDsl<T, U> for PgConnection
 where
     T: Copy + AsChangeset<Target = <T as HasTable>::Table> + IntoUpdateTarget,
     Update<T, T>: LoadQuery<PgConnection, U>,
 {
-    fn internal_save_changes(self, conn: &PgConnection) -> QueryResult<U> {
-        ::update(self).set(self).get_result(conn)
+    fn internal_save_changes(&self, changeset: T) -> QueryResult<U> {
+        ::update(changeset).set(changeset).get_result(self)
     }
 }
 
@@ -34,7 +35,7 @@ where
 use sqlite::SqliteConnection;
 
 #[cfg(feature = "sqlite")]
-impl<T, U> InternalSaveChangesDsl<SqliteConnection, U> for T
+impl<T, U> InternalSaveChangesDsl<T, U> for SqliteConnection
 where
     T: Copy + Identifiable,
     T: AsChangeset<Target = <T as HasTable>::Table> + IntoUpdateTarget,
@@ -42,9 +43,9 @@ where
     Update<T, T>: ExecuteDsl<SqliteConnection>,
     Find<T::Table, T::Id>: LoadQuery<SqliteConnection, U>,
 {
-    fn internal_save_changes(self, conn: &SqliteConnection) -> QueryResult<U> {
-        try!(::update(self).set(self).execute(conn));
-        T::table().find(self.id()).get_result(conn)
+    fn internal_save_changes(&self, changeset: T) -> QueryResult<U> {
+        try!(::update(changeset).set(changeset).execute(self));
+        T::table().find(changeset.id()).get_result(self)
     }
 }
 
@@ -52,7 +53,7 @@ where
 use mysql::MysqlConnection;
 
 #[cfg(feature = "mysql")]
-impl<T, U> InternalSaveChangesDsl<MysqlConnection, U> for T
+impl<T, U> InternalSaveChangesDsl<T, U> for MysqlConnection
 where
     T: Copy + Identifiable,
     T: AsChangeset<Target = <T as HasTable>::Table> + IntoUpdateTarget,
@@ -60,9 +61,9 @@ where
     Update<T, T>: ExecuteDsl<MysqlConnection>,
     Find<T::Table, T::Id>: LoadQuery<MysqlConnection, U>,
 {
-    fn internal_save_changes(self, conn: &MysqlConnection) -> QueryResult<U> {
-        try!(::update(self).set(self).execute(conn));
-        T::table().find(self.id()).get_result(conn)
+    fn internal_save_changes(&self, changeset: T) -> QueryResult<U> {
+        try!(::update(changeset).set(changeset).execute(self));
+        T::table().find(changeset.id()).get_result(self)
     }
 }
 
@@ -114,13 +115,13 @@ where
 /// #     Ok(())
 /// # }
 /// ```
-pub trait SaveChangesDsl<Conn> {
+pub trait SaveChangesDsl<Conn>: Sized {
     /// See the trait documentation.
     fn save_changes<T>(self, connection: &Conn) -> QueryResult<T>
     where
-        Self: InternalSaveChangesDsl<Conn, T>,
+        Conn: InternalSaveChangesDsl<Self, T>,
     {
-        self.internal_save_changes(connection)
+        connection.internal_save_changes(self)
     }
 }
 


### PR DESCRIPTION
This allows this trait to be implemented outside of diesel.
Also reexport this trait as hidden api. (It is only usfull if someone
tries to implement a additional backend)

This is not a breaking change because `InternalSaveChangesDsl` was an internal api.

Fix #1736