### PR TITLE
Added standard error handling procedure to call_with_conn! macro

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -109,7 +109,7 @@ macro_rules! call_with_conn {
         $database_url:expr,
         $($func:ident)::+ ($($args:expr),*)
     ) => {
-        match ::database::InferConnection::establish(&$database_url).unwrap() {
+        match ::database::InferConnection::establish(&$database_url).unwrap_or_else(handle_error) {
             #[cfg(feature="postgres")]
             ::database::InferConnection::Pg(ref conn) => $($func)::+ (conn, $($args),*),
             #[cfg(feature="sqlite")]


### PR DESCRIPTION
Closes #1980 

This should stop the invocations of certain cli commands from panicking
and instead print detailed error information from the backend.

I am currently too stupid to reproduce the steps in the issue because I'm unable to point cargo to my local diesel version :sweat_smile: 