### PR TITLE
`NULL` does not deserialize to `false` on Postgres

### DIFF
--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -7,10 +7,7 @@ use sql_types;
 
 impl FromSql<sql_types::Bool, Pg> for bool {
     fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        match bytes {
-            Some(bytes) => Ok(bytes[0] != 0),
-            None => Ok(false),
-        }
+        Ok(not_none!(bytes)[0] != 0)
     }
 }
 


### PR DESCRIPTION
This could happen due to #1459.
We're better off triggering an error rather than having `false`s propagating in the rest of the application logic.