### PR TITLE
Interpret paths in diesel.toml as relative to the project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   any columns from `posts`. That will now fail to compile, and any selections
   from `posts` will need to be made explicitly nullable.
 
+* Diesel CLI will now look for `diesel.toml` to determine the project root
+  before looking for `Cargo.toml`.
+
+* Any relative paths in `diesel.toml` will now be treated as relative to the
+  project root (the directory containing either `diesel.toml` or `Cargo.toml`).
+  They are no longer dependent on the current working directory (for all
+  directories in the same project)
+
 ### Deprecated
 
 * `diesel_(prefix|postfix|infix)_operator!` have been deprecated. These macros

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -13,7 +13,7 @@ use crate::result;
 #[derive(Debug)]
 pub enum MigrationError {
     /// The migration directory wasn't found
-    MigrationDirectoryNotFound,
+    MigrationDirectoryNotFound(PathBuf),
     /// Provided migration was in an unknown format
     UnknownMigrationFormat(PathBuf),
     /// General system IO error
@@ -32,9 +32,10 @@ impl Error for MigrationError {}
 impl fmt::Display for MigrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
-            MigrationError::MigrationDirectoryNotFound => write!(
+            MigrationError::MigrationDirectoryNotFound(ref p) => write!(
                 f,
-                "Unable to find migrations directory in this directory or any parent directories."
+                "Unable to find migrations directory in {:?} or any parent directories.",
+                p
             ),
             MigrationError::UnknownMigrationFormat(_) => write!(
                 f,
@@ -59,8 +60,8 @@ impl PartialEq for MigrationError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (
-                &MigrationError::MigrationDirectoryNotFound,
-                &MigrationError::MigrationDirectoryNotFound,
+                &MigrationError::MigrationDirectoryNotFound(_),
+                &MigrationError::MigrationDirectoryNotFound(_),
             ) => true,
             (
                 &MigrationError::UnknownMigrationFormat(ref p1),

--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -1,4 +1,5 @@
 use clap::ArgMatches;
+use serde::Deserialize;
 use std::env;
 use std::error::Error;
 use std::fs;

--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::error::Error;
 use std::fs;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::find_project_root;
 use crate::print_schema;
@@ -31,11 +31,17 @@ impl Config {
 
         if path.exists() {
             let mut bytes = Vec::new();
-            fs::File::open(path)?.read_to_end(&mut bytes)?;
-            toml::from_slice(&bytes).map_err(Into::into)
+            fs::File::open(&path)?.read_to_end(&mut bytes)?;
+            let mut result = toml::from_slice::<Self>(&bytes)?;
+            result.set_relative_path_base(path.parent().unwrap());
+            Ok(result)
         } else {
             Ok(Self::default())
         }
+    }
+
+    fn set_relative_path_base(&mut self, base: &Path) {
+        self.print_schema.set_relative_path_base(base)
     }
 }
 
@@ -63,6 +69,20 @@ impl PrintSchema {
 
     pub fn import_types(&self) -> Option<&[String]> {
         self.import_types.as_ref().map(|v| &**v)
+    }
+
+    fn set_relative_path_base(&mut self, base: &Path) {
+        if let Some(ref mut file) = self.file {
+            if file.is_relative() {
+                *file = base.join(&file);
+            }
+        }
+
+        if let Some(ref mut patch_file) = self.patch_file {
+            if patch_file.is_relative() {
+                *patch_file = base.join(&patch_file);
+            }
+        }
     }
 }
 

--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -42,7 +42,10 @@ impl Config {
     }
 
     fn set_relative_path_base(&mut self, base: &Path) {
-        self.print_schema.set_relative_path_base(base)
+        self.print_schema.set_relative_path_base(base);
+        if let Some(ref mut migration) = self.migrations_directory {
+            migration.set_relative_path_base(base);
+        }
     }
 }
 
@@ -91,4 +94,12 @@ impl PrintSchema {
 #[serde(deny_unknown_fields)]
 pub struct MigrationsDirectory {
     pub dir: PathBuf,
+}
+
+impl MigrationsDirectory {
+    fn set_relative_path_base(&mut self, base: &Path) {
+        if self.dir.is_relative() {
+            self.dir = base.join(&self.dir);
+        }
+    }
 }

--- a/diesel_cli/src/database_error.rs
+++ b/diesel_cli/src/database_error.rs
@@ -10,7 +10,7 @@ pub type DatabaseResult<T> = Result<T, DatabaseError>;
 
 #[derive(Debug)]
 pub enum DatabaseError {
-    CargoTomlNotFound,
+    ProjectRootNotFound,
     DatabaseUrlMissing,
     IoError(io::Error),
     QueryError(result::Error),
@@ -40,8 +40,8 @@ impl Error for DatabaseError {}
 impl fmt::Display for DatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
-            CargoTomlNotFound => {
-                f.write_str("Unable to find Cargo.toml in this directory or any parent directories.")
+            ProjectRootNotFound => {
+                f.write_str("Unable to find diesel.toml or Cargo.toml in this directory or any parent directories.")
             }
             DatabaseUrlMissing => {
                 f.write_str("The --database-url argument must be passed, or the DATABASE_URL environment variable must be set.")
@@ -65,7 +65,7 @@ impl fmt::Display for DatabaseError {
 impl PartialEq for DatabaseError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (&CargoTomlNotFound, &CargoTomlNotFound) => true,
+            (&ProjectRootNotFound, &ProjectRootNotFound) => true,
             _ => false,
         }
     }

--- a/diesel_cli/src/database_error.rs
+++ b/diesel_cli/src/database_error.rs
@@ -2,6 +2,7 @@ use diesel::result;
 
 use std::convert::From;
 use std::error::Error;
+use std::path::PathBuf;
 use std::{fmt, io};
 
 use self::DatabaseError::*;
@@ -10,7 +11,7 @@ pub type DatabaseResult<T> = Result<T, DatabaseError>;
 
 #[derive(Debug)]
 pub enum DatabaseError {
-    ProjectRootNotFound,
+    ProjectRootNotFound(PathBuf),
     DatabaseUrlMissing,
     IoError(io::Error),
     QueryError(result::Error),
@@ -40,8 +41,8 @@ impl Error for DatabaseError {}
 impl fmt::Display for DatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
-            ProjectRootNotFound => {
-                f.write_str("Unable to find diesel.toml or Cargo.toml in this directory or any parent directories.")
+            ProjectRootNotFound(ref p) => {
+                write!(f, "Unable to find diesel.toml or Cargo.toml in {:?} or any parent directories.", p)
             }
             DatabaseUrlMissing => {
                 f.write_str("The --database-url argument must be passed, or the DATABASE_URL environment variable must be set.")
@@ -65,7 +66,7 @@ impl fmt::Display for DatabaseError {
 impl PartialEq for DatabaseError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (&ProjectRootNotFound, &ProjectRootNotFound) => true,
+            (&ProjectRootNotFound(_), &ProjectRootNotFound(_)) => true,
             _ => false,
         }
     }

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -199,12 +199,15 @@ fn migrations_dir(matches: &ArgMatches) -> Result<PathBuf, MigrationError> {
     let migrations_dir = migrations_dir_from_cli(matches)
         .or_else(|| env::var("MIGRATION_DIRECTORY").map(PathBuf::from).ok())
         .or_else(|| {
-            Some(
-                Config::read(matches)
-                    .unwrap_or_else(handle_error)
-                    .migrations_directory?
-                    .dir,
-            )
+            let mut project_root = find_project_root().ok()?;
+            let migrations_dir = Config::read(matches)
+                .unwrap_or_else(handle_error)
+                .migrations_directory?
+                .dir;
+
+            project_root.push(migrations_dir);
+
+            Some(project_root)
         });
 
     match migrations_dir {

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -316,7 +316,8 @@ fn search_for_directory_containing_file(path: &Path, file: &str) -> DatabaseResu
     } else {
         path.parent()
             .map(|p| search_for_directory_containing_file(p, file))
-            .unwrap_or(Err(DatabaseError::ProjectRootNotFound))
+            .unwrap_or_else(|| Err(DatabaseError::ProjectRootNotFound(path.into())))
+            .map_err(|_| DatabaseError::ProjectRootNotFound(path.into()))
     }
 }
 

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -14,25 +14,12 @@
 )]
 #![cfg_attr(test, allow(clippy::result_unwrap_used))]
 
-extern crate chrono;
-#[macro_use]
-extern crate clap;
 #[macro_use]
 extern crate diesel;
-extern crate dotenv;
-extern crate heck;
-extern crate migrations_internals;
 #[macro_use]
-extern crate serde;
-extern crate tempfile;
-extern crate toml;
-#[cfg(feature = "url")]
-extern crate url;
+extern crate clap;
 
 mod config;
-
-#[cfg(feature = "barrel-migrations")]
-extern crate barrel;
 
 mod database_error;
 #[macro_use]
@@ -59,7 +46,7 @@ use crate::migrations::MigrationError;
 use migrations_internals::TIMESTAMP_FORMAT;
 
 fn main() {
-    use self::dotenv::dotenv;
+    use dotenv::dotenv;
     dotenv().ok();
 
     let matches = cli::build_cli().get_matches();

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -199,15 +199,12 @@ fn migrations_dir(matches: &ArgMatches) -> Result<PathBuf, MigrationError> {
     let migrations_dir = migrations_dir_from_cli(matches)
         .or_else(|| env::var("MIGRATION_DIRECTORY").map(PathBuf::from).ok())
         .or_else(|| {
-            let mut project_root = find_project_root().ok()?;
-            let migrations_dir = Config::read(matches)
-                .unwrap_or_else(handle_error)
-                .migrations_directory?
-                .dir;
-
-            project_root.push(migrations_dir);
-
-            Some(project_root)
+            Some(
+                Config::read(matches)
+                    .unwrap_or_else(handle_error)
+                    .migrations_directory?
+                    .dir,
+            )
         });
 
     match migrations_dir {

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -500,7 +500,7 @@ mod tests {
         let temp_path = dir.path().canonicalize().unwrap();
 
         assert_eq!(
-            Err(DatabaseError::ProjectRootNotFound),
+            Err(DatabaseError::ProjectRootNotFound(temp_path.clone())),
             search_for_directory_containing_file(&temp_path, "Cargo.toml")
         );
     }

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -502,7 +502,8 @@ fn verify_schema_errors_if_schema_file_would_change() {
     assert!(
         result
             .stderr()
-            .contains("Command would result in changes to src/my_schema.rs"),
+            .contains("Command would result in changes to")
+            && result.stderr().contains("src/my_schema.rs"),
         "Unexpected stderr {}",
         result.stderr()
     );

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -115,6 +115,19 @@ fn print_schema_custom_types() {
     );
 }
 
+#[test]
+fn schema_file_is_relative_to_project_root() {
+    let p = project("schema_file_is_relative_to_project_root")
+        .folder("foo")
+        .build();
+    let _db = database(&p.database_url());
+
+    p.command("setup").run();
+    p.command("migration").arg("run").cd("foo").run();
+
+    assert!(p.has_file("src/schema.rs"));
+}
+
 #[cfg(feature = "sqlite")]
 const BACKEND: &str = "sqlite";
 #[cfg(feature = "postgres")]

--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -36,6 +36,11 @@ impl TestCommand {
         self
     }
 
+    pub fn cd<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.cwd.push(path);
+        self
+    }
+
     pub fn run(self) -> CommandResult {
         let output = self.build_command().output().unwrap();
         CommandResult { output: output }

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -404,7 +404,9 @@ mod tests {
         let dir = Builder::new().prefix("diesel").tempdir().unwrap();
 
         assert_eq!(
-            Err(MigrationError::MigrationDirectoryNotFound(dir.path().into())),
+            Err(MigrationError::MigrationDirectoryNotFound(
+                dir.path().into()
+            )),
             search_for_migrations_directory(dir.path())
         );
     }

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -384,8 +384,9 @@ pub fn search_for_migrations_directory(path: &Path) -> Result<PathBuf, Migration
         Ok(migration_path)
     } else {
         path.parent()
-            .map(search_for_migrations_directory)
-            .unwrap_or(Err(MigrationError::MigrationDirectoryNotFound))
+            .map(|p| search_for_migrations_directory(p))
+            .unwrap_or_else(|| Err(MigrationError::MigrationDirectoryNotFound(path.into())))
+            .map_err(|_| MigrationError::MigrationDirectoryNotFound(path.into()))
     }
 }
 

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
         let dir = Builder::new().prefix("diesel").tempdir().unwrap();
 
         assert_eq!(
-            Err(MigrationError::MigrationDirectoryNotFound),
+            Err(MigrationError::MigrationDirectoryNotFound(dir.path().into())),
             search_for_migrations_directory(dir.path())
         );
     }


### PR DESCRIPTION
I went ahead and also changed the search for project root to look for
`diesel.toml` first, which should improve our behavior in workspaces.

Fixes #2057.