### PR TITLE
Regenerate schema.rs after running `diesel database reset`

### DIFF
--- a/diesel_cli/tests/database_reset.rs
+++ b/diesel_cli/tests/database_reset.rs
@@ -170,3 +170,23 @@ fn reset_sanitize_database_name() {
         result.stdout()
     );
 }
+
+#[test]
+fn reset_updates_schema_if_config_present() {
+    let p = project("reset_updates_schema_if_config_present")
+        .folder("migrations")
+        .file(
+            "diesel.toml",
+            r#"
+[print_schema]
+file = "src/my_schema.rs"
+"#,
+        )
+        .build();
+
+    let result = p.command("database").arg("reset").run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+
+    assert!(p.has_file("src/my_schema.rs"));
+}

--- a/diesel_cli/tests/database_reset.rs
+++ b/diesel_cli/tests/database_reset.rs
@@ -178,9 +178,9 @@ fn reset_updates_schema_if_config_present() {
         .file(
             "diesel.toml",
             r#"
-[print_schema]
-file = "src/my_schema.rs"
-"#,
+            [print_schema]
+            file = "src/my_schema.rs"
+            "#,
         )
         .build();
 

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -360,9 +360,9 @@ fn migration_run_updates_schema_if_config_present() {
         .file(
             "diesel.toml",
             r#"
-[print_schema]
-file = "src/my_schema.rs"
-"#,
+            [print_schema]
+            file = "src/my_schema.rs"
+            "#,
         )
         .build();
 


### PR DESCRIPTION
Especially in the early stages of a project it can be useful to modify
the database structure by changing old(er) migrations and recreate
everything with `diesel database reset`.

Updating the schema file saves one additional step and ensures it is
always up to date.