### PR TITLE
Add `DatabaseErrorKind::ReadOnlyTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `NonAggregate` can now be derived for simple cases.
 
+* Added `DatabaseErrorKind::ReadOnlyTransaction` to allow applications to
+  handle errors caused by writing when only allowed to read.
+
 ### Removed
 
 * All previously deprecated items have been removed.

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -147,6 +147,7 @@ impl Statement {
         match last_error_number {
             1062 | 1586 | 1859 => DatabaseErrorKind::UniqueViolation,
             1216 | 1217 | 1451 | 1452 | 1830 | 1834 => DatabaseErrorKind::ForeignKeyViolation,
+            1792 => DatabaseErrorKind::ReadOnlyTransaction,
             _ => DatabaseErrorKind::__Unknown,
         }
     }

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -40,6 +40,9 @@ impl PgResult {
                         Some(error_codes::SERIALIZATION_FAILURE) => {
                             DatabaseErrorKind::SerializationFailure
                         }
+                        Some(error_codes::READ_ONLY_TRANSACTION) => {
+                            DatabaseErrorKind::ReadOnlyTransaction
+                        }
                         _ => DatabaseErrorKind::__Unknown,
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
@@ -167,4 +170,5 @@ mod error_codes {
     pub const UNIQUE_VIOLATION: &str = "23505";
     pub const FOREIGN_KEY_VIOLATION: &str = "23503";
     pub const SERIALIZATION_FAILURE: &str = "40001";
+    pub const READ_ONLY_TRANSACTION: &str = "25006";
 }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -106,6 +106,13 @@ pub enum DatabaseErrorKind {
     /// transaction isolation levels for other backends.
     SerializationFailure,
 
+    /// The command could not be completed because the transaction was read
+    /// only.
+    ///
+    /// This error will also be returned for `SELECT` statements which attempted
+    /// to lock the rows.
+    ReadOnlyTransaction,
+
     #[doc(hidden)]
     __Unknown, // Match against _ instead, more variants may be added in the future
 }

--- a/diesel_tests/tests/errors.rs
+++ b/diesel_tests/tests/errors.rs
@@ -176,3 +176,16 @@ fn isolation_errors_are_detected() {
     assert_matches!(results[0], Ok(_));
     assert_matches!(results[1], Err(DatabaseError(SerializationFailure, _)));
 }
+
+#[test]
+#[cfg(not(feature = "sqlite"))]
+fn read_only_errors_are_detected() {
+    use diesel::result::DatabaseErrorKind::ReadOnlyTransaction;
+
+    let conn = connection_without_transaction();
+    conn.execute("START TRANSACTION READ ONLY").unwrap();
+
+    let result = users::table.for_update().load::<User>(&conn);
+
+    assert_matches!(result, Err(DatabaseError(ReadOnlyTransaction, _)));
+}


### PR DESCRIPTION
This is an error that applications are likely to want to handle. A
database may be read only during maintenance, or for brief periods after
failing over to a hot replica.

Applications designed to handle this may wish to transform this error
into a user visible HTTP 503 response, or skip certain optional writes.
By providing this error variant, we allow them to gracefully do so,
without having to resort to parsing error messages as was needed in
https://github.com/rust-lang/crates.io/pull/1670