### PR TITLE
Allow to customize foreign types in `#[derive(Associations)]`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ matrix:
     - SQLITE_DATABASE_URL=/tmp/test.db
     script:
     - (cd diesel_cli && travis-cargo test -- --no-default-features --features "sqlite-bundled")
-  - rust: 1.24.1
+  - rust: 1.27.0
     env:
-    - ENSURE_SUPPORTED_RUST_VERSION=1.24.1
+    - ENSURE_SUPPORTED_RUST_VERSION=1.27.0
     script:
     - cargo check --all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,12 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: nightly-2018-07-17
+  - rust: nightly-2018-08-17
     env: CLIPPY_AND_COMPILE_TESTS=YESPLEASE
     script:
     - rustup component add clippy-preview
     - cargo clippy
-    - (cd diesel_compile_tests && cargo update && cargo update -pproc-macro2 --precise "0.4.8" && travis-cargo test)
+    - (cd diesel_compile_tests && travis-cargo test)
   - rust: 1.26.1
     env: RUSTFMT=YESPLEASE
     script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `Tinyint` has been renamed to `TinyInt` and an alias has been created from `Tinyint` to `TinyInt`.
 
+* The minimal officially supported rustc version is now 1.27.0
+
 ## [1.3.2] - 2018-06-13
 
 ### Fixed

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", default-features = false, features = ["extras", "sqlite", "postgres", "mysql", "unstable"] }
-compiletest_rs = "=0.3.11"
+compiletest_rs = "=0.3.14"
 
 [replace]
 "diesel:1.3.2" = { path = "../diesel" }

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_options.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_options.stderr
@@ -1,38 +1,38 @@
 error: `treat_none_as_null` must be in the form `treat_none_as_null = "true"`
-  --> $DIR/as_changeset_bad_options.rs:11:10
+  --> $DIR/as_changeset_bad_options.rs:13:21
    |
-11 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+13 | #[changeset_options(treat_none_as_null("true"))]
+   |                     ^^^^^^^^^^^^^^^^^^
 
 error: `treat_none_as_null` must be in the form `treat_none_as_null = "true"`
-  --> $DIR/as_changeset_bad_options.rs:19:10
+  --> $DIR/as_changeset_bad_options.rs:21:21
    |
-19 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+21 | #[changeset_options(treat_none_as_null)]
+   |                     ^^^^^^^^^^^^^^^^^^
 
 error: `treat_none_as_null` must be in the form `treat_none_as_null = "true"`
-  --> $DIR/as_changeset_bad_options.rs:27:10
+  --> $DIR/as_changeset_bad_options.rs:29:21
    |
-27 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+29 | #[changeset_options(treat_none_as_null = "foo")]
+   |                     ^^^^^^^^^^^^^^^^^^
 
 error: Missing required option treat_none_as_null
-  --> $DIR/as_changeset_bad_options.rs:35:10
+  --> $DIR/as_changeset_bad_options.rs:37:3
    |
-35 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+37 | #[changeset_options()]
+   |   ^^^^^^^^^^^^^^^^^
 
 error: `changeset_options` must be in the form `changeset_options(...)`
-  --> $DIR/as_changeset_bad_options.rs:43:10
+  --> $DIR/as_changeset_bad_options.rs:45:3
    |
-43 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+45 | #[changeset_options = "treat_none_as_null"]
+   |   ^^^^^^^^^^^^^^^^^
 
 error: `changeset_options` must be in the form `changeset_options(...)`
-  --> $DIR/as_changeset_bad_options.rs:51:10
+  --> $DIR/as_changeset_bad_options.rs:53:3
    |
-51 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+53 | #[changeset_options]
+   |   ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/diesel_compile_tests/tests/ui/as_changeset_bad_primary_key_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_bad_primary_key_syntax.stderr
@@ -1,14 +1,14 @@
 error: Expected `bar` found `bar = "baz"`
-  --> $DIR/as_changeset_bad_primary_key_syntax.rs:11:10
+  --> $DIR/as_changeset_bad_primary_key_syntax.rs:12:19
    |
