### PR TITLE
Fix broken links in diesel::associations.

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -146,10 +146,11 @@
 //! a user and all of its posts, that type is `(User, Vec<Post>)`.
 //!
 //! Next lets look at how to load the children for more than one parent record.
-//! [`belonging_to`][belonging-to] can be used to load the data, but we'll also need to group it
-//! with its parents. For this we use an additional method [`grouped_by`][grouped-by]
+//! [`belonging_to`] can be used to load the data, but we'll also need to group it
+//! with its parents. For this we use an additional method [`grouped_by`].
 //!
-//! [grouped-by]: trait.GroupedBy.html#tymethod.grouped_by
+//! [`grouped_by`]: trait.groupedby.html#tymethod.grouped_by
+//! [`belonging_to`]: ../query_dsl/trait.BelongingToDsl.html#tymethod.belonging_to
 //!
 //! ```rust
 //! # #[macro_use] extern crate diesel;
@@ -201,7 +202,7 @@
 //! Diesel provides support for doing this grouping, once the data has been
 //! loaded.
 //!
-//! [`grouped_by`][grouped-by] is called on a `Vec<Child>` with a `&[Parent]`.
+//! [`grouped_by`] is called on a `Vec<Child>` with a `&[Parent]`.
 //! The return value will be `Vec<Vec<Child>>` indexed to match their parent.
 //! Or to put it another way, the returned data can be passed to `zip`,
 //! and it will be combined with its parent.
@@ -259,7 +260,7 @@
 //! # }
 //! ```
 //!
-//! `grouped_by` can be called multiple times
+//! [`grouped_by`] can be called multiple times
 //! if you have multiple children or grandchildren.
 //!
 //! For example, this code will load some users,

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -149,7 +149,7 @@
 //! [`belonging_to`] can be used to load the data, but we'll also need to group it
 //! with its parents. For this we use an additional method [`grouped_by`].
 //!
-//! [`grouped_by`]: trait.groupedby.html#tymethod.grouped_by
+//! [`grouped_by`]: trait.GroupedBy.html#tymethod.grouped_by
 //! [`belonging_to`]: ../query_dsl/trait.BelongingToDsl.html#tymethod.belonging_to
 //!
 //! ```rust


### PR DESCRIPTION
This pull request fixes broken links in the doc for `diesel::associations`, fixing [issue 1969][1].

  [1]: https://github.com/diesel-rs/diesel/issues/1969