### PR TITLE
fix some issues encountered while trying to follow CONTRIBUTING.md

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 if [ "$1" = "integration" ]; then
   if [ "$2" ]; then

--- a/bin/test
+++ b/bin/test
@@ -17,7 +17,8 @@ elif [ "$1" = "compile" ]; then
   shift
   (cd diesel_compile_tests && cargo test $*)
 else
-  (cd diesel && cargo test --no-default-features --features "extras sqlite postgres mysql" $*)
+  (cd diesel && cargo test --no-default-features --features "extras sqlite postgres" $*)
+  (cd diesel && RUST_TEST_THREADS=1 cargo test --no-default-features --features "mysql" $*)
 
   (cd diesel_cli && cargo test --features "sqlite" --no-default-features $*)
   (cd diesel_migrations && cargo test --features "sqlite diesel/sqlite" $*)

--- a/docker/mysql/init/init.sql
+++ b/docker/mysql/init/init.sql
@@ -1,3 +1,3 @@
 CREATE DATABASE IF NOT EXISTS diesel_test;
 CREATE DATABASE IF NOT EXISTS diesel_unit_test;
-GRANT ALL ON `diesel_%`.* TO ''@'localhost;
+GRANT ALL ON `diesel_%`.* TO 'root'@'localhost';


### PR DESCRIPTION
Hi, I was trying to set up a development environment as described in https://github.com/diesel-rs/diesel/blob/master/CONTRIBUTING.md#setting-up-diesel-locally
but did not succeed and put the fixes which helped me get closer to a running state in this PR.
I was still unable to run `bin/test` successfully, but I got much further with these commits.

Where my `bin/test` currently fails for me with these changes (as mentioned above, could not even run it as far before) is in the `diesel_tests` with `mysql` (line 37 of the changed `bin/test`).
The output I am getting is:
```
failures:                                                                         
                                                                                             
---- expressions::ops::dividing_column stdout ----                                           
thread 'expressions::ops::dividing_column' panicked at 'assertion failed: `(left == right)`      
  left: `Ok([0, 1])`,                                                                        
 right: `Err(DeserializationError(StringError("Numeric overflow/underflow occurred")))`', diesel_tests/tests/expressions/ops.rs:95:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.                            
                                                                              
---- expressions::ops::mix_and_match_all_numeric_ops stdout ----              
thread 'expressions::ops::mix_and_match_all_numeric_ops' panicked at 'assertion failed: `(left == right)`
  left: `Ok([4, 6, 7, 9])`,                                              
 right: `Err(DeserializationError(StringError("Numeric overflow/underflow occurred")))`', diesel_tests/tests/expressions/ops.rs:191:5
                                                                                                       
---- expressions::ops::test_dividing_nullables stdout ----                                       
thread 'expressions::ops::test_dividing_nullables' panicked at 'assertion failed: `(left == right)`
  left: `Ok([None, None, Some(0), Some(1), Some(0)])`,                                
 right: `Err(DeserializationError(StringError("Numeric overflow/underflow occurred")))`', diesel_tests/tests/expressions/ops.rs:165:5
                                                                          
                                                                                  
failures:                                                                                          
    expressions::ops::dividing_column                                                 
    expressions::ops::mix_and_match_all_numeric_ops                                    
    expressions::ops::test_dividing_nullables                                          
                                                                            
test result: FAILED. 190 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out
```
Any ideas on getting this even further would be greatly appreciated.