### PR TITLE
Fix a compilation error in diesel_derives with the latest version of syn

### DIFF
--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -1,8 +1,8 @@
-use proc_macro2::*;
-use syn::*;
+pub use diagnostic_shim::{Diagnostic, DiagnosticShim, EmitErrorExt};
 
-pub use diagnostic_shim::*;
-use meta::*;
+use proc_macro2::{TokenStream, Span};
+use syn::{Ident, Type, DeriveInput, Data, GenericArgument};
+use meta::MetaItem;
 
 pub fn wrap_in_dummy_mod(const_name: Ident, item: TokenStream) -> TokenStream {
     quote! {

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -1,8 +1,8 @@
 pub use diagnostic_shim::{Diagnostic, DiagnosticShim, EmitErrorExt};
 
-use proc_macro2::{TokenStream, Span};
-use syn::{Ident, Type, DeriveInput, Data, GenericArgument};
 use meta::MetaItem;
+use proc_macro2::{Span, TokenStream};
+use syn::{Data, DeriveInput, GenericArgument, Ident, Type};
 
 pub fn wrap_in_dummy_mod(const_name: Ident, item: TokenStream) -> TokenStream {
     quote! {


### PR DESCRIPTION
This PR replaces all glob imports in `diesel_derives/src/utils.rs` with concrete imports to prevent future occurrences of this error.
Closes #1921.