### PR TITLE
Use $crate to refer to diesels macros

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -427,3 +427,6 @@ pub trait Identifiable: HasTable {
     /// so that we have a lifetime to use for `Id`.
     fn id(self) -> Self::Id;
 }
+
+#[doc(hidden)]
+pub use diesel_derives::Identifiable;

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -171,6 +171,9 @@ where
     fn build(row: Self::Row) -> Self;
 }
 
+#[doc(hidden)]
+pub use diesel_derives::Queryable;
+
 /// Deserializes the result of a query constructed with [`sql_query`].
 ///
 /// # Deriving
@@ -293,6 +296,9 @@ where
     fn build<R: NamedRow<DB>>(row: &R) -> Result<Self>;
 }
 
+#[doc(hidden)]
+pub use diesel_derives::QueryableByName;
+
 /// Deserialize a single field of a given SQL type.
 ///
 /// When possible, implementations of this trait should prefer to use an
@@ -375,6 +381,9 @@ pub trait FromSqlRow<A, DB: Backend>: Sized {
     /// See the trait documentation.
     fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self>;
 }
+
+#[doc(hidden)]
+pub use diesel_derives::FromSqlRow;
 
 // Reasons we can't write this:
 //

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -272,7 +272,7 @@ macro_rules! __diesel_sql_function_body {
             {
             }
 
-            static_cond! {
+            $crate::static_cond! {
                 if $aggregate == no {
                     impl<$($type_args_bounds)* $($arg_name),*>
                         $crate::expression::NonAggregate
@@ -285,7 +285,7 @@ macro_rules! __diesel_sql_function_body {
                 }
             }
 
-            __diesel_sqlite_register_fn! {
+            $crate::__diesel_sqlite_register_fn! {
                 type_args = ($($type_args)*),
                 aggregate = $aggregate,
                 fn_name = $fn_name,

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -151,6 +151,9 @@ pub trait AsExpression<T> {
     fn as_expression(self) -> Self::Expression;
 }
 
+#[doc(hidden)]
+pub use diesel_derives::AsExpression;
+
 impl<T: Expression> AsExpression<T::SqlType> for T {
     type Expression = Self;
 

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -44,7 +44,7 @@ macro_rules! numeric_operation {
             }
         }
 
-        impl_selectable_expression!($name<Lhs, Rhs>);
+        $crate::impl_selectable_expression!($name<Lhs, Rhs>);
 
         impl<Lhs, Rhs> NonAggregate for $name<Lhs, Rhs>
         where

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -86,6 +86,9 @@ pub trait Insertable<T> {
     }
 }
 
+#[doc(hidden)]
+pub use diesel_derives::Insertable;
+
 pub trait CanInsertInSingleQuery<DB: Backend> {
     /// How many rows will this query insert?
     ///

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -166,8 +166,10 @@ extern crate bitflags;
 extern crate byteorder;
 #[macro_use]
 extern crate diesel_derives;
+
+// Re-exports derive macros that do not map to exactly one Diesel trait.
 #[doc(hidden)]
-pub use diesel_derives::*;
+pub use diesel_derives::{DieselNumericOps, SqlType, Associations};
 
 #[macro_use]
 mod macros;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -12,7 +12,7 @@ macro_rules! __diesel_column {
     ) => {
         $($meta)*
         #[allow(non_camel_case_types, dead_code)]
-        #[derive(Debug, Clone, Copy, $crate::QueryId, Default)]
+        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, Default)]
         pub struct $column_name;
 
         impl $crate::expression::Expression for $column_name {
@@ -640,7 +640,7 @@ macro_rules! __diesel_table_impl {
             pub const all_columns: ($($column_name,)+) = ($($column_name,)+);
 
             #[allow(non_camel_case_types)]
-            #[derive(Debug, Clone, Copy, $crate::QueryId)]
+            #[derive(Debug, Clone, Copy, QueryId)]
             /// The actual table struct
             ///
             /// This is the type which provides the base methods of the query

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -12,7 +12,7 @@ macro_rules! __diesel_column {
     ) => {
         $($meta)*
         #[allow(non_camel_case_types, dead_code)]
-        #[derive(Debug, Clone, Copy, QueryId, Default)]
+        #[derive(Debug, Clone, Copy, $crate::QueryId, Default)]
         pub struct $column_name;
 
         impl $crate::expression::Expression for $column_name {
@@ -86,8 +86,8 @@ macro_rules! __diesel_column {
             }
         }
 
-        __diesel_generate_ops_impls_if_numeric!($column_name, $($Type)*);
-        __diesel_generate_ops_impls_if_date_time!($column_name, $($Type)*);
+        $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($Type)*);
+        $crate::__diesel_generate_ops_impls_if_date_time!($column_name, $($Type)*);
     }
 }
 
@@ -263,7 +263,7 @@ macro_rules! __diesel_column {
 #[macro_export]
 macro_rules! table {
     ($($tokens:tt)*) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($tokens)*],
             imports = [],
             meta = [],
@@ -295,7 +295,7 @@ macro_rules! __diesel_parse_table {
         imports = [$($imports:tt)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = [$($imports)* use $($import)::+;],
             $($args)*
@@ -310,7 +310,7 @@ macro_rules! __diesel_parse_table {
         sql_name = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -326,7 +326,7 @@ macro_rules! __diesel_parse_table {
         meta = [$($meta:tt)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = [$($meta)* #$new_meta],
@@ -344,7 +344,7 @@ macro_rules! __diesel_parse_table {
         schema = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -364,7 +364,7 @@ macro_rules! __diesel_parse_table {
         name = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -385,7 +385,7 @@ macro_rules! __diesel_parse_table {
         primary_key = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -403,7 +403,7 @@ macro_rules! __diesel_parse_table {
         imports = [],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [{$($columns)*}],
             imports = [use $crate::sql_types::*;],
             $($args)*
@@ -419,7 +419,7 @@ macro_rules! __diesel_parse_table {
         name = $name:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [{$($columns)*}],
             imports = $imports,
             meta = $meta,
@@ -434,7 +434,7 @@ macro_rules! __diesel_parse_table {
         tokens = [{$($columns:tt)*}],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             tokens = [$($columns)*],
             table = { $($args)* },
             columns = [],
@@ -443,7 +443,7 @@ macro_rules! __diesel_parse_table {
 
     // Invalid syntax
     ($($tokens:tt)*) => {
-        __diesel_invalid_table_syntax!();
+        $crate::__diesel_invalid_table_syntax!();
     }
 }
 
@@ -460,7 +460,7 @@ macro_rules! __diesel_parse_columns {
         ],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$(#$meta)*],
                 name = $name,
@@ -482,7 +482,7 @@ macro_rules! __diesel_parse_columns {
         ],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$(#$meta)*],
                 name = $name,
@@ -506,7 +506,7 @@ macro_rules! __diesel_parse_columns {
         },
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$($meta)*],
                 name = $name,
@@ -529,7 +529,7 @@ macro_rules! __diesel_parse_columns {
         },
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$($unchecked_meta)*],
                 name = $name,
@@ -553,7 +553,7 @@ macro_rules! __diesel_parse_columns {
         columns = [$($columns:tt,)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             tokens = $tokens,
             table = $table,
             columns = [$($columns,)* { $($current_column)* },],
@@ -566,12 +566,12 @@ macro_rules! __diesel_parse_columns {
         tokens = [],
         $($args:tt)*
     ) => {
-        __diesel_table_impl!($($args)*);
+        $crate::__diesel_table_impl!($($args)*);
     };
 
     // Invalid syntax
     ($($tokens:tt)*) => {
-        __diesel_invalid_table_syntax!();
+        $crate::__diesel_invalid_table_syntax!();
     }
 }
 
@@ -615,7 +615,7 @@ macro_rules! __diesel_table_impl {
             /// table struct renamed to the module name. This is meant to be
             /// glob imported for functions which only deal with one table.
             pub mod dsl {
-                $(static_cond! {
+                $($crate::static_cond! {
                     if $table_name == $column_name {
                         compile_error!(concat!(
                             "Column `",
@@ -640,7 +640,7 @@ macro_rules! __diesel_table_impl {
             pub const all_columns: ($($column_name,)+) = ($($column_name,)+);
 
             #[allow(non_camel_case_types)]
-            #[derive(Debug, Clone, Copy, QueryId)]
+            #[derive(Debug, Clone, Copy, $crate::QueryId)]
             /// The actual table struct
             ///
             /// This is the type which provides the base methods of the query
@@ -663,7 +663,7 @@ macro_rules! __diesel_table_impl {
             /// Helper type for representing a boxed query from this table
             pub type BoxedQuery<'a, DB, ST = SqlType> = BoxedSelectStatement<'a, ST, table, DB>;
 
-            __diesel_table_query_source_impl!(table, $schema, $sql_name);
+            $crate::__diesel_table_query_source_impl!(table, $schema, $sql_name);
 
             impl AsQuery for table {
                 type SqlType = SqlType;
@@ -821,7 +821,7 @@ macro_rules! __diesel_table_impl {
                 impl AppearsOnTable<table> for star {
                 }
 
-                $(__diesel_column! {
+                $($crate::__diesel_column! {
                     table = table,
                     name = $column_name,
                     sql_name = $column_sql_name,
@@ -942,8 +942,8 @@ macro_rules! __diesel_table_query_source_impl {
 #[macro_export]
 macro_rules! joinable {
     ($($child:ident)::* -> $($parent:ident)::* ($source:ident)) => {
-        joinable_inner!($($child)::* ::table => $($parent)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
-        joinable_inner!($($parent)::* ::table => $($child)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
+        $crate::joinable_inner!($($child)::* ::table => $($parent)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
+        $crate::joinable_inner!($($parent)::* ::table => $($child)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
     }
 }
 
@@ -951,7 +951,7 @@ macro_rules! joinable {
 #[doc(hidden)]
 macro_rules! joinable_inner {
     ($left_table:path => $right_table:path : ($foreign_key:path = $parent_table:path)) => {
-        joinable_inner!(
+        $crate::joinable_inner!(
             left_table_ty = $left_table,
             right_table_ty = $right_table,
             right_table_expr = $right_table,
@@ -1032,7 +1032,7 @@ macro_rules! allow_tables_to_appear_in_same_query {
                 type Count = $crate::query_source::Never;
             }
         )+
-        allow_tables_to_appear_in_same_query!($($right_mod,)+);
+        $crate::allow_tables_to_appear_in_same_query!($($right_mod,)+);
     };
 
     ($last_table:ident,) => {};

--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -28,39 +28,39 @@ macro_rules! operator_allowed {
 /// for types which implement `Expression`, under its orphan rules.
 macro_rules! numeric_expr {
     ($tpe:ty) => {
-        operator_allowed!($tpe, Add, add);
-        operator_allowed!($tpe, Sub, sub);
-        operator_allowed!($tpe, Div, div);
-        operator_allowed!($tpe, Mul, mul);
+        $crate::operator_allowed!($tpe, Add, add);
+        $crate::operator_allowed!($tpe, Sub, sub);
+        $crate::operator_allowed!($tpe, Div, div);
+        $crate::operator_allowed!($tpe, Mul, mul);
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __diesel_generate_ops_impls_if_numeric {
-    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
 
-    ($column_name:ident, SmallInt) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int2) => { numeric_expr!($column_name); };
-    ($column_name:ident, Smallint) => { numeric_expr!($column_name); };
-    ($column_name:ident, SmallSerial) => { numeric_expr!($column_name); };
+    ($column_name:ident, SmallInt) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int2) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Smallint) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, SmallSerial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Integer) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int4) => { numeric_expr!($column_name); };
-    ($column_name:ident, Serial) => { numeric_expr!($column_name); };
+    ($column_name:ident, Integer) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int4) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Serial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, BigInt) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int8) => { numeric_expr!($column_name); };
-    ($column_name:ident, Bigint) => { numeric_expr!($column_name); };
-    ($column_name:ident, BigSerial) => { numeric_expr!($column_name); };
+    ($column_name:ident, BigInt) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int8) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Bigint) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, BigSerial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Float) => { numeric_expr!($column_name); };
-    ($column_name:ident, Float4) => { numeric_expr!($column_name); };
+    ($column_name:ident, Float) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Float4) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Double) => { numeric_expr!($column_name); };
-    ($column_name:ident, Float8) => { numeric_expr!($column_name); };
+    ($column_name:ident, Double) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Float8) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Numeric) => { numeric_expr!($column_name); };
+    ($column_name:ident, Numeric) => { $crate::numeric_expr!($column_name); };
 
     ($column_name:ident, $non_numeric_type:ty) => {};
 }
@@ -69,18 +69,18 @@ macro_rules! __diesel_generate_ops_impls_if_numeric {
 #[doc(hidden)]
 macro_rules! date_time_expr {
     ($tpe:ty) => {
-        operator_allowed!($tpe, Add, add);
-        operator_allowed!($tpe, Sub, sub);
+        $crate::operator_allowed!($tpe, Add, add);
+        $crate::operator_allowed!($tpe, Sub, sub);
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __diesel_generate_ops_impls_if_date_time {
-    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_date_time!($column_name, $($inner)::*); };
-    ($column_name:ident, Time) => { date_time_expr!($column_name); };
-    ($column_name:ident, Date) => { date_time_expr!($column_name); };
-    ($column_name:ident, Timestamp) => { date_time_expr!($column_name); };
-    ($column_name:ident, Timestamptz) => { date_time_expr!($column_name); };
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { $crate::__diesel_generate_ops_impls_if_date_time!($column_name, $($inner)::*); };
+    ($column_name:ident, Time) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Date) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Timestamp) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Timestamptz) => { $crate::date_time_expr!($column_name); };
     ($column_name:ident, $non_date_time_type:ty) => {};
 }

--- a/diesel/src/macros/static_cond.rs
+++ b/diesel/src/macros/static_cond.rs
@@ -21,18 +21,18 @@ macro_rules! static_cond {
 
     // no else condition provided: fall through with empty else
     (if $lhs:tt == $rhs:tt $then:tt) => {
-        static_cond!(if $lhs == $rhs $then else { });
+        $crate::static_cond!(if $lhs == $rhs $then else { });
     };
     (if $lhs:tt != $rhs:tt $then:tt) => {
-        static_cond!(if $lhs != $rhs $then else { });
+        $crate::static_cond!(if $lhs != $rhs $then else { });
     };
 
     // we evaluate a conditional by generating a new macro (in an inner scope, so name shadowing is
     // not a big concern) and calling it
     (if $lhs:tt == $rhs:tt $then:tt else $els:tt) => {
-        static_cond!(@go $lhs $rhs $then $els);
+        $crate::static_cond!(@go $lhs $rhs $then $els);
     };
     (if $lhs:tt != $rhs:tt $then:tt else $els:tt) => {
-        static_cond!(@go $lhs $rhs $els $then);
+        $crate::static_cond!(@go $lhs $rhs $els $then);
     };
 }

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -88,6 +88,9 @@ pub trait QueryId {
     }
 }
 
+#[doc(hidden)]
+pub use diesel_derives::QueryId;
+
 impl QueryId for () {
     type QueryId = ();
 

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -31,6 +31,9 @@ pub trait AsChangeset {
     fn as_changeset(self) -> Self::Changeset;
 }
 
+#[doc(hidden)]
+pub use diesel_derives::AsChangeset;
+
 impl<T: AsChangeset> AsChangeset for Option<T> {
     type Target = T::Target;
     type Changeset = Option<T::Changeset>;

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -258,7 +258,7 @@ fn drop_database(database_url: &str) -> DatabaseResult<()> {
 }
 
 #[cfg(feature = "postgres")]
-table! {
+diesel::table! {
     pg_database (datname) {
         datname -> Text,
         datistemplate -> Bool,
@@ -279,7 +279,7 @@ fn pg_database_exists(conn: &PgConnection, database_name: &str) -> QueryResult<b
 }
 
 #[cfg(feature = "mysql")]
-table! {
+diesel::table! {
     information_schema.schemata (schema_name) {
         schema_name -> Text,
     }

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -61,7 +61,7 @@ impl UsesInformationSchema for Mysql {
 
 #[allow(clippy::module_inception)]
 mod information_schema {
-    table! {
+    diesel::table! {
         information_schema.tables (table_schema, table_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -69,7 +69,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.columns (table_schema, table_name, column_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -81,7 +81,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.key_column_usage (table_schema, table_name, column_name, constraint_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -92,7 +92,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.table_constraints (table_schema, table_name, constraint_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -102,7 +102,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.referential_constraints (constraint_schema, constraint_name) {
             constraint_schema -> VarChar,
             constraint_name -> VarChar,
@@ -111,8 +111,8 @@ mod information_schema {
         }
     }
 
-    allow_tables_to_appear_in_same_query!(table_constraints, referential_constraints);
-    allow_tables_to_appear_in_same_query!(key_column_usage, table_constraints);
+    diesel::allow_tables_to_appear_in_same_query!(table_constraints, referential_constraints);
+    diesel::allow_tables_to_appear_in_same_query!(key_column_usage, table_constraints);
 }
 
 pub fn get_table_data<Conn>(conn: &Conn, table: &TableName) -> QueryResult<Vec<ColumnInformation>>

--- a/diesel_cli/src/infer_schema_internals/mysql.rs
+++ b/diesel_cli/src/infer_schema_internals/mysql.rs
@@ -7,7 +7,7 @@ use super::information_schema::UsesInformationSchema;
 use super::table_data::TableName;
 
 mod information_schema {
-    table! {
+    diesel::table! {
         information_schema.table_constraints (constraint_schema, constraint_name) {
             table_schema -> VarChar,
             constraint_schema -> VarChar,
@@ -16,7 +16,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.key_column_usage (constraint_schema, constraint_name) {
             constraint_schema -> VarChar,
             constraint_name -> VarChar,
@@ -29,7 +29,7 @@ mod information_schema {
         }
     }
 
-    allow_tables_to_appear_in_same_query!(table_constraints, key_column_usage);
+    diesel::allow_tables_to_appear_in_same_query!(table_constraints, key_column_usage);
 }
 
 /// Even though this is using `information_schema`, MySQL needs non-ANSI columns

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -17,7 +17,6 @@
 extern crate chrono;
 #[macro_use]
 extern crate clap;
-#[macro_use]
 extern crate diesel;
 extern crate dotenv;
 extern crate migrations_internals;

--- a/examples/postgres/all_about_updates/src/lib.rs
+++ b/examples/postgres/all_about_updates/src/lib.rs
@@ -8,6 +8,7 @@ use diesel::debug_query;
 #[cfg(test)]
 use diesel::pg::Pg;
 use diesel::prelude::*;
+use diesel::query_builder::AsChangeset;
 
 table! {
     posts {


### PR DESCRIPTION
Enables direct macro imports for diesel macros. Removes #[macro_use] from diesel_cli crate to demonstrate.

`$crate::` is only legal to be used in Rust 1.30+ but as of 1.4 diesel has a minimum rust version of 1.31.

See https://github.com/rust-lang/rust/issues/35896#issuecomment-407836572 for a good explanation of how to take advantage of the new macro import system.