### PR TITLE
diesel_cli: Change from Error::cause() to Error::source()

### DIFF
--- a/diesel_cli/src/database_error.rs
+++ b/diesel_cli/src/database_error.rs
@@ -45,15 +45,15 @@ impl Error for DatabaseError {
                 "The --database-url argument must be passed, or the DATABASE_URL environment variable must be set."
             }
             IoError(ref error) => error
-                .cause()
+                .source()
                 .map(|e| e.description())
                 .unwrap_or_else(|| error.description()),
             QueryError(ref error) => error
-                .cause()
+                .source()
                 .map(|e| e.description())
                 .unwrap_or_else(|| error.description()),
             ConnectionError(ref error) => error
-                .cause()
+                .source()
                 .map(|e| e.description())
                 .unwrap_or_else(|| error.description()),
         }


### PR DESCRIPTION
As of 1.30.0 there is Error::source() to replace Error::cause().
The former adds a 'static lifetime requirement.  As of 1.33
the latter is deprecated which means the nightly test runs fail.

Since the min-version supported by Diesel is now 1.31.0 we can
switch to Error::source() and thereby avoid the deprecation warnings.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>