### PR TITLE
Cache custom types OIDs on Postgres

### DIFF
--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -14,7 +14,7 @@ use self::result::PgResult;
 use self::stmt::Statement;
 use connection::*;
 use deserialize::{Queryable, QueryableByName};
-use pg::{Pg, PgMetadataCache, PgMetadataLookup, TransactionBuilder};
+use pg::{metadata_lookup::PgMetadataCache, Pg, PgMetadataLookup, TransactionBuilder};
 use query_builder::bind_collector::RawBytesBindCollector;
 use query_builder::*;
 use result::ConnectionError::CouldntSetupConfiguration;

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -14,7 +14,7 @@ use self::result::PgResult;
 use self::stmt::Statement;
 use connection::*;
 use deserialize::{Queryable, QueryableByName};
-use pg::{Pg, PgMetadataLookup, TransactionBuilder};
+use pg::{Pg, PgMetadataCache, PgMetadataLookup, TransactionBuilder};
 use query_builder::bind_collector::RawBytesBindCollector;
 use query_builder::*;
 use result::ConnectionError::CouldntSetupConfiguration;
@@ -29,6 +29,7 @@ pub struct PgConnection {
     raw_connection: RawConnection,
     transaction_manager: AnsiTransactionManager,
     statement_cache: StatementCache<Pg, Statement>,
+    metadata_cache: PgMetadataCache,
 }
 
 unsafe impl Send for PgConnection {}
@@ -52,6 +53,7 @@ impl Connection for PgConnection {
                 raw_connection: raw_conn,
                 transaction_manager: AnsiTransactionManager::new(),
                 statement_cache: StatementCache::new(),
+                metadata_cache: PgMetadataCache::new(),
             };
             conn.set_config_options()
                 .map_err(CouldntSetupConfiguration)?;
@@ -177,6 +179,10 @@ impl PgConnection {
         self.raw_connection
             .set_notice_processor(noop_notice_processor);
         Ok(())
+    }
+
+    pub(crate) fn get_metadata_cache(&self) -> &PgMetadataCache {
+        &self.metadata_cache
     }
 }
 

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -1,6 +1,9 @@
 use super::{PgConnection, PgTypeMetadata};
 use prelude::*;
 
+use std::cell::RefCell;
+use std::collections::HashMap;
+
 /// Determines the OID of types at runtime
 #[allow(missing_debug_implementations)]
 #[repr(transparent)]
@@ -20,13 +23,42 @@ impl PgMetadataLookup {
     /// come from an extension. This function may perform a SQL query to look
     /// up the type. For built-in types, a static OID should be preferred.
     pub fn lookup_type(&self, type_name: &str) -> PgTypeMetadata {
-        use self::pg_type::dsl::*;
+        let metadata_cache = self.conn.get_metadata_cache();
+        metadata_cache.lookup_type(type_name).unwrap_or_else(|| {
+            use self::pg_type::dsl::*;
 
-        pg_type
-            .select((oid, typarray))
-            .filter(typname.eq(type_name))
-            .first(&self.conn)
-            .unwrap_or_default()
+            let type_metadata = pg_type
+                .select((oid, typarray))
+                .filter(typname.eq(type_name))
+                .first(&self.conn)
+                .unwrap_or_default();
+            metadata_cache.store_type(type_name, type_metadata);
+            type_metadata
+        })
+    }
+}
+
+/// Stores a cache for the OID of custom types
+#[allow(missing_debug_implementations)]
+pub struct PgMetadataCache {
+    cache: RefCell<HashMap<String, PgTypeMetadata>>,
+}
+
+impl PgMetadataCache {
+    pub(crate) fn new() -> Self {
+        PgMetadataCache {
+            cache: RefCell::new(HashMap::new()),
+        }
+    }
+
+    fn lookup_type(&self, type_name: &str) -> Option<PgTypeMetadata> {
+        Some(*self.cache.borrow().get(type_name)?)
+    }
+
+    fn store_type(&self, type_name: &str, type_metadata: PgTypeMetadata) {
+        self.cache
+            .borrow_mut()
+            .insert(type_name.to_owned(), type_metadata);
     }
 }
 

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -17,7 +17,6 @@ mod transaction;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;
-pub use self::metadata_lookup::PgMetadataCache;
 pub use self::metadata_lookup::PgMetadataLookup;
 pub use self::query_builder::DistinctOnClause;
 pub use self::query_builder::PgQueryBuilder;

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -17,6 +17,7 @@ mod transaction;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;
+pub use self::metadata_lookup::PgMetadataCache;
 pub use self::metadata_lookup::PgMetadataLookup;
 pub use self::query_builder::DistinctOnClause;
 pub use self::query_builder::PgQueryBuilder;


### PR DESCRIPTION
Resolves #2071

This avoids sending one query per custom type bind, which caused a lot of back and forth to the database when inserting a large numbers of lines that used a custom type.

Note: The implementation was also discussed on the issue (#2071).