### PR TITLE
Fix the handling of unsigned values on MySQL

### DIFF
--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -22,12 +22,20 @@ pub struct Mysql;
 pub enum MysqlType {
     /// Sets `buffer_type` to `MYSQL_TYPE_TINY`
     Tiny,
+    /// Sets `buffer_type` to `MYSQL_TYPE_TINY` and `is_unsigned` to `true`
+    UnsignedTiny,
     /// Sets `buffer_type` to `MYSQL_TYPE_SHORT`
     Short,
+    /// Sets `buffer_type` to `MYSQL_TYPE_SHORT` and `is_unsigned` to `true`
+    UnsignedShort,
     /// Sets `buffer_type` to `MYSQL_TYPE_LONG`
     Long,
+    /// Sets `buffer_type` to `MYSQL_TYPE_LONG` and `is_unsigned` to `true`
+    UnsignedLong,
     /// Sets `buffer_type` to `MYSQL_TYPE_LONGLONG`
     LongLong,
+    /// Sets `buffer_type` to `MYSQL_TYPE_LONGLONG` and `is_unsigned` to `true`
+    UnsignedLongLong,
     /// Sets `buffer_type` to `MYSQL_TYPE_FLOAT`
     Float,
     /// Sets `buffer_type` to `MYSQL_TYPE_DOUBLE`
@@ -44,6 +52,19 @@ pub enum MysqlType {
     String,
     /// Sets `buffer_type` to `MYSQL_TYPE_BLOB`
     Blob,
+}
+
+impl MysqlType {
+    /// Is this an unsigned type?
+    pub fn is_unsigned(&self) -> bool {
+        match *self {
+            MysqlType::UnsignedTiny
+            | MysqlType::UnsignedShort
+            | MysqlType::UnsignedLong
+            | MysqlType::UnsignedLongLong => true,
+            _ => false,
+        }
+    }
 }
 
 impl Backend for Mysql {

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -81,12 +81,27 @@ impl FromSql<Bool, Mysql> for bool {
     }
 }
 
-impl<ST> HasSqlType<Unsigned<ST>> for Mysql
-where
-    Mysql: HasSqlType<ST>,
-{
-    fn metadata(lookup: &()) -> MysqlType {
-        <Mysql as HasSqlType<ST>>::metadata(lookup)
+impl HasSqlType<Unsigned<Tinyint>> for Mysql {
+    fn metadata(_: &()) -> MysqlType {
+        MysqlType::UnsignedTiny
+    }
+}
+
+impl HasSqlType<Unsigned<SmallInt>> for Mysql {
+    fn metadata(_: &()) -> MysqlType {
+        MysqlType::UnsignedShort
+    }
+}
+
+impl HasSqlType<Unsigned<Integer>> for Mysql {
+    fn metadata(_: &()) -> MysqlType {
+        MysqlType::UnsignedLong
+    }
+}
+
+impl HasSqlType<Unsigned<BigInt>> for Mysql {
+    fn metadata(_: &()) -> MysqlType {
+        MysqlType::UnsignedLongLong
     }
 }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -199,7 +199,7 @@ fn i32_to_sql_integer() {
 #[cfg(feature = "mysql")]
 fn u16_to_sql_integer() {
     assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>(
-        "-1", 65535
+        "65535", 65535
     ));
     assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>("0", 0));
     assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>("1", 1));
@@ -211,7 +211,7 @@ fn u16_to_sql_integer() {
         "50000", 49999
     ));
     assert!(!query_to_sql_equality::<Unsigned<SmallInt>, u16>(
-        "-1", 64434
+        "64435", 64434
     ));
 }
 
@@ -219,8 +219,14 @@ fn u16_to_sql_integer() {
 #[cfg(feature = "mysql")]
 fn u16_from_sql() {
     assert_eq!(0, query_single_value::<Unsigned<SmallInt>, u16>("0"));
-    assert_eq!(65535, query_single_value::<Unsigned<SmallInt>, u16>("-1"));
-    assert_ne!(65534, query_single_value::<Unsigned<SmallInt>, u16>("-1"));
+    assert_eq!(
+        65535,
+        query_single_value::<Unsigned<SmallInt>, u16>("65535")
+    );
+    assert_ne!(
+        65534,
+        query_single_value::<Unsigned<SmallInt>, u16>("65535")
+    );
     assert_eq!(7000, query_single_value::<Unsigned<SmallInt>, u16>("7000"));
 }
 
@@ -228,7 +234,8 @@ fn u16_from_sql() {
 #[cfg(feature = "mysql")]
 fn u32_to_sql_integer() {
     assert!(query_to_sql_equality::<Unsigned<Integer>, u32>(
-        "-1", 4294967295
+        "4294967295",
+        4294967295
     ));
     assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("0", 0));
     assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("1", 1));
@@ -240,7 +247,8 @@ fn u32_to_sql_integer() {
         "70000", 69999
     ));
     assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>(
-        "-1", 4294967294
+        "4294967295",
+        4294967294
     ));
 }
 
@@ -250,11 +258,11 @@ fn u32_from_sql() {
     assert_eq!(0, query_single_value::<Unsigned<Integer>, u32>("0"));
     assert_eq!(
         4294967295,
-        query_single_value::<Unsigned<Integer>, u32>("-1")
+        query_single_value::<Unsigned<Integer>, u32>("4294967295")
     );
     assert_ne!(
         4294967294,
-        query_single_value::<Unsigned<Integer>, u32>("-1")
+        query_single_value::<Unsigned<Integer>, u32>("4294967295")
     );
     assert_eq!(70000, query_single_value::<Unsigned<Integer>, u32>("70000"));
 }
@@ -263,7 +271,7 @@ fn u32_from_sql() {
 #[cfg(feature = "mysql")]
 fn u64_to_sql_integer() {
     assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>(
-        "-1",
+        "18446744073709551615",
         18446744073709551615
     ));
     assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>("0", 0));
@@ -276,7 +284,7 @@ fn u64_to_sql_integer() {
         "70000", 69999
     ));
     assert!(!query_to_sql_equality::<Unsigned<BigInt>, u64>(
-        "-1",
+        "18446744073709551615",
         18446744073709551614
     ));
 }
@@ -287,11 +295,11 @@ fn u64_from_sql() {
     assert_eq!(0, query_single_value::<Unsigned<BigInt>, u64>("0"));
     assert_eq!(
         18446744073709551615,
-        query_single_value::<Unsigned<BigInt>, u64>("-1")
+        query_single_value::<Unsigned<BigInt>, u64>("18446744073709551615")
     );
     assert_ne!(
         18446744073709551614,
-        query_single_value::<Unsigned<BigInt>, u64>("-1")
+        query_single_value::<Unsigned<BigInt>, u64>("18446744073709551615")
     );
     assert_eq!(
         700000,


### PR DESCRIPTION
We were sending the right bytes, but we weren't properly setting the
`is_unsigned` flag on the bind parameters, resulting in it always being
sent as signed. This results in a client error about overflow when
deserializing large values, and either a server error or incorrect
results when serializing them.

The fact that the tests for this all used `-1` should have been a huge
red flag, but it slipped through.

Unfortunately, there's no way for us to reasonably fix this without a
breaking change or crazy hacks (we could do something like write an
additional byte at the end if it's unsigned, but that's probably not
worth it to avoid a breaking change). For that reason, we will need to
make the next version of Diesel 2.0. We shouldn't go crazy with this
change, but this would also allow us to make #1457 happen as well.

The other alternative would be to introduce a `Mysql2` backend, and
deprecate the current one.

Fixes #1745 