### PR TITLE
Rename Tinyint to TinyInt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Diesel's derives now require that `extern crate diesel;` be at your crate root
   (e.g. `src/lib.rs` or `src/main.rs`)
 
+* `Tinyint` has been renamed to `TinyInt` and an alias has been created from `Tinyint` to `TinyInt`.
+
 ## [1.3.2] - 2018-06-13
 
 ### Fixed

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -12,13 +12,13 @@ use mysql::{Mysql, MysqlType};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::*;
 
-impl ToSql<Tinyint, Mysql> for i8 {
+impl ToSql<TinyInt, Mysql> for i8 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
         out.write_i8(*self).map(|_| IsNull::No).map_err(Into::into)
     }
 }
 
-impl FromSql<Tinyint, Mysql> for i8 {
+impl FromSql<TinyInt, Mysql> for i8 {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes);
         Ok(bytes[0] as i8)
@@ -29,15 +29,15 @@ impl FromSql<Tinyint, Mysql> for i8 {
 #[derive(Debug, Clone, Copy, Default, SqlType, QueryId)]
 pub struct Unsigned<ST>(ST);
 
-impl ToSql<Unsigned<Tinyint>, Mysql> for u8 {
+impl ToSql<Unsigned<TinyInt>, Mysql> for u8 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
-        ToSql::<Tinyint, Mysql>::to_sql(&(*self as i8), out)
+        ToSql::<TinyInt, Mysql>::to_sql(&(*self as i8), out)
     }
 }
 
-impl FromSql<Unsigned<Tinyint>, Mysql> for u8 {
+impl FromSql<Unsigned<TinyInt>, Mysql> for u8 {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let signed: i8 = FromSql::<Tinyint, Mysql>::from_sql(bytes)?;
+        let signed: i8 = FromSql::<TinyInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u8)
     }
 }

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -44,7 +44,7 @@ pub struct Bool;
 ///
 /// This is only available on MySQL.
 /// Keep in mind that `infer_schema!` will see `TINYINT(1)` as `Bool`,
-/// not `Tinyint`.
+/// not `TinyInt`.
 ///
 /// ### [`ToSql`](../serialize/trait.ToSql.html) impls
 ///
@@ -57,7 +57,9 @@ pub struct Bool;
 /// [i8]: https://doc.rust-lang.org/nightly/std/primitive.i8.html
 #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
 #[mysql_type = "Tiny"]
-pub struct Tinyint;
+pub struct TinyInt;
+#[doc(hidden)]
+pub type Tinyint = TinyInt;
 
 /// The small integer SQL type.
 ///

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -17,7 +17,7 @@ mod foreign_impls {
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Tinyint")]
+    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::TinyInt")]
     struct I8Proxy(i8);
 
     #[derive(FromSqlRow, AsExpression)]
@@ -37,7 +37,7 @@ mod foreign_impls {
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<::sql_types::Tinyint>")]
+    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<::sql_types::TinyInt>")]
     struct U8Proxy(u8);
 
     #[derive(FromSqlRow, AsExpression)]

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -15,8 +15,8 @@ pub use serialize::{IsNull, ToSql};
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Bool` instead")]
 pub type Bool = ::sql_types::Bool;
 
-#[deprecated(since = "1.1.0", note = "Use `sql_types::Tinyint` instead")]
-pub type Tinyint = ::sql_types::Tinyint;
+#[deprecated(since = "1.1.0", note = "Use `sql_types::TinyInt` instead")]
+pub type TinyInt = ::sql_types::TinyInt;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::SmallInt` instead")]
 pub type SmallInt = ::sql_types::SmallInt;

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -198,21 +198,21 @@ fn i32_to_sql_integer() {
 #[test]
 #[cfg(feature = "mysql")]
 fn u8_to_sql_integer() {
-    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("255", 255));
-    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("0", 0));
-    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("1", 1));
-    assert!(query_to_sql_equality::<Unsigned<Tinyint>, u8>("123", 123));
-    assert!(!query_to_sql_equality::<Unsigned<Tinyint>, u8>("0", 1));
-    assert!(!query_to_sql_equality::<Unsigned<Tinyint>, u8>("254", 255));
+    assert!(query_to_sql_equality::<Unsigned<TinyInt>, u8>("255", 255));
+    assert!(query_to_sql_equality::<Unsigned<TinyInt>, u8>("0", 0));
+    assert!(query_to_sql_equality::<Unsigned<TinyInt>, u8>("1", 1));
+    assert!(query_to_sql_equality::<Unsigned<TinyInt>, u8>("123", 123));
+    assert!(!query_to_sql_equality::<Unsigned<TinyInt>, u8>("0", 1));
+    assert!(!query_to_sql_equality::<Unsigned<TinyInt>, u8>("254", 255));
 }
 
 #[test]
 #[cfg(feature = "mysql")]
 fn u8_from_sql() {
-    assert_eq!(0, query_single_value::<Unsigned<Tinyint>, u8>("0"));
-    assert_eq!(255, query_single_value::<Unsigned<Tinyint>, u8>("255"));
-    assert_ne!(254, query_single_value::<Unsigned<Tinyint>, u8>("255"));
-    assert_eq!(123, query_single_value::<Unsigned<Tinyint>, u8>("123"));
+    assert_eq!(0, query_single_value::<Unsigned<TinyInt>, u8>("0"));
+    assert_eq!(255, query_single_value::<Unsigned<TinyInt>, u8>("255"));
+    assert_ne!(254, query_single_value::<Unsigned<TinyInt>, u8>("255"));
+    assert_eq!(123, query_single_value::<Unsigned<TinyInt>, u8>("123"));
 }
 
 #[test]

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -266,7 +266,7 @@ mod pg_types {
 mod mysql_types {
     use super::*;
 
-    test_round_trip!(i8_roundtrips, Tinyint, i8);
+    test_round_trip!(i8_roundtrips, TinyInt, i8);
     test_round_trip!(
         naive_datetime_roundtrips,
         Timestamp,


### PR DESCRIPTION
Rename `Tinyint` to `TinyInt` for consistent naming. 

Ref. #1803 