### PR TITLE
Upgrade dotenv

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -34,7 +34,7 @@ r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 
 [dev-dependencies]
 cfg-if = "0.1.0"
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.14"
 quickcheck = "0.4"
 tempdir = "^0.3.4"
 

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 chrono = "0.4"
 clap = "2.27"
 diesel = { version = "~1.3.0", default-features = false }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.14"
 migrations_internals = "~1.3.0"
 serde = { version = "1.0.0", features = ["derive"] }
 tempfile = "3.0.0"

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "0.4.0"
 [dev-dependencies]
 cfg-if = "0.1.0"
 diesel = "1.3.0"
-dotenv = "0.10.0"
+dotenv = "0.13.0"
 
 [lib]
 proc-macro = true

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -14,7 +14,7 @@ migrations_macros = "~1.3.0"
 
 [dev-dependencies]
 diesel = { version = "1.3.0", default-features = false, features = ["sqlite", "postgres", "mysql"] }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.14"
 cfg-if = "0.1.0"
 
 [features]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -9,7 +9,7 @@ autotests = false
 [build-dependencies]
 diesel = { path = "../diesel", default-features = false }
 diesel_migrations = { version = "1.3.0" }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.14"
 
 [dependencies]
 assert_matches = "1.0.1"
@@ -17,7 +17,7 @@ chrono = { version = "0.4" }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric", "with-deprecated"] }
 diesel_infer_schema = { version = "1.3.0" }
 diesel_migrations = { version = "1.3.0" }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.14"
 quickcheck = { version = "0.4", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.7.0" }
 serde_json = { version=">=0.9, <2.0" }

--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -7,10 +7,11 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 bcrypt = "0.1.0"
 chrono = "0.4.0"
 diesel = { version = "1.3.0", features = ["postgres", "chrono"] }
-dotenv = "0.10.0"
+dotenv = "0.13"
 structopt = "0.1.6"
 structopt-derive = "0.1.6"
 tempfile = "2.2.0"
+failure = "0.1.3"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/examples/postgres/advanced-blog-cli/src/main.rs
+++ b/examples/postgres/advanced-blog-cli/src/main.rs
@@ -8,6 +8,7 @@ extern crate dotenv;
 extern crate structopt;
 #[macro_use]
 extern crate structopt_derive;
+extern crate failure;
 
 #[cfg(test)]
 #[macro_use]

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.13"

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.3.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.13"


### PR DESCRIPTION
Not sure the best way to handle the switch to Failure. `dotenv::Error` no longer implements `std::error::Error` so its awkward to use it with `Box<Error>`.