### PR TITLE
Correct suggested type to match diesel::sql_types

### DIFF
--- a/diesel/src/type_impls/integers.rs
+++ b/diesel/src/type_impls/integers.rs
@@ -47,12 +47,12 @@ where
         debug_assert!(
             bytes.len() <= 4,
             "Received more than 4 bytes decoding i32. \
-             Was a BigInteger expression accidentally identified as Integer?"
+             Was a BigInt expression accidentally identified as Integer?"
         );
         debug_assert!(
             bytes.len() >= 4,
             "Received fewer than 4 bytes decoding i32. \
-             Was a SmallInteger expression accidentally identified as Integer?"
+             Was a SmallInt expression accidentally identified as Integer?"
         );
         bytes
             .read_i32::<DB::ByteOrder>()
@@ -77,12 +77,12 @@ where
         debug_assert!(
             bytes.len() <= 8,
             "Received more than 8 bytes decoding i64. \
-             Was an expression of a different type misidentified as BigInteger?"
+             Was an expression of a different type misidentified as BigInt?"
         );
         debug_assert!(
             bytes.len() >= 8,
             "Received fewer than 8 bytes decoding i64. \
-             Was an Integer expression misidentified as BigInteger?"
+             Was an Integer expression misidentified as BigInt?"
         );
         bytes
             .read_i64::<DB::ByteOrder>()


### PR DESCRIPTION
The SmallInt messages were inconsistent (some were SmallInt and others SmallInteger), and it was BigInteger everywhere. Corrected the types suggested so they match those in the diesel::sql_types.