### PR TITLE
Bumping minimum supported barrel version

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.0", features = ["derive"] }
 tempfile = "3.0.0"
 toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
-barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
+barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
 libsqlite3-sys = { version = ">=0.8.0, <0.13.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 
 [dev-dependencies]

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "http://diesel.rs"
 
 [dependencies]
 diesel = { version = "~1.4.0", default-features = false }
-barrel = { version = "<= 0.2.0", optional = true, features = ["diesel-filled"] }
+barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
 
 [dev-dependencies]
 tempdir = "0.3.4"


### PR DESCRIPTION
This PR bumps the minimum version of barrel that is supported.
There have recently been a few fixes in the integration and also
starting with `0.5.0` the API will become more stable, leading up
to the `1.0.0` release soon™