### PR TITLE
Do not fail on missing Cargo.toml while regenerating schema

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -270,7 +270,7 @@ fn search_for_cargo_toml_directory(path: &Path) -> DatabaseResult<PathBuf> {
     } else {
         path.parent()
             .map(search_for_cargo_toml_directory)
-            .unwrap_or(Err(DatabaseError::CargoTomlNotFound))
+            .unwrap_or_else(|| Err(DatabaseError::CargoTomlNotFound))
     }
 }
 


### PR DESCRIPTION
Hello, I am working on Docker image with migration based on https://github.com/clux/diesel-cli.
I created the following image 
```
FROM clux/diesel-cli
WORKDIR /root
COPY ./migrations ./migrations
```

After I run migrations I have noticed that container exited with `1` status code.
There was printed a list on passed migrations and after that
```
Unable to find Cargo.toml in this directory or any parent directories.
```

I guess it it comes from [here](https://github.com/diesel-rs/diesel/blob/master/diesel_cli/src/main.rs#L81).
It is said in [docs](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or) 
> Arguments passed to unwrap_or are eagerly evaluated;

Maybe it has to do something with that, though I am not sure why it works this way.

I have tested this patch on my case, it works fine: migrations are just run, exit code is `0`.

P. S.
A similar code exists [here](https://github.com/diesel-rs/diesel/blob/master/diesel_migrations/migrations_internals/src/lib.rs#L383). Maybe it should be updated too. 