### PR TITLE
Future proof us against upcoming changes to derives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [write-tuple-1-4-0]: docs.diesel.rs/diesel/serialize/trait.WriteTuple.html
 
+### Changed
+
+* Diesel's derives now require that `extern crate diesel;` be at your crate root
+  (e.g. `src/lib.rs` or `src/main.rs`)
+
 ## [1.3.2] - 2018-06-13
 
 ### Fixed

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -354,3 +354,7 @@ pub use query_builder::debug_query;
 pub use query_builder::functions::{delete, insert_into, insert_or_ignore_into, replace_into,
                                    select, sql_query, update};
 pub use result::Error::NotFound;
+
+pub(crate) mod diesel {
+    pub use super::*;
+}

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -1042,15 +1042,6 @@ macro_rules! allow_tables_to_appear_in_same_query {
     () => {};
 }
 
-#[macro_export]
-#[doc(hidden)]
-/// Used by `diesel_derives`, which can't access `$crate`
-macro_rules! __diesel_use_everything {
-    () => {
-        pub use $crate::*;
-    };
-}
-
 /// Gets the value out of an option, or returns an error.
 ///
 /// This is used by `FromSql` implementations.

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -61,8 +61,8 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("as_changeset"),
         quote!(
-            use self::diesel::query_builder::AsChangeset;
-            use self::diesel::prelude::*;
+            use diesel::query_builder::AsChangeset;
+            use diesel::prelude::*;
 
             impl #impl_generics AsChangeset for &'update #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -108,10 +108,10 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
         Ok(wrap_in_dummy_mod(
             dummy_mod.into(),
             quote! {
-                use self::diesel::expression::AsExpression;
-                use self::diesel::expression::bound::Bound;
-                use self::diesel::sql_types::Nullable;
-                use self::diesel::serialize::{self, ToSql, Output};
+                use diesel::expression::AsExpression;
+                use diesel::expression::bound::Bound;
+                use diesel::sql_types::Nullable;
+                use diesel::serialize::{self, ToSql, Output};
 
                 #(#tokens)*
             },

--- a/diesel_derives/src/diesel_numeric_ops.rs
+++ b/diesel_derives/src/diesel_numeric_ops.rs
@@ -23,10 +23,10 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         dummy_name.to_lowercase().into(),
         quote! {
-            use self::diesel::expression::{ops, Expression, AsExpression};
-            use self::diesel::sql_types::ops::{Add, Sub, Mul, Div};
+            use diesel::expression::{ops, Expression, AsExpression};
+            use diesel::sql_types::ops::{Add, Sub, Mul, Div};
 
-            impl #impl_generics self::std::ops::Add<__Rhs> for #struct_name #ty_generics
+            impl #impl_generics ::std::ops::Add<__Rhs> for #struct_name #ty_generics
             #where_clause
                 <Self as Expression>::SqlType: Add,
                 __Rhs: AsExpression<<<Self as Expression>::SqlType as Add>::Rhs>,
@@ -38,7 +38,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
                 }
             }
 
-            impl #impl_generics self::std::ops::Sub<__Rhs> for #struct_name #ty_generics
+            impl #impl_generics ::std::ops::Sub<__Rhs> for #struct_name #ty_generics
             #where_clause
                 <Self as Expression>::SqlType: Sub,
                 __Rhs: AsExpression<<<Self as Expression>::SqlType as Sub>::Rhs>,
@@ -50,7 +50,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
                 }
             }
 
-            impl #impl_generics self::std::ops::Mul<__Rhs> for #struct_name #ty_generics
+            impl #impl_generics ::std::ops::Mul<__Rhs> for #struct_name #ty_generics
             #where_clause
                 <Self as Expression>::SqlType: Mul,
                 __Rhs: AsExpression<<<Self as Expression>::SqlType as Mul>::Rhs>,
@@ -62,7 +62,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
                 }
             }
 
-            impl #impl_generics self::std::ops::Div<__Rhs> for #struct_name #ty_generics
+            impl #impl_generics ::std::ops::Div<__Rhs> for #struct_name #ty_generics
             #where_clause
                 <Self as Expression>::SqlType: Div,
                 __Rhs: AsExpression<<<Self as Expression>::SqlType as Div>::Rhs>,

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -31,7 +31,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         dummy_mod,
         quote! {
-            use self::diesel::deserialize::{self, FromSql, FromSqlRow, Queryable};
+            use diesel::deserialize::{self, FromSql, FromSqlRow, Queryable};
 
             impl #impl_generics FromSqlRow<__ST, __DB> for #struct_ty
             #where_clause

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -24,7 +24,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("identifiable"),
         quote! {
-            use self::diesel::associations::{HasTable, Identifiable};
+            use diesel::associations::{HasTable, Identifiable};
 
             impl #impl_generics HasTable for #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -51,9 +51,9 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("insertable"),
         quote! {
-            use self::diesel::insertable::Insertable;
-            use self::diesel::query_builder::UndecoratedInsertRecord;
-            use self::diesel::prelude::*;
+            use diesel::insertable::Insertable;
+            use diesel::query_builder::UndecoratedInsertRecord;
+            use diesel::prelude::*;
 
             impl #impl_generics Insertable<#table_name::table> for #struct_name #ty_generics
                 #where_clause

--- a/diesel_derives/src/query_id.rs
+++ b/diesel_derives/src/query_id.rs
@@ -24,7 +24,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         dummy_mod.into(),
         quote! {
-            use self::diesel::query_builder::QueryId;
+            use diesel::query_builder::QueryId;
 
             #[allow(non_camel_case_types)]
             impl #impl_generics QueryId for #struct_name #ty_generics

--- a/diesel_derives/src/queryable.rs
+++ b/diesel_derives/src/queryable.rs
@@ -32,7 +32,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("queryable"),
         quote! {
-            use self::diesel::Queryable;
+            use diesel::Queryable;
 
             impl #impl_generics Queryable<__ST, __DB> for #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -37,8 +37,8 @@ pub fn derive(item: syn::DeriveInput) -> Result<quote::Tokens, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("queryable_by_name"),
         quote! {
-            use self::diesel::deserialize::{self, QueryableByName};
-            use self::diesel::row::NamedRow;
+            use diesel::deserialize::{self, QueryableByName};
+            use diesel::row::NamedRow;
 
             impl #impl_generics QueryableByName<__DB>
                 for #struct_name #ty_generics

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -121,7 +121,7 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<quote::Tokens> {
             };
 
             Some(quote! {
-                use self::diesel::pg::{PgMetadataLookup, PgTypeMetadata};
+                use diesel::pg::{PgMetadataLookup, PgTypeMetadata};
 
                 impl #impl_generics diesel::sql_types::HasSqlType<#struct_name #ty_generics>
                     for diesel::pg::Pg


### PR DESCRIPTION
Macro hygiene used to ignore module scope, which meant that we could
reference a type from outside our wrapper module even if we didn't
import it. That is changing in an upcoming version of Rust.

Unfortunately, we can't just do either of the recommended solutions
(either adding `use super::*` or changing to use a function instead of a
module). `use super::*` doesn't work for types defined inside of a
function, and changing ot use a function instead of a module broke our
workaround to pretend we had `$crate` when we really didn't.

With this change, an item named `diesel` must be present at the crate
root. In the case of Diesel itself, this is just a module, but for all
users they will now have to put `extern crate diesel` at the crate root.
It's unlikely folks were renaming it, but we will no longer work if they
do (the import was already located at the crate root, since you cant do
`#[macro_use] extern crate` anywhere else).

Fixes #1785.