### PR TITLE
UI improvements for errors on migrations run and redo

### DIFF
--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -105,7 +105,7 @@ impl Error for RunMigrationsError {
 
 impl fmt::Display for RunMigrationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        self.description().fmt(f)
+        write!(f, "Failed with: {}", self.description())
     }
 }
 

--- a/diesel_cli/tests/migration_redo.rs
+++ b/diesel_cli/tests/migration_redo.rs
@@ -90,3 +90,47 @@ Running migration 12345_create_users_table
         result.stdout()
     );
 }
+
+#[test]
+fn output_contains_path_to_migration_script() {
+    let p = project("output_contains_path_to_migration_script")
+        .folder("migrations")
+        .build();
+    p.create_migration(
+        "output_contains_path_to_migration_script",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+        "DROP TABLE users};",
+    );
+
+    // Make sure the project is setup
+    p.command("setup").run();
+
+    let result = p.command("migration").arg("redo").run();
+
+    assert!(!result.is_success(), "Result was successful {:?}", result);
+    assert!(
+        result.stdout().contains("down.sql"),
+        "Unexpected stdout {}",
+        result.stdout()
+    );
+}
+
+#[test]
+fn error_migrations_fails() {
+    let p = project("redo_error_migrations_fails")
+        .folder("migrations")
+        .build();
+    p.create_migration(
+        "redo_error_migrations_fails",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+        "DROP TABLE users};",
+    );
+
+    // Make sure the project is setup
+    p.command("setup").run();
+
+    let result = p.command("migration").arg("redo").run();
+
+    assert!(!result.is_success());
+    assert!(result.stdout().contains("Failed with: "));
+}

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -105,7 +105,47 @@ fn empty_migrations_are_not_valid() {
     let result = p.command("migration").arg("run").run();
 
     assert!(!result.is_success());
-    assert!(result.stdout().contains("empty migration"));
+    assert!(
+        result
+            .stdout()
+            .contains("Failed with: Attempted to run an empty migration.")
+    );
+}
+
+#[test]
+fn error_migrations_fails() {
+    let p = project("run_error_migrations_fails")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    p.create_migration(
+        "run_error_migrations_fails",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY}",
+        "DROP TABLE users",
+    );
+
+    let result = p.command("migration").arg("run").run();
+
+    assert!(!result.is_success());
+    assert!(result.stdout().contains("Failed with: "));
+}
+
+#[test]
+fn output_contains_path_to_migration_script() {
+    let p = project("output_contains_path_to_migration_script")
+        .folder("migrations")
+        .build();
+
+    p.command("setup").run();
+
+    p.create_migration("output_contains_path_to_migration_script", "", "");
+
+    let result = p.command("migration").arg("run").run();
+
+    assert!(!result.is_success());
+    assert!(result.stdout().contains("up.sql"));
 }
 
 #[test]

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -328,7 +328,14 @@ where
         if migration.version() != "00000000000000" {
             try!(writeln!(output, "Running migration {}", name(&migration)));
         }
-        try!(migration.run(conn));
+        if let Err(e) = migration.run(conn) {
+            try!(writeln!(
+                output,
+                "Executing migration script {}",
+                file_name(&migration, "up.sql")
+            ));
+            return Err(e);
+        }
         try!(conn.insert_new_migration(migration.version()));
         Ok(())
     })
@@ -345,7 +352,14 @@ fn revert_migration<Conn: Connection>(
             "Rolling back migration {}",
             name(&migration)
         ));
-        try!(migration.revert(conn));
+        if let Err(e) = migration.revert(conn) {
+            try!(writeln!(
+                output,
+                "Executing migration script {}",
+                file_name(&migration, "down.sql")
+            ));
+            return Err(e);
+        }
         let target = __diesel_schema_migrations.filter(version.eq(migration.version()));
         try!(::diesel::delete(target).execute(conn));
         Ok(())

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -29,6 +29,31 @@ impl<'a> fmt::Display for MigrationName<'a> {
     }
 }
 
+#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy)]
+pub struct MigrationFileName<'a> {
+    pub migration: &'a Migration,
+    pub sql_file: &'a str,
+}
+
+pub fn file_name<'a>(migration: &'a Migration, sql_file: &'a str) -> MigrationFileName<'a> {
+    MigrationFileName {
+        migration,
+        sql_file,
+    }
+}
+
+impl<'a> fmt::Display for MigrationFileName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let fpath = match self.migration.file_path() {
+            None => return Err(fmt::Error),
+            Some(v) => v.join(self.sql_file),
+        };
+        f.write_str(fpath.to_str().unwrap())?;
+        Ok(())
+    }
+}
+
 pub fn migration_from(path: PathBuf) -> Result<Box<Migration>, MigrationError> {
     #[cfg(feature = "barrel")]
     match ::barrel::integrations::diesel::migration_from(&path) {


### PR DESCRIPTION
Hi!

Now output contains path to migration file if run/redo errored, like
```
Running migration 20170308040245
Executing migration script /path/to/migration/up.sql
Failed with: unrecognized token: "{"
```
refs #688