### PR TITLE
Deprecate the `diesel_` prefixed macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   have been. All types in Diesel are now correctly only considered
   non-aggregate if their parts are.
 
+### Deprecated
+
+* `diesel_(prefix|postfix|infix)_operator!` have been deprecated. These macros
+  are now available without the `diesel_` prefix. With Rust 2018 they can be
+  invoked as `diesel::infix_operator!` instead.
 
 
 

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -89,8 +89,8 @@ use dsl::AsExprOf;
 ///
 /// Apps should not need to implement this type directly, but it may be common
 /// to use this in where clauses. Libraries should consider using
-/// [`diesel_infix_operator!`](../macro.diesel_infix_operator.html) or
-/// [`diesel_postfix_operator!`](../macro.diesel_postfix_operator.html) instead of
+/// [`infix_operator!`](../macro.infix_operator.html) or
+/// [`postfix_operator!`](../macro.postfix_operator.html) instead of
 /// implementing this directly.
 pub trait Expression {
     /// The type that this expression represents in SQL

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -354,6 +354,7 @@ macro_rules! prefix_operator {
 #[macro_export]
 #[deprecated(since = "2.0.0", note = "use `diesel::prefix_operator!` instead")]
 #[cfg(feature = "with-deprecated")]
+#[doc(hidden)]
 macro_rules! diesel_prefix_operator {
     ($($args:tt)*) => {
         prefix_operator!($($args)*);

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -299,6 +299,7 @@ macro_rules! postfix_operator {
 #[macro_export]
 #[deprecated(since = "2.0.0", note = "use `diesel::postfix_operator!` instead")]
 #[cfg(feature = "with-deprecated")]
+#[doc(hidden)]
 macro_rules! diesel_postfix_operator {
     ($($args:tt)*) => {
         postfix_operator!($($args)*);

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -160,22 +160,22 @@ macro_rules! __diesel_operator_to_sql {
 ///
 /// ```ignore
 /// // The SQL type will be boolean. The backend will not be constrained
-/// diesel_infix_operator!(Matches, " @@ ");
+/// infix_operator!(Matches, " @@ ");
 ///
 /// // Queries which try to execute `Contains` on a backend other than Pg
 /// // will fail to compile
-/// diesel_infix_operator!(Contains, " @> ", backend: Pg);
+/// infix_operator!(Contains, " @> ", backend: Pg);
 ///
 /// // The type of `Concat` will be `TsVector` rather than Bool
-/// diesel_infix_operator!(Concat, " || ", TsVector);
+/// infix_operator!(Concat, " || ", TsVector);
 ///
 /// // It is perfectly fine to have multiple operators with the same SQL.
 /// // Diesel will ensure that the queries are always unambiguous in which
 /// // operator applies
-/// diesel_infix_operator!(Or, " || ", TsQuery);
+/// infix_operator!(Or, " || ", TsQuery);
 ///
 /// // Specifying both the return types and the backend
-/// diesel_infix_operator!(And, " && ", TsQuery, backend: Pg);
+/// infix_operator!(And, " && ", TsQuery, backend: Pg);
 /// ```
 ///
 /// ## Example usage
@@ -187,7 +187,7 @@ macro_rules! __diesel_operator_to_sql {
 /// # fn main() {
 /// #     use schema::users::dsl::*;
 /// #     let connection = establish_connection();
-/// diesel_infix_operator!(MyEq, " = ");
+/// infix_operator!(MyEq, " = ");
 ///
 /// use diesel::expression::AsExpression;
 ///
@@ -205,13 +205,13 @@ macro_rules! __diesel_operator_to_sql {
 /// # }
 /// ```
 #[macro_export]
-macro_rules! diesel_infix_operator {
+macro_rules! infix_operator {
     ($name:ident, $operator:expr) => {
-        diesel_infix_operator!($name, $operator, $crate::sql_types::Bool);
+        infix_operator!($name, $operator, $crate::sql_types::Bool);
     };
 
     ($name:ident, $operator:expr, backend: $backend:ty) => {
-        diesel_infix_operator!($name, $operator, $crate::sql_types::Bool, backend: $backend);
+        infix_operator!($name, $operator, $crate::sql_types::Bool, backend: $backend);
     };
 
     ($name:ident, $operator:expr, $($return_ty:tt)::*) => {
@@ -241,22 +241,31 @@ macro_rules! diesel_infix_operator {
     };
 }
 
+#[macro_export]
+#[deprecated(since = "2.0.0", note = "use `diesel::infix_operator!` instead")]
+#[cfg(feature = "with-deprecated")]
+macro_rules! diesel_infix_operator {
+    ($($args:tt)*) => {
+        infix_operator!($($args)*);
+    }
+}
+
 /// Useful for libraries adding support for new SQL types. Apps should never
 /// need to call this.
 ///
-/// Similar to [`diesel_infix_operator!`], but the generated type will only take
+/// Similar to [`infix_operator!`], but the generated type will only take
 /// a single argument rather than two. The operator SQL will be placed after
-/// the single argument. See [`diesel_infix_operator!`] for example usage.
+/// the single argument. See [`infix_operator!`] for example usage.
 ///
-/// [`diesel_infix_operator!`]: macro.diesel_infix_operator.html
+/// [`infix_operator!`]: macro.infix_operator.html
 #[macro_export]
-macro_rules! diesel_postfix_operator {
+macro_rules! postfix_operator {
     ($name:ident, $operator:expr) => {
-        diesel_postfix_operator!($name, $operator, $crate::sql_types::Bool);
+        postfix_operator!($name, $operator, $crate::sql_types::Bool);
     };
 
     ($name:ident, $operator:expr, backend: $backend:ty) => {
-        diesel_postfix_operator!($name, $operator, $crate::sql_types::Bool, backend: $backend);
+        postfix_operator!($name, $operator, $crate::sql_types::Bool, backend: $backend);
     };
 
     ($name:ident, $operator:expr, $return_ty:ty) => {
@@ -284,24 +293,33 @@ macro_rules! diesel_postfix_operator {
             backend_ty = $backend,
         );
     };
+}
+
+#[macro_export]
+#[deprecated(since = "2.0.0", note = "use `diesel::postfix_operator!` instead")]
+#[cfg(feature = "with-deprecated")]
+macro_rules! diesel_postfix_operator {
+    ($($args:tt)*) => {
+        postfix_operator!($($args)*);
+    }
 }
 
 /// Useful for libraries adding support for new SQL types. Apps should never
 /// need to call this.
 ///
-/// Similar to [`diesel_infix_operator!`], but the generated type will only take
+/// Similar to [`infix_operator!`], but the generated type will only take
 /// a single argument rather than two. The operator SQL will be placed before
-/// the single argument. See [`diesel_infix_operator!`] for example usage.
+/// the single argument. See [`infix_operator!`] for example usage.
 ///
-/// [`diesel_infix_operator!`]: macro.diesel_infix_operator.html
+/// [`infix_operator!`]: macro.infix_operator.html
 #[macro_export]
-macro_rules! diesel_prefix_operator {
+macro_rules! prefix_operator {
     ($name:ident, $operator:expr) => {
-        diesel_prefix_operator!($name, $operator, $crate::sql_types::Bool);
+        prefix_operator!($name, $operator, $crate::sql_types::Bool);
     };
 
     ($name:ident, $operator:expr, backend: $backend:ty) => {
-        diesel_prefix_operator!($name, $operator, $crate::sql_types::Bool, backend: $backend);
+        prefix_operator!($name, $operator, $crate::sql_types::Bool, backend: $backend);
     };
 
     ($name:ident, $operator:expr, $return_ty:ty) => {
@@ -331,27 +349,36 @@ macro_rules! diesel_prefix_operator {
     };
 }
 
-diesel_infix_operator!(Concat, " || ", ReturnBasedOnArgs);
-diesel_infix_operator!(And, " AND ");
-diesel_infix_operator!(Between, " BETWEEN ");
-diesel_infix_operator!(Escape, " ESCAPE ");
-diesel_infix_operator!(Eq, " = ");
-diesel_infix_operator!(Gt, " > ");
-diesel_infix_operator!(GtEq, " >= ");
-diesel_infix_operator!(Like, " LIKE ");
-diesel_infix_operator!(Lt, " < ");
-diesel_infix_operator!(LtEq, " <= ");
-diesel_infix_operator!(NotBetween, " NOT BETWEEN ");
-diesel_infix_operator!(NotEq, " != ");
-diesel_infix_operator!(NotLike, " NOT LIKE ");
-diesel_infix_operator!(Or, " OR ");
+#[macro_export]
+#[deprecated(since = "2.0.0", note = "use `diesel::prefix_operator!` instead")]
+#[cfg(feature = "with-deprecated")]
+macro_rules! diesel_prefix_operator {
+    ($($args:tt)*) => {
+        prefix_operator!($($args)*);
+    }
+}
 
-diesel_postfix_operator!(IsNull, " IS NULL");
-diesel_postfix_operator!(IsNotNull, " IS NOT NULL");
-diesel_postfix_operator!(Asc, " ASC", ());
-diesel_postfix_operator!(Desc, " DESC", ());
+infix_operator!(Concat, " || ", ReturnBasedOnArgs);
+infix_operator!(And, " AND ");
+infix_operator!(Between, " BETWEEN ");
+infix_operator!(Escape, " ESCAPE ");
+infix_operator!(Eq, " = ");
+infix_operator!(Gt, " > ");
+infix_operator!(GtEq, " >= ");
+infix_operator!(Like, " LIKE ");
+infix_operator!(Lt, " < ");
+infix_operator!(LtEq, " <= ");
+infix_operator!(NotBetween, " NOT BETWEEN ");
+infix_operator!(NotEq, " != ");
+infix_operator!(NotLike, " NOT LIKE ");
+infix_operator!(Or, " OR ");
 
-diesel_prefix_operator!(Not, "NOT ");
+postfix_operator!(IsNull, " IS NULL");
+postfix_operator!(IsNotNull, " IS NOT NULL");
+postfix_operator!(Asc, " ASC", ());
+postfix_operator!(Desc, " DESC", ());
+
+prefix_operator!(Not, "NOT ");
 
 use insertable::{ColumnInsertValue, Insertable};
 use query_builder::ValuesClause;

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -244,6 +244,7 @@ macro_rules! infix_operator {
 #[macro_export]
 #[deprecated(since = "2.0.0", note = "use `diesel::infix_operator!` instead")]
 #[cfg(feature = "with-deprecated")]
+#[doc(hidden)]
 macro_rules! diesel_infix_operator {
     ($($args:tt)*) => {
         infix_operator!($($args)*);

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,11 +1,11 @@
 use pg::Pg;
 
-diesel_infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
-diesel_infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
-diesel_infix_operator!(OverlapsWith, " && ", backend: Pg);
-diesel_infix_operator!(Contains, " @> ", backend: Pg);
-diesel_infix_operator!(IsContainedBy, " <@ ", backend: Pg);
-diesel_infix_operator!(ILike, " ILIKE ", backend: Pg);
-diesel_infix_operator!(NotILike, " NOT ILIKE ", backend: Pg);
-diesel_postfix_operator!(NullsFirst, " NULLS FIRST", (), backend: Pg);
-diesel_postfix_operator!(NullsLast, " NULLS LAST", (), backend: Pg);
+infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
+infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
+infix_operator!(OverlapsWith, " && ", backend: Pg);
+infix_operator!(Contains, " @> ", backend: Pg);
+infix_operator!(IsContainedBy, " <@ ", backend: Pg);
+infix_operator!(ILike, " ILIKE ", backend: Pg);
+infix_operator!(NotILike, " NOT ILIKE ", backend: Pg);
+postfix_operator!(NullsFirst, " NULLS FIRST", (), backend: Pg);
+postfix_operator!(NullsLast, " NULLS LAST", (), backend: Pg);


### PR DESCRIPTION
In Rust 2018 you can write `diesel::some_macro!`, removing the need for
the `diesel_` prefix on these generically named macros. Note that this
commit by itself does not make these macros usable in that form, we
either need to replace all `#[macro_export]` with
`#[macro_export(local_inner_macros)]` or prefix all macro invocations
with `$crate::` for that to be possible. The latter is planned prior to
the 2.0 release.

I want to do a similar deprecation for `#[derive(DieselNumericOps)` and
`#[diesel(...)]`, but those require a bit more investigation/design.