### PR TITLE
Use more compact encoding for NUMERIC with leading group(s) of 0

### DIFF
--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -104,10 +104,7 @@ mod bigdecimal {
             let weight = digits.len() as i16 - digits_after_decimal as i16 - 1;
 
             let unnecessary_zeroes = if weight >= 0 {
-                let index_of_decimal = (weight + 1) as usize;
                 digits
-                    .get(index_of_decimal..)
-                    .expect("enough digits exist")
                     .iter()
                     .rev()
                     .take_while(|i| i.is_zero())
@@ -185,7 +182,7 @@ mod bigdecimal {
             let expected = PgNumeric::Positive {
                 weight: 1,
                 scale: 0,
-                digits: vec![1, 0],
+                digits: vec![1],
             };
             assert_eq!(expected, decimal.into());
 
@@ -201,7 +198,7 @@ mod bigdecimal {
             let expected = PgNumeric::Positive {
                 weight: 2,
                 scale: 0,
-                digits: vec![1, 0, 0],
+                digits: vec![1],
             };
             assert_eq!(expected, decimal.into());
         }

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -104,11 +104,7 @@ mod bigdecimal {
             let weight = digits.len() as i16 - digits_after_decimal as i16 - 1;
 
             let unnecessary_zeroes = if weight >= 0 {
-                digits
-                    .iter()
-                    .rev()
-                    .take_while(|i| i.is_zero())
-                    .count()
+                digits.iter().rev().take_while(|i| i.is_zero()).count()
             } else {
                 0
             };


### PR DESCRIPTION
Diesel is not using the most compact possible encoding for NUMERIC values that end with at least one group of "0000" in their decimal representation.

For example, the value `'100000000'::numeric` can be encoded two ways using the Postgres binary protocol:

1/ `weight==2 scale==0 sign==0 digits==[1, 0, 0]`
2/ `weight==2 scale==0 sign==0 digits==[1]`

The Postgres server accepts both encodings, but the second one should be preferred since it is more compact on the wire (it is also the encoding used by the official `libpq` client library).

We discovered this because some other Postgres-compatible servers (CockroachDB in our case) handle the first form (used by Diesel) incorrectly, leading to data corruption issues. To be fair, this is a problem on their side, and not a sufficient reason to change Diesel's behaviour, but as this PR demonstrates, producing the compact format actually makes the Diesel code simpler AND more efficient.

This PR has been tested on both PostgreSQL 10 and CockroackDB 2.1.5, and works in both cases.