### PR TITLE
Fix use-after free in SQLite adapter

### DIFF
--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -121,8 +121,9 @@ impl Drop for Statement {
     fn drop(&mut self) {
         use std::thread::panicking;
 
+        let raw_connection = self.raw_connection();
         let finalize_result = unsafe { ffi::sqlite3_finalize(self.inner_statement.as_ptr()) };
-        if let Err(e) = ensure_sqlite_ok(finalize_result, self.raw_connection()) {
+        if let Err(e) = ensure_sqlite_ok(finalize_result, raw_connection) {
             if panicking() {
                 write!(
                     stderr(),


### PR DESCRIPTION
In `Statement::drop` we are attempting to get the raw connection pointer
from `inner_statement` after it has already been freed. We only use the
pointer if finalizing the statement fails, which *shouldn't* ever
happen, so this is unlikely to have caused a major issue in the wild
(e.g. we will not be issuing a security advisory for this). However,
getting that pointer in the first place is still UB, so it needs to be
fixed.

Fixes #1966