### PR TITLE
Add an explicit error kind for failed `SERIALIZABLE` transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for MySQL's `UNSIGNED TINYINT`
 
+* `DatabaseErrorKind::SerializationFailure` has been added, corresponding to
+  SQLSTATE code 40001 (A `SERIALIZABLE` isolation level transaction failed to
+  commit due to a read/write dependency on another transaction). This error is
+  currently only detected on PostgreSQL.
+
 ### Changed
 
 * Diesel's derives now require that `extern crate diesel;` be at your crate root

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -36,6 +36,9 @@ impl PgResult {
                         Some(error_codes::FOREIGN_KEY_VIOLATION) => {
                             DatabaseErrorKind::ForeignKeyViolation
                         }
+                        Some(error_codes::SERIALIZATION_FAILURE) => {
+                            DatabaseErrorKind::SerializationFailure
+                        }
                         _ => DatabaseErrorKind::__Unknown,
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
@@ -162,4 +165,5 @@ mod error_codes {
     //! They are not exposed programmatically through libpq.
     pub const UNIQUE_VIOLATION: &str = "23505";
     pub const FOREIGN_KEY_VIOLATION: &str = "23503";
+    pub const SERIALIZATION_FAILURE: &str = "40001";
 }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -87,13 +87,25 @@ pub enum Error {
 pub enum DatabaseErrorKind {
     /// A unique constraint was violated.
     UniqueViolation,
+
     /// A foreign key constraint was violated.
     ForeignKeyViolation,
+
     /// The query could not be sent to the database due to a protocol violation.
     ///
     /// An example of a case where this would occur is if you attempted to send
     /// a query with more than 65000 bind parameters using PostgreSQL.
     UnableToSendCommand,
+
+    /// A serializable transaction failed to commit due to a read/write
+    /// dependency on a concurrent transaction.
+    ///
+    /// Corresponds to SQLSTATE code 40001
+    ///
+    /// This error is only detected for PostgreSQL, as we do not yet support
+    /// transaction isolation levels for other backends.
+    SerializationFailure,
+
     #[doc(hidden)]
     __Unknown, // Match against _ instead, more variants may be added in the future
 }


### PR DESCRIPTION
"serializable" is the strictest isolation level defined in the SQL
standard. Any two transactions at this isolation level executed
concurrently must have the same results, regardless of which order they
are actually executed in. The standard also defines this as the default
isolation level, but there is no backend I'm aware of that both properly
implements the serializable isolation level, and uses is it as the
default.

We're generally very conservative about adding error kinds to this enum,
and only do so when there's a demonstrable use case for handling it
programatically. I believe this is clearly the case for this error code,
since the correct response to receiving it is almost always to retry the
transaction.

The test for this is pretty straight forward. We create two
transactions. Each one counts half the table, and then inserts a row in
the other half. When run serially, one of the transactions will get 1
for its count, and the other will get 2. Which transaction gets which
result depends on the order they are run, so one of them will fail to
commit. Interestingly, PG is too conservative in determining whether the
dependency exists. If I replace `other_i` with `i`, the transactions are
no longer dependent, but PG still thinks they are.

Currently this error is only detected on PostgreSQL, as that is the only
backend that we support isolation levels in our query builder, and the
semantics of this isolation level are unclear on other backends (SQLite
claims its the default, but the behavior it describes is `REPEATABLE
READ`. MySQL appears to just make your transactions deadlock).

This is the first half of #1612