### PR TITLE
Mark as edition 2018 and fix crate-root imports (also lets users drop macro_use)

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -20,17 +20,17 @@ else
   (cd diesel && cargo test --no-default-features --features "extras sqlite postgres mysql" $*)
 
   (cd diesel_cli && cargo test --features "sqlite" --no-default-features $*)
-  (cd diesel_migrations && cargo test --features "sqlite" $*)
+  (cd diesel_migrations && cargo test --features "sqlite diesel/sqlite" $*)
   (cd diesel_derives && cargo test --features "diesel/sqlite" $*)
   (cd diesel_tests && cargo test --features "sqlite" --no-default-features $*)
 
-  (cd diesel_migrations && cargo test --features "postgres" $*)
+  (cd diesel_migrations && cargo test --features "postgres diesel/postgres" $*)
   (cd diesel_derives && cargo test --features "diesel/postgres" $*)
   (cd diesel_cli && cargo test --features "postgres" --no-default-features $*)
   (cd diesel_tests && cargo test --features "postgres" --no-default-features $*)
 
   export RUST_TEST_THREADS=1
-  (cd diesel_migrations && cargo test --features "mysql" $*)
+  (cd diesel_migrations && cargo test --features "mysql diesel/mysql" $*)
   (cd diesel_derives && cargo test --features "diesel/mysql" $*)
   (cd diesel_cli && cargo test --features "mysql" --no-default-features $*)
   (cd diesel_tests && cargo test --features "mysql" --no-default-features $*)

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel"
 keywords = ["orm", "database", "blockchain", "sql"]
 categories = ["database"]
+edition = "2018"
 
 [dependencies]
 byteorder = "1.0"

--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -1,9 +1,9 @@
 use super::{HasTable, Identifiable};
-use dsl::{Eq, EqAny, Filter, FindBy};
-use expression::array_comparison::AsInExpression;
-use expression::AsExpression;
-use prelude::*;
-use query_dsl::methods::FilterDsl;
+use crate::dsl::{Eq, EqAny, Filter, FindBy};
+use crate::expression::array_comparison::AsInExpression;
+use crate::expression::AsExpression;
+use crate::prelude::*;
+use crate::query_dsl::methods::FilterDsl;
 
 use std::borrow::Borrow;
 use std::hash::Hash;

