### PR TITLE
Fix rustdoc warning

### DIFF
--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -29,9 +29,9 @@ operator_allowed!(now, Sub, sub);
 sql_function! {
     /// Represents the SQL `DATE` function. The argument should be a Timestamp
     /// expression, and the return value will be an expression of type Date.
-
+    ///
     /// # Examples
-
+    ///
     /// ```ignore
     /// # #[macro_use] extern crate diesel;
     /// # extern crate chrono;


### PR DESCRIPTION
I found this warning in running rustdoc.

```
warning: doc comment contains an invalid Rust code block
  --> diesel/src/expression/functions/date_and_time.rs:30:5
   |
30 | /     /// Represents the SQL `DATE` function. The argument should be a Timestamp
31 | |     /// expression, and the return value will be an expression of type Date.
32 | |
33 | |     /// # Examples
...  |
44 | |     /// # }
45 | |     /// ```
   | |___________^
```

As far as I read other code, I think this fixes by adding `///`.

ref. https://github.com/rust-lang/rust/blob/bfb443eb1de484fde141fa9090a9f4291cbe60a5/src/libstd/error.rs#L73-L130
