### PR TITLE
Fix our handling of unsigned types on MySQL

### DIFF
--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -2,9 +2,9 @@
 
 use byteorder::NativeEndian;
 
+use super::bind_collector::MysqlBindCollector;
 use super::query_builder::MysqlQueryBuilder;
 use backend::*;
-use query_builder::bind_collector::RawBytesBindCollector;
 use sql_types::TypeMetadata;
 
 /// The MySQL backend
@@ -48,7 +48,7 @@ pub enum MysqlType {
 
 impl Backend for Mysql {
     type QueryBuilder = MysqlQueryBuilder;
-    type BindCollector = RawBytesBindCollector<Mysql>;
+    type BindCollector = MysqlBindCollector;
     type RawValue = [u8];
     type ByteOrder = NativeEndian;
 }

--- a/diesel/src/mysql/bind_collector.rs
+++ b/diesel/src/mysql/bind_collector.rs
@@ -1,0 +1,38 @@
+use super::{Mysql, MysqlType};
+use query_builder::BindCollector;
+use result::Error::SerializationError;
+use result::QueryResult;
+use serialize::{IsNull, Output, ToSql};
+use sql_types::{HasSqlType, IsSigned};
+
+#[derive(Default)]
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub struct MysqlBindCollector {
+    pub(crate) binds: Vec<(MysqlType, IsSigned, Option<Vec<u8>>)>,
+}
+
+impl MysqlBindCollector {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl BindCollector<Mysql> for MysqlBindCollector {
+    fn push_bound_value<T, U>(&mut self, bind: &U, metadata_lookup: &()) -> QueryResult<()>
+    where
+        Mysql: HasSqlType<T>,
+        U: ToSql<T, Mysql>,
+    {
+        let mut to_sql_output = Output::new(Vec::new(), metadata_lookup);
+        let is_null = bind.to_sql(&mut to_sql_output).map_err(SerializationError)?;
+        let bytes = match is_null {
+            IsNull::No => Some(to_sql_output.into_inner()),
+            IsNull::Yes => None,
+        };
+        let metadata = Mysql::metadata(metadata_lookup);
+        let sign = Mysql::is_signed();
+        self.binds.push((metadata, sign, bytes));
+        Ok(())
+    }
+}

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -4,6 +4,7 @@ use super::{ffi, libc, Binds, Statement, StatementMetadata};
 use mysql::{Mysql, MysqlType};
 use result::QueryResult;
 use row::*;
+use sql_types::IsSigned;
 
 pub struct StatementIterator<'a> {
     stmt: &'a mut Statement,
@@ -12,7 +13,7 @@ pub struct StatementIterator<'a> {
 
 #[cfg_attr(feature = "clippy", allow(should_implement_trait))] // don't neet `Iterator` here
 impl<'a> StatementIterator<'a> {
-    pub fn new(stmt: &'a mut Statement, types: Vec<MysqlType>) -> QueryResult<Self> {
+    pub fn new(stmt: &'a mut Statement, types: Vec<(MysqlType, IsSigned)>) -> QueryResult<Self> {
         let mut output_binds = Binds::from_output_types(types);
 
         execute_statement(stmt, &mut output_binds)?;

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -11,6 +11,7 @@ use self::metadata::*;
 use super::bind::Binds;
 use mysql::MysqlType;
 use result::{DatabaseErrorKind, QueryResult};
+use sql_types::IsSigned;
 use util::NonNull;
 
 pub struct Statement {
@@ -39,7 +40,7 @@ impl Statement {
 
     pub fn bind<Iter>(&mut self, binds: Iter) -> QueryResult<()>
     where
-        Iter: IntoIterator<Item = (MysqlType, Option<Vec<u8>>)>,
+        Iter: IntoIterator<Item = (MysqlType, IsSigned, Option<Vec<u8>>)>,
     {
         let mut input_binds = Binds::from_input_data(binds);
         input_binds.with_mysql_binds(|bind_ptr| {
@@ -72,7 +73,10 @@ impl Statement {
     /// This function should be called instead of `execute` for queries which
     /// have a return value. After calling this function, `execute` can never
     /// be called on this statement.
-    pub unsafe fn results(&mut self, types: Vec<MysqlType>) -> QueryResult<StatementIterator> {
+    pub unsafe fn results(
+        &mut self,
+        types: Vec<(MysqlType, IsSigned)>,
+    ) -> QueryResult<StatementIterator> {
         StatementIterator::new(self, types)
     }
 

--- a/diesel/src/mysql/mod.rs
+++ b/diesel/src/mysql/mod.rs
@@ -5,6 +5,7 @@
 //! MySQL, you may need to work with this module directly.
 
 mod backend;
+mod bind_collector;
 mod connection;
 
 mod query_builder;

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -88,6 +88,10 @@ where
     fn metadata(lookup: &()) -> MysqlType {
         <Mysql as HasSqlType<ST>>::metadata(lookup)
     }
+
+    fn is_signed() -> IsSigned {
+        IsSigned::Unsigned
+    }
 }
 
 /// Represents the MySQL datetime type.

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -10,6 +10,9 @@ use row::NamedRow;
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::{HasSqlType, NotNull, Nullable};
 
+#[cfg(feature = "mysql")]
+use sql_types::IsSigned;
+
 impl<T, DB> HasSqlType<Nullable<T>> for DB
 where
     DB: Backend + HasSqlType<T>,
@@ -19,8 +22,18 @@ where
         <DB as HasSqlType<T>>::metadata(lookup)
     }
 
+    #[cfg(feature = "with-deprecated")]
+    #[allow(deprecated)]
     fn row_metadata(out: &mut Vec<DB::TypeMetadata>, lookup: &DB::MetadataLookup) {
         <DB as HasSqlType<T>>::row_metadata(out, lookup)
+    }
+
+    #[cfg(feature = "mysql")]
+    fn mysql_row_metadata(
+        out: &mut Vec<(DB::TypeMetadata, IsSigned)>,
+        lookup: &DB::MetadataLookup,
+    ) {
+        <DB as HasSqlType<T>>::mysql_row_metadata(out, lookup)
     }
 }
 

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -13,6 +13,9 @@ use row::*;
 use sql_types::{HasSqlType, NotNull};
 use util::TupleAppend;
 
+#[cfg(feature = "mysql")]
+use sql_types::IsSigned;
+
 macro_rules! tuple_impls {
     ($(
         $Tuple:tt {
@@ -28,8 +31,15 @@ macro_rules! tuple_impls {
                     unreachable!("Tuples should never implement `ToSql` directly");
                 }
 
+                #[cfg(feature = "with-deprecated")]
+                #[allow(deprecated)]
                 fn row_metadata(out: &mut Vec<__DB::TypeMetadata>, lookup: &__DB::MetadataLookup) {
                     $(<__DB as HasSqlType<$T>>::row_metadata(out, lookup);)+
+                }
+
+                #[cfg(feature = "mysql")]
+                fn mysql_row_metadata(out: &mut Vec<(__DB::TypeMetadata, IsSigned)>, lookup: &__DB::MetadataLookup) {
+                    $(<__DB as HasSqlType<$T>>::mysql_row_metadata(out, lookup);)+
                 }
             }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -199,7 +199,7 @@ fn i32_to_sql_integer() {
 #[cfg(feature = "mysql")]
 fn u16_to_sql_integer() {
     assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>(
-        "-1", 65535
+        "65535", 65535
     ));
     assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>("0", 0));
     assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>("1", 1));
@@ -211,7 +211,7 @@ fn u16_to_sql_integer() {
         "50000", 49999
     ));
     assert!(!query_to_sql_equality::<Unsigned<SmallInt>, u16>(
-        "-1", 64434
+        "64435", 64434
     ));
 }
 
@@ -219,8 +219,14 @@ fn u16_to_sql_integer() {
 #[cfg(feature = "mysql")]
 fn u16_from_sql() {
     assert_eq!(0, query_single_value::<Unsigned<SmallInt>, u16>("0"));
-    assert_eq!(65535, query_single_value::<Unsigned<SmallInt>, u16>("-1"));
-    assert_ne!(65534, query_single_value::<Unsigned<SmallInt>, u16>("-1"));
+    assert_eq!(
+        65535,
+        query_single_value::<Unsigned<SmallInt>, u16>("65535")
+    );
+    assert_ne!(
+        65534,
+        query_single_value::<Unsigned<SmallInt>, u16>("65535")
+    );
     assert_eq!(7000, query_single_value::<Unsigned<SmallInt>, u16>("7000"));
 }
 
@@ -228,7 +234,8 @@ fn u16_from_sql() {
 #[cfg(feature = "mysql")]
 fn u32_to_sql_integer() {
     assert!(query_to_sql_equality::<Unsigned<Integer>, u32>(
-        "-1", 4294967295
+        "4294967295",
+        4294967295
     ));
     assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("0", 0));
     assert!(query_to_sql_equality::<Unsigned<Integer>, u32>("1", 1));
@@ -240,7 +247,8 @@ fn u32_to_sql_integer() {
         "70000", 69999
     ));
     assert!(!query_to_sql_equality::<Unsigned<Integer>, u32>(
-        "-1", 4294967294
+        "4294967295",
+        4294967294
     ));
 }
 
@@ -250,11 +258,11 @@ fn u32_from_sql() {
     assert_eq!(0, query_single_value::<Unsigned<Integer>, u32>("0"));
     assert_eq!(
         4294967295,
-        query_single_value::<Unsigned<Integer>, u32>("-1")
+        query_single_value::<Unsigned<Integer>, u32>("4294967295")
     );
     assert_ne!(
         4294967294,
-        query_single_value::<Unsigned<Integer>, u32>("-1")
+        query_single_value::<Unsigned<Integer>, u32>("4294967295")
     );
     assert_eq!(70000, query_single_value::<Unsigned<Integer>, u32>("70000"));
 }
@@ -263,7 +271,7 @@ fn u32_from_sql() {
 #[cfg(feature = "mysql")]
 fn u64_to_sql_integer() {
     assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>(
-        "-1",
+        "18446744073709551615",
         18446744073709551615
     ));
     assert!(query_to_sql_equality::<Unsigned<BigInt>, u64>("0", 0));
@@ -276,7 +284,7 @@ fn u64_to_sql_integer() {
         "70000", 69999
     ));
     assert!(!query_to_sql_equality::<Unsigned<BigInt>, u64>(
-        "-1",
+        "18446744073709551615",
         18446744073709551614
     ));
 }
@@ -287,11 +295,11 @@ fn u64_from_sql() {
     assert_eq!(0, query_single_value::<Unsigned<BigInt>, u64>("0"));
     assert_eq!(
         18446744073709551615,
-        query_single_value::<Unsigned<BigInt>, u64>("-1")
+        query_single_value::<Unsigned<BigInt>, u64>("18446744073709551615")
     );
     assert_ne!(
         18446744073709551614,
-        query_single_value::<Unsigned<BigInt>, u64>("-1")
+        query_single_value::<Unsigned<BigInt>, u64>("18446744073709551615")
     );
     assert_eq!(
         700000,


### PR DESCRIPTION
We were sending the right bytes, but we weren't properly setting the
`is_unsigned` flag on the bind parameters, resulting in it always being
sent as signed. This results in a client error about overflow when
deserializing large values, and either a server error or incorrect
results when serializing them.

The fact that the tests for this all used `-1` should have been a huge
red flag, but it slipped through.

While changing the type of `Mysql::BindCollector` could technically be
considered a breaking change under the strictest definition, I do not
consider this to be one. We have stated in the past that folks should
not rely on the exact types used in `impl Backend`. And unlike changing
`RawValue`, there's literally no reason for anybody to have depended on
the exact value of this type, unless they're implementing their own
Connection.

If we really want to avoid any potential source incompatibility, we can
actually do this without the custom bind collector, if we have the
`ToSql` implementations for `Unsigned` add an extra byte at the end, and
check to see if the length of the buffer is 1 byte larger than the
expected length. However, this is super hacky and much more likely to
break applications than this approach.

Fixes #1745.
Close #1749.