### PR TITLE
Use $crate and re-export diesels macros

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -431,3 +431,6 @@ pub trait Identifiable: HasTable {
 
 #[doc(inline)]
 pub use diesel_derives::Identifiable;
+
+#[doc(inline)]
+pub use diesel_derives::Associations;

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -428,3 +428,6 @@ pub trait Identifiable: HasTable {
     /// so that we have a lifetime to use for `Id`.
     fn id(self) -> Self::Id;
 }
+
+#[doc(inline)]
+pub use diesel_derives::Identifiable;

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -40,7 +40,7 @@ pub type Result<T> = result::Result<T, Box<dyn Error + Send + Sync>>;
 /// If we just want to map a query to our struct, we can use `derive`.
 ///
 /// ```rust
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// #
 /// #[derive(Queryable, PartialEq, Debug)]
@@ -67,7 +67,7 @@ pub type Result<T> = result::Result<T, Box<dyn Error + Send + Sync>>;
 /// `deserialize_as` to use a different implementation.
 ///
 /// ```rust
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// #
 /// # use schema::users;
@@ -118,7 +118,7 @@ pub type Result<T> = result::Result<T, Box<dyn Error + Send + Sync>>;
 /// Alternatively, we can implement the trait for our struct manually.
 ///
 /// ```rust
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// #
 /// use schema::users;
@@ -171,6 +171,9 @@ where
     fn build(row: Self::Row) -> Self;
 }
 
+#[doc(inline)]
+pub use diesel_derives::Queryable;
+
 /// Deserializes the result of a query constructed with [`sql_query`].
 ///
 /// # Deriving
@@ -207,7 +210,7 @@ where
 /// If we just want to map a query to our struct, we can use `derive`.
 ///
 /// ```rust
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// # use schema::users;
 /// # use diesel::sql_query;
@@ -237,7 +240,7 @@ where
 /// `deserialize_as` to use a different implementation.
 ///
 /// ```rust
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// # use diesel::sql_query;
 /// # use schema::users;
@@ -292,6 +295,9 @@ where
     /// Construct an instance of `Self` from the database row
     fn build<R: NamedRow<DB>>(row: &R) -> Result<Self>;
 }
+
+#[doc(inline)]
+pub use diesel_derives::QueryableByName;
 
 /// Deserialize a single field of a given SQL type.
 ///
@@ -375,6 +381,9 @@ pub trait FromSqlRow<A, DB: Backend>: Sized {
     /// See the trait documentation.
     fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self>;
 }
+
+#[doc(inline)]
+pub use diesel_derives::FromSqlRow;
 
 // Reasons we can't write this:
 //

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -213,6 +213,7 @@ pub use diesel_derives::Queryable;
 /// # extern crate diesel;
 /// # include!("doctest_setup.rs");
 /// # use schema::users;
+/// # use diesel::deserialize::QueryableByName;
 /// # use diesel::sql_query;
 /// #
 /// #[derive(QueryableByName, PartialEq, Debug)]
@@ -245,7 +246,7 @@ pub use diesel_derives::Queryable;
 /// # use diesel::sql_query;
 /// # use schema::users;
 /// # use diesel::backend::{self, Backend};
