### PR TITLE
Strip scheme from sqlite database urls

### DIFF
--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -18,7 +18,7 @@ pub struct RawConnection {
 impl RawConnection {
     pub fn establish(database_url: &str) -> ConnectionResult<Self> {
         let mut conn_pointer = ptr::null_mut();
-        let database_url = CString::new(database_url)?;
+        let database_url = CString::new(database_url.trim_start_matches("sqlite://"))?;
         let connection_status =
             unsafe { ffi::sqlite3_open(database_url.as_ptr(), &mut conn_pointer) };
 

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -73,3 +73,11 @@ fn managing_updated_at_for_table() {
     let new_time: NaiveDateTime = query.first(&connection).unwrap();
     assert!(old_time < new_time);
 }
+
+#[test]
+#[cfg(feature = "sqlite")]
+fn strips_sqlite_url_prefix() {
+    let mut path = std::env::temp_dir();
+    path.push("diesel_test_sqlite.db");
+    assert!(SqliteConnection::establish(&format!("sqlite://{}", path.display())).is_ok());
+}


### PR DESCRIPTION
This PR rebases #1895 and adds a test case as requested there.

> This PR strips the `sqlite://` scheme from sqlite database URLs, as mentioned in [#1124 (comment)](https://github.com/diesel-rs/diesel/issues/1124#issuecomment-333334217)
> 
> I wasn't able to locate anywhere that tested the functionality I was editing, please let me know if I just missed it and I'll be happy to update this PR.
