### PR TITLE
Replace trim_right with trim_end

### DIFF
--- a/examples/postgres/getting_started_step_3/src/bin/write_post.rs
+++ b/examples/postgres/getting_started_step_3/src/bin/write_post.rs
@@ -12,7 +12,7 @@ fn main() {
 
     println!("What would you like your title to be?");
     stdin().read_line(&mut title).unwrap();
-    let title = title.trim_right(); // Remove the trailing newline
+    let title = title.trim_end(); // Remove the trailing newline
 
     println!(
         "\nOk! Let's write {} (Press {} when finished)\n",


### PR DESCRIPTION
According to the [doc](https://doc.rust-lang.org/std/primitive.str.html#method.trim_right), `trim_right` is deprecated since Rust 1.33.0 and superseded by `trim_end`. So I replaced `trim_right` with `trim_end`.