### PR TITLE
Allow some deprecated items

### DIFF
--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -3,7 +3,7 @@ extern crate mysqlclient_sys as ffi;
 use std::ffi::CStr;
 use std::os::raw as libc;
 use std::ptr::{self, NonNull};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 use super::stmt::Statement;
 use super::url::ConnectionOptions;
@@ -195,7 +195,7 @@ impl Drop for RawConnection {
 /// > any other client library call.
 ///
 /// <https://dev.mysql.com/doc/refman/5.7/en/mysql-init.html>
-static MYSQL_THREAD_UNSAFE_INIT: Once = ONCE_INIT;
+static MYSQL_THREAD_UNSAFE_INIT: Once = Once::new();
 
 fn perform_thread_unsafe_library_initialization() {
     MYSQL_THREAD_UNSAFE_INIT.call_once(|| {

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -30,6 +30,7 @@ macro_rules! mysql_time_impls {
             fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
                 let bytes = not_none!(bytes);
                 let bytes_ptr = bytes.as_ptr() as *const ffi::MYSQL_TIME;
+                #[allow(deprecated)] // min 1.36.0
                 unsafe {
                     let mut result = mem::uninitialized();
                     ptr::copy_nonoverlapping(bytes_ptr, &mut result, 1);

--- a/diesel/src/serialize.rs
+++ b/diesel/src/serialize.rs
@@ -76,7 +76,7 @@ impl<DB: TypeMetadata> Output<'static, Vec<u8>, DB> {
     /// Unsafe to use for testing types which perform dynamic metadata lookup.
     pub fn test() -> Self {
         use std::mem;
-        #[allow(clippy::invalid_ref)]
+        #[allow(clippy::invalid_ref, deprecated)] // min 1.36.0
         Self::new(Vec::new(), unsafe { mem::uninitialized() })
     }
 }


### PR DESCRIPTION
These were deprecated recently but we don't want to use them yet to not
break compatibility with older rustc versions unnecessary. Explicitly
allowing them should fix the build for nightly with `#[deny(warnings)]`.