### PR TITLE
Add SimpleConnection::as_pg_connection()

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -10,6 +10,8 @@ use deserialize::{Queryable, QueryableByName};
 use query_builder::{AsQuery, QueryFragment, QueryId};
 use result::*;
 use sql_types::HasSqlType;
+#[cfg(feature = "postgres")]
+use crate::pg::PgConnection;
 
 #[doc(hidden)]
 pub use self::statement_cache::{MaybeCached, StatementCache, StatementCacheKey};
@@ -24,6 +26,10 @@ pub trait SimpleConnection {
     /// This function is used to execute migrations,
     /// which may contain more than one SQL statement.
     fn batch_execute(&self, query: &str) -> QueryResult<()>;
+
+    /// Return the underlying `PgConnection` if it is one.
+    #[cfg(feature = "postgres")]
+    fn as_pg_connection(&self) -> Option<&PgConnection>;
 }
 
 /// A connection to a database

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -5,13 +5,13 @@ mod transaction_manager;
 
 use std::fmt::Debug;
 
+#[cfg(feature = "postgres")]
+use crate::pg::PgConnection;
 use backend::Backend;
 use deserialize::{Queryable, QueryableByName};
 use query_builder::{AsQuery, QueryFragment, QueryId};
 use result::*;
 use sql_types::HasSqlType;
-#[cfg(feature = "postgres")]
-use crate::pg::PgConnection;
 
 #[doc(hidden)]
 pub use self::statement_cache::{MaybeCached, StatementCache, StatementCacheKey};

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -37,7 +37,7 @@ impl Migration for Box<Migration> {
     }
 }
 
-impl<'a> Migration for &'a Migration {
+impl<'a, T: ?Sized + 'a + Migration> Migration for &'a T {
     fn version(&self) -> &str {
         (&**self).version()
     }

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -30,6 +30,11 @@ impl SimpleConnection for MysqlConnection {
         self.raw_connection
             .enable_multi_statements(|| self.raw_connection.execute(query))
     }
+
+    #[cfg(feature = "postgres")]
+    fn as_pg_connection(&self) -> Option<&crate::pg::PgConnection> {
+        None
+    }
 }
 
 impl Connection for MysqlConnection {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -40,6 +40,10 @@ impl SimpleConnection for PgConnection {
         PgResult::new(inner_result?)?;
         Ok(())
     }
+
+    fn as_pg_connection(&self) -> Option<&PgConnection> {
+        Some(self)
+    }
 }
 
 impl Connection for PgConnection {

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -105,6 +105,11 @@ where
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
         (&**self).batch_execute(query)
     }
+
+    #[cfg(feature = "postgres")]
+    fn as_pg_connection(&self) -> Option<&PgConnection> {
+        None
+    }
 }
 
 impl<M> Connection for PooledConnection<M>

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -43,6 +43,11 @@ impl SimpleConnection for SqliteConnection {
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
         self.raw_connection.exec(query)
     }
+
+    #[cfg(feature = "postgres")]
+    fn as_pg_connection(&self) -> Option<&crate::pg::PgConnection> {
+        None
+    }
 }
 
 impl Connection for SqliteConnection {

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -345,7 +345,7 @@ where
     })
 }
 
-fn revert_migration<Conn: Connection>(
+pub fn revert_migration<Conn: Connection>(
     conn: &Conn,
     migration: &Migration,
     output: &mut Write,

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -45,11 +45,14 @@ pub fn file_name<'a>(migration: &'a Migration, sql_file: &'a str) -> MigrationFi
 
 impl<'a> fmt::Display for MigrationFileName<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let fpath = match self.migration.file_path() {
-            None => return Err(fmt::Error),
-            Some(v) => v.join(self.sql_file),
+        match self.migration.file_path() {
+            None => f.write_str("<no file name>")?,
+            Some(v) => f.write_str(
+                v.join(self.sql_file)
+                    .to_str()
+                    .unwrap_or("Invalid utf8 in filename"),
+            )?,
         };
-        f.write_str(fpath.to_str().unwrap_or("Invalid utf8 in filename"))?;
         Ok(())
     }
 }

--- a/diesel_migrations/migrations_macros/src/lib.rs
+++ b/diesel_migrations/migrations_macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "128"]
 // Built-in Lints
 #![deny(warnings, missing_debug_implementations, missing_copy_implementations)]
 // Clippy lints
@@ -36,7 +37,10 @@ mod util;
 use proc_macro::TokenStream;
 use syn::DeriveInput;
 
-#[proc_macro_derive(EmbedMigrations, attributes(embed_migrations_options))]
+#[proc_macro_derive(
+    EmbedMigrations,
+    attributes(embed_migrations_options, embed_rust_migrations)
+)]
 pub fn derive_embed_migrations(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
     embed_migrations::derive_embed_migrations(&item)

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -97,6 +97,8 @@ pub use migrations_internals::revert_latest_migration;
 #[doc(inline)]
 pub use migrations_internals::revert_latest_migration_in_directory;
 #[doc(inline)]
+pub use migrations_internals::revert_migration;
+#[doc(inline)]
 pub use migrations_internals::revert_migration_with_version;
 #[doc(inline)]
 pub use migrations_internals::run_migration_with_version;

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -190,4 +190,14 @@ macro_rules! embed_migrations {
             struct _Dummy;
         }
     };
+
+    ($migrations_path:expr, [$($rust_migration:expr /* str */),*]) => {
+        #[allow(dead_code)]
+        mod embedded_migrations {
+            #[derive(EmbedMigrations)]
+            #[embed_migrations_options(migrations_path=$migrations_path)]
+            #[embed_rust_migrations($($rust_migration),*)]
+            struct _Dummy;
+        }
+    };
 }


### PR DESCRIPTION
This PR adds a new method `as_pg_connection` to the `SimpleConnection` trait:
```rust
    fn as_pg_connection(&self) -> Option<&PgConnection>;
```
The purpose of this is to allow Rust structs that impl `Migration` to do something useful.
Why is this method necessary? Currently, `Migration::run` only gets a `SimpleConnection` which only provides the method [`batch_execute`](https://docs.rs/diesel/1.4.0/diesel/connection/trait.SimpleConnection.html?search=#tymethod.batch_execute) that takes a raw sql query string and returns `QueryResult<()>`, thus it cannot be used to fetch values from any table, convert them in Rust code and then update the table with the new values (which is our primary use case for wanting to have migrations written in Rust).
With this method, it allows us to downcast the `SimpleConnection` to a `PgConnection` so that we can do useful (e.g. data-converting) migrations with it (e.g. re-hashing passwords or other things that wouldn't be easily possible in PL/pgSQL).

E.g. with this method, we can then write:
```rust
trait RustMigration {
    const VERSION: &'static str;

    fn run(&self, conn: &PgConnection) -> Result<(), RunMigrationsError>;

    ...
}

struct RustMigrationWrapper<T: RustMigration>(T);

impl<T: RustMigration> Migration for RustMigrationWrapper<T> {
    fn version(&self) -> &str {
        T::VERSION
    }

    fn run(&self, conn: &dyn SimpleConnection) -> Result<(), RunMigrationsError> {
        if let Some(conn) = conn.as_pg_connection() {
            <T as RustMigration>::run(&self.0, conn)
        } else {
            // Err
        }
    }

    ...
}
```

This is the first step towards being able to integrate Rust-based migrations with embedded migrations.
The next step is to extend the `embed_migrations` macro to accept as argument a list of structs that impl `Migration`, and to include those (chronologically) in the embedded migration array (`ALL_MIGRATIONS`).