### PR TITLE
Remove unused import from `embed_migrations!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## Unreleased
+
+### Fixed
+
+* `embed_migrations!` will no longer emit an unused import warning
+
 ## [1.3.1] - 2018-05-23
 
 ### Fixed

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -66,7 +66,6 @@ pub fn derive_embed_migrations(input: &syn::DeriveInput) -> quote::Tokens {
         extern crate diesel_migrations;
 
         use self::diesel_migrations::*;
-        use self::diesel::migration::*;
         use self::diesel::connection::SimpleConnection;
         use std::io;
 


### PR DESCRIPTION
The changes for barrel support led to `diesel_migrations` exporting
everything required by this macro, leading to the warning being
generated.

Fixes #1739