### PR TITLE
Introduce a derive for `NonAggregate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
+### Added
+
+* `NonAggregate` can now be derived for simple cases.
+
 ### Removed
 
 * All previously deprecated items have been removed.
@@ -20,6 +24,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 [backend-2-0-0]: http://docs.diesel.rs/diesel/backend/trait.Backend.html
 [raw-value-2-0-0]: http://docs.diesel.rs/diesel/backend/type.RawValue.html
+
+### Fixed
+
+* Many types were incorrectly considered non-aggregate when they should not
+  have been. All types in Diesel are now correctly only considered
+  non-aggregate if their parts are.
 
 
 

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -5,13 +5,13 @@ use query_builder::*;
 use result::QueryResult;
 use sql_types::Bool;
 
-#[derive(Debug, Copy, Clone, QueryId)]
+#[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct In<T, U> {
     left: T,
     values: U,
 }
 
-#[derive(Debug, Copy, Clone, QueryId)]
+#[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct NotIn<T, U> {
     left: T,
     values: U,
@@ -50,10 +50,6 @@ where
 {
     type SqlType = Bool;
 }
-
-impl<T, U> NonAggregate for In<T, U> where In<T, U>: Expression {}
-
-impl<T, U> NonAggregate for NotIn<T, U> where NotIn<T, U>: Expression {}
 
 impl<T, U, DB> QueryFragment<DB> for In<T, U>
 where
@@ -144,7 +140,7 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, NonAggregate)]
 pub struct Many<T>(Vec<T>);
 
 impl<T: Expression> Expression for Many<T> {

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -47,4 +47,4 @@ impl<T, U, QS> SelectableExpression<QS> for Bound<T, U> where Bound<T, U>: Appea
 
 impl<T, U, QS> AppearsOnTable<QS> for Bound<T, U> where Bound<T, U>: Expression {}
 
-impl<T, U> NonAggregate for Bound<T, U> where Bound<T, U>: Expression {}
+impl<T, U> NonAggregate for Bound<T, U> {}

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -53,9 +53,4 @@ where
     }
 }
 
-impl<T, ST> NonAggregate for Coerce<T, ST>
-where
-    T: NonAggregate,
-    Coerce<T, ST>: Expression,
-{
-}
+impl<T, ST> NonAggregate for Coerce<T, ST> where T: NonAggregate {}

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -43,7 +43,7 @@ where
     type SqlType = Bool;
 }
 
-impl<T> NonAggregate for Exists<T> {}
+impl<T> NonAggregate for Exists<T> where Subselect<T, ()>: NonAggregate {}
 
 impl<T, DB> QueryFragment<DB> for Exists<T>
 where

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,6 +1,6 @@
 use backend::Backend;
 use expression::coerce::Coerce;
-use expression::{AsExpression, Expression, NonAggregate};
+use expression::{AsExpression, Expression};
 use query_builder::*;
 use result::QueryResult;
 use sql_types::*;
@@ -8,14 +8,12 @@ use sql_types::*;
 /// Represents the SQL `CURRENT_TIMESTAMP` constant. This is equivalent to the
 /// `NOW()` function on backends that support it.
 #[allow(non_camel_case_types)]
-#[derive(Debug, Copy, Clone, QueryId)]
+#[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct now;
 
 impl Expression for now {
     type SqlType = Timestamp;
 }
-
-impl NonAggregate for now {}
 
 impl<DB: Backend> QueryFragment<DB> for now {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -174,7 +174,7 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
     ($type_name:ident, $return_type:ty, $docs:expr) => {
         #[allow(non_camel_case_types)]
         #[doc=$docs]
-        #[derive(Debug, Clone, Copy, QueryId)]
+        #[derive(Debug, Clone, Copy, QueryId, NonAggregate)]
         pub struct $type_name;
 
         impl $crate::expression::Expression for $type_name {
@@ -184,8 +184,6 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
         impl<QS> $crate::expression::SelectableExpression<QS> for $type_name {}
 
         impl<QS> $crate::expression::AppearsOnTable<QS> for $type_name {}
-
-        impl $crate::expression::NonAggregate for $type_name {}
     };
 }
 

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -1,9 +1,9 @@
 use backend::Backend;
-use expression::{Expression, NonAggregate};
+use expression::Expression;
 use query_builder::*;
 use result::QueryResult;
 
-#[derive(Debug, Copy, Clone, QueryId, Default, DieselNumericOps)]
+#[derive(Debug, Copy, Clone, QueryId, Default, DieselNumericOps, NonAggregate)]
 pub struct Grouped<T>(pub T);
 
 impl<T: Expression> Expression for Grouped<T> {
@@ -20,5 +20,3 @@ impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
 }
 
 impl_selectable_expression!(Grouped<T>);
-
-impl<T: NonAggregate> NonAggregate for Grouped<T> where Grouped<T>: Expression {}

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -266,6 +266,25 @@ where
 /// Used to ensure that aggregate expressions aren't mixed with
 /// non-aggregate expressions in a select clause, and that they're never
 /// included in a where clause.
+///
+/// ## Deriving
+///
+/// This trait can be automatically derived for structs with no type parameters
+/// which are not aggregate, as well as for structs which are `NonAggregate`
+/// when all type parameters are `NonAggregate`. For example:
+///
+/// ```ignore
+/// #[derive(NonAggregate)]
+/// struct Plus<Lhs, Rhs>(Lhs, Rhs);
+///
+/// // The following impl will be generated:
+/// impl<Lhs, Rhs> NonAggregate for Plus<Lhs, Rhs>
+/// where
+///     Lhs: NonAggregate,
+///     Rhs: NonAggregate,
+/// {
+/// }
+/// ```
 pub trait NonAggregate {}
 
 impl<T: NonAggregate + ?Sized> NonAggregate for Box<T> {}

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -5,7 +5,7 @@ use query_source::Table;
 use result::QueryResult;
 use sql_types::IntoNullable;
 
