### PR TITLE
Impl `UndecoratedInsertRecord` for `OwnedBatchInsert`. 

### DIFF
--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -111,7 +111,7 @@ where
     }
 }
 
-impl<T, DB> CanInsertInSingleQuery<DB> for OwnedBatchInsert<T>
+impl<T, Table, DB> CanInsertInSingleQuery<DB> for OwnedBatchInsert<T, Table>
 where
     DB: Backend + SupportsDefaultKeyword,
 {
@@ -231,11 +231,12 @@ impl<T, Tab> Insertable<Tab> for Vec<T>
 where
     T: Insertable<Tab> + UndecoratedInsertRecord<Tab>,
 {
-    type Values = OwnedBatchInsert<T::Values>;
+    type Values = OwnedBatchInsert<T::Values, Tab>;
 
     fn values(self) -> Self::Values {
         OwnedBatchInsert {
             values: self.into_iter().map(Insertable::values).collect(),
+            _marker: PhantomData,
         }
     }
 }
@@ -291,11 +292,12 @@ where
 }
 
 #[derive(Debug)]
-pub struct OwnedBatchInsert<V> {
+pub struct OwnedBatchInsert<V, Tab> {
     pub(crate) values: Vec<V>,
+    _marker: PhantomData<Tab>,
 }
 
-impl<Tab, DB, Inner> QueryFragment<DB> for OwnedBatchInsert<ValuesClause<Inner, Tab>>
+impl<Tab, DB, Inner> QueryFragment<DB> for OwnedBatchInsert<ValuesClause<Inner, Tab>, Tab>
 where
     DB: Backend + SupportsDefaultKeyword,
     ValuesClause<Inner, Tab>: QueryFragment<DB>,

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -244,7 +244,7 @@ where
 
 #[cfg(feature = "sqlite")]
 impl<T, U, Op> ExecuteDsl<SqliteConnection>
-    for InsertStatement<T, OwnedBatchInsert<ValuesClause<U, T>>, Op>
+    for InsertStatement<T, OwnedBatchInsert<ValuesClause<U, T>, T>, Op>
 where
     InsertStatement<T, ValuesClause<U, T>, Op>: QueryFragment<Sqlite>,
     T: Copy,
@@ -406,6 +406,12 @@ where
 }
 
 impl<'a, T, Table> UndecoratedInsertRecord<Table> for BatchInsert<'a, T, Table>
+where
+    T: UndecoratedInsertRecord<Table>,
+{
+}
+
+impl<T, Table> UndecoratedInsertRecord<Table> for OwnedBatchInsert<T, Table>
 where
     T: UndecoratedInsertRecord<Table>,
 {

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -1,5 +1,5 @@
 use proc_macro2::*;
-use syn::*;
+use syn;
 
 pub use diagnostic_shim::*;
 use meta::*;
@@ -17,24 +17,24 @@ pub fn wrap_in_dummy_mod(const_name: Ident, item: TokenStream) -> TokenStream {
     }
 }
 
-pub fn inner_of_option_ty(ty: &Type) -> &Type {
+pub fn inner_of_option_ty(ty: &syn::Type) -> &syn::Type {
     option_ty_arg(ty).unwrap_or(ty)
 }
 
-pub fn is_option_ty(ty: &Type) -> bool {
+pub fn is_option_ty(ty: &syn::Type) -> bool {
     option_ty_arg(ty).is_some()
 }
 
-fn option_ty_arg(ty: &Type) -> Option<&Type> {
+fn option_ty_arg(ty: &syn::Type) -> Option<&syn::Type> {
     use syn::PathArguments::AngleBracketed;
 
     match *ty {
-        Type::Path(ref ty) => {
+        syn::Type::Path(ref ty) => {
             let last_segment = ty.path.segments.iter().last().unwrap();
             match last_segment.arguments {
                 AngleBracketed(ref args) if last_segment.ident == "Option" => {
                     match args.args.iter().last() {
-                        Some(&GenericArgument::Type(ref ty)) => Some(ty),
+                        Some(&syn::GenericArgument::Type(ref ty)) => Some(ty),
                         _ => None,
                     }
                 }
@@ -45,10 +45,10 @@ fn option_ty_arg(ty: &Type) -> Option<&Type> {
     }
 }
 
-pub fn ty_for_foreign_derive(item: &DeriveInput, flags: &MetaItem) -> Result<Type, Diagnostic> {
+pub fn ty_for_foreign_derive(item: &syn::DeriveInput, flags: &MetaItem) -> Result<syn::Type, Diagnostic> {
     if flags.has_flag("foreign_derive") {
         match item.data {
-            Data::Struct(ref body) => match body.fields.iter().nth(0) {
+            syn::Data::Struct(ref body) => match body.fields.iter().nth(0) {
                 Some(field) => Ok(field.ty.clone()),
                 None => Err(flags
                     .span()

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -243,6 +243,17 @@ fn upsert_with_no_changes_executes_do_nothing() {
         .execute(&connection);
 
     assert_eq!(Ok(0), result);
+
+    // Try the same thing with an owned type.
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let result = insert_into(users::table)
+        .values(User::new(1, "Sean"))
+        .on_conflict(users::id)
+        .do_update()
+        .set(&Changes { hair_color: None })
+        .execute(&connection);
+
+    assert_eq!(Ok(0), result);
 }
 
 #[test]


### PR DESCRIPTION
Attempts to resolve #1930.  Unfortunately, I can't run the unit tests
for reasons I don't fully understand, so it's not a FULL fix.  It builds
fine, but trying to do `cargo test` gives me:

```
error: At least one backend must be specified for use with this crate.
 In Cargo.toml, please specify `features = ["postgresql"]`, `features = ["mysql"]`, or `features = ["sqlite"]`

 ex. `infer_schema_internals { features = ["postgres"] }`

  --> /home/icefox/.cargo/registry/src/github.com-1ecc6299db9ec823/infer_schema_internals-1.3.0/src/inference.rs:70:14
   |
70 |           _ => compile_error!(
   |  ______________^
71 | |             "At least one backend must be specified for use with this crate.\n \
72 | |              In Cargo.toml, please specify `features = [\"postgresql\"]`, \
73 | |              `features = [\"mysql\"]`, or `features = [\"sqlite\"]`\n\n \
74 | |              ex. `infer_schema_internals { features = [\"postgres\"] }`\n "
75 | |         ),
   | |_________^

error: aborting due to previous error
```

Also, relies on #1923 or something equivalent.  (included)  Let me know if I can get the unit tests working, and I'll re-implement this based off of #1923 instead of my duplicated version.