### PR TITLE
Align getting started example imports with repo

### DIFF
--- a/examples/postgres/getting_started_step_1/src/lib.rs
+++ b/examples/postgres/getting_started_step_1/src/lib.rs
@@ -5,8 +5,8 @@ extern crate dotenv;
 pub mod models;
 pub mod schema;
 
-use diesel::prelude::*;
 use diesel::pg::PgConnection;
+use diesel::prelude::*;
 use dotenv::dotenv;
 use std::env;
 

--- a/examples/postgres/getting_started_step_1/src/lib.rs
+++ b/examples/postgres/getting_started_step_1/src/lib.rs
@@ -6,6 +6,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
+use diesel::pg::PgConnection;
 use dotenv::dotenv;
 use std::env;
 


### PR DESCRIPTION
While the prelude imports `PgConnection`, it's a confusing mis-match for beginners.

Fixes #1758