### PR TITLE
Bump pq-sys to 0.4.1

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4", optional = true }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.16.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
-pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
+pq-sys = { version = "0.4.1", optional = true }
 quickcheck = { version = "0.4", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }
 time = { version = "0.1", optional = true }


### PR DESCRIPTION
This avoids errors when building with `-Z minimal-versions`