### PR TITLE
Experiment with a Queryable implementation that does take field names in account

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -32,6 +32,7 @@ num-integer = { version = "0.1.32", optional = true }
 bigdecimal = { version = ">= 0.0.10, <= 0.0.15", optional = true }
 bitflags = { version = "1.0", optional = true }
 r2d2 = { version = ">= 0.8, < 0.9", optional = true }
+frunk = "0.3"
 
 [dev-dependencies]
 cfg-if = "0.1.0"

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -96,11 +96,12 @@
 #![cfg_attr(feature = "unstable", feature(specialization))]
 // Built-in Lints
 #![deny(
-    warnings,
+//    warnings,
     missing_debug_implementations,
     missing_copy_implementations,
-    missing_docs
+  //  missing_docs
 )]
+#![warn(missing_docs)]
 // Clippy lints
 #![allow(
     clippy::option_map_unwrap_or_else,
@@ -140,6 +141,8 @@ mod macros;
 #[cfg(test)]
 #[macro_use]
 extern crate cfg_if;
+#[macro_use]
+pub extern crate frunk;
 
 #[cfg(test)]
 pub mod test_helpers;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -12,7 +12,7 @@ macro_rules! __diesel_column {
     ) => {
         $($meta)*
         #[allow(non_camel_case_types, dead_code)]
-        #[derive(Debug, Clone, Copy, QueryId, Default)]
+        #[derive(Debug, Clone, Copy, QueryId, Default, NamedQueryFragment)]
         pub struct $column_name;
 
         impl $crate::expression::Expression for $column_name {

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -309,3 +309,24 @@ impl<T: Query> AsQuery for T {
 pub fn debug_query<DB, T>(query: &T) -> DebugQuery<T, DB> {
     DebugQuery::new(query)
 }
+
+pub trait NamedQueryFragment {
+    type Name;
+}
+
+macro_rules! named_query_fragment {
+    ($(
+        $Tuple:tt {
+            $(($idx:tt) -> $T:ident, $ST:ident, $TT:ident,)+
+        }
+    )+) => {
+        $(
+            impl<$($T,)*> NamedQueryFragment for ($($T,)*)
+            where $($T: NamedQueryFragment,)* {
+                type Name = ($($T::Name,)*);
+            }
+        )*
+    }
+}
+
+__diesel_for_each_tuple!(named_query_fragment);

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -50,3 +50,33 @@ where
         source.default_selection().walk_ast(pass)
     }
 }
+
+macro_rules! named_query_fragment {
+    ($(
+        $Tuple:tt {
+            $(($idx:tt) -> $T:ident, $ST:ident, $TT:ident,)+
+        }
+    )+) => {
+        $(
+
+            impl<$($T,)*> NamedQueryFragment for SelectClause<($($T,)*)>
+            where
+                $($T: NamedQueryFragment,)*
+            {
+                type Name = ($($T::Name,)*);
+            }
+
+        )*
+    }
+}
+
+__diesel_for_each_tuple!(named_query_fragment);
+
+use query_source::Column;
+
+impl<C> NamedQueryFragment for SelectClause<C>
+where
+    C: Column + NamedQueryFragment,
+{
+    type Name = (C::Name,);
+}

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -15,7 +15,9 @@ use query_builder::order_clause::*;
 use query_builder::select_clause::*;
 use query_builder::update_statement::*;
 use query_builder::where_clause::*;
-use query_builder::{AsQuery, Query, QueryFragment, SelectQuery, SelectStatement};
+use query_builder::{
+    AsQuery, NamedQueryFragment, Query, QueryFragment, SelectQuery, SelectStatement,
+};
 use query_dsl::boxed_dsl::BoxedDsl;
 use query_dsl::methods::*;
 use query_dsl::*;
@@ -512,4 +514,20 @@ where
             self.locking,
         )
     }
