### PR TITLE
Add Send bound to BoxedSelectStatement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,18 +48,17 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `Mysql::TypeMetadata`, you will need to take the new struct
   `MysqlTypeMetadata` instead.
 
-<<<<<<< HEAD
-* The minimal officially supported rustc version is now 1.36.0
+* The minimal officially supported rustc version is now 1.37.0
 
 * The `RawValue` types for the `Mysql` and `Postgresql` backend where changed
   from `[u8]` to distinct opaque types. If you used the concrete `RawValue` type
   somewhere you need to change it to `mysql::MysqlValue` or `pg::PgValue`.
   For the postgres backend additionally type information where added to the `RawValue`
   type. This allows to dynamically deserialize `RawValues` in container types.
+
 * The uuidv07 feature was renamed to uuid, due to the removal of support for older uuid versions
-=======
+
 * Boxed queries (constructed from `.into_boxed()`) are now `Send`.
->>>>>>> Add a minimal changelog entry for making boxed queries Send
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `Mysql::TypeMetadata`, you will need to take the new struct
   `MysqlTypeMetadata` instead.
 
+<<<<<<< HEAD
 * The minimal officially supported rustc version is now 1.36.0
 
 * The `RawValue` types for the `Mysql` and `Postgresql` backend where changed
@@ -56,6 +57,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   For the postgres backend additionally type information where added to the `RawValue`
   type. This allows to dynamically deserialize `RawValues` in container types.
 * The uuidv07 feature was renamed to uuid, due to the removal of support for older uuid versions
+=======
+* Boxed queries (constructed from `.into_boxed()`) are now `Send`.
+>>>>>>> Add a minimal changelog entry for making boxed queries Send
 
 ### Fixed
 

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -279,7 +279,7 @@ macro_rules! table {
             sql_name = unknown,
             name = unknown,
             schema = public,
-            primary_key = (id),
+            primary_key = id,
         }
     }
 }

--- a/diesel/src/query_builder/order_clause.rs
+++ b/diesel/src/query_builder/order_clause.rs
@@ -1,20 +1,20 @@
 simple_clause!(NoOrderClause, OrderClause, " ORDER BY ");
 
-impl<'a, DB, Expr> Into<Option<Box<dyn QueryFragment<DB> + 'a>>> for OrderClause<Expr>
+impl<'a, DB, Expr> Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>> for OrderClause<Expr>
 where
     DB: Backend,
-    Expr: QueryFragment<DB> + 'a,
+    Expr: QueryFragment<DB> + Send + 'a,
 {
-    fn into(self) -> Option<Box<dyn QueryFragment<DB> + 'a>> {
+    fn into(self) -> Option<Box<dyn QueryFragment<DB> + Send + 'a>> {
         Some(Box::new(self.0))
     }
 }
 
-impl<'a, DB> Into<Option<Box<dyn QueryFragment<DB> + 'a>>> for NoOrderClause
+impl<'a, DB> Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>> for NoOrderClause
 where
     DB: Backend,
 {
-    fn into(self) -> Option<Box<dyn QueryFragment<DB> + 'a>> {
+    fn into(self) -> Option<Box<dyn QueryFragment<DB> + Send + 'a>> {
         None
     }
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -22,28 +22,28 @@ use crate::sql_types::{BigInt, Bool, NotNull, Nullable};
 
 #[allow(missing_debug_implementations)]
 pub struct BoxedSelectStatement<'a, ST, QS, DB> {
-    select: Box<dyn QueryFragment<DB> + 'a>,
+    select: Box<dyn QueryFragment<DB> + Send + 'a>,
     from: QS,
-    distinct: Box<dyn QueryFragment<DB> + 'a>,
+    distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
     where_clause: BoxedWhereClause<'a, DB>,
-    order: Option<Box<dyn QueryFragment<DB> + 'a>>,
-    limit: Box<dyn QueryFragment<DB> + 'a>,
-    offset: Box<dyn QueryFragment<DB> + 'a>,
-    group_by: Box<dyn QueryFragment<DB> + 'a>,
+    order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
+    limit: Box<dyn QueryFragment<DB> + Send + 'a>,
+    offset: Box<dyn QueryFragment<DB> + Send + 'a>,
+    group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
     _marker: PhantomData<ST>,
 }
 
 impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        select: Box<dyn QueryFragment<DB> + 'a>,
