### PR TITLE
Bump bigdecimal version to 0.0.12

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -29,7 +29,7 @@ ipnetwork = { version = "0.12.2", optional = true }
 num-bigint = { version = "0.1.41", optional = true }
 num-traits = { version = "0.2", optional = true }
 num-integer = { version = "0.1.32", optional = true }
-bigdecimal = { version = ">= 0.0.10, < 0.0.12", optional = true }
+bigdecimal = { version = ">= 0.0.10, < 0.0.13", optional = true }
 bitflags = { version = "1.0", optional = true }
 r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -21,7 +21,7 @@ quickcheck = { version = "0.4", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.7.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = "0.12.2"
-bigdecimal = ">= 0.0.10, < 0.0.12"
+bigdecimal = ">= 0.0.10, < 0.0.13"
 
 [features]
 default = []


### PR DESCRIPTION
Using the latest 0.0.12 version currently leads to compile errors, this fixes that issue.