### PR TITLE
Allow mysql's unsigned types to be used with aggregate functions

### DIFF
--- a/diesel/src/sql_types/fold.rs
+++ b/diesel/src/sql_types/fold.rs
@@ -38,3 +38,10 @@ foldable_impls! {
 
     sql_types::Interval => (sql_types::Interval, sql_types::Interval),
 }
+
+#[cfg(feature = "mysql")]
+foldable_impls! {
+    sql_types::Unsigned<sql_types::SmallInt> => (sql_types::Unsigned<sql_types::BigInt>, sql_types::Numeric),
+    sql_types::Unsigned<sql_types::Integer> => (sql_types::Unsigned<sql_types::BigInt>, sql_types::Numeric),
+    sql_types::Unsigned<sql_types::BigInt> => (sql_types::Numeric, sql_types::Numeric),
+}

--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -17,3 +17,10 @@ impl<T: SqlOrd + NotNull> SqlOrd for sql_types::Nullable<T> {}
 
 #[cfg(feature = "postgres")]
 impl<T: SqlOrd> SqlOrd for sql_types::Array<T> {}
+
+#[cfg(feature = "mysql")]
+impl SqlOrd for sql_types::Unsigned<sql_types::SmallInt> {}
+#[cfg(feature = "mysql")]
+impl SqlOrd for sql_types::Unsigned<sql_types::Integer> {}
+#[cfg(feature = "mysql")]
+impl SqlOrd for sql_types::Unsigned<sql_types::BigInt> {}


### PR DESCRIPTION
In the cases where the output type is `Numeric`, the output is signed as
there's no representation of an unsigned arbitrary precision decimal
number.

Fixes #1870.