-11 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+12 | #[primary_key(id, bar = "baz", qux(id))]
+   |                   ^^^
 
 error: Expected `qux` found `qux ( id )`
-  --> $DIR/as_changeset_bad_primary_key_syntax.rs:11:10
+  --> $DIR/as_changeset_bad_primary_key_syntax.rs:12:32
    |
-11 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+12 | #[primary_key(id, bar = "baz", qux(id))]
+   |                                ^^^
 
 error: aborting due to 2 previous errors
 

--- a/diesel_compile_tests/tests/ui/as_changeset_deprecated_column_name.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_deprecated_column_name.stderr
@@ -1,8 +1,8 @@
 warning: The form `table_name(value)` is deprecated. Use `table_name = "value"` instead
-  --> $DIR/as_changeset_deprecated_column_name.rs:11:10
+  --> $DIR/as_changeset_deprecated_column_name.rs:12:3
    |
-11 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^
+12 | #[table_name(users)]
+   |   ^^^^^^^^^^
 
 warning: The form `column_name(value)` is deprecated. Use `column_name = "value"` instead
   --> $DIR/as_changeset_deprecated_column_name.rs:15:7

--- a/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_missing_table_import.stderr
@@ -5,10 +5,10 @@ error[E0433]: failed to resolve. Use of undeclared type or module `users`
   |        ^^^^ Use of undeclared type or module `users`
 
 error[E0433]: failed to resolve. Use of undeclared type or module `users`
-  --> $DIR/as_changeset_missing_table_import.rs:10:10
+  --> $DIR/as_changeset_missing_table_import.rs:11:16
    |
-10 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^ Use of undeclared type or module `users`
+11 | #[table_name = "users"]
+   |                ^^^^^^^ Use of undeclared type or module `users`
 
 error: aborting due to 2 previous errors
 

--- a/diesel_compile_tests/tests/ui/as_expression_bad_sql_type.stderr
+++ b/diesel_compile_tests/tests/ui/as_expression_bad_sql_type.stderr
@@ -1,14 +1,26 @@
 error: `sql_type` must be in the form `sql_type = "value"`
- --> $DIR/as_expression_bad_sql_type.rs:4:10
+ --> $DIR/as_expression_bad_sql_type.rs:5:3
   |
-4 | #[derive(AsExpression)]
-  |          ^^^^^^^^^^^^
+5 | #[sql_type(Foo)]
+  |   ^^^^^^^^
+
+error: `sql_type` must be in the form `sql_type = "value"`
+ --> $DIR/as_expression_bad_sql_type.rs:6:3
+  |
+6 | #[sql_type]
+  |   ^^^^^^^^
 
 error: Invalid Rust type
- --> $DIR/as_expression_bad_sql_type.rs:4:10
+ --> $DIR/as_expression_bad_sql_type.rs:7:14
   |
-4 | #[derive(AsExpression)]
-  |          ^^^^^^^^^^^^
+7 | #[sql_type = "@%&&*"]
+  |              ^^^^^^^
 
-error: aborting due to 2 previous errors
+error: Invalid Rust type
+ --> $DIR/as_expression_bad_sql_type.rs:8:14
+  |
+8 | #[sql_type = "1omg"]
+  |              ^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
@@ -1,34 +1,48 @@
 error: `belongs_to` must be in the form `belongs_to(...)`
-  --> $DIR/belongs_to_invalid_option_syntax.rs:22:10
+  --> $DIR/belongs_to_invalid_option_syntax.rs:23:3
    |
-22 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^
+23 | #[belongs_to]
+   |   ^^^^^^^^^^
+
+error: `belongs_to` must be in the form `belongs_to(...)`
+  --> $DIR/belongs_to_invalid_option_syntax.rs:24:3
+   |
+24 | #[belongs_to = "Bar"]
+   |   ^^^^^^^^^^
 
 error: Expected a struct name