-#[derive(Debug, Copy, Clone, DieselNumericOps)]
+#[derive(Debug, Copy, Clone, DieselNumericOps, NonAggregate)]
 pub struct Nullable<T>(T);
 
 impl<T> Nullable<T> {
@@ -45,13 +45,6 @@ impl<T: QueryId> QueryId for Nullable<T> {
     type QueryId = T::QueryId;
 
     const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
-}
-
-impl<T> NonAggregate for Nullable<T>
-where
-    T: NonAggregate,
-    Nullable<T>: Expression,
-{
 }
 
 impl<T, QS> SelectableExpression<QS> for Nullable<T>

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -63,7 +63,7 @@ macro_rules! __diesel_operator_body {
         expression_ty_params = ($($expression_ty_params:ident,)*),
         expression_bounds = ($($expression_bounds:tt)*),
     ) => {
-        #[derive(Debug, Clone, Copy, QueryId, DieselNumericOps)]
+        #[derive(Debug, Clone, Copy, QueryId, DieselNumericOps, NonAggregate)]
         #[doc(hidden)]
         pub struct $name<$($ty_param,)+> {
             $(pub(crate) $field_name: $ty_param,)+
@@ -81,11 +81,6 @@ macro_rules! __diesel_operator_body {
             $($expression_bounds)*
         {
             type SqlType = $return_ty;
-        }
-
-        impl<$($ty_param,)+> $crate::expression::NonAggregate for $name<$($ty_param,)+> where
-            $($ty_param: $crate::expression::NonAggregate,)+
-        {
         }
 
         impl<$($ty_param,)+ $($backend_ty_param,)*> $crate::query_builder::QueryFragment<$backend_ty>

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -322,7 +322,7 @@ where
     type SqlType = Q::SqlType;
 }
 
-impl<Query, Value> NonAggregate for UncheckedBind<Query, Value> where Self: Expression {}
+impl<Query, Value> NonAggregate for UncheckedBind<Query, Value> {}
 
 impl<QS, Query, Value> SelectableExpression<QS> for UncheckedBind<Query, Value> where
     Self: AppearsOnTable<QS>

--- a/diesel/src/expression/subselect.rs
+++ b/diesel/src/expression/subselect.rs
@@ -44,6 +44,9 @@ where
 {
 }
 
+// FIXME: This probably isn't sound. The subselect can reference columns from
+// the outer query, and is affected by the `GROUP BY` clause of the outer query
+// identically to using it outside of a subselect
 impl<T, ST> NonAggregate for Subselect<T, ST> {}
 
 impl<T, ST, DB> QueryFragment<DB> for Subselect<T, ST>

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -1,5 +1,5 @@
 use expression::subselect::Subselect;
-use expression::{AsExpression, Expression, NonAggregate};
+use expression::{AsExpression, Expression};
 use pg::Pg;
 use query_builder::*;
 use result::QueryResult;
@@ -64,7 +64,7 @@ where
 }
 
 #[doc(hidden)]
-#[derive(Debug, Copy, Clone, QueryId)]
+#[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct Any<Expr> {
     expr: Expr,
 }
@@ -96,10 +96,8 @@ where
 
 impl_selectable_expression!(Any<Expr>);
 
-impl<Expr> NonAggregate for Any<Expr> where Expr: NonAggregate {}
-
 #[doc(hidden)]
-#[derive(Debug, Copy, Clone, QueryId)]
+#[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct All<Expr> {
     expr: Expr,
 }
@@ -130,8 +128,6 @@ where
 }
 
 impl_selectable_expression!(All<Expr>);
