### PR TITLE
R2D2 transaction check

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -94,6 +94,7 @@ where
 
     fn is_valid(&self, conn: &mut T) -> Result<(), Error> {
         if conn.transaction_manager().get_transaction_depth() > 0 {
+            println!("Connection still open, can't reuse");
             Err(Error::InvalidConnectionError("An uncommitted transaction from the previous connection is still present".to_owned()))
         } else{
             Ok(())

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -94,8 +94,9 @@ where
 
     fn is_valid(&self, conn: &mut T) -> Result<(), Error> {
         if conn.transaction_manager().get_transaction_depth() > 0 {
-            Err(Error::InvalidConnectionError("An uncommitted transaction from the previous connection is still present".to_owned()))
-        } else{
+            Err(Error::InvalidConnectionError(
+                "An uncommitted transaction from the previous connection is still present".to_owned()))
+        } else {
             conn.execute("SELECT 1")
                 .map(|_| ())
                 .map_err(Error::QueryError)
@@ -103,6 +104,8 @@ where
     }
 
     fn has_broken(&self, conn: &mut T) -> bool {
+        // If there is a transaction open, it should not be put back into the pool, otherwise
+        // the next thread to get connection will be working on data that is potentially invalid
         conn.transaction_manager().get_transaction_depth() > 0
     }
 }

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -93,6 +93,7 @@ where
     }
 
     fn is_valid(&self, conn: &mut T) -> Result<(), Error> {
+        println!("checking Is valid");
         if conn.transaction_manager().get_transaction_depth() > 0 {
             println!("Connection still open, can't reuse");
             Err(Error::InvalidConnectionError("An uncommitted transaction from the previous connection is still present".to_owned()))

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -102,7 +102,7 @@ where
         }
     }
 
-    fn has_broken(&self, _conn: &mut T) -> bool {
+    fn has_broken(&self, conn: &mut T) -> bool {
         conn.transaction_manager().get_transaction_depth() > 0
     }
 }

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -93,17 +93,17 @@ where
     }
 
     fn is_valid(&self, conn: &mut T) -> Result<(), Error> {
-        println!("checking Is valid");
         if conn.transaction_manager().get_transaction_depth() > 0 {
-            println!("Connection still open, can't reuse");
             Err(Error::InvalidConnectionError("An uncommitted transaction from the previous connection is still present".to_owned()))
         } else{
-            Ok(())
+            conn.execute("SELECT 1")
+                .map(|_| ())
+                .map_err(Error::QueryError)
         }
     }
 
     fn has_broken(&self, _conn: &mut T) -> bool {
-        false
+        conn.transaction_manager().get_transaction_depth() > 0
     }
 }
 


### PR DESCRIPTION
Add a check to see if there is a transaction still open before giving the connection back to the pool.

We found that if the thread panics, the connection kept its locks, and potentially the next thread to pick up the connection could commit the data even if it was incorrect. There has been some fixes to R2D2 to check whether the thread has panicked, but this check should also catch any cases where a developer may have not called commit.