### PR TITLE
Expose the ConnectionOptions object for use by client.

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -1,7 +1,7 @@
 mod bind;
 mod raw;
 mod stmt;
-mod url;
+pub mod url;
 
 use self::raw::RawConnection;
 use self::stmt::Statement;


### PR DESCRIPTION
I've submitted this as a PR, but it's really more of a suggestion.

I was recently writing some code, and I wanted to log which database was being connected to, without displaying the password. One solution is to duplicate the parsing code, but it would be easier to just use the code in diesel. This PR exposes that code and adds documentation for it.

# Reasons not to do this

Some reasons to reject this PR:

 - CStrings are confusing (probably ok since you don't normally need to use this functionality).
 - Making the strategy public means that it cannot be changed without breaking backwards compatibility.

Let me know what you think.