### PR TITLE
Deprecate `no_arg_sql_function!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Support for `mysqlclient-sys` < 0.2.0 has been removed.
 * The `NonNull` for sql types has been removed in favour of the new `SqlType` trait.
 
+* `no_arg_sql_function!` has been deprecated without replacement.
+  [`sql_function!`][sql-function-2-0-0] can now be used for functions with zero
+  arguments. See [the migration guide][2-0-migration] for more details.
+
 ### Changed
 
 * The way [the `Backend` trait][backend-2-0-0] handles its `RawValue` type has

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -5,6 +5,7 @@ pub use diesel_derives::sql_function_proc as sql_function;
 
 #[macro_export]
 #[doc(hidden)]
+#[cfg(feature = "with-deprecated")]
 macro_rules! no_arg_sql_function_body_except_to_sql {
     ($type_name:ident, $return_type:ty, $docs:expr) => {
         #[allow(non_camel_case_types)]
@@ -30,6 +31,7 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
 
 #[macro_export]
 #[doc(hidden)]
+#[cfg(feature = "with-deprecated")]
 macro_rules! no_arg_sql_function_body {
     ($type_name:ident, $return_type:ty, $docs:expr, $($constraint:ident)::+) => {
         no_arg_sql_function_body_except_to_sql!($type_name, $return_type, $docs);
@@ -72,6 +74,11 @@ macro_rules! no_arg_sql_function_body {
 ///
 /// You can optionally pass the name of a trait, as a constraint for backends which support the
 /// function.
+#[deprecated(
+    since = "2.0.0",
+    note = "Use `sql_function!` instead. See `CHANGELOG.md` for migration instructions"
+)]
+#[cfg(feature = "with-deprecated")]
 macro_rules! no_arg_sql_function {
     ($type_name:ident, $return_type:ty) => {
         no_arg_sql_function!($type_name, $return_type, "");

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -44,6 +44,9 @@ impl UsesInformationSchema for Pg {
 }
 
 #[cfg(feature = "mysql")]
+sql_function!(fn database() -> VarChar);
+
+#[cfg(feature = "mysql")]
 impl UsesInformationSchema for Mysql {
     type TypeColumn = self::information_schema::columns::column_type;
 
@@ -56,8 +59,7 @@ impl UsesInformationSchema for Mysql {
         C: Connection<Backend = Self>,
         String: FromSql<sql_types::Text, C::Backend>,
     {
-        no_arg_sql_function!(database, sql_types::VarChar);
-        select(database).get_result(conn)
+        select(database()).get_result(conn)
     }
 }
 

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -51,7 +51,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
         .type_params()
         .map(|type_param| type_param.ident.clone())
         .collect::<Vec<_>>();
-    let type_args2 = &type_args.clone();
+
     for StrictFnArg { name, .. } in args {
         generics.params.push(parse_quote!(#name));
     }
@@ -77,15 +77,14 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
         // FIXME: We can always derive once trivial bounds are stable
         numeric_derive = None;
     } else {
-        sql_type = Some(quote!((#(#arg_name),*)));
+        sql_type = Some(quote!((#(#arg_name),*): Expression,));
         numeric_derive = Some(quote!(#[derive(diesel::sql_types::DieselNumericOps)]));
     }
-
 
     let args_iter = args.iter();
     let mut tokens = quote! {
         use diesel::{self, QueryResult};
-        use diesel::expression::{AsExpression, Expression, SelectableExpression, AppearsOnTable};
+        use diesel::expression::{AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping};
         use diesel::query_builder::{QueryFragment, AstPass};
         use diesel::sql_types::*;
         use super::*;
@@ -104,7 +103,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
 
         impl #impl_generics Expression for #fn_name #ty_generics
         #where_clause
-            #(#sql_type: Expression,)*
+            #sql_type
         {
             type SqlType = #return_type;
         }
@@ -149,9 +148,6 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
 
             impl #impl_generics_internal ValidGrouping<__DieselInternal>
                 for #fn_name #ty_generics
-            #where_clause
-                #(#arg_name: diesel::expression::NonAggregate,)*
-                Self: Expression,
             {
                 type IsAggregate = diesel::expression::is_aggregate::Yes;
             }
@@ -236,7 +232,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
             }
         };
 
-        if cfg!(feature = "sqlite") && type_args.is_empty() {
+        if cfg!(feature = "sqlite") && type_args.is_empty() && !arg_name.is_empty() {
             tokens = quote! {
                 #tokens
 

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -440,6 +440,7 @@ fn filter_subselect_with_boxed_query() {
 }
 
 #[test]
+#[cfg(not(feature = "mysql"))] // FIXME: this test shouldn't need to modify schema each run
 fn filter_subselect_with_nullable_column() {
     use crate::schema_dsl::*;
     table! {


### PR DESCRIPTION
This makes the minor changes to `sql_function!` required to allow 0
argument functions to be defined with this macro. `no_arg_sql_function!`
has been deprecated. Even though we could technically remove it since
this is a major version bump, I still would prefer to deprecate things
when possible, so `no_arg_sql_function!` will live on until 3.0.

There are some changes in behavior here. The most notable is that we
generate a function rather than a unit struct. I had previously
considered having the macro create a unit struct instead of a module if
there were no arguments, but ultimately I think the difference in
behavior is confusing, and requiring folks to put `()` at the end of
calls isn't a huge migration pain.

The biggest thing that `sql_function!` doesn't support is the ability to
add a constraint to the backends allowed. This capability was originally
added for `NOW()`, back when we actually generated that SQL instead of
`CURRENT_TIMESTAMP`. We stopped using it a long time ago, and I doubt
anyone else is using this in the wild. Honestly it was a pretty poorly
thought out feature to begin with, so I'm happy to see it go. If we
decide in the future we want to support this for `sql_function!`, I
think the best way to do it is to allow `where` clauses at the end, and
any bounds that are on `DB` get magically applied to the write
impls/type variable. That behavior feels really implicit and confusing,
so I think we should probably just encourage folks to not use
`sql_function!` if they need lower level control.

One unfortunate side effect of this is that `now` still doesn't get
parenthesis, and we can't have a function and struct with the same name.
If we *really* want to migrate `now` to be consistent, we could
implement all the traits implemented on `now` for `fn() -> now`. This is
a terrible terrible awful hack but could actually work.