### PR TITLE
Make `migrations_internals::setup_database` public

### DIFF
--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -256,7 +256,7 @@ fn migration_with_version(
     }
 }
 
-#[doc(hidden)]
+/// Creates all diesel-internal tables and data (if needed).
 pub fn setup_database<Conn: Connection>(conn: &Conn) -> QueryResult<usize> {
     create_schema_migrations_table_if_needed(conn)
 }


### PR DESCRIPTION
This is the only additional method you need to call for automatically setting up an empty database from inside the application.