### PR TITLE
Add examples for typical trivial `ToSql`/`FromSql` impls

### DIFF
--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -164,6 +164,38 @@ where
 /// - For third party backends, consult that backend's documentation.
 ///
 /// [`MysqlType`]: ../mysql/enum.MysqlType.html
+///
+/// ### Examples
+///
+/// Most implementations of this trait will be defined in terms of an existing
+/// implementation.
+///
+/// ```rust
+/// # use diesel::backend::Backend;
+/// # use diesel::sql_types::*;
+/// # use diesel::deserialize::{self, FromSql};
+/// #
+/// #[repr(i32)]
+/// #[derive(Debug, Clone, Copy)]
+/// pub enum MyEnum {
+///     A = 1,
+///     B = 2,
+/// }
+///
+/// impl<DB> FromSql<Integer, DB> for MyEnum
+/// where
+///     DB: Backend,
+///     i32: FromSql<Integer, DB>,
+/// {
+///     fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+///         match i32::from_sql(bytes)? {
+///             1 => Ok(MyEnum::A),
+///             2 => Ok(MyEnum::B),
+///             x => Err(format!("Unrecognized variant {}", x).into()),
+///         }
+///     }
+/// }
+/// ```
 pub trait FromSql<A, DB: Backend>: Sized {
     /// See the trait documentation.
     fn from_sql(bytes: Option<&DB::RawValue>) -> Result<Self>;

--- a/diesel/src/serialize.rs
+++ b/diesel/src/serialize.rs
@@ -156,6 +156,35 @@ where
 /// - For third party backends, consult that backend's documentation.
 ///
 /// [`MysqlType`]: ../mysql/enum.MysqlType.html
+///
+/// ### Examples
+///
+/// Most implementations of this trait will be defined in terms of an existing
+/// implementation.
+///
+/// ```rust
+/// # use diesel::backend::Backend;
+/// # use diesel::sql_types::*;
+/// # use diesel::serialize::{self, ToSql, Output};
+/// # use std::io::Write;
+/// #
+/// #[repr(i32)]
+/// #[derive(Debug, Clone, Copy)]
+/// pub enum MyEnum {
+///     A = 1,
+///     B = 2,
+/// }
+///
+/// impl<DB> ToSql<Integer, DB> for MyEnum
+/// where
+///     DB: Backend,
+///     i32: ToSql<Integer, DB>,
+/// {
+///     fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+///         (*self as i32).to_sql(out)
+///     }
+/// }
+/// ```
 pub trait ToSql<A, DB: Backend>: fmt::Debug {
     /// See the trait documentation.
     fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> Result;


### PR DESCRIPTION
We point people to a test case way too frequently, and should have some
example impls in our code (especially for the simpler case of "I'm using
an integer/string/whatever column and not creating a custom SQL type")

Fixes #1783.