### PR TITLE
Update lib.rs to reflect 2018 same crate path syntax

### DIFF
--- a/examples/postgres/getting_started_step_2/src/lib.rs
+++ b/examples/postgres/getting_started_step_2/src/lib.rs
@@ -20,7 +20,7 @@ pub fn establish_connection() -> PgConnection {
 }
 
 pub fn create_post(conn: &PgConnection, title: &str, body: &str) -> Post {
-    use schema::posts;
+    use crate::schema::posts;
 
     let new_post = NewPost { title, body };
 


### PR DESCRIPTION
Does not compile without this change. Alternatively stipulate upper limit of rust version for which the example is valid.