-  --> $DIR/belongs_to_invalid_option_syntax.rs:22:10
+  --> $DIR/belongs_to_invalid_option_syntax.rs:25:3
    |
-22 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^
+25 | #[belongs_to()]
+   |   ^^^^^^^^^^
+   |
+   = help: e.g. `#[belongs_to(User)]`
+
+error: Expected a struct name
+  --> $DIR/belongs_to_invalid_option_syntax.rs:26:14
+   |
+26 | #[belongs_to(foreign_key = "bar_id")]
+   |              ^^^^^^^^^^^
    |
    = help: e.g. `#[belongs_to(User)]`
 
 error: `foreign_key` must be in the form `foreign_key = "value"`
-  --> $DIR/belongs_to_invalid_option_syntax.rs:22:10
+  --> $DIR/belongs_to_invalid_option_syntax.rs:27:19
    |
-22 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^
+27 | #[belongs_to(Bar, foreign_key)]
+   |                   ^^^^^^^^^^^
 
 warning: The form `foreign_key(value)` is deprecated. Use `foreign_key = "value"` instead
-  --> $DIR/belongs_to_invalid_option_syntax.rs:22:10
+  --> $DIR/belongs_to_invalid_option_syntax.rs:28:19
    |
-22 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^
+28 | #[belongs_to(Bar, foreign_key(bar_id))]
+   |                   ^^^^^^^^^^^
 
 warning: Unrecognized option random_option
-  --> $DIR/belongs_to_invalid_option_syntax.rs:22:10
+  --> $DIR/belongs_to_invalid_option_syntax.rs:29:43
    |
-22 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^
+29 | #[belongs_to(Baz, foreign_key = "bar_id", random_option)]
+   |                                           ^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 

--- a/diesel_compile_tests/tests/ui/belongs_to_missing_foreign_key_column.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_missing_foreign_key_column.stderr
@@ -1,50 +1,50 @@
 error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:12:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:13:14
    |
-12 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+13 | #[belongs_to(Bar)]
+   |              ^^^ not found in `foo`
 
 error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:12:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:13:14
    |
-12 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+13 | #[belongs_to(Bar)]
+   |              ^^^ not found in `foo`
 
 error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:19:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:20:33
    |
-19 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+20 | #[belongs_to(Bar, foreign_key = "bar_id")]
+   |                                 ^^^^^^^^ not found in `foo`
 
 error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:19:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:20:33
    |
-19 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+20 | #[belongs_to(Bar, foreign_key = "bar_id")]
+   |                                 ^^^^^^^^ not found in `foo`
 
 error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:26:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:27:14
    |
-26 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+27 | #[belongs_to(Bar)]
+   |              ^^^ not found in `foo`
 
 error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:26:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:27:14
    |
-26 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+27 | #[belongs_to(Bar)]
+   |              ^^^ not found in `foo`
 
 error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:34:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:35:33
    |
-34 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+35 | #[belongs_to(Bar, foreign_key = "bar_id")]
+   |                                 ^^^^^^^^ not found in `foo`
 
 error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:34:10
+  --> $DIR/belongs_to_missing_foreign_key_column.rs:35:33
    |
-34 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in `foo`
+35 | #[belongs_to(Bar, foreign_key = "bar_id")]
+   |                                 ^^^^^^^^ not found in `foo`
 
 error: aborting due to 8 previous errors
 

--- a/diesel_compile_tests/tests/ui/belongs_to_missing_foreign_key_field.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_missing_foreign_key_field.stderr
@@ -1,14 +1,26 @@
 error: No field with column name bar_id
- --> $DIR/belongs_to_missing_foreign_key_field.rs:6:10
+ --> $DIR/belongs_to_missing_foreign_key_field.rs:7:14
   |
-6 | #[derive(Associations)]
-  |          ^^^^^^^^^^^^
+7 | #[belongs_to(Bar)]
+  |              ^^^
 
 error: No field with column name bar_id