+        select: Box<dyn QueryFragment<DB> + Send + 'a>,
         from: QS,
-        distinct: Box<dyn QueryFragment<DB> + 'a>,
+        distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
         where_clause: BoxedWhereClause<'a, DB>,
-        order: Option<Box<dyn QueryFragment<DB> + 'a>>,
-        limit: Box<dyn QueryFragment<DB> + 'a>,
-        offset: Box<dyn QueryFragment<DB> + 'a>,
-        group_by: Box<dyn QueryFragment<DB> + 'a>,
+        order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
+        limit: Box<dyn QueryFragment<DB> + Send + 'a>,
+        offset: Box<dyn QueryFragment<DB> + Send + 'a>,
+        group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
     ) -> Self {
         BoxedSelectStatement {
             select: select,
@@ -164,7 +164,7 @@ where
 impl<'a, ST, QS, DB, Selection> SelectDsl<Selection> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    Selection: SelectableExpression<QS> + QueryFragment<DB> + 'a,
+    Selection: SelectableExpression<QS> + QueryFragment<DB> + Send + 'a,
 {
     type Output = BoxedSelectStatement<'a, Selection::SqlType, QS, DB>;
 
@@ -237,7 +237,7 @@ where
 impl<'a, ST, QS, DB, Order> OrderDsl<Order> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    Order: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
+    Order: QueryFragment<DB> + AppearsOnTable<QS> + Send + 'a,
 {
     type Output = Self;
 
@@ -250,7 +250,7 @@ where
 impl<'a, ST, QS, DB, Order> ThenOrderDsl<Order> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend + 'a,
-    Order: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
+    Order: QueryFragment<DB> + AppearsOnTable<QS> + Send + 'a,
 {
     type Output = Self;
 
@@ -266,7 +266,7 @@ where
 impl<'a, ST, QS, DB, Expr> GroupByDsl<Expr> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    Expr: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
+    Expr: QueryFragment<DB> + AppearsOnTable<QS> + Send + 'a,
     Self: Query,
 {
     type Output = Self;

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -40,10 +40,17 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
         from: QS,
         distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
         where_clause: BoxedWhereClause<'a, DB>,
+<<<<<<< HEAD
         order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
         limit: Box<dyn QueryFragment<DB> + Send + 'a>,
         offset: Box<dyn QueryFragment<DB> + Send + 'a>,
         group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
+=======
+        order: Option<Box<QueryFragment<DB> + Send + 'a>>,
+        limit: Box<QueryFragment<DB> + Send + 'a>,
+        offset: Box<QueryFragment<DB> + Send + 'a>,
+        group_by: Box<QueryFragment<DB> + Send + 'a>,
+>>>>>>> Run rustfmt
     ) -> Self {
         BoxedSelectStatement {
             select: select,

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -40,17 +40,10 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
         from: QS,
         distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
         where_clause: BoxedWhereClause<'a, DB>,
-<<<<<<< HEAD
         order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
         limit: Box<dyn QueryFragment<DB> + Send + 'a>,
         offset: Box<dyn QueryFragment<DB> + Send + 'a>,
         group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
-=======
-        order: Option<Box<QueryFragment<DB> + Send + 'a>>,
-        limit: Box<QueryFragment<DB> + Send + 'a>,
-        offset: Box<QueryFragment<DB> + Send + 'a>,
-        group_by: Box<QueryFragment<DB> + Send + 'a>,
->>>>>>> Run rustfmt
     ) -> Self {
         BoxedSelectStatement {
             select: select,
@@ -350,8 +343,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::*;
     use crate::backend::Backend;
+    use crate::prelude::*;
 
     table! {
         users {
@@ -359,7 +352,11 @@ mod tests {
         }
     }
 
-    fn assert_send<T>(_: T) where T: Send {}
+    fn assert_send<T>(_: T)
+    where
+        T: Send,
+    {
+    }
 
     fn assert_boxed_query_send<B: Backend>() {
         assert_send(users::table.into_boxed::<B>());

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -347,3 +347,34 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use crate::backend::Backend;
+
+    table! {
+        users {
+            id -> Integer,
+        }
+    }
+
+    fn assert_send<T>(_: T) where T: Send {}
+
+    fn assert_boxed_query_send<B: Backend>() {
+        assert_send(users::table.into_boxed::<B>());
+        assert_send(users::table.filter(users::id.eq(10)).into_boxed::<B>());
+    }
+
+    #[test]
+    fn boxed_is_send() {
+        #[cfg(feature = "postgres")]
+        assert_boxed_query_send::<crate::pg::Pg>();
+
+        #[cfg(feature = "sqlite")]
+        assert_boxed_query_send::<crate::sqlite::Sqlite>();
+
+        #[cfg(feature = "mysql")]
+        assert_boxed_query_send::<crate::mysql::Mysql>();
+    }
+}

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -344,13 +344,13 @@ impl<'a, F, S, D, W, O, L, Of, G, DB> BoxedDsl<'a, DB>
 where
     Self: AsQuery,
     DB: Backend,
-    S: QueryFragment<DB> + SelectableExpression<F> + 'a,
-    D: QueryFragment<DB> + 'a,
+    S: QueryFragment<DB> + SelectableExpression<F> + Send + 'a,
+    D: QueryFragment<DB> + Send + 'a,
     W: Into<BoxedWhereClause<'a, DB>>,
-    O: Into<Option<Box<dyn QueryFragment<DB> + 'a>>>,
-    L: QueryFragment<DB> + 'a,
-    Of: QueryFragment<DB> + 'a,
-    G: QueryFragment<DB> + 'a,
+    O: Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>>,
+    L: QueryFragment<DB> + Send + 'a,
+    Of: QueryFragment<DB> + Send + 'a,
+    G: QueryFragment<DB> + Send + 'a,
 {
     type Output = BoxedSelectStatement<'a, S::SqlType, F, DB>;
 
@@ -374,13 +374,13 @@ where
     Self: AsQuery,
     DB: Backend,
     F: QuerySource,
-    F::DefaultSelection: QueryFragment<DB> + 'a,
-    D: QueryFragment<DB> + 'a,
+    F::DefaultSelection: QueryFragment<DB> + Send + 'a,
+    D: QueryFragment<DB> + Send + 'a,
     W: Into<BoxedWhereClause<'a, DB>>,
-    O: Into<Option<Box<dyn QueryFragment<DB> + 'a>>>,
-    L: QueryFragment<DB> + 'a,
-    Of: QueryFragment<DB> + 'a,
-    G: QueryFragment<DB> + 'a,
+    O: Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>>,
+    L: QueryFragment<DB> + Send + 'a,
+    Of: QueryFragment<DB> + Send + 'a,
+    G: QueryFragment<DB> + Send + 'a,
 {
     type Output = BoxedSelectStatement<'a, <F::DefaultSelection as Expression>::SqlType, F, DB>;
     fn internal_into_boxed(self) -> Self::Output {

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -108,7 +108,7 @@ where
 impl<'a, DB, Predicate> Into<BoxedWhereClause<'a, DB>> for WhereClause<Predicate>
 where
     DB: Backend,
-    Predicate: QueryFragment<DB> + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
 {
     fn into(self) -> BoxedWhereClause<'a, DB> {
         BoxedWhereClause::Where(Box::new(self.0))
@@ -125,7 +125,7 @@ impl<QS, Expr> ValidWhereClause<QS> for WhereClause<Expr> where Expr: AppearsOnT
 
 #[allow(missing_debug_implementations)] // We can't...
 pub enum BoxedWhereClause<'a, DB> {
-    Where(Box<dyn QueryFragment<DB> + 'a>),
+    Where(Box<dyn QueryFragment<DB> + Send + 'a>),
     None,
 }
 
@@ -153,7 +153,7 @@ impl<'a, DB> QueryId for BoxedWhereClause<'a, DB> {
 impl<'a, DB, Predicate> WhereAnd<Predicate> for BoxedWhereClause<'a, DB>
 where
     DB: Backend + 'a,
-    Predicate: QueryFragment<DB> + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
 {
     type Output = Self;
 
@@ -170,7 +170,7 @@ where
 impl<'a, DB, Predicate> WhereOr<Predicate> for BoxedWhereClause<'a, DB>
 where
     DB: Backend + 'a,
-    Predicate: QueryFragment<DB> + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
 {
     type Output = Self;
 


### PR DESCRIPTION
Fixes #1625 

---

Motivation is to enable conditional queries to be executed asynchronously _now_. The current version of my async adapter ( see https://github.com/mehcode/actix-diesel ) requires the query to be `Send`.

Hoping that the incoming 2.0 bump will let us make these breaking changes.