### PR TITLE
Call `setup_database` in `any_pending_migrations`

### DIFF
--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -180,6 +180,7 @@ where
 {
     let migrations_dir = find_migrations_directory()?;
     let all_migrations = migrations_in_directory(&migrations_dir)?;
+    setup_database(conn)?;
     let already_run = conn.previously_run_migration_versions()?;
 
     let pending = all_migrations


### PR DESCRIPTION
This addresses https://github.com/diesel-rs/diesel/pull/1978#issuecomment-463140990 and makes `any_pending_migrations` usable for automatically checking for and running pending migrations.

This does have the downside of mutating the DB in a function that looks like it would be entirely read-only, but AFAIK Diesel has no way of detecting the error case we'd have to check for (missing Diesel migrations table).