### PR TITLE
Implement Unsigned<Tinyint> for Mysql

### DIFF
--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -29,6 +29,19 @@ impl FromSql<Tinyint, Mysql> for i8 {
 #[derive(Debug, Clone, Copy, Default, SqlType, QueryId)]
 pub struct Unsigned<ST>(ST);
 
+impl ToSql<Unsigned<Tinyint>, Mysql> for u8 {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
+        ToSql::<Tinyint, Mysql>::to_sql(&(*self as i8), out)
+    }
+}
+
+impl FromSql<Unsigned<Tinyint>, Mysql> for u8 {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        let signed: i8 = FromSql::<Tinyint, Mysql>::from_sql(bytes)?;
+        Ok(signed as u8)
+    }
+}
+
 impl ToSql<Unsigned<SmallInt>, Mysql> for u16 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
         ToSql::<SmallInt, Mysql>::to_sql(&(*self as i16), out)

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -37,6 +37,11 @@ mod foreign_impls {
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
+    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<::sql_types::Tinyint>")]
+    struct U8Proxy(u8);
+
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(foreign_derive)]
     #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<SmallInt>")]
     struct U16Proxy(u16);
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -197,6 +197,26 @@ fn i32_to_sql_integer() {
 
 #[test]
 #[cfg(feature = "mysql")]
+fn u8_to_sql_integer() {
+    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("255", 255));
+    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("0", 0));
+    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("1", 1));
+    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("123", 123));
+    assert!(!query_to_sql_equality::<Unsigned<Tinyint>, u8>("0", 1));
+    assert!(!query_to_sql_equality::<Unsigned<Tinyint>, u8>("254", 255));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn u8_from_sql() {
+    assert_eq!(0, query_single_value::<Unsigned<Tinyint>, u8>("0"));
+    assert_eq!(255, query_single_value::<Unsigned<Tinyint>, u8>("255"));
+    assert_ne!(254, query_single_value::<Unsigned<Tinyint>, u8>("255"));
+    assert_eq!(123, query_single_value::<Unsigned<Tinyint>, u8>("123"));
+}
+
+#[test]
+#[cfg(feature = "mysql")]
 fn u16_to_sql_integer() {
     assert!(query_to_sql_equality::<Unsigned<SmallInt>, u16>(
         "65535", 65535


### PR DESCRIPTION
Add the implementation for `Unsigned<Tinyint>` for Mysql.

Closes #1771