### PR TITLE
Allows migrations to run without Cargo.toml

### DIFF
--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use toml;
 
-use super::{find_project_root, handle_error};
+use super::find_project_root;
 use print_schema;
 
 #[derive(Deserialize, Default)]
@@ -22,11 +22,7 @@ impl Config {
             .value_of("CONFIG_FILE")
             .map(PathBuf::from)
             .or_else(|| env::var_os("DIESEL_CONFIG_FILE").map(PathBuf::from))
-            .unwrap_or_else(|| {
-                find_project_root()
-                    .unwrap_or_else(handle_error)
-                    .join("diesel.toml")
-            })
+            .unwrap_or_else(|| find_project_root().unwrap_or_default().join("diesel.toml"))
     }
 
     pub fn read(matches: &ArgMatches) -> Result<Self, Box<Error>> {

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -1,7 +1,7 @@
 use diesel::dsl::sql;
 use diesel::sql_types::Bool;
 use diesel::{select, RunQueryDsl};
-use std::Path::Path;
+use std::path::Path;
 use support::{database, project};
 
 #[test]

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -89,6 +89,11 @@ impl Project {
             .collect()
     }
 
+    pub fn delete_single_file<P: AsRef<Path>>(&self, path: P) {
+        let file = self.directory.path().join(path);
+        fs::remove_file(file).unwrap();
+    }
+
     #[cfg(any(feature = "postgres", feature = "mysql"))]
     fn database_url_from_env(&self, var: &str) -> url::Url {
         use self::dotenv::dotenv;


### PR DESCRIPTION
This allows migrations to be run without Cargo.toml. Previously, the error occurs when Diesel tries to find the config file which defaults to where Cargo.toml is if the location is not specified. Now not finding Cargo.toml is treated like not finding the config file.

Fixes #1760.