### PR TITLE
Fix name of SQLite in-memory database name

### DIFF
--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -25,7 +25,8 @@ use sql_types::HasSqlType;
 use sqlite::Sqlite;
 
 /// Connections for the SQLite backend. Unlike other backends, "connection URLs"
-/// for SQLite are file paths or special identifiers like `:memory:`.
+/// for SQLite are file paths, [URIs](https://sqlite.org/uri.html), or special
+/// identifiers like `:memory:`.
 #[allow(missing_debug_implementations)]
 pub struct SqliteConnection {
     statement_cache: StatementCache<Sqlite, Statement>,

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -25,7 +25,7 @@ use sql_types::HasSqlType;
 use sqlite::Sqlite;
 
 /// Connections for the SQLite backend. Unlike other backends, "connection URLs"
-/// for SQLite are file paths or special identifiers like `:memory`.
+/// for SQLite are file paths or special identifiers like `:memory:`.
 #[allow(missing_debug_implementations)]
 pub struct SqliteConnection {
     statement_cache: StatementCache<Sqlite, Statement>,


### PR DESCRIPTION
The `:memory` name just opens a database on disk.