### PR TITLE
Make diesel-cli panic on URLs for disabled features

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -29,21 +29,46 @@ enum Backend {
 impl Backend {
     fn for_url(database_url: &str) -> Self {
         match database_url {
-            #[cfg(feature = "postgres")]
             _ if database_url.starts_with("postgres://")
                 || database_url.starts_with("postgresql://") =>
             {
-                Backend::Pg
+                #[cfg(feature = "postgres")]
+                {
+                    Backend::Pg
+                }
+                #[cfg(not(feature = "postgres"))]
+                {
+                    panic!(
+                        "Database url `{}` requires the `postgres` feature but it's not enabled.",
+                        database_url
+                    );
+                }
             }
-            #[cfg(feature = "mysql")]
             _ if database_url.starts_with("mysql://") =>
             {
-                Backend::Mysql
+                #[cfg(feature = "mysql")]
+                {
+                    Backend::Mysql
+                }
+                #[cfg(not(feature = "mysql"))]
+                {
+                    panic!(
+                        "Database url `{}` requires the `mysql` feature but it's not enabled.",
+                        database_url
+                    );
+                }
             }
             #[cfg(feature = "sqlite")]
             _ => Backend::Sqlite,
             #[cfg(not(feature = "sqlite"))]
             _ => {
+                if database_url.starts_with("sqlite://") {
+                    panic!(
+                        "Database url `{}` requires the `sqlite` feature but it's not enabled.",
+                        database_url
+                    );
+                }
+
                 let mut available_schemes: Vec<&str> = Vec::new();
 
                 // One of these will always be true, or you are compiling
@@ -57,7 +82,7 @@ impl Backend {
                 }
 
                 panic!(
-                    "`{}` is not a valid database URL. It should start with {}",
+                    "`{}` is not a valid database URL. It should start with {}, or maybe you meant to use the `sqlite` feature which is not enabled.",
                     database_url,
                     available_schemes.join(" or ")
                 );

--- a/diesel_cli/tests/database_url_errors.rs
+++ b/diesel_cli/tests/database_url_errors.rs
@@ -1,0 +1,70 @@
+#[allow(unused_imports)]
+use support::{database, project};
+
+#[test]
+#[cfg(not(feature = "sqlite"))]
+fn missing_sqlite_panic_bare() {
+    let p = project("missing_sqlite_panic_bare").build();
+    let result = p
+        .command_without_database_url("setup")
+        .env("DATABASE_URL", "example.db")
+        .run();
+    assert!(result
+        .stderr()
+        .contains("`example.db` is not a valid database URL. It should start with "));
+    assert!(result
+        .stderr()
+        .contains("or maybe you meant to use the `sqlite` feature which is not enabled."));
+}
+
+#[test]
+#[cfg(not(feature = "sqlite"))]
+fn missing_sqlite_panic_scheme() {
+    let p = project("missing_sqlite_panic_scheme").build();
+    let result = p
+        .command_without_database_url("setup")
+        .env("DATABASE_URL", "sqlite://example.db")
+        .run();
+    assert!(result
+        .stderr()
+        .contains("panicked at 'Database url `sqlite://example.db` requires the `sqlite` feature but it's not enabled.'"));
+}
+
+#[test]
+#[cfg(not(feature = "postgres"))]
+fn missing_postgres_panic_postgres() {
+    let p = project("missing_postgres_panic_postgres").build();
+    let result = p
+        .command_without_database_url("setup")
+        .env("DATABASE_URL", "postgres://localhost")
+        .run();
+    assert!(result
+        .stderr()
+        .contains("panicked at 'Database url `postgres://localhost` requires the `postgres` feature but it's not enabled.'"));
+}
+
+#[test]
+#[cfg(not(feature = "postgres"))]
+fn missing_postgres_panic_postgresql() {
+    let p = project("missing_postgres_panic_postgresql").build();
+    let result = p
+        .command_without_database_url("setup")
+        .env("DATABASE_URL", "postgresql://localhost")
+        .run();
+    assert!(result
+        .stderr()
+        .contains("panicked at 'Database url `postgresql://localhost` requires the `postgres` feature but it's not enabled.'"));
+}
+
+#[test]
+#[cfg(not(feature = "mysql"))]
+fn missing_mysql_panic() {
+    let p = project("missing_mysql_panic").build();
+    let result = p
+        .command_without_database_url("setup")
+        .env("DATABASE_URL", "mysql://localhost")
+        .run();
+    assert!(result
+        .stderr()
+        .contains("panicked at 'Database url `mysql://localhost` requires the `mysql` feature but it's not enabled.'"));
+}

--- a/diesel_cli/tests/tests.rs
+++ b/diesel_cli/tests/tests.rs
@@ -12,6 +12,7 @@ mod completion_generation;
 mod database_drop;
 mod database_reset;
 mod database_setup;
+mod database_url_errors;
 mod exit_codes;
 mod migration_generate;
 mod migration_list;


### PR DESCRIPTION
Now if you give diesel a `sqlite://`, `postgres://`, or `mysql://` url without the corresponding feature enabled, it'll panic with a more specific error rather than giving a generic "cannot create file" error. In addition, using a bare URL without the sqlite feature enabled will mention the possibility that you wanted the sqlite feature.

One of the missing SQLite error messages here anticipates #2176 being merged.

This handles #1124 for the diesel-cli case, I'm not sure if there are confusing cases in applications, or if diesel-cli is the main sore spot.