### PR TITLE
Allow setting a specific test bin

### DIFF
--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -37,7 +37,10 @@ impl TestCommand {
     }
 
     pub fn run(self) -> CommandResult {
-        let output = self.build_command().output().unwrap();
+        let output = self
+            .build_command()
+            .output()
+            .expect("failed to execute process");
         CommandResult { output: output }
     }
 
@@ -83,12 +86,16 @@ impl CommandResult {
 }
 
 fn path_to_diesel_cli() -> PathBuf {
-    Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap())
-        .parent()
-        .unwrap()
-        .join("target")
-        .join("debug")
-        .join("diesel")
+    if let Some(path) = env::var_os("DIESEL_TEST_BIN") {
+        Path::new(&path).into()
+    } else {
+        Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap())
+            .parent()
+            .unwrap()
+            .join("target")
+            .join("debug")
+            .join("diesel")
+    }
 }
 
 impl Debug for CommandResult {


### PR DESCRIPTION
This is related to packaging, I noticed that every test paniced with no specific error and it turned out this is because I ran `cargo test --release` instead of `cargo test`.

I'm currently running `cargo test` for that reason instead, which means diesel is built twice, once for packaging and once for testing. This patch would allow me to specify the release binary instead. It also adds some context in case this fails for any reason.