### PR TITLE
Add must use to insert update and delete statements

### DIFF
--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -10,6 +10,7 @@ use query_source::Table;
 use result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
+#[must_use="Queries are only executed when calling `load`, `get_result` or similar."]
 /// Represents a SQL `DELETE` statement.
 ///
 /// The type parameters on this struct represent:

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -10,7 +10,7 @@ use query_source::Table;
 use result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
-#[must_use="Queries are only executed when calling `load`, `get_result` or similar."]
+#[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
 /// Represents a SQL `DELETE` statement.
 ///
 /// The type parameters on this struct represent:

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -32,7 +32,7 @@ use sqlite::{Sqlite, SqliteConnection};
 /// [`values`]: #method.values
 /// [`default_values`]: #method.default_values
 #[derive(Debug, Clone, Copy)]
-#[must_use="Queries are only executed when calling `load`, `get_result` or similar."]
+#[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
 pub struct IncompleteInsertStatement<T, Op> {
     target: T,
     operator: Op,
@@ -110,7 +110,7 @@ impl<T, Op> IncompleteInsertStatement<T, Op> {
 }
 
 #[derive(Debug, Copy, Clone)]
-#[must_use="Queries are only executed when calling `load`, `get_result` or similar."]
+#[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
 /// A fully constructed insert statement.
 ///
 /// The parameters of this struct represent:

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -32,6 +32,7 @@ use sqlite::{Sqlite, SqliteConnection};
 /// [`values`]: #method.values
 /// [`default_values`]: #method.default_values
 #[derive(Debug, Clone, Copy)]
+#[must_use="Queries are only executed when calling `load`, `get_result` or similar."]
 pub struct IncompleteInsertStatement<T, Op> {
     target: T,
     operator: Op,
@@ -109,6 +110,7 @@ impl<T, Op> IncompleteInsertStatement<T, Op> {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[must_use="Queries are only executed when calling `load`, `get_result` or similar."]
 /// A fully constructed insert statement.
 ///
 /// The parameters of this struct represent:

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -53,6 +53,7 @@ impl<T, U> UpdateStatement<T, U, SetNotCalled> {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
 /// Represents a complete `UPDATE` statement.
 ///
 /// See [`update`](../fn.update.html) for usage examples, or [the update

--- a/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
+++ b/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
@@ -11,10 +11,9 @@ table! {
     }
 }
 
-
 fn main() {
-    use stuff::table as st;
     use stuff::b;
+    use stuff::table as st;
 
     st.select(b); //~ ERROR unused `diesel::query_builder::SelectStatement`
     st.select(b).distinct(); //~ ERROR unused `diesel::query_builder::SelectStatement`
@@ -26,14 +25,12 @@ fn main() {
     st.filter(b.eq(true)); //~ ERROR unused `diesel::query_builder::SelectStatement`
     st.filter(b.eq(true)).limit(1); //~ ERROR unused `diesel::query_builder::SelectStatement`
 
-    insert_into(stuff)
-        .values(b.eq(true)); //- ERROR unused `diesel::query_builder::InsertStatement`
-    insert_into(stuff)
-        .values(&vec![b.eq(true), b.eq(false)]); //~ ERROR unused `diesel::query_builder::InsertStatement`
+    insert_into(st).values(b.eq(true)); //~ ERROR unused
+    insert_into(st).values(&vec![b.eq(true), b.eq(false)]); //~ ERROR unused
 
-    update(stuff).set(b.eq(true)); //~ ERROR unused `diesel::query_builder::UpdateStatement`
+    update(st).set(b.eq(true)); //~ ERROR unused
 
-    delete(stuff); //~ ERROR unused `diesel::query_builder::DeleteStatement`
+    delete(st); //~ ERROR unused
 
     let _thingies = st.filter(b.eq(true)); // No ERROR
 }

--- a/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
+++ b/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
@@ -25,7 +25,7 @@ fn main() {
     st.filter(b.eq(true)); //~ ERROR unused `diesel::query_builder::SelectStatement`
     st.filter(b.eq(true)).limit(1); //~ ERROR unused `diesel::query_builder::SelectStatement`
 
-    insert_into(st).values(b.eq(true)); //~ ERROR unused
+    insert_into(st); //~ ERROR unused
     insert_into(st).values(&vec![b.eq(true), b.eq(false)]); //~ ERROR unused
 
     update(st).set(b.eq(true)); //~ ERROR unused

--- a/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
+++ b/diesel_compile_tests/tests/compile-fail/must_use_query_methods.rs
@@ -26,5 +26,14 @@ fn main() {
     st.filter(b.eq(true)); //~ ERROR unused `diesel::query_builder::SelectStatement`
     st.filter(b.eq(true)).limit(1); //~ ERROR unused `diesel::query_builder::SelectStatement`
 
+    insert_into(stuff)
+        .values(b.eq(true)); //- ERROR unused `diesel::query_builder::InsertStatement`
+    insert_into(stuff)
+        .values(&vec![b.eq(true), b.eq(false)]); //~ ERROR unused `diesel::query_builder::InsertStatement`
+
+    update(stuff).set(b.eq(true)); //~ ERROR unused `diesel::query_builder::UpdateStatement`
+
+    delete(stuff); //~ ERROR unused `diesel::query_builder::DeleteStatement`
+
     let _thingies = st.filter(b.eq(true)); // No ERROR
 }


### PR DESCRIPTION
This PR adds `must_use` statements to:
 - `DeleteStatement`
 - `IncompleteInsertStatement`
 - `InsertStatement`
 - `UpdateStatement`

Closes https://github.com/diesel-rs/diesel/issues/609