-  --> $DIR/belongs_to_missing_foreign_key_field.rs:11:10
-   |
-11 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^
+ --> $DIR/belongs_to_missing_foreign_key_field.rs:8:33
+  |
+8 | #[belongs_to(Bar, foreign_key = "bar_id")]
+  |                                 ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: No field with column name bar_id
+  --> $DIR/belongs_to_missing_foreign_key_field.rs:12:14
+   |
+12 | #[belongs_to(Bar)]
+   |              ^^^
+
+error: No field with column name bar_id
+  --> $DIR/belongs_to_missing_foreign_key_field.rs:13:33
+   |
+13 | #[belongs_to(Bar, foreign_key = "bar_id")]
+   |                                 ^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/diesel_compile_tests/tests/ui/belongs_to_missing_parent_import.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_missing_parent_import.stderr
@@ -1,8 +1,8 @@
 error[E0412]: cannot find type `Bar` in this scope
-  --> $DIR/belongs_to_missing_parent_import.rs:11:10
+  --> $DIR/belongs_to_missing_parent_import.rs:12:14
    |
-11 | #[derive(Associations)]
-   |          ^^^^^^^^^^^^ not found in this scope
+12 | #[belongs_to(Bar)]
+   |              ^^^ not found in this scope
 
 error: aborting due to previous error
 

--- a/diesel_compile_tests/tests/ui/identifiable_missing_pk_field.stderr
+++ b/diesel_compile_tests/tests/ui/identifiable_missing_pk_field.stderr
@@ -11,28 +11,28 @@ error: No field with column name id
    |          ^^^^^^^^^^^^
 
 error: No field with column name bar
-  --> $DIR/identifiable_missing_pk_field.rs:22:10
+  --> $DIR/identifiable_missing_pk_field.rs:23:15
    |
-22 | #[derive(Identifiable)]
-   |          ^^^^^^^^^^^^
+23 | #[primary_key(bar)]
+   |               ^^^
 
 error: No field with column name baz
-  --> $DIR/identifiable_missing_pk_field.rs:28:10
+  --> $DIR/identifiable_missing_pk_field.rs:29:15
    |
-28 | #[derive(Identifiable)]
-   |          ^^^^^^^^^^^^
+29 | #[primary_key(baz)]
+   |               ^^^
 
 error: No field with column name bar
-  --> $DIR/identifiable_missing_pk_field.rs:36:10
+  --> $DIR/identifiable_missing_pk_field.rs:37:20
    |
-36 | #[derive(Identifiable)]
-   |          ^^^^^^^^^^^^
+37 | #[primary_key(foo, bar)]
+   |                    ^^^
 
 error: No field with column name bar
-  --> $DIR/identifiable_missing_pk_field.rs:43:10
+  --> $DIR/identifiable_missing_pk_field.rs:44:20
    |
-43 | #[derive(Identifiable)]
-   |          ^^^^^^^^^^^^
+44 | #[primary_key(foo, bar)]
+   |                    ^^^
 
 error: aborting due to 6 previous errors
 

--- a/diesel_compile_tests/tests/ui/insertable_missing_table_or_column.stderr
+++ b/diesel_compile_tests/tests/ui/insertable_missing_table_or_column.stderr
@@ -5,10 +5,10 @@ error[E0433]: failed to resolve. Use of undeclared type or module `posts`
    |        ^^^^ Use of undeclared type or module `posts`
 
 error[E0433]: failed to resolve. Use of undeclared type or module `posts`
-  --> $DIR/insertable_missing_table_or_column.rs:15:10
+  --> $DIR/insertable_missing_table_or_column.rs:16:16
    |
-15 | #[derive(Insertable)]
-   |          ^^^^^^^^^^ Use of undeclared type or module `posts`
+16 | #[table_name = "posts"]
+   |                ^^^^^^^ Use of undeclared type or module `posts`
 
 error[E0412]: cannot find type `name` in module `users`
   --> $DIR/insertable_missing_table_or_column.rs:21:10

