### PR TITLE
Strip scheme from sqlite database URL

### DIFF
--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -18,7 +18,7 @@ pub struct RawConnection {
 impl RawConnection {
     pub fn establish(database_url: &str) -> ConnectionResult<Self> {
         let mut conn_pointer = ptr::null_mut();
-        let database_url = try!(CString::new(database_url));
+        let database_url = try!(CString::new(database_url.trim_left_matches("sqlite://")));
         let connection_status =
             unsafe { ffi::sqlite3_open(database_url.as_ptr(), &mut conn_pointer) };
 


### PR DESCRIPTION
This PR strips the `sqlite://` scheme from sqlite database URLs, as mentioned in https://github.com/diesel-rs/diesel/issues/1124#issuecomment-333334217

I wasn't able to locate anywhere that tested the functionality I was editing, please let me know if I just missed it and I'll be happy to update this PR.