### PR TITLE
Add any_pending_migrations to `embed_migrations!`

### DIFF
--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -190,7 +190,10 @@ where
 ///
 /// See the [module level documentation](index.html) for information on how migrations should be
 /// structured, and where Diesel will look for them by default.
-pub fn any_pending_migrations_from<Conn, List>(conn: &Conn, migrations: List) -> Result<bool, RunMigrationsError>
+pub fn any_pending_migrations_from<Conn, List>(
+    conn: &Conn,
+    migrations: List,
+) -> Result<bool, RunMigrationsError>
 where
     Conn: MigrationConnection,
     List: IntoIterator,

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -169,8 +169,8 @@ where
     Ok(migrations)
 }
 
-// Returns true if there are outstanding migrations in the migrations directory, otherwise
-// returns false. Returns an `Err` if there are problems with migration setup.
+/// Returns true if there are outstanding migrations in the migrations directory, otherwise
+/// returns false. Returns an `Err` if there are problems with migration setup.
 ///
 /// See the [module level documentation](index.html) for information on how migrations should be
 /// structured, and where Diesel will look for them by default.
@@ -181,9 +181,24 @@ where
     let migrations_dir = find_migrations_directory()?;
     let all_migrations = migrations_in_directory(&migrations_dir)?;
     setup_database(conn)?;
+
+    any_pending_migrations_from(conn, all_migrations)
+}
+
+/// Returns true if there are outstanding migrations in the list provided to the function,
+/// otherwise returns false. Returns an `Err` if there are problems with migration setup.
+///
+/// See the [module level documentation](index.html) for information on how migrations should be
+/// structured, and where Diesel will look for them by default.
+pub fn any_pending_migrations_from<Conn, List>(conn: &Conn, migrations: List) -> Result<bool, RunMigrationsError>
+where
+    Conn: MigrationConnection,
+    List: IntoIterator,
+    List::Item: Migration,
+{
     let already_run = conn.previously_run_migration_versions()?;
 
-    let pending = all_migrations
+    let pending = migrations
         .into_iter()
         .any(|m| !already_run.contains(&m.version().to_string()));
 

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -50,6 +50,10 @@ pub fn derive_embed_migrations(input: &syn::DeriveInput) -> proc_macro2::TokenSt
                 unreachable!()
             }
         }
+
+        pub fn any_pending_migrations<C: MigrationConnection>(conn: &C) -> Result<bool, RunMigrationsError> {
+            any_pending_migrations_from(conn, ALL_MIGRATIONS.iter().map(|v| *v))
+        }
     );
 
     let run_fns = quote!(

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -83,6 +83,8 @@ extern crate migrations_macros;
 #[doc(inline)]
 pub use migrations_internals::any_pending_migrations;
 #[doc(inline)]
+pub use migrations_internals::any_pending_migrations_from;
+#[doc(inline)]
 pub use migrations_internals::find_migrations_directory;
 #[doc(inline)]
 pub use migrations_internals::mark_migrations_in_directory;


### PR DESCRIPTION
Implements #1845

It turned out the logic already exists, but hasn't been exposed for the `embed_migrations!` macro yet.

```rust
if embedded_migrations::any_pending_migrations()? {
    println!("executing migrations);
    embedded_migrations::run(&db)?;
}
```