### PR TITLE
Add `--verify-schema` to CLI, for use in CI and production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* Diesel CLI can be configured to error if a command would result in changes
+  to your schema file by passing `--locked-schema`. This is intended for use
+  in CI and production deploys, to ensure that the committed schema file is
+  up to date.
+
 * A helper trait has been added for implementing `ToSql` for PG composite types.
   See [`WriteTuple`][write-tuple-1-4-0] for details.
 

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -182,6 +182,17 @@ pub fn build_cli() -> App<'static, 'static> {
         .global(true)
         .takes_value(true);
 
+    let locked_schema_arg = Arg::with_name("LOCKED_SCHEMA")
+        .long("locked-schema")
+        .help("Require that the schema file is up to date")
+        .long_help(
+            "When `print_schema.file` is specified in your config file, this \
+             flag will cause Diesel CLI to error if any command would result in \
+             changes to that file. It is recommended that you use this flag when \
+             running migrations in CI or production.",
+        )
+        .global(true);
+
     App::new("diesel")
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::VersionlessSubcommands)
@@ -190,6 +201,7 @@ pub fn build_cli() -> App<'static, 'static> {
         )
         .arg(database_arg)
         .arg(config_arg)
+        .arg(locked_schema_arg)
         .subcommand(migration_subcommand)
         .subcommand(setup_subcommand)
         .subcommand(database_subcommand)

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer};
 use std::error::Error;
 use std::fmt::{self, Display, Formatter, Write};
 use std::fs::File;
-use std::io::{self, stdout, Write as IoWrite};
+use std::io::{self, Write as IoWrite};
 use std::path::Path;
 use std::process::Command;
 use tempfile::NamedTempFile;
@@ -35,9 +35,10 @@ impl Filtering {
     }
 }
 
-pub fn run_print_schema(
+pub fn run_print_schema<W: IoWrite>(
     database_url: &str,
     config: &config::PrintSchema,
+    output: &mut W,
 ) -> Result<(), Box<Error>> {
     let tempfile = NamedTempFile::new()?;
     let file = tempfile.reopen()?;
@@ -46,7 +47,7 @@ pub fn run_print_schema(
     // patch "replaces" our tempfile, meaning the old handle
     // does not include the patched output.
     let mut file = File::open(tempfile.path())?;
-    io::copy(&mut file, &mut stdout())?;
+    io::copy(&mut file, output)?;
     Ok(())
 }
 

--- a/diesel_cli/tests/migration_redo.rs
+++ b/diesel_cli/tests/migration_redo.rs
@@ -132,5 +132,5 @@ fn error_migrations_fails() {
     let result = p.command("migration").arg("redo").run();
 
     assert!(!result.is_success());
-    assert!(result.stdout().contains("Failed with: "));
+    assert!(result.stderr().contains("Failed with: "));
 }


### PR DESCRIPTION
While the config file and auto-updating schema file is a nice quality of
life change, it's too easy to accidentally have the contents of
src/schema.rs not reflect reality, but have CI pass because the file
gets changed when the test setup runs.

This adds a new flag, `--verify-schema` which causes any command that
would update the schema file specified in your config to error if the
contents changed as a result of that command. It's expected that this
command would always be run in CI and production deploys.