--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -48,7 +48,7 @@ pub trait BelongsTo<Parent> {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use schema::{posts, users};
+/// # use self::schema::{posts, users};
 /// #
 /// # #[derive(Identifiable, Queryable, PartialEq, Debug)]
 /// # pub struct User {

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -356,7 +356,7 @@ mod belongs_to;
 
 use std::hash::Hash;
 
-use query_source::Table;
+use crate::query_source::Table;
 
 pub use self::belongs_to::{BelongsTo, GroupedBy};
 

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -5,7 +5,6 @@
 //! Unlike other ORMs, Diesel has no concept of `#[has_many`]
 //!
 //! ```rust
-//! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
 //! use self::schema::{posts, users};
 //!

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -7,7 +7,7 @@
 //! ```rust
 //! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
-//! use schema::{posts, users};
+//! use self::schema::{posts, users};
 //!
 //! #[derive(Identifiable, Queryable, PartialEq, Debug)]
 //! #[table_name = "users"]
@@ -31,7 +31,7 @@
 //! #
 //! # fn run_test() -> QueryResult<()> {
 //! #     let connection = establish_connection();
-//! #     use users::dsl::*;
+//! #     use self::users::dsl::*;
 //! let user = users.find(2).get_result::<User>(&connection)?;
 //! let users_post = Post::belonging_to(&user)
 //!     .first(&connection)?;
@@ -56,7 +56,7 @@
 //! ```rust
 //! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
-//! # use schema::{posts, users};
+//! # use self::schema::{posts, users};
 //! # use std::borrow::Cow;
 //! #
 //! #[derive(Identifiable)]
@@ -100,8 +100,8 @@
 //! ```rust
 //! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
-//! # use schema::users;
-//! # use schema::posts;
+//! # use self::schema::users;
+//! # use self::schema::posts;
 //! #
 //! # #[derive(Debug, PartialEq, Identifiable, Queryable)]
 //! # pub struct User {
@@ -118,7 +118,7 @@
 //! # }
 //! #
 //! # fn main() {
-//! #   use users::dsl::*;
+//! #   use self::users::dsl::*;
 //! #   let connection = establish_connection();
 //! #
 //! let user = users.find(1).first::<User>(&connection).expect("Error loading user");
@@ -154,7 +154,7 @@
 //! ```rust
 //! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
-//! # use schema::{posts, users};
+//! # use self::schema::{posts, users};
 //! #
 //! # #[derive(Identifiable, Queryable)]
 //! # pub struct User {
@@ -177,8 +177,8 @@
 //! #
 //! # fn run_test() -> QueryResult<()> {
 //! #     let connection = establish_connection();
-//! #     use users::dsl::*;
-//! #     use posts::dsl::{posts, title};
+//! #     use self::users::dsl::*;
+//! #     use self::posts::dsl::{posts, title};
 //! let sean = users.filter(name.eq("Sean")).first::<User>(&connection)?;
 //! let tess = users.filter(name.eq("Tess")).first::<User>(&connection)?;
 //!
@@ -209,7 +209,7 @@
 //! ```rust
 //! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
-//! # use schema::{posts, users};
+//! # use self::schema::{posts, users};
 //! #
 //! # #[derive(Identifiable, Queryable, PartialEq, Debug)]
 //! # pub struct User {
@@ -271,7 +271,7 @@
 //! ```rust
 //! # #[macro_use] extern crate diesel;
 //! # include!("../doctest_setup.rs");
-//! # use schema::{users, posts, comments};
+//! # use self::schema::{users, posts, comments};
 //! #
 //! # #[derive(Debug, PartialEq, Identifiable, Queryable)]
 //! # pub struct User {

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -2,9 +2,9 @@
 
 use byteorder::ByteOrder;
 
-use query_builder::bind_collector::BindCollector;
-use query_builder::QueryBuilder;
-use sql_types::{self, HasSqlType};
+use crate::query_builder::bind_collector::BindCollector;
+use crate::query_builder::QueryBuilder;
+use crate::sql_types::{self, HasSqlType};
 
 /// A database backend
 ///
@@ -61,4 +61,4 @@ pub trait UsesAnsiSavepointSyntax {}
 
 #[cfg(feature = "with-deprecated")]
 #[deprecated(since = "1.1.0", note = "use `sql_types::TypeMetadata` instead")]
-pub use sql_types::TypeMetadata;
+pub use crate::sql_types::TypeMetadata;

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -5,11 +5,11 @@ mod transaction_manager;
 
 use std::fmt::Debug;
 
-use backend::Backend;
-use deserialize::{Queryable, QueryableByName};
-use query_builder::{AsQuery, QueryFragment, QueryId};
-use result::*;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::result::*;
+use crate::sql_types::HasSqlType;
 
 #[doc(hidden)]
 pub use self::statement_cache::{MaybeCached, StatementCache, StatementCacheKey};

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -57,7 +57,7 @@ pub trait Connection: SimpleConnection + Sized + Send {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = establish_connection();
     /// conn.transaction::<_, Error, _>(|| {
     ///     diesel::insert_into(users)
@@ -130,7 +130,7 @@ pub trait Connection: SimpleConnection + Sized + Send {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = establish_connection();
     /// conn.test_transaction::<_, Error, _>(|| {
     ///     diesel::insert_into(users)

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -98,9 +98,9 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -1,6 +1,6 @@
-use backend::UsesAnsiSavepointSyntax;
-use connection::{Connection, SimpleConnection};
-use result::QueryResult;
+use crate::backend::UsesAnsiSavepointSyntax;
+use crate::connection::{Connection, SimpleConnection};
+use crate::result::QueryResult;
 
 /// Manages the internal transaction state for a connection.
 ///
@@ -68,7 +68,7 @@ impl AnsiTransactionManager {
     where
         Conn: SimpleConnection,
     {
-        use result::Error::AlreadyInTransaction;
+        use crate::result::Error::AlreadyInTransaction;
 
         if self.transaction_depth.get() == 0 {
             self.change_transaction_depth(1, conn.batch_execute(sql))

--- a/diesel/src/data_types.rs
+++ b/diesel/src/data_types.rs
@@ -4,4 +4,4 @@
 //! all backend specific data structures when compiled against that
 //! backend.
 #[cfg(feature = "postgres")]
-pub use pg::data_types::*;
+pub use crate::pg::data_types::*;

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -3,8 +3,8 @@
 use std::error::Error;
 use std::result;
 
-use backend::Backend;
-use row::{NamedRow, Row};
+use crate::backend::Backend;
+use crate::row::{NamedRow, Row};
 
 /// A specialized result type representing the result of deserializing
 /// a value from the database.

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -72,7 +72,6 @@ pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;
 /// #
 /// # use self::schema::users;
 /// # use diesel::backend::Backend;
-/// # use diesel::deserialize::Queryable;
 /// #
 /// struct LowercaseString(String);
 ///
@@ -122,7 +121,6 @@ pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;
 /// # include!("doctest_setup.rs");
 /// #
 /// use self::schema::users;
-/// use diesel::deserialize::Queryable;
 ///
 /// # /*
 /// type DB = diesel::sqlite::Sqlite;

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -54,7 +54,7 @@ pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// let first_user = users.first(&connection)?;
 /// let expected = User { id: 1, name: "Sean".into() };
@@ -70,7 +70,7 @@ pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;
 /// # #[macro_use] extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// #
-/// # use schema::users;
+/// # use self::schema::users;
 /// # use diesel::backend::Backend;
 /// # use diesel::deserialize::Queryable;
 /// #
@@ -106,7 +106,7 @@ pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// let first_user = users.first(&connection)?;
 /// let expected = User { id: 1, name: "sean".into() };
@@ -121,7 +121,7 @@ pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;
 /// # #[macro_use] extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// #
-/// use schema::users;
+/// use self::schema::users;
 /// use diesel::deserialize::Queryable;
 ///
 /// # /*
@@ -150,7 +150,7 @@ pub type Result<T> = result::Result<T, Box<Error + Send + Sync>>;
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// let first_user = users.first(&connection)?;
 /// let expected = User { id: 1, name: "sean".into() };
@@ -183,7 +183,7 @@ where
 ///
 /// If you are using `#[table_name]`, the module for that table must be in
 /// scope. For example, to derive this for a struct called `User`, you will
-/// likely need a line such as `use schema::users;`
+/// likely need a line such as `use self::schema::users;`
 ///
 /// If the name of a field on your struct is different than the column in your
 /// `table!` declaration, or if you are deriving this trait on a tuple struct,
@@ -209,7 +209,7 @@ where
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("doctest_setup.rs");
-/// # use schema::users;
+/// # use self::schema::users;
 /// # use diesel::sql_query;
 /// #
 /// #[derive(QueryableByName, PartialEq, Debug)]
@@ -240,7 +240,7 @@ where
 /// # #[macro_use] extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// # use diesel::sql_query;
-/// # use schema::users;
+/// # use self::schema::users;
 /// # use diesel::backend::Backend;
 /// # use diesel::deserialize::{self, FromSql};
 /// #

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -1,10 +1,8 @@
-extern crate dotenv;
-#[macro_use] extern crate cfg_if;
-
 use diesel::prelude::*;
-use self::dotenv::dotenv;
+use diesel::{Identifiable, Queryable, Associations};
+use dotenv::dotenv;
 
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(feature = "postgres")] {
         #[allow(dead_code)]
         type DB = diesel::pg::Pg;
@@ -104,7 +102,7 @@ cfg_if! {
                 (1, 'My first post'),
                 (1, 'About Rust'),
                 (2, 'My first post too')").unwrap();
-            
+
             connection.execute("CREATE TABLE comments (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 post_id INTEGER NOT NULL,
@@ -161,7 +159,7 @@ cfg_if! {
                 (1, 'My first post'),
                 (1, 'About Rust'),
                 (2, 'My first post too')").unwrap();
-            
+
             connection.execute("CREATE TABLE comments (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 post_id INTEGER NOT NULL,
@@ -197,7 +195,7 @@ fn database_url_from_env(backend_specific_env_var: &str) -> String {
 
 
 mod schema {
-    table! {
+    diesel::table! {
         animals {
             id -> Integer,
             species -> VarChar,
@@ -206,7 +204,7 @@ mod schema {
         }
     }
 
-    table! {
+    diesel::table! {
         comments {
             id -> Integer,
             post_id -> Integer,
@@ -214,7 +212,7 @@ mod schema {
         }
     }
 
-    table! {
+    diesel::table! {
         posts {
             id -> Integer,
             user_id -> Integer,
@@ -222,13 +220,13 @@ mod schema {
         }
     }
 
-    table! {
+    diesel::table! {
         users {
             id -> Integer,
             name -> VarChar,
         }
     }
 
-    joinable!(posts -> users (user_id));
-    allow_tables_to_appear_in_same_query!(animals, comments, posts, users);
+    diesel::joinable!(posts -> users (user_id));
+    diesel::allow_tables_to_appear_in_same_query!(animals, comments, posts, users);
 }

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::subselect::Subselect;
-use expression::*;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Bool;
+use crate::backend::Backend;
+use crate::expression::subselect::Subselect;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
 
 #[derive(Debug, Copy, Clone, QueryId)]
 pub struct In<T, U> {
@@ -96,7 +96,7 @@ where
 impl_selectable_expression!(In<T, U>);
 impl_selectable_expression!(NotIn<T, U>);
 
-use query_builder::{BoxedSelectStatement, SelectStatement};
+use crate::query_builder::{BoxedSelectStatement, SelectStatement};
 
 pub trait AsInExpression<T> {
     type InExpression: MaybeEmpty + Expression<SqlType = T>;

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -1,11 +1,11 @@
 use std::marker::PhantomData;
 
 use super::*;
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
-use serialize::ToSql;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::serialize::ToSql;
+use crate::sql_types::HasSqlType;
 
 #[derive(Debug, Clone, Copy, DieselNumericOps)]
 pub struct Bound<T, U> {

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use expression::*;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone, QueryId, DieselNumericOps)]
 #[doc(hidden)]

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,8 +1,8 @@
 use super::Expression;
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::BigInt;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::BigInt;
 
 sql_function! {
     /// Creates a SQL `COUNT` expression

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -19,7 +19,7 @@ sql_function! {
     /// # use diesel::dsl::*;
     /// #
     /// # fn main() {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// assert_eq!(Ok(1), animals.select(count(name)).first(&connection));
     /// # }
@@ -46,7 +46,7 @@ sql_function! {
 /// # use diesel::dsl::*;
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// assert_eq!(Ok(2), users.select(count_star()).first(&connection));
 /// # }

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::subselect::Subselect;
-use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Bool;
+use crate::backend::Backend;
+use crate::expression::subselect::Subselect;
+use crate::expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
 
 /// Creates a SQL `EXISTS` expression.
 ///

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -17,7 +17,7 @@ use crate::sql_types::Bool;
 /// # include!("../doctest_setup.rs");
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     use diesel::select;
 /// #     use diesel::dsl::exists;
 /// #     let connection = establish_connection();

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,4 +1,4 @@
-use sql_types::Foldable;
+use crate::sql_types::Foldable;
 
 sql_function! {
     /// Represents a SQL `SUM` function. This function can only take types which are

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -12,7 +12,7 @@ sql_function! {
     /// # use diesel::dsl::*;
     /// #
     /// # fn main() {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// assert_eq!(Ok(Some(12i64)), animals.select(sum(legs)).first(&connection));
     /// # }
@@ -47,7 +47,7 @@ sql_function! {
     /// # #[cfg(all(feature = "numeric", any(feature = "postgres", not(feature = "sqlite"))))]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use bigdecimal::BigDecimal;
-    /// #     use numbers::dsl::*;
+    /// #     use self::numbers::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("DROP TABLE IF EXISTS numbers")?;
     /// #     conn.execute("CREATE TABLE numbers (number INTEGER)")?;

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,4 +1,4 @@
-use sql_types::{IntoNullable, SqlOrd};
+use crate::sql_types::{IntoNullable, SqlOrd};
 
 sql_function! {
     /// Represents a SQL `MAX` function. This function can only take types which are

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -12,7 +12,7 @@ sql_function! {
     /// # use diesel::dsl::*;
     /// #
     /// # fn main() {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// assert_eq!(Ok(Some(8)), animals.select(max(legs)).first(&connection));
     /// # }
@@ -32,7 +32,7 @@ sql_function! {
     /// # use diesel::dsl::*;
     /// #
     /// # fn main() {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// assert_eq!(Ok(Some(4)), animals.select(min(legs)).first(&connection));
     /// # }

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::coerce::Coerce;
-use expression::{AsExpression, Expression, NonAggregate};
-use query_builder::*;
-use result::QueryResult;
-use sql_types::*;
+use crate::backend::Backend;
+use crate::expression::coerce::Coerce;
+use crate::expression::{AsExpression, Expression, NonAggregate};
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::*;
 
 /// Represents the SQL `CURRENT_TIMESTAMP` constant. This is equivalent to the
 /// `NOW()` function on backends that support it.

--- a/diesel/src/expression/functions/helper_types.rs
+++ b/diesel/src/expression/functions/helper_types.rs
@@ -1,9 +1,9 @@
 #![allow(non_camel_case_types)]
 
-use dsl::{AsExprOf, SqlTypeOf};
-use expression::grouped::Grouped;
-use expression::operators;
-use sql_types::Bool;
+use crate::dsl::{AsExprOf, SqlTypeOf};
+use crate::expression::grouped::Grouped;
+use crate::expression::operators;
+use crate::sql_types::Bool;
 
 /// The return type of [`not(expr)`](../dsl/fn.not.html)
 pub type not<Expr> = operators::Not<Grouped<AsExprOf<Expr, Bool>>>;

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -397,6 +397,8 @@ macro_rules! __diesel_sqlite_register_fn {
 /// given, and a module with a helper type representing the return type of your
 /// function. For example, this invocation:
 ///
+/// [`diesel::sql_types`]: sql_types/index.html
+///
 /// ```ignore
 /// sql_function!(fn lower(x: Text) -> Text);
 /// ```

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -108,7 +108,7 @@ macro_rules! __diesel_sql_function_body {
             $args:tt -> $return_type:ty $(;)*
         ),
     ) => {
-        __diesel_sql_function_body! {
+        $crate::__diesel_sql_function_body! {
             meta = $meta,
             fn_name = $fn_name,
             type_args = $type_args,
@@ -124,7 +124,7 @@ macro_rules! __diesel_sql_function_body {
         fn_name = $fn_name:ident,
         $($rest:tt)*
     ) => {
-        __diesel_sql_function_body! {
+        $crate::__diesel_sql_function_body! {
             aggregate = no,
             sql_name = stringify!($fn_name),
             unchecked_meta = $meta,
@@ -142,7 +142,7 @@ macro_rules! __diesel_sql_function_body {
         meta = $meta:tt,
         $($rest:tt)*
     ) => {
-        __diesel_sql_function_body! {
+        $crate::__diesel_sql_function_body! {
             aggregate = yes,
             sql_name = $sql_name,
             unchecked_meta = ($($unchecked)*),
@@ -159,7 +159,7 @@ macro_rules! __diesel_sql_function_body {
         meta = $meta:tt,
         $($rest:tt)*
     ) => {
-        __diesel_sql_function_body! {
+        $crate::__diesel_sql_function_body! {
             aggregate = $aggregate,
             sql_name = $sql_name,
             unchecked_meta = ($($unchecked)*),
@@ -176,7 +176,7 @@ macro_rules! __diesel_sql_function_body {
         meta = ($($meta:tt)*),
         $($rest:tt)*
     ) => {
-        __diesel_sql_function_body! {
+        $crate::__diesel_sql_function_body! {
             aggregate = $aggregate,
             sql_name = $sql_name,
             unchecked_meta = ($($unchecked)*),
@@ -285,7 +285,7 @@ macro_rules! __diesel_sql_function_body {
                 }
             }
 
-            __diesel_sqlite_register_fn! {
+            $crate::__diesel_sqlite_register_fn! {
                 type_args = ($($type_args)*),
                 aggregate = $aggregate,
                 fn_name = $fn_name,
@@ -435,8 +435,8 @@ macro_rules! __diesel_sqlite_register_fn {
 /// }
 ///
 /// pub mod dsl {
-///     pub use functions::*;
-///     pub use helper_types::*;
+///     pub use super::functions::*;
+///     pub use super::helper_types::*;
 /// }
 /// ```
 ///
@@ -548,11 +548,11 @@ macro_rules! __diesel_sqlite_register_fn {
 /// ```
 macro_rules! sql_function {
     ($(#$meta:tt)* fn $fn_name:ident $args:tt $(;)*) => {
-        sql_function!($(#$meta)* fn $fn_name $args -> ());
+        $crate::sql_function!($(#$meta)* fn $fn_name $args -> ());
     };
 
     ($(#$meta:tt)* fn $fn_name:ident $args:tt -> $return_type:ty $(;)*) => {
-        sql_function!($(#$meta)* fn $fn_name <> $args -> $return_type);
+        $crate::sql_function!($(#$meta)* fn $fn_name <> $args -> $return_type);
     };
 
     (
@@ -561,7 +561,7 @@ macro_rules! sql_function {
         <
         $($tokens:tt)*
     ) => {
-        __diesel_parse_type_args!(
+        $crate::__diesel_parse_type_args!(
             data = (
                 meta = ($(#$meta)*),
                 fn_name = $fn_name,
@@ -572,15 +572,15 @@ macro_rules! sql_function {
     };
 
     ($fn_name:ident, $struct_name:ident, $args:tt -> $return_type:ty) => {
-        sql_function!($fn_name, $struct_name, $args -> $return_type, "");
+        $crate::sql_function!($fn_name, $struct_name, $args -> $return_type, "");
     };
 
     ($fn_name:ident, $struct_name:ident, $args:tt -> $return_type:ty, $docs:expr) => {
-        sql_function!($fn_name, $struct_name, $args -> $return_type, $docs, "");
+        $crate::sql_function!($fn_name, $struct_name, $args -> $return_type, $docs, "");
     };
 
     ($fn_name:ident, $struct_name:ident, ($($arg_name:ident: $arg_type:ty),*)) => {
-        sql_function!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> ());
+        $crate::sql_function!($fn_name, $struct_name, ($($arg_name: $arg_type),*) -> ());
     };
 
     (
@@ -590,7 +590,7 @@ macro_rules! sql_function {
         $docs:expr,
         $helper_ty_docs:expr
     ) => {
-        sql_function_body!($fn_name, $struct_name, $args -> $return_type, $docs, $helper_ty_docs);
+        $crate::sql_function_body!($fn_name, $struct_name, $args -> $return_type, $docs, $helper_ty_docs);
     };
 }
 
@@ -619,7 +619,7 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
 #[doc(hidden)]
 macro_rules! no_arg_sql_function_body {
     ($type_name:ident, $return_type:ty, $docs:expr, $($constraint:ident)::+) => {
-        no_arg_sql_function_body_except_to_sql!($type_name, $return_type, $docs);
+        $crate::no_arg_sql_function_body_except_to_sql!($type_name, $return_type, $docs);
 
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend + $($constraint)::+,
@@ -632,7 +632,7 @@ macro_rules! no_arg_sql_function_body {
     };
 
     ($type_name:ident, $return_type:ty, $docs:expr) => {
-        no_arg_sql_function_body_except_to_sql!($type_name, $return_type, $docs);
+        $crate::no_arg_sql_function_body_except_to_sql!($type_name, $return_type, $docs);
 
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend,
@@ -662,15 +662,15 @@ macro_rules! no_arg_sql_function_body {
 /// function.
 macro_rules! no_arg_sql_function {
     ($type_name:ident, $return_type:ty) => {
-        no_arg_sql_function!($type_name, $return_type, "");
+        $crate::no_arg_sql_function!($type_name, $return_type, "");
     };
 
     ($type_name:ident, $return_type:ty, $docs:expr) => {
-        no_arg_sql_function_body!($type_name, $return_type, $docs);
+        $crate::no_arg_sql_function_body!($type_name, $return_type, $docs);
     };
 
     ($type_name:ident, $return_type:ty, $docs:expr, $($constraint:ident)::+) => {
-        no_arg_sql_function_body!($type_name, $return_type, $docs, $($constraint)::+);
+        $crate::no_arg_sql_function_body!($type_name, $return_type, $docs, $($constraint)::+);
     };
 }
 

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -1,7 +1,7 @@
-use backend::Backend;
-use expression::{Expression, NonAggregate};
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::{Expression, NonAggregate};
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone, QueryId, Default, DieselNumericOps)]
 pub struct Grouped<T>(pub T);

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -4,7 +4,7 @@
 use super::array_comparison::{AsInExpression, In, NotIn};
 use super::grouped::Grouped;
 use super::{AsExpression, Expression};
-use sql_types;
+use crate::sql_types;
 
 /// The SQL type of an expression
 pub type SqlTypeOf<Expr> = <Expr as Expression>::SqlType;

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -49,7 +49,7 @@ pub mod subselect;
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 pub mod dsl {
-    use dsl::SqlTypeOf;
+    use crate::dsl::SqlTypeOf;
 
     #[doc(inline)]
     pub use super::count::*;
@@ -67,7 +67,7 @@ pub mod dsl {
     pub use super::sql_literal::sql;
 
     #[cfg(feature = "postgres")]
-    pub use pg::expression::dsl::*;
+    pub use crate::pg::expression::dsl::*;
 
     /// The return type of [`count(expr)`](../dsl/fn.count.html)
     pub type count<Expr> = super::count::count::HelperType<SqlTypeOf<Expr>, Expr>;
@@ -82,8 +82,8 @@ pub mod dsl {
 #[doc(inline)]
 pub use self::sql_literal::{SqlLiteral, UncheckedBind};
 
-use backend::Backend;
-use dsl::AsExprOf;
+use crate::backend::Backend;
+use crate::dsl::AsExprOf;
 
 /// Represents a typed fragment of SQL.
 ///
@@ -272,7 +272,7 @@ impl<T: NonAggregate + ?Sized> NonAggregate for Box<T> {}
 
 impl<'a, T: NonAggregate + ?Sized> NonAggregate for &'a T {}
 
-use query_builder::{QueryFragment, QueryId};
+use crate::query_builder::{QueryFragment, QueryId};
 
 /// Helper trait used when boxing expressions.
 ///

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -171,7 +171,7 @@ impl<T: Expression> AsExpression<T::SqlType> for T {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use schema::users;
+/// # use self::schema::users;
 /// #
 /// # fn main() {
 /// use diesel::sql_types::Text;
@@ -291,7 +291,7 @@ use crate::query_builder::{QueryFragment, QueryId};
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use schema::users;
+/// # use self::schema::users;
 /// use diesel::sql_types::Bool;
 ///
 /// # fn main() {

--- a/diesel/src/expression/not.rs
+++ b/diesel/src/expression/not.rs
@@ -1,7 +1,7 @@
-use expression::grouped::Grouped;
-use expression::AsExpression;
-use helper_types::not;
-use sql_types::Bool;
+use crate::expression::grouped::Grouped;
+use crate::expression::AsExpression;
+use crate::helper_types::not;
+use crate::sql_types::Bool;
 
 /// Creates a SQL `NOT` expression
 ///

--- a/diesel/src/expression/not.rs
+++ b/diesel/src/expression/not.rs
@@ -12,7 +12,7 @@ use crate::sql_types::Bool;
 /// # include!("../doctest_setup.rs");
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// use diesel::dsl::not;
 ///

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::*;
-use query_builder::*;
-use query_source::Table;
-use result::QueryResult;
-use sql_types::IntoNullable;
+use crate::backend::Backend;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::query_source::Table;
+use crate::result::QueryResult;
+use crate::sql_types::IntoNullable;
 
 #[derive(Debug, Copy, Clone, DieselNumericOps)]
 pub struct Nullable<T>(T);

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -358,9 +358,9 @@ diesel_postfix_operator!(Desc, " DESC", ());
 
 diesel_prefix_operator!(Not, "NOT ");
 
-use insertable::{ColumnInsertValue, Insertable};
-use query_builder::ValuesClause;
-use query_source::Column;
+use crate::insertable::{ColumnInsertValue, Insertable};
+use crate::query_builder::ValuesClause;
+use crate::query_source::Column;
 
 impl<T, U> Insertable<T::Table> for Eq<T, U>
 where

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -190,7 +190,7 @@ macro_rules! __diesel_operator_to_sql {
 /// # include!("../doctest_setup.rs");
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// diesel_infix_operator!(MyEq, " = ");
 ///

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -1,8 +1,8 @@
-use backend::Backend;
-use expression::{Expression, NonAggregate};
-use query_builder::*;
-use result::QueryResult;
-use sql_types;
+use crate::backend::Backend;
+use crate::expression::{Expression, NonAggregate};
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types;
 
 macro_rules! numeric_operation {
     ($name:ident, $op:expr) => {

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use expression::*;
-use query_builder::*;
-use query_dsl::RunQueryDsl;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::query_dsl::RunQueryDsl;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, DieselNumericOps)]
 #[must_use = "Queries are only executed when calling `load`, `get_result`, or similar."]

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -215,7 +215,7 @@ impl<ST, T> NonAggregate for SqlLiteral<ST, T> {}
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// use diesel::dsl::sql;
 /// #     let connection = establish_connection();
 /// let user = users.filter(sql("name = 'Sean'")).first(&connection)?;

--- a/diesel/src/expression/subselect.rs
+++ b/diesel/src/expression/subselect.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use expression::array_comparison::MaybeEmpty;
-use expression::*;
-use query_builder::*;
-use result::QueryResult;
+use crate::expression::array_comparison::MaybeEmpty;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone, QueryId)]
 pub struct Subselect<T, ST> {

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -1,7 +1,7 @@
-use expression::grouped::Grouped;
-use expression::operators::{And, Or};
-use expression::{AsExpression, Expression};
-use sql_types::Bool;
+use crate::expression::grouped::Grouped;
+use crate::expression::operators::{And, Or};
+use crate::expression::{AsExpression, Expression};
+use crate::sql_types::Bool;
 
 /// Methods present on boolean expressions
 pub trait BoolExpressionMethods: Expression<SqlType = Bool> + Sized {

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -18,7 +18,7 @@ pub trait BoolExpressionMethods: Expression<SqlType = Bool> + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// diesel::insert_into(animals)
@@ -58,7 +58,7 @@ pub trait BoolExpressionMethods: Expression<SqlType = Bool> + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// diesel::insert_into(animals)

--- a/diesel/src/expression_methods/eq_all.rs
+++ b/diesel/src/expression_methods/eq_all.rs
@@ -1,7 +1,7 @@
-use expression::operators::And;
-use expression::Expression;
-use expression_methods::*;
-use sql_types::Bool;
+use crate::expression::operators::And;
+use crate::expression::Expression;
+use crate::expression_methods::*;
+use crate::sql_types::Bool;
 
 /// This method is used by `FindDsl` to work with tuples. Because we cannot
 /// express this without specialization or overlapping impls, it is brute force

--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -1,7 +1,7 @@
-use dsl::AsExprOf;
-use expression::operators::{Escape, Like, NotLike};
-use expression::IntoSql;
-use sql_types::VarChar;
+use crate::dsl::AsExprOf;
+use crate::expression::operators::{Escape, Like, NotLike};
+use crate::expression::IntoSql;
+use crate::sql_types::VarChar;
 
 /// Adds the `escape` method to `LIKE` and `NOT LIKE`. This is used to specify
 /// the escape character for the pattern.

--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -16,7 +16,7 @@ use crate::sql_types::VarChar;
 /// # include!("../doctest_setup.rs");
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     use diesel::insert_into;
 /// #     let connection = establish_connection();
 /// #     insert_into(users).values(name.eq("Ha%%0r"))

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -1,7 +1,7 @@
-use expression::array_comparison::{AsInExpression, In, NotIn};
-use expression::operators::*;
-use expression::{nullable, AsExpression, Expression};
-use sql_types::SingleValue;
+use crate::expression::array_comparison::{AsInExpression, In, NotIn};
+use crate::expression::operators::*;
+use crate::expression::{nullable, AsExpression, Expression};
+use crate::sql_types::SingleValue;
 
 /// Methods present on all expressions, except tuples
 pub trait ExpressionMethods: Expression + Sized {

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -14,7 +14,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users.select(id).filter(name.eq("Sean"));
     /// assert_eq!(Ok(1), data.first(&connection));
@@ -33,7 +33,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users.select(id).filter(name.ne("Sean"));
     /// assert_eq!(Ok(2), data.first(&connection));
@@ -57,7 +57,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("INSERT INTO users (name) VALUES
     /// #         ('Jim')").unwrap();
@@ -83,7 +83,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("INSERT INTO users (name) VALUES
     /// #         ('Jim')").unwrap();
@@ -121,7 +121,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("INSERT INTO users (name) VALUES
     /// #         ('Jim')").unwrap();
@@ -156,7 +156,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
@@ -183,7 +183,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
@@ -210,7 +210,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users
     ///     .select(name)
@@ -237,7 +237,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users
     ///     .select(name)
@@ -264,7 +264,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users
     ///     .select(name)
@@ -291,7 +291,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users
     ///     .select(name)
@@ -314,7 +314,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
@@ -347,7 +347,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let data = animals
@@ -383,7 +383,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let names = users
@@ -412,7 +412,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let order = "name";
     /// let ordering: Box<BoxableExpression<users, DB, SqlType=()>> =
     ///     if order == "name" {
@@ -446,7 +446,7 @@ pub trait NullableExpressionMethods: Expression + Sized {
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
     /// # use diesel::sql_types::*;
-    /// # use schema::users;
+    /// # use self::schema::users;
     /// #
     /// table! {
     ///     posts {

--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -23,4 +23,4 @@ pub use self::text_expression_methods::TextExpressionMethods;
 
 #[cfg(feature = "postgres")]
 #[doc(inline)]
-pub use pg::expression::expression_methods::*;
+pub use crate::pg::expression::expression_methods::*;

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -1,6 +1,6 @@
-use expression::operators::{Concat, Like, NotLike};
-use expression::{AsExpression, Expression};
-use sql_types::{Nullable, Text};
+use crate::expression::operators::{Concat, Like, NotLike};
+use crate::expression::{AsExpression, Expression};
+use crate::sql_types::{Nullable, Text};
 
 /// Methods present on text expressions
 pub trait TextExpressionMethods: Expression + Sized {

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -77,7 +77,7 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let starts_with_s = users
@@ -110,7 +110,7 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #
     /// let doesnt_start_with_s = users

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -1,14 +1,14 @@
 use std::marker::PhantomData;
 
-use backend::{Backend, SupportsDefaultKeyword};
-use expression::{AppearsOnTable, Expression};
-use query_builder::{
+use crate::backend::{Backend, SupportsDefaultKeyword};
+use crate::expression::{AppearsOnTable, Expression};
+use crate::query_builder::{
     AstPass, InsertStatement, QueryFragment, UndecoratedInsertRecord, ValuesClause,
 };
-use query_source::{Column, Table};
-use result::QueryResult;
+use crate::query_source::{Column, Table};
+use crate::result::QueryResult;
 #[cfg(feature = "sqlite")]
-use sqlite::Sqlite;
+use crate::sqlite::Sqlite;
 
 /// Represents that a structure can be used to insert a new row into the
 /// database. This is automatically implemented for `&[T]` and `&Vec<T>` for
@@ -82,7 +82,7 @@ pub trait Insertable<T> {
     where
         Self: Sized,
     {
-        ::insert_into(table).values(self)
+        crate::insert_into(table).values(self)
     }
 }
 

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -58,7 +58,7 @@ pub trait Insertable<T> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::{posts, users};
+    /// #     use self::schema::{posts, users};
     /// #     let conn = establish_connection();
     /// #     diesel::delete(posts::table).execute(&conn)?;
     /// users::table

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -217,13 +217,13 @@ pub mod dsl {
     //! generically to be included in prelude, but are often used when using Diesel.
 
     #[doc(inline)]
-    pub use helper_types::*;
+    pub use super::helper_types::*;
 
     #[doc(inline)]
-    pub use expression::dsl::*;
+    pub use super::expression::dsl::*;
 
     #[doc(inline)]
-    pub use query_builder::functions::{
+    pub use super::query_builder::functions::{
         delete, insert_into, insert_or_ignore_into, replace_into, select, sql_query, update,
     };
 }
@@ -245,7 +245,7 @@ pub mod helper_types {
     use super::query_source::joins;
 
     #[doc(inline)]
-    pub use expression::helper_types::*;
+    pub use super::expression::helper_types::*;
 
     /// Represents the return type of `.select(selection)`
     pub type Select<Source, Selection> = <Source as SelectDsl<Selection>>::Output;
@@ -334,42 +334,42 @@ pub mod helper_types {
 
 pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using Diesel.
-    pub use associations::{GroupedBy, Identifiable};
-    pub use connection::Connection;
+    pub use super::associations::{GroupedBy, Identifiable};
+    pub use super::connection::Connection;
     #[deprecated(
         since = "1.1.0",
         note = "Explicitly `use diesel::deserialize::Queryable"
     )]
-    pub use deserialize::Queryable;
-    pub use expression::{
+    pub use super::deserialize::Queryable;
+    pub use super::expression::{
         AppearsOnTable, BoxableExpression, Expression, IntoSql, SelectableExpression,
     };
-    pub use expression_methods::*;
+    pub use super::expression_methods::*;
     #[doc(inline)]
-    pub use insertable::Insertable;
+    pub use super::insertable::Insertable;
     #[doc(hidden)]
-    pub use query_dsl::GroupByDsl;
-    pub use query_dsl::{BelongingToDsl, JoinOnDsl, QueryDsl, RunQueryDsl, SaveChangesDsl};
+    pub use super::query_dsl::GroupByDsl;
+    pub use super::query_dsl::{BelongingToDsl, JoinOnDsl, QueryDsl, RunQueryDsl, SaveChangesDsl};
 
-    pub use query_source::{Column, JoinTo, QuerySource, Table};
-    pub use result::{ConnectionError, ConnectionResult, OptionalExtension, QueryResult};
+    pub use super::query_source::{Column, JoinTo, QuerySource, Table};
+    pub use super::result::{ConnectionError, ConnectionResult, OptionalExtension, QueryResult};
 
     #[cfg(feature = "mysql")]
-    pub use mysql::MysqlConnection;
+    pub use super::mysql::MysqlConnection;
     #[cfg(feature = "postgres")]
-    pub use pg::PgConnection;
+    pub use super::pg::PgConnection;
     #[cfg(feature = "sqlite")]
-    pub use sqlite::SqliteConnection;
+    pub use super::sqlite::SqliteConnection;
 }
 
-pub use prelude::*;
+pub use self::prelude::*;
 #[doc(inline)]
-pub use query_builder::debug_query;
+pub use self::query_builder::debug_query;
 #[doc(inline)]
-pub use query_builder::functions::{
+pub use self::query_builder::functions::{
     delete, insert_into, insert_or_ignore_into, replace_into, select, sql_query, update,
 };
-pub use result::Error::NotFound;
+pub use self::result::Error::NotFound;
 
 pub(crate) mod diesel {
     pub use super::*;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -370,7 +370,3 @@ pub use self::query_builder::functions::{
     delete, insert_into, insert_or_ignore_into, replace_into, select, sql_query, update,
 };
 pub use self::result::Error::NotFound;
-
-pub(crate) mod diesel {
-    pub use super::*;
-}

--- a/diesel/src/macros/internal.rs
+++ b/diesel/src/macros/internal.rs
@@ -8,11 +8,11 @@
 #[doc(hidden)]
 macro_rules! impl_selectable_expression {
     ($struct_name:ident) => {
-        impl_selectable_expression!(ty_params = (), struct_ty = $struct_name,);
+        $crate::impl_selectable_expression!(ty_params = (), struct_ty = $struct_name,);
     };
 
     ($struct_name:ident<$($ty_params:ident),+>) => {
-        impl_selectable_expression!(
+        $crate::impl_selectable_expression!(
             ty_params = ($($ty_params),+),
             struct_ty = $struct_name<$($ty_params),+>,
         );
@@ -74,7 +74,7 @@ macro_rules! __diesel_parse_type_args {
         callback = $callback:ident,
         tokens = $tokens:tt,
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             data = $data,
             callback = $callback,
             args = (),
@@ -97,7 +97,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = ($next_arg:ident : $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             brackets = (),
             data = $data,
             callback = $callback,
@@ -119,7 +119,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = ($next_arg:ident $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             data = $data,
             callback = $callback,
             args = ($($args)* $next_arg,),
@@ -141,7 +141,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = (> $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             data = $data,
             callback = $callback,
             args = $args,
@@ -163,7 +163,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = (, $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             data = $data,
             callback = $callback,
             args = $args,
@@ -186,7 +186,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = (< $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             brackets = (< $($brackets)*),
             data = $data,
             callback = $callback,
@@ -209,7 +209,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = (>> $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             brackets = ($($brackets)*),
             data = $data,
             callback = $callback,
@@ -234,7 +234,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = (> $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             brackets = ($($brackets)*),
             data = $data,
             callback = $callback,
@@ -258,7 +258,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = ($($bounds:tt)*),
         tokens = ($token:tt $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             brackets = $brackets,
             data = $data,
             callback = $callback,
@@ -280,7 +280,7 @@ macro_rules! __diesel_parse_type_args {
         bounds = $bounds:tt,
         tokens = (, $($tokens:tt)*),
     ) => {
-        __diesel_parse_type_args! {
+        $crate::__diesel_parse_type_args! {
             data = $data,
             callback = $callback,
             args = $args,

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -1068,7 +1068,7 @@ mod tuples;
 
 #[cfg(test)]
 mod tests {
-    use prelude::*;
+    use crate::prelude::*;
 
     table! {
         foo.bars {
@@ -1083,8 +1083,8 @@ mod tests {
     }
 
     table! {
-        use sql_types::*;
-        use macros::tests::my_types::*;
+        use crate::sql_types::*;
+        use crate::macros::tests::my_types::*;
 
         table_with_custom_types {
             id -> Integer,
@@ -1093,8 +1093,8 @@ mod tests {
     }
 
     table! {
-        use sql_types::*;
-        use macros::tests::my_types::*;
+        use crate::sql_types::*;
+        use crate::macros::tests::my_types::*;
 
         /// Table documentation
         ///
@@ -1111,17 +1111,17 @@ mod tests {
     #[test]
     #[cfg(feature = "postgres")]
     fn table_with_custom_schema() {
-        use pg::Pg;
+        use crate::pg::Pg;
         let expected_sql = r#"SELECT "foo"."bars"."baz" FROM "foo"."bars" -- binds: []"#;
         assert_eq!(
             expected_sql,
-            &::debug_query::<Pg, _>(&bars::table.select(bars::baz)).to_string()
+            &crate::debug_query::<Pg, _>(&bars::table.select(bars::baz)).to_string()
         );
     }
 
     table! {
-        use sql_types;
-        use sql_types::*;
+        use crate::sql_types;
+        use crate::sql_types::*;
 
         table_with_arbitrarily_complex_types {
             id -> sql_types::Integer,
@@ -1152,41 +1152,41 @@ mod tests {
     #[test]
     #[cfg(feature = "postgres")]
     fn table_with_column_renaming_postgres() {
-        use pg::Pg;
+        use crate::pg::Pg;
         let expected_sql =
             r#"SELECT "foo"."id", "foo"."type", "foo"."bleh" FROM "foo" WHERE "foo"."type" = $1 -- binds: [1]"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Pg, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
+            crate::debug_query::<Pg, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "mysql")]
     fn table_with_column_renaming_mysql() {
-        use mysql::Mysql;
+        use crate::mysql::Mysql;
         let expected_sql =
             r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Mysql, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
+            crate::debug_query::<Mysql, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "sqlite")]
     fn table_with_column_renaming_sqlite() {
-        use sqlite::Sqlite;
+        use crate::sqlite::Sqlite;
         let expected_sql =
             r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Sqlite, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
+            crate::debug_query::<Sqlite, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
         );
     }
 
     table!(
-        use sql_types::*;
+        use crate::sql_types::*;
 
         /// Some documentation
         #[sql_name="mod"]
@@ -1199,33 +1199,33 @@ mod tests {
     #[test]
     #[cfg(feature = "postgres")]
     fn table_renaming_postgres() {
-        use pg::Pg;
+        use crate::pg::Pg;
         let expected_sql = r#"SELECT "mod"."id" FROM "mod" -- binds: []"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Pg, _>(&bar::table.select(bar::id)).to_string()
+            crate::debug_query::<Pg, _>(&bar::table.select(bar::id)).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "mysql")]
     fn table_renaming_mysql() {
-        use mysql::Mysql;
+        use crate::mysql::Mysql;
         let expected_sql = r#"SELECT `mod`.`id` FROM `mod` -- binds: []"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Mysql, _>(&bar::table.select(bar::id)).to_string()
+            crate::debug_query::<Mysql, _>(&bar::table.select(bar::id)).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "sqlite")]
     fn table_renaming_sqlite() {
-        use sqlite::Sqlite;
+        use crate::sqlite::Sqlite;
         let expected_sql = r#"SELECT `mod`.`id` FROM `mod` -- binds: []"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Sqlite, _>(&bar::table.select(bar::id)).to_string()
+            crate::debug_query::<Sqlite, _>(&bar::table.select(bar::id)).to_string()
         );
     }
 }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -170,7 +170,10 @@ macro_rules! __diesel_column {
 ///
 /// table! {
 ///     use diesel::sql_types::*;
+///     # /*
 ///     use diesel_full_text_search::*;
+///     # */
+///     # use crate::diesel_full_text_search::*;
 ///
 ///     posts {
 ///         id -> Integer,
@@ -898,7 +901,7 @@ macro_rules! __diesel_table_query_source_impl {
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// use schema::*;
+/// use self::schema::*;
 ///
 /// # /*
 /// joinable!(posts -> users (user_id));

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -12,7 +12,7 @@ macro_rules! __diesel_column {
     ) => {
         $($meta)*
         #[allow(non_camel_case_types, dead_code)]
-        #[derive(Debug, Clone, Copy, QueryId, Default)]
+        #[derive(Debug, Clone, Copy, $crate::QueryId, Default)]
         pub struct $column_name;
 
         impl $crate::expression::Expression for $column_name {
@@ -86,8 +86,8 @@ macro_rules! __diesel_column {
             }
         }
 
-        __diesel_generate_ops_impls_if_numeric!($column_name, $($Type)*);
-        __diesel_generate_ops_impls_if_date_time!($column_name, $($Type)*);
+        $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($Type)*);
+        $crate::__diesel_generate_ops_impls_if_date_time!($column_name, $($Type)*);
     }
 }
 
@@ -263,7 +263,7 @@ macro_rules! __diesel_column {
 #[macro_export]
 macro_rules! table {
     ($($tokens:tt)*) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($tokens)*],
             imports = [],
             meta = [],
@@ -295,7 +295,7 @@ macro_rules! __diesel_parse_table {
         imports = [$($imports:tt)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = [$($imports)* use $($import)::+;],
             $($args)*
@@ -310,7 +310,7 @@ macro_rules! __diesel_parse_table {
         sql_name = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -326,7 +326,7 @@ macro_rules! __diesel_parse_table {
         meta = [$($meta:tt)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = [$($meta)* #$new_meta],
@@ -344,7 +344,7 @@ macro_rules! __diesel_parse_table {
         schema = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -364,7 +364,7 @@ macro_rules! __diesel_parse_table {
         name = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -385,7 +385,7 @@ macro_rules! __diesel_parse_table {
         primary_key = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -403,7 +403,7 @@ macro_rules! __diesel_parse_table {
         imports = [],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [{$($columns)*}],
             imports = [use $crate::sql_types::*;],
             $($args)*
@@ -419,7 +419,7 @@ macro_rules! __diesel_parse_table {
         name = $name:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [{$($columns)*}],
             imports = $imports,
             meta = $meta,
@@ -434,7 +434,7 @@ macro_rules! __diesel_parse_table {
         tokens = [{$($columns:tt)*}],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             tokens = [$($columns)*],
             table = { $($args)* },
             columns = [],
@@ -443,7 +443,7 @@ macro_rules! __diesel_parse_table {
 
     // Invalid syntax
     ($($tokens:tt)*) => {
-        __diesel_invalid_table_syntax!();
+        $crate::__diesel_invalid_table_syntax!();
     }
 }
 
@@ -460,7 +460,7 @@ macro_rules! __diesel_parse_columns {
         ],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$(#$meta)*],
                 name = $name,
@@ -482,7 +482,7 @@ macro_rules! __diesel_parse_columns {
         ],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$(#$meta)*],
                 name = $name,
@@ -506,7 +506,7 @@ macro_rules! __diesel_parse_columns {
         },
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$($meta)*],
                 name = $name,
@@ -529,7 +529,7 @@ macro_rules! __diesel_parse_columns {
         },
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$($unchecked_meta)*],
                 name = $name,
@@ -553,7 +553,7 @@ macro_rules! __diesel_parse_columns {
         columns = [$($columns:tt,)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             tokens = $tokens,
             table = $table,
             columns = [$($columns,)* { $($current_column)* },],
@@ -566,12 +566,12 @@ macro_rules! __diesel_parse_columns {
         tokens = [],
         $($args:tt)*
     ) => {
-        __diesel_table_impl!($($args)*);
+        $crate::__diesel_table_impl!($($args)*);
     };
 
     // Invalid syntax
     ($($tokens:tt)*) => {
-        __diesel_invalid_table_syntax!();
+        $crate::__diesel_invalid_table_syntax!();
     }
 }
 
@@ -615,7 +615,7 @@ macro_rules! __diesel_table_impl {
             /// table struct renamed to the module name. This is meant to be
             /// glob imported for functions which only deal with one table.
             pub mod dsl {
-                $(static_cond! {
+                $($crate::static_cond! {
                     if $table_name == $column_name {
                         compile_error!(concat!(
                             "Column `",
@@ -640,7 +640,7 @@ macro_rules! __diesel_table_impl {
             pub const all_columns: ($($column_name,)+) = ($($column_name,)+);
 
             #[allow(non_camel_case_types)]
-            #[derive(Debug, Clone, Copy, QueryId)]
+            #[derive(Debug, Clone, Copy, $crate::QueryId)]
             /// The actual table struct
             ///
             /// This is the type which provides the base methods of the query
@@ -663,7 +663,7 @@ macro_rules! __diesel_table_impl {
             /// Helper type for representing a boxed query from this table
             pub type BoxedQuery<'a, DB, ST = SqlType> = BoxedSelectStatement<'a, ST, table, DB>;
 
-            __diesel_table_query_source_impl!(table, $schema, $sql_name);
+            $crate::__diesel_table_query_source_impl!(table, $schema, $sql_name);
 
             impl AsQuery for table {
                 type SqlType = SqlType;
@@ -821,7 +821,7 @@ macro_rules! __diesel_table_impl {
                 impl AppearsOnTable<table> for star {
                 }
 
-                $(__diesel_column! {
+                $($crate::__diesel_column! {
                     table = table,
                     name = $column_name,
                     sql_name = $column_sql_name,
@@ -942,8 +942,8 @@ macro_rules! __diesel_table_query_source_impl {
 #[macro_export]
 macro_rules! joinable {
     ($($child:ident)::* -> $($parent:ident)::* ($source:ident)) => {
-        joinable_inner!($($child)::* ::table => $($parent)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
-        joinable_inner!($($parent)::* ::table => $($child)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
+        $crate::joinable_inner!($($child)::* ::table => $($parent)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
+        $crate::joinable_inner!($($parent)::* ::table => $($child)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
     }
 }
 
@@ -951,7 +951,7 @@ macro_rules! joinable {
 #[doc(hidden)]
 macro_rules! joinable_inner {
     ($left_table:path => $right_table:path : ($foreign_key:path = $parent_table:path)) => {
-        joinable_inner!(
+        $crate::joinable_inner!(
             left_table_ty = $left_table,
             right_table_ty = $right_table,
             right_table_expr = $right_table,
@@ -1032,7 +1032,7 @@ macro_rules! allow_tables_to_appear_in_same_query {
                 type Count = $crate::query_source::Never;
             }
         )+
-        allow_tables_to_appear_in_same_query!($($right_mod,)+);
+        $crate::allow_tables_to_appear_in_same_query!($($right_mod,)+);
     };
 
     ($last_table:ident,) => {};

--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -28,39 +28,39 @@ macro_rules! operator_allowed {
 /// for types which implement `Expression`, under its orphan rules.
 macro_rules! numeric_expr {
     ($tpe:ty) => {
-        operator_allowed!($tpe, Add, add);
-        operator_allowed!($tpe, Sub, sub);
-        operator_allowed!($tpe, Div, div);
-        operator_allowed!($tpe, Mul, mul);
+        $crate::operator_allowed!($tpe, Add, add);
+        $crate::operator_allowed!($tpe, Sub, sub);
+        $crate::operator_allowed!($tpe, Div, div);
+        $crate::operator_allowed!($tpe, Mul, mul);
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __diesel_generate_ops_impls_if_numeric {
-    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
 
-    ($column_name:ident, SmallInt) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int2) => { numeric_expr!($column_name); };
-    ($column_name:ident, Smallint) => { numeric_expr!($column_name); };
-    ($column_name:ident, SmallSerial) => { numeric_expr!($column_name); };
+    ($column_name:ident, SmallInt) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int2) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Smallint) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, SmallSerial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Integer) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int4) => { numeric_expr!($column_name); };
-    ($column_name:ident, Serial) => { numeric_expr!($column_name); };
+    ($column_name:ident, Integer) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int4) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Serial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, BigInt) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int8) => { numeric_expr!($column_name); };
-    ($column_name:ident, Bigint) => { numeric_expr!($column_name); };
-    ($column_name:ident, BigSerial) => { numeric_expr!($column_name); };
+    ($column_name:ident, BigInt) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int8) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Bigint) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, BigSerial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Float) => { numeric_expr!($column_name); };
-    ($column_name:ident, Float4) => { numeric_expr!($column_name); };
+    ($column_name:ident, Float) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Float4) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Double) => { numeric_expr!($column_name); };
-    ($column_name:ident, Float8) => { numeric_expr!($column_name); };
+    ($column_name:ident, Double) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Float8) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Numeric) => { numeric_expr!($column_name); };
+    ($column_name:ident, Numeric) => { $crate::numeric_expr!($column_name); };
 
     ($column_name:ident, $non_numeric_type:ty) => {};
 }
@@ -69,18 +69,18 @@ macro_rules! __diesel_generate_ops_impls_if_numeric {
 #[doc(hidden)]
 macro_rules! date_time_expr {
     ($tpe:ty) => {
-        operator_allowed!($tpe, Add, add);
-        operator_allowed!($tpe, Sub, sub);
+        $crate::operator_allowed!($tpe, Add, add);
+        $crate::operator_allowed!($tpe, Sub, sub);
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __diesel_generate_ops_impls_if_date_time {
-    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_date_time!($column_name, $($inner)::*); };
-    ($column_name:ident, Time) => { date_time_expr!($column_name); };
-    ($column_name:ident, Date) => { date_time_expr!($column_name); };
-    ($column_name:ident, Timestamp) => { date_time_expr!($column_name); };
-    ($column_name:ident, Timestamptz) => { date_time_expr!($column_name); };
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { $crate::__diesel_generate_ops_impls_if_date_time!($column_name, $($inner)::*); };
+    ($column_name:ident, Time) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Date) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Timestamp) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Timestamptz) => { $crate::date_time_expr!($column_name); };
     ($column_name:ident, $non_date_time_type:ty) => {};
 }

--- a/diesel/src/macros/static_cond.rs
+++ b/diesel/src/macros/static_cond.rs
@@ -21,18 +21,18 @@ macro_rules! static_cond {
 
     // no else condition provided: fall through with empty else
     (if $lhs:tt == $rhs:tt $then:tt) => {
-        static_cond!(if $lhs == $rhs $then else { });
+        $crate::static_cond!(if $lhs == $rhs $then else { });
     };
     (if $lhs:tt != $rhs:tt $then:tt) => {
-        static_cond!(if $lhs != $rhs $then else { });
+        $crate::static_cond!(if $lhs != $rhs $then else { });
     };
 
     // we evaluate a conditional by generating a new macro (in an inner scope, so name shadowing is
     // not a big concern) and calling it
     (if $lhs:tt == $rhs:tt $then:tt else $els:tt) => {
-        static_cond!(@go $lhs $rhs $then $els);
+        $crate::static_cond!(@go $lhs $rhs $then $els);
     };
     (if $lhs:tt != $rhs:tt $then:tt else $els:tt) => {
-        static_cond!(@go $lhs $rhs $els $then);
+        $crate::static_cond!(@go $lhs $rhs $els $then);
     };
 }

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::{fmt, io};
 
-use result;
+use crate::result;
 
 /// Errors that occur while preparing to run migrations
 #[derive(Debug)]

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -3,7 +3,7 @@
 mod errors;
 pub use self::errors::{MigrationError, RunMigrationsError};
 
-use connection::SimpleConnection;
+use crate::connection::SimpleConnection;
 use std::path::Path;
 
 /// Represents a migration that interacts with diesel

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -4,8 +4,8 @@ use byteorder::NativeEndian;
 
 use super::bind_collector::MysqlBindCollector;
 use super::query_builder::MysqlQueryBuilder;
-use backend::*;
-use sql_types::TypeMetadata;
+use crate::backend::*;
+use crate::sql_types::TypeMetadata;
 
 /// The MySQL backend
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/diesel/src/mysql/bind_collector.rs
+++ b/diesel/src/mysql/bind_collector.rs
@@ -1,9 +1,9 @@
 use super::{Mysql, MysqlType};
-use query_builder::BindCollector;
-use result::Error::SerializationError;
-use result::QueryResult;
-use serialize::{IsNull, Output, ToSql};
-use sql_types::{HasSqlType, IsSigned};
+use crate::query_builder::BindCollector;
+use crate::result::Error::SerializationError;
+use crate::result::QueryResult;
+use crate::serialize::{IsNull, Output, ToSql};
+use crate::sql_types::{HasSqlType, IsSigned};
 
 #[derive(Default)]
 #[doc(hidden)]

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -4,9 +4,9 @@ use std::mem;
 use std::os::raw as libc;
 
 use super::stmt::Statement;
-use mysql::MysqlType;
-use result::QueryResult;
-use sql_types::IsSigned;
+use crate::mysql::MysqlType;
+use crate::result::QueryResult;
+use crate::sql_types::IsSigned;
 
 pub struct Binds {
     data: Vec<BindData>,
@@ -195,7 +195,7 @@ impl BindData {
     }
 
     fn did_numeric_overflow_occur(&self) -> QueryResult<()> {
-        use result::Error::DeserializationError;
+        use crate::result::Error::DeserializationError;
 
         if self.is_truncated() && self.is_fixed_size_buffer() {
             Err(DeserializationError(

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -8,11 +8,11 @@ use self::stmt::Statement;
 use self::url::ConnectionOptions;
 use super::backend::Mysql;
 use super::bind_collector::MysqlBindCollector;
-use connection::*;
-use deserialize::{Queryable, QueryableByName};
-use query_builder::*;
-use result::*;
-use sql_types::HasSqlType;
+use crate::connection::*;
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::query_builder::*;
+use crate::result::*;
+use crate::sql_types::HasSqlType;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 /// A connection to a MySQL database. Connection URLs should be in the form
@@ -37,7 +37,7 @@ impl Connection for MysqlConnection {
     type TransactionManager = AnsiTransactionManager;
 
     fn establish(database_url: &str) -> ConnectionResult<Self> {
-        use result::ConnectionError::CouldntSetupConfiguration;
+        use crate::result::ConnectionError::CouldntSetupConfiguration;
 
         let raw_connection = RawConnection::new();
         let connection_options = ConnectionOptions::parse(database_url)?;
@@ -67,8 +67,8 @@ impl Connection for MysqlConnection {
         Self::Backend: HasSqlType<T::SqlType>,
         U: Queryable<T::SqlType, Self::Backend>,
     {
-        use deserialize::FromSqlRow;
-        use result::Error::DeserializationError;
+        use crate::deserialize::FromSqlRow;
+        use crate::result::Error::DeserializationError;
 
         let mut stmt = self.prepare_query(&source.as_query())?;
         let mut metadata = Vec::new();
@@ -87,7 +87,7 @@ impl Connection for MysqlConnection {
         T: QueryFragment<Self::Backend> + QueryId,
         U: QueryableByName<Self::Backend>,
     {
-        use result::Error::DeserializationError;
+        use crate::result::Error::DeserializationError;
 
         let mut stmt = self.prepare_query(source)?;
         let results = unsafe { stmt.named_results()? };

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -7,7 +7,7 @@ use std::sync::{Once, ONCE_INIT};
 
 use super::stmt::Statement;
 use super::url::ConnectionOptions;
-use result::{ConnectionError, ConnectionResult, QueryResult};
+use crate::result::{ConnectionError, ConnectionResult, QueryResult};
 
 pub struct RawConnection(NonNull<ffi::MYSQL>);
 
@@ -134,8 +134,8 @@ impl RawConnection {
     }
 
     fn did_an_error_occur(&self) -> QueryResult<()> {
-        use result::DatabaseErrorKind;
-        use result::Error::DatabaseError;
+        use crate::result::DatabaseErrorKind;
+        use crate::result::Error::DatabaseError;
 
         let error_message = self.last_error_message();
         if error_message.is_empty() {

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use super::{ffi, libc, Binds, Statement, StatementMetadata};
-use mysql::{Mysql, MysqlType};
-use result::QueryResult;
-use row::*;
-use sql_types::IsSigned;
+use crate::mysql::{Mysql, MysqlType};
+use crate::result::QueryResult;
+use crate::row::*;
+use crate::sql_types::IsSigned;
 
 pub struct StatementIterator<'a> {
     stmt: &'a mut Statement,

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -10,9 +10,9 @@ use std::ptr::NonNull;
 use self::iterator::*;
 use self::metadata::*;
 use super::bind::Binds;
-use mysql::MysqlType;
-use result::{DatabaseErrorKind, QueryResult};
-use sql_types::IsSigned;
+use crate::mysql::MysqlType;
+use crate::result::{DatabaseErrorKind, QueryResult};
+use crate::sql_types::IsSigned;
 
 pub struct Statement {
     stmt: NonNull<ffi::MYSQL_STMT>,
@@ -116,7 +116,7 @@ impl Statement {
     }
 
     fn metadata(&self) -> QueryResult<StatementMetadata> {
-        use result::Error::DeserializationError;
+        use crate::result::Error::DeserializationError;
 
         let result_ptr = unsafe { ffi::mysql_stmt_result_metadata(self.stmt.as_ptr()).as_mut() };
         self.did_an_error_occur()?;
@@ -126,7 +126,7 @@ impl Statement {
     }
 
     fn did_an_error_occur(&self) -> QueryResult<()> {
-        use result::Error::DatabaseError;
+        use crate::result::Error::DatabaseError;
 
         let error_message = self.last_error_message();
         if error_message.is_empty() {

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -4,7 +4,7 @@ use self::url::percent_encoding::percent_decode;
 use self::url::{Host, Url};
 use std::ffi::{CStr, CString};
 
-use result::{ConnectionError, ConnectionResult};
+use crate::result::{ConnectionError, ConnectionResult};
 
 pub struct ConnectionOptions {
     host: Option<CString>,

--- a/diesel/src/mysql/query_builder/mod.rs
+++ b/diesel/src/mysql/query_builder/mod.rs
@@ -1,6 +1,6 @@
 use super::backend::Mysql;
-use query_builder::QueryBuilder;
-use result::QueryResult;
+use crate::query_builder::QueryBuilder;
+use crate::result::QueryResult;
 
 mod query_fragment_impls;
 

--- a/diesel/src/mysql/query_builder/query_fragment_impls.rs
+++ b/diesel/src/mysql/query_builder/query_fragment_impls.rs
@@ -1,7 +1,7 @@
-use mysql::Mysql;
-use query_builder::locking_clause::{ForShare, ForUpdate, NoModifier, NoWait, SkipLocked};
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
+use crate::mysql::Mysql;
+use crate::query_builder::locking_clause::{ForShare, ForUpdate, NoModifier, NoWait, SkipLocked};
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
 
 impl QueryFragment<Mysql> for ForUpdate {
     fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -6,10 +6,10 @@ use std::io::Write;
 use std::os::raw as libc;
 use std::{mem, ptr, slice};
 
-use deserialize::{self, FromSql};
-use mysql::Mysql;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{Date, Datetime, Time, Timestamp};
+use crate::deserialize::{self, FromSql};
+use crate::mysql::Mysql;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{Date, Datetime, Time, Timestamp};
 
 macro_rules! mysql_time_impls {
     ($ty:ty) => {
@@ -154,10 +154,10 @@ mod tests {
     use self::chrono::{Duration, NaiveDate, NaiveTime, Utc};
     use self::dotenv::dotenv;
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::{Date, Datetime, Time, Timestamp};
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::{Date, Datetime, Time, Timestamp};
 
     fn connection() -> MysqlConnection {
         dotenv().ok();

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -7,10 +7,10 @@ mod numeric;
 use byteorder::WriteBytesExt;
 use std::io::Write;
 
-use deserialize::{self, FromSql};
-use mysql::{Mysql, MysqlType};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::*;
+use crate::deserialize::{self, FromSql};
+use crate::mysql::{Mysql, MysqlType};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::*;
 
 impl ToSql<TinyInt, Mysql> for i8 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {

--- a/diesel/src/mysql/types/numeric.rs
+++ b/diesel/src/mysql/types/numeric.rs
@@ -5,11 +5,11 @@ pub mod bigdecimal {
     use self::bigdecimal::BigDecimal;
     use std::io::prelude::*;
 
-    use backend::Backend;
-    use deserialize::{self, FromSql};
-    use mysql::Mysql;
-    use serialize::{self, IsNull, Output, ToSql};
-    use sql_types::{Binary, Numeric};
+    use crate::backend::Backend;
+    use crate::deserialize::{self, FromSql};
+    use crate::mysql::Mysql;
+    use crate::serialize::{self, IsNull, Output, ToSql};
+    use crate::sql_types::{Binary, Numeric};
 
     impl ToSql<Numeric, Mysql> for BigDecimal {
         fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -4,10 +4,10 @@ use byteorder::NetworkEndian;
 
 use super::query_builder::PgQueryBuilder;
 use super::PgMetadataLookup;
-use backend::*;
-use prelude::Queryable;
-use query_builder::bind_collector::RawBytesBindCollector;
-use sql_types::{Oid, TypeMetadata};
+use crate::backend::*;
+use crate::prelude::Queryable;
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::sql_types::{Oid, TypeMetadata};
 
 /// The PostgreSQL backend
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -1,9 +1,9 @@
 use super::result::PgResult;
 use super::row::PgNamedRow;
-use deserialize::{FromSqlRow, Queryable, QueryableByName};
-use pg::Pg;
-use result::Error::DeserializationError;
-use result::QueryResult;
+use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
+use crate::pg::Pg;
+use crate::result::Error::DeserializationError;
+use crate::result::QueryResult;
 
 use std::marker::PhantomData;
 
@@ -59,7 +59,7 @@ impl NamedCursor {
     where
         T: QueryableByName<Pg>,
     {
-        use result::Error::DeserializationError;
+        use crate::result::Error::DeserializationError;
 
         (0..self.db_result.num_rows())
             .map(|i| {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -12,14 +12,14 @@ use self::cursor::*;
 use self::raw::RawConnection;
 use self::result::PgResult;
 use self::stmt::Statement;
-use connection::*;
-use deserialize::{Queryable, QueryableByName};
-use pg::{Pg, PgMetadataLookup, TransactionBuilder};
-use query_builder::bind_collector::RawBytesBindCollector;
-use query_builder::*;
-use result::ConnectionError::CouldntSetupConfiguration;
-use result::*;
-use sql_types::HasSqlType;
+use crate::connection::*;
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::pg::{Pg, PgMetadataLookup, TransactionBuilder};
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::query_builder::*;
+use crate::result::ConnectionError::CouldntSetupConfiguration;
+use crate::result::*;
+use crate::sql_types::HasSqlType;
 
 /// The connection string expected by `PgConnection::establish`
 /// should be a PostgreSQL connection string, as documented at
@@ -190,15 +190,15 @@ mod tests {
     use std::env;
 
     use super::*;
-    use dsl::sql;
-    use prelude::*;
-    use sql_types::{Integer, VarChar};
+    use crate::dsl::sql;
+    use crate::prelude::*;
+    use crate::sql_types::{Integer, VarChar};
 
     #[test]
     fn prepared_statements_are_cached() {
         let connection = connection();
 
-        let query = ::select(1.into_sql::<Integer>());
+        let query = crate::select(1.into_sql::<Integer>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -209,8 +209,8 @@ mod tests {
     fn queries_with_identical_sql_but_different_types_are_cached_separately() {
         let connection = connection();
 
-        let query = ::select(1.into_sql::<Integer>());
-        let query2 = ::select("hi".into_sql::<VarChar>());
+        let query = crate::select(1.into_sql::<Integer>());
+        let query2 = crate::select("hi".into_sql::<VarChar>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok("hi".to_string()), query2.get_result(&connection));
@@ -221,8 +221,8 @@ mod tests {
     fn queries_with_identical_types_and_sql_but_different_bind_types_are_cached_separately() {
         let connection = connection();
 
-        let query = ::select(1.into_sql::<Integer>()).into_boxed::<Pg>();
-        let query2 = ::select("hi".into_sql::<VarChar>()).into_boxed::<Pg>();
+        let query = crate::select(1.into_sql::<Integer>()).into_boxed::<Pg>();
+        let query2 = crate::select("hi".into_sql::<VarChar>()).into_boxed::<Pg>();
 
         assert_eq!(0, connection.statement_cache.len());
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -236,8 +236,8 @@ mod tests {
 
         sql_function!(fn lower(x: VarChar) -> VarChar);
         let hi = "HI".into_sql::<VarChar>();
-        let query = ::select(hi).into_boxed::<Pg>();
-        let query2 = ::select(lower(hi)).into_boxed::<Pg>();
+        let query = crate::select(hi).into_boxed::<Pg>();
+        let query2 = crate::select(lower(hi)).into_boxed::<Pg>();
 
         assert_eq!(0, connection.statement_cache.len());
         assert_eq!(Ok("HI".to_string()), query.get_result(&connection));
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn queries_with_sql_literal_nodes_are_not_cached() {
         let connection = connection();
-        let query = ::select(sql::<Integer>("1"));
+        let query = crate::select(sql::<Integer>("1"));
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(0, connection.statement_cache.len());

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -123,7 +123,7 @@ impl PgConnection {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = connection_no_transaction();
     /// conn.build_transaction()
     ///     .read_only()

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -8,7 +8,7 @@ use std::os::raw as libc;
 use std::ptr::NonNull;
 use std::{ptr, str};
 
-use result::*;
+use crate::result::*;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct RawConnection {

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -7,7 +7,7 @@ use std::{slice, str};
 
 use super::raw::RawResult;
 use super::row::PgRow;
-use result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
+use crate::result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
 
 pub struct PgResult {
     internal_result: RawResult,

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -1,7 +1,7 @@
 use super::cursor::NamedCursor;
 use super::result::PgResult;
-use pg::Pg;
-use row::*;
+use crate::pg::Pg;
+use crate::row::*;
 
 pub struct PgRow<'a> {
     db_result: &'a PgResult,

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -5,8 +5,8 @@ use std::os::raw as libc;
 use std::ptr;
 
 use super::result::PgResult;
-use pg::PgTypeMetadata;
-use result::QueryResult;
+use crate::pg::PgTypeMetadata;
+use crate::result::QueryResult;
 
 pub use super::raw::RawConnection;
 

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::{
+use crate::backend::Backend;
+use crate::expression::{
     AppearsOnTable, AsExpressionList, Expression, NonAggregate, SelectableExpression,
 };
-use query_builder::{AstPass, QueryFragment};
-use sql_types;
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::sql_types;
 use std::marker::PhantomData;
 
 /// An ARRAY[...] literal.
@@ -69,7 +69,7 @@ where
     DB: Backend,
     for<'a> (&'a T): QueryFragment<DB>,
 {
-    fn walk_ast(&self, mut out: AstPass<DB>) -> ::result::QueryResult<()> {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> crate::result::QueryResult<()> {
         out.push_sql("ARRAY[");
         QueryFragment::walk_ast(&&self.elements, out.reborrow())?;
         out.push_sql("]");

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -29,7 +29,7 @@ pub struct ArrayLiteral<T, ST> {
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     use diesel::dsl::array;
 /// #     use diesel::sql_types::Integer;
 /// #     let connection = establish_connection();

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -1,9 +1,9 @@
-use expression::subselect::Subselect;
-use expression::{AsExpression, Expression, NonAggregate};
-use pg::Pg;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Array;
+use crate::expression::subselect::Subselect;
+use crate::expression::{AsExpression, Expression, NonAggregate};
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Array;
 
 /// Creates a PostgreSQL `ANY` expression.
 ///

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -19,7 +19,7 @@ use crate::sql_types::Array;
 /// # use diesel::dsl::*;
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// #     connection.execute("INSERT INTO users (name) VALUES ('Jim')").unwrap();
 /// let sean = (1, "Sean".to_string());
@@ -48,7 +48,7 @@ where
 /// # use diesel::dsl::*;
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// #     connection.execute("INSERT INTO users (name) VALUES ('Jim')").unwrap();
 /// let tess = (2, "Tess".to_string());

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -1,8 +1,8 @@
-use expression::{Expression, NonAggregate};
-use pg::Pg;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::{Date, Timestamp, Timestamptz, VarChar};
+use crate::expression::{Expression, NonAggregate};
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::{Date, Timestamp, Timestamptz, VarChar};
 
 /// Marker trait for types which are valid in `AT TIME ZONE` expressions
 pub trait DateTimeLike {}

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -1,8 +1,8 @@
 //! PostgreSQL specific expression methods
 
 use super::operators::*;
-use expression::{AsExpression, Expression};
-use sql_types::{Array, Nullable, Text};
+use crate::expression::{AsExpression, Expression};
+use crate::sql_types::{Array, Nullable, Text};
 
 /// PostgreSQL specific methods which are present on all expressions.
 pub trait PgExpressionMethods: Expression + Sized {
@@ -64,7 +64,7 @@ pub trait PgExpressionMethods: Expression + Sized {
 impl<T: Expression> PgExpressionMethods for T {}
 
 use super::date_and_time::{AtTimeZone, DateTimeLike};
-use sql_types::VarChar;
+use crate::sql_types::VarChar;
 
 /// PostgreSQL specific methods present on timestamp expressions.
 pub trait PgTimestampExpressionMethods: Expression + Sized {
@@ -302,7 +302,7 @@ pub trait PgArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized 
 
 impl<T, ST> PgArrayExpressionMethods<ST> for T where T: Expression<SqlType = Array<ST>> {}
 
-use expression::operators::{Asc, Desc};
+use crate::expression::operators::{Asc, Desc};
 
 /// PostgreSQL expression methods related to sorting.
 ///

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -18,7 +18,7 @@ pub trait PgExpressionMethods: Expression + Sized {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let distinct = users.select(id).filter(name.is_distinct_from("Sean"));
     /// let not_distinct = users.select(id).filter(name.is_not_distinct_from("Sean"));
@@ -45,7 +45,7 @@ pub trait PgExpressionMethods: Expression + Sized {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let distinct = users.select(id).filter(name.is_distinct_from("Sean"));
     /// let not_distinct = users.select(id).filter(name.is_not_distinct_from("Sean"));
@@ -98,7 +98,7 @@ pub trait PgTimestampExpressionMethods: Expression + Sized {
     /// #
     /// # #[cfg(all(feature = "postgres", feature = "chrono"))]
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use timestamps::dsl::*;
+    /// #     use self::timestamps::dsl::*;
     /// #     use chrono::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("CREATE TABLE timestamps (\"timestamp\"
@@ -427,7 +427,7 @@ pub trait PgTextExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// let starts_with_s = animals
     ///     .select(species)
@@ -454,7 +454,7 @@ pub trait PgTextExpressionMethods: Expression + Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// let doesnt_start_with_s = animals
     ///     .select(species)

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -1,6 +1,6 @@
 use std::ops::Mul;
 
-use data_types::PgInterval;
+use crate::data_types::PgInterval;
 
 /// A DSL added to integers and `f64` to construct PostgreSQL intervals.
 ///
@@ -243,10 +243,10 @@ mod tests {
     use self::quickcheck::quickcheck;
 
     use super::*;
-    use data_types::PgInterval;
-    use dsl::sql;
-    use prelude::*;
-    use {select, sql_types};
+    use crate::data_types::PgInterval;
+    use crate::dsl::sql;
+    use crate::prelude::*;
+    use crate::{select, sql_types};
 
     thread_local! {
         static CONN: PgConnection = {

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,5 +1,5 @@
-use dsl::AsExprOf;
-use sql_types::VarChar;
+use crate::dsl::AsExprOf;
+use crate::sql_types::VarChar;
 
 /// The return type of `lhs.ilike(rhs)`
 pub type ILike<Lhs, Rhs> = super::operators::ILike<Lhs, AsExprOf<Rhs, VarChar>>;

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,4 +1,4 @@
-use pg::Pg;
+use crate::pg::Pg;
 
 diesel_infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
 diesel_infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -1,5 +1,5 @@
 use super::{PgConnection, PgTypeMetadata};
-use prelude::*;
+use crate::prelude::*;
 
 /// Determines the OID of types at runtime
 #[allow(missing_debug_implementations)]

--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -1,8 +1,8 @@
-use expression::SelectableExpression;
-use pg::Pg;
-use query_builder::{AstPass, QueryFragment, SelectQuery, SelectStatement};
-use query_dsl::methods::DistinctOnDsl;
-use result::QueryResult;
+use crate::expression::SelectableExpression;
+use crate::pg::Pg;
+use crate::query_builder::{AstPass, QueryFragment, SelectQuery, SelectStatement};
+use crate::query_dsl::methods::DistinctOnDsl;
+use crate::result::QueryResult;
 
 /// Represents `DISTINCT ON (...)`
 #[derive(Debug, Clone, Copy, QueryId)]

--- a/diesel/src/pg/query_builder/mod.rs
+++ b/diesel/src/pg/query_builder/mod.rs
@@ -1,6 +1,6 @@
 use super::backend::Pg;
-use query_builder::QueryBuilder;
-use result::QueryResult;
+use crate::query_builder::QueryBuilder;
+use crate::result::QueryResult;
 
 mod distinct_on;
 mod query_fragment_impls;

--- a/diesel/src/pg/query_builder/query_fragment_impls.rs
+++ b/diesel/src/pg/query_builder/query_fragment_impls.rs
@@ -1,9 +1,9 @@
-use pg::Pg;
-use query_builder::locking_clause::{
+use crate::pg::Pg;
+use crate::query_builder::locking_clause::{
     ForKeyShare, ForNoKeyUpdate, ForShare, ForUpdate, NoModifier, NoWait, SkipLocked,
 };
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
 
 impl QueryFragment<Pg> for ForUpdate {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {

--- a/diesel/src/pg/serialize/write_tuple.rs
+++ b/diesel/src/pg/serialize/write_tuple.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
-use pg::Pg;
-use serialize::{self, Output};
+use crate::pg::Pg;
+use crate::serialize::{self, Output};
 
 /// Helper trait for writing tuples as named composite types
 ///

--- a/diesel/src/pg/transaction.rs
+++ b/diesel/src/pg/transaction.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
-use backend::Backend;
-use connection::TransactionManager;
-use pg::Pg;
-use prelude::*;
-use query_builder::{AstPass, QueryBuilder, QueryFragment};
-use result::Error;
+use crate::backend::Backend;
+use crate::connection::TransactionManager;
+use crate::pg::Pg;
+use crate::prelude::*;
+use crate::query_builder::{AstPass, QueryBuilder, QueryFragment};
+use crate::result::Error;
 
 /// Used to build a transaction, specifying additional details.
 ///

--- a/diesel/src/pg/transaction.rs
+++ b/diesel/src/pg/transaction.rs
@@ -56,8 +56,8 @@ impl<'a> TransactionBuilder<'a> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use users_for_read_only::table as users;
-    /// #     use users_for_read_only::columns::*;
+    /// #     use self::users_for_read_only::table as users;
+    /// #     use self::users_for_read_only::columns::*;
     /// #     let conn = connection_no_transaction();
     /// #     sql_query("CREATE TABLE IF NOT EXISTS users_for_read_only (
     /// #       id SERIAL PRIMARY KEY,
@@ -103,7 +103,7 @@ impl<'a> TransactionBuilder<'a> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = connection_no_transaction();
     /// conn.build_transaction()
     ///     .read_write()
@@ -145,7 +145,7 @@ impl<'a> TransactionBuilder<'a> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = connection_no_transaction();
     /// conn.build_transaction()
     ///     .deferrable()
@@ -173,7 +173,7 @@ impl<'a> TransactionBuilder<'a> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = connection_no_transaction();
     /// conn.build_transaction()
     ///     .not_deferrable()
@@ -201,7 +201,7 @@ impl<'a> TransactionBuilder<'a> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = connection_no_transaction();
     /// conn.build_transaction()
     ///     .read_committed()
@@ -226,7 +226,7 @@ impl<'a> TransactionBuilder<'a> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = connection_no_transaction();
     /// conn.build_transaction()
     ///     .repeatable_read()
@@ -251,7 +251,7 @@ impl<'a> TransactionBuilder<'a> {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let conn = connection_no_transaction();
     /// conn.build_transaction()
     ///     .serializable()

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -2,10 +2,10 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::fmt;
 use std::io::Write;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgMetadataLookup, PgTypeMetadata};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{Array, HasSqlType, Nullable};
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgMetadataLookup, PgTypeMetadata};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{Array, HasSqlType, Nullable};
 
 impl<T> HasSqlType<Array<T>> for Pg
 where
@@ -55,8 +55,8 @@ where
     }
 }
 
-use expression::bound::Bound;
-use expression::AsExpression;
+use crate::expression::bound::Bound;
+use crate::expression::AsExpression;
 
 macro_rules! array_as_expression {
     ($ty:ty, $sql_type:ty) => {

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -8,10 +8,10 @@ use self::chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Time
 use std::io::Write;
 
 use super::{PgDate, PgTime, PgTimestamp};
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, Output, ToSql};
-use sql_types::{Date, Time, Timestamp, Timestamptz};
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types::{Date, Time, Timestamp, Timestamptz};
 
 // Postgres timestamps start from January 1st 2000.
 fn pg_epoch() -> NaiveDateTime {
@@ -125,10 +125,10 @@ mod tests {
     use self::chrono::{Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};
     use self::dotenv::dotenv;
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::{Date, Time, Timestamp, Timestamptz};
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::{Date, Time, Timestamp, Timestamptz};
 
     fn connection() -> PgConnection {
         dotenv().ok();

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -4,10 +4,10 @@ use std::io::Write;
 
 use self::time::{Duration, Timespec};
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
 
 #[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
@@ -44,10 +44,10 @@ mod tests {
     use self::dotenv::dotenv;
     use self::time::{Duration, Timespec};
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::Timestamp;
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::Timestamp;
 
     fn connection() -> PgConnection {
         dotenv().ok();

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 use std::ops::Add;
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{self, Date, Interval, Time, Timestamp, Timestamptz};
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{self, Date, Interval, Time, Timestamp, Timestamptz};
 
 #[cfg(feature = "chrono")]
 mod chrono;

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
 
 fn pg_epoch() -> SystemTime {
     let thirty_years = Duration::from_secs(946_684_800);
@@ -64,10 +64,10 @@ mod tests {
     use self::dotenv::dotenv;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::Timestamp;
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::Timestamp;
 
     fn connection() -> PgConnection {
         dotenv().ok();

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -2,10 +2,10 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -1,10 +1,10 @@
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl FromSql<sql_types::Oid, Pg> for u32 {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -4,15 +4,15 @@ extern crate serde_json;
 
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 #[allow(dead_code)]
 mod foreign_derives {
     use super::serde_json;
-    use sql_types::{Json, Jsonb};
+    use crate::sql_types::{Json, Jsonb};
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -105,17 +105,17 @@ pub mod sql_types {
     pub struct Range<ST>(ST);
 
     #[doc(hidden)]
-    pub type Int4range = Range<::sql_types::Int4>;
+    pub type Int4range = Range<crate::sql_types::Int4>;
     #[doc(hidden)]
-    pub type Int8range = Range<::sql_types::Int8>;
+    pub type Int8range = Range<crate::sql_types::Int8>;
     #[doc(hidden)]
-    pub type Daterange = Range<::sql_types::Date>;
+    pub type Daterange = Range<crate::sql_types::Date>;
     #[doc(hidden)]
-    pub type Numrange = Range<::sql_types::Numeric>;
+    pub type Numrange = Range<crate::sql_types::Numeric>;
     #[doc(hidden)]
-    pub type Tsrange = Range<::sql_types::Timestamp>;
+    pub type Tsrange = Range<crate::sql_types::Timestamp>;
     #[doc(hidden)]
-    pub type Tstzrange = Range<::sql_types::Timestamptz>;
+    pub type Tstzrange = Range<crate::sql_types::Timestamptz>;
 
     /// The `Record` (a.k.a. tuple) SQL type.
     ///
@@ -159,13 +159,13 @@ pub mod sql_types {
     pub struct Record<ST>(ST);
 
     /// Alias for `SmallInt`
-    pub type SmallSerial = ::sql_types::SmallInt;
+    pub type SmallSerial = crate::sql_types::SmallInt;
 
     /// Alias for `Integer`
-    pub type Serial = ::sql_types::Integer;
+    pub type Serial = crate::sql_types::Integer;
 
     /// Alias for `BigInt`
-    pub type BigSerial = ::sql_types::BigInt;
+    pub type BigSerial = crate::sql_types::BigInt;
 
     /// The `UUID` SQL type. This type can only be used with `feature = "uuid"`
     ///
@@ -186,10 +186,10 @@ pub mod sql_types {
 
     /// Alias for `Binary`, to ensure `infer_schema!` works
     #[doc(hidden)]
-    pub type Bytea = ::sql_types::Binary;
+    pub type Bytea = crate::sql_types::Binary;
 
     #[doc(hidden)]
-    pub type Bpchar = ::sql_types::VarChar;
+    pub type Bpchar = crate::sql_types::VarChar;
 
     /// The JSON SQL type.  This type can only be used with `feature =
     /// "serde_json"`
@@ -492,8 +492,8 @@ pub mod sql_types {
 
 mod ops {
     use super::sql_types::*;
-    use sql_types::ops::*;
-    use sql_types::Interval;
+    use crate::sql_types::ops::*;
+    use crate::sql_types::Interval;
 
     impl Add for Timestamptz {
         type Rhs = Interval;

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -263,7 +263,7 @@ pub mod sql_types {
     ///
     /// # fn main() {
     /// #     use diesel::insert_into;
-    /// #     use contacts::dsl::*;
+    /// #     use self::contacts::dsl::*;
     /// #     let connection = connection_no_data();
     /// #     connection.execute("CREATE TABLE contacts (
     /// #         id SERIAL PRIMARY KEY,
@@ -319,7 +319,7 @@ pub mod sql_types {
     ///
     /// # fn main() {
     /// #     use diesel::insert_into;
-    /// #     use items::dsl::*;
+    /// #     use self::items::dsl::*;
     /// #     let connection = connection_no_data();
     /// #     connection.execute("CREATE TABLE items (
     /// #         id SERIAL PRIMARY KEY,
@@ -365,7 +365,7 @@ pub mod sql_types {
     ///
     /// # fn main() {
     /// #     use diesel::insert_into;
-    /// #     use devices::dsl::*;
+    /// #     use self::devices::dsl::*;
     /// #     let connection = connection_no_data();
     /// #     connection.execute("CREATE TABLE devices (
     /// #         id SERIAL PRIMARY KEY,
@@ -419,7 +419,7 @@ pub mod sql_types {
     ///
     /// # fn main() {
     /// #     use diesel::insert_into;
-    /// #     use clients::dsl::*;
+    /// #     use self::clients::dsl::*;
     /// #     use std::str::FromStr;
     /// #     let connection = connection_no_data();
     /// #     connection.execute("CREATE TABLE clients (
@@ -470,7 +470,7 @@ pub mod sql_types {
     ///
     /// # fn main() {
     /// #     use diesel::insert_into;
-    /// #     use clients::dsl::*;
+    /// #     use self::clients::dsl::*;
     /// #     use std::str::FromStr;
     /// #     let connection = connection_no_data();
     /// #     connection.execute("CREATE TABLE clients (

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -3,10 +3,10 @@
 use std::io::prelude::*;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, Output, ToSql};
-use sql_types::{BigInt, Money};
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types::{BigInt, Money};
 
 /// Money is represented in Postgres as a 64 bit signed integer.  This struct is a dumb wrapper
 /// type, meant only to indicate the integer's meaning.  The fractional precision of the value is

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -5,10 +5,10 @@ use self::ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use std::io::prelude::*;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{Cidr, Inet, MacAddr};
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{Cidr, Inet, MacAddr};
 
 #[cfg(windows)]
 const AF_INET: u8 = 2;

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -11,11 +11,11 @@ mod bigdecimal {
     use self::num_traits::{Signed, ToPrimitive, Zero};
     use std::io::prelude::*;
 
-    use deserialize::{self, FromSql};
-    use pg::data_types::PgNumeric;
-    use pg::Pg;
-    use serialize::{self, Output, ToSql};
-    use sql_types::Numeric;
+    use crate::deserialize::{self, FromSql};
+    use crate::pg::data_types::PgNumeric;
+    use crate::pg::Pg;
+    use crate::serialize::{self, Output, ToSql};
+    use crate::sql_types::Numeric;
 
     #[cfg(feature = "unstable")]
     use std::convert::{TryFrom, TryInto};

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -1,9 +1,9 @@
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl FromSql<sql_types::Bool, Pg> for bool {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -2,12 +2,12 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::Bound;
 use std::io::Write;
 
-use deserialize::{self, FromSql, FromSqlRow, Queryable};
-use expression::bound::Bound as SqlBound;
-use expression::AsExpression;
-use pg::{Pg, PgMetadataLookup, PgTypeMetadata};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::*;
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::expression::bound::Bound as SqlBound;
+use crate::expression::AsExpression;
+use crate::pg::{Pg, PgMetadataLookup, PgTypeMetadata};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::*;
 
 // https://github.com/postgres/postgres/blob/113b0045e20d40f726a0a30e33214455e4f1385e/src/include/utils/rangetypes.h#L35-L43
 bitflags! {
@@ -69,7 +69,7 @@ impl<T, ST> FromSqlRow<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     (Bound<T>, Bound<T>): FromSql<Range<ST>, Pg>,
 {
-    fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> deserialize::Result<Self> {
+    fn build_from_row<R: crate::row::Row<Pg>>(row: &mut R) -> deserialize::Result<Self> {
         FromSql::<Range<ST>, Pg>::from_sql(row.take())
     }
 }

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -1,14 +1,14 @@
 use byteorder::*;
 use std::io::Write;
 
-use deserialize::{self, FromSql, FromSqlRow, Queryable};
-use expression::{AppearsOnTable, AsExpression, Expression, NonAggregate, SelectableExpression};
-use pg::Pg;
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
-use row::Row;
-use serialize::{self, IsNull, Output, ToSql, WriteTuple};
-use sql_types::{HasSqlType, Record};
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::expression::{AppearsOnTable, AsExpression, Expression, NonAggregate, SelectableExpression};
+use crate::pg::Pg;
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
+use crate::row::Row;
+use crate::serialize::{self, IsNull, Output, ToSql, WriteTuple};
+use crate::sql_types::{HasSqlType, Record};
 
 macro_rules! tuple_impls {
     ($(
@@ -175,10 +175,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dsl::sql;
-    use prelude::*;
-    use sql_types::*;
-    use test_helpers::*;
+    use crate::dsl::sql;
+    use crate::prelude::*;
+    use crate::sql_types::*;
+    use crate::test_helpers::*;
 
     #[test]
     fn record_deserializes_correctly() {
@@ -207,11 +207,11 @@ mod tests {
         let conn = pg_connection();
 
         let tup = sql::<Record<(Integer, Text)>>("(1, 'hi')");
-        let res = ::select(tup.eq((1, "hi"))).get_result(&conn);
+        let res = crate::select(tup.eq((1, "hi"))).get_result(&conn);
         assert_eq!(Ok(true), res);
 
         let tup = sql::<Record<(Record<(Integer, Text)>, Integer)>>("((2, 'bye'::text), 3)");
-        let res = ::select(tup.eq(((2, "bye"), 3))).get_result(&conn);
+        let res = crate::select(tup.eq(((2, "bye"), 3))).get_result(&conn);
         assert_eq!(Ok(true), res);
 
         let tup = sql::<
@@ -220,7 +220,7 @@ mod tests {
                 Nullable<Integer>,
             )>,
         >("((4, NULL::text), NULL::int4)");
-        let res = ::select(tup.is_not_distinct_from(((Some(4), None::<&str>), None::<i32>)))
+        let res = crate::select(tup.is_not_distinct_from(((Some(4), None::<&str>), None::<i32>)))
             .get_result(&conn);
         assert_eq!(Ok(true), res);
     }
@@ -243,11 +243,11 @@ mod tests {
 
         let conn = pg_connection();
 
-        ::sql_query("CREATE TYPE my_type AS (i int4, t text)")
+        crate::sql_query("CREATE TYPE my_type AS (i int4, t text)")
             .execute(&conn)
             .unwrap();
         let sql = sql::<Bool>("(1, 'hi')::my_type = ").bind::<MyType, _>(MyStruct(1, "hi"));
-        let res = ::select(sql).get_result(&conn);
+        let res = crate::select(sql).get_result(&conn);
         assert_eq!(Ok(true), res);
     }
 }

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -2,7 +2,9 @@ use byteorder::*;
 use std::io::Write;
 
 use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
-use crate::expression::{AppearsOnTable, AsExpression, Expression, NonAggregate, SelectableExpression};
+use crate::expression::{
+    AppearsOnTable, AsExpression, Expression, NonAggregate, SelectableExpression,
+};
 use crate::pg::Pg;
 use crate::query_builder::{AstPass, QueryFragment};
 use crate::result::QueryResult;

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -2,10 +2,10 @@ extern crate uuid;
 
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::Pg;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::Uuid;
+use crate::deserialize::{self, FromSql};
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::Uuid;
 
 #[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -1,8 +1,8 @@
-use expression::{AppearsOnTable, Expression};
-use pg::Pg;
-use query_builder::*;
-use query_source::*;
-use result::QueryResult;
+use crate::expression::{AppearsOnTable, Expression};
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::query_source::*;
+use crate::result::QueryResult;
 
 /// Represents `excluded.column` in an `ON CONFLICT DO UPDATE` clause.
 pub fn excluded<T>(excluded: T) -> Excluded<T> {

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -1,9 +1,9 @@
 use super::on_conflict_actions::*;
 use super::on_conflict_target::*;
-use insertable::*;
-use pg::Pg;
-use query_builder::*;
-use result::QueryResult;
+use crate::insertable::*;
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy)]

--- a/diesel/src/pg/upsert/on_conflict_docs_setup.rs
+++ b/diesel/src/pg/upsert/on_conflict_docs_setup.rs
@@ -1,5 +1,5 @@
 include!("../../doctest_setup.rs");
-use crate::schema::users;
+use self::schema::users;
 
 #[derive(Clone, Copy, Insertable, AsChangeset)]
 #[table_name="users"]

--- a/diesel/src/pg/upsert/on_conflict_docs_setup.rs
+++ b/diesel/src/pg/upsert/on_conflict_docs_setup.rs
@@ -1,5 +1,5 @@
 include!("../../doctest_setup.rs");
-use schema::users;
+use crate::schema::users;
 
 #[derive(Clone, Copy, Insertable, AsChangeset)]
 #[table_name="users"]

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -1,8 +1,8 @@
 use super::on_conflict_actions::*;
 use super::on_conflict_clause::*;
 use super::on_conflict_target::*;
-use query_builder::{AsChangeset, InsertStatement, UndecoratedInsertRecord};
-use query_source::QuerySource;
+use crate::query_builder::{AsChangeset, InsertStatement, UndecoratedInsertRecord};
+use crate::query_source::QuerySource;
 
 impl<T, U, Op, Ret> InsertStatement<T, U, Op, Ret>
 where

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -20,7 +20,7 @@ where
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Sean", };
@@ -46,7 +46,7 @@ where
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Sean", };
@@ -82,7 +82,7 @@ where
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// conn.execute("CREATE UNIQUE INDEX users_name ON users (name)").unwrap();
@@ -131,7 +131,7 @@ where
     /// # }
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// use diesel::pg::upsert::*;
     ///
     /// #     let conn = establish_connection();
@@ -221,7 +221,7 @@ impl<Stmt, Target> IncompleteOnConflict<Stmt, Target> {
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Pascal" };
@@ -249,7 +249,7 @@ impl<Stmt, Target> IncompleteOnConflict<Stmt, Target> {
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Pascal" };
@@ -277,7 +277,7 @@ impl<Stmt, Target> IncompleteOnConflict<Stmt, Target> {
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// use diesel::pg::upsert::excluded;
     ///
     /// #     let conn = establish_connection();

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -1,8 +1,8 @@
-use expression::SqlLiteral;
-use pg::Pg;
-use query_builder::*;
-use query_source::Column;
-use result::QueryResult;
+use crate::expression::SqlLiteral;
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::query_source::Column;
+use crate::result::QueryResult;
 
 /// Used to specify the constraint name for an upsert statement in the form `ON
 /// CONFLICT ON CONSTRAINT`. Note that `constraint_name` must be the name of a
@@ -117,10 +117,10 @@ macro_rules! on_conflict_tuples {
         {
             fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
                 out.push_sql(" (");
-                try!(out.push_identifier(T::NAME));
+                out.push_identifier(T::NAME)?;
                 $(
                     out.push_sql(", ");
-                    try!(out.push_identifier($col::NAME));
+                    out.push_identifier($col::NAME)?;
                 )+
                 out.push_sql(")");
                 Ok(())

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -15,7 +15,7 @@ use crate::result::QueryResult;
 /// # include!("on_conflict_docs_setup.rs");
 /// #
 /// # fn main() {
-/// #     use users::dsl::*;
+/// #     use self::users::dsl::*;
 /// use diesel::pg::upsert::*;
 ///
 /// #     let conn = establish_connection();

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -1,10 +1,10 @@
 use std::{fmt, mem};
 
-use backend::Backend;
-use query_builder::{BindCollector, QueryBuilder};
-use result::QueryResult;
-use serialize::ToSql;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::query_builder::{BindCollector, QueryBuilder};
+use crate::result::QueryResult;
+use crate::serialize::ToSql;
+use crate::sql_types::HasSqlType;
 
 #[allow(missing_debug_implementations)]
 /// The primary type used when walking a Diesel AST during query execution.

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -1,10 +1,10 @@
 //! Types related to managing bind parameters during query construction.
 
-use backend::Backend;
-use result::Error::SerializationError;
-use result::QueryResult;
-use serialize::{IsNull, Output, ToSql};
-use sql_types::{HasSqlType, TypeMetadata};
+use crate::backend::Backend;
+use crate::result::Error::SerializationError;
+use crate::result::QueryResult;
+use crate::serialize::{IsNull, Output, ToSql};
+use crate::sql_types::{HasSqlType, TypeMetadata};
 
 /// A type which manages serializing bind parameters during query construction.
 ///

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -4,8 +4,8 @@ macro_rules! simple_clause {
     };
 
     ($no_clause:ident, $clause:ident, $sql:expr, backend_bounds = $($backend_bounds:ident),*) => {
-        use backend::Backend;
-        use result::QueryResult;
+        use crate::backend::Backend;
+        use crate::result::QueryResult;
         use super::{QueryFragment, AstPass};
 
         #[derive(Debug, Clone, Copy, QueryId)]

--- a/diesel/src/query_builder/debug_query.rs
+++ b/diesel/src/query_builder/debug_query.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::mem;
 
 use super::{AstPass, QueryBuilder, QueryFragment};
-use backend::Backend;
+use crate::backend::Backend;
 
 /// A struct that implements `fmt::Display` and `fmt::Debug` to show the SQL
 /// representation of a query.

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -1,13 +1,13 @@
-use backend::Backend;
-use dsl::{Filter, IntoBoxed};
-use expression::{AppearsOnTable, SelectableExpression};
-use query_builder::returning_clause::*;
-use query_builder::where_clause::*;
-use query_builder::*;
-use query_dsl::methods::{BoxedDsl, FilterDsl};
-use query_dsl::RunQueryDsl;
-use query_source::Table;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::dsl::{Filter, IntoBoxed};
+use crate::expression::{AppearsOnTable, SelectableExpression};
+use crate::query_builder::returning_clause::*;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::*;
+use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
+use crate::query_dsl::RunQueryDsl;
+use crate::query_source::Table;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 #[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -54,7 +54,7 @@ impl<T, U> DeleteStatement<T, U, NoReturningClause> {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let deleted_rows = diesel::delete(users)
     ///     .filter(name.eq("Sean"))
@@ -97,7 +97,7 @@ impl<T, U> DeleteStatement<T, U, NoReturningClause> {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use std::collections::HashMap;
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     let mut params = HashMap::new();
     /// #     params.insert("sean_has_been_a_jerk", true);
@@ -212,7 +212,7 @@ impl<T, U> DeleteStatement<T, U, NoReturningClause> {
     /// #
     /// # #[cfg(feature = "postgres")]
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let deleted_name = diesel::delete(users.filter(name.eq("Sean")))
     ///     .returning(name)

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,6 +1,6 @@
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct NoDistinctClause;
@@ -21,4 +21,4 @@ impl<DB: Backend> QueryFragment<DB> for DistinctClause {
 }
 
 #[cfg(feature = "postgres")]
-pub use pg::DistinctOnClause;
+pub use crate::pg::DistinctOnClause;

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -3,9 +3,9 @@ use super::insert_statement::{Insert, InsertOrIgnore, Replace};
 use super::{
     IncompleteInsertStatement, IntoUpdateTarget, SelectStatement, SqlQuery, UpdateStatement,
 };
-use dsl::Select;
-use expression::Expression;
-use query_dsl::methods::SelectDsl;
+use crate::dsl::Select;
+use crate::expression::Expression;
+use crate::query_dsl::methods::SelectDsl;
 
 /// Creates an `UPDATE` statement.
 ///

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -26,7 +26,7 @@ use crate::query_dsl::methods::SelectDsl;
 /// #
 /// # #[cfg(feature = "postgres")]
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// let updated_row = diesel::update(users.filter(id.eq(1)))
 ///     .set(name.eq("James"))
@@ -59,7 +59,7 @@ use crate::query_dsl::methods::SelectDsl;
 /// #
 /// # #[cfg(feature = "postgres")]
 /// # fn main() {
-/// # use users::dsl::*;
+/// # use self::users::dsl::*;
 /// # let connection = establish_connection();
 /// # connection.execute("DROP TABLE users").unwrap();
 /// # connection.execute("CREATE TABLE users (
@@ -103,11 +103,11 @@ pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::Wh
 /// # }
 /// #
 /// # fn delete() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// #     let get_count = || users.count().first::<i64>(&connection);
 /// let old_count = get_count();
-/// try!(diesel::delete(users.filter(id.eq(1))).execute(&connection));
+/// diesel::delete(users.filter(id.eq(1))).execute(&connection)?;
 /// assert_eq!(old_count.map(|count| count - 1), get_count());
 /// # Ok(())
 /// # }
@@ -124,10 +124,10 @@ pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::Wh
 /// # }
 /// #
 /// # fn delete() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// #     let get_count = || users.count().first::<i64>(&connection);
-/// try!(diesel::delete(users).execute(&connection));
+/// diesel::delete(users).execute(&connection)?;
 /// assert_eq!(Ok(0), get_count());
 /// # Ok(())
 /// # }
@@ -158,7 +158,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// # include!("../doctest_setup.rs");
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// let rows_inserted = diesel::insert_into(users)
 ///     .values(&name.eq("Sean"))
@@ -186,7 +186,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// # include!("../doctest_setup.rs");
 /// #
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// #     diesel::delete(users).execute(&connection).unwrap();
 /// let new_user = (id.eq(1), name.eq("Sean"));
@@ -214,7 +214,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use schema::users;
+/// # use self::schema::users;
 /// #
 /// #[derive(Insertable)]
 /// #[table_name = "users"]
@@ -223,7 +223,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// }
 ///
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// // Insert one record at a time
 ///
@@ -267,7 +267,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use schema::{posts, users};
+/// #     use self::schema::{posts, users};
 /// #     let conn = establish_connection();
 /// #     diesel::delete(posts::table).execute(&conn)?;
 /// let new_posts = users::table
@@ -297,7 +297,7 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// #
 /// # #[cfg(feature = "postgres")]
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// let inserted_names = diesel::insert_into(users)
 ///     .values(&vec![
@@ -337,7 +337,7 @@ pub fn insert_into<T>(target: T) -> IncompleteInsertStatement<T, Insert> {
 /// #
 /// # #[cfg(not(feature = "postgres"))]
 /// # fn run_test() -> QueryResult<()> {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     use diesel::{delete, insert_or_ignore_into};
 /// #
 /// #     let connection = establish_connection();
@@ -392,7 +392,7 @@ where
 /// #
 /// # #[cfg(not(feature = "postgres"))]
 /// # fn main() {
-/// #     use schema::users::dsl::*;
+/// #     use self::schema::users::dsl::*;
 /// #     use diesel::{insert_into, replace_into};
 /// #
 /// #     let conn = establish_connection();
@@ -439,7 +439,7 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
 /// #
-/// # use schema::users;
+/// # use self::schema::users;
 /// #
 /// # #[derive(QueryableByName, Debug, PartialEq)]
 /// # #[table_name="users"]

--- a/diesel/src/query_builder/insert_statement/column_list.rs
+++ b/diesel/src/query_builder/insert_statement/column_list.rs
@@ -1,7 +1,7 @@
-use backend::Backend;
-use query_builder::*;
-use query_source::Column;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::query_source::Column;
+use crate::result::QueryResult;
 
 /// Represents the column list for use in an insert statement.
 ///

--- a/diesel/src/query_builder/insert_statement/insert_from_select.rs
+++ b/diesel/src/query_builder/insert_statement/insert_from_select.rs
@@ -1,8 +1,8 @@
-use backend::Backend;
-use expression::{Expression, NonAggregate, SelectableExpression};
-use insertable::*;
-use query_builder::*;
-use query_source::Table;
+use crate::backend::Backend;
+use crate::expression::{Expression, NonAggregate, SelectableExpression};
+use crate::insertable::*;
+use crate::query_builder::*;
+use crate::query_source::Table;
 
 /// Represents `(Columns) SELECT FROM ...` for use in an `INSERT` statement
 #[derive(Debug, Clone, Copy)]

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -8,20 +8,20 @@ use std::any::*;
 use std::marker::PhantomData;
 
 use super::returning_clause::*;
-use backend::Backend;
-use expression::operators::Eq;
-use expression::{Expression, NonAggregate, SelectableExpression};
-use insertable::*;
+use crate::backend::Backend;
+use crate::expression::operators::Eq;
+use crate::expression::{Expression, NonAggregate, SelectableExpression};
+use crate::insertable::*;
 #[cfg(feature = "mysql")]
-use mysql::Mysql;
-use query_builder::*;
+use crate::mysql::Mysql;
+use crate::query_builder::*;
 #[cfg(feature = "sqlite")]
-use query_dsl::methods::ExecuteDsl;
-use query_dsl::RunQueryDsl;
-use query_source::{Column, Table};
-use result::QueryResult;
+use crate::query_dsl::methods::ExecuteDsl;
+use crate::query_dsl::RunQueryDsl;
+use crate::query_source::{Column, Table};
+use crate::result::QueryResult;
 #[cfg(feature = "sqlite")]
-use sqlite::{Sqlite, SqliteConnection};
+use crate::sqlite::{Sqlite, SqliteConnection};
 
 /// The structure returned by [`insert_into`].
 ///
@@ -214,7 +214,7 @@ where
     Op: Copy,
 {
     fn execute(query: Self, conn: &SqliteConnection) -> QueryResult<usize> {
-        use connection::Connection;
+        use crate::connection::Connection;
         conn.transaction(|| {
             let mut result = 0;
             for record in query.records {
@@ -256,7 +256,7 @@ where
     Op: Copy,
 {
     fn execute(query: Self, conn: &SqliteConnection) -> QueryResult<usize> {
-        use connection::Connection;
+        use crate::connection::Connection;
         conn.transaction(|| {
             let mut result = 0;
             for value in query.records.values {
@@ -445,7 +445,7 @@ where
     #[cfg(feature = "mysql")]
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         // This can be less hacky once stabilization lands
-        if TypeId::of::<DB>() == TypeId::of::<::mysql::Mysql>() {
+        if TypeId::of::<DB>() == TypeId::of::<crate::mysql::Mysql>() {
             out.push_sql("() VALUES ()");
         } else {
             out.push_sql("DEFAULT VALUES");

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -62,7 +62,7 @@ impl<T, Op> IncompleteInsertStatement<T, Op> {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::insert_into;
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let connection = connection_no_data();
     /// connection.execute("CREATE TABLE users (
     ///     name VARCHAR(255) NOT NULL DEFAULT 'Sean',
@@ -309,7 +309,7 @@ impl<T, U, Op> InsertStatement<T, U, Op> {
     /// #
     /// # #[cfg(feature = "postgres")]
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let inserted_names = diesel::insert_into(users)
     ///     .values(&vec![name.eq("Timmy"), name.eq("Jimmy")])

--- a/diesel/src/query_builder/locking_clause.rs
+++ b/diesel/src/query_builder/locking_clause.rs
@@ -1,6 +1,6 @@
-use backend::Backend;
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct NoLockingClause;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -55,8 +55,8 @@ pub(crate) use self::insert_statement::ColumnList;
 
 use std::error::Error;
 
-use backend::Backend;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::result::QueryResult;
 
 #[doc(hidden)]
 pub type Binds = Vec<Option<Vec<u8>>>;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -277,10 +277,10 @@ impl<T: Query> AsQuery for T {
 /// #
 /// # #[macro_use] extern crate diesel;
 /// # use diesel::*;
-/// # use schema::*;
+/// # use self::schema::*;
 /// #
 /// # fn main() {
-/// #   use schema::users::dsl::*;
+/// #   use self::schema::users::dsl::*;
 /// let sql = debug_query::<DB, _>(&users.count()).to_string();
 /// # if cfg!(feature = "postgres") {
 /// #     assert_eq!(sql, r#"SELECT COUNT(*) FROM "users" -- binds: []"#);

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -1,6 +1,6 @@
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Identifier<'a>(pub &'a str);

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -117,7 +117,7 @@ mod tests {
     use std::any::TypeId;
 
     use super::QueryId;
-    use prelude::*;
+    use crate::prelude::*;
 
     table! {
         users {

--- a/diesel/src/query_builder/returning_clause.rs
+++ b/diesel/src/query_builder/returning_clause.rs
@@ -1,4 +1,4 @@
-use backend::SupportsReturningClause;
+use crate::backend::SupportsReturningClause;
 
 simple_clause!(
     NoReturningClause,

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -1,7 +1,7 @@
-use backend::Backend;
-use expression::{Expression, SelectableExpression};
-use query_builder::*;
-use query_source::QuerySource;
+use crate::backend::Backend;
+use crate::expression::{Expression, SelectableExpression};
+use crate::query_builder::*;
+use crate::query_source::QuerySource;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct DefaultSelectClause;

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -1,24 +1,24 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use dsl::AsExprOf;
-use expression::subselect::ValidSubselect;
-use expression::*;
-use insertable::Insertable;
-use query_builder::distinct_clause::DistinctClause;
-use query_builder::group_by_clause::GroupByClause;
-use query_builder::insert_statement::InsertFromSelect;
-use query_builder::limit_clause::LimitClause;
-use query_builder::offset_clause::OffsetClause;
-use query_builder::order_clause::OrderClause;
-use query_builder::where_clause::*;
-use query_builder::*;
-use query_dsl::methods::*;
-use query_dsl::*;
-use query_source::joins::*;
-use query_source::{QuerySource, Table};
-use result::QueryResult;
-use sql_types::{BigInt, Bool, NotNull, Nullable};
+use crate::backend::Backend;
+use crate::dsl::AsExprOf;
+use crate::expression::subselect::ValidSubselect;
+use crate::expression::*;
+use crate::insertable::Insertable;
+use crate::query_builder::distinct_clause::DistinctClause;
+use crate::query_builder::group_by_clause::GroupByClause;
+use crate::query_builder::insert_statement::InsertFromSelect;
+use crate::query_builder::limit_clause::LimitClause;
+use crate::query_builder::offset_clause::OffsetClause;
+use crate::query_builder::order_clause::OrderClause;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::*;
+use crate::query_dsl::methods::*;
+use crate::query_dsl::*;
+use crate::query_source::joins::*;
+use crate::query_source::{QuerySource, Table};
+use crate::result::QueryResult;
+use crate::sql_types::{BigInt, Bool, NotNull, Nullable};
 
 #[allow(missing_debug_implementations)]
 pub struct BoxedSelectStatement<'a, ST, QS, DB> {

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -1,27 +1,27 @@
 use super::BoxedSelectStatement;
-use associations::HasTable;
-use backend::Backend;
-use dsl::AsExprOf;
-use expression::nullable::Nullable;
-use expression::*;
-use insertable::Insertable;
-use query_builder::distinct_clause::*;
-use query_builder::group_by_clause::*;
-use query_builder::insert_statement::InsertFromSelect;
-use query_builder::limit_clause::*;
-use query_builder::locking_clause::*;
-use query_builder::offset_clause::*;
-use query_builder::order_clause::*;
-use query_builder::select_clause::*;
-use query_builder::update_statement::*;
-use query_builder::where_clause::*;
-use query_builder::{AsQuery, Query, QueryFragment, SelectQuery, SelectStatement};
-use query_dsl::boxed_dsl::BoxedDsl;
-use query_dsl::methods::*;
-use query_dsl::*;
-use query_source::joins::{Join, JoinOn, JoinTo};
-use query_source::QuerySource;
-use sql_types::{BigInt, Bool};
+use crate::associations::HasTable;
+use crate::backend::Backend;
+use crate::dsl::AsExprOf;
+use crate::expression::nullable::Nullable;
+use crate::expression::*;
+use crate::insertable::Insertable;
+use crate::query_builder::distinct_clause::*;
+use crate::query_builder::group_by_clause::*;
+use crate::query_builder::insert_statement::InsertFromSelect;
+use crate::query_builder::limit_clause::*;
+use crate::query_builder::locking_clause::*;
+use crate::query_builder::offset_clause::*;
+use crate::query_builder::order_clause::*;
+use crate::query_builder::select_clause::*;
+use crate::query_builder::update_statement::*;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::{AsQuery, Query, QueryFragment, SelectQuery, SelectStatement};
+use crate::query_dsl::boxed_dsl::BoxedDsl;
+use crate::query_dsl::methods::*;
+use crate::query_dsl::*;
+use crate::query_source::joins::{Join, JoinOn, JoinTo};
+use crate::query_source::QuerySource;
+use crate::sql_types::{BigInt, Bool};
 
 impl<F, S, D, W, O, L, Of, G, LC, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On>
     for SelectStatement<F, S, D, W, O, L, Of, G, LC>
@@ -136,9 +136,9 @@ where
     }
 }
 
-use dsl::Filter;
-use expression_methods::EqAll;
-use query_source::Table;
+use crate::dsl::Filter;
+use crate::expression_methods::EqAll;
+use crate::query_source::Table;
 
 impl<F, S, D, W, O, L, Of, G, LC, PK> FindDsl<PK> for SelectStatement<F, S, D, W, O, L, Of, G, LC>
 where
@@ -207,7 +207,7 @@ where
     Expr: Expression,
     Self: OrderDsl<Expr>,
 {
-    type Output = ::dsl::Order<Self, Expr>;
+    type Output = crate::dsl::Order<Self, Expr>;
 
     fn then_order_by(self, expr: Expr) -> Self::Output {
         self.order_by(expr)

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -25,13 +25,13 @@ use super::order_clause::NoOrderClause;
 use super::select_clause::*;
 use super::where_clause::*;
 use super::{AstPass, Query, QueryFragment};
-use backend::Backend;
-use expression::subselect::ValidSubselect;
-use expression::*;
-use query_builder::SelectQuery;
-use query_source::joins::{AppendSelection, Inner, Join};
-use query_source::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::subselect::ValidSubselect;
+use crate::expression::*;
+use crate::query_builder::SelectQuery;
+use crate::query_source::joins::{AppendSelection, Inner, Join};
+use crate::query_source::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 #[doc(hidden)]

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -1,13 +1,13 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use connection::Connection;
-use deserialize::QueryableByName;
-use query_builder::{AstPass, QueryFragment, QueryId};
-use query_dsl::{LoadQuery, RunQueryDsl};
-use result::QueryResult;
-use serialize::ToSql;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::connection::Connection;
+use crate::deserialize::QueryableByName;
+use crate::query_builder::{AstPass, QueryFragment, QueryId};
+use crate::query_dsl::{LoadQuery, RunQueryDsl};
+use crate::result::QueryResult;
+use crate::serialize::ToSql;
+use crate::sql_types::HasSqlType;
 
 #[derive(Debug, Clone)]
 #[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -41,7 +41,7 @@ impl SqlQuery {
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
     /// #
-    /// # use schema::users;
+    /// # use self::schema::users;
     /// #
     /// # #[derive(QueryableByName, Debug, PartialEq)]
     /// # #[table_name="users"]

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::operators::Eq;
-use expression::AppearsOnTable;
-use query_builder::*;
-use query_source::{Column, QuerySource};
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::operators::Eq;
+use crate::expression::AppearsOnTable;
+use crate::query_builder::*;
+use crate::query_source::{Column, QuerySource};
+use crate::result::QueryResult;
 
 /// Types which can be passed to
 /// [`update.set`](struct.UpdateStatement.html#method.set).

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -4,17 +4,17 @@ pub mod target;
 pub use self::changeset::AsChangeset;
 pub use self::target::{IntoUpdateTarget, UpdateTarget};
 
-use backend::Backend;
-use dsl::{Filter, IntoBoxed};
-use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
-use query_builder::returning_clause::*;
-use query_builder::where_clause::*;
-use query_builder::*;
-use query_dsl::methods::{BoxedDsl, FilterDsl};
-use query_dsl::RunQueryDsl;
-use query_source::Table;
-use result::Error::QueryBuilderError;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::dsl::{Filter, IntoBoxed};
+use crate::expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
+use crate::query_builder::returning_clause::*;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::*;
+use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
+use crate::query_dsl::RunQueryDsl;
+use crate::query_source::Table;
+use crate::result::Error::QueryBuilderError;
+use crate::result::QueryResult;
 
 /// The type returned by [`update`](../fn.update.html). The only thing you can do
 /// with this type is call `set` on it.

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -85,7 +85,7 @@ impl<T, U, V, Ret> UpdateStatement<T, U, V, Ret> {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let updated_rows = diesel::update(users)
     ///     .set(name.eq("Jim"))
@@ -129,7 +129,7 @@ impl<T, U, V, Ret> UpdateStatement<T, U, V, Ret> {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use std::collections::HashMap;
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     let mut params = HashMap::new();
     /// #     params.insert("tess_has_been_a_jerk", false);
@@ -261,7 +261,7 @@ impl<T, U, V> UpdateStatement<T, U, V, NoReturningClause> {
     /// #
     /// # #[cfg(feature = "postgres")]
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let updated_name = diesel::update(users.filter(id.eq(1)))
     ///     .set(name.eq("Dean"))

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -1,7 +1,7 @@
-use associations::{HasTable, Identifiable};
-use dsl::Find;
-use query_dsl::methods::FindDsl;
-use query_source::Table;
+use crate::associations::{HasTable, Identifiable};
+use crate::dsl::Find;
+use crate::query_dsl::methods::FindDsl;
+use crate::query_source::Table;
 
 #[doc(hidden)]
 #[derive(Debug)]

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -1,11 +1,11 @@
 use super::*;
-use backend::Backend;
-use dsl::Or;
-use expression::operators::And;
-use expression::*;
-use expression_methods::*;
-use result::QueryResult;
-use sql_types::Bool;
+use crate::backend::Backend;
+use crate::dsl::Or;
+use crate::expression::operators::And;
+use crate::expression::*;
+use crate::expression_methods::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
 
 /// Add `Predicate` to the current `WHERE` clause, joining with `AND` if
 /// applicable.
@@ -159,7 +159,7 @@ where
 
     fn and(self, predicate: Predicate) -> Self::Output {
         use self::BoxedWhereClause::Where;
-        use expression::operators::And;
+        use crate::expression::operators::And;
 
         match self {
             Where(where_clause) => Where(Box::new(And::new(where_clause, predicate))),
@@ -177,8 +177,8 @@ where
 
     fn or(self, predicate: Predicate) -> Self::Output {
         use self::BoxedWhereClause::Where;
-        use expression::grouped::Grouped;
-        use expression::operators::Or;
+        use crate::expression::grouped::Grouped;
+        use crate::expression::operators::Or;
 
         match self {
             Where(where_clause) => Where(Box::new(Grouped(Or::new(where_clause, predicate)))),

--- a/diesel/src/query_dsl/belonging_to_dsl.rs
+++ b/diesel/src/query_dsl/belonging_to_dsl.rs
@@ -5,7 +5,7 @@
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use schema::{posts, users};
+/// # use self::schema::{posts, users};
 /// #
 /// # #[derive(Identifiable, Queryable)]
 /// # pub struct User {
@@ -28,8 +28,8 @@
 /// #
 /// # fn run_test() -> QueryResult<()> {
 /// #     let connection = establish_connection();
-/// #     use users::dsl::*;
-/// #     use posts::dsl::{posts, title};
+/// #     use self::users::dsl::*;
+/// #     use self::posts::dsl::{posts, title};
 /// let sean = users.filter(name.eq("Sean")).first::<User>(&connection)?;
 /// let tess = users.filter(name.eq("Tess")).first::<User>(&connection)?;
 ///

--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -1,5 +1,5 @@
-use query_builder::AsQuery;
-use query_source::Table;
+use crate::query_builder::AsQuery;
+use crate::query_source::Table;
 
 /// The `into_boxed` method
 ///

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "postgres")]
-use expression::SelectableExpression;
-use query_source::Table;
+use crate::expression::SelectableExpression;
+use crate::query_source::Table;
 
 /// The `distinct` method
 ///

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -1,6 +1,6 @@
-use dsl::{Filter, OrFilter};
-use expression_methods::*;
-use query_source::*;
+use crate::dsl::{Filter, OrFilter};
+use crate::expression_methods::*;
+use crate::query_source::*;
 
 /// The `filter` method
 ///

--- a/diesel/src/query_dsl/group_by_dsl.rs
+++ b/diesel/src/query_dsl/group_by_dsl.rs
@@ -1,6 +1,6 @@
-use expression::Expression;
-use query_builder::{AsQuery, Query};
-use query_source::Table;
+use crate::expression::Expression;
+use crate::query_builder::{AsQuery, Query};
+use crate::query_source::Table;
 
 /// This trait is not yet part of Diesel's public API. It may change in the
 /// future without a major version bump.

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -1,6 +1,6 @@
-use query_builder::AsQuery;
-use query_source::joins::OnClauseWrapper;
-use query_source::{JoinTo, QuerySource, Table};
+use crate::query_builder::AsQuery;
+use crate::query_source::joins::OnClauseWrapper;
+use crate::query_source::{JoinTo, QuerySource, Table};
 
 #[doc(hidden)]
 /// `JoinDsl` support trait to emulate associated type constructors

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -54,7 +54,7 @@ where
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use schema::{users, posts};
+/// # use self::schema::{users, posts};
 /// #
 /// # fn main() {
 /// #     let connection = establish_connection();

--- a/diesel/src/query_dsl/limit_dsl.rs
+++ b/diesel/src/query_dsl/limit_dsl.rs
@@ -1,4 +1,4 @@
-use query_source::Table;
+use crate::query_source::Table;
 
 /// The `limit` method
 ///

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,10 +1,10 @@
 use super::RunQueryDsl;
-use backend::Backend;
-use connection::Connection;
-use deserialize::Queryable;
-use query_builder::{AsQuery, QueryFragment, QueryId};
-use result::QueryResult;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::connection::Connection;
+use crate::deserialize::Queryable;
+use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::result::QueryResult;
+use crate::sql_types::HasSqlType;
 
 /// The `load` method
 ///

--- a/diesel/src/query_dsl/locking_dsl.rs
+++ b/diesel/src/query_dsl/locking_dsl.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "with-deprecated")]
-use query_builder::locking_clause::ForUpdate;
-use query_builder::AsQuery;
-use query_source::Table;
+use crate::query_builder::locking_clause::ForUpdate;
+use crate::query_builder::AsQuery;
+use crate::query_source::Table;
 
 /// The `for_update` method
 ///

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -13,14 +13,14 @@
 //! [`QueryDsl`]: trait.QueryDsl.html
 //! [`RunQueryDsl`]: trait.RunQueryDsl.html
 
-use backend::Backend;
-use connection::Connection;
-use expression::count::CountStar;
-use expression::Expression;
-use helper_types::*;
-use query_builder::locking_clause as lock;
-use query_source::{joins, Table};
-use result::{first_or_not_found, QueryResult};
+use crate::backend::Backend;
+use crate::connection::Connection;
+use crate::expression::count::CountStar;
+use crate::expression::Expression;
+use crate::helper_types::*;
+use crate::query_builder::locking_clause as lock;
+use crate::query_source::{joins, Table};
+use crate::result::{first_or_not_found, QueryResult};
 
 mod belonging_to_dsl;
 #[doc(hidden)]
@@ -313,7 +313,7 @@ pub trait QueryDsl: Sized {
     where
         Self: methods::SelectDsl<CountStar>,
     {
-        use dsl::count_star;
+        use crate::dsl::count_star;
 
         QueryDsl::select(self, count_star())
     }

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -94,7 +94,7 @@ pub trait QueryDsl: Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("DELETE FROM users").unwrap();
     /// diesel::insert_into(users)
@@ -122,7 +122,7 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::animals;
+    /// # use self::schema::animals;
     /// #
     /// # #[derive(Queryable, Debug, PartialEq)]
     /// # struct Animal {
@@ -194,7 +194,7 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::users;
+    /// # use self::schema::users;
     /// #
     /// # fn main() {
     /// #     run_test().unwrap();
@@ -218,7 +218,7 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::{users, posts};
+    /// # use self::schema::{users, posts};
     /// #
     /// # #[derive(Queryable, PartialEq, Eq, Debug)]
     /// # struct User {
@@ -303,7 +303,7 @@ pub trait QueryDsl: Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let count = users.count().get_result(&connection);
     /// assert_eq!(Ok(2), count);
@@ -370,7 +370,7 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::{users, posts};
+    /// # use self::schema::{users, posts};
     /// # /*
     /// joinable!(posts -> users (user_id));
     /// allow_tables_to_appear_in_same_query!(users, posts);
@@ -398,7 +398,7 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::{users, posts};
+    /// # use self::schema::{users, posts};
     /// #
     /// # /*
     /// allow_tables_to_appear_in_same_query!(users, posts);
@@ -468,7 +468,7 @@ pub trait QueryDsl: Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let seans_id = users.filter(name.eq("Sean")).select(id)
     ///     .first(&connection);
@@ -503,7 +503,7 @@ pub trait QueryDsl: Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::animals::dsl::*;
+    /// #     use self::schema::animals::dsl::*;
     /// #     let connection = establish_connection();
     /// #     diesel::delete(animals).execute(&connection)?;
     /// diesel::insert_into(animals)
@@ -543,7 +543,7 @@ pub trait QueryDsl: Sized {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     use diesel::result::Error::NotFound;
     /// #     let connection = establish_connection();
     /// let sean = (1, "Sean".to_string());
@@ -584,7 +584,7 @@ pub trait QueryDsl: Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("DELETE FROM users")?;
     /// diesel::insert_into(users)
@@ -652,7 +652,7 @@ pub trait QueryDsl: Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("DELETE FROM users")?;
     /// diesel::insert_into(users)
@@ -694,14 +694,14 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::users;
+    /// # use self::schema::users;
     /// #
     /// # fn main() {
     /// #     run_test().unwrap();
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     diesel::delete(users).execute(&connection)?;
     /// #     diesel::insert_into(users)
@@ -744,14 +744,14 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::users;
+    /// # use self::schema::users;
     /// #
     /// # fn main() {
     /// #     run_test().unwrap();
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     diesel::delete(users).execute(&connection)?;
     /// #     diesel::insert_into(users)
@@ -952,7 +952,7 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::users;
+    /// # use self::schema::users;
     /// #
     /// # fn main() {
     /// #     use std::collections::HashMap;
@@ -983,7 +983,7 @@ pub trait QueryDsl: Sized {
     /// ```rust
     /// # #[macro_use] extern crate diesel;
     /// # include!("../doctest_setup.rs");
-    /// # use schema::users;
+    /// # use self::schema::users;
     /// #
     /// # fn main() {
     /// #     let connection = establish_connection();
@@ -1026,8 +1026,8 @@ pub trait QueryDsl: Sized {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::insert_into;
-    /// #     use schema::users::dsl::*;
-    /// #     use schema::posts;
+    /// #     use self::schema::users::dsl::*;
+    /// #     use self::schema::posts;
     /// #     let connection = establish_connection();
     /// insert_into(posts::table)
     ///     .values(posts::user_id.eq(1))
@@ -1115,7 +1115,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::insert_into;
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let inserted_rows = insert_into(users)
     ///     .values(name.eq("Ruby"))
@@ -1169,7 +1169,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::insert_into;
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users.select(name)
     ///     .load::<String>(&connection)?;
@@ -1190,7 +1190,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::insert_into;
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users
     ///     .load::<(i32, String)>(&connection)?;
@@ -1221,7 +1221,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::insert_into;
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let data = users
     ///     .load::<User>(&connection)?;
@@ -1263,7 +1263,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// # #[cfg(feature = "postgres")]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::{insert_into, update};
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// let inserted_row = insert_into(users)
     ///     .values(name.eq("Ruby"))
@@ -1321,7 +1321,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use schema::users::dsl::*;
+    /// #     use self::schema::users::dsl::*;
     /// #     let connection = establish_connection();
     /// diesel::insert_into(users)
     ///     .values(&vec![name.eq("Sean"), name.eq("Pascal")])

--- a/diesel/src/query_dsl/offset_dsl.rs
+++ b/diesel/src/query_dsl/offset_dsl.rs
@@ -1,4 +1,4 @@
-use query_source::Table;
+use crate::query_source::Table;
 
 /// The `offset` method
 ///

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -1,5 +1,5 @@
-use expression::Expression;
-use query_source::Table;
+use crate::expression::Expression;
+use crate::query_source::Table;
 
 /// The `order` method
 ///

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -1,17 +1,17 @@
-use associations::HasTable;
+use crate::associations::HasTable;
 #[cfg(any(feature = "sqlite", feature = "mysql"))]
-use associations::Identifiable;
-use connection::Connection;
+use crate::associations::Identifiable;
+use crate::connection::Connection;
 #[cfg(any(feature = "sqlite", feature = "mysql"))]
-use dsl::Find;
+use crate::dsl::Find;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-use dsl::Update;
-use query_builder::{AsChangeset, IntoUpdateTarget};
+use crate::dsl::Update;
+use crate::query_builder::{AsChangeset, IntoUpdateTarget};
 #[cfg(any(feature = "sqlite", feature = "mysql"))]
-use query_dsl::methods::{ExecuteDsl, FindDsl};
+use crate::query_dsl::methods::{ExecuteDsl, FindDsl};
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-use query_dsl::{LoadQuery, RunQueryDsl};
-use result::QueryResult;
+use crate::query_dsl::{LoadQuery, RunQueryDsl};
+use crate::result::QueryResult;
 
 /// A trait defining how to update a record and fetch the updated entry
 /// on a certain backend.
@@ -29,7 +29,7 @@ pub trait UpdateAndFetchResults<Changes, Output>: Connection {
 }
 
 #[cfg(feature = "postgres")]
-use pg::PgConnection;
+use crate::pg::PgConnection;
 
 #[cfg(feature = "postgres")]
 impl<Changes, Output> UpdateAndFetchResults<Changes, Output> for PgConnection
@@ -38,12 +38,12 @@ where
     Update<Changes, Changes>: LoadQuery<PgConnection, Output>,
 {
     fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
-        ::update(changeset).set(changeset).get_result(self)
+        crate::update(changeset).set(changeset).get_result(self)
     }
 }
 
 #[cfg(feature = "sqlite")]
-use sqlite::SqliteConnection;
+use crate::sqlite::SqliteConnection;
 
 #[cfg(feature = "sqlite")]
 impl<Changes, Output> UpdateAndFetchResults<Changes, Output> for SqliteConnection
@@ -55,13 +55,13 @@ where
     Find<Changes::Table, Changes::Id>: LoadQuery<SqliteConnection, Output>,
 {
     fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
-        ::update(changeset).set(changeset).execute(self)?;
+        crate::update(changeset).set(changeset).execute(self)?;
         Changes::table().find(changeset.id()).get_result(self)
     }
 }
 
 #[cfg(feature = "mysql")]
-use mysql::MysqlConnection;
+use crate::mysql::MysqlConnection;
 
 #[cfg(feature = "mysql")]
 impl<Changes, Output> UpdateAndFetchResults<Changes, Output> for MysqlConnection
@@ -73,7 +73,7 @@ where
     Find<Changes::Table, Changes::Id>: LoadQuery<MysqlConnection, Output>,
 {
     fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
-        ::update(changeset).set(changeset).execute(self)?;
+        crate::update(changeset).set(changeset).execute(self)?;
         Changes::table().find(changeset.id()).get_result(self)
     }
 }

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -90,7 +90,7 @@ where
 /// ```rust
 /// # #[macro_use] extern crate diesel;
 /// # include!("../doctest_setup.rs");
-/// # use schema::animals;
+/// # use self::schema::animals;
 /// #
 /// #[derive(Queryable, Debug, PartialEq)]
 /// struct Animal {
@@ -112,7 +112,7 @@ where
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use animals::dsl::*;
+/// #     use self::animals::dsl::*;
 /// #     let connection = establish_connection();
 /// let form = AnimalForm { id: 2, name: "Super scary" };
 /// let changed_animal = form.save_changes(&connection)?;

--- a/diesel/src/query_dsl/select_dsl.rs
+++ b/diesel/src/query_dsl/select_dsl.rs
@@ -1,5 +1,5 @@
-use expression::Expression;
-use query_source::Table;
+use crate::expression::Expression;
+use crate::query_source::Table;
 
 /// The `select` method
 ///

--- a/diesel/src/query_dsl/single_value_dsl.rs
+++ b/diesel/src/query_dsl/single_value_dsl.rs
@@ -1,9 +1,9 @@
 use super::methods::LimitDsl;
-use dsl::Limit;
-use expression::grouped::Grouped;
-use expression::subselect::Subselect;
-use query_builder::SelectQuery;
-use sql_types::{IntoNullable, SingleValue};
+use crate::dsl::Limit;
+use crate::expression::grouped::Grouped;
+use crate::expression::subselect::Subselect;
+use crate::query_builder::SelectQuery;
+use crate::sql_types::{IntoNullable, SingleValue};
 
 /// The `single_value` method
 ///

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -1,13 +1,13 @@
 use super::{AppearsInFromClause, Plus, QuerySource};
-use backend::Backend;
-use expression::grouped::Grouped;
-use expression::nullable::Nullable;
-use expression::SelectableExpression;
-use prelude::*;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Bool;
-use util::TupleAppend;
+use crate::backend::Backend;
+use crate::expression::grouped::Grouped;
+use crate::expression::nullable::Nullable;
+use crate::expression::SelectableExpression;
+use crate::prelude::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
+use crate::util::TupleAppend;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 /// A query source representing the join between two tables

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -7,18 +7,18 @@
 pub mod joins;
 mod peano_numbers;
 
-use expression::{Expression, NonAggregate, SelectableExpression};
-use query_builder::*;
+use crate::expression::{Expression, NonAggregate, SelectableExpression};
+use crate::query_builder::*;
 
 pub use self::joins::JoinTo;
 pub use self::peano_numbers::*;
 
 #[cfg(feature = "with-deprecated")]
 #[deprecated(since = "1.1.0", note = "Use `deserialize::Queryable` instead")]
-pub use deserialize::Queryable;
+pub use crate::deserialize::Queryable;
 #[cfg(feature = "with-deprecated")]
 #[deprecated(since = "1.1.0", note = "Use `deserialize::QueryableByName` instead")]
-pub use deserialize::QueryableByName;
+pub use crate::deserialize::QueryableByName;
 
 /// Represents a type which can appear in the `FROM` clause. Apps should not
 /// need to concern themselves with this trait.

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -16,12 +16,12 @@ use std::convert::Into;
 use std::fmt;
 use std::marker::PhantomData;
 
-use backend::UsesAnsiSavepointSyntax;
-use connection::{AnsiTransactionManager, SimpleConnection};
-use deserialize::QueryableByName;
-use prelude::*;
-use query_builder::{AsQuery, QueryFragment, QueryId};
-use sql_types::HasSqlType;
+use crate::backend::UsesAnsiSavepointSyntax;
+use crate::connection::{AnsiTransactionManager, SimpleConnection};
+use crate::deserialize::QueryableByName;
+use crate::prelude::*;
+use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::sql_types::HasSqlType;
 
 /// An r2d2 connection manager for use with Diesel.
 ///
@@ -54,7 +54,7 @@ pub enum Error {
     ConnectionError(ConnectionError),
 
     /// An error occurred pinging the database
-    QueryError(::result::Error),
+    QueryError(crate::result::Error),
 }
 
 impl fmt::Display for Error {
@@ -160,8 +160,8 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
-    use r2d2::*;
-    use test_helpers::*;
+    use crate::r2d2::*;
+    use crate::test_helpers::*;
 
     #[test]
     fn establish_basic_connection() {
@@ -207,8 +207,8 @@ mod tests {
 
     #[test]
     fn pooled_connection_impls_connection() {
-        use select;
-        use sql_types::Text;
+        use crate::select;
+        use crate::sql_types::Text;
 
         let manager = ConnectionManager::<TestConnection>::new(database_url());
         let pool = Pool::builder()

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -1,7 +1,7 @@
 //! Contains the `Row` trait
 
-use backend::Backend;
-use deserialize::{self, FromSql};
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSql};
 
 /// Represents a single database row.
 /// Apps should not need to concern themselves with this trait.

--- a/diesel/src/serialize.rs
+++ b/diesel/src/serialize.rs
@@ -6,11 +6,11 @@ use std::io::{self, Write};
 use std::ops::{Deref, DerefMut};
 use std::result;
 
-use backend::Backend;
-use sql_types::TypeMetadata;
+use crate::backend::Backend;
+use crate::sql_types::TypeMetadata;
 
 #[cfg(feature = "postgres")]
-pub use pg::serialize::*;
+pub use crate::pg::serialize::*;
 
 /// A specialized result type representing the result of serializing
 /// a value for the database.

--- a/diesel/src/sql_types/fold.rs
+++ b/diesel/src/sql_types/fold.rs
@@ -1,4 +1,4 @@
-use sql_types::{self, NotNull};
+use crate::sql_types::{self, NotNull};
 
 /// Represents SQL types which can be used with `SUM` and `AVG`
 pub trait Foldable {

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -356,10 +356,10 @@ pub struct Timestamp;
 pub struct Nullable<ST: NotNull>(ST);
 
 #[cfg(feature = "postgres")]
-pub use pg::types::sql_types::*;
+pub use crate::pg::types::sql_types::*;
 
 #[cfg(feature = "mysql")]
-pub use mysql::types::*;
+pub use crate::mysql::types::*;
 
 /// Indicates that a SQL type exists for a backend.
 ///

--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -1,4 +1,4 @@
-use sql_types::{self, NotNull};
+use crate::sql_types::{self, NotNull};
 
 /// Marker trait for types which can be used with `MAX` and `MIN`
 pub trait SqlOrd {}

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -3,9 +3,9 @@ use byteorder::NativeEndian;
 
 use super::connection::SqliteValue;
 use super::query_builder::SqliteQueryBuilder;
-use backend::*;
-use query_builder::bind_collector::RawBytesBindCollector;
-use sql_types::TypeMetadata;
+use crate::backend::*;
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::sql_types::TypeMetadata;
 
 /// The SQLite backend
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -3,11 +3,11 @@ extern crate libsqlite3_sys as ffi;
 use super::raw::RawConnection;
 use super::serialized_value::SerializedValue;
 use super::{Sqlite, SqliteValue};
-use deserialize::{FromSqlRow, Queryable};
-use result::{DatabaseErrorKind, Error, QueryResult};
-use row::Row;
-use serialize::{IsNull, Output, ToSql};
-use sql_types::HasSqlType;
+use crate::deserialize::{FromSqlRow, Queryable};
+use crate::result::{DatabaseErrorKind, Error, QueryResult};
+use crate::row::Row;
+use crate::serialize::{IsNull, Output, ToSql};
+use crate::sql_types::HasSqlType;
 
 pub fn register<ArgsSqlType, RetSqlType, Args, Ret, F>(
     conn: &RawConnection,

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -15,14 +15,14 @@ use std::os::raw as libc;
 use self::raw::RawConnection;
 use self::statement_iterator::*;
 use self::stmt::{Statement, StatementUse};
-use connection::*;
-use deserialize::{Queryable, QueryableByName};
-use query_builder::bind_collector::RawBytesBindCollector;
-use query_builder::*;
-use result::*;
-use serialize::ToSql;
-use sql_types::HasSqlType;
-use sqlite::Sqlite;
+use crate::connection::*;
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::query_builder::*;
+use crate::result::*;
+use crate::serialize::ToSql;
+use crate::sql_types::HasSqlType;
+use crate::sqlite::Sqlite;
 
 /// Connections for the SQLite backend. Unlike other backends, "connection URLs"
 /// for SQLite are file paths, [URIs](https://sqlite.org/uri.html), or special
@@ -237,14 +237,14 @@ fn error_message(err_code: libc::c_int) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dsl::sql;
-    use prelude::*;
-    use sql_types::Integer;
+    use crate::dsl::sql;
+    use crate::prelude::*;
+    use crate::sql_types::Integer;
 
     #[test]
     fn prepared_statements_are_cached_when_run() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
-        let query = ::select(1.into_sql::<Integer>());
+        let query = crate::select(1.into_sql::<Integer>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn sql_literal_nodes_are_not_cached() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
-        let query = ::select(sql::<Integer>("1"));
+        let query = crate::select(sql::<Integer>("1"));
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(0, connection.statement_cache.len());
@@ -264,7 +264,7 @@ mod tests {
     fn queries_containing_sql_literal_nodes_are_not_cached() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
         let one_as_expr = 1.into_sql::<Integer>();
-        let query = ::select(one_as_expr.eq(sql::<Integer>("1")));
+        let query = crate::select(one_as_expr.eq(sql::<Integer>("1")));
 
         assert_eq!(Ok(true), query.get_result(&connection));
         assert_eq!(0, connection.statement_cache.len());
@@ -274,7 +274,7 @@ mod tests {
     fn queries_containing_in_with_vec_are_not_cached() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
         let one_as_expr = 1.into_sql::<Integer>();
-        let query = ::select(one_as_expr.eq_any(vec![1, 2, 3]));
+        let query = crate::select(one_as_expr.eq_any(vec![1, 2, 3]));
 
         assert_eq!(Ok(true), query.get_result(&connection));
         assert_eq!(0, connection.statement_cache.len());
@@ -284,13 +284,13 @@ mod tests {
     fn queries_containing_in_with_subselect_are_cached() {
         let connection = SqliteConnection::establish(":memory:").unwrap();
         let one_as_expr = 1.into_sql::<Integer>();
-        let query = ::select(one_as_expr.eq_any(::select(one_as_expr)));
+        let query = crate::select(one_as_expr.eq_any(crate::select(one_as_expr)));
 
         assert_eq!(Ok(true), query.get_result(&connection));
         assert_eq!(1, connection.statement_cache.len());
     }
 
-    use sql_types::Text;
+    use crate::sql_types::Text;
     sql_function!(fn fun_case(x: Text) -> Text);
 
     #[test]
@@ -310,7 +310,7 @@ mod tests {
         })
         .unwrap();
 
-        let mapped_string = ::select(fun_case("foobar"))
+        let mapped_string = crate::select(fun_case("foobar"))
             .get_result::<String>(&connection)
             .unwrap();
         assert_eq!("fOoBaR", mapped_string);
@@ -323,7 +323,7 @@ mod tests {
         let connection = SqliteConnection::establish(":memory:").unwrap();
         my_add::register_impl(&connection, |x: i32, y: i32| x + y).unwrap();
 
-        let added = ::select(my_add(1, 2)).get_result::<i32>(&connection);
+        let added = crate::select(my_add(1, 2)).get_result::<i32>(&connection);
         assert_eq!(Ok(3), added);
     }
 
@@ -339,7 +339,7 @@ mod tests {
         })
         .unwrap();
 
-        let added = ::select((add_counter(1), add_counter(1), add_counter(1)))
+        let added = crate::select((add_counter(1), add_counter(1), add_counter(1)))
             .get_result::<(i32, i32, i32)>(&connection);
         assert_eq!(Ok((2, 3, 4)), added);
     }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -7,8 +7,8 @@ use std::ptr::NonNull;
 use std::{ptr, slice, str};
 
 use super::serialized_value::SerializedValue;
-use result::Error::DatabaseError;
-use result::*;
+use crate::result::Error::DatabaseError;
+use crate::result::*;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct RawConnection {

--- a/diesel/src/sqlite/connection/serialized_value.rs
+++ b/diesel/src/sqlite/connection/serialized_value.rs
@@ -3,7 +3,7 @@ extern crate libsqlite3_sys as ffi;
 use std::os::raw as libc;
 use std::ptr::{self, NonNull};
 
-use sqlite::SqliteType;
+use crate::sqlite::SqliteType;
 
 pub struct SerializedValue {
     pub ty: SqliteType,

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -5,8 +5,8 @@ use std::os::raw as libc;
 use std::ptr::NonNull;
 use std::{slice, str};
 
-use row::*;
-use sqlite::Sqlite;
+use crate::row::*;
+use crate::sqlite::Sqlite;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct SqliteValue {

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use super::stmt::StatementUse;
-use deserialize::{FromSqlRow, Queryable, QueryableByName};
-use result::Error::DeserializationError;
-use result::QueryResult;
-use sqlite::Sqlite;
+use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
+use crate::result::Error::DeserializationError;
+use crate::result::QueryResult;
+use crate::sqlite::Sqlite;
 
 pub struct StatementIterator<'a, ST, T> {
     stmt: StatementUse<'a>,

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -8,9 +8,9 @@ use std::ptr::{self, NonNull};
 use super::raw::RawConnection;
 use super::serialized_value::SerializedValue;
 use super::sqlite_value::SqliteRow;
-use result::Error::DatabaseError;
-use result::*;
-use sqlite::SqliteType;
+use crate::result::Error::DatabaseError;
+use crate::result::*;
+use crate::sqlite::SqliteType;
 
 pub struct Statement {
     inner_statement: NonNull<ffi::sqlite3_stmt>,

--- a/diesel/src/sqlite/query_builder/mod.rs
+++ b/diesel/src/sqlite/query_builder/mod.rs
@@ -1,8 +1,8 @@
 //! The SQLite query builder
 
 use super::backend::Sqlite;
-use query_builder::QueryBuilder;
-use result::QueryResult;
+use crate::query_builder::QueryBuilder;
+use crate::result::QueryResult;
 
 /// Constructs SQL queries for use with the SQLite backend
 #[allow(missing_debug_implementations)]

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -3,11 +3,11 @@ extern crate chrono;
 use self::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use std::io::Write;
 
-use backend::Backend;
-use deserialize::{self, FromSql};
-use serialize::{self, Output, ToSql};
-use sql_types::{Date, Text, Time, Timestamp};
-use sqlite::Sqlite;
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types::{Date, Text, Time, Timestamp};
+use crate::sqlite::Sqlite;
 
 const SQLITE_DATE_FORMAT: &str = "%F";
 
@@ -111,10 +111,10 @@ mod tests {
     use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
     use self::dotenv::dotenv;
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::{Date, Text, Time, Timestamp};
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::{Date, Text, Time, Timestamp};
 
     sql_function!(fn datetime(x: Text) -> Timestamp);
     sql_function!(fn time(x: Text) -> Time);

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 
-use deserialize::{self, FromSql};
-use serialize::{self, Output, ToSql};
-use sql_types;
-use sqlite::connection::SqliteValue;
-use sqlite::Sqlite;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
+use crate::sqlite::connection::SqliteValue;
+use crate::sqlite::Sqlite;
 
 #[cfg(feature = "chrono")]
 mod chrono;

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -5,9 +5,9 @@ use std::io::prelude::*;
 
 use super::connection::SqliteValue;
 use super::Sqlite;
-use deserialize::{self, FromSql};
-use serialize::{self, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
 
 /// The returned pointer is *only* valid for the lifetime to the argument of
 /// `from_sql`. This impl is intended for uses where you want to write a new

--- a/diesel/src/sqlite/types/numeric.rs
+++ b/diesel/src/sqlite/types/numeric.rs
@@ -4,10 +4,10 @@ extern crate bigdecimal;
 
 use self::bigdecimal::BigDecimal;
 
-use deserialize::{self, FromSql};
-use sql_types::{Double, Numeric};
-use sqlite::connection::SqliteValue;
-use sqlite::Sqlite;
+use crate::deserialize::{self, FromSql};
+use crate::sql_types::{Double, Numeric};
+use crate::sqlite::connection::SqliteValue;
+use crate::sqlite::Sqlite;
 
 impl FromSql<Numeric, Sqlite> for BigDecimal {
     fn from_sql(bytes: Option<&SqliteValue>) -> deserialize::Result<Self> {

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -1,6 +1,6 @@
 extern crate dotenv;
 
-use prelude::*;
+use crate::prelude::*;
 
 cfg_if! {
     if #[cfg(feature = "sqlite")] {

--- a/diesel/src/type_impls/date_and_time.rs
+++ b/diesel/src/type_impls/date_and_time.rs
@@ -4,14 +4,14 @@ use std::time::SystemTime;
 
 #[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
-#[sql_type = "::sql_types::Timestamp"]
+#[sql_type = "crate::sql_types::Timestamp"]
 struct SystemTimeProxy(SystemTime);
 
 #[cfg(feature = "chrono")]
 mod chrono {
     extern crate chrono;
     use self::chrono::*;
-    use sql_types::{Date, Time, Timestamp};
+    use crate::sql_types::{Date, Time, Timestamp};
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
@@ -26,12 +26,12 @@ mod chrono {
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
     #[sql_type = "Timestamp"]
-    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Timestamptz")]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Datetime")]
+    #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Timestamptz")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Datetime")]
     struct NaiveDateTimeProxy(NaiveDateTime);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Timestamptz")]
+    #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Timestamptz")]
     struct DateTimeProxy<Tz: TimeZone>(DateTime<Tz>);
 }

--- a/diesel/src/type_impls/decimal.rs
+++ b/diesel/src/type_impls/decimal.rs
@@ -4,7 +4,7 @@
 mod bigdecimal {
     extern crate bigdecimal;
     use self::bigdecimal::BigDecimal;
-    use sql_types::Numeric;
+    use crate::sql_types::Numeric;
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]

--- a/diesel/src/type_impls/floats.rs
+++ b/diesel/src/type_impls/floats.rs
@@ -2,10 +2,10 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use backend::Backend;
-use deserialize::{self, FromSql};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl<DB: Backend<RawValue = [u8]>> FromSql<sql_types::Float, DB> for f32 {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {

--- a/diesel/src/type_impls/integers.rs
+++ b/diesel/src/type_impls/integers.rs
@@ -2,10 +2,10 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use backend::Backend;
-use deserialize::{self, FromSql};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl<DB: Backend<RawValue = [u8]>> FromSql<sql_types::SmallInt, DB> for i16 {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -1,17 +1,17 @@
 use std::io::Write;
 
-use backend::Backend;
-use deserialize::{self, FromSql, FromSqlRow, Queryable, QueryableByName};
-use expression::bound::Bound;
-use expression::*;
-use query_builder::QueryId;
-use result::UnexpectedNullError;
-use row::NamedRow;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{HasSqlType, NotNull, Nullable};
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable, QueryableByName};
+use crate::expression::bound::Bound;
+use crate::expression::*;
+use crate::query_builder::QueryId;
+use crate::result::UnexpectedNullError;
+use crate::row::NamedRow;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{HasSqlType, NotNull, Nullable};
 
 #[cfg(feature = "mysql")]
-use sql_types::IsSigned;
+use crate::sql_types::IsSigned;
 
 impl<T, DB> HasSqlType<Nullable<T>> for DB
 where
@@ -101,7 +101,7 @@ where
 {
     const FIELDS_NEEDED: usize = T::FIELDS_NEEDED;
 
-    fn build_from_row<R: ::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
+    fn build_from_row<R: crate::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
         let fields_needed = Self::FIELDS_NEEDED;
         if row.next_is_null(fields_needed) {
             row.advance(fields_needed);
@@ -150,14 +150,14 @@ where
 }
 
 #[cfg(all(test, feature = "postgres"))]
-use pg::Pg;
+use crate::pg::Pg;
 #[cfg(all(test, feature = "postgres"))]
-use sql_types;
+use crate::sql_types;
 
 #[test]
 #[cfg(feature = "postgres")]
 fn option_to_sql() {
-    type Type = sql_types::Nullable<sql_types::VarChar>;
+    type Type = crate::sql_types::Nullable<sql_types::VarChar>;
     let mut bytes = Output::test();
 
     let is_null = ToSql::<Type, Pg>::to_sql(&None::<String>, &mut bytes).unwrap();

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -1,10 +1,10 @@
 use std::error::Error;
 use std::io::Write;
 
-use backend::Backend;
-use deserialize::{self, FromSql, FromSqlRow, Queryable};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text};
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text};
 
 #[allow(dead_code)]
 mod foreign_impls {
@@ -17,7 +17,7 @@ mod foreign_impls {
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::TinyInt")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::TinyInt")]
     struct I8Proxy(i8);
 
     #[derive(FromSqlRow, AsExpression)]
@@ -39,24 +39,24 @@ mod foreign_impls {
     #[diesel(foreign_derive)]
     #[cfg_attr(
         feature = "mysql",
-        sql_type = "::sql_types::Unsigned<::sql_types::TinyInt>"
+        sql_type = "crate::sql_types::Unsigned<crate::sql_types::TinyInt>"
     )]
     struct U8Proxy(u8);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<SmallInt>")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<SmallInt>")]
     struct U16Proxy(u16);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<Integer>")]
-    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Oid")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<Integer>")]
+    #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Oid")]
     struct U32Proxy(u32);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<BigInt>")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<BigInt>")]
     struct U64Proxy(u64);
 
     #[derive(FromSqlRow, AsExpression)]
@@ -72,17 +72,17 @@ mod foreign_impls {
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
     #[sql_type = "Text"]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Date")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Time")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Timestamp")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Date")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Time")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Timestamp")]
     struct StringProxy(String);
 
     #[derive(AsExpression)]
     #[diesel(foreign_derive, not_sized)]
     #[sql_type = "Text"]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Date")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Time")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Timestamp")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Date")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Time")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Timestamp")]
     struct StrProxy(str);
 
     #[derive(FromSqlRow)]
@@ -218,7 +218,7 @@ where
     DB: Backend,
     Cow<'a, T>: FromSql<ST, DB>,
 {
-    fn build_from_row<R: ::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
+    fn build_from_row<R: crate::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
         FromSql::<ST, DB>::from_sql(row.take())
     }
 }
@@ -236,8 +236,8 @@ where
     }
 }
 
-use expression::bound::Bound;
-use expression::{AsExpression, Expression};
+use crate::expression::bound::Bound;
+use crate::expression::{AsExpression, Expression};
 
 impl<'a, T: ?Sized, ST> AsExpression<ST> for Cow<'a, T>
 where

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -4,7 +4,9 @@ use std::io::Write;
 use crate::backend::Backend;
 use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
 use crate::serialize::{self, IsNull, Output, ToSql};
-use crate::sql_types::{self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text};
+use crate::sql_types::{
+    self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text,
+};
 
 #[allow(dead_code)]
 mod foreign_impls {

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -1,21 +1,21 @@
 use std::error::Error;
 
-use associations::BelongsTo;
-use backend::Backend;
-use deserialize::{self, FromSqlRow, Queryable, QueryableByName};
-use expression::{
+use crate::associations::BelongsTo;
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSqlRow, Queryable, QueryableByName};
+use crate::expression::{
     AppearsOnTable, AsExpression, AsExpressionList, Expression, NonAggregate, SelectableExpression,
 };
-use insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
-use query_builder::*;
-use query_source::*;
-use result::QueryResult;
-use row::*;
-use sql_types::{HasSqlType, NotNull};
-use util::TupleAppend;
+use crate::insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
+use crate::query_builder::*;
+use crate::query_source::*;
+use crate::result::QueryResult;
+use crate::row::*;
+use crate::sql_types::{HasSqlType, NotNull};
+use crate::util::TupleAppend;
 
 #[cfg(feature = "mysql")]
-use sql_types::IsSigned;
+use crate::sql_types::IsSigned;
 
 macro_rules! tuple_impls {
     ($(
@@ -54,7 +54,7 @@ macro_rules! tuple_impls {
                 const FIELDS_NEEDED: usize = $($T::FIELDS_NEEDED +)+ 0;
 
                 fn build_from_row<RowT: Row<__DB>>(row: &mut RowT) -> Result<Self, Box<Error+Send+Sync>> {
-                    Ok(($(try!($T::build_from_row(row)),)+))
+                    Ok(($($T::build_from_row(row)?,)+))
                 }
             }
 

--- a/diesel/src/types/mod.rs
+++ b/diesel/src/types/mod.rs
@@ -4,109 +4,109 @@
 #![deprecated(since = "1.1.0", note = "Use `sql_types`, `serialize`, or `deserialize` instead")]
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types` instead")]
-pub use sql_types::*;
+pub use crate::sql_types::*;
 
 #[deprecated(since = "1.1.0", note = "Use `deserialize` instead")]
-pub use deserialize::{FromSql, FromSqlRow};
+pub use crate::deserialize::{FromSql, FromSqlRow};
 
 #[deprecated(since = "1.1.0", note = "Use `serialize` instead")]
-pub use serialize::{IsNull, ToSql};
+pub use crate::serialize::{IsNull, ToSql};
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Bool` instead")]
-pub type Bool = ::sql_types::Bool;
+pub type Bool = crate::sql_types::Bool;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::TinyInt` instead")]
-pub type TinyInt = ::sql_types::TinyInt;
+pub type TinyInt = crate::sql_types::TinyInt;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::SmallInt` instead")]
-pub type SmallInt = ::sql_types::SmallInt;
+pub type SmallInt = crate::sql_types::SmallInt;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Integer` instead")]
-pub type Integer = ::sql_types::Integer;
+pub type Integer = crate::sql_types::Integer;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::BigInt` instead")]
-pub type BigInt = ::sql_types::BigInt;
+pub type BigInt = crate::sql_types::BigInt;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Float` instead")]
-pub type Float = ::sql_types::Float;
+pub type Float = crate::sql_types::Float;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Double` instead")]
-pub type Double = ::sql_types::Double;
+pub type Double = crate::sql_types::Double;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Numeric` instead")]
-pub type Numeric = ::sql_types::Numeric;
+pub type Numeric = crate::sql_types::Numeric;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Text` instead")]
-pub type Text = ::sql_types::Text;
+pub type Text = crate::sql_types::Text;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Binary` instead")]
-pub type Binary = ::sql_types::Binary;
+pub type Binary = crate::sql_types::Binary;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Date` instead")]
-pub type Date = ::sql_types::Date;
+pub type Date = crate::sql_types::Date;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Interval` instead")]
-pub type Interval = ::sql_types::Interval;
+pub type Interval = crate::sql_types::Interval;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Time` instead")]
-pub type Time = ::sql_types::Time;
+pub type Time = crate::sql_types::Time;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Timestamp` instead")]
-pub type Timestamp = ::sql_types::Timestamp;
+pub type Timestamp = crate::sql_types::Timestamp;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Datetime` instead")]
 #[cfg(feature = "mysql")]
-pub type Datetime = ::sql_types::Datetime;
+pub type Datetime = crate::sql_types::Datetime;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Oid` instead")]
 #[cfg(feature = "postgres")]
-pub type Oid = ::sql_types::Oid;
+pub type Oid = crate::sql_types::Oid;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Timestamptz` instead")]
 #[cfg(feature = "postgres")]
-pub type Timestamptz = ::sql_types::Timestamptz;
+pub type Timestamptz = crate::sql_types::Timestamptz;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Array<ST>(ST)` instead")]
 #[cfg(feature = "postgres")]
-pub type Array<ST> = ::sql_types::Array<ST>;
+pub type Array<ST> = crate::sql_types::Array<ST>;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Range<ST>(ST)` instead")]
 #[cfg(feature = "postgres")]
-pub type Range<ST> = ::sql_types::Range<ST>;
+pub type Range<ST> = crate::sql_types::Range<ST>;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Uuid` instead")]
 #[cfg(feature = "postgres")]
-pub type Uuid = ::sql_types::Uuid;
+pub type Uuid = crate::sql_types::Uuid;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Json` instead")]
 #[cfg(feature = "postgres")]
-pub type Json = ::sql_types::Json;
+pub type Json = crate::sql_types::Json;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Jsonb` instead")]
 #[cfg(feature = "postgres")]
-pub type Jsonb = ::sql_types::Jsonb;
+pub type Jsonb = crate::sql_types::Jsonb;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Money` instead")]
 #[cfg(feature = "postgres")]
-pub type Money = ::sql_types::Money;
+pub type Money = crate::sql_types::Money;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::MacAddr` instead")]
 #[cfg(feature = "postgres")]
-pub type MacAddr = ::sql_types::MacAddr;
+pub type MacAddr = crate::sql_types::MacAddr;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Inet` instead")]
 #[cfg(feature = "postgres")]
-pub type Inet = ::sql_types::Inet;
+pub type Inet = crate::sql_types::Inet;
 
 #[deprecated(since = "1.1.0", note = "Use `sql_types::Cidr` instead")]
 #[cfg(feature = "postgres")]
-pub type Cidr = ::sql_types::Cidr;
+pub type Cidr = crate::sql_types::Cidr;
 
 #[deprecated(
     since = "1.1.0",
     note = "Use `sql_types::Nullable<ST: NotNull>(ST)` instead"
 )]
-pub type Nullable<ST> = ::sql_types::Nullable<ST>;
+pub type Nullable<ST> = crate::sql_types::Nullable<ST>;
 
 #[deprecated(since = "1.1.0", note = "Use `serialize::Output` instead")]
-pub type ToSqlOutput<'a, T, DB> = ::serialize::Output<'a, T, DB>;
+pub type ToSqlOutput<'a, T, DB> = crate::serialize::Output<'a, T, DB>;

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -61,7 +61,7 @@ impl UsesInformationSchema for Mysql {
 
 #[allow(clippy::module_inception)]
 mod information_schema {
-    table! {
+    diesel::table! {
         information_schema.tables (table_schema, table_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -69,7 +69,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.columns (table_schema, table_name, column_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -81,7 +81,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.key_column_usage (table_schema, table_name, column_name, constraint_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -92,7 +92,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.table_constraints (table_schema, table_name, constraint_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -102,7 +102,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.referential_constraints (constraint_schema, constraint_name) {
             constraint_schema -> VarChar,
             constraint_name -> VarChar,
@@ -111,8 +111,8 @@ mod information_schema {
         }
     }
 
-    allow_tables_to_appear_in_same_query!(table_constraints, referential_constraints);
-    allow_tables_to_appear_in_same_query!(key_column_usage, table_constraints);
+    diesel::allow_tables_to_appear_in_same_query!(table_constraints, referential_constraints);
+    diesel::allow_tables_to_appear_in_same_query!(key_column_usage, table_constraints);
 }
 
 pub fn get_table_data<Conn>(conn: &Conn, table: &TableName) -> QueryResult<Vec<ColumnInformation>>

--- a/diesel_cli/src/infer_schema_internals/mysql.rs
+++ b/diesel_cli/src/infer_schema_internals/mysql.rs
@@ -7,7 +7,7 @@ use super::information_schema::UsesInformationSchema;
 use super::table_data::TableName;
 
 mod information_schema {
-    table! {
+    diesel::table! {
         information_schema.table_constraints (constraint_schema, constraint_name) {
             table_schema -> VarChar,
             constraint_schema -> VarChar,
@@ -16,7 +16,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.key_column_usage (constraint_schema, constraint_name) {
             constraint_schema -> VarChar,
             constraint_name -> VarChar,
@@ -29,7 +29,7 @@ mod information_schema {
         }
     }
 
-    allow_tables_to_appear_in_same_query!(table_constraints, key_column_usage);
+    diesel::allow_tables_to_appear_in_same_query!(table_constraints, key_column_usage);
 }
 
 /// Even though this is using `information_schema`, MySQL needs non-ANSI columns

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -17,7 +17,6 @@
 extern crate chrono;
 #[macro_use]
 extern crate clap;
-#[macro_use]
 extern crate diesel;
 extern crate dotenv;
 extern crate migrations_internals;

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://diesel.rs/guides/"
 homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_derives"
 autotests = false
+edition = "2018"
 
 [dependencies]
 syn = { version = "0.15.0", features = ["full", "fold"] }

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -2,11 +2,11 @@ use proc_macro2;
 use proc_macro2::Span;
 use syn;
 
-use diagnostic_shim::*;
-use field::*;
-use meta::*;
-use model::*;
-use util::*;
+use crate::diagnostic_shim::*;
+use crate::field::*;
+use crate::meta::*;
+use crate::model::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let treat_none_as_null = MetaItem::with_name(&item.attrs, "changeset_options")

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -58,11 +58,13 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
             .emit();
     }
 
+    let diesel = imp_root();
+
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("as_changeset"),
         quote!(
-            use diesel::query_builder::AsChangeset;
-            use diesel::prelude::*;
+            use #diesel::query_builder::AsChangeset;
+            use #diesel::prelude::*;
 
             impl #impl_generics AsChangeset for &'update #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{self, Ident, Span};
 use syn;
 
-use meta::*;
-use util::*;
+use crate::meta::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let dummy_mod = format!("_impl_as_expression_for_{}", item.ident,).to_lowercase();

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -4,10 +4,10 @@ use syn;
 use syn::fold::Fold;
 use syn::spanned::Spanned;
 
-use diagnostic_shim::*;
-use meta::*;
-use model::*;
-use util::*;
+use crate::diagnostic_shim::*;
+use crate::meta::*;
+use crate::model::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let model = Model::from_item(&item)?;

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -45,6 +45,7 @@ fn derive_belongs_to(
     let foreign_key_access = foreign_key_field.name.access();
     let foreign_key_ty = inner_of_option_ty(&foreign_key_field.ty);
     let table_name = model.table_name();
+    let diesel = imp_root();
 
     let mut generics = generics.clone();
 
@@ -75,7 +76,7 @@ fn derive_belongs_to(
                 parse_quote!(for<'__a> &'__a #foreign_key_ty: std::convert::Into<::std::option::Option<&'__a __FK>>),
             );
             where_clause.predicates.push(
-                parse_quote!(for<'__a> &'__a #parent_struct: diesel::associations::Identifiable<Id = &'__a __FK>),
+                parse_quote!(for<'__a> &'__a #parent_struct: #diesel::associations::Identifiable<Id = &'__a __FK>),
             );
         }
 
@@ -88,7 +89,7 @@ fn derive_belongs_to(
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
-        impl #impl_generics diesel::associations::BelongsTo<#parent_struct>
+        impl #impl_generics #diesel::associations::BelongsTo<#parent_struct>
             for #struct_name #ty_generics
         #where_clause
         {

--- a/diesel_derives/src/diesel_numeric_ops.rs
+++ b/diesel_derives/src/diesel_numeric_ops.rs
@@ -20,12 +20,13 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
     let (impl_generics, _, _) = impl_generics.split_for_impl();
 
     let dummy_name = format!("_impl_diesel_numeric_ops_for_{}", item.ident);
+    let diesel = imp_root();
 
     Ok(wrap_in_dummy_mod(
         Ident::new(&dummy_name.to_lowercase(), Span::call_site()),
         quote! {
-            use diesel::expression::{ops, Expression, AsExpression};
-            use diesel::sql_types::ops::{Add, Sub, Mul, Div};
+            use #diesel::expression::{ops, Expression, AsExpression};
+            use #diesel::sql_types::ops::{Add, Sub, Mul, Div};
 
             impl #impl_generics ::std::ops::Add<__Rhs> for #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/diesel_numeric_ops.rs
+++ b/diesel_derives/src/diesel_numeric_ops.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{self, Ident, Span};
 use syn;
 
-use util::*;
+use crate::util::*;
 
 pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let struct_name = &item.ident;

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 use syn;
 use syn::spanned::Spanned;
 
-use meta::*;
-use util::*;
+use crate::meta::*;
+use crate::util::*;
 
 pub struct Field {
     pub ty: syn::Type,

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -1,8 +1,8 @@
 use proc_macro2::*;
 use syn;
 
-use meta::*;
-use util::*;
+use crate::meta::*;
+use crate::util::*;
 
 pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
     let flags =

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -8,6 +8,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
     let flags =
         MetaItem::with_name(&item.attrs, "diesel").unwrap_or_else(|| MetaItem::empty("diesel"));
     let struct_ty = ty_for_foreign_derive(&item, &flags)?;
+    let diesel = imp_root();
 
     item.generics.params.push(parse_quote!(__ST));
     item.generics.params.push(parse_quote!(__DB));
@@ -18,7 +19,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
             .get_or_insert(parse_quote!(where));
         where_clause
             .predicates
-            .push(parse_quote!(__DB: diesel::backend::Backend));
+            .push(parse_quote!(__DB: #diesel::backend::Backend));
         where_clause
             .predicates
             .push(parse_quote!(Self: FromSql<__ST, __DB>));
@@ -29,12 +30,12 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
     Ok(wrap_in_dummy_mod(
         Ident::new(&dummy_mod, Span::call_site()),
         quote! {
-            use diesel::deserialize::{self, FromSql, FromSqlRow, Queryable};
+            use #diesel::deserialize::{self, FromSql, FromSqlRow, Queryable};
 
             impl #impl_generics FromSqlRow<__ST, __DB> for #struct_ty
             #where_clause
             {
-                fn build_from_row<R: diesel::row::Row<__DB>>(row: &mut R)
+                fn build_from_row<R: #diesel::row::Row<__DB>>(row: &mut R)
                     -> deserialize::Result<Self>
                 {
                     FromSql::<__ST, __DB>::from_sql(row.take())

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -1,8 +1,8 @@
 use proc_macro2;
 use syn;
 
-use model::*;
-use util::*;
+use crate::model::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let model = Model::from_item(&item)?;

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -13,6 +13,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     let mut ref_generics = item.generics.clone();
     ref_generics.params.push(parse_quote!('ident));
     let (ref_generics, ..) = ref_generics.split_for_impl();
+    let diesel = imp_root();
 
     let (field_ty, field_access): (Vec<_>, Vec<_>) = model
         .primary_key_names
@@ -24,7 +25,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("identifiable"),
         quote! {
-            use diesel::associations::{HasTable, Identifiable};
+            use #diesel::associations::{HasTable, Identifiable};
 
             impl #impl_generics HasTable for #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -48,12 +48,14 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
         })
         .unzip();
 
+    let diesel = imp_root();
+
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("insertable"),
         quote! {
-            use diesel::insertable::Insertable;
-            use diesel::query_builder::UndecoratedInsertRecord;
-            use diesel::prelude::*;
+            use #diesel::insertable::Insertable;
+            use #diesel::query_builder::UndecoratedInsertRecord;
+            use #diesel::prelude::*;
 
             impl #impl_generics Insertable<#table_name::table> for #struct_name #ty_generics
                 #where_clause
@@ -90,6 +92,8 @@ fn field_ty(
     table_name: &syn::Ident,
     lifetime: Option<proc_macro2::TokenStream>,
 ) -> syn::Type {
+    let diesel = imp_root();
+
     if field.has_flag("embed") {
         let field_ty = &field.ty;
         parse_quote!(#lifetime #field_ty)
@@ -97,7 +101,7 @@ fn field_ty(
         let inner_ty = inner_of_option_ty(&field.ty);
         let column_name = field.column_name();
         parse_quote!(
-            std::option::Option<diesel::dsl::Eq<
+            std::option::Option<#diesel::dsl::Eq<
                 #table_name::#column_name,
                 #lifetime #inner_ty,
             >>

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -2,9 +2,9 @@ use proc_macro2;
 use proc_macro2::Span;
 use syn;
 
-use field::*;
-use model::*;
-use util::*;
+use crate::field::*;
+use crate::model::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let model = Model::from_item(&item)?;

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -47,44 +47,44 @@ mod queryable;
 mod queryable_by_name;
 mod sql_type;
 
-use diagnostic_shim::*;
+use self::diagnostic_shim::*;
 
 #[proc_macro_derive(
     AsChangeset,
     attributes(table_name, primary_key, column_name, changeset_options)
 )]
 pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
-    expand_derive(input, as_changeset::derive)
+    expand_derive(input, self::as_changeset::derive)
 }
 
 #[proc_macro_derive(AsExpression, attributes(diesel, sql_type))]
 pub fn derive_as_expression(input: TokenStream) -> TokenStream {
-    expand_derive(input, as_expression::derive)
+    expand_derive(input, self::as_expression::derive)
 }
 
 #[proc_macro_derive(Associations, attributes(belongs_to, column_name, table_name))]
 pub fn derive_associations(input: TokenStream) -> TokenStream {
-    expand_derive(input, associations::derive)
+    expand_derive(input, self::associations::derive)
 }
 
 #[proc_macro_derive(DieselNumericOps)]
 pub fn derive_diesel_numeric_ops(input: TokenStream) -> TokenStream {
-    expand_derive(input, diesel_numeric_ops::derive)
+    expand_derive(input, self::diesel_numeric_ops::derive)
 }
 
 #[proc_macro_derive(FromSqlRow, attributes(diesel))]
 pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
-    expand_derive(input, from_sql_row::derive)
+    expand_derive(input, self::from_sql_row::derive)
 }
 
 #[proc_macro_derive(Identifiable, attributes(table_name, primary_key, column_name))]
 pub fn derive_identifiable(input: TokenStream) -> TokenStream {
-    expand_derive(input, identifiable::derive)
+    expand_derive(input, self::identifiable::derive)
 }
 
 #[proc_macro_derive(Insertable, attributes(table_name, column_name, diesel))]
 pub fn derive_insertable(input: TokenStream) -> TokenStream {
-    expand_derive(input, insertable::derive)
+    expand_derive(input, self::insertable::derive)
 }
 
 #[proc_macro_derive(QueryId)]
@@ -94,17 +94,17 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(Queryable, attributes(column_name, diesel))]
 pub fn derive_queryable(input: TokenStream) -> TokenStream {
-    expand_derive(input, queryable::derive)
+    expand_derive(input, self::queryable::derive)
 }
 
 #[proc_macro_derive(QueryableByName, attributes(table_name, column_name, sql_type, diesel))]
 pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
-    expand_derive(input, queryable_by_name::derive)
+    expand_derive(input, self::queryable_by_name::derive)
 }
 
 #[proc_macro_derive(SqlType, attributes(postgres, sqlite_type, mysql_type))]
 pub fn derive_sql_type(input: TokenStream) -> TokenStream {
-    expand_derive(input, sql_type::derive)
+    expand_derive(input, self::sql_type::derive)
 }
 
 fn expand_derive(

--- a/diesel_derives/src/meta.rs
+++ b/diesel_derives/src/meta.rs
@@ -3,8 +3,8 @@ use syn;
 use syn::fold::Fold;
 use syn::spanned::Spanned;
 
-use resolved_at_shim::*;
-use util::*;
+use crate::resolved_at_shim::*;
+use crate::util::*;
 
 pub struct MetaItem {
     meta: syn::Meta,

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -1,10 +1,10 @@
 use proc_macro2::{Ident, Span};
 use syn;
 
-use diagnostic_shim::*;
-use field::*;
-use meta::*;
-use resolved_at_shim::*;
+use crate::diagnostic_shim::*;
+use crate::field::*;
+use crate::meta::*;
+use crate::resolved_at_shim::*;
 
 pub struct Model {
     pub name: syn::Ident,

--- a/diesel_derives/src/query_id.rs
+++ b/diesel_derives/src/query_id.rs
@@ -23,11 +23,13 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
         .map(|ty_param| &ty_param.ident)
         .map(|ty_param| quote!(<#ty_param as QueryId>::HAS_STATIC_QUERY_ID));
 
+    let diesel = imp_root();
+
     let dummy_mod = format!("_impl_query_id_for_{}", item.ident).to_lowercase();
     Ok(wrap_in_dummy_mod(
         Ident::new(&dummy_mod, Span::call_site()),
         quote! {
-            use diesel::query_builder::QueryId;
+            use #diesel::query_builder::QueryId;
 
             #[allow(non_camel_case_types)]
             impl #impl_generics QueryId for #struct_name #ty_generics

--- a/diesel_derives/src/query_id.rs
+++ b/diesel_derives/src/query_id.rs
@@ -2,7 +2,7 @@ use proc_macro2;
 use proc_macro2::*;
 use syn;
 
-use util::*;
+use crate::util::*;
 
 pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     for ty_param in item.generics.type_params_mut() {

--- a/diesel_derives/src/queryable.rs
+++ b/diesel_derives/src/queryable.rs
@@ -1,8 +1,8 @@
 use proc_macro2;
 use syn;
 
-use model::*;
-use util::*;
+use crate::model::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let model = Model::from_item(&item)?;

--- a/diesel_derives/src/queryable.rs
+++ b/diesel_derives/src/queryable.rs
@@ -32,11 +32,12 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
             .push(parse_quote!((#(#field_ty,)*): Queryable<__ST, __DB>));
     }
     let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let diesel = imp_root();
 
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("queryable"),
         quote! {
-            use diesel::Queryable;
+            use #diesel::Queryable;
 
             impl #impl_generics Queryable<__ST, __DB> for #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -37,12 +37,13 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     }
 
     let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let diesel = imp_root();
 
     Ok(wrap_in_dummy_mod(
         model.dummy_mod_name("queryable_by_name"),
         quote! {
-            use diesel::deserialize::{self, QueryableByName};
-            use diesel::row::NamedRow;
+            use #diesel::deserialize::{self, QueryableByName};
+            use #diesel::row::NamedRow;
 
             impl #impl_generics QueryableByName<__DB>
                 for #struct_name #ty_generics
@@ -76,12 +77,13 @@ fn field_expr(field: &Field, model: &Model) -> Result<syn::FieldValue, Diagnosti
 fn sql_type(field: &Field, model: &Model) -> syn::Type {
     let table_name = model.table_name();
     let column_name = field.column_name();
+    let diesel = imp_root();
 
     match field.sql_type {
         Some(ref st) => st.clone(),
         None => {
             if model.has_table_name_attribute() {
-                parse_quote!(diesel::dsl::SqlTypeOf<#table_name::#column_name>)
+                parse_quote!(#diesel::dsl::SqlTypeOf<#table_name::#column_name>)
             } else {
                 let field_name = match field.name {
                     FieldName::Named(ref x) => x.clone(),

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -1,9 +1,9 @@
 use proc_macro2::{self, Ident, Span};
 use syn;
 
-use field::*;
-use model::*;
-use util::*;
+use crate::field::*;
+use crate::model::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let model = Model::from_item(&item)?;

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -2,8 +2,8 @@ use proc_macro2;
 use proc_macro2::*;
 use syn;
 
-use meta::*;
-use util::*;
+use crate::meta::*;
+use crate::util::*;
 
 pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
     let struct_name = &item.ident;

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -82,7 +82,10 @@ pub fn fix_span(maybe_bad_span: Span, mut fallback: Span) -> Span {
 // This is definitely a hack. Can be removed once
 // https://github.com/rust-lang/rust/issues/56409 is stable.
 pub fn imp_root() -> TokenStream {
-    if std::env::var("CARGO_PKG_NAME").unwrap() == "diesel" {
+    let in_self = std::env::var("CARGO_PKG_NAME").unwrap() == "diesel";
+    let in_doctest = std::env::args().next().unwrap_or_default().contains("rustdoc");
+
+    if in_self && !in_doctest {
         quote!(crate)
     } else {
         quote!(::diesel)

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -1,6 +1,6 @@
-pub use diagnostic_shim::{Diagnostic, DiagnosticShim, EmitErrorExt};
+pub use crate::diagnostic_shim::{Diagnostic, DiagnosticShim, EmitErrorExt};
 
-use meta::MetaItem;
+use crate::meta::MetaItem;
 use proc_macro2::{Span, TokenStream};
 use syn::{Data, DeriveInput, GenericArgument, Ident, Type};
 

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -83,7 +83,10 @@ pub fn fix_span(maybe_bad_span: Span, mut fallback: Span) -> Span {
 // https://github.com/rust-lang/rust/issues/56409 is stable.
 pub fn imp_root() -> TokenStream {
     let in_self = std::env::var("CARGO_PKG_NAME").unwrap() == "diesel";
-    let in_doctest = std::env::args().next().unwrap_or_default().contains("rustdoc");
+    let in_doctest = std::env::args()
+        .next()
+        .unwrap_or_default()
+        .contains("rustdoc");
 
     if in_self && !in_doctest {
         quote!(crate)

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -10,8 +10,6 @@ pub fn wrap_in_dummy_mod(const_name: Ident, item: TokenStream) -> TokenStream {
         fn #const_name() {
             // https://github.com/rust-lang/rust/issues/47314
             extern crate std;
-            use diesel;
-
             #item
         }
     }
@@ -77,5 +75,16 @@ pub fn fix_span(maybe_bad_span: Span, mut fallback: Span) -> Span {
         fallback
     } else {
         maybe_bad_span
+    }
+}
+
+// Returns the name used to import modules from diesel.
+// This is definitely a hack. Can be removed once
+// https://github.com/rust-lang/rust/issues/56409 is stable.
+pub fn imp_root() -> TokenStream {
+    if std::env::var("CARGO_PKG_NAME").unwrap() == "diesel" {
+        quote!(crate)
+    } else {
+        quote!(::diesel)
     }
 }

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -83,10 +83,10 @@ pub fn fix_span(maybe_bad_span: Span, mut fallback: Span) -> Span {
 // https://github.com/rust-lang/rust/issues/56409 is stable.
 pub fn imp_root() -> TokenStream {
     let in_self = std::env::var("CARGO_PKG_NAME").unwrap() == "diesel";
-    let in_doctest = std::env::args()
-        .next()
-        .unwrap_or_default()
-        .contains("rustdoc");
+
+    let mut args = std::env::args();
+    let bin = args.next().unwrap_or_default();
+    let in_doctest = bin.ends_with("/rustdoc") && args.find(|s| s == "--test").is_some();
 
     if in_self && !in_doctest {
         quote!(crate)

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -86,7 +86,7 @@ pub fn imp_root() -> TokenStream {
 
     let mut args = std::env::args();
     let bin = args.next().unwrap_or_default();
-    let in_doctest = bin.ends_with("/rustdoc") && args.find(|s| s == "--test").is_some();
+    let in_doctest = bin.ends_with("/rustdoc") && args.any(|s| s == "--test");
 
     if in_self && !in_doctest {
         quote!(crate)

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -1,6 +1,6 @@
-use diesel::*;
 use super::helpers::*;
 use super::schema::*;
+use diesel::*;
 
 #[test]
 fn named_ref_struct() {

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -1,6 +1,6 @@
 use diesel::*;
-use helpers::*;
-use schema::*;
+use super::helpers::*;
+use super::schema::*;
 
 #[test]
 fn named_ref_struct() {

--- a/diesel_derives/tests/associations.rs
+++ b/diesel_derives/tests/associations.rs
@@ -1,5 +1,5 @@
-use diesel::*;
 use super::helpers::*;
+use diesel::*;
 
 type Backend = <TestConnection as Connection>::Backend;
 

--- a/diesel_derives/tests/associations.rs
+++ b/diesel_derives/tests/associations.rs
@@ -1,5 +1,5 @@
 use diesel::*;
-use helpers::*;
+use super::helpers::*;
 
 type Backend = <TestConnection as Connection>::Backend;
 

--- a/diesel_derives/tests/helpers.rs
+++ b/diesel_derives/tests/helpers.rs
@@ -66,7 +66,7 @@ cfg_if! {
 }
 
 pub fn connection_with_sean_and_tess_in_users_table() -> TestConnection {
-    use schema::users::dsl::*;
+    use super::schema::users::dsl::*;
 
     let connection = connection();
     ::diesel::insert_into(users)

--- a/diesel_derives/tests/insertable.rs
+++ b/diesel_derives/tests/insertable.rs
@@ -1,5 +1,5 @@
-use diesel::*;
 use super::helpers::*;
+use diesel::*;
 
 table! {
     users {

--- a/diesel_derives/tests/insertable.rs
+++ b/diesel_derives/tests/insertable.rs
@@ -1,5 +1,5 @@
 use diesel::*;
-use helpers::*;
+use super::helpers::*;
 
 table! {
     users {

--- a/diesel_derives/tests/queryable.rs
+++ b/diesel_derives/tests/queryable.rs
@@ -2,7 +2,7 @@ use diesel::dsl::sql;
 use diesel::sql_types::Integer;
 use diesel::*;
 
-use helpers::connection;
+use super::helpers::connection;
 
 #[test]
 fn named_struct_definition() {

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -1,6 +1,6 @@
 use diesel::*;
 
-use helpers::connection;
+use super::helpers::connection;
 
 #[cfg(feature = "mysql")]
 type IntSql = ::diesel::sql_types::BigInt;

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Migration management for diesel"
 documentation = "https://docs.rs/crate/diesel_migrations"
 homepage = "http://diesel.rs"
-
+edition = "2018"
 
 [dependencies]
 migrations_internals = "~1.3.0"

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 description = "Internal implementation of diesels migration mechanism"
 homepage = "http://diesel.rs"
+edition = "2018"
 
 [dependencies]
 diesel = { version = "~1.3.0", default-features = false }

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Codegeneration macros for diesels embedded migrations"
 documentation = "http://docs.diesel.rs"
 homepage = "http://diesel.rs"
+edition = "2018"
 
 [dependencies]
 migrations_internals = "~1.3.0"

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -1,12 +1,11 @@
-use quote;
 use syn;
 
-use migrations::migration_directory_from_given_path;
+use crate::migrations::migration_directory_from_given_path;
 use migrations_internals::{migration_paths_in_directory, version_from_path};
 use std::error::Error;
 use std::path::Path;
 
-use util::{get_option, get_options_from_input};
+use crate::util::{get_option, get_options_from_input};
 
 pub fn derive_embed_migrations(input: &syn::DeriveInput) -> quote::Tokens {
     fn bug() -> ! {


### PR DESCRIPTION
Working on an async connection interface as a side-project. This is a required first step for async functions.

Didn't see a nice way to run tests locally so this build probably won't be green. Do we have something setup with docker to run all the tests? If not, should we?

---

Neat bonus here, that was easy while I was in the middle of it, is all Diesel macros and derives work via standard `use` imports now. `#[macro_use] extern crate diesel;` can be dropped from usage. They still work fine in Rust 2015 (and 2018) using `#[macro_use]` though (as proven by tests as I only changed 1 to use the new import style).