### PR TITLE
Do not rebuild documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,15 +76,15 @@ env:
   global:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: NmCM1VNEzid6bROA7tXV1R63n9S9KvY1etXsDzd1608cvjRnG3ZDAWXISbY1BxqrvleElreUJOvz/3TSQCHivpT2ezeyk2sntYtZpw0TWbz1SQMAPNWPTjP3bNQzpmNwfU4p6ui6qIOnQza4JxOu3SZSveNlehDBPkkS+52R7Zw/EPdwi9jTYJArV2+8pnEsQECAdRLttbtA2JBl3hZ4VHfGpHRZyeULn63UzyVbQVzQ3NVhqyQUKTPdpUciQTI3fZEkfaWuLV8QPPa5026/yJEEi2Fsl3r7fyY8ia67k4Zo9THlPVD0YOUlkWuZWwvkxNA8RQSVPv4FidEpwbxG8y6nAra4CjwiEChcpFhZJtrH7ZrXO/tJk7vtc5CFVWUsQtNX92QY1QFdPxwYNBSICLyUN+A+BQURwvQgxdcJsJyQmh5Ed7yuavcAinVq7fPeOyBWcPL5mt17no16aG1rzvXSUnD0aH7F3S3DHkoM9P9iHgJMLk+2YNmJtFescBxCeG8bA7t5bw0kQNH5KUWAD1uYpC9ikB3NVdlc+q17dKTAe4rcYA+sIO+UGudvpmLWT0lXtEMqDfxfCmyICDESs9bNfueCGJEAnfTBNunsJqR7rMUvjNndS2/Ssok6c/0Yfb9X8cM9nI4QLAj/+hClqdYphmpCjuC34bWxFSt/KJI=
-after_success:
-- |
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    (cd diesel && travis-cargo doc -- --features "postgres sqlite mysql extras")
-    mkdir diesel/target
-    mv target/doc diesel/target/doc
-    echo "docs.diesel.rs" > diesel/target/doc/CNAME
-    (cd diesel && travis-cargo doc-upload)
-  fi
+# after_success:
+# - |
+#   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+#     (cd diesel && travis-cargo doc -- --features "postgres sqlite mysql extras")
+#     mkdir diesel/target
+#     mv target/doc diesel/target/doc
+#     echo "docs.diesel.rs" > diesel/target/doc/CNAME
+#     (cd diesel && travis-cargo doc-upload)
+#   fi
 branches:
   only:
     - master


### PR DESCRIPTION
Our documentation is currently unable to build due to
https://github.com/rust-lang/rust/issues/52545. Until that is resolved
we need to disable updates to our hosted documentation. Hopefully this
issue is resolved upstream soon, but there's nothing we can do until
then.

I'm not entirely sure why broken doc builds got uploaded, but I will be
looking into that separately.