+}
+
+impl<F, S, D, W, O, L, Of, G> NamedQueryFragment for SelectStatement<F, S, D, W, O, L, Of, G>
+where
+    S: NamedQueryFragment,
+{
+    type Name = S::Name;
+}
+
+impl<F, D, W, O, L, Of, G> NamedQueryFragment
+    for SelectStatement<F, DefaultSelectClause, D, W, O, L, Of, G>
+where
+    F: QuerySource,
+    F::DefaultSelection: NamedQueryFragment,
+{
+    type Name = <F::DefaultSelection as NamedQueryFragment>::Name;
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -42,6 +42,8 @@ mod diesel_numeric_ops;
 mod from_sql_row;
 mod identifiable;
 mod insertable;
+mod named_query_fragment;
+mod named_queryable;
 mod non_aggregate;
 mod query_id;
 mod queryable;
@@ -117,6 +119,16 @@ pub fn derive_sql_type(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn sql_function_proc(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, sql_function::expand)
+}
+
+#[proc_macro_derive(NamedQueryFragment)]
+pub fn derive_named_query_fragment(input: TokenStream) -> TokenStream {
+    expand_proc_macro(input, named_query_fragment::derive)
+}
+
+#[proc_macro_derive(NamedQueryable)]
+pub fn derive_named_queryable(input: TokenStream) -> TokenStream {
+    expand_proc_macro(input, named_queryable::derive)
 }
 
 fn expand_proc_macro<T: syn::parse::Parse>(

--- a/diesel_derives/src/named_query_fragment.rs
+++ b/diesel_derives/src/named_query_fragment.rs
@@ -1,0 +1,33 @@
+use proc_macro2;
+use proc_macro2::*;
+use syn;
+
+use util::*;
+
+pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
+    let struct_name = &item.ident;
+
+    let chars = struct_name
+        .to_string()
+        .chars()
+        .map(|c| match c {
+            c @ 'a'..='z' | c @ 'A'..='Z' => c.to_string(),
+            c @ '0'..='9' | c @ '_' => format!("_{}", c),
+            _ => panic!("Unsupported name"),
+        })
+        .collect::<Vec<_>>();
+    let chars = chars
+        .iter()
+        .map(|c| Ident::new(c, Span::call_site()))
+        .map(|c| quote!(diesel::frunk::labelled::chars::#c));
+
+    let dummy_name = format!("_impl_named_query_fragment_for_{}", item.ident);
+    Ok(wrap_in_dummy_mod(
+        Ident::new(&dummy_name.to_lowercase(), Span::call_site()),
+        quote! {
+            impl diesel::query_builder::NamedQueryFragment for #struct_name {
+                type Name = (#(#chars,)*);
+            }
+        },
+    ))
+}

--- a/diesel_derives/src/named_queryable.rs
+++ b/diesel_derives/src/named_queryable.rs
@@ -1,0 +1,69 @@
+use proc_macro2;
+use proc_macro2::*;
+use syn;
+
+use field::FieldName;
+use model::Model;
+use util::*;
+
+pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
+    let model = Model::from_item(&item)?;
+
+    let struct_name = &item.ident;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let row = model
+        .fields()
+        .iter()
+        .map(|f| {
+            let ty = f.ty_for_deserialize()?;
+            if let FieldName::Named(ref name) = f.name {
+                let chars = name
+                    .to_string()
+                    .chars()
+                    .map(|c| match c {
+                        c @ 'a'..='z' | c @ 'A'..='Z' => c.to_string(),
+                        c @ '0'..='9' | c @ '_' => format!("_{}", c),
+                        _ => panic!("Unsupported name"),
+                    })
+                    .collect::<Vec<_>>();
+                let chars = chars
+                    .iter()
+                    .map(|c| Ident::new(c, Span::call_site()))
+                    .map(|c| quote!(diesel::frunk::labelled::chars::#c));
+                Ok(quote!(diesel::deserialize::Field<(#(#chars,)*), #ty>))
+            } else {
+                panic!("Only named fields are supported")
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let field_assign = model
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            let i = syn::Index::from(i);
+            f.name.assign(parse_quote!(row.#i.value))
+        })
+        .collect::<Vec<_>>();
+
+    let dummy_name = format!("_impl_named_queryable_for_{}", item.ident);
+    Ok(wrap_in_dummy_mod(
+        Ident::new(&dummy_name.to_lowercase(), Span::call_site()),
+        quote! {
+            impl#impl_generics diesel::deserialize::NamedQueryable for #struct_name #ty_generics
+                #where_clause
+            {
+                type Row = (#(#row,)*);
+
+                fn build(row: Self::Row) -> Self {
+                    Self {
+                        #(#field_assign,)*
+                    }
+                }
+            }
+        },
+    ))
+}

--- a/diesel_tests/tests/labeled_queryable.rs
+++ b/diesel_tests/tests/labeled_queryable.rs
@@ -1,0 +1,74 @@
+use super::schema::*;
+use diesel::connection::SimpleConnection;
+use diesel::*;
+use schema_dsl::*;
+
+use diesel::deserialize::Field;
+use diesel::deserialize::NamedQueryable;
+use diesel::frunk::labelled::chars::*;
+use diesel::frunk::{HCons, HNil};
+use diesel::query_dsl::load_dsl::labelled_query;
+
+#[derive(Debug, PartialEq, NamedQueryable)]
+struct ReorderedUser {
+    name: String,
+    id: i32,
+    hair_color: Option<String>,
+}
+
+#[test]
+fn selecting_basic_data() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    connection
+        .execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .unwrap();
+
+    let actual_data: Vec<ReorderedUser> =
+        labelled_query(users.select((hair_color, id, name)), &connection).unwrap();
+
+    let expected_data = vec![
+        ReorderedUser {
+            name: "Sean".into(),
+            id: 1,
+            hair_color: None,
+        },
+        ReorderedUser {
+            name: "Tess".into(),
+            id: 2,
+            hair_color: None,
+        },
+    ];
+
+    assert_eq!(expected_data, actual_data);
+}
+
+#[derive(Debug, PartialEq, NamedQueryable)]
+struct SingleFieldUser {
+    name: String,
+}
+
+#[test]
+fn selecting_single_field_data() {
+    use schema::users::dsl::*;
+
+    let connection = connection();
+    connection
+        .execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .unwrap();
+
+    let actual_data: Vec<SingleFieldUser> =
+        labelled_query(users.select(name), &connection).unwrap();
+
+    let expected_data = vec![
+        SingleFieldUser {
+            name: "Sean".into(),
+        },
+        SingleFieldUser {
+            name: "Tess".into(),
+        },
+    ];
+
+    assert_eq!(expected_data, actual_data);
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -51,6 +51,7 @@ mod transactions;
 mod types;
 mod types_roundtrip;
 mod update;
+mod labeled_queryable;
 
 #[cfg(rustfmt)]
 mod postgres_specific_schema;


### PR DESCRIPTION
So first the important things: I'm totally aware that code is currently not nicely structured or documented, that needs to be fixed before we think about merging this into diesel. Currently this is only a experiment to test some things out and maybe get some feedback if we really want something like this.

# Why?

A commonly mistake seems to be that people assume that deriving `Queryable` maps field by name and not by indices. This experiment is a try to provide something that is more in line with that expectation.

# How?

The idea is basically the same as that one behind frunk's labelled generics implementation, so I [just link their description ](https://beachape.com/blog/2017/03/04/labelledgeneric-in-rust-what-why-how/#how-it-works).
There are a few modifications to adapt that into something that could be used to implement this feature in such a way that actual loading continues to use indices internally. The mapping is done entirely at type after that.

# What is missing

Probably a lot

Open Questions:
- [ ] How do we handle boxed queries?
- [ ] This currently incoperates only field names, not table names. So this will fail as soon as a query involve fields with the same name from multiple tables. Maybe this is fixable
- [ ] Do we event want this thing?
- [ ] Is it ok to depend on frunk that way and convert forth and back to hlists
- [ ] How to incorporate this with `LoadDsl`?
- [ ] How to verify that this really optimized away?

Additional points to fix if we want this:
- [ ] Implement `FromHlist` for bigger `Hlist`'s 
- [ ] Cleanup
- [ ] Documentation
- [ ] More tests (specifically compile tests)