### PR TITLE
Fix missing error information when running embedded migrations.

### DIFF
--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -46,6 +46,10 @@ pub fn derive_embed_migrations(input: &syn::DeriveInput) -> quote::Tokens {
             fn revert(&self, _conn: &SimpleConnection) -> Result<(), RunMigrationsError> {
                 unreachable!()
             }
+
+            fn file_path(&self) -> Option<&Path> {
+                Some(Path::new(self.version))
+            }
         }
     );
 
@@ -69,6 +73,7 @@ pub fn derive_embed_migrations(input: &syn::DeriveInput) -> quote::Tokens {
         use self::diesel_migrations::*;
         use self::diesel::connection::SimpleConnection;
         use std::io;
+        use std::path::Path;
 
         const ALL_MIGRATIONS: &[&Migration] = &[#(#migrations_expr),*];
 


### PR DESCRIPTION
When using embedded migrations, all error information is currently lost due to a mysterious `formatting error` replacing the actual error. The error itself is not important, as long as it happens within the migration run. For example, the following migration:

**up.sql**
```
SELECT 1 FROM does_not_exist;
```

Executed with:

```rust
embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("unable to migrate");
```

Will result in the following output:

> Running migration 20190221123919
> thread 'main' panicked at 'unable to migrate: MigrationError(IoError(Custom { kind: Other, error: StringError("formatter error") }))', src/libcore/result.rs:997:5
> note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
> Executing migration script

What SHOULD be shown is something along the lines of:

> thread 'main' panicked at 'unable to migrate: QueryError(DatabaseError(__Unknown, "relation \"does_not_exist\" does not exist"))', src/libcore/result.rs:997:5

It turns out that the reason is very simple. Upon encountering an error, diesel attempts to display the filename of the failed migration:

https://github.com/diesel-rs/diesel/blob/03ec1d96ffa8a4f957ba6dc9bd5ab5b556a96d12/diesel_migrations/migrations_internals/src/lib.rs#L337-L344

Since the embedded migration's `impl Migration` is left without a `file_path()` implementation:

https://github.com/diesel-rs/diesel/blob/03ec1d96ffa8a4f957ba6dc9bd5ab5b556a96d12/diesel_migrations/migrations_macros/src/embed_migrations.rs#L37-L49

...  it returns the default `None`, which then triggers the formatting error here:

https://github.com/diesel-rs/diesel/blob/03ec1d96ffa8a4f957ba6dc9bd5ab5b556a96d12/diesel_migrations/migrations_internals/src/migration.rs#L49-L52

And since the `writeln!()` for the error message uses `?`, the formatting error from above ends up replacing the original error entirely.

This PR introduces a fake path based on the version identifier that lets things proceed as usual while providing useful information.

Fixes #1977 