### PR TITLE
Fix compatibility with MySQL 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `embed_migrations!` will no longer emit an unused import warning
 
+* Fixed an issue that occurred with MySQL 8.0 when calling `.execute` or
+  `.batch_execute` with a single query that returned a result set (such as our
+  `SELECT 1` health check in `r2d2`).
+
 ### Added
 
 * A helper trait has been added for implementing `ToSql` for PG composite types.

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -152,12 +152,10 @@ impl RawConnection {
     fn flush_pending_results(&self) -> QueryResult<()> {
         // We may have a result to process before advancing
         self.consume_current_result()?;
-        while self.next_result()? {
+        while self.more_results() {
+            self.next_result()?;
             self.consume_current_result()?;
         }
-        // next_result returns whether we've advanced to the *last* one, not
-        // whether we're completely done.
-        self.consume_current_result()?;
         Ok(())
     }
 
@@ -171,12 +169,13 @@ impl RawConnection {
         self.did_an_error_occur()
     }
 
-    /// Calls `mysql_next_result` and returns whether there are more results
-    /// after this one.
-    fn next_result(&self) -> QueryResult<bool> {
-        let more_results = unsafe { ffi::mysql_next_result(self.0.as_ptr()) == 0 };
-        self.did_an_error_occur()?;
-        Ok(more_results)
+    fn more_results(&self) -> bool {
+        unsafe { ffi::mysql_more_results(self.0.as_ptr()) != 0 }
+    }
+
+    fn next_result(&self) -> QueryResult<()> {
+        unsafe { ffi::mysql_next_result(self.0.as_ptr()) };
+        self.did_an_error_occur()
     }
 }
 


### PR DESCRIPTION
MySQL's client library puts the responsibility on us to clear the
network buffers before continuing. This is problematic in cases where we
execute a query that returns results (and thus has additional frames
that need to be flushed), but in a context where we're ignoring them.

The old implementation used `mysql_next_result`, which advances to the
next result in the query, and returns whether we just advanced to the
final result or not. Because it returns false on the last result, and
not if there are no more results to advance to, we had to call
`mysql_store_result` a final time after the last call to
`mysql_next_result`.

The problem case is when a query only has a single result. In MySQL 6
and earlier, the second call to `mysql_store_result` would return a null
pointer. In MySQL 8, it will return an error instead. To fix this, I've
separated out the "more results", which will give us the behavior we
wish `mysql_next_result` had.

I'm honestly not sure why migrations weren't affected by this, as I'd
expect to get the same behavior in a migration that contained only a
single statement with no results, but apparently this only occurs if
there is a statement that does have results.

I have not updated the version of MySQL on Travis, because I want a CI
run to make sure I didn't break things on 6.x. I will update it to point
at 8.0 before merging.

This change does not require additional tests, as we already have
regression tests in place for this case.

This fix justifies a patch release backported to 1.3.

Fixes #1826.