--- a/diesel_compile_tests/tests/ui/sql_type_bad_options.stderr
+++ b/diesel_compile_tests/tests/ui/sql_type_bad_options.stderr
@@ -1,52 +1,52 @@
 error: Missing required options
- --> $DIR/sql_type_bad_options.rs:4:10
+ --> $DIR/sql_type_bad_options.rs:5:3
   |
-4 | #[derive(SqlType)]
-  |          ^^^^^^^
+5 | #[postgres]
+  |   ^^^^^^^^
   |
   = help: Valid options are `type_name` or `oid` and `array_oid`
 
 warning: Option oid has no effect
- --> $DIR/sql_type_bad_options.rs:8:10
+ --> $DIR/sql_type_bad_options.rs:9:31
   |
-8 | #[derive(SqlType)]
-  |          ^^^^^^^
+9 | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
+  |                               ^^^
 
 warning: Option array_oid has no effect
- --> $DIR/sql_type_bad_options.rs:8:10
+ --> $DIR/sql_type_bad_options.rs:9:42
   |
-8 | #[derive(SqlType)]
-  |          ^^^^^^^
+9 | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
+  |                                          ^^^^^^^^^
 
 error: Missing required option array_oid
-  --> $DIR/sql_type_bad_options.rs:12:10
+  --> $DIR/sql_type_bad_options.rs:13:3
    |
-12 | #[derive(SqlType)]
-   |          ^^^^^^^
+13 | #[postgres(oid = "2")]
+   |   ^^^^^^^^
 
 error: Expected a number
-  --> $DIR/sql_type_bad_options.rs:16:10
+  --> $DIR/sql_type_bad_options.rs:17:18
    |
-16 | #[derive(SqlType)]
-   |          ^^^^^^^
+17 | #[postgres(oid = "NaN", array_oid = "1")]
+   |                  ^^^^^
 
 warning: Option ary_oid has no effect
-  --> $DIR/sql_type_bad_options.rs:20:10
+  --> $DIR/sql_type_bad_options.rs:21:25
    |
-20 | #[derive(SqlType)]
-   |          ^^^^^^^
+21 | #[postgres(oid = "NaN", ary_oid = "1")]
+   |                         ^^^^^^^
 
 error: Missing required option array_oid
-  --> $DIR/sql_type_bad_options.rs:20:10
+  --> $DIR/sql_type_bad_options.rs:21:3
    |
-20 | #[derive(SqlType)]
-   |          ^^^^^^^
+21 | #[postgres(oid = "NaN", ary_oid = "1")]
+   |   ^^^^^^^^
 
 error: Expected a number
-  --> $DIR/sql_type_bad_options.rs:20:10
+  --> $DIR/sql_type_bad_options.rs:21:18
    |
-20 | #[derive(SqlType)]
-   |          ^^^^^^^
+21 | #[postgres(oid = "NaN", ary_oid = "1")]
+   |                  ^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -35,7 +35,7 @@ fn derive_belongs_to(
         parent_struct,
         foreign_key,
     } = AssociationOptions::from_meta(meta)?;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let (_, ty_generics, _) = generics.split_for_impl();
 
     let foreign_key_field = model.find_column(&foreign_key)?;
     let struct_name = &model.name;
