### PR TITLE
Separate raw value representations of postgresql and mysql backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * The minimal officially supported rustc version is now 1.36.0
 
+* The `RawValue` types for the `Mysql` and `Postgresql` backend where changed
+  from `[u8]` to distinct opaque types. If you used the concrete `RawValue` type
+  somewhere you need to change it to `mysql::MysqlValue` or `pg::PgValue`.
+  For the postgres backend additionally type information where added to the `RawValue`
+  type. This allows to dynamically deserialize `RawValues` in container types.
+
 ### Fixed
 
 * Many types were incorrectly considered non-aggregate when they should not

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -60,6 +60,12 @@ pub trait HasRawValue<'a> {
     type RawValue;
 }
 
+/// A trait indicating that the provided raw value uses a binary representation internally
+pub trait BinaryRawValue<'a>: HasRawValue<'a> {
+    /// Get the underlying binary representation of the raw value
+    fn as_bytes(value: Self::RawValue) -> &'a [u8];
+}
+
 /// A helper type to get the raw representation of a database type given to
 /// `FromSql`. Equivalent to `<DB as Backend>::RawValue<'a>`.
 pub type RawValue<'a, DB> = <DB as HasRawValue<'a>>::RawValue;

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -3,6 +3,7 @@
 use byteorder::NativeEndian;
 
 use super::query_builder::MysqlQueryBuilder;
+use super::MysqlValue;
 use backend::*;
 use query_builder::bind_collector::RawBytesBindCollector;
 use sql_types::TypeMetadata;
@@ -69,7 +70,7 @@ impl Backend for Mysql {
 }
 
 impl<'a> HasRawValue<'a> for Mysql {
-    type RawValue = &'a [u8];
+    type RawValue = MysqlValue<'a>;
 }
 
 impl TypeMetadata for Mysql {

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -4,7 +4,7 @@ use std::mem;
 use std::os::raw as libc;
 
 use super::stmt::Statement;
-use mysql::{MysqlType, MysqlTypeMetadata};
+use mysql::{MysqlType, MysqlTypeMetadata, MysqlValue};
 use result::QueryResult;
 
 pub struct Binds {
@@ -23,7 +23,7 @@ impl Binds {
             })
             .collect();
 
-        Binds { data: data }
+        Binds { data }
     }
 
     pub fn from_output_types(types: Vec<MysqlTypeMetadata>) -> Self {
@@ -38,7 +38,7 @@ impl Binds {
             .map(BindData::for_output)
             .collect();
 
-        Binds { data: data }
+        Binds { data }
     }
 
     pub fn from_result_metadata(fields: &[ffi::MYSQL_FIELD]) -> Self {
@@ -86,8 +86,8 @@ impl Binds {
         }
     }
 
-    pub fn field_data(&self, idx: usize) -> Option<&[u8]> {
-        self.data[idx].bytes()
+    pub fn field_data(&self, idx: usize) -> Option<MysqlValue> {
+        self.data[idx].bytes().map(MysqlValue::new)
     }
 }
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -86,7 +86,7 @@ impl Binds {
         }
     }
 
-    pub fn field_data(&self, idx: usize) -> Option<MysqlValue> {
+    pub fn field_data(&self, idx: usize) -> Option<MysqlValue<'_>> {
         self.data[idx].bytes().map(MysqlValue::new)
     }
 }

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use super::{ffi, libc, Binds, Statement, StatementMetadata};
-use mysql::{Mysql, MysqlTypeMetadata};
+use mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
 use result::QueryResult;
 use row::*;
 
@@ -18,10 +18,7 @@ impl<'a> StatementIterator<'a> {
 
         execute_statement(stmt, &mut output_binds)?;
 
-        Ok(StatementIterator {
-            stmt: stmt,
-            output_binds: output_binds,
-        })
+        Ok(StatementIterator { stmt, output_binds })
     }
 
     pub fn map<F, T>(mut self, mut f: F) -> QueryResult<Vec<T>>
