### PR TITLE
Grab connection before finalizing statement for SQLite

### DIFF
--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -122,8 +122,9 @@ impl Drop for Statement {
     fn drop(&mut self) {
         use std::thread::panicking;
 
+        let conn = self.raw_connection();
         let finalize_result = unsafe { ffi::sqlite3_finalize(self.inner_statement.as_ptr()) };
-        if let Err(e) = ensure_sqlite_ok(finalize_result, self.raw_connection()) {
+        if let Err(e) = ensure_sqlite_ok(finalize_result, conn) {
             if panicking() {
                 write!(
                     stderr(),


### PR DESCRIPTION
When dropping statement, inner_statement is finalized first,
and then is used to get the raw connection, which may cause a crash.
https://www.sqlite.org/c3ref/finalize.html