-/// # use diesel::deserialize::{self, FromSql};
+/// # use diesel::deserialize::{self, FromSql, QueryableByName};
 /// #
 /// struct LowercaseString(String);
 ///

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -197,7 +197,7 @@ fn database_url_from_env(backend_specific_env_var: &str) -> String {
 
 
 mod schema {
-    table! {
+    diesel::table! {
         animals {
             id -> Integer,
             species -> VarChar,
@@ -206,7 +206,7 @@ mod schema {
         }
     }
 
-    table! {
+    diesel::table! {
         comments {
             id -> Integer,
             post_id -> Integer,
@@ -214,7 +214,7 @@ mod schema {
         }
     }
 
-    table! {
+    diesel::table! {
         posts {
             id -> Integer,
             user_id -> Integer,
@@ -222,13 +222,13 @@ mod schema {
         }
     }
 
-    table! {
+    diesel::table! {
         users {
             id -> Integer,
             name -> VarChar,
         }
     }
 
-    joinable!(posts -> users (user_id));
-    allow_tables_to_appear_in_same_query!(animals, comments, posts, users);
+    diesel::joinable!(posts -> users (user_id));
+    diesel::allow_tables_to_appear_in_same_query!(animals, comments, posts, users);
 }

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,5 +1,6 @@
 use super::Expression;
 use crate::backend::Backend;
+use crate::diesel::sql_function;
 use crate::query_builder::*;
 use crate::result::QueryResult;
 use crate::sql_types::BigInt;

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,3 +1,4 @@
+use crate::diesel::sql_function;
 use crate::sql_types::Foldable;
 
 sql_function! {

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,3 +1,4 @@
+use crate::diesel::sql_function;
 use crate::sql_types::{IntoNullable, SqlOrd};
 
 sql_function! {

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,4 +1,5 @@
 use crate::backend::Backend;
+use crate::diesel::sql_function;
 use crate::expression::coerce::Coerce;
 use crate::expression::{AsExpression, Expression};
 use crate::query_builder::*;

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -167,7 +167,7 @@
 /// ```
 macro_rules! sql_function {
     ($($args:tt)*) => {
-        sql_function_proc! { $($args)* }
+        $crate::macros::sql_function_proc! { $($args)* }
     }
 }
 

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -62,12 +62,13 @@
 /// # Adding Doc Comments
 ///
 /// ```no_run
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # use diesel::*;
 /// #
 /// # table! { crates { id -> Integer, name -> VarChar, } }
 /// #
 /// use diesel::sql_types::Text;
+/// use diesel::query_builder::QueryId;
 ///
 /// sql_function! {
 ///     /// Represents the `canon_crate_name` SQL function, created in
@@ -101,12 +102,13 @@
 /// of all of this:
 ///
 /// ```no_run
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # use diesel::*;
 /// #
 /// # table! { crates { id -> Integer, name -> VarChar, } }
 /// #
 /// use diesel::sql_types::Foldable;
+/// use diesel::query_builder::QueryId;
 ///
 /// sql_function! {
 ///     #[aggregate]
@@ -133,7 +135,7 @@
 /// are not supported on SQLite.
 ///
 /// ```rust
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
 /// # use diesel::*;
 /// #
 /// # #[cfg(feature = "sqlite")]
@@ -146,6 +148,7 @@
 /// # }
 /// #
 /// use diesel::sql_types::{Integer, Double};
+/// use diesel::query_builder::QueryId;
 /// sql_function!(fn add_mul(x: Integer, y: Integer, z: Double) -> Double);
 ///
 /// # #[cfg(feature = "sqlite")]
@@ -174,7 +177,7 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
     ($type_name:ident, $return_type:ty, $docs:expr) => {
         #[allow(non_camel_case_types)]
         #[doc=$docs]
-        #[derive(Debug, Clone, Copy, QueryId, NonAggregate)]
+        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, NonAggregate)]
         pub struct $type_name;
 
         impl $crate::expression::Expression for $type_name {
@@ -224,9 +227,9 @@ macro_rules! no_arg_sql_function_body {
 /// generated using:
 ///
 /// ```no_run
-/// # #[macro_use] extern crate diesel;
-/// # pub use diesel::*;
-/// no_arg_sql_function!(now, sql_types::Timestamp, "Represents the SQL NOW() function");
+/// # extern crate diesel;
+/// # use diesel::*;
+/// diesel::no_arg_sql_function!(now, sql_types::Timestamp, "Represents the SQL NOW() function");
 /// # fn main() {}
 /// ```
 ///

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -177,7 +177,7 @@ macro_rules! no_arg_sql_function_body_except_to_sql {
     ($type_name:ident, $return_type:ty, $docs:expr) => {
         #[allow(non_camel_case_types)]
         #[doc=$docs]
-        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, NonAggregate)]
+        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, $crate::expression::NonAggregate)]
         pub struct $type_name;
 
         impl $crate::expression::Expression for $type_name {

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -37,6 +37,7 @@
 /// ```ignore
 /// pub mod functions {
 ///     use super::types::*;
+///     use diesel::sql_function;
 ///     use diesel::sql_types::*;
 ///
 ///     sql_function! {
@@ -67,6 +68,7 @@
 /// #
 /// # table! { crates { id -> Integer, name -> VarChar, } }
 /// #
+/// use diesel::sql_function;
 /// use diesel::sql_types::Text;
 /// use diesel::query_builder::QueryId;
 ///
@@ -107,6 +109,7 @@
 /// #
 /// # table! { crates { id -> Integer, name -> VarChar, } }
 /// #
+/// use diesel::sql_function;
 /// use diesel::sql_types::Foldable;
 /// use diesel::query_builder::QueryId;
 ///
@@ -147,6 +150,7 @@
 /// # fn main() {
 /// # }
 /// #
+/// use diesel::sql_function;
 /// use diesel::sql_types::{Integer, Double};
 /// use diesel::query_builder::QueryId;
 /// sql_function!(fn add_mul(x: Integer, y: Integer, z: Double) -> Double);
@@ -165,13 +169,7 @@
 /// #     Ok(())
 /// # }
 /// ```
-macro_rules! sql_function {
-    ($($args:tt)*) => {
-        $crate::macros::sql_function_proc! { $($args)* }
-    }
-}
 
-#[macro_export]
 #[doc(hidden)]
 macro_rules! no_arg_sql_function_body_except_to_sql {
     ($type_name:ident, $return_type:ty, $docs:expr) => {

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -151,6 +151,9 @@ pub trait AsExpression<T> {
     fn as_expression(self) -> Self::Expression;
 }
 
+#[doc(inline)]
+pub use diesel_derives::AsExpression;
+
 impl<T: Expression> AsExpression<T::SqlType> for T {
     type Expression = Self;
 
@@ -286,6 +289,9 @@ where
 /// }
 /// ```
 pub trait NonAggregate {}
+
+#[doc(inline)]
+pub use diesel_derives::NonAggregate;
 
 impl<T: NonAggregate + ?Sized> NonAggregate for Box<T> {}
 

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -61,7 +61,7 @@ macro_rules! __diesel_operator_body {
         expression_ty_params = ($($expression_ty_params:ident,)*),
         expression_bounds = ($($expression_bounds:tt)*),
     ) => {
-        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, DieselNumericOps, $crate::expression::NonAggregate)]
+        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, $crate::sql_types::DieselNumericOps, $crate::expression::NonAggregate)]
         #[doc(hidden)]
         pub struct $name<$($ty_param,)+> {
             $(pub(crate) $field_name: $ty_param,)+
@@ -406,6 +406,9 @@ where
         Eq::new(self.left, &self.right).values()
     }
 }
+
+#[doc(inline)]
+use crate::sql_types::DieselNumericOps;
 
 #[derive(Debug, Clone, Copy, QueryId, DieselNumericOps, NonAggregate)]
 #[doc(hidden)]

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -61,7 +61,7 @@ macro_rules! __diesel_operator_body {
         expression_ty_params = ($($expression_ty_params:ident,)*),
         expression_bounds = ($($expression_bounds:tt)*),
     ) => {
-        #[derive(Debug, Clone, Copy, QueryId, DieselNumericOps, NonAggregate)]
+        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, DieselNumericOps, $crate::expression::NonAggregate)]
         #[doc(hidden)]
         pub struct $name<$($ty_param,)+> {
             $(pub(crate) $field_name: $ty_param,)+
@@ -185,7 +185,7 @@ macro_rules! __diesel_operator_to_sql {
 /// # fn main() {
 /// #     use schema::users::dsl::*;
 /// #     let connection = establish_connection();
-/// infix_operator!(MyEq, " = ");
+/// diesel::infix_operator!(MyEq, " = ");
 ///
 /// use diesel::expression::AsExpression;
 ///

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -46,7 +46,7 @@ macro_rules! numeric_operation {
             }
         }
 
-        impl_selectable_expression!($name<Lhs, Rhs>);
+        $crate::impl_selectable_expression!($name<Lhs, Rhs>);
 
         impl<Lhs, Rhs> NonAggregate for $name<Lhs, Rhs>
         where

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -86,6 +86,9 @@ pub trait Insertable<T> {
     }
 }
 
+#[doc(inline)]
+pub use diesel_derives::Insertable;
+
 pub trait CanInsertInSingleQuery<DB: Backend> {
     /// How many rows will this query insert?
     ///

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -129,11 +129,13 @@
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
-#[macro_use]
-extern crate diesel_derives;
 
 #[macro_use]
-pub mod macros;
+extern crate diesel_derives;
+pub use diesel_derives::sql_function_proc as sql_function;
+
+#[macro_use]
+mod macros;
 
 #[cfg(test)]
 #[macro_use]

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -131,8 +131,11 @@ extern crate bitflags;
 extern crate byteorder;
 #[macro_use]
 extern crate diesel_derives;
+
 #[doc(hidden)]
-pub use diesel_derives::*;
+pub use diesel_derives::{
+    sql_function_proc, Associations, DieselNumericOps, NonAggregate, SqlType,
+};
 
 #[macro_use]
 mod macros;
@@ -298,13 +301,17 @@ pub mod prelude {
         since = "1.1.0",
         note = "Explicitly `use diesel::deserialize::Queryable"
     )]
-    pub use crate::deserialize::Queryable;
+    pub use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
     pub use crate::expression::{
-        AppearsOnTable, BoxableExpression, Expression, IntoSql, SelectableExpression,
+        AppearsOnTable, AsExpression, BoxableExpression, Expression, IntoSql, SelectableExpression,
     };
+
     pub use crate::expression_methods::*;
     #[doc(inline)]
     pub use crate::insertable::Insertable;
+
+    pub use crate::query_builder::{AsChangeset, QueryId};
+
     #[doc(hidden)]
     pub use crate::query_dsl::GroupByDsl;
     pub use crate::query_dsl::{BelongingToDsl, JoinOnDsl, QueryDsl, RunQueryDsl, SaveChangesDsl};

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -305,7 +305,7 @@ pub mod prelude {
     #[doc(inline)]
     pub use crate::insertable::Insertable;
 
-    pub use crate::query_builder::{AsChangeset, QueryId};
+    pub use crate::query_builder::AsChangeset;
 
     #[doc(hidden)]
     pub use crate::query_dsl::GroupByDsl;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -134,7 +134,7 @@ extern crate diesel_derives;
 
 #[doc(hidden)]
 pub use diesel_derives::{
-    sql_function_proc, Associations, DieselNumericOps, SqlType,
+    sql_function_proc, DieselNumericOps, SqlType,
 };
 
 #[macro_use]
@@ -295,7 +295,7 @@ pub mod helper_types {
 
 pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using Diesel.
-    pub use crate::associations::{GroupedBy, Identifiable};
+    pub use crate::associations::{Associations, GroupedBy, Identifiable};
     pub use crate::connection::Connection;
     #[deprecated(
         since = "1.1.0",

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -298,7 +298,7 @@ pub mod prelude {
     )]
     pub use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
     pub use crate::expression::{
-        AppearsOnTable, AsExpression, BoxableExpression, Expression, IntoSql, SelectableExpression,
+        AppearsOnTable, BoxableExpression, Expression, IntoSql, SelectableExpression,
     };
 
     pub use crate::expression_methods::*;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -296,7 +296,7 @@ pub mod prelude {
         since = "1.1.0",
         note = "Explicitly `use diesel::deserialize::Queryable"
     )]
-    pub use crate::deserialize::{Queryable, QueryableByName};
+    pub use crate::deserialize::Queryable;
     pub use crate::expression::{
         AppearsOnTable, BoxableExpression, Expression, IntoSql, SelectableExpression,
     };

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -132,9 +132,6 @@ extern crate byteorder;
 #[macro_use]
 extern crate diesel_derives;
 
-#[doc(hidden)]
-pub use diesel_derives::{DieselNumericOps, SqlType};
-
 #[macro_use]
 pub mod macros;
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -296,7 +296,7 @@ pub mod prelude {
         since = "1.1.0",
         note = "Explicitly `use diesel::deserialize::Queryable"
     )]
-    pub use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
+    pub use crate::deserialize::{Queryable, QueryableByName};
     pub use crate::expression::{
         AppearsOnTable, BoxableExpression, Expression, IntoSql, SelectableExpression,
     };

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -134,7 +134,7 @@ extern crate diesel_derives;
 
 #[doc(hidden)]
 pub use diesel_derives::{
-    sql_function_proc, Associations, DieselNumericOps, NonAggregate, SqlType,
+    sql_function_proc, Associations, DieselNumericOps, SqlType,
 };
 
 #[macro_use]

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -133,12 +133,10 @@ extern crate byteorder;
 extern crate diesel_derives;
 
 #[doc(hidden)]
-pub use diesel_derives::{
-    sql_function_proc, DieselNumericOps, SqlType,
-};
+pub use diesel_derives::{DieselNumericOps, SqlType};
 
 #[macro_use]
-mod macros;
+pub mod macros;
 
 #[cfg(test)]
 #[macro_use]

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -1,4 +1,9 @@
 #![allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
+//! Dummy Docs for now
+//!
+//! Probably need something about sql_function_proc or the other macros here
+//!
+
 #![cfg_attr(rustfmt, rustfmt_skip)] // https://github.com/rust-lang-nursery/rustfmt/issues/2755
 
 #[macro_export]
@@ -1237,3 +1242,6 @@ mod tests {
         );
     }
 }
+
+#[doc(hidden)]
+pub use diesel_derives::sql_function_proc;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -1,9 +1,4 @@
 #![allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
-//! Dummy Docs for now
-//!
-//! Probably need something about sql_function_proc or the other macros here
-//!
-
 #![cfg_attr(rustfmt, rustfmt_skip)] // https://github.com/rust-lang-nursery/rustfmt/issues/2755
 
 #[macro_export]
@@ -1242,6 +1237,3 @@ mod tests {
         );
     }
 }
-
-#[doc(hidden)]
-pub use diesel_derives::sql_function_proc;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -13,7 +13,7 @@ macro_rules! __diesel_column {
     ) => {
         $($meta)*
         #[allow(non_camel_case_types, dead_code)]
-        #[derive(Debug, Clone, Copy, QueryId, Default)]
+        #[derive(Debug, Clone, Copy, $crate::query_builder::QueryId, Default)]
         pub struct $column_name;
 
         impl $crate::expression::Expression for $column_name {
@@ -95,8 +95,8 @@ macro_rules! __diesel_column {
             }
         }
 
-        __diesel_generate_ops_impls_if_numeric!($column_name, $($Type)*);
-        __diesel_generate_ops_impls_if_date_time!($column_name, $($Type)*);
+        $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($Type)*);
+        $crate::__diesel_generate_ops_impls_if_date_time!($column_name, $($Type)*);
     }
 }
 
@@ -272,7 +272,7 @@ macro_rules! __diesel_column {
 #[macro_export]
 macro_rules! table {
     ($($tokens:tt)*) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($tokens)*],
             imports = [],
             meta = [],
@@ -304,7 +304,7 @@ macro_rules! __diesel_parse_table {
         imports = [$($imports:tt)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = [$($imports)* use $($import)::+;],
             $($args)*
@@ -319,7 +319,7 @@ macro_rules! __diesel_parse_table {
         sql_name = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -335,7 +335,7 @@ macro_rules! __diesel_parse_table {
         meta = [$($meta:tt)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = [$($meta)* #$new_meta],
@@ -353,7 +353,7 @@ macro_rules! __diesel_parse_table {
         schema = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -373,7 +373,7 @@ macro_rules! __diesel_parse_table {
         name = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -394,7 +394,7 @@ macro_rules! __diesel_parse_table {
         primary_key = $ignore:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [$($rest)*],
             imports = $imports,
             meta = $meta,
@@ -412,7 +412,7 @@ macro_rules! __diesel_parse_table {
         imports = [],
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [{$($columns)*}],
             imports = [use $crate::sql_types::*;],
             $($args)*
@@ -428,7 +428,7 @@ macro_rules! __diesel_parse_table {
         name = $name:tt,
         $($args:tt)*
     ) => {
-        __diesel_parse_table! {
+        $crate::__diesel_parse_table! {
             tokens = [{$($columns)*}],
             imports = $imports,
             meta = $meta,
@@ -443,7 +443,7 @@ macro_rules! __diesel_parse_table {
         tokens = [{$($columns:tt)*}],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             tokens = [$($columns)*],
             table = { $($args)* },
             columns = [],
@@ -452,7 +452,7 @@ macro_rules! __diesel_parse_table {
 
     // Invalid syntax
     ($($tokens:tt)*) => {
-        __diesel_invalid_table_syntax!();
+        $crate::__diesel_invalid_table_syntax!();
     }
 }
 
@@ -469,7 +469,7 @@ macro_rules! __diesel_parse_columns {
         ],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$(#$meta)*],
                 name = $name,
@@ -491,7 +491,7 @@ macro_rules! __diesel_parse_columns {
         ],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$(#$meta)*],
                 name = $name,
@@ -515,7 +515,7 @@ macro_rules! __diesel_parse_columns {
         },
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$($meta)*],
                 name = $name,
@@ -538,7 +538,7 @@ macro_rules! __diesel_parse_columns {
         },
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             current_column = {
                 unchecked_meta = [$($unchecked_meta)*],
                 name = $name,
@@ -562,7 +562,7 @@ macro_rules! __diesel_parse_columns {
         columns = [$($columns:tt,)*],
         $($args:tt)*
     ) => {
-        __diesel_parse_columns! {
+        $crate::__diesel_parse_columns! {
             tokens = $tokens,
             table = $table,
             columns = [$($columns,)* { $($current_column)* },],
@@ -575,12 +575,12 @@ macro_rules! __diesel_parse_columns {
         tokens = [],
         $($args:tt)*
     ) => {
-        __diesel_table_impl!($($args)*);
+        $crate::__diesel_table_impl!($($args)*);
     };
 
     // Invalid syntax
     ($($tokens:tt)*) => {
-        __diesel_invalid_table_syntax!();
+        $crate::__diesel_invalid_table_syntax!();
     }
 }
 
@@ -624,7 +624,7 @@ macro_rules! __diesel_table_impl {
             /// table struct renamed to the module name. This is meant to be
             /// glob imported for functions which only deal with one table.
             pub mod dsl {
-                $(static_cond! {
+                $($crate::static_cond! {
                     if $table_name == $column_name {
                         compile_error!(concat!(
                             "Column `",
@@ -672,7 +672,7 @@ macro_rules! __diesel_table_impl {
             /// Helper type for representing a boxed query from this table
             pub type BoxedQuery<'a, DB, ST = SqlType> = BoxedSelectStatement<'a, ST, table, DB>;
 
-            __diesel_table_query_source_impl!(table, $schema, $sql_name);
+            $crate::__diesel_table_query_source_impl!(table, $schema, $sql_name);
 
             impl AsQuery for table {
                 type SqlType = SqlType;
@@ -831,7 +831,7 @@ macro_rules! __diesel_table_impl {
                 impl AppearsOnTable<table> for star {
                 }
 
-                $(__diesel_column! {
+                $($crate::__diesel_column! {
                     table = table,
                     name = $column_name,
                     sql_name = $column_sql_name,
@@ -952,8 +952,8 @@ macro_rules! __diesel_table_query_source_impl {
 #[macro_export]
 macro_rules! joinable {
     ($($child:ident)::* -> $($parent:ident)::* ($source:ident)) => {
-        joinable_inner!($($child)::* ::table => $($parent)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
-        joinable_inner!($($parent)::* ::table => $($child)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
+        $crate::joinable_inner!($($child)::* ::table => $($parent)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
+        $crate::joinable_inner!($($parent)::* ::table => $($child)::* ::table : ($($child)::* ::$source = $($parent)::* ::table));
     }
 }
 
@@ -961,7 +961,7 @@ macro_rules! joinable {
 #[doc(hidden)]
 macro_rules! joinable_inner {
     ($left_table:path => $right_table:path : ($foreign_key:path = $parent_table:path)) => {
-        joinable_inner!(
+        $crate::joinable_inner!(
             left_table_ty = $left_table,
             right_table_ty = $right_table,
             right_table_expr = $right_table,
@@ -1042,7 +1042,7 @@ macro_rules! allow_tables_to_appear_in_same_query {
                 type Count = $crate::query_source::Never;
             }
         )+
-        allow_tables_to_appear_in_same_query!($($right_mod,)+);
+        $crate::allow_tables_to_appear_in_same_query!($($right_mod,)+);
     };
 
     ($last_table:ident,) => {};

--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -28,41 +28,41 @@ macro_rules! operator_allowed {
 /// for types which implement `Expression`, under its orphan rules.
 macro_rules! numeric_expr {
     ($tpe:ty) => {
-        operator_allowed!($tpe, Add, add);
-        operator_allowed!($tpe, Sub, sub);
-        operator_allowed!($tpe, Div, div);
-        operator_allowed!($tpe, Mul, mul);
+        $crate::operator_allowed!($tpe, Add, add);
+        $crate::operator_allowed!($tpe, Sub, sub);
+        $crate::operator_allowed!($tpe, Div, div);
+        $crate::operator_allowed!($tpe, Mul, mul);
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __diesel_generate_ops_impls_if_numeric {
-    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
     
-    ($column_name:ident, Unsigned<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
+    ($column_name:ident, Unsigned<$($inner:tt)::*>) => { $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
 
-    ($column_name:ident, SmallInt) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int2) => { numeric_expr!($column_name); };
-    ($column_name:ident, Smallint) => { numeric_expr!($column_name); };
-    ($column_name:ident, SmallSerial) => { numeric_expr!($column_name); };
+    ($column_name:ident, SmallInt) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int2) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Smallint) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, SmallSerial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Integer) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int4) => { numeric_expr!($column_name); };
-    ($column_name:ident, Serial) => { numeric_expr!($column_name); };
+    ($column_name:ident, Integer) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int4) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Serial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, BigInt) => { numeric_expr!($column_name); };
-    ($column_name:ident, Int8) => { numeric_expr!($column_name); };
-    ($column_name:ident, Bigint) => { numeric_expr!($column_name); };
-    ($column_name:ident, BigSerial) => { numeric_expr!($column_name); };
+    ($column_name:ident, BigInt) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Int8) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Bigint) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, BigSerial) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Float) => { numeric_expr!($column_name); };
-    ($column_name:ident, Float4) => { numeric_expr!($column_name); };
+    ($column_name:ident, Float) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Float4) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Double) => { numeric_expr!($column_name); };
-    ($column_name:ident, Float8) => { numeric_expr!($column_name); };
+    ($column_name:ident, Double) => { $crate::numeric_expr!($column_name); };
+    ($column_name:ident, Float8) => { $crate::numeric_expr!($column_name); };
 
-    ($column_name:ident, Numeric) => { numeric_expr!($column_name); };
+    ($column_name:ident, Numeric) => { $crate::numeric_expr!($column_name); };
 
     ($column_name:ident, $non_numeric_type:ty) => {};
 }
@@ -71,18 +71,18 @@ macro_rules! __diesel_generate_ops_impls_if_numeric {
 #[doc(hidden)]
 macro_rules! date_time_expr {
     ($tpe:ty) => {
-        operator_allowed!($tpe, Add, add);
-        operator_allowed!($tpe, Sub, sub);
+        $crate::operator_allowed!($tpe, Add, add);
+        $crate::operator_allowed!($tpe, Sub, sub);
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __diesel_generate_ops_impls_if_date_time {
-    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_date_time!($column_name, $($inner)::*); };
-    ($column_name:ident, Time) => { date_time_expr!($column_name); };
-    ($column_name:ident, Date) => { date_time_expr!($column_name); };
-    ($column_name:ident, Timestamp) => { date_time_expr!($column_name); };
-    ($column_name:ident, Timestamptz) => { date_time_expr!($column_name); };
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { $crate::__diesel_generate_ops_impls_if_date_time!($column_name, $($inner)::*); };
+    ($column_name:ident, Time) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Date) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Timestamp) => { $crate::date_time_expr!($column_name); };
+    ($column_name:ident, Timestamptz) => { $crate::date_time_expr!($column_name); };
     ($column_name:ident, $non_date_time_type:ty) => {};
 }

--- a/diesel/src/macros/static_cond.rs
+++ b/diesel/src/macros/static_cond.rs
@@ -21,18 +21,18 @@ macro_rules! static_cond {
 
     // no else condition provided: fall through with empty else
     (if $lhs:tt == $rhs:tt $then:tt) => {
-        static_cond!(if $lhs == $rhs $then else { });
+        $crate::static_cond!(if $lhs == $rhs $then else { });
     };
     (if $lhs:tt != $rhs:tt $then:tt) => {
-        static_cond!(if $lhs != $rhs $then else { });
+        $crate::static_cond!(if $lhs != $rhs $then else { });
     };
 
     // we evaluate a conditional by generating a new macro (in an inner scope, so name shadowing is
     // not a big concern) and calling it
     (if $lhs:tt == $rhs:tt $then:tt else $els:tt) => {
-        static_cond!(@go $lhs $rhs $then $els);
+        $crate::static_cond!(@go $lhs $rhs $then $els);
     };
     (if $lhs:tt != $rhs:tt $then:tt else $els:tt) => {
-        static_cond!(@go $lhs $rhs $els $then);
+        $crate::static_cond!(@go $lhs $rhs $els $then);
     };
 }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -229,6 +229,7 @@ mod tests {
         assert_eq!(2, connection.statement_cache.len());
     }
 
+    use crate::diesel::sql_function;
     sql_function!(fn lower(x: VarChar) -> VarChar);
 
     #[test]

--- a/diesel/src/pg/serialize/write_tuple.rs
+++ b/diesel/src/pg/serialize/write_tuple.rs
@@ -15,14 +15,13 @@ use crate::serialize::{self, Output};
 /// # Example
 ///
 /// ```no_run
-/// # #[macro_use]
 /// # extern crate diesel;
 /// #
 /// # #[cfg(feature = "postgres")]
 /// # mod the_impl {
 /// #     use diesel::pg::Pg;
 /// #     use diesel::serialize::{self, ToSql, Output, WriteTuple};
-/// #     use diesel::sql_types::{Integer, Text};
+/// #     use diesel::sql_types::{Integer, SqlType, Text};
 /// #     use std::io::Write;
 /// #
 ///     #[derive(SqlType)]

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -440,6 +440,7 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 /// # include!("../doctest_setup.rs");
 /// #
 /// # use schema::users;
+/// # use diesel::deserialize::QueryableByName;
 /// #
 /// # #[derive(QueryableByName, Debug, PartialEq)]
 /// # #[table_name="users"]

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -88,6 +88,9 @@ pub trait QueryId {
     }
 }
 
+#[doc(hidden)]
+pub use diesel_derives::QueryId;
+
 impl QueryId for () {
     type QueryId = ();
 

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -19,7 +19,8 @@ use std::any::{Any, TypeId};
 /// For example, given this struct:
 ///
 /// ```rust
-/// # #[macro_use] extern crate diesel;
+/// # extern crate diesel;
+/// # use diesel::query_builder::QueryId;
 /// #[derive(QueryId)]
 /// pub struct And<Left, Right> {
 ///     left: Left,
@@ -88,7 +89,7 @@ pub trait QueryId {
     }
 }
 
-#[doc(hidden)]
+#[doc(inline)]
 pub use diesel_derives::QueryId;
 
 impl QueryId for () {

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -47,6 +47,7 @@ impl<Inner> SqlQuery<Inner> {
     /// # include!("../doctest_setup.rs");
     /// #
     /// # use schema::users;
+    /// # use diesel::deserialize::QueryableByName;
     /// #
     /// # #[derive(QueryableByName, Debug, PartialEq)]
     /// # #[table_name="users"]

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -31,6 +31,9 @@ pub trait AsChangeset {
     fn as_changeset(self) -> Self::Changeset;
 }
 
+#[doc(inline)]
+pub use diesel_derives::AsChangeset;
+
 impl<T: AsChangeset> AsChangeset for Option<T> {
     type Target = T::Target;
     type Changeset = Option<T::Changeset>;

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -387,8 +387,8 @@ pub use crate::mysql::types::*;
 /// # Example
 ///
 /// ```rust
-/// # #[macro_use]
 /// # extern crate diesel;
+/// # use diesel::sql_types::SqlType;
 /// #[derive(SqlType)]
 /// #[postgres(oid = "23", array_oid = "1007")]
 /// #[sqlite_type = "Integer"]
@@ -464,3 +464,6 @@ impl<T: NotNull> IntoNullable for Nullable<T> {
 pub trait SingleValue {}
 
 impl<T: NotNull + SingleValue> SingleValue for Nullable<T> {}
+
+#[doc(inline)]
+pub use diesel_derives::{DieselNumericOps, SqlType};

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -319,6 +319,7 @@ mod tests {
         assert_eq!(1, connection.statement_cache.len());
     }
 
+    use crate::diesel::sql_function;
     use crate::sql_types::Text;
     sql_function!(fn fun_case(x: Text) -> Text);
 

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -111,6 +111,7 @@ mod tests {
     use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
     use self::dotenv::dotenv;
 
+    use crate::diesel::sql_function;
     use crate::dsl::{now, sql};
     use crate::prelude::*;
     use crate::select;

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -282,7 +282,7 @@ fn drop_database(database_url: &str) -> DatabaseResult<()> {
 }
 
 #[cfg(feature = "postgres")]
-table! {
+diesel::table! {
     pg_database (datname) {
         datname -> Text,
         datistemplate -> Bool,
@@ -303,7 +303,7 @@ fn pg_database_exists(conn: &PgConnection, database_name: &str) -> QueryResult<b
 }
 
 #[cfg(feature = "mysql")]
-table! {
+diesel::table! {
     information_schema.schemata (schema_name) {
         schema_name -> Text,
     }

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -55,14 +55,14 @@ impl UsesInformationSchema for Mysql {
         C: Connection,
         String: FromSql<sql_types::Text, C::Backend>,
     {
-        no_arg_sql_function!(database, sql_types::VarChar);
+        diesel::no_arg_sql_function!(database, sql_types::VarChar);
         select(database).get_result(conn)
     }
 }
 
 #[allow(clippy::module_inception)]
 mod information_schema {
-    table! {
+    diesel::table! {
         information_schema.tables (table_schema, table_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -70,7 +70,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.columns (table_schema, table_name, column_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -82,7 +82,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.key_column_usage (table_schema, table_name, column_name, constraint_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -93,7 +93,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.table_constraints (table_schema, table_name, constraint_name) {
             table_schema -> VarChar,
             table_name -> VarChar,
@@ -103,7 +103,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.referential_constraints (constraint_schema, constraint_name) {
             constraint_schema -> VarChar,
             constraint_name -> VarChar,
@@ -112,8 +112,8 @@ mod information_schema {
         }
     }
 
-    allow_tables_to_appear_in_same_query!(table_constraints, referential_constraints);
-    allow_tables_to_appear_in_same_query!(key_column_usage, table_constraints);
+    diesel::allow_tables_to_appear_in_same_query!(table_constraints, referential_constraints);
+    diesel::allow_tables_to_appear_in_same_query!(key_column_usage, table_constraints);
 }
 
 pub fn get_table_data<Conn>(conn: &Conn, table: &TableName) -> QueryResult<Vec<ColumnInformation>>

--- a/diesel_cli/src/infer_schema_internals/mysql.rs
+++ b/diesel_cli/src/infer_schema_internals/mysql.rs
@@ -8,7 +8,7 @@ use super::information_schema::UsesInformationSchema;
 use super::table_data::TableName;
 
 mod information_schema {
-    table! {
+    diesel::table! {
         information_schema.table_constraints (constraint_schema, constraint_name) {
             table_schema -> VarChar,
             constraint_schema -> VarChar,
@@ -17,7 +17,7 @@ mod information_schema {
         }
     }
 
-    table! {
+    diesel::table! {
         information_schema.key_column_usage (constraint_schema, constraint_name) {
             constraint_schema -> VarChar,
             constraint_name -> VarChar,
@@ -30,7 +30,7 @@ mod information_schema {
         }
     }
 
-    allow_tables_to_appear_in_same_query!(table_constraints, key_column_usage);
+    diesel::allow_tables_to_appear_in_same_query!(table_constraints, key_column_usage);
 }
 
 /// Even though this is using `information_schema`, MySQL needs non-ANSI columns

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -17,7 +17,6 @@
 extern crate chrono;
 #[macro_use]
 extern crate clap;
-#[macro_use]
 extern crate diesel;
 extern crate dotenv;
 extern crate heck;

--- a/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/compile-fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate diesel;
+extern crate diesel;
 
 use diesel::*;
 use diesel::dsl::*;

--- a/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/compile-fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate diesel;
+extern crate diesel;
 
 use diesel::*;
 use diesel::pg::upsert::*;

--- a/diesel_compile_tests/tests/ui/as_changeset_struct_with_only_primary_key.stderr
+++ b/diesel_compile_tests/tests/ui/as_changeset_struct_with_only_primary_key.stderr
@@ -11,11 +11,11 @@ error[E0601]: `main` function not found in crate `as_changeset_struct_with_only_
   |
   = note: consider adding a `main` function to `$DIR/as_changeset_struct_with_only_primary_key.rs`
 
-error[E0277]: the trait bound `(): diesel::query_builder::AsChangeset` is not satisfied
+error[E0277]: the trait bound `(): diesel::AsChangeset` is not satisfied
   --> $DIR/as_changeset_struct_with_only_primary_key.rs:17:10
    |
 17 | #[derive(AsChangeset)]
-   |          ^^^^^^^^^^^ the trait `diesel::query_builder::AsChangeset` is not implemented for `()`
+   |          ^^^^^^^^^^^ the trait `diesel::AsChangeset` is not implemented for `()`
 
 error: aborting due to 3 previous errors
 

--- a/diesel_compile_tests/tests/ui/as_expression_bad_sql_type.rs
+++ b/diesel_compile_tests/tests/ui/as_expression_bad_sql_type.rs
@@ -1,5 +1,6 @@
-#[macro_use]
 extern crate diesel;
+
+use diesel::expression::AsExpression;
 
 #[derive(AsExpression)]
 #[sql_type(Foo)]

--- a/diesel_compile_tests/tests/ui/as_expression_bad_sql_type.stderr
+++ b/diesel_compile_tests/tests/ui/as_expression_bad_sql_type.stderr
@@ -1,25 +1,25 @@
 error: `sql_type` must be in the form `sql_type = "value"`
- --> $DIR/as_expression_bad_sql_type.rs:5:3
+ --> $DIR/as_expression_bad_sql_type.rs:6:3
   |
-5 | #[sql_type(Foo)]
+6 | #[sql_type(Foo)]
   |   ^^^^^^^^^^^^^
 
 error: `sql_type` must be in the form `sql_type = "value"`
- --> $DIR/as_expression_bad_sql_type.rs:6:3
+ --> $DIR/as_expression_bad_sql_type.rs:7:3
   |
-6 | #[sql_type]
+7 | #[sql_type]
   |   ^^^^^^^^
-
-error: Invalid Rust type
- --> $DIR/as_expression_bad_sql_type.rs:7:14
-  |
-7 | #[sql_type = "@%&&*"]
-  |              ^^^^^^^
 
 error: Invalid Rust type
  --> $DIR/as_expression_bad_sql_type.rs:8:14
   |
-8 | #[sql_type = "1omg"]
+8 | #[sql_type = "@%&&*"]
+  |              ^^^^^^^
+
+error: Invalid Rust type
+ --> $DIR/as_expression_bad_sql_type.rs:9:14
+  |
+9 | #[sql_type = "1omg"]
   |              ^^^^^^
 
 error: aborting due to 4 previous errors

--- a/diesel_compile_tests/tests/ui/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
+++ b/diesel_compile_tests/tests/ui/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate diesel;
+extern crate diesel;
+use diesel::deserialize::QueryableByName;
 
 #[derive(QueryableByName)]
 struct Foo {

--- a/diesel_compile_tests/tests/ui/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
+++ b/diesel_compile_tests/tests/ui/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
@@ -1,43 +1,43 @@
 error: Cannot determine the SQL type of foo
- --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:5:5
+ --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:6:5
   |
-5 |     foo: i32,
+6 |     foo: i32,
   |     ^^^^^^^^
   |
   = help: Your struct must either be annotated with `#[table_name = "foo"]` or have all of its fields annotated with `#[sql_type = "Integer"]`
 
 error: Cannot determine the SQL type of bar
- --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:6:5
+ --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:7:5
   |
-6 |     bar: String,
+7 |     bar: String,
   |     ^^^^^^^^^^^
   |
   = help: Your struct must either be annotated with `#[table_name = "foo"]` or have all of its fields annotated with `#[sql_type = "Integer"]`
 
 error: All fields of tuple structs must be annotated with `#[column_name]`
-  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:12
+  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:11:12
    |
-10 | struct Bar(i32, String);
+11 | struct Bar(i32, String);
    |            ^^^
 
 error: Cannot determine the SQL type of field
-  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:12
+  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:11:12
    |
-10 | struct Bar(i32, String);
+11 | struct Bar(i32, String);
    |            ^^^
    |
    = help: Your struct must either be annotated with `#[table_name = "foo"]` or have all of its fields annotated with `#[sql_type = "Integer"]`
 
 error: All fields of tuple structs must be annotated with `#[column_name]`
-  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:17
+  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:11:17
    |
-10 | struct Bar(i32, String);
+11 | struct Bar(i32, String);
    |                 ^^^^^^
 
 error: Cannot determine the SQL type of field
-  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:17
+  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:11:17
    |
-10 | struct Bar(i32, String);
+11 | struct Bar(i32, String);
    |                 ^^^^^^
    |
    = help: Your struct must either be annotated with `#[table_name = "foo"]` or have all of its fields annotated with `#[sql_type = "Integer"]`

--- a/diesel_compile_tests/tests/ui/sql_type_bad_options.rs
+++ b/diesel_compile_tests/tests/ui/sql_type_bad_options.rs
@@ -1,5 +1,6 @@
-#[macro_use]
 extern crate diesel;
+
+use diesel::sql_types::SqlType;
 
 #[derive(SqlType)]
 #[postgres]

--- a/diesel_compile_tests/tests/ui/sql_type_bad_options.stderr
+++ b/diesel_compile_tests/tests/ui/sql_type_bad_options.stderr
@@ -1,49 +1,49 @@
 error: `postgres` must be in the form `postgres(...)`
- --> $DIR/sql_type_bad_options.rs:5:3
+ --> $DIR/sql_type_bad_options.rs:6:3
   |
-5 | #[postgres]
+6 | #[postgres]
   |   ^^^^^^^^
 
 warning: Option oid has no effect
- --> $DIR/sql_type_bad_options.rs:9:31
-  |
-9 | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
-  |                               ^^^^^^^^^
+  --> $DIR/sql_type_bad_options.rs:10:31
+   |
+10 | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
+   |                               ^^^^^^^^^
 
 warning: Option array_oid has no effect
- --> $DIR/sql_type_bad_options.rs:9:42
-  |
-9 | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
-  |                                          ^^^^^^^^^^^^^^^
+  --> $DIR/sql_type_bad_options.rs:10:42
+   |
+10 | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
+   |                                          ^^^^^^^^^^^^^^^
 
 error: Missing required option `array_oid`
-  --> $DIR/sql_type_bad_options.rs:13:3
+  --> $DIR/sql_type_bad_options.rs:14:3
    |
-13 | #[postgres(oid = "2")]
+14 | #[postgres(oid = "2")]
    |   ^^^^^^^^^^^^^^^^^^^
 
 error: Expected a number
-  --> $DIR/sql_type_bad_options.rs:17:18
+  --> $DIR/sql_type_bad_options.rs:18:18
    |
-17 | #[postgres(oid = "NaN", array_oid = "1")]
+18 | #[postgres(oid = "NaN", array_oid = "1")]
    |                  ^^^^^
 
 warning: Option ary_oid has no effect
-  --> $DIR/sql_type_bad_options.rs:21:25
+  --> $DIR/sql_type_bad_options.rs:22:25
    |
-21 | #[postgres(oid = "NaN", ary_oid = "1")]
+22 | #[postgres(oid = "NaN", ary_oid = "1")]
    |                         ^^^^^^^^^^^^^
 
 error: Missing required option `array_oid`
-  --> $DIR/sql_type_bad_options.rs:21:3
+  --> $DIR/sql_type_bad_options.rs:22:3
    |
-21 | #[postgres(oid = "NaN", ary_oid = "1")]
+22 | #[postgres(oid = "NaN", ary_oid = "1")]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `postgres` must be in the form `postgres(...)`
-  --> $DIR/sql_type_bad_options.rs:25:3
+  --> $DIR/sql_type_bad_options.rs:26:3
    |
-25 | #[postgres = "foo"]
+26 | #[postgres = "foo"]
    |   ^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -67,7 +67,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
     let mut tokens = quote! {
         use diesel::{self, QueryResult};
         use diesel::expression::{AsExpression, Expression, SelectableExpression, AppearsOnTable};
-        use diesel::query_builder::{QueryFragment, AstPass};
+        use diesel::query_builder::{AstPass, QueryFragment, QueryId};
         use diesel::sql_types::*;
         use super::*;
 

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -1,5 +1,5 @@
+use diesel::deserialize::QueryableByName;
 use diesel::*;
-
 use helpers::connection;
 
 #[cfg(feature = "mysql")]

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -148,7 +148,7 @@ pub mod connection {
 /// # #[macro_use] extern crate diesel;
 /// # #[macro_use] extern crate diesel_migrations;
 /// # include!("../../diesel/src/doctest_setup.rs");
-/// # table! {
+/// # diesel::table! {
 /// #   users {
 /// #       id -> Integer,
 /// #       name -> VarChar,

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -1,6 +1,6 @@
 use crate::schema::*;
 use diesel::connection::SimpleConnection;
-use diesel::deserialize::{self, FromSql};
+use diesel::deserialize::{self, FromSql, FromSqlRow};
 use diesel::expression::AsExpression;
 use diesel::pg::{Pg, PgValue};
 use diesel::serialize::{self, IsNull, Output, ToSql};

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -3,6 +3,7 @@ use diesel::connection::SimpleConnection;
 use diesel::deserialize::{self, FromSql};
 use diesel::pg::{Pg, PgValue};
 use diesel::serialize::{self, IsNull, Output, ToSql};
+use diesel::sql_types::SqlType;
 use diesel::*;
 use std::io::Write;
 

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -1,6 +1,7 @@
 use crate::schema::*;
 use diesel::connection::SimpleConnection;
 use diesel::deserialize::{self, FromSql};
+use diesel::expression::AsExpression;
 use diesel::pg::{Pg, PgValue};
 use diesel::serialize::{self, IsNull, Output, ToSql};
 use diesel::sql_types::SqlType;

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -216,6 +216,8 @@ fn test_min() {
     assert_eq!(Ok(None::<i32>), source.first(&connection));
 }
 
+use diesel::sql_function;
+
 sql_function!(fn coalesce(x: sql_types::Nullable<sql_types::VarChar>, y: sql_types::VarChar) -> sql_types::VarChar);
 
 #[test]

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -1,3 +1,4 @@
+use diesel::deserialize::QueryableByName;
 use diesel::*;
 
 #[cfg(all(feature = "postgres", feature = "backend_specific_database_url"))]


### PR DESCRIPTION
Enables direct macro imports for diesel macros.

Re-implementation of #1956 with re-exporting from within prelude as a best effort to keep existing code working.

There are probably a few doc items related to `#[macro_use]` to be cleaned up and removed but getting eyes on the current re-exporting state would be great.