-
-impl<Expr> NonAggregate for All<Expr> where Expr: NonAggregate {}
 
 pub trait AsArrayExpression<ST> {
     type Expression: Expression<SqlType = Array<ST>>;

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -1,4 +1,4 @@
-use expression::{Expression, NonAggregate};
+use expression::Expression;
 use pg::Pg;
 use query_builder::*;
 use result::QueryResult;
@@ -10,7 +10,7 @@ impl DateTimeLike for Date {}
 impl DateTimeLike for Timestamp {}
 impl DateTimeLike for Timestamptz {}
 
-#[derive(Debug, Copy, Clone, QueryId)]
+#[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct AtTimeZone<Ts, Tz> {
     timestamp: Ts,
     timezone: Tz,
@@ -33,8 +33,6 @@ where
 {
     type SqlType = Timestamp;
 }
-
-impl<Ts, Tz> NonAggregate for AtTimeZone<Ts, Tz> where AtTimeZone<Ts, Tz>: Expression {}
 
 impl<Ts, Tz> QueryFragment<Pg> for AtTimeZone<Ts, Tz>
 where

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -2,7 +2,7 @@ use byteorder::*;
 use std::io::Write;
 
 use deserialize::{self, FromSql, FromSqlRow, Queryable};
-use expression::{AppearsOnTable, AsExpression, Expression, NonAggregate, SelectableExpression};
+use expression::{AppearsOnTable, AsExpression, Expression, SelectableExpression};
 use pg::Pg;
 use query_builder::{AstPass, QueryFragment};
 use result::QueryResult;
@@ -129,7 +129,7 @@ macro_rules! tuple_impls {
 
 __diesel_for_each_tuple!(tuple_impls);
 
-#[derive(Debug, Clone, Copy, QueryId)]
+#[derive(Debug, Clone, Copy, QueryId, NonAggregate)]
 pub struct PgTuple<T>(T);
 
 impl<T> QueryFragment<Pg> for PgTuple<T>
@@ -161,13 +161,6 @@ where
 impl<T, QS> AppearsOnTable<QS> for PgTuple<T>
 where
     T: AppearsOnTable<QS>,
-    Self: Expression,
-{
-}
-
-impl<T> NonAggregate for PgTuple<T>
-where
-    T: NonAggregate,
     Self: Expression,
 {
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -42,6 +42,7 @@ mod diesel_numeric_ops;
 mod from_sql_row;
 mod identifiable;
 mod insertable;
+mod non_aggregate;
 mod query_id;
 mod queryable;
 mod queryable_by_name;
@@ -86,6 +87,11 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Insertable, attributes(table_name, column_name, diesel))]
 pub fn derive_insertable(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, insertable::derive)
+}
+
+#[proc_macro_derive(NonAggregate)]
+pub fn derive_non_aggregate(input: TokenStream) -> TokenStream {
+    expand_proc_macro(input, non_aggregate::derive)
 }
 
 #[proc_macro_derive(QueryId)]

--- a/diesel_derives/src/non_aggregate.rs
+++ b/diesel_derives/src/non_aggregate.rs
@@ -1,0 +1,34 @@
+use proc_macro2::*;
+use syn;
+
+use util::*;
+
+pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
+    let type_params = item
+        .generics
+        .type_params()
+        .map(|param| param.ident.clone())
+        .collect::<Vec<_>>();
+    for type_param in type_params {
+        let where_clause = item.generics.make_where_clause();
+        where_clause
+            .predicates
+            .push(parse_quote!(#type_param: NonAggregate));
+    }
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+    let struct_name = &item.ident;
+
+    let dummy_mod = format!("_impl_non_aggregate_for_{}", item.ident).to_lowercase();
+    Ok(wrap_in_dummy_mod(
+        Ident::new(&dummy_mod, Span::call_site()),
+        quote! {
+            use diesel::expression::NonAggregate;
+
+            impl #impl_generics NonAggregate for #struct_name #ty_generics
+            #where_clause
+            {
+            }
+        },
+    ))
+}

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -131,7 +131,6 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                 for #fn_name #ty_generics
             #where_clause
                 #(#arg_name: diesel::expression::NonAggregate,)*
-                Self: Expression,
             {
             }
         };


### PR DESCRIPTION
This introduces a derive for the `NonAggregate` trait, which we're
planning on removing as laid out in
https://discourse.diesel.rs/t/proposed-change-replace-nonaggregate-with-something-less-broken-that-can-support-group-by/18.
The purpose of this derive is mostly to reduce the churn caused by the
changes laid out there in the most common case. Because we don't yet
have a PR opened for that change, and it's not clear that is actually
the direction we will end up going, I have written this as a standalone
change that can be shipped in terms of documentation and CHANGELOG
entries.

As part of this, I reviewed every impl of `NonAggregate`. A *lot* of
these impls were missing the bounds required to make them sound. That's
been fixed for most of them by using the new derive. A few others that
can't use the derive have been fixed manually. In a lot of cases there
was also a useless `Self: Expression` bound which is no longer required
and has been removed.