### PR TITLE
Remove support for libsqlite3-sys 0.10.0

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.0"
 diesel_derives = "~1.3.0"
 chrono = { version = "0.4", optional = true }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.11.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.10.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
 quickcheck = { version = "0.4", optional = true }


### PR DESCRIPTION
Similar to #1900 libsqlite3-sys 0.10.0 is not selected by cargo because
it misses the `min_sqlite_version_3_7_16`. Similar to the situation
there we need to continue to support the old versions (Not because it's
part of a public api in this case, but because it is only possible to
link one version of a native library).

cc @SergioBenitez because he has done the PR that bump's libsqlite3-sys to 0.10