### PR TITLE
Allow associations to structs with lifetime parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Diesel CLI can now generate completions for zsh and fish. See `diesel
   completions --help` for details.
 
+* `#[belongs_to]` can now accept types that are generic over lifetimes (for
+  example, if one of the fields has the type `Cow<'a, str>`). To define an
+  association to such a type, write `#[belongs_to(parent = "User<'_>")]`
+
 ### Changed
 
 * Diesel's derives now require that `extern crate diesel;` be at your crate root

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -49,6 +49,35 @@
 //! The struct given to `#[belongs_to]` must be in scope,
 //! so you will need `use some_module::User` if `User` is defined in another module.
 //!
+//! If the parent record is generic over lifetimes, they can be written as `'_`.
+//! You will also need to wrap the type in quotes until
+//! `unrestricted_attribute_tokens` is stable.
+//!
+//! ```rust
+//! # #[macro_use] extern crate diesel;
+//! # include!("../doctest_setup.rs");
+//! # use schema::{posts, users};
+//! # use std::borrow::Cow;
+//! #
+//! #[derive(Identifiable)]
+//! #[table_name = "users"]
+//! pub struct User<'a> {
+//!     id: i32,
+//!     name: Cow<'a, str>,
+//! }
+//!
+//! #[derive(Associations)]
+//! #[belongs_to(parent = "User<'_>")]
+//! #[table_name = "posts"]
+//! pub struct Post {
+//!     id: i32,
+//!     user_id: i32,
+//!     title: String,
+//! }
+//! #
+//! # fn main() {}
+//! ```
+//!
 //! [`Identifiable`]: trait.Identifiable.html
 //!
 //! By default, Diesel assumes that your foreign keys will follow the convention `table_name_id`.

--- a/diesel_compile_tests/tests/ui/belongs_to_incorrect_lifetime_syntax.rs
+++ b/diesel_compile_tests/tests/ui/belongs_to_incorrect_lifetime_syntax.rs
@@ -1,0 +1,30 @@
+#[macro_use] extern crate diesel;
+
+table! {
+    foo {
+        id -> Integer,
+    }
+}
+
+table! {
+    bars {
+        id -> Integer,
+        foo_id -> Integer,
+    }
+}
+
+#[derive(Identifiable)]
+#[table_name = "foo"]
+struct Foo<'a> {
+    id: i32,
+    _marker: ::std::marker::PhantomData<&'a ()>,
+}
+
+
+#[derive(Associations)]
+#[belongs_to(parent = "Foo<'a>")]
+struct Bar {
+    foo_id: i32,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/ui/belongs_to_incorrect_lifetime_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_incorrect_lifetime_syntax.stderr
@@ -1,0 +1,9 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/belongs_to_incorrect_lifetime_syntax.rs:25:23
+   |
+25 | #[belongs_to(parent = "Foo<'a>")]
+   |                       ^^^^^^^^^ undeclared lifetime
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0261`.

--- a/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
@@ -16,15 +16,15 @@ error: Expected a struct name
 25 | #[belongs_to()]
    |   ^^^^^^^^^^
    |
-   = help: e.g. `#[belongs_to(User)]`
+   = help: e.g. `#[belongs_to(User)]` or `#[belongs_to(parent = "User<'_>")]
 
 error: Expected a struct name
-  --> $DIR/belongs_to_invalid_option_syntax.rs:26:14
+  --> $DIR/belongs_to_invalid_option_syntax.rs:26:3
    |
 26 | #[belongs_to(foreign_key = "bar_id")]
-   |              ^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: e.g. `#[belongs_to(User)]`
+   = help: e.g. `#[belongs_to(User)]` or `#[belongs_to(parent = "User<'_>")]
 
 error: `foreign_key` must be in the form `foreign_key = "value"`
   --> $DIR/belongs_to_invalid_option_syntax.rs:27:19


### PR DESCRIPTION
This was a bit of a pain to implement... I had hoped to just have the
syntax be `#[belongs_to(User<'_>)]`, which works on nightly... but is
feature gated on stable. I think that might be going away in 1.30, but
I'm not 100% certain yet. Second attempt was `#[belongs_to("User<'_>")]`
which works on nightly, but is feature gated on stable.

So the API has to be `#[belongs_to(some_key = "User<'_>")]` for the time
being. I've gone with `parent` as the key. This also makes our parsing
logic much more complicated, since we're now handling multiple forms
potentially given in multiple places. I want to refactor meta handling
in general eventually, but for now a little bit of spaghetti is fine.

The bigger messiness comes from what happens after the parsing. Next we
need to go through the type, and replace all instances of `'_` with some
unique lifetime, and stick that on the generics that we use for the
impl. This would actually look a bit cleaner if we had the users provide
lifetime names, but I'd rather be consistent with Rust syntax, instead
of simplifying our impl.

Fixes #1827.