### PR TITLE
Implement all expression method traits for nullable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added `DatabaseErrorKind::ReadOnlyTransaction` to allow applications to
   handle errors caused by writing when only allowed to read.
 
+* All expression methods can now be called on expressions of nullable types.
+
 ### Removed
 
 * All previously deprecated items have been removed.

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -2,13 +2,14 @@ use expression::Expression;
 use pg::Pg;
 use query_builder::*;
 use result::QueryResult;
-use sql_types::{Date, Timestamp, Timestamptz, VarChar};
+use sql_types::{Date, NotNull, Nullable, Timestamp, Timestamptz, VarChar};
 
 /// Marker trait for types which are valid in `AT TIME ZONE` expressions
 pub trait DateTimeLike {}
 impl DateTimeLike for Date {}
 impl DateTimeLike for Timestamp {}
 impl DateTimeLike for Timestamptz {}
+impl<T: NotNull + DateTimeLike> DateTimeLike for Nullable<T> {}
 
 #[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct AtTimeZone<Ts, Tz> {

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -138,7 +138,7 @@ pub trait PgTimestampExpressionMethods: Expression + Sized {
 impl<T: Expression> PgTimestampExpressionMethods for T where T::SqlType: DateTimeLike {}
 
 /// PostgreSQL specific methods present on array expressions.
-pub trait PgArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized {
+pub trait PgArrayExpressionMethods: Expression + Sized {
     /// Creates a PostgreSQL `&&` expression.
     ///
     /// This operator returns whether two arrays have common elements.
@@ -300,7 +300,21 @@ pub trait PgArrayExpressionMethods<ST>: Expression<SqlType = Array<ST>> + Sized 
     }
 }
 
-impl<T, ST> PgArrayExpressionMethods<ST> for T where T: Expression<SqlType = Array<ST>> {}
+impl<T> PgArrayExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: ArrayOrNullableArray,
+{
+}
+
+#[doc(hidden)]
+/// Marker trait used to implement `ArrayExpressionMethods` on the appropriate
+/// types. Once coherence takes associated types into account, we can remove
+/// this trait.
+pub trait ArrayOrNullableArray {}
+
+impl<T> ArrayOrNullableArray for Array<T> {}
+impl<T> ArrayOrNullableArray for Nullable<Array<T>> {}
 
 use expression::operators::{Asc, Desc};
 


### PR DESCRIPTION
This *should* be the last remaining places we've forgotten to do this.
The nullable impl for `BoolExpressionMethods` is probably overkill, but
I've done it anyway for completeness.

Fixes #2066