### PR TITLE
Added first pass of solution

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -198,10 +198,9 @@ fn migrations_dir(matches: &ArgMatches) -> PathBuf {
     if let Some(dir_entry) = fs::read_dir(&dir_path).unwrap()
         .filter(|x| x.is_ok())
         .map(|x| x.unwrap())
-        .filter(|x| {
+        .find(|x| {
             x.file_type().unwrap().is_file() && &x.file_name() == ".gitkeep"
         })
-        .next()
     {
         fs::remove_file(dir_entry.path()).unwrap_or_else(|e| eprintln!(
             "WARNING: Unable to delete existing `migrations/.gitkeep`:\n{}", e

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -283,7 +283,7 @@ fn generate_completions_command(matches: &ArgMatches) {
 fn create_migrations_directory(path: &Path) -> DatabaseResult<PathBuf> {
     println!("Creating migrations directory at: {}", path.display());
     fs::create_dir(path)?;
-   fs::File::create(path.join(".keep"))?;
+    fs::File::create(path.join(".keep"))?;
     Ok(path.to_owned())
 }
 

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -195,16 +195,18 @@ fn migrations_dir(matches: &ArgMatches) -> PathBuf {
     // This is a convenient cleanup code for when a user migrates from an
     // older version of diesel_cli that set a `.gitkeep` instead of a `.keep` file
     // TODO: remove this after a few releases
-    if let Some(dir_entry) = fs::read_dir(&dir_path).unwrap()
+    if let Some(dir_entry) = fs::read_dir(&dir_path)
+        .unwrap()
         .filter(|x| x.is_ok())
         .map(|x| x.unwrap())
-        .find(|x| {
-            x.file_type().unwrap().is_file() && &x.file_name() == ".gitkeep"
-        })
+        .find(|x| x.file_type().unwrap().is_file() && &x.file_name() == ".gitkeep")
     {
-        fs::remove_file(dir_entry.path()).unwrap_or_else(|e| eprintln!(
-            "WARNING: Unable to delete existing `migrations/.gitkeep`:\n{}", e
-        ));
+        fs::remove_file(dir_entry.path()).unwrap_or_else(|e| {
+            eprintln!(
+                "WARNING: Unable to delete existing `migrations/.gitkeep`:\n{}",
+                e
+            )
+        });
     }
 
     dir_path


### PR DESCRIPTION
Issue diesel-rs/diesel#1399

I changed the file name of `.gitkeep` in the `migrations/` directory to `.keep`. I also added some logic in the diesel_cli function to get the migrations directory path (`migrations_dir`) to remove the `.gitkeep` if it already exists. This way the next time someone runs a diesel_cli migration, it'll get deleted.

I'm also not sure how to deal with cleaning up that code after a few releases so any suggestions for that would also be appreciated.

This is also a first attempt at contributing to a rust project in general so I'll welcome any and all criticism :)