### PR TITLE
Fix a hanging test

### DIFF
--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -243,7 +243,11 @@ fn upsert_with_no_changes_executes_do_nothing() {
         .execute(&connection);
 
     assert_eq!(Ok(0), result);
+}
 
+#[test]
+#[cfg(feature = "postgres")]
+fn upsert_with_no_changes_executes_do_nothing_owned() {
     // Try the same thing with an owned type.
     let connection = connection_with_sean_and_tess_in_users_table();
     let result = insert_into(users::table)


### PR DESCRIPTION
The "underlying issue here is that this stalls as soon as we try to
get the second connection.

Seperate them as a quick fix into 2 test cases.