### PR TITLE
Adjust clippy config to reflect 'cyclomatic' -> 'cognitive' rename

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-cyclomatic-complexity-threshold = 30
+cognitive-complexity-threshold = 30
 doc-valid-idents = [
   "MiB", "GiB", "TiB", "PiB", "EiB",
   "DirectX", "OpenGL", "TrueType",

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -7,7 +7,7 @@ use meta::*;
 use util::*;
 
 // Extremely curious why this triggers on a nearly branchless function
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> {
     let SqlFunctionDecl {
         mut attributes,


### PR DESCRIPTION
In only one case is `allow` called with this lint, and there is also a reference in the `clippy.toml` configuration file. This (teensy) PR just updates the lint name to reflect the changes that have been made in the naming of this lint.