### PR TITLE
Replace try! with ? in more places

### DIFF
--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -117,10 +117,10 @@ macro_rules! on_conflict_tuples {
         {
             fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
                 out.push_sql(" (");
-                try!(out.push_identifier(T::NAME));
+                out.push_identifier(T::NAME)?;
                 $(
                     out.push_sql(", ");
-                    try!(out.push_identifier($col::NAME));
+                    out.push_identifier($col::NAME)?;
                 )+
                 out.push_sql(")");
                 Ok(())

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -107,7 +107,7 @@ pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::Wh
 /// #     let connection = establish_connection();
 /// #     let get_count = || users.count().first::<i64>(&connection);
 /// let old_count = get_count();
-/// try!(diesel::delete(users.filter(id.eq(1))).execute(&connection));
+/// diesel::delete(users.filter(id.eq(1))).execute(&connection)?;
 /// assert_eq!(old_count.map(|count| count - 1), get_count());
 /// # Ok(())
 /// # }
@@ -127,7 +127,7 @@ pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::Wh
 /// #     use schema::users::dsl::*;
 /// #     let connection = establish_connection();
 /// #     let get_count = || users.count().first::<i64>(&connection);
-/// try!(diesel::delete(users).execute(&connection));
+/// diesel::delete(users).execute(&connection)?;
 /// assert_eq!(Ok(0), get_count());
 /// # Ok(())
 /// # }

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -54,7 +54,7 @@ macro_rules! tuple_impls {
                 const FIELDS_NEEDED: usize = $($T::FIELDS_NEEDED +)+ 0;
 
                 fn build_from_row<RowT: Row<__DB>>(row: &mut RowT) -> Result<Self, Box<Error+Send+Sync>> {
-                    Ok(($(try!($T::build_from_row(row)),)+))
+                    Ok(($($T::build_from_row(row)?,)+))
                 }
             }
 


### PR DESCRIPTION
It seems #1936 removed most uses of try! with rustfmt but rustfmt can't see inside macro usage or doc comments (both of which will trigger errors under rust 2018).