### PR TITLE
Mention ilike in changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   example, if one of the fields has the type `Cow<'a, str>`). To define an
   association to such a type, write `#[belongs_to(parent = "User<'_>")]`
 
+* `Nullable<Text>` now supports `ilike` expression on  in PostgreSQL.
+
 ### Changed
 
 * Diesel's derives now require that `extern crate diesel;` be at your crate root


### PR DESCRIPTION
Now that PR #1835 is merged, I think it should be mentioned in the changelog that `Nullable<Text>` now supports ilike on PostgreSQL.