### PR TITLE
Allow `now` to coerce to `Nullable<Timestamp>`

### DIFF
--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,5 +1,6 @@
 use backend::Backend;
-use expression::{Expression, NonAggregate};
+use expression::coerce::Coerce;
+use expression::{AsExpression, Expression, NonAggregate};
 use query_builder::*;
 use result::QueryResult;
 use sql_types::*;
@@ -47,10 +48,13 @@ sql_function! {
     fn date(expr: Timestamp) -> Date;
 }
 
-#[cfg(feature = "postgres")]
-use expression::coerce::Coerce;
-#[cfg(feature = "postgres")]
-use expression::AsExpression;
+impl AsExpression<Nullable<Timestamp>> for now {
+    type Expression = Coerce<now, Nullable<Timestamp>>;
+
+    fn as_expression(self) -> Self::Expression {
+        Coerce::new(self)
+    }
+}
 
 #[cfg(feature = "postgres")]
 impl AsExpression<Timestamptz> for now {

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -124,6 +124,17 @@ fn now_can_be_used_as_nullable_timestamptz() {
 }
 
 #[test]
+fn now_can_be_used_as_nullable() {
+    use diesel::sql_types::Timestamp;
+
+    let nullable_timestamp = sql::<Nullable<Timestamp>>("CURRENT_TIMESTAMP");
+    let result = select(nullable_timestamp.eq(now))
+        .get_result(&connection());
+
+    assert_eq!(Ok(true), result);
+}
+
+#[test]
 #[cfg(feature = "sqlite")]
 fn now_executes_sql_function_now() {
     use self::has_timestamps::dsl::*;


### PR DESCRIPTION
It is able to coerce to `Nullable<Timestamptz>`, so it makes no sense
for it not to coerce to `Nullable<Timestamp>`.

I'd love to use `expression::Nullable<now>` both in the test and as the
return type of the coercion (or remove the nullable coercion entirely).
However, `expression::Nullable` can only be used in select clauses with
left outer joins for complicated coherence reasons