@@ -53,7 +50,7 @@ pub struct MysqlRow<'a> {
 }
 
 impl<'a> Row<Mysql> for MysqlRow<'a> {
-    fn take(&mut self) -> Option<&[u8]> {
+    fn take(&mut self) -> Option<MysqlValue> {
         let current_idx = self.col_idx;
         self.col_idx += 1;
         self.binds.field_data(current_idx)
@@ -119,7 +116,7 @@ impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
         self.column_indices.get(column_name).cloned()
     }
 
-    fn get_raw_value(&self, idx: usize) -> Option<&[u8]> {
+    fn get_raw_value(&self, idx: usize) -> Option<MysqlValue> {
         self.binds.field_data(idx)
     }
 }

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -50,7 +50,7 @@ pub struct MysqlRow<'a> {
 }
 
 impl<'a> Row<Mysql> for MysqlRow<'a> {
-    fn take(&mut self) -> Option<MysqlValue> {
+    fn take(&mut self) -> Option<MysqlValue<'_>> {
         let current_idx = self.col_idx;
         self.col_idx += 1;
         self.binds.field_data(current_idx)
@@ -116,7 +116,7 @@ impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
         self.column_indices.get(column_name).cloned()
     }
 
-    fn get_raw_value(&self, idx: usize) -> Option<MysqlValue> {
+    fn get_raw_value(&self, idx: usize) -> Option<MysqlValue<'_>> {
         self.binds.field_data(idx)
     }
 }

--- a/diesel/src/mysql/mod.rs
+++ b/diesel/src/mysql/mod.rs
@@ -6,6 +6,7 @@
 
 mod backend;
 mod connection;
+mod value;
 
 mod query_builder;
 pub mod types;
@@ -13,3 +14,4 @@ pub mod types;
 pub use self::backend::{Mysql, MysqlType, MysqlTypeMetadata};
 pub use self::connection::MysqlConnection;
 pub use self::query_builder::MysqlQueryBuilder;
+pub use self::value::MysqlValue;

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -25,7 +25,7 @@ macro_rules! mysql_time_impls {
         }
 
         impl FromSql<$ty, Mysql> for ffi::MYSQL_TIME {
-            fn from_sql(value: Option<MysqlValue>) -> deserialize::Result<Self> {
+            fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
                 let value = not_none!(value);
                 let bytes_ptr = value.as_bytes().as_ptr() as *const ffi::MYSQL_TIME;
                 unsafe {
@@ -55,7 +55,7 @@ impl ToSql<Datetime, Mysql> for NaiveDateTime {
 }
 
 impl FromSql<Datetime, Mysql> for NaiveDateTime {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         <NaiveDateTime as FromSql<Timestamp, Mysql>>::from_sql(bytes)
     }
 }
@@ -77,7 +77,7 @@ impl ToSql<Timestamp, Mysql> for NaiveDateTime {
 }
 
 impl FromSql<Timestamp, Mysql> for NaiveDateTime {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let mysql_time = <ffi::MYSQL_TIME as FromSql<Timestamp, Mysql>>::from_sql(bytes)?;
 
         NaiveDate::from_ymd_opt(
@@ -110,7 +110,7 @@ impl ToSql<Time, Mysql> for NaiveTime {
 }
 
 impl FromSql<Time, Mysql> for NaiveTime {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let mysql_time = <ffi::MYSQL_TIME as FromSql<Time, Mysql>>::from_sql(bytes)?;
         NaiveTime::from_hms_opt(
             mysql_time.hour as u32,
@@ -134,7 +134,7 @@ impl ToSql<Date, Mysql> for NaiveDate {
 }
 
 impl FromSql<Date, Mysql> for NaiveDate {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let mysql_time = <ffi::MYSQL_TIME as FromSql<Date, Mysql>>::from_sql(bytes)?;
         NaiveDate::from_ymd_opt(
             mysql_time.year as i32,

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -7,7 +7,7 @@ use std::os::raw as libc;
 use std::{mem, ptr, slice};
 
 use deserialize::{self, FromSql};
-use mysql::Mysql;
+use mysql::{Mysql, MysqlValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::{Date, Datetime, Time, Timestamp};
 
@@ -25,9 +25,9 @@ macro_rules! mysql_time_impls {
         }
 
         impl FromSql<$ty, Mysql> for ffi::MYSQL_TIME {
-            fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-                let bytes = not_none!(bytes);
-                let bytes_ptr = bytes.as_ptr() as *const ffi::MYSQL_TIME;
+            fn from_sql(value: Option<MysqlValue>) -> deserialize::Result<Self> {
+                let value = not_none!(value);
+                let bytes_ptr = value.as_bytes().as_ptr() as *const ffi::MYSQL_TIME;
                 unsafe {
                     let mut result = mem::MaybeUninit::uninit();
                     ptr::copy_nonoverlapping(bytes_ptr, result.as_mut_ptr(), 1);
@@ -55,7 +55,7 @@ impl ToSql<Datetime, Mysql> for NaiveDateTime {
 }
 
 impl FromSql<Datetime, Mysql> for NaiveDateTime {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         <NaiveDateTime as FromSql<Timestamp, Mysql>>::from_sql(bytes)
     }
 }
@@ -77,7 +77,7 @@ impl ToSql<Timestamp, Mysql> for NaiveDateTime {
 }
 
 impl FromSql<Timestamp, Mysql> for NaiveDateTime {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         let mysql_time = <ffi::MYSQL_TIME as FromSql<Timestamp, Mysql>>::from_sql(bytes)?;
 
         NaiveDate::from_ymd_opt(
@@ -110,7 +110,7 @@ impl ToSql<Time, Mysql> for NaiveTime {
 }
 
 impl FromSql<Time, Mysql> for NaiveTime {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         let mysql_time = <ffi::MYSQL_TIME as FromSql<Time, Mysql>>::from_sql(bytes)?;
         NaiveTime::from_hms_opt(
             mysql_time.hour as u32,
@@ -134,7 +134,7 @@ impl ToSql<Date, Mysql> for NaiveDate {
 }
 
 impl FromSql<Date, Mysql> for NaiveDate {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         let mysql_time = <ffi::MYSQL_TIME as FromSql<Date, Mysql>>::from_sql(bytes)?;
         NaiveDate::from_ymd_opt(
             mysql_time.year as i32,

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -8,7 +8,7 @@ use byteorder::WriteBytesExt;
 use std::io::Write;
 
 use deserialize::{self, FromSql};
-use mysql::{Mysql, MysqlTypeMetadata};
+use mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::*;
 
@@ -19,8 +19,9 @@ impl ToSql<TinyInt, Mysql> for i8 {
 }
 
 impl FromSql<TinyInt, Mysql> for i8 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
+    fn from_sql(value: Option<MysqlValue>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let bytes = value.as_bytes();
         Ok(bytes[0] as i8)
     }
 }
@@ -36,7 +37,7 @@ impl ToSql<Unsigned<TinyInt>, Mysql> for u8 {
 }
 
 impl FromSql<Unsigned<TinyInt>, Mysql> for u8 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         let signed: i8 = FromSql::<TinyInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u8)
     }
@@ -49,7 +50,7 @@ impl ToSql<Unsigned<SmallInt>, Mysql> for u16 {
 }
 
 impl FromSql<Unsigned<SmallInt>, Mysql> for u16 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         let signed: i16 = FromSql::<SmallInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u16)
     }
@@ -62,7 +63,7 @@ impl ToSql<Unsigned<Integer>, Mysql> for u32 {
 }
 
 impl FromSql<Unsigned<Integer>, Mysql> for u32 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         let signed: i32 = FromSql::<Integer, Mysql>::from_sql(bytes)?;
         Ok(signed as u32)
     }
@@ -75,7 +76,7 @@ impl ToSql<Unsigned<BigInt>, Mysql> for u64 {
 }
 
 impl FromSql<Unsigned<BigInt>, Mysql> for u64 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
         let signed: i64 = FromSql::<BigInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u64)
     }
@@ -89,8 +90,8 @@ impl ToSql<Bool, Mysql> for bool {
 }
 
 impl FromSql<Bool, Mysql> for bool {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        Ok(not_none!(bytes).iter().any(|x| *x != 0))
+    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+        Ok(not_none!(bytes).as_bytes().iter().any(|x| *x != 0))
     }
 }
 

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -19,7 +19,7 @@ impl ToSql<TinyInt, Mysql> for i8 {
 }
 
 impl FromSql<TinyInt, Mysql> for i8 {
-    fn from_sql(value: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let bytes = value.as_bytes();
         Ok(bytes[0] as i8)
@@ -37,7 +37,7 @@ impl ToSql<Unsigned<TinyInt>, Mysql> for u8 {
 }
 
 impl FromSql<Unsigned<TinyInt>, Mysql> for u8 {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let signed: i8 = FromSql::<TinyInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u8)
     }
@@ -50,7 +50,7 @@ impl ToSql<Unsigned<SmallInt>, Mysql> for u16 {
 }
 
 impl FromSql<Unsigned<SmallInt>, Mysql> for u16 {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let signed: i16 = FromSql::<SmallInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u16)
     }
@@ -63,7 +63,7 @@ impl ToSql<Unsigned<Integer>, Mysql> for u32 {
 }
 
 impl FromSql<Unsigned<Integer>, Mysql> for u32 {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let signed: i32 = FromSql::<Integer, Mysql>::from_sql(bytes)?;
         Ok(signed as u32)
     }
@@ -76,7 +76,7 @@ impl ToSql<Unsigned<BigInt>, Mysql> for u64 {
 }
 
 impl FromSql<Unsigned<BigInt>, Mysql> for u64 {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         let signed: i64 = FromSql::<BigInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u64)
     }
@@ -90,7 +90,7 @@ impl ToSql<Bool, Mysql> for bool {
 }
 
 impl FromSql<Bool, Mysql> for bool {
-    fn from_sql(bytes: Option<MysqlValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
         Ok(not_none!(bytes).as_bytes().iter().any(|x| *x != 0))
     }
 }

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -1,0 +1,25 @@
+use super::Mysql;
+use backend::BinaryRawValue;
+
+/// Raw mysql value as received from the database
+#[derive(Copy, Clone, Debug)]
+pub struct MysqlValue<'a> {
+    raw: &'a [u8],
+}
+
+impl<'a> MysqlValue<'a> {
+    pub(crate) fn new(raw: &'a [u8]) -> Self {
+        Self { raw }
+    }
+
+    /// Get the underlying raw byte representation
+    pub fn as_bytes(&self) -> &[u8] {
+        self.raw
+    }
+}
+
+impl<'a> BinaryRawValue<'a> for Mysql {
+    fn as_bytes(value: Self::RawValue) -> &'a [u8] {
+        value.raw
+    }
+}

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -3,7 +3,7 @@
 use byteorder::NetworkEndian;
 
 use super::query_builder::PgQueryBuilder;
-use super::PgMetadataLookup;
+use super::{PgMetadataLookup, PgValue};
 use backend::*;
 use deserialize::Queryable;
 use query_builder::bind_collector::RawBytesBindCollector;
@@ -43,7 +43,7 @@ impl Backend for Pg {
 }
 
 impl<'a> HasRawValue<'a> for Pg {
-    type RawValue = &'a [u8];
+    type RawValue = PgValue<'a>;
 }
 
 impl TypeMetadata for Pg {

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -20,7 +20,7 @@ impl<ST, T> Cursor<ST, T> {
     pub fn new(db_result: PgResult) -> Self {
         Cursor {
             current_row: 0,
-            db_result: db_result,
+            db_result,
             _marker: PhantomData,
         }
     }
@@ -47,7 +47,7 @@ where
 }
 
 pub struct NamedCursor {
-    db_result: PgResult,
+    pub(crate) db_result: PgResult,
 }
 
 impl NamedCursor {

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -9,15 +9,15 @@ use std::marker::PhantomData;
 
 /// The type returned by various [`Connection`](struct.Connection.html) methods.
 /// Acts as an iterator over `T`.
-pub struct Cursor<ST, T> {
+pub struct Cursor<'a, ST, T> {
     current_row: usize,
-    db_result: PgResult,
+    db_result: PgResult<'a>,
     _marker: PhantomData<(ST, T)>,
 }
 
-impl<ST, T> Cursor<ST, T> {
+impl<'a, ST, T> Cursor<'a, ST, T> {
     #[doc(hidden)]
-    pub fn new(db_result: PgResult) -> Self {
+    pub fn new(db_result: PgResult<'a>) -> Self {
         Cursor {
             current_row: 0,
             db_result,
@@ -26,7 +26,7 @@ impl<ST, T> Cursor<ST, T> {
     }
 }
 
-impl<ST, T> Iterator for Cursor<ST, T>
+impl<'a, ST, T> Iterator for Cursor<'a, ST, T>
 where
     T: Queryable<ST, Pg>,
 {
@@ -46,12 +46,12 @@ where
     }
 }
 
-pub struct NamedCursor {
-    pub(crate) db_result: PgResult,
+pub struct NamedCursor<'a> {
+    pub(crate) db_result: PgResult<'a>,
 }
 
-impl NamedCursor {
-    pub fn new(db_result: PgResult) -> Self {
+impl<'a> NamedCursor<'a> {
+    pub fn new(db_result: PgResult<'a>) -> Self {
         NamedCursor { db_result }
     }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -26,7 +26,7 @@ use sql_types::HasSqlType;
 /// <https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING>
 #[allow(missing_debug_implementations)]
 pub struct PgConnection {
-    raw_connection: RawConnection,
+    pub(crate) raw_connection: RawConnection,
     transaction_manager: AnsiTransactionManager,
     statement_cache: StatementCache<Pg, Statement>,
     metadata_cache: PgMetadataCache,
@@ -38,7 +38,7 @@ impl SimpleConnection for PgConnection {
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
         let query = CString::new(query)?;
         let inner_result = unsafe { self.raw_connection.exec(query.as_ptr()) };
-        PgResult::new(inner_result?)?;
+        PgResult::new(inner_result?, self)?;
         Ok(())
     }
 }
@@ -76,7 +76,7 @@ impl Connection for PgConnection {
     {
         let (query, params) = self.prepare_query(&source.as_query())?;
         query
-            .execute(&self.raw_connection, &params)
+            .execute(self, &params)
             .and_then(|r| Cursor::new(r).collect())
     }
 
@@ -88,7 +88,7 @@ impl Connection for PgConnection {
     {
         let (query, params) = self.prepare_query(source)?;
         query
-            .execute(&self.raw_connection, &params)
+            .execute(self, &params)
             .and_then(|r| NamedCursor::new(r).collect())
     }
 
@@ -98,9 +98,7 @@ impl Connection for PgConnection {
         T: QueryFragment<Pg> + QueryId,
     {
         let (query, params) = self.prepare_query(source)?;
-        query
-            .execute(&self.raw_connection, &params)
-            .map(|r| r.rows_affected())
+        query.execute(self, &params).map(|r| r.rows_affected())
     }
 
     #[doc(hidden)]
@@ -157,20 +155,15 @@ impl PgConnection {
                 } else {
                     None
                 };
-                Statement::prepare(
-                    &self.raw_connection,
-                    sql,
-                    query_name.as_ref().map(|s| &**s),
-                    &metadata,
-                )
+                Statement::prepare(self, sql, query_name.as_ref().map(|s| &**s), &metadata)
             });
 
         Ok((query?, binds))
     }
 
     fn execute_inner(&self, query: &str) -> QueryResult<PgResult> {
-        let query = Statement::prepare(&self.raw_connection, query, None, &[])?;
-        query.execute(&self.raw_connection, &Vec::new())
+        let query = Statement::prepare(self, query, None, &[])?;
+        query.execute(self, &Vec::new())
     }
 
     fn set_config_options(&self) -> QueryResult<()> {

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -8,20 +8,25 @@ use std::{slice, str};
 
 use super::raw::RawResult;
 use super::row::PgRow;
+use pg::PgConnection;
 use result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
 
-pub struct PgResult {
+pub struct PgResult<'a> {
     internal_result: RawResult,
+    pub(crate) connection: &'a PgConnection,
 }
 
-impl PgResult {
+impl<'a> PgResult<'a> {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(internal_result: RawResult) -> QueryResult<Self> {
+    pub fn new(internal_result: RawResult, connection: &'a PgConnection) -> QueryResult<Self> {
         use self::ExecStatusType::*;
 
         let result_status = unsafe { PQresultStatus(internal_result.as_ptr()) };
         match result_status {
-            PGRES_COMMAND_OK | PGRES_TUPLES_OK => Ok(PgResult { internal_result }),
+            PGRES_COMMAND_OK | PGRES_TUPLES_OK => Ok(PgResult {
+                internal_result,
+                connection,
+            }),
             PGRES_EMPTY_QUERY => {
                 let error_message = "Received an empty query".to_string();
                 Err(Error::DatabaseError(

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -1,6 +1,6 @@
 use super::cursor::NamedCursor;
 use super::result::PgResult;
-use pg::Pg;
+use pg::{Pg, PgValue};
 use row::*;
 
 pub struct PgRow<'a> {
@@ -12,18 +12,20 @@ pub struct PgRow<'a> {
 impl<'a> PgRow<'a> {
     pub fn new(db_result: &'a PgResult, row_idx: usize) -> Self {
         PgRow {
-            db_result: db_result,
-            row_idx: row_idx,
+            db_result,
+            row_idx,
             col_idx: 0,
         }
     }
 }
 
 impl<'a> Row<Pg> for PgRow<'a> {
-    fn take(&mut self) -> Option<&[u8]> {
+    fn take(&mut self) -> Option<PgValue> {
         let current_idx = self.col_idx;
         self.col_idx += 1;
-        self.db_result.get(self.row_idx, current_idx)
+        let raw = self.db_result.get(self.row_idx, current_idx)?;
+
+        Some(PgValue::new(raw, self.db_result.column_type(current_idx)))
     }
 
     fn next_is_null(&self, count: usize) -> bool {
@@ -43,8 +45,9 @@ impl<'a> PgNamedRow<'a> {
 }
 
 impl<'a> NamedRow<Pg> for PgNamedRow<'a> {
-    fn get_raw_value(&self, index: usize) -> Option<&[u8]> {
-        self.cursor.get_value(self.idx, index)
+    fn get_raw_value(&self, index: usize) -> Option<PgValue> {
+        let raw = self.cursor.get_value(self.idx, index)?;
+        Some(PgValue::new(raw, self.cursor.db_result.column_type(index)))
     }
 
     fn index_of(&self, column_name: &str) -> Option<usize> {

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -20,7 +20,7 @@ impl<'a> PgRow<'a> {
 }
 
 impl<'a> Row<Pg> for PgRow<'a> {
-    fn take(&mut self) -> Option<PgValue> {
+    fn take(&mut self) -> Option<PgValue<'_>> {
         let current_idx = self.col_idx;
         self.col_idx += 1;
         let raw = self.db_result.get(self.row_idx, current_idx)?;
@@ -49,7 +49,7 @@ impl<'a> PgNamedRow<'a> {
 }
 
 impl<'a> NamedRow<Pg> for PgNamedRow<'a> {
-    fn get_raw_value(&self, index: usize) -> Option<PgValue> {
+    fn get_raw_value(&self, index: usize) -> Option<PgValue<'_>> {
         let raw = self.cursor.get_value(self.idx, index)?;
         Some(PgValue::new(
             raw,

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -22,7 +22,7 @@ pub use self::metadata_lookup::PgMetadataLookup;
 pub use self::query_builder::DistinctOnClause;
 pub use self::query_builder::PgQueryBuilder;
 pub use self::transaction::TransactionBuilder;
-pub use self::value::{PgValue, StaticSqlType};
+pub use self::value::PgValue;
 
 /// Data structures for PG types which have no corresponding Rust type
 ///

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -14,6 +14,7 @@ mod metadata_lookup;
 mod query_builder;
 pub(crate) mod serialize;
 mod transaction;
+mod value;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;
@@ -21,6 +22,7 @@ pub use self::metadata_lookup::PgMetadataLookup;
 pub use self::query_builder::DistinctOnClause;
 pub use self::query_builder::PgQueryBuilder;
 pub use self::transaction::TransactionBuilder;
+pub use self::value::{PgValue, StaticSqlType};
 
 /// Data structures for PG types which have no corresponding Rust type
 ///

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -49,7 +49,11 @@ where
                 } else {
                     let (elem_bytes, new_bytes) = bytes.split_at(elem_size as usize);
                     bytes = new_bytes;
-                    T::from_sql(Some(PgValue::new(elem_bytes, value.get_oid())))
+                    T::from_sql(Some(PgValue::new(
+                        elem_bytes,
+                        value.get_oid(),
+                        value.get_metadata_lookup(),
+                    )))
                 }
             })
             .collect()

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -23,7 +23,7 @@ impl<T, ST> FromSql<Array<ST>, Pg> for Vec<T>
 where
     T: FromSql<ST, Pg>,
 {
-    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let mut bytes = value.as_bytes();
         let num_dimensions = bytes.read_i32::<NetworkEndian>()?;

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 
 use super::{PgDate, PgTime, PgTimestamp};
 use deserialize::{self, FromSql};
-use pg::{Pg, PgValue, StaticSqlType};
+use pg::{Pg, PgValue};
 use serialize::{self, Output, ToSql};
 use sql_types::{Date, Time, Timestamp, Timestamptz};
 
@@ -47,7 +47,7 @@ impl ToSql<Timestamp, Pg> for NaiveDateTime {
 
 impl FromSql<Timestamptz, Pg> for NaiveDateTime {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        FromSql::<Timestamp, Pg>::from_sql(bytes.map(|b| b.with_new_oid(Timestamp::OID)))
+        FromSql::<Timestamp, Pg>::from_sql(bytes)
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -19,7 +19,7 @@ fn pg_epoch() -> NaiveDateTime {
 }
 
 impl FromSql<Timestamp, Pg> for NaiveDateTime {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let PgTimestamp(offset) = FromSql::<Timestamp, Pg>::from_sql(bytes)?;
         match pg_epoch().checked_add_signed(Duration::microseconds(offset)) {
             Some(v) => Ok(v),
@@ -46,7 +46,7 @@ impl ToSql<Timestamp, Pg> for NaiveDateTime {
 }
 
 impl FromSql<Timestamptz, Pg> for NaiveDateTime {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<Timestamp, Pg>::from_sql(bytes)
     }
 }
@@ -58,7 +58,7 @@ impl ToSql<Timestamptz, Pg> for NaiveDateTime {
 }
 
 impl FromSql<Timestamptz, Pg> for DateTime<Utc> {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let naive_date_time = <NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes)?;
         Ok(DateTime::from_utc(naive_date_time, Utc))
     }
@@ -85,7 +85,7 @@ impl ToSql<Time, Pg> for NaiveTime {
 }
 
 impl FromSql<Time, Pg> for NaiveTime {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let PgTime(offset) = FromSql::<Time, Pg>::from_sql(bytes)?;
         let duration = Duration::microseconds(offset);
         Ok(midnight() + duration)
@@ -104,7 +104,7 @@ impl ToSql<Date, Pg> for NaiveDate {
 }
 
 impl FromSql<Date, Pg> for NaiveDate {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let PgDate(offset) = FromSql::<Date, Pg>::from_sql(bytes)?;
         match pg_epoch_date().checked_add_signed(Duration::days(i64::from(offset))) {
             Some(date) => Ok(date),

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -28,9 +28,7 @@ impl ToSql<sql_types::Timestamp, Pg> for Timespec {
 
 impl FromSql<sql_types::Timestamp, Pg> for Timespec {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        let t = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(
-            bytes,
-        )?;
+        let t = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(bytes)?;
         let pg_epoch = Timespec::new(TIME_SEC_CONV, 0);
         let duration = Duration::microseconds(t);
         let out = pg_epoch + duration;

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use self::time::{Duration, Timespec};
 
 use deserialize::{self, FromSql};
-use pg::{Pg, PgValue, StaticSqlType};
+use pg::{Pg, PgValue};
 use serialize::{self, Output, ToSql};
 use sql_types;
 
@@ -29,7 +29,7 @@ impl ToSql<sql_types::Timestamp, Pg> for Timespec {
 impl FromSql<sql_types::Timestamp, Pg> for Timespec {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
         let t = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(
-            bytes.map(|b| b.with_new_oid(sql_types::BigInt::OID)),
+            bytes,
         )?;
         let pg_epoch = Timespec::new(TIME_SEC_CONV, 0);
         let duration = Duration::microseconds(t);

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -27,7 +27,7 @@ impl ToSql<sql_types::Timestamp, Pg> for Timespec {
 }
 
 impl FromSql<sql_types::Timestamp, Pg> for Timespec {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let t = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(bytes)?;
         let pg_epoch = Timespec::new(TIME_SEC_CONV, 0);
         let duration = Duration::microseconds(t);

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::ops::Add;
 
 use deserialize::{self, FromSql};
-use pg::{Pg, PgValue, StaticSqlType};
+use pg::{Pg, PgValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::{self, Date, Interval, Time, Timestamp, Timestamptz};
 
@@ -90,10 +90,7 @@ impl ToSql<sql_types::Timestamp, Pg> for PgTimestamp {
 
 impl FromSql<sql_types::Timestamp, Pg> for PgTimestamp {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        FromSql::<sql_types::BigInt, Pg>::from_sql(
-            bytes.map(|b| b.with_new_oid(sql_types::BigInt::OID)),
-        )
-        .map(PgTimestamp)
+        FromSql::<sql_types::BigInt, Pg>::from_sql(bytes).map(PgTimestamp)
     }
 }
 
@@ -105,9 +102,7 @@ impl ToSql<sql_types::Timestamptz, Pg> for PgTimestamp {
 
 impl FromSql<sql_types::Timestamptz, Pg> for PgTimestamp {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        FromSql::<sql_types::Timestamp, Pg>::from_sql(
-            bytes.map(|b| b.with_new_oid(sql_types::Timestamp::OID)),
-        )
+        FromSql::<sql_types::Timestamp, Pg>::from_sql(bytes)
     }
 }
 
@@ -119,10 +114,7 @@ impl ToSql<sql_types::Date, Pg> for PgDate {
 
 impl FromSql<sql_types::Date, Pg> for PgDate {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        FromSql::<sql_types::Integer, Pg>::from_sql(
-            bytes.map(|b| b.with_new_oid(sql_types::Integer::OID)),
-        )
-        .map(PgDate)
+        FromSql::<sql_types::Integer, Pg>::from_sql(bytes).map(PgDate)
     }
 }
 
@@ -134,10 +126,7 @@ impl ToSql<sql_types::Time, Pg> for PgTime {
 
 impl FromSql<sql_types::Time, Pg> for PgTime {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        FromSql::<sql_types::BigInt, Pg>::from_sql(
-            bytes.map(|b| b.with_new_oid(sql_types::BigInt::OID)),
-        )
-        .map(PgTime)
+        FromSql::<sql_types::BigInt, Pg>::from_sql(bytes).map(PgTime)
     }
 }
 
@@ -153,20 +142,10 @@ impl ToSql<sql_types::Interval, Pg> for PgInterval {
 impl FromSql<sql_types::Interval, Pg> for PgInterval {
     fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
         let value = not_none!(value);
-        let bytes = value.as_bytes();
         Ok(PgInterval {
-            microseconds: FromSql::<sql_types::BigInt, Pg>::from_sql(Some(PgValue::new(
-                &bytes[..8],
-                sql_types::BigInt::OID,
-            )))?,
-            days: FromSql::<sql_types::Integer, Pg>::from_sql(Some(PgValue::new(
-                &bytes[8..12],
-                sql_types::Integer::OID,
-            )))?,
-            months: FromSql::<sql_types::Integer, Pg>::from_sql(Some(PgValue::new(
-                &bytes[12..16],
-                sql_types::Integer::OID,
-            )))?,
+            microseconds: FromSql::<sql_types::BigInt, Pg>::from_sql(Some(value.subslice(0..8)))?,
+            days: FromSql::<sql_types::Integer, Pg>::from_sql(Some(value.subslice(8..12)))?,
+            months: FromSql::<sql_types::Integer, Pg>::from_sql(Some(value.subslice(12..16)))?,
         })
     }
 }

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -89,7 +89,7 @@ impl ToSql<sql_types::Timestamp, Pg> for PgTimestamp {
 }
 
 impl FromSql<sql_types::Timestamp, Pg> for PgTimestamp {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<sql_types::BigInt, Pg>::from_sql(bytes).map(PgTimestamp)
     }
 }
@@ -101,7 +101,7 @@ impl ToSql<sql_types::Timestamptz, Pg> for PgTimestamp {
 }
 
 impl FromSql<sql_types::Timestamptz, Pg> for PgTimestamp {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Timestamp, Pg>::from_sql(bytes)
     }
 }
@@ -113,7 +113,7 @@ impl ToSql<sql_types::Date, Pg> for PgDate {
 }
 
 impl FromSql<sql_types::Date, Pg> for PgDate {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Integer, Pg>::from_sql(bytes).map(PgDate)
     }
 }
@@ -125,7 +125,7 @@ impl ToSql<sql_types::Time, Pg> for PgTime {
 }
 
 impl FromSql<sql_types::Time, Pg> for PgTime {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<sql_types::BigInt, Pg>::from_sql(bytes).map(PgTime)
     }
 }
@@ -140,7 +140,7 @@ impl ToSql<sql_types::Interval, Pg> for PgInterval {
 }
 
 impl FromSql<sql_types::Interval, Pg> for PgInterval {
-    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         Ok(PgInterval {
             microseconds: FromSql::<sql_types::BigInt, Pg>::from_sql(Some(value.subslice(0..8)))?,

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use deserialize::{self, FromSql};
-use pg::{Pg, PgValue, StaticSqlType};
+use pg::{Pg, PgValue};
 use serialize::{self, Output, ToSql};
 use sql_types;
 
@@ -29,7 +29,7 @@ impl ToSql<sql_types::Timestamp, Pg> for SystemTime {
 impl FromSql<sql_types::Timestamp, Pg> for SystemTime {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
         let usecs_passed = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(
-            bytes.map(|b| b.with_new_oid(sql_types::BigInt::OID)),
+            bytes,
         )?;
         let before_epoch = usecs_passed < 0;
         let time_passed = usecs_to_duration(usecs_passed.abs() as u64);

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -28,9 +28,7 @@ impl ToSql<sql_types::Timestamp, Pg> for SystemTime {
 
 impl FromSql<sql_types::Timestamp, Pg> for SystemTime {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        let usecs_passed = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(
-            bytes,
-        )?;
+        let usecs_passed = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(bytes)?;
         let before_epoch = usecs_passed < 0;
         let time_passed = usecs_to_duration(usecs_passed.abs() as u64);
 

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -27,7 +27,7 @@ impl ToSql<sql_types::Timestamp, Pg> for SystemTime {
 }
 
 impl FromSql<sql_types::Timestamp, Pg> for SystemTime {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let usecs_passed = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(bytes)?;
         let before_epoch = usecs_passed < 0;
         let time_passed = usecs_to_duration(usecs_passed.abs() as u64);

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::io::prelude::*;
 
 use deserialize::{self, FromSql};
-use pg::Pg;
+use pg::{Pg, PgValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
@@ -53,8 +53,9 @@ impl Error for InvalidNumericSign {
 }
 
 impl FromSql<sql_types::Numeric, Pg> for PgNumeric {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+        let bytes = not_none!(bytes);
+        let mut bytes = bytes.as_bytes();
         let digit_count = bytes.read_u16::<NetworkEndian>()?;
         let mut digits = Vec::with_capacity(digit_count as usize);
         let weight = bytes.read_i16::<NetworkEndian>()?;

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -53,7 +53,7 @@ impl Error for InvalidNumericSign {
 }
 
 impl FromSql<sql_types::Numeric, Pg> for PgNumeric {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes);
         let mut bytes = bytes.as_bytes();
         let digit_count = bytes.read_u16::<NetworkEndian>()?;

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -2,13 +2,14 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::io::prelude::*;
 
 use deserialize::{self, FromSql};
-use pg::Pg;
+use pg::{Pg, PgValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
 impl FromSql<sql_types::Oid, Pg> for u32 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+        let bytes = not_none!(bytes);
+        let mut bytes = bytes.as_bytes();
         bytes.read_u32::<NetworkEndian>().map_err(Into::into)
     }
 }

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -7,7 +7,7 @@ use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
 impl FromSql<sql_types::Oid, Pg> for u32 {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let bytes = not_none!(bytes);
         let mut bytes = bytes.as_bytes();
         bytes.read_u32::<NetworkEndian>().map_err(Into::into)

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -5,7 +5,7 @@ extern crate serde_json;
 use std::io::prelude::*;
 
 use deserialize::{self, FromSql};
-use pg::Pg;
+use pg::{Pg, PgValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
@@ -22,9 +22,9 @@ mod foreign_derives {
 }
 
 impl FromSql<sql_types::Json, Pg> for serde_json::Value {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
-        serde_json::from_slice(bytes).map_err(Into::into)
+    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        serde_json::from_slice(value.as_bytes()).map_err(Into::into)
     }
 }
 
@@ -37,8 +37,9 @@ impl ToSql<sql_types::Json, Pg> for serde_json::Value {
 }
 
 impl FromSql<sql_types::Jsonb, Pg> for serde_json::Value {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
+    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let bytes = value.as_bytes();
         if bytes[0] != 1 {
             return Err("Unsupported JSONB encoding version".into());
         }
@@ -65,16 +66,20 @@ fn json_to_sql() {
 
 #[test]
 fn some_json_from_sql() {
+    use pg::StaticSqlType;
     let input_json = b"true";
-    let output_json: serde_json::Value =
-        FromSql::<sql_types::Json, Pg>::from_sql(Some(input_json)).unwrap();
+    let output_json: serde_json::Value = FromSql::<sql_types::Json, Pg>::from_sql(Some(
+        PgValue::new(input_json, sql_types::Json::OID),
+    ))
+    .unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
 }
 
 #[test]
 fn bad_json_from_sql() {
+    use pg::StaticSqlType;
     let uuid: Result<serde_json::Value, _> =
-        FromSql::<sql_types::Json, Pg>::from_sql(Some(b"boom"));
+        FromSql::<sql_types::Json, Pg>::from_sql(Some(PgValue::new(b"boom", sql_types::Json::OID)));
     assert_eq!(uuid.unwrap_err().description(), "JSON error");
 }
 
@@ -97,23 +102,30 @@ fn jsonb_to_sql() {
 
 #[test]
 fn some_jsonb_from_sql() {
+    use pg::StaticSqlType;
     let input_json = b"\x01true";
-    let output_json: serde_json::Value =
-        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(input_json)).unwrap();
+    let output_json: serde_json::Value = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
+        PgValue::new(input_json, sql_types::Jsonb::OID),
+    ))
+    .unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
 }
 
 #[test]
 fn bad_jsonb_from_sql() {
-    let uuid: Result<serde_json::Value, _> =
-        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(b"\x01boom"));
+    use pg::StaticSqlType;
+    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
+        PgValue::new(b"\x01boom", sql_types::Jsonb::OID),
+    ));
     assert_eq!(uuid.unwrap_err().description(), "JSON error");
 }
 
 #[test]
 fn bad_jsonb_version_from_sql() {
-    let uuid: Result<serde_json::Value, _> =
-        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(b"\x02true"));
+    use pg::StaticSqlType;
+    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
+        PgValue::new(b"\x02true", sql_types::Jsonb::OID),
+    ));
     assert_eq!(
         uuid.unwrap_err().description(),
         "Unsupported JSONB encoding version"

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -67,10 +67,8 @@ fn json_to_sql() {
 #[test]
 fn some_json_from_sql() {
     let input_json = b"true";
-    let output_json: serde_json::Value = FromSql::<sql_types::Json, Pg>::from_sql(Some(
-        PgValue::for_test(input_json),
-    ))
-    .unwrap();
+    let output_json: serde_json::Value =
+        FromSql::<sql_types::Json, Pg>::from_sql(Some(PgValue::for_test(input_json))).unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
 }
 
@@ -101,26 +99,22 @@ fn jsonb_to_sql() {
 #[test]
 fn some_jsonb_from_sql() {
     let input_json = b"\x01true";
-    let output_json: serde_json::Value = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
-        PgValue::for_test(input_json),
-    ))
-    .unwrap();
+    let output_json: serde_json::Value =
+        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(PgValue::for_test(input_json))).unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
 }
 
 #[test]
 fn bad_jsonb_from_sql() {
-    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
-        PgValue::for_test(b"\x01boom"),
-    ));
+    let uuid: Result<serde_json::Value, _> =
+        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(PgValue::for_test(b"\x01boom")));
     assert_eq!(uuid.unwrap_err().description(), "JSON error");
 }
 
 #[test]
 fn bad_jsonb_version_from_sql() {
-    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
-        PgValue::for_test(b"\x02true"),
-    ));
+    let uuid: Result<serde_json::Value, _> =
+        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(PgValue::for_test(b"\x02true")));
     assert_eq!(
         uuid.unwrap_err().description(),
         "Unsupported JSONB encoding version"

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -22,7 +22,7 @@ mod foreign_derives {
 }
 
 impl FromSql<sql_types::Json, Pg> for serde_json::Value {
-    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         serde_json::from_slice(value.as_bytes()).map_err(Into::into)
     }
@@ -37,7 +37,7 @@ impl ToSql<sql_types::Json, Pg> for serde_json::Value {
 }
 
 impl FromSql<sql_types::Jsonb, Pg> for serde_json::Value {
-    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let bytes = value.as_bytes();
         if bytes[0] != 1 {

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -66,10 +66,9 @@ fn json_to_sql() {
 
 #[test]
 fn some_json_from_sql() {
-    use pg::StaticSqlType;
     let input_json = b"true";
     let output_json: serde_json::Value = FromSql::<sql_types::Json, Pg>::from_sql(Some(
-        PgValue::new(input_json, sql_types::Json::OID),
+        PgValue::for_test(input_json),
     ))
     .unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
@@ -77,9 +76,8 @@ fn some_json_from_sql() {
 
 #[test]
 fn bad_json_from_sql() {
-    use pg::StaticSqlType;
     let uuid: Result<serde_json::Value, _> =
-        FromSql::<sql_types::Json, Pg>::from_sql(Some(PgValue::new(b"boom", sql_types::Json::OID)));
+        FromSql::<sql_types::Json, Pg>::from_sql(Some(PgValue::for_test(b"boom")));
     assert_eq!(uuid.unwrap_err().description(), "JSON error");
 }
 
@@ -102,10 +100,9 @@ fn jsonb_to_sql() {
 
 #[test]
 fn some_jsonb_from_sql() {
-    use pg::StaticSqlType;
     let input_json = b"\x01true";
     let output_json: serde_json::Value = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
-        PgValue::new(input_json, sql_types::Jsonb::OID),
+        PgValue::for_test(input_json),
     ))
     .unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
@@ -113,18 +110,16 @@ fn some_jsonb_from_sql() {
 
 #[test]
 fn bad_jsonb_from_sql() {
-    use pg::StaticSqlType;
     let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
-        PgValue::new(b"\x01boom", sql_types::Jsonb::OID),
+        PgValue::for_test(b"\x01boom"),
     ));
     assert_eq!(uuid.unwrap_err().description(), "JSON error");
 }
 
 #[test]
 fn bad_jsonb_version_from_sql() {
-    use pg::StaticSqlType;
     let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(
-        PgValue::new(b"\x02true", sql_types::Jsonb::OID),
+        PgValue::for_test(b"\x02true"),
     ));
     assert_eq!(
         uuid.unwrap_err().description(),

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 use deserialize::{self, FromSql};
-use pg::Pg;
+use pg::{Pg, PgValue};
 use serialize::{self, Output, ToSql};
 use sql_types::{BigInt, Money};
 
@@ -24,7 +24,7 @@ use sql_types::{BigInt, Money};
 pub struct PgMoney(pub i64);
 
 impl FromSql<Money, Pg> for PgMoney {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
         FromSql::<BigInt, Pg>::from_sql(bytes).map(PgMoney)
     }
 }

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -24,7 +24,7 @@ use sql_types::{BigInt, Money};
 pub struct PgMoney(pub i64);
 
 impl FromSql<Money, Pg> for PgMoney {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<BigInt, Pg>::from_sql(bytes).map(PgMoney)
     }
 }

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -159,13 +159,12 @@ impl_Sql!(Cidr, 1);
 
 #[test]
 fn macaddr_roundtrip() {
-    use pg::StaticSqlType;
 
     let mut bytes = Output::test();
     let input_address = [0x52, 0x54, 0x00, 0xfb, 0xc6, 0x16];
     ToSql::<MacAddr, Pg>::to_sql(&input_address, &mut bytes).unwrap();
     let output_address: [u8; 6] =
-        FromSql::from_sql(Some(PgValue::new(bytes.as_ref(), MacAddr::OID))).unwrap();
+        FromSql::from_sql(Some(PgValue::for_test(bytes.as_ref()))).unwrap();
     assert_eq!(input_address, output_address);
 }
 
@@ -187,8 +186,6 @@ fn v4address_to_sql() {
 
 #[test]
 fn some_v4address_from_sql() {
-    use pg::StaticSqlType;
-
     macro_rules! test_some_address_from_sql {
         ($ty:tt) => {
             let input_address =
@@ -196,7 +193,7 @@ fn some_v4address_from_sql() {
             let mut bytes = Output::test();
             ToSql::<$ty, Pg>::to_sql(&input_address, &mut bytes).unwrap();
             let output_address =
-                FromSql::<$ty, Pg>::from_sql(Some(PgValue::new(bytes.as_ref(), $ty::OID))).unwrap();
+                FromSql::<$ty, Pg>::from_sql(Some(PgValue::for_test(bytes.as_ref()))).unwrap();
             assert_eq!(input_address, output_address);
         };
     }
@@ -247,8 +244,6 @@ fn v6address_to_sql() {
 
 #[test]
 fn some_v6address_from_sql() {
-    use pg::StaticSqlType;
-
     macro_rules! test_some_address_from_sql {
         ($ty:tt) => {
             let input_address =
@@ -256,7 +251,7 @@ fn some_v6address_from_sql() {
             let mut bytes = Output::test();
             ToSql::<$ty, Pg>::to_sql(&input_address, &mut bytes).unwrap();
             let output_address =
-                FromSql::<$ty, Pg>::from_sql(Some(PgValue::new(bytes.as_ref(), $ty::OID))).unwrap();
+                FromSql::<$ty, Pg>::from_sql(Some(PgValue::for_test(bytes.as_ref()))).unwrap();
             assert_eq!(input_address, output_address);
         };
     }
@@ -267,11 +262,10 @@ fn some_v6address_from_sql() {
 
 #[test]
 fn bad_address_from_sql() {
-    use pg::StaticSqlType;
     macro_rules! bad_address_from_sql {
         ($ty:tt) => {
             let address: Result<IpNetwork, _> =
-                FromSql::<$ty, Pg>::from_sql(Some(PgValue::new(&[7, PGSQL_AF_INET, 0], $ty::OID)));
+                FromSql::<$ty, Pg>::from_sql(Some(PgValue::for_test(&[7, PGSQL_AF_INET, 0])));
             assert_eq!(
                 address.unwrap_err().description(),
                 "invalid network address format. input is too short."

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -159,7 +159,6 @@ impl_Sql!(Cidr, 1);
 
 #[test]
 fn macaddr_roundtrip() {
-
     let mut bytes = Output::test();
     let input_address = [0x52, 0x54, 0x00, 0xfb, 0xc6, 0x16];
     ToSql::<MacAddr, Pg>::to_sql(&input_address, &mut bytes).unwrap();

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -62,7 +62,7 @@ macro_rules! assert_or_error {
 }
 
 impl FromSql<MacAddr, Pg> for [u8; 6] {
-    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         value
             .as_bytes()
@@ -81,7 +81,7 @@ impl ToSql<MacAddr, Pg> for [u8; 6] {
 macro_rules! impl_Sql {
     ($ty: ty, $net_type: expr) => {
         impl FromSql<$ty, Pg> for IpNetwork {
-            fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+            fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
                 // https://github.com/postgres/postgres/blob/55c3391d1e6a201b5b891781d21fe682a8c64fe6/src/include/utils/inet.h#L23-L28
                 let value = not_none!(value);
                 let bytes = value.as_bytes();

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -13,7 +13,7 @@ mod bigdecimal {
 
     use deserialize::{self, FromSql};
     use pg::data_types::PgNumeric;
-    use pg::Pg;
+    use pg::{Pg, PgValue};
     use serialize::{self, Output, ToSql};
     use sql_types::Numeric;
 
@@ -153,7 +153,7 @@ mod bigdecimal {
     }
 
     impl FromSql<Numeric, Pg> for BigDecimal {
-        fn from_sql(numeric: Option<&[u8]>) -> deserialize::Result<Self> {
+        fn from_sql(numeric: Option<PgValue>) -> deserialize::Result<Self> {
             PgNumeric::from_sql(numeric)?.try_into()
         }
     }

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -153,7 +153,7 @@ mod bigdecimal {
     }
 
     impl FromSql<Numeric, Pg> for BigDecimal {
-        fn from_sql(numeric: Option<PgValue>) -> deserialize::Result<Self> {
+        fn from_sql(numeric: Option<PgValue<'_>>) -> deserialize::Result<Self> {
             PgNumeric::from_sql(numeric)?.try_into()
         }
     }

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -1,14 +1,14 @@
 use std::io::prelude::*;
 
 use deserialize::{self, FromSql};
-use pg::Pg;
+use pg::{Pg, PgValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
 impl FromSql<sql_types::Bool, Pg> for bool {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
         match bytes {
-            Some(bytes) => Ok(bytes[0] != 0),
+            Some(bytes) => Ok(bytes.as_bytes()[0] != 0),
             None => Ok(false),
         }
     }

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -6,7 +6,7 @@ use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
 impl FromSql<sql_types::Bool, Pg> for bool {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         match bytes {
             Some(bytes) => Ok(bytes.as_bytes()[0] != 0),
             None => Ok(false),

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use deserialize::{self, FromSql, FromSqlRow, Queryable};
 use expression::bound::Bound as SqlBound;
 use expression::AsExpression;
-use pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue, StaticSqlType};
+use pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::*;
 
@@ -26,7 +26,6 @@ bitflags! {
 impl<T, ST> Queryable<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg> + Queryable<ST, Pg>,
-    ST: StaticSqlType,
 {
     type Row = Self;
     fn build(row: Self) -> Self {
@@ -78,11 +77,10 @@ where
 impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg>,
-    ST: StaticSqlType,
 {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
-        let mut bytes = bytes.as_bytes();
+        let value = not_none!(bytes);
+        let mut bytes = value.as_bytes();
         let flags: RangeFlags = RangeFlags::from_bits_truncate(bytes.read_u8()?);
         let mut lower_bound = Bound::Unbounded;
         let mut upper_bound = Bound::Unbounded;
@@ -91,7 +89,10 @@ where
             let elem_size = bytes.read_i32::<NetworkEndian>()?;
             let (elem_bytes, new_bytes) = bytes.split_at(elem_size as usize);
             bytes = new_bytes;
-            let value = T::from_sql(Some(PgValue::new(elem_bytes, ST::OID)))?;
+            let value = T::from_sql(Some(PgValue::new(
+                elem_bytes,
+                value.get_oid(),
+            )))?;
 
             lower_bound = if flags.contains(RangeFlags::LB_INC) {
                 Bound::Included(value)
@@ -102,7 +103,10 @@ where
 
         if !flags.contains(RangeFlags::UB_INF) {
             let _size = bytes.read_i32::<NetworkEndian>()?;
-            let value = T::from_sql(Some(PgValue::new(bytes, ST::OID)))?;
+            let value = T::from_sql(Some(PgValue::new(
+                bytes,
+                value.get_oid(),
+            )))?;
 
             upper_bound = if flags.contains(RangeFlags::UB_INC) {
                 Bound::Included(value)

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -92,6 +92,7 @@ where
             let value = T::from_sql(Some(PgValue::new(
                 elem_bytes,
                 value.get_oid(),
+                value.get_metadata_lookup(),
             )))?;
 
             lower_bound = if flags.contains(RangeFlags::LB_INC) {
@@ -106,6 +107,7 @@ where
             let value = T::from_sql(Some(PgValue::new(
                 bytes,
                 value.get_oid(),
+                value.get_metadata_lookup(),
             )))?;
 
             upper_bound = if flags.contains(RangeFlags::UB_INC) {

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use deserialize::{self, FromSql, FromSqlRow, Queryable};
 use expression::bound::Bound as SqlBound;
 use expression::AsExpression;
-use pg::{Pg, PgMetadataLookup, PgTypeMetadata};
+use pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue, StaticSqlType};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::*;
 
@@ -26,6 +26,7 @@ bitflags! {
 impl<T, ST> Queryable<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg> + Queryable<ST, Pg>,
+    ST: StaticSqlType,
 {
     type Row = Self;
     fn build(row: Self) -> Self {
@@ -77,9 +78,11 @@ where
 impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg>,
+    ST: StaticSqlType,
 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+        let bytes = not_none!(bytes);
+        let mut bytes = bytes.as_bytes();
         let flags: RangeFlags = RangeFlags::from_bits_truncate(bytes.read_u8()?);
         let mut lower_bound = Bound::Unbounded;
         let mut upper_bound = Bound::Unbounded;
@@ -88,7 +91,7 @@ where
             let elem_size = bytes.read_i32::<NetworkEndian>()?;
             let (elem_bytes, new_bytes) = bytes.split_at(elem_size as usize);
             bytes = new_bytes;
-            let value = T::from_sql(Some(elem_bytes))?;
+            let value = T::from_sql(Some(PgValue::new(elem_bytes, ST::OID)))?;
 
             lower_bound = if flags.contains(RangeFlags::LB_INC) {
                 Bound::Included(value)
@@ -99,7 +102,7 @@ where
 
         if !flags.contains(RangeFlags::UB_INF) {
             let _size = bytes.read_i32::<NetworkEndian>()?;
-            let value = T::from_sql(Some(bytes))?;
+            let value = T::from_sql(Some(PgValue::new(bytes, ST::OID)))?;
 
             upper_bound = if flags.contains(RangeFlags::UB_INC) {
                 Bound::Included(value)

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -78,7 +78,7 @@ impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg>,
 {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(bytes);
         let mut bytes = value.as_bytes();
         let flags: RangeFlags = RangeFlags::from_bits_truncate(bytes.read_u8()?);

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -51,7 +51,11 @@ macro_rules! tuple_impls {
                     } else {
                         let (elem_bytes, new_bytes) = bytes.split_at(num_bytes as usize);
                         bytes = new_bytes;
-                        $T::from_sql(Some(PgValue::new(elem_bytes, oid)))?
+                        $T::from_sql(Some(PgValue::new(
+                            elem_bytes,
+                            oid,
+                            value.get_metadata_lookup()
+                        )))?
                     }
                 },)+);
 

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -25,9 +25,9 @@ macro_rules! tuple_impls {
             // but the only other option would be to use `mem::uninitialized`
             // and `ptr::write`.
             #[allow(clippy::eval_order_dependence)]
-            fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-                let bytes = not_none!(bytes);
-                let mut bytes = bytes.as_bytes();
+            fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+                let value = not_none!(value);
+                let mut bytes = value.as_bytes();
                 let num_elements = bytes.read_i32::<NetworkEndian>()?;
 
                 if num_elements != $Tuple {

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -25,7 +25,7 @@ macro_rules! tuple_impls {
             // but the only other option would be to use `mem::uninitialized`
             // and `ptr::write`.
             #[allow(clippy::eval_order_dependence)]
-            fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+            fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
                 let value = not_none!(value);
                 let mut bytes = value.as_bytes();
                 let num_elements = bytes.read_i32::<NetworkEndian>()?;

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -3,7 +3,7 @@ extern crate uuid;
 use std::io::prelude::*;
 
 use deserialize::{self, FromSql};
-use pg::Pg;
+use pg::{Pg, PgValue};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types::Uuid;
 
@@ -14,9 +14,9 @@ use sql_types::Uuid;
 struct UuidProxy(uuid::Uuid);
 
 impl FromSql<Uuid, Pg> for uuid::Uuid {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
-        uuid::Uuid::from_bytes(bytes).map_err(Into::into)
+    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        uuid::Uuid::from_bytes(value.as_bytes()).map_err(Into::into)
     }
 }
 
@@ -38,14 +38,18 @@ fn uuid_to_sql() {
 
 #[test]
 fn some_uuid_from_sql() {
+    use pg::StaticSqlType;
     let input_uuid = uuid::Uuid::from_fields(0xFFFF_FFFF, 0xFFFF, 0xFFFF, b"abcdef12").unwrap();
-    let output_uuid = FromSql::<Uuid, Pg>::from_sql(Some(input_uuid.as_bytes())).unwrap();
+    let output_uuid =
+        FromSql::<Uuid, Pg>::from_sql(Some(PgValue::new(input_uuid.as_bytes(), Uuid::OID)))
+            .unwrap();
     assert_eq!(input_uuid, output_uuid);
 }
 
 #[test]
 fn bad_uuid_from_sql() {
-    let uuid = uuid::Uuid::from_sql(Some(b"boom"));
+    use pg::StaticSqlType;
+    let uuid = uuid::Uuid::from_sql(Some(PgValue::new(b"boom", Uuid::OID)));
     assert_eq!(uuid.unwrap_err().description(), "UUID parse error");
 }
 

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -14,7 +14,7 @@ use sql_types::Uuid;
 struct UuidProxy(uuid::Uuid);
 
 impl FromSql<Uuid, Pg> for uuid::Uuid {
-    fn from_sql(value: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         uuid::Uuid::from_bytes(value.as_bytes()).map_err(Into::into)
     }

--- a/diesel/src/pg/types/uuid.rs
+++ b/diesel/src/pg/types/uuid.rs
@@ -38,18 +38,15 @@ fn uuid_to_sql() {
 
 #[test]
 fn some_uuid_from_sql() {
-    use pg::StaticSqlType;
     let input_uuid = uuid::Uuid::from_fields(0xFFFF_FFFF, 0xFFFF, 0xFFFF, b"abcdef12").unwrap();
     let output_uuid =
-        FromSql::<Uuid, Pg>::from_sql(Some(PgValue::new(input_uuid.as_bytes(), Uuid::OID)))
-            .unwrap();
+        FromSql::<Uuid, Pg>::from_sql(Some(PgValue::for_test(input_uuid.as_bytes()))).unwrap();
     assert_eq!(input_uuid, output_uuid);
 }
 
 #[test]
 fn bad_uuid_from_sql() {
-    use pg::StaticSqlType;
-    let uuid = uuid::Uuid::from_sql(Some(PgValue::new(b"boom", Uuid::OID)));
+    let uuid = uuid::Uuid::from_sql(Some(PgValue::for_test(b"boom")));
     assert_eq!(uuid.unwrap_err().description(), "UUID parse error");
 }
 

--- a/diesel/src/pg/types/uuid_v0_7.rs
+++ b/diesel/src/pg/types/uuid_v0_7.rs
@@ -15,7 +15,7 @@ struct UuidProxy(uuid::Uuid);
 
 impl FromSql<Uuid, Pg> for uuid::Uuid {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+        let value = not_none!(bytes);
         uuid::Uuid::from_slice(value.as_bytes()).map_err(Into::into)
     }
 }

--- a/diesel/src/pg/types/uuid_v0_7.rs
+++ b/diesel/src/pg/types/uuid_v0_7.rs
@@ -14,7 +14,7 @@ use sql_types::Uuid;
 struct UuidProxy(uuid::Uuid);
 
 impl FromSql<Uuid, Pg> for uuid::Uuid {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(bytes);
         uuid::Uuid::from_slice(value.as_bytes()).map_err(Into::into)
     }

--- a/diesel/src/pg/types/uuid_v0_7.rs
+++ b/diesel/src/pg/types/uuid_v0_7.rs
@@ -47,7 +47,10 @@ fn some_uuid_from_sql() {
 #[test]
 fn bad_uuid_from_sql() {
     let uuid = uuid::Uuid::from_sql(Some(PgValue::for_test(b"boom")));
-    assert_eq!(uuid.unwrap_err().description(), "invalid number of uuid bytes");
+    assert_eq!(
+        uuid.unwrap_err().description(),
+        "invalid number of uuid bytes"
+    );
 }
 
 #[test]

--- a/diesel/src/pg/types/uuid_v0_7.rs
+++ b/diesel/src/pg/types/uuid_v0_7.rs
@@ -38,19 +38,16 @@ fn uuid_to_sql() {
 
 #[test]
 fn some_uuid_from_sql() {
-    use pg::StaticSqlType;
     let input_uuid = uuid::Uuid::from_fields(0xFFFF_FFFF, 0xFFFF, 0xFFFF, b"abcdef12").unwrap();
     let output_uuid =
-        FromSql::<Uuid, Pg>::from_sql(Some(PgValue::new(input_uuid.as_bytes(), Uuid::OID)))
-            .unwrap();
+        FromSql::<Uuid, Pg>::from_sql(Some(PgValue::for_test(input_uuid.as_bytes()))).unwrap();
     assert_eq!(input_uuid, output_uuid);
 }
 
 #[test]
 fn bad_uuid_from_sql() {
-    use pg::StaticSqlType;
-    let uuid = uuid::Uuid::from_sql(Some(PgValue::new(b"boom", Uuid::OID)));
-    assert_eq!(uuid.unwrap_err().description(), "UUID parse error");
+    let uuid = uuid::Uuid::from_sql(Some(PgValue::for_test(b"boom")));
+    assert_eq!(uuid.unwrap_err().description(), "invalid number of uuid bytes");
 }
 
 #[test]

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -1,14 +1,7 @@
-use super::Pg;
+use super::{Pg, PgMetadataLookup};
 use backend::BinaryRawValue;
 use std::num::NonZeroU32;
-
-/// Marker trait for types with oid's known at compile time
-pub trait StaticSqlType {
-    /// Type oid
-    const OID: NonZeroU32;
-    /// Array oid
-    const ARRAY_OID: NonZeroU32;
-}
+use std::ops::Range;
 
 /// Raw postgres value as received from the database
 #[derive(Clone, Copy)]
@@ -42,7 +35,10 @@ impl<'a> PgValue<'a> {
         self.type_oid
     }
 
-    pub(crate) fn with_new_oid(self, type_oid: NonZeroU32) -> Self {
-        Self { type_oid, ..self }
+    pub(crate) fn subslice(&self, range: Range<usize>) -> Self {
+        Self {
+            raw_value: &self.raw_value[range],
+            ..*self
+        }
     }
 }

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -9,6 +9,7 @@ use std::ops::Range;
 pub struct PgValue<'a> {
     raw_value: &'a [u8],
     type_oid: NonZeroU32,
+    metadata: &'a PgMetadataLookup,
 }
 
 impl<'a> BinaryRawValue<'a> for Pg {
@@ -18,10 +19,15 @@ impl<'a> BinaryRawValue<'a> for Pg {
 }
 
 impl<'a> PgValue<'a> {
-    pub(crate) fn new(raw_value: &'a [u8], type_oid: NonZeroU32) -> Self {
+    pub(crate) fn new(
+        raw_value: &'a [u8],
+        type_oid: NonZeroU32,
+        metadata: &'a PgMetadataLookup,
+    ) -> Self {
         Self {
             raw_value,
             type_oid,
+            metadata,
         }
     }
 
@@ -33,6 +39,11 @@ impl<'a> PgValue<'a> {
     /// Get the type oid of this value
     pub fn get_oid(&self) -> NonZeroU32 {
         self.type_oid
+    }
+
+    /// Get a instance for type lookup
+    pub fn get_metadata_lookup(&self) -> &PgMetadataLookup {
+        self.metadata
     }
 
     pub(crate) fn subslice(&self, range: Range<usize>) -> Self {

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -1,0 +1,48 @@
+use super::Pg;
+use backend::BinaryRawValue;
+use std::num::NonZeroU32;
+
+/// Marker trait for types with oid's known at compile time
+pub trait StaticSqlType {
+    /// Type oid
+    const OID: NonZeroU32;
+    /// Array oid
+    const ARRAY_OID: NonZeroU32;
+}
+
+/// Raw postgres value as received from the database
+#[derive(Clone, Copy)]
+#[allow(missing_debug_implementations)]
+pub struct PgValue<'a> {
+    raw_value: &'a [u8],
+    type_oid: NonZeroU32,
+}
+
+impl<'a> BinaryRawValue<'a> for Pg {
+    fn as_bytes(value: PgValue<'a>) -> &'a [u8] {
+        value.raw_value
+    }
+}
+
+impl<'a> PgValue<'a> {
+    pub(crate) fn new(raw_value: &'a [u8], type_oid: NonZeroU32) -> Self {
+        Self {
+            raw_value,
+            type_oid,
+        }
+    }
+
+    /// Get the underlying raw byte representation
+    pub fn as_bytes(&self) -> &[u8] {
+        self.raw_value
+    }
+
+    /// Get the type oid of this value
+    pub fn get_oid(&self) -> NonZeroU32 {
+        self.type_oid
+    }
+
+    pub(crate) fn with_new_oid(self, type_oid: NonZeroU32) -> Self {
+        Self { type_oid, ..self }
+    }
+}

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 pub struct PgValue<'a> {
     raw_value: &'a [u8],
     type_oid: NonZeroU32,
-    metadata: &'a PgMetadataLookup,
+    metadata: Option<&'a PgMetadataLookup>,
 }
 
 impl<'a> BinaryRawValue<'a> for Pg {
@@ -19,6 +19,15 @@ impl<'a> BinaryRawValue<'a> for Pg {
 }
 
 impl<'a> PgValue<'a> {
+    #[cfg(test)]
+    pub(crate) fn for_test(raw_value: &'a [u8]) -> Self {
+        Self {
+            raw_value,
+            type_oid: NonZeroU32::new(42).unwrap(),
+            metadata: None,
+        }
+    }
+
     pub(crate) fn new(
         raw_value: &'a [u8],
         type_oid: NonZeroU32,
@@ -27,7 +36,7 @@ impl<'a> PgValue<'a> {
         Self {
             raw_value,
             type_oid,
-            metadata,
+            metadata: Some(metadata),
         }
     }
 
@@ -43,7 +52,7 @@ impl<'a> PgValue<'a> {
 
     /// Get a instance for type lookup
     pub fn get_metadata_lookup(&self) -> &PgMetadataLookup {
-        self.metadata
+        self.metadata.expect("It's only not there for tests")
     }
 
     pub(crate) fn subslice(&self, range: Range<usize>) -> Self {

--- a/diesel/src/type_impls/floats.rs
+++ b/diesel/src/type_impls/floats.rs
@@ -2,17 +2,18 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use backend::{Backend, HasRawValue};
+use backend::{Backend, BinaryRawValue};
 use deserialize::{self, FromSql};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
 impl<DB> FromSql<sql_types::Float, DB> for f32
 where
-    DB: Backend + for<'a> HasRawValue<'a, RawValue = &'a [u8]>,
+    DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 4,
             "Received more than 4 bytes while decoding \
@@ -34,10 +35,11 @@ impl<DB: Backend> ToSql<sql_types::Float, DB> for f32 {
 
 impl<DB> FromSql<sql_types::Double, DB> for f64
 where
-    DB: Backend + for<'a> HasRawValue<'a, RawValue = &'a [u8]>,
+    DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 8,
             "Received more than 8 bytes while decoding \

--- a/diesel/src/type_impls/integers.rs
+++ b/diesel/src/type_impls/integers.rs
@@ -2,17 +2,18 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use backend::{Backend, HasRawValue};
+use backend::{Backend, BinaryRawValue};
 use deserialize::{self, FromSql};
 use serialize::{self, IsNull, Output, ToSql};
 use sql_types;
 
 impl<DB> FromSql<sql_types::SmallInt, DB> for i16
 where
-    DB: Backend + for<'a> HasRawValue<'a, RawValue = &'a [u8]>,
+    DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 2,
             "Received more than 2 bytes decoding i16. \
@@ -40,10 +41,11 @@ impl<DB: Backend> ToSql<sql_types::SmallInt, DB> for i16 {
 
 impl<DB> FromSql<sql_types::Integer, DB> for i32
 where
-    DB: Backend + for<'a> HasRawValue<'a, RawValue = &'a [u8]>,
+    DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 4,
             "Received more than 4 bytes decoding i32. \
@@ -70,10 +72,11 @@ impl<DB: Backend> ToSql<sql_types::Integer, DB> for i32 {
 
 impl<DB> FromSql<sql_types::BigInt, DB> for i64
 where
-    DB: Backend + for<'a> HasRawValue<'a, RawValue = &'a [u8]>,
+    DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        let mut bytes = not_none!(bytes);
+    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 8,
             "Received more than 8 bytes decoding i64. \

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -110,20 +110,32 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
             let struct_name = &item.ident;
             let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
-            let metadata_fn = match ty {
-                PgType::Fixed { oid, array_oid } => quote!(
-                    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-                        PgTypeMetadata {
-                            oid: #oid,
-                            array_oid: #array_oid,
+            let (metadata_fn, const_metadata) = match ty {
+                PgType::Fixed { oid, array_oid } => {
+                    let metadata_fn = quote!(
+                        fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+                            PgTypeMetadata {
+                                oid: #oid,
+                                array_oid: #array_oid,
+                            }
                         }
-                    }
-                ),
-                PgType::Lookup(type_name) => quote!(
+                    );
+
+                    let const_metadata = quote! {
+                        impl #impl_generics diesel::pg::StaticSqlType for #struct_name #ty_generics
+                        {
+                            const OID: std::num::NonZeroU32 = unsafe {std::num::NonZeroU32::new_unchecked(#oid) };
+                            const ARRAY_OID: std::num::NonZeroU32 = unsafe {std::num::NonZeroU32::new_unchecked(#array_oid) };
+                        }
+                    };
+
+                    (metadata_fn, Some(const_metadata))
+                }
+                PgType::Lookup(type_name) => (quote!(
                     fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
                         lookup.lookup_type(#type_name)
                     }
-                ),
+                ), None)
             };
 
             Some(quote! {
@@ -135,6 +147,8 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
                 {
                     #metadata_fn
                 }
+
+                #const_metadata
             })
         })
 }

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -111,22 +111,19 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
             let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
             let metadata_fn = match ty {
-                PgType::Fixed { oid, array_oid } => {
-                    quote!(
-                        fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-                            PgTypeMetadata {
-                                oid: #oid,
-                                array_oid: #array_oid,
-                            }
+                PgType::Fixed { oid, array_oid } => quote!(
+                    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+                        PgTypeMetadata {
+                            oid: #oid,
+                            array_oid: #array_oid,
                         }
-                    )
-
-                }
+                    }
+                ),
                 PgType::Lookup(type_name) => quote!(
                     fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
                         lookup.lookup_type(#type_name)
                     }
-                )
+                ),
             };
 
             Some(quote! {

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -1,6 +1,6 @@
 use diesel::connection::SimpleConnection;
 use diesel::deserialize::{self, FromSql};
-use diesel::pg::Pg;
+use diesel::pg::{Pg, PgValue};
 use diesel::serialize::{self, IsNull, Output, ToSql};
 use diesel::*;
 use schema::*;
@@ -37,8 +37,8 @@ impl ToSql<MyType, Pg> for MyEnum {
 }
 
 impl FromSql<MyType, Pg> for MyEnum {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        match not_none!(bytes) {
+    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+        match not_none!(bytes).as_bytes() {
             b"foo" => Ok(MyEnum::Foo),
             b"bar" => Ok(MyEnum::Bar),
             _ => Err("Unrecognized enum variant".into()),

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -37,7 +37,7 @@ impl ToSql<MyType, Pg> for MyEnum {
 }
 
 impl FromSql<MyType, Pg> for MyEnum {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         match not_none!(bytes).as_bytes() {
             b"foo" => Ok(MyEnum::Foo),
             b"bar" => Ok(MyEnum::Bar),

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1128,6 +1128,8 @@ fn text_array_can_be_assigned_to_varchar_array_column() {
 #[test]
 #[cfg(feature = "postgres")]
 fn third_party_crates_can_add_new_types() {
+    use diesel::pg::PgValue;
+
     #[derive(Debug, Clone, Copy, QueryId, SqlType)]
     struct MyInt;
 
@@ -1138,7 +1140,7 @@ fn third_party_crates_can_add_new_types() {
     }
 
     impl FromSql<MyInt, Pg> for i32 {
-        fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
             FromSql::<Integer, Pg>::from_sql(bytes)
         }
     }

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1140,7 +1140,7 @@ fn third_party_crates_can_add_new_types() {
     }
 
     impl FromSql<MyInt, Pg> for i32 {
-        fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
+        fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
             FromSql::<Integer, Pg>::from_sql(bytes)
         }
     }


### PR DESCRIPTION
This commit separates the raw value representation of the mysql and
postgresql backend from raw `&[u8]` to specific types that could hold
additional information. To avoid code duplication for commonly used
types an additional trait (`BinaryRawValue`) is introduced, which is
basically equivalent to `AsRef<[u8]>` but has the existing
`HasRawValue` trait as super trait. This is required to workaround
some higher ranked life time issues in rustc.
Additionally some type information are added to the postgresql value
type. Those information may allow to do dynamic type conversations in
future diesel versions.

Basically a improved reimplementation of #1833 on top of #1976. As @sgrif stated there this PR keeps the common impl's in place by adding a `BinaryRawValue` trait.

That said: I'm not super sure if the newly added public types/functions have meaningful names or if we should choose something different.

cc @pgab