### PR TITLE
Remove `mut` keyword

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -427,7 +427,7 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), Box<E
                 .into());
             }
         } else {
-            let mut file = fs::File::create(path)?;
+            let file = fs::File::create(path)?;
             print_schema::output_schema(&database_url, &config.print_schema, file, path)?;
         }
     }


### PR DESCRIPTION
Recently nightly pipelines are failed because `file` variable is mutable unnecessarily.

The log:

```
error: variable does not need to be mutable
   --> diesel_cli/src/main.rs:430:17
    |
430 |             let mut file = fs::File::create(path)?;
    |                 ----^^^^
    |                 |
    |                 help: remove this `mut`
    |
note: lint level defined here
   --> diesel_cli/src/main.rs:2:9
    |
2   | #![deny(warnings, missing_copy_implementations)]
    |         ^^^^^^^^
    = note: #[deny(unused_mut)] implied by #[deny(warnings)]

error: aborting due to previous error
```

I'll fix this.