### PR TITLE
Add `#[repr(transparent)]` to `PgMetadataLookup`

### DIFF
--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -3,6 +3,7 @@ use prelude::*;
 
 /// Determines the OID of types at runtime
 #[allow(missing_debug_implementations)]
+#[repr(transparent)]
 pub struct PgMetadataLookup {
     conn: PgConnection,
 }


### PR DESCRIPTION
Otherwise the constructor exploits implementation defined behaviour by
assuming a specific memory layout which may change in the future