### PR TITLE
Add a special warning when multiple parents are used in one belongs_to

### DIFF
--- a/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.rs
+++ b/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.rs
@@ -2,19 +2,25 @@
 extern crate diesel;
 
 table! {
-    foo {
+    bar (id) {
         id -> Integer,
     }
 }
 
+table! {
+    foo (bar_id) {
+        bar_id -> Integer,
+    }
+}
+
 #[derive(Identifiable)]
-#[table_name = "foo"]
+#[table_name = "bar"]
 struct Bar {
     id: i32,
 }
 
 #[derive(Identifiable)]
-#[table_name = "foo"]
+#[table_name = "bar"]
 struct Baz {
     id: i32,
 }
@@ -27,6 +33,7 @@ struct Baz {
 #[belongs_to(Bar, foreign_key)]
 #[belongs_to(Bar, foreign_key(bar_id))]
 #[belongs_to(Baz, foreign_key = "bar_id", random_option)]
+#[table_name = "foo"]
 struct Foo {
     bar_id: i32,
 }

--- a/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
@@ -39,14 +39,14 @@ warning: The form `foreign_key(value)` is deprecated. Use `foreign_key = "value"
    |                   ^^^^^^^^^^^^^^^^^^^
 
 warning: belongs_to takes a single parent. Change
-    belongs_to(Parent1, Parent2)
+    belongs_to(Baz, random_option)
 to
-    belongs_to(Parent1)
-    belongs_to(Parent2)
-  --> $DIR/belongs_to_invalid_option_syntax.rs:29:43
+    belongs_to(Baz)
+    belongs_to(random_option)
+  --> $DIR/belongs_to_invalid_option_syntax.rs:29:3
    |
 29 | #[belongs_to(Baz, foreign_key = "bar_id", random_option)]
-   |                                           ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0433]: failed to resolve: use of undeclared type or module `foos`
   --> $DIR/belongs_to_invalid_option_syntax.rs:30:8

--- a/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
@@ -38,7 +38,11 @@ warning: The form `foreign_key(value)` is deprecated. Use `foreign_key = "value"
 28 | #[belongs_to(Bar, foreign_key(bar_id))]
    |                   ^^^^^^^^^^^^^^^^^^^
 
-warning: Unrecognized option random_option
+warning: belongs_to takes a single parent. Change
+    belongs_to(Parent1, Parent2)
+to
+    belongs_to(Parent1)
+    belongs_to(Parent2)
   --> $DIR/belongs_to_invalid_option_syntax.rs:29:43
    |
 29 | #[belongs_to(Baz, foreign_key = "bar_id", random_option)]

--- a/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_invalid_option_syntax.stderr
@@ -1,41 +1,41 @@
 error: `belongs_to` must be in the form `belongs_to(...)`
-  --> $DIR/belongs_to_invalid_option_syntax.rs:23:3
+  --> $DIR/belongs_to_invalid_option_syntax.rs:29:3
    |
-23 | #[belongs_to]
+29 | #[belongs_to]
    |   ^^^^^^^^^^
 
 error: `belongs_to` must be in the form `belongs_to(...)`
-  --> $DIR/belongs_to_invalid_option_syntax.rs:24:3
+  --> $DIR/belongs_to_invalid_option_syntax.rs:30:3
    |
-24 | #[belongs_to = "Bar"]
+30 | #[belongs_to = "Bar"]
    |   ^^^^^^^^^^^^^^^^^^
 
 error: Expected a struct name
-  --> $DIR/belongs_to_invalid_option_syntax.rs:25:3
+  --> $DIR/belongs_to_invalid_option_syntax.rs:31:3
    |
-25 | #[belongs_to()]
+31 | #[belongs_to()]
    |   ^^^^^^^^^^^^
    |
    = help: e.g. `#[belongs_to(User)]` or `#[belongs_to(parent = "User<'_>")]
 
 error: Expected a struct name
-  --> $DIR/belongs_to_invalid_option_syntax.rs:26:3
+  --> $DIR/belongs_to_invalid_option_syntax.rs:32:3
    |
-26 | #[belongs_to(foreign_key = "bar_id")]
+32 | #[belongs_to(foreign_key = "bar_id")]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: e.g. `#[belongs_to(User)]` or `#[belongs_to(parent = "User<'_>")]
 
 error: `foreign_key` must be in the form `foreign_key = "value"`
-  --> $DIR/belongs_to_invalid_option_syntax.rs:27:19
+  --> $DIR/belongs_to_invalid_option_syntax.rs:33:19
    |
-27 | #[belongs_to(Bar, foreign_key)]
+33 | #[belongs_to(Bar, foreign_key)]
    |                   ^^^^^^^^^^^
 
 warning: The form `foreign_key(value)` is deprecated. Use `foreign_key = "value"` instead
-  --> $DIR/belongs_to_invalid_option_syntax.rs:28:19
+  --> $DIR/belongs_to_invalid_option_syntax.rs:34:19
    |
-28 | #[belongs_to(Bar, foreign_key(bar_id))]
+34 | #[belongs_to(Bar, foreign_key(bar_id))]
    |                   ^^^^^^^^^^^^^^^^^^^
 
 warning: belongs_to takes a single parent. Change
@@ -43,17 +43,10 @@ warning: belongs_to takes a single parent. Change
 to
     belongs_to(Baz)
     belongs_to(random_option)
-  --> $DIR/belongs_to_invalid_option_syntax.rs:29:3
+  --> $DIR/belongs_to_invalid_option_syntax.rs:35:3
    |
-29 | #[belongs_to(Baz, foreign_key = "bar_id", random_option)]
+35 | #[belongs_to(Baz, foreign_key = "bar_id", random_option)]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `foos`
-  --> $DIR/belongs_to_invalid_option_syntax.rs:30:8
-   |
-30 | struct Foo {
-   |        ^^^ use of undeclared type or module `foos`
+error: aborting due to 5 previous errors
 
-error: aborting due to 6 previous errors
-
-For more information about this error, try `rustc --explain E0433`.

--- a/diesel_compile_tests/tests/ui/belongs_to_second_parent.rs
+++ b/diesel_compile_tests/tests/ui/belongs_to_second_parent.rs
@@ -2,25 +2,32 @@
 extern crate diesel;
 
 table! {
-    foo {
+    bar (id) {
         id -> Integer,
     }
 }
 
+table! {
+    foo (bar_id) {
+        bar_id -> Integer,
+    }
+}
+
 #[derive(Identifiable)]
-#[table_name = "foo"]
+#[table_name = "bar"]
 struct Bar {
     id: i32,
 }
 
 #[derive(Identifiable)]
-#[table_name = "foo"]
+#[table_name = "bar"]
 struct Baz {
     id: i32,
 }
 
 #[derive(Associations)]
 #[belongs_to(Bar, Baz)]
+#[table_name = "foo"]
 struct Foo {
     bar_id: i32,
 }

--- a/diesel_compile_tests/tests/ui/belongs_to_second_parent.rs
+++ b/diesel_compile_tests/tests/ui/belongs_to_second_parent.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    foo {
+        id -> Integer,
+    }
+}
+
+#[derive(Identifiable)]
+#[table_name = "foo"]
+struct Bar {
+    id: i32,
+}
+
+#[derive(Identifiable)]
+#[table_name = "foo"]
+struct Baz {
+    id: i32,
+}
+
+#[derive(Associations)]
+#[belongs_to(Bar, Baz)]
+struct Foo {
+    bar_id: i32,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
@@ -3,10 +3,10 @@ warning: belongs_to takes a single parent. Change
 to
     belongs_to(Bar)
     belongs_to(Baz)
-  --> $DIR/belongs_to_second_parent.rs:23:19
+  --> $DIR/belongs_to_second_parent.rs:23:3
    |
 23 | #[belongs_to(Bar, Baz)]
-   |                   ^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 
 error[E0433]: failed to resolve: use of undeclared type or module `foos`
   --> $DIR/belongs_to_second_parent.rs:24:8

--- a/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
@@ -1,0 +1,19 @@
+warning: belongs_to takes a single parent. Change
+    belongs_to(Parent1, Parent2)
+to
+    belongs_to(Parent1)
+    belongs_to(Parent2)
+  --> $DIR/belongs_to_second_parent.rs:23:19
+   |
+23 | #[belongs_to(Bar, Baz)]
+   |                   ^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `foos`
+  --> $DIR/belongs_to_second_parent.rs:24:8
+   |
+24 | struct Foo {
+   |        ^^^ use of undeclared type or module `foos`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
@@ -8,5 +8,3 @@ to
 29 | #[belongs_to(Bar, Baz)]
    |   ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
-

--- a/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
@@ -1,8 +1,8 @@
 warning: belongs_to takes a single parent. Change
-    belongs_to(Parent1, Parent2)
+    belongs_to(Bar, Baz)
 to
-    belongs_to(Parent1)
-    belongs_to(Parent2)
+    belongs_to(Bar)
+    belongs_to(Baz)
   --> $DIR/belongs_to_second_parent.rs:23:19
    |
 23 | #[belongs_to(Bar, Baz)]

--- a/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
+++ b/diesel_compile_tests/tests/ui/belongs_to_second_parent.stderr
@@ -3,17 +3,10 @@ warning: belongs_to takes a single parent. Change
 to
     belongs_to(Bar)
     belongs_to(Baz)
-  --> $DIR/belongs_to_second_parent.rs:23:3
+  --> $DIR/belongs_to_second_parent.rs:29:3
    |
-23 | #[belongs_to(Bar, Baz)]
+29 | #[belongs_to(Bar, Baz)]
    |   ^^^^^^^^^^^^^^^^^^^^
-
-error[E0433]: failed to resolve: use of undeclared type or module `foos`
-  --> $DIR/belongs_to_second_parent.rs:24:8
-   |
-24 | struct Foo {
-   |        ^^^ use of undeclared type or module `foos`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0433`.

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -147,13 +147,29 @@ impl AssociationOptions {
             .skip(1)
             .filter(|n| !n.name().is_ident("foreign_key"));
         for ignored in unrecognized_options {
-            ignored
-                .span()
-                .warning(format!(
-                    "Unrecognized option {}",
-                    path_to_string(&ignored.name())
-                ))
-                .emit();
+            match ignored.word() {
+                Ok(_) => {
+                    ignored
+                        .span()
+                        .warning(format!(
+                            "belongs_to takes a single parent. Change\n\
+                            \tbelongs_to(Parent1, Parent2)\n\
+                            to\n\
+                            \tbelongs_to(Parent1)\n\
+                            \tbelongs_to(Parent2)"
+                        ))
+                        .emit();
+                },
+                Err(_) => {
+                    ignored
+                        .span()
+                        .warning(format!(
+                            "Unrecognized option {}",
+                            path_to_string(&ignored.name())
+                        ))
+                        .emit();
+                }
+            }
         }
 
         Ok(Self {

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -155,21 +155,21 @@ impl AssociationOptions {
                 .filter_map(|item| item.path().as_ref().map(path_to_string).ok())
                 .collect();
 
-            meta
-                .span()
+            meta.span()
                 .warning(format!(
                     "belongs_to takes a single parent. Change\n\
-                    \tbelongs_to({}, {})\n\
-                    to\n\
-                    \tbelongs_to({})\n\
-                    {}",
+                     \tbelongs_to({}, {})\n\
+                     to\n\
+                     \tbelongs_to({})\n\
+                     {}",
                     parent_path_string,
                     unrecognized_path_strings.join(","),
                     parent_path_string,
                     unrecognized_path_strings
                         .iter()
                         .map(|path| format!("\tbelongs_to({})", path))
-                        .collect::<Vec<_>>().join("\n")
+                        .collect::<Vec<_>>()
+                        .join("\n")
                 ))
                 .emit();
         }

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -142,34 +142,46 @@ impl AssociationOptions {
                 .unwrap_or_else(|| Ok(infer_foreign_key(&parent_struct_name.ident)))?
         };
 
-        let unrecognized_options = meta
+        let (unrecognized_paths, unrecognized_options): (Vec<_>, Vec<_>) = meta
             .nested()?
             .skip(1)
-            .filter(|n| !n.name().is_ident("foreign_key"));
+            .filter(|n| !n.name().is_ident("foreign_key"))
+            .partition(|item| item.path().is_ok());
+
+        if !unrecognized_paths.is_empty() {
+            let parent_path_string = path_to_string(&parent_struct.path);
+            let unrecognized_path_strings: Vec<_> = unrecognized_paths
+                .iter()
+                .filter_map(|item| item.path().as_ref().map(path_to_string).ok())
+                .collect();
+
+            meta
+                .span()
+                .warning(format!(
+                    "belongs_to takes a single parent. Change\n\
+                    \tbelongs_to({}, {})\n\
+                    to\n\
+                    \tbelongs_to({})\n\
+                    {}",
+                    parent_path_string,
+                    unrecognized_path_strings.join(","),
+                    parent_path_string,
+                    unrecognized_path_strings
+                        .iter()
+                        .map(|path| format!("\tbelongs_to({})", path))
+                        .collect::<Vec<_>>().join("\n")
+                ))
+                .emit();
+        }
+
         for ignored in unrecognized_options {
-            match ignored.path() {
-                Ok(_) => {
-                    ignored
-                        .span()
-                        .warning(
-                            "belongs_to takes a single parent. Change\n\
-                            \tbelongs_to(Parent1, Parent2)\n\
-                            to\n\
-                            \tbelongs_to(Parent1)\n\
-                            \tbelongs_to(Parent2)"
-                        )
-                        .emit();
-                },
-                Err(_) => {
-                    ignored
-                        .span()
-                        .warning(format!(
-                            "Unrecognized option {}",
-                            path_to_string(&ignored.name())
-                        ))
-                        .emit();
-                }
-            }
+            ignored
+                .span()
+                .warning(format!(
+                    "Unrecognized option {}",
+                    path_to_string(&ignored.name())
+                ))
+                .emit();
         }
 
         Ok(Self {

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -147,7 +147,7 @@ impl AssociationOptions {
             .skip(1)
             .filter(|n| !n.name().is_ident("foreign_key"));
         for ignored in unrecognized_options {
-            match ignored.word() {
+            match ignored.path() {
                 Ok(_) => {
                     ignored
                         .span()

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -151,13 +151,13 @@ impl AssociationOptions {
                 Ok(_) => {
                     ignored
                         .span()
-                        .warning(format!(
+                        .warning(
                             "belongs_to takes a single parent. Change\n\
                             \tbelongs_to(Parent1, Parent2)\n\
                             to\n\
                             \tbelongs_to(Parent1)\n\
                             \tbelongs_to(Parent2)"
-                        ))
+                        )
                         .emit();
                 },
                 Err(_) => {


### PR DESCRIPTION
There was already a warning being emitted (unrecognized option), but this new warning is more user-friendly.

Closes #2091