### PR TITLE
Update our issue policy to make the issue tracker more manageable

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,7 @@
 <!--
+Note that feature requests are not accepted on the issue tracker, and should be
+submitted to discourse.diesel.rs instead. See CONTRIBUTING.md for details
+
 If you want to report a bug, we added some points below you can fill out. If you want to request a feature, feel free to remove all the irrelevant text. In addition to this [issue tracker](https://github.com/diesel-rs/diesel/issues), you can also talk to Diesel maintainers and users on [Gitter](https://gitter.im/diesel-rs/diesel).
 -->
 
@@ -43,6 +46,8 @@ Please post as much of your database schema as necessary. If you are using `infe
 - [ ] I have already looked over the [issue tracker](https://github.com/diesel-rs/diesel/issues) for similar issues.
 - [ ] This issue can be reproduced on Rust's stable channel. (Your issue will be
   closed if this is not the case)
+- [ ] This issue is not a feature request, or I was asked to open it by a member
+  of the Diesel team.
 
 <!--
 Thank you for your submission!  You're helping make Diesel more robust 🎉

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,16 @@ Thank you! We'll try to respond as quickly as possible.
 
 ## Submitting feature requests
 
-If you can't find an issue (open or closed) describing your idea on our [issue
-tracker], open an issue. Adding answers to the following
+Diesel's issue tracker is meant to represent our current roadmap.
+An open issue represents either a bug, or a new feature that a member of the
+Diesel team is actively working on.
+
+This means that you should not submit a feature request to our issue tracker,
+unless you were asked to do so by a member of the Diesel team.
+Feature requests should instead be posted at discourse.diesel.rs.
+
+If you can't find thread describing your idea on our [discourse],
+create a new one. Adding answers to the following
 questions in your description is +1:
 
 - What do you want to do, and how do you expect Diesel to support you with that?
@@ -47,6 +55,7 @@ questions in your description is +1:
 
 Thank you! We'll try to respond as quickly as possible.
 
+[discourse]: discourse.diesel.rs
 
 ## Contribute code to Diesel
 


### PR DESCRIPTION
As per the discussions we've been having in gitter, this is a change
that is meant to make the issue tracker more manageable, and more
useful at surfacing features we should work on next.

The goal is to have every open issue be something immediately
actionable, meaning it is either a bug, or a feature we are actively
planning to work on in the near future. Doing this effectively turns the
issue tracker into a todo list, where any open issue is something we can
actually work on today. It also gives better visibility into our
roadmap, so folks can see what is coming in upcoming versions, vs things
that sound reasonable for some point in the future.

The other problem with using the issue tracker for feature requests is
how binary open/closed is. We have to immediately decide whether a
feature is reasonable for some point in the future, even before
discussion around it happens. If we close the issue, that likely kills
any discussion, but leaving it open implies that it's a feature we'd
accept a PR for.

Feature requests are something we still want to accept, but we will only
accept them on our discourse going forward. This moves the discussion to
a platform more designed for those sort of open ended discussions. It
also effectively creates an informal RFC process, where asking someone
to open an issue with their feature requests is effectively an accepted
RFC, while leaving a thread open without explicitly rejecting the
feature is effectively a postponed RFC.

After this is merged I will go through all open issues and enforce this
policy.