### PR TITLE
Bring back `__diesel_use_everything`

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -354,7 +354,3 @@ pub use query_builder::debug_query;
 pub use query_builder::functions::{delete, insert_into, insert_or_ignore_into, replace_into,
                                    select, sql_query, update};
 pub use result::Error::NotFound;
-
-pub(crate) mod diesel {
-    pub use super::*;
-}

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -2,6 +2,14 @@
 
 #[macro_export]
 #[doc(hidden)]
+macro_rules! __diesel_use_everything {
+    () => {
+        pub use $crate::*;
+    }
+}
+
+#[macro_export]
+#[doc(hidden)]
 macro_rules! __diesel_column {
     (
         table = $table:ident,

--- a/diesel_derives/src/diesel_numeric_ops.rs
+++ b/diesel_derives/src/diesel_numeric_ops.rs
@@ -10,7 +10,9 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
         let where_clause = item.generics
             .where_clause
             .get_or_insert(parse_quote!(where));
-        where_clause.predicates.push(parse_quote!(Self: Expression));
+        where_clause
+            .predicates
+            .push(parse_quote!(Self: diesel::expression::Expression));
         where_clause.predicates.push_punct(Default::default());
     }
     let (_, ty_generics, where_clause) = item.generics.split_for_impl();
@@ -21,56 +23,66 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
     let dummy_name = format!("_impl_diesel_numeric_ops_for_{}", item.ident);
 
     Ok(wrap_in_dummy_mod(
-        Ident::new(&dummy_name.to_lowercase(), Span::call_site()),
+        Ident::new(&dummy_name.to_uppercase(), Span::call_site()),
         quote! {
-            use diesel::expression::{ops, Expression, AsExpression};
-            use diesel::sql_types::ops::{Add, Sub, Mul, Div};
 
             impl #impl_generics ::std::ops::Add<__Rhs> for #struct_name #ty_generics
             #where_clause
-                <Self as Expression>::SqlType: Add,
-                __Rhs: AsExpression<<<Self as Expression>::SqlType as Add>::Rhs>,
+                <Self as diesel::expression::Expression>::SqlType: diesel::sql_types::ops::Add,
+                  __Rhs: diesel::expression::AsExpression<
+                    <<Self as diesel::expression::Expression>::SqlType
+                        as diesel::sql_types::ops::Add>::Rhs
+                >,
             {
-                type Output = ops::Add<Self, __Rhs::Expression>;
+                type Output = diesel::expression::ops::Add<Self, __Rhs::Expression>;
 
                 fn add(self, rhs: __Rhs) -> Self::Output {
-                    ops::Add::new(self, rhs.as_expression())
+                    diesel::expression::ops::Add::new(self, rhs.as_expression())
                 }
             }
 
             impl #impl_generics ::std::ops::Sub<__Rhs> for #struct_name #ty_generics
             #where_clause
-                <Self as Expression>::SqlType: Sub,
-                __Rhs: AsExpression<<<Self as Expression>::SqlType as Sub>::Rhs>,
+                <Self as diesel::expression::Expression>::SqlType: diesel::sql_types::ops::Sub,
+                __Rhs: diesel::expression::AsExpression<
+                    <<Self as diesel::expression::Expression>::SqlType
+                        as diesel::sql_types::ops::Sub>::Rhs
+                >,
             {
-                type Output = ops::Sub<Self, __Rhs::Expression>;
+                type Output = diesel::expression::ops::Sub<Self, __Rhs::Expression>;
 
                 fn sub(self, rhs: __Rhs) -> Self::Output {
-                    ops::Sub::new(self, rhs.as_expression())
+                    diesel::expression::ops::Sub::new(self, rhs.as_expression())
                 }
             }
 
             impl #impl_generics ::std::ops::Mul<__Rhs> for #struct_name #ty_generics
             #where_clause
-                <Self as Expression>::SqlType: Mul,
-                __Rhs: AsExpression<<<Self as Expression>::SqlType as Mul>::Rhs>,
+                <Self as diesel::expression::Expression>::SqlType: diesel::sql_types::ops::Mul,
+                __Rhs: diesel::expression::AsExpression<
+                    <<Self as diesel::expression::Expression>::SqlType
+                        as diesel::sql_types::ops::Mul>::Rhs
+                >,
             {
-                type Output = ops::Mul<Self, __Rhs::Expression>;
+                type Output = diesel::expression::ops::Mul<Self, __Rhs::Expression>;
 
                 fn mul(self, rhs: __Rhs) -> Self::Output {
-                    ops::Mul::new(self, rhs.as_expression())
+                    diesel::expression::ops::Mul::new(self, rhs.as_expression())
                 }
             }
 
             impl #impl_generics ::std::ops::Div<__Rhs> for #struct_name #ty_generics
             #where_clause
-                <Self as Expression>::SqlType: Div,
-                __Rhs: AsExpression<<<Self as Expression>::SqlType as Div>::Rhs>,
+                <Self as diesel::expression::Expression>::SqlType: diesel::sql_types::ops::Div,
+                __Rhs: diesel::expression::AsExpression<
+                    <<Self as diesel::expression::Expression>::SqlType
+                        as diesel::sql_types::ops::Div>::Rhs
+                >,
             {
-                type Output = ops::Div<Self, __Rhs::Expression>;
+                type Output = diesel::expression::ops::Div<Self, __Rhs::Expression>;
 
                 fn div(self, rhs: __Rhs) -> Self::Output {
-                    ops::Div::new(self, rhs.as_expression())
+                    diesel::expression::ops::Div::new(self, rhs.as_expression())
                 }
             }
         },

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -20,27 +20,26 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
             .push(parse_quote!(__DB: diesel::backend::Backend));
         where_clause
             .predicates
-            .push(parse_quote!(Self: FromSql<__ST, __DB>));
+            .push(parse_quote!(Self: diesel::deserialize::FromSql<__ST, __DB>));
     }
     let (impl_generics, _, where_clause) = item.generics.split_for_impl();
 
-    let dummy_mod = format!("_impl_from_sql_row_for_{}", item.ident,).to_lowercase();
+    let dummy_mod = format!("_impl_from_sql_row_for_{}", item.ident,).to_uppercase();
     Ok(wrap_in_dummy_mod(
         Ident::new(&dummy_mod, Span::call_site()),
         quote! {
-            use diesel::deserialize::{self, FromSql, FromSqlRow, Queryable};
 
-            impl #impl_generics FromSqlRow<__ST, __DB> for #struct_ty
+            impl #impl_generics diesel::deserialize::FromSqlRow<__ST, __DB> for #struct_ty
             #where_clause
             {
                 fn build_from_row<R: diesel::row::Row<__DB>>(row: &mut R)
-                    -> deserialize::Result<Self>
+                    -> diesel::deserialize::Result<Self>
                 {
-                    FromSql::<__ST, __DB>::from_sql(row.take())
+                    diesel::deserialize::FromSql::<__ST, __DB>::from_sql(row.take())
                 }
             }
 
-            impl #impl_generics Queryable<__ST, __DB> for #struct_ty
+            impl #impl_generics diesel::deserialize::Queryable<__ST, __DB> for #struct_ty
             #where_clause
             {
                 type Row = Self;

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -24,9 +24,8 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("identifiable"),
         quote! {
-            use diesel::associations::{HasTable, Identifiable};
 
-            impl #impl_generics HasTable for #struct_name #ty_generics
+            impl #impl_generics diesel::associations::HasTable for #struct_name #ty_generics
             #where_clause
             {
                 type Table = #table_name::table;
@@ -36,7 +35,8 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
                 }
             }
 
-            impl #ref_generics Identifiable for &'ident #struct_name #ty_generics
+            impl #ref_generics diesel::associations::Identifiable
+                for &'ident #struct_name #ty_generics
             #where_clause
             {
                 type Id = (#(&'ident #field_ty),*);

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -39,7 +39,7 @@ impl Model {
     }
 
     pub fn dummy_mod_name(&self, trait_name: &str) -> syn::Ident {
-        let name = format!("_impl_{}_for_{}", trait_name, self.name).to_lowercase();
+        let name = format!("_impl_{}_for_{}", trait_name, self.name).to_uppercase();
         Ident::new(&name, Span::call_site())
     }
 

--- a/diesel_derives/src/query_id.rs
+++ b/diesel_derives/src/query_id.rs
@@ -6,7 +6,9 @@ use util::*;
 
 pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     for ty_param in item.generics.type_params_mut() {
-        ty_param.bounds.push(parse_quote!(QueryId));
+        ty_param
+            .bounds
+            .push(parse_quote!(diesel::query_builder::QueryId));
     }
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
@@ -15,20 +17,19 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
     let query_id_ty_params = item.generics
         .type_params()
         .map(|ty_param| &ty_param.ident)
-        .map(|ty_param| quote!(<#ty_param as QueryId>::QueryId));
+        .map(|ty_param| quote!(<#ty_param as diesel::query_builder::QueryId>::QueryId));
     let has_static_query_id = item.generics
         .type_params()
         .map(|ty_param| &ty_param.ident)
-        .map(|ty_param| quote!(<#ty_param as QueryId>::HAS_STATIC_QUERY_ID));
+        .map(|ty_param| quote!(<#ty_param as diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID));
 
-    let dummy_mod = format!("_impl_query_id_for_{}", item.ident).to_lowercase();
+    let dummy_mod = format!("_impl_query_id_for_{}", item.ident).to_uppercase();
     Ok(wrap_in_dummy_mod(
         Ident::new(&dummy_mod, Span::call_site()),
         quote! {
-            use diesel::query_builder::QueryId;
 
             #[allow(non_camel_case_types)]
-            impl #impl_generics QueryId for #struct_name #ty_generics
+            impl #impl_generics diesel::query_builder::QueryId for #struct_name #ty_generics
             #where_clause
             {
                 type QueryId = #struct_name<#(#lifetimes,)* #(#query_id_ty_params,)*>;

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -15,7 +15,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
 
     let dummy_name = format!("_impl_sql_type_for_{}", item.ident);
     Ok(wrap_in_dummy_mod(
-        Ident::new(&dummy_name.to_lowercase(), Span::call_site()),
+        Ident::new(&dummy_name.to_uppercase(), Span::call_site()),
         quote! {
             impl #impl_generics diesel::sql_types::NotNull
                 for #struct_name #ty_generics
@@ -108,22 +108,21 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
 
             let metadata_fn = match ty {
                 PgType::Fixed { oid, array_oid } => quote!(
-                    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-                        PgTypeMetadata {
+                    fn metadata(_: &diesel::pg::PgMetadataLookup) -> diesel::pg::PgTypeMetadata {
+                        diesel::pg::PgTypeMetadata {
                             oid: #oid,
                             array_oid: #array_oid,
                         }
                     }
                 ),
                 PgType::Lookup(type_name) => quote!(
-                    fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
+                    fn metadata(lookup: &diesel::pg::PgMetadataLookup) -> diesel::pg::PgTypeMetadata {
                         lookup.lookup_type(#type_name)
                     }
                 ),
             };
 
             Some(quote! {
-                use diesel::pg::{PgMetadataLookup, PgTypeMetadata};
 
                 impl #impl_generics diesel::sql_types::HasSqlType<#struct_name #ty_generics>
                     for diesel::pg::Pg

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -7,13 +7,15 @@ use meta::*;
 pub fn wrap_in_dummy_mod(const_name: Ident, item: TokenStream) -> TokenStream {
     quote! {
         #[allow(non_snake_case, unused_extern_crates, unused_imports)]
-        fn #const_name() {
+        const #const_name: () = {
             // https://github.com/rust-lang/rust/issues/47314
             extern crate std;
-            use diesel;
+            mod diesel {
+                __diesel_use_everything!();
+            }
 
             #item
-        }
+        };
     }
 }
 


### PR DESCRIPTION
This allows to rename diesel while importing the crate

This rolls back the breaking change that it was required to import diesel as `#[macro_use] extern crate diesel;` in your crate root.

Site note:

It seems like it is [possible to use items from a mod defined inside of a constant by using the full path without self](https://play.rust-lang.org/?gist=8cd4e24b186df6ba50f926202c4e3eac&version=stable&mode=debug&edition=2015), but it seems not to be possible to [create use statements for those things](https://play.rust-lang.org/?gist=89eb3a97a41d3ce2d2980ec817b68dca&version=stable&mode=debug&edition=2015). Not sure if that should be reported as bug against rustc?