@@ -43,18 +43,40 @@ fn derive_belongs_to(
     let foreign_key_ty = inner_of_option_ty(&foreign_key_field.ty);
     let table_name = model.table_name();
 
+    let mut generics = generics.clone();
+
+    // TODO: Remove this specialcasing as soon as we bump our minimal supported
+    // rust version to >= 1.30.0
+    // Then we could use the `&Option<T> -> `Option<&T>` from implementation in
+    // std lib
     let foreign_key_expr = if is_option_ty(&foreign_key_field.ty) {
-        quote!(self#foreign_key_access.as_ref())
+        quote!(self#foreign_key_access.as_ref().and_then(std::convert::Into::into))
     } else {
-        quote!(std::option::Option::Some(&self#foreign_key_access))
+        quote!(std::convert::Into::into(&self#foreign_key_access))
     };
+
+    generics.params.push(parse_quote!(__FK));
+    {
+        let where_clause = generics.where_clause.get_or_insert(parse_quote!(where));
+        where_clause
+            .predicates
+            .push(parse_quote!(__FK: std::hash::Hash + std::cmp::Eq));
+        where_clause.predicates.push(
+            parse_quote!(for<'__a> &'__a #foreign_key_ty: std::convert::Into<::std::option::Option<&'__a __FK>>),
+        );
+        where_clause.predicates.push(
+            parse_quote!(for<'__a> &'__a #parent_struct: diesel::associations::Identifiable<Id = &'__a __FK>),
+        );
+    }
+
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
         impl #impl_generics diesel::associations::BelongsTo<#parent_struct>
             for #struct_name #ty_generics
-        #where_clause
+            #where_clause
         {
-            type ForeignKey = #foreign_key_ty;
+            type ForeignKey = __FK;
             type ForeignKeyColumn = #table_name::#foreign_key;
 
             fn foreign_key(&self) -> std::option::Option<&Self::ForeignKey> {

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -46,9 +46,8 @@ fn derive_belongs_to(
     let mut generics = generics.clone();
 
     // TODO: Remove this specialcasing as soon as we bump our minimal supported
-    // rust version to >= 1.30.0
-    // Then we could use the `&Option<T> -> `Option<&T>` from implementation in
-    // std lib
+    // rust version to >= 1.30.0 because this version will add
+    // `impl<'a, T> From<&'a Option<T>> for Option<&'a T>` to the std-lib
     let foreign_key_expr = if is_option_ty(&foreign_key_field.ty) {
         quote!(self#foreign_key_access.as_ref().and_then(std::convert::Into::into))
     } else {
@@ -74,7 +73,7 @@ fn derive_belongs_to(
     Ok(quote! {
         impl #impl_generics diesel::associations::BelongsTo<#parent_struct>
             for #struct_name #ty_generics
-            #where_clause
+        #where_clause
         {
             type ForeignKey = __FK;
             type ForeignKeyColumn = #table_name::#foreign_key;

--- a/examples/mysql/getting_started_step_1/src/lib.rs
+++ b/examples/mysql/getting_started_step_1/src/lib.rs
@@ -14,5 +14,5 @@ pub fn establish_connection() -> MysqlConnection {
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     MysqlConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url))
+        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }

--- a/examples/postgres/getting_started_step_3/src/lib.rs
+++ b/examples/postgres/getting_started_step_3/src/lib.rs
@@ -15,16 +15,14 @@ pub fn establish_connection() -> PgConnection {
     dotenv().ok();
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    PgConnection::establish(&database_url).expect(&format!("Error connecting to {}", database_url))
+    PgConnection::establish(&database_url)
+        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }
 
 pub fn create_post(conn: &PgConnection, title: &str, body: &str) -> Post {
     use schema::posts;
 
-    let new_post = NewPost {
-        title: title,
-        body: body,
-    };
+    let new_post = NewPost { title, body };
 
     diesel::insert_into(posts::table)
         .values(&new_post)

--- a/examples/sqlite/getting_started_step_3/src/lib.rs
+++ b/examples/sqlite/getting_started_step_3/src/lib.rs
@@ -17,16 +17,13 @@ pub fn establish_connection() -> SqliteConnection {
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     SqliteConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url))
+        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }
 
 pub fn create_post(conn: &SqliteConnection, title: &str, body: &str) -> usize {
     use schema::posts;
 
-    let new_post = NewPost {
-        title: title,
-        body: body,
-    };
+    let new_post = NewPost { title, body };
 
     diesel::insert_into(posts::table)
         .values(&new_post)


### PR DESCRIPTION
This commit enables to usage of wrapper types for foreign keys in
`#[derive(Associations)]`
Basically those wrapper types must fulfil the following condition:
`&'a FieldType: Into<Option<&'a <ParentStruct as Identifiable>::Id>>`