### PR TITLE
Allow to implement a dynamic select clause feature in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   functionality of `NonAggregate`. See [the upgrade
   notes](#2-0-0-upgrade-non-aggregate) for details.
 
+* It is now possible to inspect the type of values returned from the database
+  in such a way to support constructing a dynamic value depending on this type.
+
 
 ### Removed
 
@@ -47,6 +50,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Support for `bigdecimal` < 0.0.13 has been removed.
 * Support for `pq-sys` < 0.4.0 has been removed.
 * Support for `mysqlclient-sys` < 0.2.0 has been removed.
+* The `NonNull` for sql types has been removed in favour of the new `SqlType` trait.
 
 ### Changed
 
@@ -68,8 +72,6 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * The `RawValue` types for the `Mysql` and `Postgresql` backend where changed
   from `[u8]` to distinct opaque types. If you used the concrete `RawValue` type
   somewhere you need to change it to `mysql::MysqlValue` or `pg::PgValue`.
-  For the postgres backend additionally type information where added to the `RawValue`
-  type. This allows to dynamically deserialize `RawValues` in container types.
 
 * The uuidv07 feature was renamed to uuid, due to the removal of support for older uuid versions
 
@@ -92,6 +94,26 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Various `__NonExhaustive` variants in different (error-) enums are replaced with
   `#[non_exhaustive]`. If you matched on one of those variants explicitly you need to
   introduce a wild card match instead.
+
+* `FromSql::from_sql` is changed to construct value from non nullable database values.
+   To construct a rust value for nullable values use the new `FromSql::from_nullable_sql`
+   method instead.
+
+* Custom sql types are now required to implement the new `SqlType` trait. Diesel will
+  automatically create implementations of that trait for all types having a `#[derive(SqlType)]`
+
+* The workflow for manually implementing support custom types has changed. Implementing
+  `FromSqlRow<ST, DB>` is not required anymore, as this is now implied by implementing
+  `FromSql<ST, DB>`. The requirement of implementing `Queryable<ST, DB>` remains
+  unchanged. For types using `#[derive(FromSqlRow)]` no changes are required as the
+  derive automatically generates the correct code
+
+* The structure of our deserialization trait has changed. Loading values from the database
+  requires now that the result type implements `FromSqlRow<ST, DB>`. Diesel provides wild
+  card implementations for types implementing `Queryable<ST, DB>` or `QueryableByName<DB>`
+  so non generic code does not require any change. For generic code you likely need to
+  replace a trait bound on `Queryable<ST, DB>` with a trait bound on `FromSqlRow<ST, DB>`
+  and a bound to `QueryableByName<DB>` with `FromSqlRow<Untyped, DB>`.
 
 
 ### Fixed
@@ -129,6 +151,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * We've refactored our type translation layer for Mysql to handle more types now.
 
+* We've refactored our type level representation of nullable values. This allowed us to
+  fix multiple long standing bugs regarding the correct handling of nullable values in some
+  corner cases (#104, #2274)
+
 ### Deprecated
 
 * `diesel_(prefix|postfix|infix)_operator!` have been deprecated. These macros
@@ -137,7 +163,6 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * `diesel::pg::upsert` has been deprecated to support upsert queries on more than one backend.
   Please use `diesel::upsert` instead.
-
 
 ### Upgrade Notes
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -32,6 +32,7 @@ num-integer = { version = "0.1.39", optional = true }
 bigdecimal = { version = ">= 0.0.13, < 0.2.0", optional = true }
 bitflags = { version = "1.2.0", optional = true }
 r2d2 = { version = ">= 0.8, < 0.9", optional = true }
+itoa = "0.4"
 
 [dependencies.diesel_derives]
 version = "~2.0.0"

--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -4,6 +4,7 @@ use crate::expression::array_comparison::AsInExpression;
 use crate::expression::AsExpression;
 use crate::prelude::*;
 use crate::query_dsl::methods::FilterDsl;
+use crate::sql_types::SqlType;
 
 use std::borrow::Borrow;
 use std::hash::Hash;
@@ -139,6 +140,7 @@ where
     Id<&'a Parent>: AsExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
     Child::Table: FilterDsl<Eq<Child::ForeignKeyColumn, Id<&'a Parent>>>,
     Child::ForeignKeyColumn: ExpressionMethods,
+    <Child::ForeignKeyColumn as Expression>::SqlType: SqlType,
 {
     type Output = FindBy<Child::Table, Child::ForeignKeyColumn, Id<&'a Parent>>;
 
@@ -154,6 +156,7 @@ where
     Vec<Id<&'a Parent>>: AsInExpression<<Child::ForeignKeyColumn as Expression>::SqlType>,
     <Child as HasTable>::Table: FilterDsl<EqAny<Child::ForeignKeyColumn, Vec<Id<&'a Parent>>>>,
     Child::ForeignKeyColumn: ExpressionMethods,
+    <Child::ForeignKeyColumn as Expression>::SqlType: SqlType,
 {
     type Output = Filter<Child::Table, EqAny<Child::ForeignKeyColumn, Vec<Id<&'a Parent>>>>;
 

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -325,16 +325,27 @@ pub trait FromSql<A, DB: Backend>: Sized {
 ///
 /// This trait can be [derived](derive.FromSqlRow.html)
 pub trait FromSqlRow<A, DB: Backend>: Sized {
-    /// The number of fields that this type will consume. Must be equal to
-    /// the number of times you would call `row.take()` in `build_from_row`
-    const FIELDS_NEEDED: usize = 1;
-
     /// See the trait documentation.
     fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self>;
 }
 
 #[doc(inline)]
 pub use diesel_derives::FromSqlRow;
+
+/// A marker trait indicating that the corresponding type is a statically sized row
+///
+/// This trait is implemented for all types provided by diesel, that
+/// implement `FromSqlRow`.
+///
+/// For dynamically sized types, like `diesel_dynamic_schema::DynamicRow`
+/// this traits should not be implemented.
+///
+/// This trait can be [derived](derive.FromSqlRow.html)
+pub trait StaticallySizedRow<A, DB: Backend>: FromSqlRow<A, DB> {
+    /// The number of fields that this type will consume. Must be equal to
+    /// the number of times you would call `row.take()` in `build_from_row`
+    const FIELD_COUNT: usize = 1;
+}
 
 // Reasons we can't write this:
 //

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -251,7 +251,7 @@ where
     DB: Backend,
 {
     /// Construct an instance of `Self` from the database row
-    fn build(row: &impl NamedRow<DB>) -> Result<Self>;
+    fn build<'a>(row: &impl NamedRow<'a, DB>) -> Result<Self>;
 }
 
 #[doc(inline)]

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -417,7 +417,7 @@ where
 // diesel may implement `SingleValue` for tuples
 // in the future. While that is theoretically true,
 // that will likly not happen in practice.
-// If we get negative trait impls at some point it time
+// If we get negative trait impls at some point in time
 // it should be possible to make this work.
 /*impl<T, ST, DB> Queryable<ST, DB> for T
 where

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -5,6 +5,7 @@ use std::result;
 
 use crate::backend::{self, Backend};
 use crate::row::{NamedRow, Row};
+use crate::sql_types::{SingleValue, SqlType, Untyped};
 
 /// A specialized result type representing the result of deserializing
 /// a value from the database.
@@ -56,7 +57,8 @@ pub type Result<T> = result::Result<T, Box<dyn Error + Send + Sync>>;
 /// #
 /// # use schema::users;
 /// # use diesel::backend::{self, Backend};
-/// # use diesel::deserialize::Queryable;
+/// # use diesel::deserialize::{Queryable, FromSql};
+/// # use diesel::sql_types::Text;
 /// #
 /// struct LowercaseString(String);
 ///
@@ -66,15 +68,15 @@ pub type Result<T> = result::Result<T, Box<dyn Error + Send + Sync>>;
 ///     }
 /// }
 ///
-/// impl<DB, ST> Queryable<ST, DB> for LowercaseString
+/// impl<DB> Queryable<Text, DB> for LowercaseString
 /// where
 ///     DB: Backend,
-///     String: Queryable<ST, DB>,
+///     String: FromSql<Text, DB>,
 /// {
-///     type Row = <String as Queryable<ST, DB>>::Row;
+///     type Row = String;
 ///
-///     fn build(row: Self::Row) -> Self {
-///         LowercaseString(String::build(row).to_lowercase())
+///     fn build(s: String) -> Self {
+///         LowercaseString(s.to_lowercase())
 ///     }
 /// }
 ///
@@ -148,7 +150,7 @@ where
     /// The Rust type you'd like to map from.
     ///
     /// This is typically a tuple of all of your struct's fields.
-    type Row: FromSqlRow<ST, DB>;
+    type Row: FromStaticSqlRow<ST, DB>;
 
     /// Construct an instance of this type
     fn build(row: Self::Row) -> Self;
@@ -216,7 +218,7 @@ pub use diesel_derives::Queryable;
 ///     DB: Backend,
 ///     String: FromSql<ST, DB>,
 /// {
-///     fn from_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
+///     fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
 ///         String::from_sql(bytes)
 ///             .map(|s| LowercaseString(s.to_lowercase()))
 ///     }
@@ -249,7 +251,7 @@ where
     DB: Backend,
 {
     /// Construct an instance of `Self` from the database row
-    fn build<R: NamedRow<DB>>(row: &R) -> Result<Self>;
+    fn build(row: &impl NamedRow<DB>) -> Result<Self>;
 }
 
 #[doc(inline)]
@@ -260,7 +262,8 @@ pub use diesel_derives::QueryableByName;
 /// When possible, implementations of this trait should prefer to use an
 /// existing implementation, rather than reading from `bytes`. (For example, if
 /// you are implementing this for an enum which is represented as an integer in
-/// the database, prefer `i32::from_sql(bytes)` over reading from `bytes`
+/// the database, prefer `i32::from_sql(bytes)` (or the explicit form
+/// `<i32 as FromSql<Integer, DB>>::from_sql(bytes)`) over reading from `bytes`
 /// directly)
 ///
 /// Types which implement this trait should also have `#[derive(FromSqlRow)]`
@@ -285,10 +288,10 @@ pub use diesel_derives::QueryableByName;
 /// ```rust
 /// # use diesel::backend::{self, Backend};
 /// # use diesel::sql_types::*;
-/// # use diesel::deserialize::{self, FromSql};
+/// # use diesel::deserialize::{self, FromSql, FromSqlRow};
 /// #
 /// #[repr(i32)]
-/// #[derive(Debug, Clone, Copy)]
+/// #[derive(Debug, Clone, Copy, FromSqlRow)]
 /// pub enum MyEnum {
 ///     A = 1,
 ///     B = 2,
@@ -299,7 +302,7 @@ pub use diesel_derives::QueryableByName;
 ///     DB: Backend,
 ///     i32: FromSql<Integer, DB>,
 /// {
-///     fn from_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
+///     fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
 ///         match i32::from_sql(bytes)? {
 ///             1 => Ok(MyEnum::A),
 ///             2 => Ok(MyEnum::B),
@@ -310,75 +313,130 @@ pub use diesel_derives::QueryableByName;
 /// ```
 pub trait FromSql<A, DB: Backend>: Sized {
     /// See the trait documentation.
-    fn from_sql(bytes: Option<backend::RawValue<DB>>) -> Result<Self>;
+    fn from_sql(bytes: backend::RawValue<DB>) -> Result<Self>;
+
+    /// A specialized variant of `from_sql` for handling null values.
+    ///
+    /// The default implementation returns an `UnexpectedNullError` for
+    /// an encountered null value and calls `Self::from_sql` otherwise
+    ///
+    /// If your custom type supports null values you need to provide a
+    /// custom implementation.
+    #[inline(always)]
+    fn from_nullable_sql(bytes: Option<backend::RawValue<DB>>) -> Result<Self> {
+        match bytes {
+            Some(bytes) => Self::from_sql(bytes),
+            None => Err(Box::new(crate::result::UnexpectedNullError)),
+        }
+    }
 }
 
-/// Deserialize one or more fields.
+/// Deserialize a database row into a rust data structure
 ///
-/// All types which implement `FromSql` should also implement this trait. This
-/// trait differs from `FromSql` in that it is also implemented by tuples.
-/// Implementations of this trait are usually derived.
-///
-/// In the future, we hope to be able to provide a blanket impl of this trait
-/// for all types which implement `FromSql`. However, as of Diesel 1.0, such an
-/// impl would conflict with our impl for tuples.
-///
-/// This trait can be [derived](derive.FromSqlRow.html)
-pub trait FromSqlRow<A, DB: Backend>: Sized {
+/// Diesel provides wild card implementations of this trait for all types
+/// that implement one of the following traits:
+///    * [`Queryable`](trait.Queryable.html)
+///    * [`QueryableByName`](trait.QueryableByName.html)
+pub trait FromSqlRow<ST, DB: Backend>: Sized {
     /// See the trait documentation.
-    fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self>;
+    fn build_from_row<'a>(row: &impl Row<'a, DB>) -> Result<Self>;
 }
 
 #[doc(inline)]
 pub use diesel_derives::FromSqlRow;
 
-/// A marker trait indicating that the corresponding type is a statically sized row
+/// A marker trait indicating that the corresponding type consumes a static at
+/// compile time known number of field
 ///
-/// This trait is implemented for all types provided by diesel, that
-/// implement `FromSqlRow`.
-///
-/// For dynamically sized types, like `diesel_dynamic_schema::DynamicRow`
-/// this traits should not be implemented.
-///
-/// This trait can be [derived](derive.FromSqlRow.html)
-pub trait StaticallySizedRow<A, DB: Backend>: FromSqlRow<A, DB> {
-    /// The number of fields that this type will consume. Must be equal to
-    /// the number of times you would call `row.take()` in `build_from_row`
-    const FIELD_COUNT: usize = 1;
+/// There is normally no need to implement this trait. Diesel provides
+/// wild card impls for all types that implement `FromSql<ST, DB>` or `Queryable<ST, DB>`
+/// where the size of `ST` is known
+pub trait StaticallySizedRow<ST, DB: Backend>: FromSqlRow<ST, DB> {
+    /// The number of fields that this type will consume.
+    const FIELD_COUNT: usize;
 }
 
-// Reasons we can't write this:
-//
-// impl<T, ST, DB> FromSqlRow<ST, DB> for T
-// where
-//     DB: Backend + HasSqlType<ST>,
-//     T: FromSql<ST, DB>,
-// {
-//     fn build_from_row<T: Row<DB>>(row: &mut T) -> Result<Self> {
-//         Self::from_sql(row.take())
-//     }
-// }
-//
-// (this is mostly here so @sgrif has a better reference every time they think
-// they've somehow had a breakthrough on solving this problem):
-//
-// - It conflicts with our impl for tuples, because `DB` is a bare type
-//   parameter, it could in theory be a local type for some other impl.
-//   - This is fixed by replacing our impl with 3 impls, where `DB` is changed
-//     concrete backends. This would mean that any third party crates adding new
-//     backends would need to add the tuple impls, which sucks but is fine.
-// - It conflicts with our impl for `Option`
-//   - So we could in theory fix this by both splitting the generic impl into
-//     backend specific impls, and removing the `FromSql` impls. In theory there
-//     is no reason that it needs to implement `FromSql`, since everything
-//     requires `FromSqlRow`, but it really feels like it should.
-//   - Specialization might also fix this one. The impl isn't quite a strict
-//     subset (the `FromSql` impl has `T: FromSql`, and the `FromSqlRow` impl
-//     has `T: FromSqlRow`), but if `FromSql` implies `FromSqlRow`,
-//     specialization might consider that a subset?
-// - I don't know that we really need it. `#[derive(FromSqlRow)]` is probably
-//   good enough. That won't improve our own codebase, since 99% of our
-//   `FromSqlRow` impls are for types from another crate, but it's almost
-//   certainly good enough for user types.
-//   - Still, it really feels like `FromSql` *should* be able to imply both
-//   `FromSqlRow` and `Queryable`
+impl<DB, T> FromSqlRow<Untyped, DB> for T
+where
+    DB: Backend,
+    T: QueryableByName<DB>,
+{
+    fn build_from_row<'a>(row: &impl Row<'a, DB>) -> Result<Self> {
+        T::build(row)
+    }
+}
+
+/// A helper trait to deserialize a statically sized row into an tuple
+///
+/// **If you see an error message mentioning this trait you likly
+///   trying to map the result of an query to an struct with missmatching
+///   field types. Recheck your field order and the concrete field types**
+///
+/// You should not need to implement this trait directly.
+/// Diesel provides wild card implementations for any supported tuple size
+/// and for any type that implements `FromSql<ST, DB>`.
+///
+// This is a distinct trait from `FromSqlRow` because otherwise we
+// are getting conflicting implementation errors for our `FromSqlRow`
+// implementation for tuples and our wild card impl for all types
+// implementing `Queryable`
+pub trait FromStaticSqlRow<ST, DB: Backend>: Sized {
+    /// See the trait documentation
+    fn build_from_row<'a>(row: &impl Row<'a, DB>) -> Result<Self>;
+}
+
+impl<T, ST, DB> FromSqlRow<ST, DB> for T
+where
+    T: Queryable<ST, DB>,
+    ST: SqlType,
+    DB: Backend,
+    T::Row: FromStaticSqlRow<ST, DB>,
+{
+    fn build_from_row<'a>(row: &impl Row<'a, DB>) -> Result<Self> {
+        let row = <T::Row as FromStaticSqlRow<ST, DB>>::build_from_row(row)?;
+        Ok(T::build(row))
+    }
+}
+
+impl<T, ST, DB> FromStaticSqlRow<ST, DB> for T
+where
+    DB: Backend,
+    T: FromSql<ST, DB>,
+    ST: SingleValue,
+{
+    fn build_from_row<'a>(row: &impl Row<'a, DB>) -> Result<Self> {
+        use crate::row::Field;
+
+        let field = row.get(0).ok_or(crate::result::UnexpectedEndOfRow)?;
+        T::from_nullable_sql(field.value())
+    }
+}
+
+// We cannot have this impl because rustc
+// then complains in third party crates that
+// diesel may implement `SingleValue` for tuples
+// in the future. While that is theoretically true,
+// that will likly not happen in practice.
+// If we get negative trait impls at some point it time
+// it should be possible to make this work.
+/*impl<T, ST, DB> Queryable<ST, DB> for T
+where
+    DB: Backend,
+    T: FromStaticSqlRow<ST, DB>,
+    ST: SingleValue,
+{
+    type Row = Self;
+
+    fn build(row: Self::Row) -> Self {
+        row
+    }
+}*/
+
+impl<T, ST, DB> StaticallySizedRow<ST, DB> for T
+where
+    ST: SqlType + crate::type_impls::tuples::TupleSize,
+    T: Queryable<ST, DB>,
+    DB: Backend,
+{
+    const FIELD_COUNT: usize = <ST as crate::type_impls::tuples::TupleSize>::SIZE;
+}

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -2,6 +2,7 @@ use crate::backend::Backend;
 use crate::expression::subselect::Subselect;
 use crate::expression::*;
 use crate::query_builder::*;
+use crate::query_builder::{BoxedSelectStatement, SelectStatement};
 use crate::result::QueryResult;
 use crate::sql_types::Bool;
 
@@ -92,9 +93,7 @@ where
 impl_selectable_expression!(In<T, U>);
 impl_selectable_expression!(NotIn<T, U>);
 
-use crate::query_builder::{BoxedSelectStatement, SelectStatement};
-
-pub trait AsInExpression<T> {
+pub trait AsInExpression<T: SqlType + TypedExpressionType> {
     type InExpression: MaybeEmpty + Expression<SqlType = T>;
 
     fn as_in_expression(self) -> Self::InExpression;
@@ -104,6 +103,7 @@ impl<I, T, ST> AsInExpression<ST> for I
 where
     I: IntoIterator<Item = T>,
     T: AsExpression<ST>,
+    ST: SqlType + TypedExpressionType,
 {
     type InExpression = Many<T::Expression>;
 
@@ -119,6 +119,7 @@ pub trait MaybeEmpty {
 
 impl<ST, S, F, W, O, L, Of, G, LC> AsInExpression<ST> for SelectStatement<S, F, W, O, L, Of, G, LC>
 where
+    ST: SqlType + TypedExpressionType,
     Subselect<Self, ST>: Expression<SqlType = ST>,
     Self: SelectQuery<SqlType = ST>,
 {
@@ -131,6 +132,7 @@ where
 
 impl<'a, ST, QS, DB> AsInExpression<ST> for BoxedSelectStatement<'a, ST, QS, DB>
 where
+    ST: SqlType + TypedExpressionType,
     Subselect<BoxedSelectStatement<'a, ST, QS, DB>, ST>: Expression<SqlType = ST>,
 {
     type InExpression = Subselect<Self, ST>;

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -5,7 +5,7 @@ use crate::backend::Backend;
 use crate::query_builder::*;
 use crate::result::QueryResult;
 use crate::serialize::ToSql;
-use crate::sql_types::{DieselNumericOps, HasSqlType};
+use crate::sql_types::{DieselNumericOps, HasSqlType, SqlType};
 
 #[derive(Debug, Clone, Copy, DieselNumericOps)]
 pub struct Bound<T, U> {
@@ -22,7 +22,10 @@ impl<T, U> Bound<T, U> {
     }
 }
 
-impl<T, U> Expression for Bound<T, U> {
+impl<T, U> Expression for Bound<T, U>
+where
+    T: SqlType + TypedExpressionType,
+{
     type SqlType = T;
 }
 

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -4,7 +4,7 @@ use crate::backend::Backend;
 use crate::expression::*;
 use crate::query_builder::*;
 use crate::result::QueryResult;
-use crate::sql_types::DieselNumericOps;
+use crate::sql_types::{DieselNumericOps, SqlType};
 
 #[derive(Debug, Copy, Clone, QueryId, DieselNumericOps)]
 #[doc(hidden)]
@@ -36,13 +36,24 @@ impl<T, ST> Coerce<T, ST> {
 impl<T, ST> Expression for Coerce<T, ST>
 where
     T: Expression,
+    ST: SqlType + TypedExpressionType,
 {
     type SqlType = ST;
 }
 
-impl<T, ST, QS> SelectableExpression<QS> for Coerce<T, ST> where T: SelectableExpression<QS> {}
+impl<T, ST, QS> SelectableExpression<QS> for Coerce<T, ST>
+where
+    T: SelectableExpression<QS>,
+    Self: Expression,
+{
+}
 
-impl<T, ST, QS> AppearsOnTable<QS> for Coerce<T, ST> where T: AppearsOnTable<QS> {}
+impl<T, ST, QS> AppearsOnTable<QS> for Coerce<T, ST>
+where
+    T: AppearsOnTable<QS>,
+    Self: Expression,
+{
+}
 
 impl<T, ST, DB> QueryFragment<DB> for Coerce<T, ST>
 where

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -3,7 +3,7 @@ use super::{Expression, ValidGrouping};
 use crate::backend::Backend;
 use crate::query_builder::*;
 use crate::result::QueryResult;
-use crate::sql_types::{BigInt, DieselNumericOps};
+use crate::sql_types::{BigInt, DieselNumericOps, SingleValue, SqlType};
 
 sql_function! {
     /// Creates a SQL `COUNT` expression
@@ -25,7 +25,7 @@ sql_function! {
     /// # }
     /// ```
     #[aggregate]
-    fn count<T>(expr: T) -> BigInt;
+    fn count<T: SqlType + SingleValue>(expr: T) -> BigInt;
 }
 
 /// Creates a SQL `COUNT(*)` expression

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -32,21 +32,21 @@ pub fn exists<T>(query: T) -> Exists<T> {
     Exists(Subselect::new(query))
 }
 
-#[derive(Debug, Clone, Copy, QueryId)]
-pub struct Exists<T>(pub Subselect<T, ()>);
+#[derive(Clone, Copy, QueryId, Debug)]
+pub struct Exists<T>(pub Subselect<T, Bool>);
 
 impl<T> Expression for Exists<T>
 where
-    Subselect<T, ()>: Expression,
+    Subselect<T, Bool>: Expression,
 {
     type SqlType = Bool;
 }
 
 impl<T, GB> ValidGrouping<GB> for Exists<T>
 where
-    Subselect<T, ()>: ValidGrouping<GB>,
+    Subselect<T, Bool>: ValidGrouping<GB>,
 {
-    type IsAggregate = <Subselect<T, ()> as ValidGrouping<GB>>::IsAggregate;
+    type IsAggregate = <Subselect<T, Bool> as ValidGrouping<GB>>::IsAggregate;
 }
 
 #[cfg(not(feature = "unstable"))]
@@ -80,13 +80,13 @@ where
 impl<T, QS> SelectableExpression<QS> for Exists<T>
 where
     Self: AppearsOnTable<QS>,
-    Subselect<T, ()>: SelectableExpression<QS>,
+    Subselect<T, Bool>: SelectableExpression<QS>,
 {
 }
 
 impl<T, QS> AppearsOnTable<QS> for Exists<T>
 where
     Self: Expression,
-    Subselect<T, ()>: AppearsOnTable<QS>,
+    Subselect<T, Bool>: AppearsOnTable<QS>,
 {
 }

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -1,4 +1,5 @@
 use crate::backend::Backend;
+use crate::expression::TypedExpressionType;
 use crate::expression::*;
 use crate::query_builder::*;
 use crate::query_source::joins::ToInnerJoin;
@@ -17,9 +18,10 @@ impl<T> Nullable<T> {
 impl<T> Expression for Nullable<T>
 where
     T: Expression,
-    <T as Expression>::SqlType: IntoNullable,
+    T::SqlType: IntoNullable,
+    <T::SqlType as IntoNullable>::Nullable: TypedExpressionType,
 {
-    type SqlType = <<T as Expression>::SqlType as IntoNullable>::Nullable;
+    type SqlType = <T::SqlType as IntoNullable>::Nullable;
 }
 
 impl<T, DB> QueryFragment<DB> for Nullable<T>

--- a/diesel/src/expression/ops/mod.rs
+++ b/diesel/src/expression/ops/mod.rs
@@ -2,7 +2,8 @@ macro_rules! generic_numeric_expr_inner {
     ($tpe: ident, ($($param: ident),*), $op: ident, $fn_name: ident) => {
         impl<Rhs, $($param),*> ::std::ops::$op<Rhs> for $tpe<$($param),*> where
             $tpe<$($param),*>: $crate::expression::Expression,
-            <$tpe<$($param),*> as $crate::Expression>::SqlType: $crate::sql_types::ops::$op,
+            <$tpe<$($param),*> as $crate::Expression>::SqlType: $crate::sql_types::SqlType + $crate::sql_types::ops::$op,
+            <<$tpe<$($param),*> as $crate::Expression>::SqlType as $crate::sql_types::ops::$op>::Rhs: $crate::expression::TypedExpressionType,
             Rhs: $crate::expression::AsExpression<
                 <<$tpe<$($param),*> as $crate::Expression>::SqlType as $crate::sql_types::ops::$op>::Rhs,
             >,

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -1,5 +1,5 @@
 use crate::backend::Backend;
-use crate::expression::{Expression, ValidGrouping};
+use crate::expression::{Expression, TypedExpressionType, ValidGrouping};
 use crate::query_builder::*;
 use crate::result::QueryResult;
 use crate::sql_types;
@@ -26,6 +26,7 @@ macro_rules! numeric_operation {
             Lhs: Expression,
             Lhs::SqlType: sql_types::ops::$name,
             Rhs: Expression,
+            <Lhs::SqlType as sql_types::ops::$name>::Output: TypedExpressionType,
         {
             type SqlType = <Lhs::SqlType as sql_types::ops::$name>::Output;
         }

--- a/diesel/src/expression/subselect.rs
+++ b/diesel/src/expression/subselect.rs
@@ -4,6 +4,7 @@ use crate::expression::array_comparison::MaybeEmpty;
 use crate::expression::*;
 use crate::query_builder::*;
 use crate::result::QueryResult;
+use crate::sql_types::SqlType;
 
 #[derive(Debug, Copy, Clone, QueryId)]
 pub struct Subselect<T, ST> {
@@ -20,7 +21,10 @@ impl<T, ST> Subselect<T, ST> {
     }
 }
 
-impl<T: SelectQuery, ST> Expression for Subselect<T, ST> {
+impl<T: SelectQuery, ST> Expression for Subselect<T, ST>
+where
+    ST: SqlType + TypedExpressionType,
+{
     type SqlType = ST;
 }
 

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -1,7 +1,7 @@
 use crate::expression::grouped::Grouped;
 use crate::expression::operators::{And, Or};
-use crate::expression::{AsExpression, Expression};
-use crate::sql_types::{Bool, Nullable};
+use crate::expression::{AsExpression, Expression, TypedExpressionType};
+use crate::sql_types::{BoolOrNullableBool, SqlType};
 
 /// Methods present on boolean expressions
 pub trait BoolExpressionMethods: Expression + Sized {
@@ -36,7 +36,13 @@ pub trait BoolExpressionMethods: Expression + Sized {
     /// assert_eq!(expected, data);
     /// #     Ok(())
     /// # }
-    fn and<T: AsExpression<Self::SqlType>>(self, other: T) -> And<Self, T::Expression> {
+    fn and<T, ST>(self, other: T) -> And<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        ST: SqlType + TypedExpressionType,
+        T: AsExpression<ST>,
+        And<Self, T::Expression>: Expression,
+    {
         And::new(self, other.as_expression())
     }
 
@@ -77,7 +83,13 @@ pub trait BoolExpressionMethods: Expression + Sized {
     /// assert_eq!(expected, data);
     /// #     Ok(())
     /// # }
-    fn or<T: AsExpression<Self::SqlType>>(self, other: T) -> Grouped<Or<Self, T::Expression>> {
+    fn or<T, ST>(self, other: T) -> Grouped<Or<Self, T::Expression>>
+    where
+        Self::SqlType: SqlType,
+        ST: SqlType + TypedExpressionType,
+        T: AsExpression<ST>,
+        Or<Self, T::Expression>: Expression,
+    {
         Grouped(Or::new(self, other.as_expression()))
     }
 }
@@ -88,12 +100,3 @@ where
     T::SqlType: BoolOrNullableBool,
 {
 }
-
-#[doc(hidden)]
-/// Marker trait used to implement `BoolExpressionMethods` on the appropriate
-/// types. Once coherence takes associated types into account, we can remove
-/// this trait.
-pub trait BoolOrNullableBool {}
-
-impl BoolOrNullableBool for Bool {}
-impl BoolOrNullableBool for Nullable<Bool> {}

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -1,7 +1,7 @@
 use crate::expression::array_comparison::{AsInExpression, In, NotIn};
 use crate::expression::operators::*;
 use crate::expression::{nullable, AsExpression, Expression};
-use crate::sql_types::SingleValue;
+use crate::sql_types::{SingleValue, SqlType};
 
 /// Methods present on all expressions, except tuples
 pub trait ExpressionMethods: Expression + Sized {
@@ -19,7 +19,11 @@ pub trait ExpressionMethods: Expression + Sized {
     /// assert_eq!(Ok(1), data.first(&connection));
     /// # }
     /// ```
-    fn eq<T: AsExpression<Self::SqlType>>(self, other: T) -> Eq<Self, T::Expression> {
+    fn eq<T>(self, other: T) -> Eq<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
         Eq::new(self, other.as_expression())
     }
 
@@ -37,7 +41,11 @@ pub trait ExpressionMethods: Expression + Sized {
     /// assert_eq!(Ok(2), data.first(&connection));
     /// # }
     /// ```
-    fn ne<T: AsExpression<Self::SqlType>>(self, other: T) -> NotEq<Self, T::Expression> {
+    fn ne<T>(self, other: T) -> NotEq<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
         NotEq::new(self, other.as_expression())
     }
 
@@ -68,6 +76,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```
     fn eq_any<T>(self, values: T) -> In<Self, T::InExpression>
     where
+        Self::SqlType: SqlType,
         T: AsInExpression<Self::SqlType>,
     {
         In::new(self, values.as_in_expression())
@@ -103,6 +112,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```
     fn ne_all<T>(self, values: T) -> NotIn<Self, T::InExpression>
     where
+        Self::SqlType: SqlType,
         T: AsInExpression<Self::SqlType>,
     {
         NotIn::new(self, values.as_in_expression())
@@ -182,7 +192,11 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn gt<T: AsExpression<Self::SqlType>>(self, other: T) -> Gt<Self, T::Expression> {
+    fn gt<T>(self, other: T) -> Gt<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
         Gt::new(self, other.as_expression())
     }
 
@@ -208,7 +222,11 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn ge<T: AsExpression<Self::SqlType>>(self, other: T) -> GtEq<Self, T::Expression> {
+    fn ge<T>(self, other: T) -> GtEq<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
         GtEq::new(self, other.as_expression())
     }
 
@@ -234,7 +252,11 @@ pub trait ExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn lt<T: AsExpression<Self::SqlType>>(self, other: T) -> Lt<Self, T::Expression> {
+    fn lt<T>(self, other: T) -> Lt<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
         Lt::new(self, other.as_expression())
     }
 
@@ -259,7 +281,11 @@ pub trait ExpressionMethods: Expression + Sized {
     /// assert_eq!("Sean", data);
     /// #     Ok(())
     /// # }
-    fn le<T: AsExpression<Self::SqlType>>(self, other: T) -> LtEq<Self, T::Expression> {
+    fn le<T>(self, other: T) -> LtEq<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
         LtEq::new(self, other.as_expression())
     }
 
@@ -285,6 +311,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```
     fn between<T, U>(self, lower: T, upper: U) -> Between<Self, And<T::Expression, U::Expression>>
     where
+        Self::SqlType: SqlType,
         T: AsExpression<Self::SqlType>,
         U: AsExpression<Self::SqlType>,
     {
@@ -320,6 +347,7 @@ pub trait ExpressionMethods: Expression + Sized {
         upper: U,
     ) -> NotBetween<Self, And<T::Expression, U::Expression>>
     where
+        Self::SqlType: SqlType,
         T: AsExpression<Self::SqlType>,
         U: AsExpression<Self::SqlType>,
     {
@@ -365,11 +393,12 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # include!("../doctest_setup.rs");
+    /// # use diesel::expression::expression_types::NotSelectable;
     /// #
     /// # fn main() {
     /// #     use schema::users::dsl::*;
     /// #     let order = "name";
-    /// let ordering: Box<BoxableExpression<users, DB, SqlType=()>> =
+    /// let ordering: Box<dyn BoxableExpression<users, DB, SqlType = NotSelectable>> =
     ///     if order == "name" {
     ///         Box::new(name.desc())
     ///     } else {

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -1,6 +1,6 @@
 use crate::expression::operators::{Concat, Like, NotLike};
 use crate::expression::{AsExpression, Expression};
-use crate::sql_types::{Nullable, Text};
+use crate::sql_types::{Nullable, SqlType, Text};
 
 /// Methods present on text expressions
 pub trait TextExpressionMethods: Expression + Sized {
@@ -54,7 +54,11 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// assert_eq!(Ok(expected_names), names);
     /// # }
     /// ```
-    fn concat<T: AsExpression<Self::SqlType>>(self, other: T) -> Concat<Self, T::Expression> {
+    fn concat<T>(self, other: T) -> Concat<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
         Concat::new(self, other.as_expression())
     }
 
@@ -86,8 +90,12 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn like<T: AsExpression<Self::SqlType>>(self, other: T) -> Like<Self, T::Expression> {
-        Like::new(self.as_expression(), other.as_expression())
+    fn like<T>(self, other: T) -> Like<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
+        Like::new(self, other.as_expression())
     }
 
     /// Returns a SQL `NOT LIKE` expression
@@ -118,8 +126,12 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn not_like<T: AsExpression<Self::SqlType>>(self, other: T) -> NotLike<Self, T::Expression> {
-        NotLike::new(self.as_expression(), other.as_expression())
+    fn not_like<T>(self, other: T) -> NotLike<Self, T::Expression>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
+        NotLike::new(self, other.as_expression())
     }
 }
 

--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -39,7 +39,7 @@ macro_rules! numeric_expr {
 #[doc(hidden)]
 macro_rules! __diesel_generate_ops_impls_if_numeric {
     ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
-    
+
     ($column_name:ident, Unsigned<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_numeric!($column_name, $($inner)::*); };
 
     ($column_name:ident, SmallInt) => { numeric_expr!($column_name); };

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -73,7 +73,7 @@ impl<'a> HasRawValue<'a> for Mysql {
 }
 
 impl TypeMetadata for Mysql {
-    type TypeMetadata = MysqlType;
+    type TypeMetadata = Option<MysqlType>;
     type MetadataLookup = ();
 }
 

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -73,7 +73,7 @@ impl<'a> HasRawValue<'a> for Mysql {
 }
 
 impl TypeMetadata for Mysql {
-    type TypeMetadata = Option<MysqlType>;
+    type TypeMetadata = MysqlType;
     type MetadataLookup = ();
 }
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -121,6 +121,10 @@ bitflags::bitflags! {
         const GET_FIXED_FIELDS_FLAG = (1<<18);
         const FIELD_IN_PART_FUNC_FLAG = (1 << 19);
     }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
 }
 
 struct BindData {

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -8,11 +8,11 @@ use self::stmt::Statement;
 use self::url::ConnectionOptions;
 use super::backend::Mysql;
 use crate::connection::*;
-use crate::deserialize::{Queryable, QueryableByName};
+use crate::deserialize::FromSqlRow;
+use crate::expression::QueryMetadata;
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::*;
-use crate::sql_types::HasSqlType;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 /// A connection to a MySQL database. Connection URLs should be in the form
@@ -60,38 +60,20 @@ impl Connection for MysqlConnection {
     }
 
     #[doc(hidden)]
-    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>>
+    fn load<T, U>(&self, source: T) -> QueryResult<Vec<U>>
     where
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
-        Self::Backend: HasSqlType<T::SqlType>,
-        U: Queryable<T::SqlType, Self::Backend>,
+        U: FromSqlRow<T::SqlType, Self::Backend>,
+        Self::Backend: QueryMetadata<T::SqlType>,
     {
-        use crate::deserialize::FromSqlRow;
         use crate::result::Error::DeserializationError;
 
         let mut stmt = self.prepare_query(&source.as_query())?;
         let mut metadata = Vec::new();
-        Mysql::mysql_row_metadata(&mut metadata, &());
+        Mysql::row_metadata(&(), &mut metadata);
         let results = unsafe { stmt.results(metadata)? };
-        results.map(|mut row| {
-            U::Row::build_from_row(&mut row)
-                .map(U::build)
-                .map_err(DeserializationError)
-        })
-    }
-
-    #[doc(hidden)]
-    fn query_by_name<T, U>(&self, source: &T) -> QueryResult<Vec<U>>
-    where
-        T: QueryFragment<Self::Backend> + QueryId,
-        U: QueryableByName<Self::Backend>,
-    {
-        use crate::result::Error::DeserializationError;
-
-        let mut stmt = self.prepare_query(source)?;
-        let results = unsafe { stmt.named_results()? };
-        results.map(|row| U::build(&row).map_err(DeserializationError))
+        results.map(|row| U::build_from_row(&row).map_err(DeserializationError))
     }
 
     #[doc(hidden)]

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -67,14 +67,20 @@ impl<'a> Row<Mysql> for MysqlRow<'a> {
         self.binds.len()
     }
 
-    fn column_name(&self) -> &str {
+    fn column_name(&self) -> Option<&str> {
         let metadata = self.stmt.metadata().expect("Failed to get metadata");
         let field = if self.col_idx == 0 {
             metadata.fields()[0]
         } else {
             metadata.fields()[self.col_idx - 1]
         };
-        unsafe { CStr::from_ptr(field.name).to_str().expect("It's utf8") }
+        unsafe {
+            Some(CStr::from_ptr(field.name).to_str().expect(
+                "Diesel assumes that your mysql database uses the \
+                 utf8mb4 encoding. That's not the case if you hit \
+                 this error message.",
+            ))
+        }
     }
 }
 

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -77,11 +77,7 @@ impl<'a> Row<Mysql> for MysqlRow<'a> {
             .stmt
             .metadata()
             .expect("Failed to get result metadata from the mysql backend");
-        let field = if self.col_idx == 0 {
-            metadata.fields()[0]
-        } else {
-            metadata.fields()[self.col_idx - 1]
-        };
+        let field = metadata.fields()[self.col_idx];
         unsafe {
             Some(CStr::from_ptr(field.name).to_str().expect(
                 "Diesel assumes that your mysql database uses the \

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -68,7 +68,10 @@ impl<'a> Row<Mysql> for MysqlRow<'a> {
     }
 
     fn column_name(&self) -> Option<&str> {
-        let metadata = self.stmt.metadata().expect("Failed to get metadata");
+        let metadata = self
+            .stmt
+            .metadata()
+            .expect("Failed to get result metadata from the mysql backend");
         let field = if self.col_idx == 0 {
             metadata.fields()[0]
         } else {

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -150,4 +150,3 @@ impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
             .collect()
     }
 }
-

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -119,6 +119,7 @@ impl<'a> NamedStatementIterator<'a> {
             Ok(Some(())) => Some(Ok(NamedMysqlRow {
                 binds: &self.output_binds,
                 column_indices: self.metadata.column_indices(),
+                metadata: &self.metadata,
             })),
             Ok(None) => None,
             Err(e) => Some(Err(e)),
@@ -129,6 +130,7 @@ impl<'a> NamedStatementIterator<'a> {
 pub struct NamedMysqlRow<'a> {
     binds: &'a Binds,
     column_indices: &'a HashMap<&'a str, usize>,
+    metadata: &'a StatementMetadata,
 }
 
 impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
@@ -141,6 +143,11 @@ impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
     }
 
     fn field_names(&self) -> Vec<&str> {
-        todo!()
+        self.metadata
+            .fields()
+            .iter()
+            .filter_map(|f| f.field_name())
+            .collect()
     }
 }
+

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
-use super::{Binds, Statement, StatementMetadata};
-use crate::mysql::{Mysql, MysqlType, MysqlValue};
+use super::{metadata::MysqlFieldMetadata, BindData, Binds, Statement, StatementMetadata};
+use crate::mysql::{Mysql, MysqlType};
 use crate::result::QueryResult;
 use crate::row::*;
 
@@ -16,11 +14,8 @@ impl<'a> StatementIterator<'a> {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(stmt: &'a mut Statement, types: Vec<Option<MysqlType>>) -> QueryResult<Self> {
         let metadata = stmt.metadata()?;
-        let mut output_binds = if types.iter().any(Option::is_none) {
-            Binds::from_output_types(types, Some(&metadata))
-        } else {
-            Binds::from_output_types(types, None)
-        };
+
+        let mut output_binds = Binds::from_output_types(types, &metadata);
 
         stmt.execute_statement(&mut output_binds)?;
 
@@ -55,98 +50,73 @@ impl<'a> StatementIterator<'a> {
     }
 }
 
+#[derive(Clone)]
 pub struct MysqlRow<'a> {
     col_idx: usize,
     binds: &'a Binds,
     metadata: &'a StatementMetadata,
 }
 
-impl<'a> Row<Mysql> for MysqlRow<'a> {
-    fn take(&mut self) -> Option<MysqlValue<'_>> {
-        let current_idx = self.col_idx;
-        self.col_idx += 1;
-        self.binds.field_data(current_idx)
-    }
+impl<'a> Row<'a, Mysql> for MysqlRow<'a> {
+    type Field = MysqlField<'a>;
+    type InnerPartialRow = Self;
 
-    fn next_is_null(&self, count: usize) -> bool {
-        (0..count).all(|i| self.binds.field_data(self.col_idx + i).is_none())
-    }
-
-    fn column_count(&self) -> usize {
+    fn field_count(&self) -> usize {
         self.binds.len()
     }
 
-    fn column_name(&self) -> Option<&str> {
-        self.metadata.fields()[self.col_idx].field_name()
-    }
-}
-
-pub struct NamedStatementIterator<'a> {
-    stmt: &'a mut Statement,
-    output_binds: Binds,
-    metadata: StatementMetadata,
-}
-
-#[allow(clippy::should_implement_trait)] // don't need `Iterator` here
-impl<'a> NamedStatementIterator<'a> {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(stmt: &'a mut Statement) -> QueryResult<Self> {
-        let metadata = stmt.metadata()?;
-        let mut output_binds = Binds::from_result_metadata(&metadata);
-
-        stmt.execute_statement(&mut output_binds)?;
-
-        Ok(NamedStatementIterator {
-            stmt,
-            output_binds,
-            metadata,
+    fn get<I>(&self, idx: I) -> Option<Self::Field>
+    where
+        Self: RowIndex<I>,
+    {
+        let idx = self.idx(idx)?;
+        Some(MysqlField {
+            bind: &self.binds[idx],
+            metadata: &self.metadata.fields()[idx],
         })
     }
 
-    pub fn map<F, T>(mut self, mut f: F) -> QueryResult<Vec<T>>
-    where
-        F: FnMut(NamedMysqlRow) -> QueryResult<T>,
-    {
-        let mut results = Vec::new();
-        while let Some(row) = self.next() {
-            results.push(f(row?)?);
-        }
-        Ok(results)
+    fn partial_row(&self, range: std::ops::Range<usize>) -> PartialRow<Self::InnerPartialRow> {
+        PartialRow::new(self, range)
     }
+}
 
-    fn next(&mut self) -> Option<QueryResult<NamedMysqlRow>> {
-        match self.stmt.populate_row_buffers(&mut self.output_binds) {
-            Ok(Some(())) => Some(Ok(NamedMysqlRow {
-                binds: &self.output_binds,
-                column_indices: self.metadata.column_indices(),
-                metadata: &self.metadata,
-            })),
-            Ok(None) => None,
-            Err(e) => Some(Err(e)),
+impl<'a> RowIndex<usize> for MysqlRow<'a> {
+    fn idx(&self, idx: usize) -> Option<usize> {
+        if idx < self.field_count() {
+            Some(idx)
+        } else {
+            None
         }
     }
 }
 
-pub struct NamedMysqlRow<'a> {
-    binds: &'a Binds,
-    column_indices: &'a HashMap<&'a str, usize>,
-    metadata: &'a StatementMetadata,
-}
-
-impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
-    fn index_of(&self, column_name: &str) -> Option<usize> {
-        self.column_indices.get(column_name).cloned()
-    }
-
-    fn get_raw_value(&self, idx: usize) -> Option<MysqlValue<'_>> {
-        self.binds.field_data(idx)
-    }
-
-    fn field_names(&self) -> Vec<&str> {
+impl<'a, 'b> RowIndex<&'a str> for MysqlRow<'b> {
+    fn idx(&self, idx: &'a str) -> Option<usize> {
         self.metadata
             .fields()
             .iter()
-            .filter_map(|f| f.field_name())
-            .collect()
+            .enumerate()
+            .find(|(_, field_meta)| field_meta.field_name() == Some(idx))
+            .map(|(idx, _)| idx)
+    }
+}
+
+pub struct MysqlField<'a> {
+    bind: &'a BindData,
+    metadata: &'a MysqlFieldMetadata<'a>,
+}
+
+impl<'a> Field<'a, Mysql> for MysqlField<'a> {
+    fn field_name(&self) -> Option<&str> {
+        self.metadata.field_name()
+    }
+
+    fn is_null(&self) -> bool {
+        self.bind.is_null()
+    }
+
+    fn value(&self) -> Option<crate::backend::RawValue<'a, Mysql>> {
+        self.bind.value()
     }
 }

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -108,7 +108,7 @@ pub struct MysqlField<'a> {
 }
 
 impl<'a> Field<'a, Mysql> for MysqlField<'a> {
-    fn field_name(&self) -> Option<&str> {
+    fn field_name(&self) -> Option<&'a str> {
         self.metadata.field_name()
     }
 

--- a/diesel/src/mysql/connection/stmt/metadata.rs
+++ b/diesel/src/mysql/connection/stmt/metadata.rs
@@ -1,16 +1,23 @@
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::ptr::NonNull;
 use std::slice;
 
 use super::ffi;
+use crate::mysql::connection::bind::Flags;
 
 pub struct StatementMetadata {
-    result: &'static mut ffi::MYSQL_RES,
+    result: NonNull<ffi::MYSQL_RES>,
+    // The strings in this hash map are only valid
+    // as long as we do not free the result pointer above
+    // We use a 'static lifetime here, because we cannot
+    // have a self referential lifetime.
+    // Therefore this lifetime must not leave this module
     column_indices: HashMap<&'static str, usize>,
 }
 
 impl StatementMetadata {
-    pub fn new(result: &'static mut ffi::MYSQL_RES) -> Self {
+    pub fn new(result: NonNull<ffi::MYSQL_RES>) -> Self {
         let mut res = StatementMetadata {
             column_indices: HashMap::new(),
             result,
@@ -19,16 +26,19 @@ impl StatementMetadata {
         res
     }
 
-    pub fn fields(&self) -> &[ffi::MYSQL_FIELD] {
+    pub fn fields<'a>(&'a self) -> &'a [MysqlFieldMetadata] {
         unsafe {
-            let ptr = self.result as *const _ as *mut _;
-            let num_fields = ffi::mysql_num_fields(ptr);
-            let field_ptr = ffi::mysql_fetch_fields(ptr);
-            slice::from_raw_parts(field_ptr, num_fields as usize)
+            let num_fields = ffi::mysql_num_fields(self.result.as_ptr());
+            let field_ptr = ffi::mysql_fetch_fields(self.result.as_ptr());
+            if field_ptr.is_null() {
+                &[]
+            } else {
+                slice::from_raw_parts(field_ptr as _, num_fields as usize)
+            }
         }
     }
 
-    pub fn column_indices(&self) -> &HashMap<&str, usize> {
+    pub fn column_indices<'a>(&'a self) -> &'a HashMap<&'a str, usize> {
         &self.column_indices
     }
 
@@ -37,9 +47,19 @@ impl StatementMetadata {
             .fields()
             .iter()
             .enumerate()
-            .map(|(i, field)| {
-                let c_name = unsafe { CStr::from_ptr(field.name) };
-                (c_name.to_str().unwrap_or_default(), i)
+            .filter_map(|(i, field)| unsafe {
+                // This is highly unsafe because we create strings slices with a static life time
+                // * We cannot use `MysqlFieldMetadata` because of this reason
+                // * We cannot have a concrete life time because otherwise this would be
+                //   an self referential struct
+                // * This relies on the invariant that non of the slices leave this
+                //   type with anything other then a concrete life time bound to this
+                //   type
+                if field.0.name.is_null() {
+                    None
+                } else {
+                    CStr::from_ptr(field.0.name).to_str().ok().map(|f| (f, i))
+                }
             })
             .collect()
     }
@@ -47,6 +67,27 @@ impl StatementMetadata {
 
 impl Drop for StatementMetadata {
     fn drop(&mut self) {
-        unsafe { ffi::mysql_free_result(self.result) };
+        unsafe { ffi::mysql_free_result(self.result.as_mut()) };
+    }
+}
+
+#[repr(transparent)]
+pub struct MysqlFieldMetadata<'a>(ffi::MYSQL_FIELD, std::marker::PhantomData<&'a ()>);
+
+impl<'a> MysqlFieldMetadata<'a> {
+    pub fn field_name(&self) -> Option<&str> {
+        if self.0.name.is_null() {
+            None
+        } else {
+            unsafe { CStr::from_ptr(self.0.name).to_str().ok() }
+        }
+    }
+
+    pub fn field_type(&self) -> ffi::enum_field_types {
+        self.0.type_
+    }
+
+    pub(crate) fn flags(&self) -> Flags {
+        Flags::from(self.0.flags)
     }
 }

--- a/diesel/src/mysql/connection/stmt/metadata.rs
+++ b/diesel/src/mysql/connection/stmt/metadata.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ptr::NonNull;
 use std::slice;
@@ -8,25 +7,14 @@ use crate::mysql::connection::bind::Flags;
 
 pub struct StatementMetadata {
     result: NonNull<ffi::MYSQL_RES>,
-    // The strings in this hash map are only valid
-    // as long as we do not free the result pointer above
-    // We use a 'static lifetime here, because we cannot
-    // have a self referential lifetime.
-    // Therefore this lifetime must not leave this module
-    column_indices: HashMap<&'static str, usize>,
 }
 
 impl StatementMetadata {
     pub fn new(result: NonNull<ffi::MYSQL_RES>) -> Self {
-        let mut res = StatementMetadata {
-            column_indices: HashMap::new(),
-            result,
-        };
-        res.populate_column_indices();
-        res
+        StatementMetadata { result }
     }
 
-    pub fn fields<'a>(&'a self) -> &'a [MysqlFieldMetadata] {
+    pub fn fields(&'_ self) -> &'_ [MysqlFieldMetadata<'_>] {
         unsafe {
             let num_fields = ffi::mysql_num_fields(self.result.as_ptr());
             let field_ptr = ffi::mysql_fetch_fields(self.result.as_ptr());
@@ -36,32 +24,6 @@ impl StatementMetadata {
                 slice::from_raw_parts(field_ptr as _, num_fields as usize)
             }
         }
-    }
-
-    pub fn column_indices<'a>(&'a self) -> &'a HashMap<&'a str, usize> {
-        &self.column_indices
-    }
-
-    fn populate_column_indices(&mut self) {
-        self.column_indices = self
-            .fields()
-            .iter()
-            .enumerate()
-            .filter_map(|(i, field)| unsafe {
-                // This is highly unsafe because we create strings slices with a static life time
-                // * We cannot use `MysqlFieldMetadata` because of this reason
-                // * We cannot have a concrete life time because otherwise this would be
-                //   an self referential struct
-                // * This relies on the invariant that non of the slices leave this
-                //   type with anything other then a concrete life time bound to this
-                //   type
-                if field.0.name.is_null() {
-                    None
-                } else {
-                    CStr::from_ptr(field.0.name).to_str().ok().map(|f| (f, i))
-                }
-            })
-            .collect()
     }
 }
 

--- a/diesel/src/mysql/connection/stmt/metadata.rs
+++ b/diesel/src/mysql/connection/stmt/metadata.rs
@@ -41,7 +41,12 @@ impl<'a> MysqlFieldMetadata<'a> {
         if self.0.name.is_null() {
             None
         } else {
-            unsafe { CStr::from_ptr(self.0.name).to_str().ok() }
+            unsafe {
+                Some(CStr::from_ptr(self.0.name).to_str().expect(
+                    "Expect mysql field names to be UTF-8, because we \
+                     requested UTF-8 encoding on connection setup",
+                ))
+            }
         }
     }
 

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -39,9 +39,9 @@ impl Statement {
 
     pub fn bind<Iter>(&mut self, binds: Iter) -> QueryResult<()>
     where
-        Iter: IntoIterator<Item = (MysqlType, Option<Vec<u8>>)>,
+        Iter: IntoIterator<Item = (Option<MysqlType>, Option<Vec<u8>>)>,
     {
-        let input_binds = Binds::from_input_data(binds);
+        let input_binds = Binds::from_input_data(binds)?;
         self.input_bind(input_binds)
     }
 
@@ -76,7 +76,10 @@ impl Statement {
     /// This function should be called instead of `execute` for queries which
     /// have a return value. After calling this function, `execute` can never
     /// be called on this statement.
-    pub unsafe fn results(&mut self, types: Vec<MysqlType>) -> QueryResult<StatementIterator> {
+    pub unsafe fn results(
+        &mut self,
+        types: Vec<Option<MysqlType>>,
+    ) -> QueryResult<StatementIterator> {
         StatementIterator::new(self, types)
     }
 

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -8,7 +8,7 @@ use std::os::raw as libc;
 use std::ptr::NonNull;
 
 use self::iterator::*;
-use super::bind::Binds;
+use super::bind::{BindData, Binds};
 use crate::mysql::MysqlType;
 use crate::result::{DatabaseErrorKind, QueryResult};
 
@@ -40,7 +40,7 @@ impl Statement {
 
     pub fn bind<Iter>(&mut self, binds: Iter) -> QueryResult<()>
     where
-        Iter: IntoIterator<Item = (Option<MysqlType>, Option<Vec<u8>>)>,
+        Iter: IntoIterator<Item = (MysqlType, Option<Vec<u8>>)>,
     {
         let input_binds = Binds::from_input_data(binds)?;
         self.input_bind(input_binds)
@@ -82,13 +82,6 @@ impl Statement {
         types: Vec<Option<MysqlType>>,
     ) -> QueryResult<StatementIterator> {
         StatementIterator::new(self, types)
-    }
-
-    /// This function should be called instead of `execute` for queries which
-    /// have a return value. After calling this function, `execute` can never
-    /// be called on this statement.
-    pub unsafe fn named_results(&mut self) -> QueryResult<NamedStatementIterator> {
-        NamedStatementIterator::new(self)
     }
 
     fn last_error_message(&self) -> String {

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -24,9 +24,8 @@ macro_rules! mysql_time_impls {
         }
 
         impl FromSql<$ty, Mysql> for MYSQL_TIME {
-            fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-                let data = not_none!(value);
-                data.time_value()
+            fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
+                value.time_value()
             }
         }
     };
@@ -44,7 +43,7 @@ impl ToSql<Datetime, Mysql> for NaiveDateTime {
 }
 
 impl FromSql<Datetime, Mysql> for NaiveDateTime {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         <NaiveDateTime as FromSql<Timestamp, Mysql>>::from_sql(bytes)
     }
 }
@@ -69,7 +68,7 @@ impl ToSql<Timestamp, Mysql> for NaiveDateTime {
 }
 
 impl FromSql<Timestamp, Mysql> for NaiveDateTime {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let mysql_time = <MYSQL_TIME as FromSql<Timestamp, Mysql>>::from_sql(bytes)?;
 
         NaiveDate::from_ymd_opt(
@@ -109,7 +108,7 @@ impl ToSql<Time, Mysql> for NaiveTime {
 }
 
 impl FromSql<Time, Mysql> for NaiveTime {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let mysql_time = <MYSQL_TIME as FromSql<Time, Mysql>>::from_sql(bytes)?;
         NaiveTime::from_hms_opt(
             mysql_time.hour as u32,
@@ -140,7 +139,7 @@ impl ToSql<Date, Mysql> for NaiveDate {
 }
 
 impl FromSql<Date, Mysql> for NaiveDate {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let mysql_time = <MYSQL_TIME as FromSql<Date, Mysql>>::from_sql(bytes)?;
         NaiveDate::from_ymd_opt(
             mysql_time.year as i32,

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -46,8 +46,7 @@ impl ToSql<TinyInt, Mysql> for i8 {
 }
 
 impl FromSql<TinyInt, Mysql> for i8 {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         let bytes = value.as_bytes();
         Ok(bytes[0] as i8)
     }
@@ -96,7 +95,7 @@ impl ToSql<Unsigned<TinyInt>, Mysql> for u8 {
 }
 
 impl FromSql<Unsigned<TinyInt>, Mysql> for u8 {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i8 = FromSql::<TinyInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u8)
     }
@@ -109,7 +108,7 @@ impl ToSql<Unsigned<SmallInt>, Mysql> for u16 {
 }
 
 impl FromSql<Unsigned<SmallInt>, Mysql> for u16 {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i16 = FromSql::<SmallInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u16)
     }
@@ -122,7 +121,7 @@ impl ToSql<Unsigned<Integer>, Mysql> for u32 {
 }
 
 impl FromSql<Unsigned<Integer>, Mysql> for u32 {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i32 = FromSql::<Integer, Mysql>::from_sql(bytes)?;
         Ok(signed as u32)
     }
@@ -135,7 +134,7 @@ impl ToSql<Unsigned<BigInt>, Mysql> for u64 {
 }
 
 impl FromSql<Unsigned<BigInt>, Mysql> for u64 {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i64 = FromSql::<BigInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u64)
     }
@@ -149,32 +148,32 @@ impl ToSql<Bool, Mysql> for bool {
 }
 
 impl FromSql<Bool, Mysql> for bool {
-    fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-        Ok(not_none!(bytes).as_bytes().iter().any(|x| *x != 0))
+    fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
+        Ok(bytes.as_bytes().iter().any(|x| *x != 0))
     }
 }
 
 impl HasSqlType<Unsigned<TinyInt>> for Mysql {
-    fn metadata(_lookup: &()) -> Option<MysqlType> {
-        Some(MysqlType::UnsignedTiny)
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedTiny
     }
 }
 
 impl HasSqlType<Unsigned<SmallInt>> for Mysql {
-    fn metadata(_lookup: &()) -> Option<MysqlType> {
-        Some(MysqlType::UnsignedShort)
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedShort
     }
 }
 
 impl HasSqlType<Unsigned<Integer>> for Mysql {
-    fn metadata(_lookup: &()) -> Option<MysqlType> {
-        Some(MysqlType::UnsignedLong)
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedLong
     }
 }
 
 impl HasSqlType<Unsigned<BigInt>> for Mysql {
-    fn metadata(_lookup: &()) -> Option<MysqlType> {
-        Some(MysqlType::UnsignedLongLong)
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedLongLong
     }
 }
 

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -155,26 +155,26 @@ impl FromSql<Bool, Mysql> for bool {
 }
 
 impl HasSqlType<Unsigned<TinyInt>> for Mysql {
-    fn metadata(_lookup: &()) -> MysqlType {
-        MysqlType::UnsignedTiny
+    fn metadata(_lookup: &()) -> Option<MysqlType> {
+        Some(MysqlType::UnsignedTiny)
     }
 }
 
 impl HasSqlType<Unsigned<SmallInt>> for Mysql {
-    fn metadata(_lookup: &()) -> MysqlType {
-        MysqlType::UnsignedShort
+    fn metadata(_lookup: &()) -> Option<MysqlType> {
+        Some(MysqlType::UnsignedShort)
     }
 }
 
 impl HasSqlType<Unsigned<Integer>> for Mysql {
-    fn metadata(_lookup: &()) -> MysqlType {
-        MysqlType::UnsignedLong
+    fn metadata(_lookup: &()) -> Option<MysqlType> {
+        Some(MysqlType::UnsignedLong)
     }
 }
 
 impl HasSqlType<Unsigned<BigInt>> for Mysql {
-    fn metadata(_lookup: &()) -> MysqlType {
-        MysqlType::UnsignedLongLong
+    fn metadata(_lookup: &()) -> Option<MysqlType> {
+        Some(MysqlType::UnsignedLongLong)
     }
 }
 

--- a/diesel/src/mysql/types/numeric.rs
+++ b/diesel/src/mysql/types/numeric.rs
@@ -19,10 +19,10 @@ pub mod bigdecimal {
     }
 
     impl FromSql<Numeric, Mysql> for BigDecimal {
-        fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
             use crate::mysql::NumericRepresentation::*;
-            let data = not_none!(value);
-            match data.numeric_value()? {
+
+            match value.numeric_value()? {
                 Tiny(x) => Ok(x.into()),
                 Small(x) => Ok(x.into()),
                 Medium(x) => Ok(x.into()),

--- a/diesel/src/mysql/types/primitives.rs
+++ b/diesel/src/mysql/types/primitives.rs
@@ -29,11 +29,10 @@ where
 }
 
 impl FromSql<SmallInt, Mysql> for i16 {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         use crate::mysql::NumericRepresentation::*;
 
-        let data = not_none!(value);
-        match data.numeric_value()? {
+        match value.numeric_value()? {
             Tiny(x) => Ok(x.into()),
             Small(x) => Ok(x),
             Medium(x) => Ok(x as Self),
@@ -46,11 +45,10 @@ impl FromSql<SmallInt, Mysql> for i16 {
 }
 
 impl FromSql<Integer, Mysql> for i32 {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         use crate::mysql::NumericRepresentation::*;
 
-        let data = not_none!(value);
-        match data.numeric_value()? {
+        match value.numeric_value()? {
             Tiny(x) => Ok(x.into()),
             Small(x) => Ok(x.into()),
             Medium(x) => Ok(x),
@@ -63,11 +61,10 @@ impl FromSql<Integer, Mysql> for i32 {
 }
 
 impl FromSql<BigInt, Mysql> for i64 {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         use crate::mysql::NumericRepresentation::*;
 
-        let data = not_none!(value);
-        match data.numeric_value()? {
+        match value.numeric_value()? {
             Tiny(x) => Ok(x.into()),
             Small(x) => Ok(x.into()),
             Medium(x) => Ok(x.into()),
@@ -80,11 +77,10 @@ impl FromSql<BigInt, Mysql> for i64 {
 }
 
 impl FromSql<Float, Mysql> for f32 {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         use crate::mysql::NumericRepresentation::*;
 
-        let data = not_none!(value);
-        match data.numeric_value()? {
+        match value.numeric_value()? {
             Tiny(x) => Ok(x.into()),
             Small(x) => Ok(x.into()),
             Medium(x) => Ok(x as Self),
@@ -97,11 +93,10 @@ impl FromSql<Float, Mysql> for f32 {
 }
 
 impl FromSql<Double, Mysql> for f64 {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         use crate::mysql::NumericRepresentation::*;
 
-        let data = not_none!(value);
-        match data.numeric_value()? {
+        match value.numeric_value()? {
             Tiny(x) => Ok(x.into()),
             Small(x) => Ok(x.into()),
             Medium(x) => Ok(x.into()),
@@ -114,15 +109,13 @@ impl FromSql<Double, Mysql> for f64 {
 }
 
 impl FromSql<Text, Mysql> for String {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         String::from_utf8(value.as_bytes().into()).map_err(Into::into)
     }
 }
 
 impl FromSql<Binary, Mysql> for Vec<u8> {
-    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         Ok(value.as_bytes().into())
     }
 }

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -20,6 +20,11 @@ impl<'a> MysqlValue<'a> {
         self.raw
     }
 
+    /// Get the mysql type of the current value
+    pub fn value_type(&self) -> MysqlType {
+        self.tpe
+    }
+
     /// Checks that the type code is valid, and interprets the data as a
     /// `MYSQL_TIME` pointer
     // We use `ptr.read_unaligned()` to read the potential unaligned ptr,

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -7,7 +7,7 @@ use super::{PgMetadataLookup, PgValue};
 use crate::backend::*;
 use crate::deserialize::Queryable;
 use crate::query_builder::bind_collector::RawBytesBindCollector;
-use crate::sql_types::{Oid, TypeMetadata};
+use crate::sql_types::TypeMetadata;
 
 /// The PostgreSQL backend
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -16,7 +16,7 @@ pub struct Pg;
 /// The [OIDs] for a SQL type
 ///
 /// [OIDs]: https://www.postgresql.org/docs/current/static/datatype-oid.html
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default, Queryable)]
 pub struct PgTypeMetadata {
     /// The [OID] of `T`
     ///
@@ -26,14 +26,6 @@ pub struct PgTypeMetadata {
     ///
     /// [OID]: https://www.postgresql.org/docs/current/static/datatype-oid.html
     pub array_oid: u32,
-}
-
-impl Queryable<(Oid, Oid), Pg> for PgTypeMetadata {
-    type Row = (u32, u32);
-
-    fn build((oid, array_oid): Self::Row) -> Self {
-        PgTypeMetadata { oid, array_oid }
-    }
 }
 
 impl Backend for Pg {

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -27,13 +27,12 @@ impl<'a> Iterator for Cursor<'a> {
     type Item = PgRow<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_row >= self.db_result.num_rows() {
-            None
-        } else {
+        if self.current_row < self.db_result.num_rows() {
             let row = self.db_result.get_row(self.current_row);
             self.current_row += 1;
-
             Some(row)
+        } else {
+            None
         }
     }
 

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -1,77 +1,45 @@
 use super::result::PgResult;
-use super::row::PgNamedRow;
-use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
-use crate::pg::Pg;
-use crate::result::Error::DeserializationError;
-use crate::result::QueryResult;
-
-use std::marker::PhantomData;
+use super::row::PgRow;
 
 /// The type returned by various [`Connection`](struct.Connection.html) methods.
 /// Acts as an iterator over `T`.
-pub struct Cursor<ST, T> {
+pub struct Cursor<'a> {
     current_row: usize,
-    db_result: PgResult,
-    _marker: PhantomData<(ST, T)>,
+    db_result: &'a PgResult,
 }
 
-impl<ST, T> Cursor<ST, T> {
-    #[doc(hidden)]
-    pub fn new(db_result: PgResult) -> Self {
+impl<'a> Cursor<'a> {
+    pub(super) fn new(db_result: &'a PgResult) -> Self {
         Cursor {
             current_row: 0,
             db_result,
-            _marker: PhantomData,
         }
     }
 }
 
-impl<ST, T> Iterator for Cursor<ST, T>
-where
-    T: Queryable<ST, Pg>,
-{
-    type Item = QueryResult<T>;
+impl<'a> ExactSizeIterator for Cursor<'a> {}
+
+impl<'a> Iterator for Cursor<'a> {
+    type Item = PgRow<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_row >= self.db_result.num_rows() {
             None
         } else {
-            let mut row = self.db_result.get_row(self.current_row);
+            let row = self.db_result.get_row(self.current_row);
             self.current_row += 1;
-            let value = T::Row::build_from_row(&mut row)
-                .map(T::build)
-                .map_err(DeserializationError);
-            Some(value)
+
+            Some(row)
         }
     }
-}
 
-pub struct NamedCursor {
-    pub(crate) db_result: PgResult,
-}
-
-impl NamedCursor {
-    pub fn new(db_result: PgResult) -> Self {
-        NamedCursor { db_result }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.current_row += n;
+        self.next()
     }
 
-    pub fn collect<T>(self) -> QueryResult<Vec<T>>
-    where
-        T: QueryableByName<Pg>,
-    {
-        (0..self.db_result.num_rows())
-            .map(|i| {
-                let row = PgNamedRow::new(&self, i);
-                T::build(&row).map_err(DeserializationError)
-            })
-            .collect()
-    }
-
-    pub fn index_of_column(&self, column_name: &str) -> Option<usize> {
-        self.db_result.field_number(column_name)
-    }
-
-    pub fn get_value(&self, row: usize, column: usize) -> Option<&[u8]> {
-        self.db_result.get(row, column)
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.db_result.num_rows();
+        (len, Some(len))
     }
 }

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -17,7 +17,11 @@ impl<'a> Cursor<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for Cursor<'a> {}
+impl<'a> ExactSizeIterator for Cursor<'a> {
+    fn len(&self) -> usize {
+        self.db_result.num_rows() - self.current_row
+    }
+}
 
 impl<'a> Iterator for Cursor<'a> {
     type Item = PgRow<'a>;
@@ -34,12 +38,12 @@ impl<'a> Iterator for Cursor<'a> {
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.current_row += n;
+        self.current_row = (self.current_row + n).min(self.db_result.num_rows());
         self.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.db_result.num_rows();
+        let len = self.len();
         (len, Some(len))
     }
 }

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -113,6 +113,21 @@ impl PgResult {
         }
     }
 
+    pub fn column_name(&self, col_idx: usize) -> &str {
+        unsafe {
+            CStr::from_ptr(PQfname(
+                self.internal_result.as_ptr(),
+                col_idx as libc::c_int,
+            ))
+            .to_str()
+            .expect("Utf8")
+        }
+    }
+
+    pub fn column_count(&self) -> usize {
+        unsafe { PQnfields(self.internal_result.as_ptr()) as usize }
+    }
+
     pub fn field_number(&self, column_name: &str) -> Option<usize> {
         let cstr = CString::new(column_name).unwrap_or_default();
         let fnum = unsafe { PQfnumber(self.internal_result.as_ptr(), cstr.as_ptr()) };

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -113,14 +113,14 @@ impl PgResult {
         }
     }
 
-    pub fn column_name(&self, col_idx: usize) -> &str {
+    pub fn column_name(&self, col_idx: usize) -> Option<&str> {
         unsafe {
-            CStr::from_ptr(PQfname(
-                self.internal_result.as_ptr(),
-                col_idx as libc::c_int,
-            ))
-            .to_str()
-            .expect("Utf8")
+            let ptr = PQfname(self.internal_result.as_ptr(), col_idx as libc::c_int);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_str().expect("Utf8"))
+            }
         }
     }
 

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -36,8 +36,8 @@ impl<'a> Row<Pg> for PgRow<'a> {
         self.db_result.column_count()
     }
 
-    fn column_name(&self) -> &str {
-        self.db_result.column_name(self.col_idx)
+    fn column_name(&self) -> Option<&str> {
+        Some(self.db_result.column_name(self.col_idx))
     }
 }
 

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -37,7 +37,7 @@ impl<'a> Row<Pg> for PgRow<'a> {
     }
 
     fn column_name(&self) -> Option<&str> {
-        Some(self.db_result.column_name(self.col_idx))
+        self.db_result.column_name(self.col_idx)
     }
 }
 
@@ -60,5 +60,11 @@ impl<'a> NamedRow<Pg> for PgNamedRow<'a> {
 
     fn index_of(&self, column_name: &str) -> Option<usize> {
         self.cursor.index_of_column(column_name)
+    }
+
+    fn field_names(&self) -> Vec<&str> {
+        (0..self.cursor.db_result.column_count())
+            .filter_map(|i| self.cursor.db_result.column_name(i))
+            .collect()
     }
 }

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -31,6 +31,14 @@ impl<'a> Row<Pg> for PgRow<'a> {
     fn next_is_null(&self, count: usize) -> bool {
         (0..count).all(|i| self.db_result.is_null(self.row_idx, self.col_idx + i))
     }
+
+    fn column_count(&self) -> usize {
+        self.db_result.column_count()
+    }
+
+    fn column_name(&self) -> &str {
+        self.db_result.column_name(self.col_idx)
+    }
 }
 
 pub struct PgNamedRow<'a> {

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -27,15 +27,11 @@ impl<'a> Row<'a, Pg> for PgRow<'a> {
         Self: RowIndex<I>,
     {
         let idx = self.idx(idx)?;
-        if idx < self.field_count() {
-            Some(PgField {
-                db_result: self.db_result,
-                row_idx: self.row_idx,
-                col_idx: idx,
-            })
-        } else {
-            None
-        }
+        Some(PgField {
+            db_result: self.db_result,
+            row_idx: self.row_idx,
+            col_idx: idx,
+        })
     }
 
     fn partial_row(&self, range: std::ops::Range<usize>) -> PartialRow<Self::InnerPartialRow> {
@@ -45,7 +41,11 @@ impl<'a> Row<'a, Pg> for PgRow<'a> {
 
 impl<'a> RowIndex<usize> for PgRow<'a> {
     fn idx(&self, idx: usize) -> Option<usize> {
-        Some(idx)
+        if idx < self.field_count() {
+            Some(idx)
+        } else {
+            None
+        }
     }
 }
 
@@ -62,7 +62,7 @@ pub struct PgField<'a> {
 }
 
 impl<'a> Field<'a, Pg> for PgField<'a> {
-    fn field_name(&self) -> Option<&str> {
+    fn field_name(&self) -> Option<&'a str> {
         self.db_result.column_name(self.col_idx)
     }
 

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -1,70 +1,75 @@
-use super::cursor::NamedCursor;
 use super::result::PgResult;
 use crate::pg::{Pg, PgValue};
 use crate::row::*;
 
+#[derive(Clone)]
 pub struct PgRow<'a> {
+    db_result: &'a PgResult,
+    row_idx: usize,
+}
+
+impl<'a> PgRow<'a> {
+    pub fn new(db_result: &'a PgResult, row_idx: usize) -> Self {
+        PgRow { row_idx, db_result }
+    }
+}
+
+impl<'a> Row<'a, Pg> for PgRow<'a> {
+    type Field = PgField<'a>;
+    type InnerPartialRow = Self;
+
+    fn field_count(&self) -> usize {
+        self.db_result.column_count()
+    }
+
+    fn get<I>(&self, idx: I) -> Option<Self::Field>
+    where
+        Self: RowIndex<I>,
+    {
+        let idx = self.idx(idx)?;
+        if idx < self.field_count() {
+            Some(PgField {
+                db_result: self.db_result,
+                row_idx: self.row_idx,
+                col_idx: idx,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn partial_row(&self, range: std::ops::Range<usize>) -> PartialRow<Self::InnerPartialRow> {
+        PartialRow::new(self, range)
+    }
+}
+
+impl<'a> RowIndex<usize> for PgRow<'a> {
+    fn idx(&self, idx: usize) -> Option<usize> {
+        Some(idx)
+    }
+}
+
+impl<'a, 'b> RowIndex<&'a str> for PgRow<'b> {
+    fn idx(&self, field_name: &'a str) -> Option<usize> {
+        (0..self.field_count()).find(|idx| self.db_result.column_name(*idx) == Some(field_name))
+    }
+}
+
+pub struct PgField<'a> {
     db_result: &'a PgResult,
     row_idx: usize,
     col_idx: usize,
 }
 
-impl<'a> PgRow<'a> {
-    pub fn new(db_result: &'a PgResult, row_idx: usize) -> Self {
-        PgRow {
-            db_result,
-            row_idx,
-            col_idx: 0,
-        }
-    }
-}
-
-impl<'a> Row<Pg> for PgRow<'a> {
-    fn take(&mut self) -> Option<PgValue<'_>> {
-        let current_idx = self.col_idx;
-        self.col_idx += 1;
-        let raw = self.db_result.get(self.row_idx, current_idx)?;
-
-        Some(PgValue::new(raw, self.db_result.column_type(current_idx)))
-    }
-
-    fn next_is_null(&self, count: usize) -> bool {
-        (0..count).all(|i| self.db_result.is_null(self.row_idx, self.col_idx + i))
-    }
-
-    fn column_count(&self) -> usize {
-        self.db_result.column_count()
-    }
-
-    fn column_name(&self) -> Option<&str> {
+impl<'a> Field<'a, Pg> for PgField<'a> {
+    fn field_name(&self) -> Option<&str> {
         self.db_result.column_name(self.col_idx)
     }
-}
 
-pub struct PgNamedRow<'a> {
-    cursor: &'a NamedCursor,
-    idx: usize,
-}
+    fn value(&self) -> Option<crate::backend::RawValue<'a, Pg>> {
+        let raw = self.db_result.get(self.row_idx, self.col_idx)?;
+        let type_oid = self.db_result.column_type(self.col_idx);
 
-impl<'a> PgNamedRow<'a> {
-    pub fn new(cursor: &'a NamedCursor, idx: usize) -> Self {
-        PgNamedRow { cursor, idx }
-    }
-}
-
-impl<'a> NamedRow<Pg> for PgNamedRow<'a> {
-    fn get_raw_value(&self, index: usize) -> Option<PgValue<'_>> {
-        let raw = self.cursor.get_value(self.idx, index)?;
-        Some(PgValue::new(raw, self.cursor.db_result.column_type(index)))
-    }
-
-    fn index_of(&self, column_name: &str) -> Option<usize> {
-        self.cursor.index_of_column(column_name)
-    }
-
-    fn field_names(&self) -> Vec<&str> {
-        (0..self.cursor.db_result.column_count())
-            .filter_map(|i| self.cursor.db_result.column_name(i))
-            .collect()
+        Some(PgValue::new(raw, type_oid))
     }
 }

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -1,9 +1,9 @@
 use crate::expression::subselect::Subselect;
-use crate::expression::{AsExpression, Expression, ValidGrouping};
+use crate::expression::{AsExpression, Expression, TypedExpressionType, ValidGrouping};
 use crate::pg::Pg;
 use crate::query_builder::*;
 use crate::result::QueryResult;
-use crate::sql_types::Array;
+use crate::sql_types::{Array, SqlType};
 
 /// Creates a PostgreSQL `ANY` expression.
 ///
@@ -75,6 +75,7 @@ impl<Expr> Any<Expr> {
 impl<Expr, ST> Expression for Any<Expr>
 where
     Expr: Expression<SqlType = Array<ST>>,
+    ST: SqlType + TypedExpressionType,
 {
     type SqlType = ST;
 }
@@ -108,6 +109,7 @@ impl<Expr> All<Expr> {
 impl<Expr, ST> Expression for All<Expr>
 where
     Expr: Expression<SqlType = Array<ST>>,
+    ST: SqlType + TypedExpressionType,
 {
     type SqlType = ST;
 }

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -2,15 +2,14 @@ use crate::expression::{Expression, ValidGrouping};
 use crate::pg::Pg;
 use crate::query_builder::*;
 use crate::result::QueryResult;
-use crate::sql_types::{Date, NotNull, Nullable, Timestamp, Timestamptz, VarChar};
+use crate::sql_types::{is_nullable, Date, Nullable, SqlType, Timestamp, Timestamptz, VarChar};
 
 /// Marker trait for types which are valid in `AT TIME ZONE` expressions
 pub trait DateTimeLike {}
 impl DateTimeLike for Date {}
 impl DateTimeLike for Timestamp {}
 impl DateTimeLike for Timestamptz {}
-impl<T: NotNull + DateTimeLike> DateTimeLike for Nullable<T> {}
-
+impl<T> DateTimeLike for Nullable<T> where T: SqlType<IsNull = is_nullable::NotNull> + DateTimeLike {}
 #[derive(Debug, Copy, Clone, QueryId, ValidGrouping)]
 pub struct AtTimeZone<Ts, Tz> {
     timestamp: Ts,

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,3 +1,4 @@
+use crate::expression::expression_types::NotSelectable;
 use crate::pg::Pg;
 
 infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
@@ -7,5 +8,5 @@ infix_operator!(Contains, " @> ", backend: Pg);
 infix_operator!(IsContainedBy, " <@ ", backend: Pg);
 infix_operator!(ILike, " ILIKE ", backend: Pg);
 infix_operator!(NotILike, " NOT ILIKE ", backend: Pg);
-postfix_operator!(NullsFirst, " NULLS FIRST", (), backend: Pg);
-postfix_operator!(NullsLast, " NULLS LAST", (), backend: Pg);
+postfix_operator!(NullsFirst, " NULLS FIRST", NotSelectable, backend: Pg);
+postfix_operator!(NullsLast, " NULLS LAST", NotSelectable, backend: Pg);

--- a/diesel/src/pg/query_builder/mod.rs
+++ b/diesel/src/pg/query_builder/mod.rs
@@ -37,8 +37,8 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
 
     fn push_bind_param(&mut self) {
         self.bind_idx += 1;
-        let sql = format!("${}", self.bind_idx);
-        self.push_sql(&sql);
+        self.sql += "$";
+        itoa::fmt(&mut self.sql, self.bind_idx).expect("int formating does not fail");
     }
 
     fn finish(self) -> String {

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -19,7 +19,7 @@ fn pg_epoch() -> NaiveDateTime {
 }
 
 impl FromSql<Timestamp, Pg> for NaiveDateTime {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let PgTimestamp(offset) = FromSql::<Timestamp, Pg>::from_sql(bytes)?;
         match pg_epoch().checked_add_signed(Duration::microseconds(offset)) {
             Some(v) => Ok(v),
@@ -46,7 +46,7 @@ impl ToSql<Timestamp, Pg> for NaiveDateTime {
 }
 
 impl FromSql<Timestamptz, Pg> for NaiveDateTime {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         FromSql::<Timestamp, Pg>::from_sql(bytes)
     }
 }
@@ -58,14 +58,14 @@ impl ToSql<Timestamptz, Pg> for NaiveDateTime {
 }
 
 impl FromSql<Timestamptz, Pg> for DateTime<Utc> {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let naive_date_time = <NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes)?;
         Ok(DateTime::from_utc(naive_date_time, Utc))
     }
 }
 
 impl FromSql<Timestamptz, Pg> for DateTime<Local> {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let naive_date_time = <NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes)?;
         Ok(Local::from_utc_datetime(&Local, &naive_date_time))
     }
@@ -92,7 +92,7 @@ impl ToSql<Time, Pg> for NaiveTime {
 }
 
 impl FromSql<Time, Pg> for NaiveTime {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let PgTime(offset) = FromSql::<Time, Pg>::from_sql(bytes)?;
         let duration = Duration::microseconds(offset);
         Ok(midnight() + duration)
@@ -111,7 +111,7 @@ impl ToSql<Date, Pg> for NaiveDate {
 }
 
 impl FromSql<Date, Pg> for NaiveDate {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let PgDate(offset) = FromSql::<Date, Pg>::from_sql(bytes)?;
         match pg_epoch_date().checked_add_signed(Duration::days(i64::from(offset))) {
             Some(date) => Ok(date),

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -10,7 +10,7 @@ use crate::pg::{Pg, PgValue};
 use crate::serialize::{self, Output, ToSql};
 use crate::sql_types;
 
-#[derive(FromSqlRow, AsExpression)]
+#[derive(AsExpression, FromSqlRow)]
 #[diesel(foreign_derive)]
 #[sql_type = "sql_types::Timestamp"]
 #[allow(dead_code)]
@@ -28,7 +28,7 @@ impl ToSql<sql_types::Timestamp, Pg> for Timespec {
 }
 
 impl FromSql<sql_types::Timestamp, Pg> for Timespec {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let t = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(bytes)?;
         let pg_epoch = Timespec::new(TIME_SEC_CONV, 0);
         let duration = Duration::microseconds(t);

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -15,7 +15,7 @@ mod deprecated_time;
 mod quickcheck_impls;
 mod std_time;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, AsExpression, FromSqlRow)]
 #[sql_type = "Timestamp"]
 #[sql_type = "Timestamptz"]
 /// Timestamps are represented in Postgres as a 64 bit signed integer representing the number of
@@ -23,7 +23,7 @@ mod std_time;
 /// the integer's meaning.
 pub struct PgTimestamp(pub i64);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, AsExpression, FromSqlRow)]
 #[sql_type = "Date"]
 /// Dates are represented in Postgres as a 32 bit signed integer representing the number of julian
 /// days since January 1st 2000. This struct is a dumb wrapper type, meant only to indicate the
@@ -33,7 +33,7 @@ pub struct PgDate(pub i32);
 /// Time is represented in Postgres as a 64 bit signed integer representing the number of
 /// microseconds since midnight. This struct is a dumb wrapper type, meant only to indicate the
 /// integer's meaning.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, AsExpression, FromSqlRow)]
 #[sql_type = "Time"]
 pub struct PgTime(pub i64);
 
@@ -41,7 +41,7 @@ pub struct PgTime(pub i64);
 /// microseconds, a 32 bit integer representing number of days, and a 32 bit integer
 /// representing number of months. This struct is a dumb wrapper type, meant only to indicate the
 /// meaning of these parts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromSqlRow, AsExpression)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AsExpression, FromSqlRow)]
 #[sql_type = "Interval"]
 pub struct PgInterval {
     /// The number of whole microseconds
@@ -90,7 +90,7 @@ impl ToSql<sql_types::Timestamp, Pg> for PgTimestamp {
 }
 
 impl FromSql<sql_types::Timestamp, Pg> for PgTimestamp {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         FromSql::<sql_types::BigInt, Pg>::from_sql(bytes).map(PgTimestamp)
     }
 }
@@ -102,7 +102,7 @@ impl ToSql<sql_types::Timestamptz, Pg> for PgTimestamp {
 }
 
 impl FromSql<sql_types::Timestamptz, Pg> for PgTimestamp {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Timestamp, Pg>::from_sql(bytes)
     }
 }
@@ -114,7 +114,7 @@ impl ToSql<sql_types::Date, Pg> for PgDate {
 }
 
 impl FromSql<sql_types::Date, Pg> for PgDate {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Integer, Pg>::from_sql(bytes).map(PgDate)
     }
 }
@@ -126,7 +126,7 @@ impl ToSql<sql_types::Time, Pg> for PgTime {
 }
 
 impl FromSql<sql_types::Time, Pg> for PgTime {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         FromSql::<sql_types::BigInt, Pg>::from_sql(bytes).map(PgTime)
     }
 }
@@ -141,12 +141,11 @@ impl ToSql<sql_types::Interval, Pg> for PgInterval {
 }
 
 impl FromSql<sql_types::Interval, Pg> for PgInterval {
-    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         Ok(PgInterval {
-            microseconds: FromSql::<sql_types::BigInt, Pg>::from_sql(Some(value.subslice(0..8)))?,
-            days: FromSql::<sql_types::Integer, Pg>::from_sql(Some(value.subslice(8..12)))?,
-            months: FromSql::<sql_types::Integer, Pg>::from_sql(Some(value.subslice(12..16)))?,
+            microseconds: FromSql::<sql_types::BigInt, Pg>::from_sql(value.subslice(0..8))?,
+            days: FromSql::<sql_types::Integer, Pg>::from_sql(value.subslice(8..12))?,
+            months: FromSql::<sql_types::Integer, Pg>::from_sql(value.subslice(12..16))?,
         })
     }
 }

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -27,7 +27,7 @@ impl ToSql<sql_types::Timestamp, Pg> for SystemTime {
 }
 
 impl FromSql<sql_types::Timestamp, Pg> for SystemTime {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let usecs_passed = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(bytes)?;
         let before_epoch = usecs_passed < 0;
         let time_passed = usecs_to_duration(usecs_passed.abs() as u64);

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -11,7 +11,7 @@ use crate::sql_types;
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
 
-#[derive(Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression)]
+#[derive(Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow)]
 #[sql_type = "sql_types::Numeric"]
 /// Represents a NUMERIC value, closely mirroring the PG wire protocol
 /// representation
@@ -50,8 +50,7 @@ impl ::std::fmt::Display for InvalidNumericSign {
 impl Error for InvalidNumericSign {}
 
 impl FromSql<sql_types::Numeric, Pg> for PgNumeric {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = bytes.as_bytes();
         let digit_count = bytes.read_u16::<NetworkEndian>()?;
         let mut digits = Vec::with_capacity(digit_count as usize);

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -7,8 +7,7 @@ use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types;
 
 impl FromSql<sql_types::Oid, Pg> for u32 {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = bytes.as_bytes();
         bytes.read_u32::<NetworkEndian>().map_err(Into::into)
     }

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -10,8 +10,7 @@ use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types;
 
 impl FromSql<sql_types::Json, Pg> for serde_json::Value {
-    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         serde_json::from_slice(value.as_bytes()).map_err(|_| "Invalid Json".into())
     }
 }
@@ -25,8 +24,7 @@ impl ToSql<sql_types::Json, Pg> for serde_json::Value {
 }
 
 impl FromSql<sql_types::Jsonb, Pg> for serde_json::Value {
-    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let bytes = value.as_bytes();
         if bytes[0] != 1 {
             return Err("Unsupported JSONB encoding version".into());
@@ -56,20 +54,21 @@ fn json_to_sql() {
 fn some_json_from_sql() {
     let input_json = b"true";
     let output_json: serde_json::Value =
-        FromSql::<sql_types::Json, Pg>::from_sql(Some(PgValue::for_test(input_json))).unwrap();
+        FromSql::<sql_types::Json, Pg>::from_sql(PgValue::for_test(input_json)).unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
 }
 
 #[test]
 fn bad_json_from_sql() {
     let uuid: Result<serde_json::Value, _> =
-        FromSql::<sql_types::Json, Pg>::from_sql(Some(PgValue::for_test(b"boom")));
+        FromSql::<sql_types::Json, Pg>::from_sql(PgValue::for_test(b"boom"));
     assert_eq!(uuid.unwrap_err().to_string(), "Invalid Json");
 }
 
 #[test]
 fn no_json_from_sql() {
-    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Json, Pg>::from_sql(None);
+    let uuid: Result<serde_json::Value, _> =
+        FromSql::<sql_types::Json, Pg>::from_nullable_sql(None);
     assert_eq!(
         uuid.unwrap_err().to_string(),
         "Unexpected null for non-null column"
@@ -88,21 +87,21 @@ fn jsonb_to_sql() {
 fn some_jsonb_from_sql() {
     let input_json = b"\x01true";
     let output_json: serde_json::Value =
-        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(PgValue::for_test(input_json))).unwrap();
+        FromSql::<sql_types::Jsonb, Pg>::from_sql(PgValue::for_test(input_json)).unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
 }
 
 #[test]
 fn bad_jsonb_from_sql() {
     let uuid: Result<serde_json::Value, _> =
-        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(PgValue::for_test(b"\x01boom")));
+        FromSql::<sql_types::Jsonb, Pg>::from_sql(PgValue::for_test(b"\x01boom"));
     assert_eq!(uuid.unwrap_err().to_string(), "Invalid Json");
 }
 
 #[test]
 fn bad_jsonb_version_from_sql() {
     let uuid: Result<serde_json::Value, _> =
-        FromSql::<sql_types::Jsonb, Pg>::from_sql(Some(PgValue::for_test(b"\x02true")));
+        FromSql::<sql_types::Jsonb, Pg>::from_sql(PgValue::for_test(b"\x02true"));
     assert_eq!(
         uuid.unwrap_err().to_string(),
         "Unsupported JSONB encoding version"
@@ -111,7 +110,8 @@ fn bad_jsonb_version_from_sql() {
 
 #[test]
 fn no_jsonb_from_sql() {
-    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Jsonb, Pg>::from_sql(None);
+    let uuid: Result<serde_json::Value, _> =
+        FromSql::<sql_types::Jsonb, Pg>::from_nullable_sql(None);
     assert_eq!(
         uuid.unwrap_err().to_string(),
         "Unexpected null for non-null column"

--- a/diesel/src/pg/types/mac_addr.rs
+++ b/diesel/src/pg/types/mac_addr.rs
@@ -12,15 +12,14 @@ mod foreign_derives {
     use crate::deserialize::FromSqlRow;
     use crate::expression::AsExpression;
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "MacAddr"]
     struct ByteArrayProxy([u8; 6]);
 }
 
 impl FromSql<MacAddr, Pg> for [u8; 6] {
-    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         value
             .as_bytes()
             .try_into()
@@ -41,7 +40,6 @@ fn macaddr_roundtrip() {
     let mut bytes = Output::test();
     let input_address = [0x52, 0x54, 0x00, 0xfb, 0xc6, 0x16];
     ToSql::<MacAddr, Pg>::to_sql(&input_address, &mut bytes).unwrap();
-    let output_address: [u8; 6] =
-        FromSql::from_sql(Some(PgValue::for_test(bytes.as_ref()))).unwrap();
+    let output_address: [u8; 6] = FromSql::from_sql(PgValue::for_test(bytes.as_ref())).unwrap();
     assert_eq!(input_address, output_address);
 }

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -20,12 +20,12 @@ use crate::sql_types::{BigInt, Money};
 /// use diesel::data_types::PgMoney as Pence; // 1/100th unit of Pound
 /// use diesel::data_types::PgMoney as Fils;  // 1/1000th unit of Dinar
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, AsExpression, FromSqlRow)]
 #[sql_type = "Money"]
 pub struct PgMoney(pub i64);
 
 impl FromSql<Money, Pg> for PgMoney {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         FromSql::<BigInt, Pg>::from_sql(bytes).map(PgMoney)
     }
 }

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -153,7 +153,7 @@ mod bigdecimal {
     }
 
     impl FromSql<Numeric, Pg> for BigDecimal {
-        fn from_sql(numeric: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+        fn from_sql(numeric: PgValue<'_>) -> deserialize::Result<Self> {
             PgNumeric::from_sql(numeric)?.try_into()
         }
     }

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -7,10 +7,8 @@ use crate::sql_types;
 
 impl FromSql<sql_types::Bool, Pg> for bool {
     fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        match bytes {
-            Some(bytes) => Ok(bytes.as_bytes()[0] != 0),
-            None => Ok(false),
-        }
+        let bytes = not_none!(bytes);
+        Ok(bytes.as_bytes()[0] != 0)
     }
 }
 

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -6,8 +6,7 @@ use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types;
 
 impl FromSql<sql_types::Bool, Pg> for bool {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         Ok(bytes.as_bytes()[0] != 0)
     }
 }
@@ -29,7 +28,10 @@ fn bool_to_sql() {
 }
 
 #[test]
-fn bool_from_sql_treats_null_as_false() {
-    let result = <bool as FromSql<sql_types::Bool, Pg>>::from_sql(None).unwrap();
-    assert!(!result);
+fn no_bool_from_sql() {
+    let result = <bool as FromSql<sql_types::Bool, Pg>>::from_nullable_sql(None);
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Unexpected null for non-null column"
+    );
 }

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -2,7 +2,7 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::Bound;
 use std::io::Write;
 
-use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::deserialize::{self, FromSql, Queryable};
 use crate::expression::bound::Bound as SqlBound;
 use crate::expression::AsExpression;
 use crate::pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
@@ -20,16 +20,6 @@ bitflags! {
         const LB_NULL = 0x20;
         const UB_NULL = 0x40;
         const CONTAIN_EMPTY = 0x80;
-    }
-}
-
-impl<T, ST> Queryable<Range<ST>, Pg> for (Bound<T>, Bound<T>)
-where
-    T: FromSql<ST, Pg> + Queryable<ST, Pg>,
-{
-    type Row = Self;
-    fn build(row: Self) -> Self {
-        row
     }
 }
 
@@ -65,21 +55,11 @@ impl<'a, ST, T> AsExpression<Nullable<Range<ST>>> for &'a (Bound<T>, Bound<T>) {
     }
 }
 
-impl<T, ST> FromSqlRow<Range<ST>, Pg> for (Bound<T>, Bound<T>)
-where
-    (Bound<T>, Bound<T>): FromSql<Range<ST>, Pg>,
-{
-    fn build_from_row<R: crate::row::Row<Pg>>(row: &mut R) -> deserialize::Result<Self> {
-        FromSql::<Range<ST>, Pg>::from_sql(row.take())
-    }
-}
-
 impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: FromSql<ST, Pg>,
 {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(bytes);
+    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
         let flags: RangeFlags = RangeFlags::from_bits_truncate(bytes.read_u8()?);
         let mut lower_bound = Bound::Unbounded;
@@ -89,7 +69,7 @@ where
             let elem_size = bytes.read_i32::<NetworkEndian>()?;
             let (elem_bytes, new_bytes) = bytes.split_at(elem_size as usize);
             bytes = new_bytes;
-            let value = T::from_sql(Some(PgValue::new(elem_bytes, value.get_oid())))?;
+            let value = T::from_sql(PgValue::new(elem_bytes, value.get_oid()))?;
 
             lower_bound = if flags.contains(RangeFlags::LB_INC) {
                 Bound::Included(value)
@@ -100,7 +80,7 @@ where
 
         if !flags.contains(RangeFlags::UB_INF) {
             let _size = bytes.read_i32::<NetworkEndian>()?;
-            let value = T::from_sql(Some(PgValue::new(bytes, value.get_oid())))?;
+            let value = T::from_sql(PgValue::new(bytes, value.get_oid()))?;
 
             upper_bound = if flags.contains(RangeFlags::UB_INC) {
                 Bound::Included(value)
@@ -110,6 +90,17 @@ where
         }
 
         Ok((lower_bound, upper_bound))
+    }
+}
+
+impl<T, ST> Queryable<Range<ST>, Pg> for (Bound<T>, Bound<T>)
+where
+    T: FromSql<ST, Pg>,
+{
+    type Row = Self;
+
+    fn build(row: Self) -> Self {
+        row
     }
 }
 

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -73,8 +73,6 @@ macro_rules! tuple_impls {
         where
             Self: FromSql<Record<($($ST,)+)>, Pg>,
         {
-            const FIELDS_NEEDED: usize = 1;
-
             fn build_from_row<RowT: Row<Pg>>(row: &mut RowT) -> deserialize::Result<Self> {
                 Self::from_sql(row.take())
             }

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -2,16 +2,16 @@ use byteorder::*;
 use std::io::Write;
 use std::num::NonZeroU32;
 
-use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::deserialize::{self, FromSql, Queryable};
 use crate::expression::{
-    AppearsOnTable, AsExpression, Expression, SelectableExpression, ValidGrouping,
+    AppearsOnTable, AsExpression, Expression, SelectableExpression, TypedExpressionType,
+    ValidGrouping,
 };
 use crate::pg::{Pg, PgValue};
 use crate::query_builder::{AstPass, QueryFragment, QueryId};
 use crate::result::QueryResult;
-use crate::row::Row;
 use crate::serialize::{self, IsNull, Output, ToSql, WriteTuple};
-use crate::sql_types::{HasSqlType, Record};
+use crate::sql_types::{HasSqlType, Record, SqlType};
 
 macro_rules! tuple_impls {
     ($(
@@ -27,8 +27,7 @@ macro_rules! tuple_impls {
             // but the only other option would be to use `mem::uninitialized`
             // and `ptr::write`.
             #[allow(clippy::eval_order_dependence)]
-            fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-                let value = not_none!(value);
+            fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
                 let mut bytes = value.as_bytes();
                 let num_elements = bytes.read_i32::<NetworkEndian>()?;
 
@@ -49,14 +48,14 @@ macro_rules! tuple_impls {
                     let num_bytes = bytes.read_i32::<NetworkEndian>()?;
 
                     if num_bytes == -1 {
-                        $T::from_sql(None)?
+                        $T::from_nullable_sql(None)?
                     } else {
                         let (elem_bytes, new_bytes) = bytes.split_at(num_bytes as usize);
                         bytes = new_bytes;
-                        $T::from_sql(Some(PgValue::new(
+                        $T::from_sql(PgValue::new(
                             elem_bytes,
                             oid,
-                        )))?
+                        ))?
                     }
                 },)+);
 
@@ -69,18 +68,8 @@ macro_rules! tuple_impls {
             }
         }
 
-        impl<$($T,)+ $($ST,)+> FromSqlRow<Record<($($ST,)+)>, Pg> for ($($T,)+)
-        where
-            Self: FromSql<Record<($($ST,)+)>, Pg>,
-        {
-            fn build_from_row<RowT: Row<Pg>>(row: &mut RowT) -> deserialize::Result<Self> {
-                Self::from_sql(row.take())
-            }
-        }
-
         impl<$($T,)+ $($ST,)+> Queryable<Record<($($ST,)+)>, Pg> for ($($T,)+)
-        where
-            Self: FromSqlRow<Record<($($ST,)+)>, Pg>,
+        where Self: FromSql<Record<($($ST,)+)>, Pg>
         {
             type Row = Self;
 
@@ -91,6 +80,7 @@ macro_rules! tuple_impls {
 
         impl<$($T,)+ $($ST,)+> AsExpression<Record<($($ST,)+)>> for ($($T,)+)
         where
+            $($ST: SqlType + TypedExpressionType,)+
             $($T: AsExpression<$ST>,)+
             PgTuple<($($T::Expression,)+)>: Expression<SqlType = Record<($($ST,)+)>>,
         {

--- a/diesel/src/query_builder/insert_statement/insert_from_select.rs
+++ b/diesel/src/query_builder/insert_statement/insert_from_select.rs
@@ -46,8 +46,8 @@ where
 impl<DB, Select, Columns> QueryFragment<DB> for InsertFromSelect<Select, Columns>
 where
     DB: Backend,
-    Columns: ColumnList + Expression<SqlType = Select::SqlType>,
-    Select: Query + QueryFragment<DB>,
+    Columns: ColumnList + Expression,
+    Select: Query<SqlType = Columns::SqlType> + QueryFragment<DB>,
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.push_sql("(");
@@ -60,7 +60,7 @@ where
 
 impl<Select, Columns> UndecoratedInsertRecord<Columns::Table> for InsertFromSelect<Select, Columns>
 where
-    Columns: ColumnList + Expression<SqlType = Select::SqlType>,
-    Select: Query,
+    Columns: ColumnList + Expression,
+    Select: Query<SqlType = Columns::SqlType>,
 {
 }

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -162,8 +162,8 @@ impl<T, U, C, Op, Ret> InsertStatement<T, InsertFromSelect<U, C>, Op, Ret> {
         columns: C2,
     ) -> InsertStatement<T, InsertFromSelect<U, C2>, Op, Ret>
     where
-        C2: ColumnList<Table = T> + Expression<SqlType = U::SqlType>,
-        U: Query,
+        C2: ColumnList<Table = T> + Expression,
+        U: Query<SqlType = C2::SqlType>,
     {
         InsertStatement::new(
             self.target,

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -43,7 +43,9 @@ pub use self::insert_statement::{
 };
 pub use self::query_id::QueryId;
 #[doc(inline)]
-pub use self::select_clause::{SelectClauseExpression, SelectClauseQueryFragment};
+pub use self::select_clause::{
+    IntoBoxedSelectClause, SelectClauseExpression, SelectClauseQueryFragment,
+};
 #[doc(hidden)]
 pub use self::select_statement::{BoxedSelectStatement, SelectStatement};
 pub use self::sql_query::{BoxedSqlQuery, SqlQuery};

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -26,7 +26,7 @@ pub mod nodes;
 pub(crate) mod offset_clause;
 mod order_clause;
 mod returning_clause;
-mod select_clause;
+pub(crate) mod select_clause;
 mod select_statement;
 mod sql_query;
 mod update_statement;
@@ -42,6 +42,8 @@ pub use self::insert_statement::{
     IncompleteInsertStatement, InsertStatement, UndecoratedInsertRecord, ValuesClause,
 };
 pub use self::query_id::QueryId;
+#[doc(inline)]
+pub use self::select_clause::{SelectClauseExpression, SelectClauseQueryFragment};
 #[doc(hidden)]
 pub use self::select_statement::{BoxedSelectStatement, SelectStatement};
 pub use self::sql_query::{BoxedSqlQuery, SqlQuery};

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -13,6 +13,7 @@ pub struct SelectClause<T>(pub T);
 /// The difference to the normal `Expression` trait is the query source (`QS`)
 /// generic type parameter. This allows to access the query source in generic code.
 pub trait SelectClauseExpression<QS> {
+    /// The expression represented by the given select clause
     type Selection: SelectableExpression<QS>;
     /// SQL type of the select clause
     type SelectClauseSqlType;
@@ -67,5 +68,43 @@ where
 {
     fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()> {
         source.default_selection().walk_ast(pass)
+    }
+}
+
+/// An internal helper trait to convert different select clauses
+/// into their boxed counter part.
+///
+/// You normally don't need this trait, at least as long as you
+/// don't implement your own select clause representation
+pub trait IntoBoxedSelectClause<'a, DB, QS> {
+    /// The sql type of the select clause
+    type SqlType;
+
+    /// Convert the select clause into a the boxed representation
+    fn into_boxed(self, source: &QS) -> Box<dyn QueryFragment<DB> + Send + 'a>;
+}
+
+impl<'a, DB, T, QS> IntoBoxedSelectClause<'a, DB, QS> for SelectClause<T>
+where
+    T: QueryFragment<DB> + SelectableExpression<QS> + Send + 'a,
+    DB: Backend,
+{
+    type SqlType = T::SqlType;
+
+    fn into_boxed(self, _source: &QS) -> Box<dyn QueryFragment<DB> + Send + 'a> {
+        Box::new(self.0)
+    }
+}
+
+impl<'a, DB, QS> IntoBoxedSelectClause<'a, DB, QS> for DefaultSelectClause
+where
+    QS: QuerySource,
+    QS::DefaultSelection: QueryFragment<DB> + Send + 'a,
+    DB: Backend,
+{
+    type SqlType = <QS::DefaultSelection as Expression>::SqlType;
+
+    fn into_boxed(self, source: &QS) -> Box<dyn QueryFragment<DB> + Send + 'a> {
+        Box::new(source.default_selection())
     }
 }

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -8,8 +8,13 @@ pub struct DefaultSelectClause;
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct SelectClause<T>(pub T);
 
+/// Specialised variant of `Expression` for select clause types
+///
+/// The difference to the normal `Expression` trait is the query source (`QS`)
+/// generic type parameter. This allows to access the query source in generic code.
 pub trait SelectClauseExpression<QS> {
     type Selection: SelectableExpression<QS>;
+    /// SQL type of the select clause
     type SelectClauseSqlType;
 }
 
@@ -29,7 +34,18 @@ where
     type SelectClauseSqlType = <QS::DefaultSelection as Expression>::SqlType;
 }
 
+/// Specialised variant of `QueryFragment` for select clause types
+///
+/// The difference to the normal `QueryFragment` trait is the query source (`QS`)
+/// generic type parameter.
 pub trait SelectClauseQueryFragment<QS, DB: Backend> {
+    /// Walk over this `SelectClauseQueryFragment` for all passes.
+    ///
+    /// This method is where the actual behavior of an select clause is implemented.
+    /// This method will contain the behavior required for all possible AST
+    /// passes. See [`AstPass`] for more details.
+    ///
+    /// [`AstPass`]: struct.AstPass.html
     fn walk_ast(&self, source: &QS, pass: AstPass<DB>) -> QueryResult<()>;
 }
 

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -24,7 +24,7 @@ use crate::query_dsl::methods::*;
 use crate::query_dsl::*;
 use crate::query_source::joins::{Join, JoinOn, JoinTo};
 use crate::query_source::QuerySource;
-use crate::sql_types::{BigInt, Bool};
+use crate::sql_types::{BigInt, BoolOrNullableBool};
 
 impl<F, S, D, W, O, LOf, G, LC, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On>
     for SelectStatement<F, S, D, W, O, LOf, G, LC>
@@ -94,7 +94,8 @@ where
 impl<F, S, D, W, O, LOf, G, LC, Predicate> FilterDsl<Predicate>
     for SelectStatement<F, S, D, W, O, LOf, G, LC>
 where
-    Predicate: Expression<SqlType = Bool> + NonAggregate,
+    Predicate: Expression + NonAggregate,
+    Predicate::SqlType: BoolOrNullableBool,
     W: WhereAnd<Predicate>,
 {
     type Output = SelectStatement<F, S, D, W::Output, O, LOf, G, LC>;
@@ -116,7 +117,8 @@ where
 impl<F, S, D, W, O, LOf, G, LC, Predicate> OrFilterDsl<Predicate>
     for SelectStatement<F, S, D, W, O, LOf, G, LC>
 where
-    Predicate: Expression<SqlType = Bool> + NonAggregate,
+    Predicate: Expression + NonAggregate,
+    Predicate::SqlType: BoolOrNullableBool,
     W: WhereOr<Predicate>,
 {
     type Output = SelectStatement<F, S, D, W::Output, O, LOf, G, LC>;

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,10 +1,10 @@
 use super::RunQueryDsl;
 use crate::backend::Backend;
 use crate::connection::Connection;
-use crate::deserialize::Queryable;
+use crate::deserialize::FromSqlRow;
+use crate::expression::QueryMetadata;
 use crate::query_builder::{AsQuery, QueryFragment, QueryId};
 use crate::result::QueryResult;
-use crate::sql_types::HasSqlType;
 
 /// The `load` method
 ///
@@ -21,13 +21,13 @@ pub trait LoadQuery<Conn, U>: RunQueryDsl<Conn> {
 impl<Conn, T, U> LoadQuery<Conn, U> for T
 where
     Conn: Connection,
-    Conn::Backend: HasSqlType<T::SqlType>,
     T: AsQuery + RunQueryDsl<Conn>,
     T::Query: QueryFragment<Conn::Backend> + QueryId,
-    U: Queryable<T::SqlType, Conn::Backend>,
+    U: FromSqlRow<T::SqlType, Conn::Backend>,
+    Conn::Backend: QueryMetadata<T::SqlType>,
 {
     fn internal_load(self, conn: &Conn) -> QueryResult<Vec<U>> {
-        conn.query_by_index(self)
+        conn.load(self)
     }
 }
 

--- a/diesel/src/query_dsl/single_value_dsl.rs
+++ b/diesel/src/query_dsl/single_value_dsl.rs
@@ -3,7 +3,7 @@ use crate::dsl::Limit;
 use crate::expression::grouped::Grouped;
 use crate::expression::subselect::Subselect;
 use crate::query_builder::SelectQuery;
-use crate::sql_types::{IntoNullable, SingleValue};
+use crate::sql_types::IntoNullable;
 
 /// The `single_value` method
 ///
@@ -20,13 +20,13 @@ pub trait SingleValueDsl {
     fn single_value(self) -> Self::Output;
 }
 
-impl<T, ST> SingleValueDsl for T
+impl<T> SingleValueDsl for T
 where
-    Self: SelectQuery<SqlType = ST> + LimitDsl,
-    ST: IntoNullable,
-    ST::Nullable: SingleValue,
+    Self: SelectQuery + LimitDsl,
+    <Self as SelectQuery>::SqlType: IntoNullable,
 {
-    type Output = Grouped<Subselect<Limit<Self>, ST::Nullable>>;
+    type Output =
+        Grouped<Subselect<Limit<Self>, <<Self as SelectQuery>::SqlType as IntoNullable>::Nullable>>;
 
     fn single_value(self) -> Self::Output {
         Grouped(Subselect::new(self.limit(1)))

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -6,7 +6,7 @@ use crate::expression::SelectableExpression;
 use crate::prelude::*;
 use crate::query_builder::*;
 use crate::result::QueryResult;
-use crate::sql_types::Bool;
+use crate::sql_types::BoolOrNullableBool;
 use crate::util::TupleAppend;
 
 #[derive(Debug, Clone, Copy, QueryId)]
@@ -84,7 +84,8 @@ where
 impl<Join, On> QuerySource for JoinOn<Join, On>
 where
     Join: QuerySource,
-    On: AppearsOnTable<Join::FromClause, SqlType = Bool> + Clone,
+    On: AppearsOnTable<Join::FromClause> + Clone,
+    On::SqlType: BoolOrNullableBool,
     Join::DefaultSelection: SelectableExpression<Self>,
 {
     type FromClause = Grouped<nodes::InfixNode<'static, Join::FromClause, On>>;

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -355,3 +355,15 @@ impl fmt::Display for UnexpectedNullError {
 }
 
 impl StdError for UnexpectedNullError {}
+
+/// Expected more fields then present in the current row while deserialising results
+#[derive(Debug, Clone, Copy)]
+pub struct UnexpectedEndOfRow;
+
+impl fmt::Display for UnexpectedEndOfRow {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unexpected end of row")
+    }
+}
+
+impl StdError for UnexpectedEndOfRow {}

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -72,4 +72,7 @@ pub trait NamedRow<DB: Backend> {
     fn index_of(&self, column_name: &str) -> Option<usize>;
     #[doc(hidden)]
     fn get_raw_value(&self, index: usize) -> Option<backend::RawValue<DB>>;
+
+    /// Get a list of all field names in the current row
+    fn field_names(&self) -> Vec<&str>;
 }

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -32,6 +32,9 @@ pub trait Row<DB: Backend> {
     fn column_count(&self) -> usize;
 
     /// Name of the current column
+    ///
+    /// May return `None` in cases where the field is not
+    /// named on sql side
     fn column_name(&self) -> Option<&str>;
 }
 

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -32,7 +32,7 @@ pub trait Row<DB: Backend> {
     fn column_count(&self) -> usize;
 
     /// Name of the current column
-    fn column_name(&self) -> &str;
+    fn column_name(&self) -> Option<&str>;
 }
 
 /// Represents a row of a SQL query, where the values are accessed by name

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -27,6 +27,12 @@ pub trait Row<DB: Backend> {
             self.take();
         }
     }
+
+    /// Number of columns in the current result set
+    fn column_count(&self) -> usize;
+
+    /// Name of the current column
+    fn column_name(&self) -> &str;
 }
 
 /// Represents a row of a SQL query, where the values are accessed by name

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -19,15 +19,6 @@ pub trait Row<DB: Backend> {
     /// would all return `None`.
     fn next_is_null(&self, count: usize) -> bool;
 
-    /// Skips the next `count` columns. This method must be called if you are
-    /// choosing not to call `take` as a result of `next_is_null` returning
-    /// `true`.
-    fn advance(&mut self, count: usize) {
-        for _ in 0..count {
-            self.take();
-        }
-    }
-
     /// Number of columns in the current result set
     fn column_count(&self) -> usize;
 

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -1,32 +1,166 @@
 //! Contains the `Row` trait
 
-use crate::backend::{self, Backend};
-use crate::deserialize::{self, FromSql};
+use crate::{
+    backend::{self, Backend},
+    deserialize,
+};
+use deserialize::FromSql;
+use std::ops::Range;
+
+/// Representing a way to index into database rows
+///
+/// * Crates using existing backends should use existing implementations of
+///   this traits. Diesel provides `RowIndex<usize>` and `RowIndex<&str>` for
+///   all bulit-in backends
+///
+/// * Crates implementing custom backends need to provide `RowIndex<usize>` and
+///   `RowIndex<&str>` impls for their [`Row`] type.
+///
+/// [`Row`]: trait.Row.html
+pub trait RowIndex<I> {
+    /// Get the numeric index inside the current row for the provided index value
+    fn idx(&self, idx: I) -> Option<usize>;
+}
 
 /// Represents a single database row.
-/// Apps should not need to concern themselves with this trait.
 ///
-/// This trait is only used as an argument to [`FromSqlRow`].
+/// This trait is used as an argument to [`FromSqlRow`].
 ///
 /// [`FromSqlRow`]: ../deserialize/trait.FromSqlRow.html
-pub trait Row<DB: Backend> {
-    /// Returns the value of the next column in the row.
-    fn take(&mut self) -> Option<backend::RawValue<DB>>;
-
-    /// Returns whether the next `count` columns are all `NULL`.
+pub trait Row<'a, DB: Backend>: RowIndex<usize> + for<'b> RowIndex<&'b str> + Sized {
+    /// Field type returned by a `Row` implementation
     ///
-    /// If this method returns `true`, then the next `count` calls to `take`
-    /// would all return `None`.
-    fn next_is_null(&self, count: usize) -> bool;
-
-    /// Number of columns in the current result set
-    fn column_count(&self) -> usize;
-
-    /// Name of the current column
+    /// * Crates using existing backend should not concern themself with the
+    ///   concrete type of this associated type.
     ///
-    /// May return `None` in cases where the field is not
-    /// named on sql side
-    fn column_name(&self) -> Option<&str>;
+    /// * Crates implementing custom backends should provide their own type
+    ///   meeting the required trait bounds
+    type Field: Field<'a, DB>;
+
+    /// Return type of `PartialRow`
+    ///
+    /// For all implementations, beside of the `Row` implementation on `PartialRow` itself
+    /// this should be `Self`.
+    #[doc(hidden)]
+    type InnerPartialRow: Row<'a, DB>;
+
+    /// Get the number of fields in the current row
+    fn field_count(&self) -> usize;
+
+    /// Get the field with the provided index from the row.
+    ///
+    /// Returns `None` if there is no matching field for the given index
+    fn get<I>(&self, idx: I) -> Option<Self::Field>
+    where
+        Self: RowIndex<I>;
+
+    /// Returns a wrapping row that allows only to access fields, where the index is part of
+    /// the provided range.
+    #[doc(hidden)]
+    fn partial_row(&self, range: Range<usize>) -> PartialRow<Self::InnerPartialRow>;
+}
+
+/// Represents a single field in a database row.
+///
+/// This trait allows retrieving information on the name of the colum and on the value of the
+/// field.
+pub trait Field<'a, DB: Backend> {
+    /// The name of the current field
+    ///
+    /// Returns `None` if it's an unnamed field
+    fn field_name(&self) -> Option<&str>;
+
+    /// Get the value representing the current field in the raw representation
+    /// as it is transmitted by the database
+    fn value(&self) -> Option<backend::RawValue<'a, DB>>;
+
+    /// Checks whether this field is null or not.
+    fn is_null(&self) -> bool {
+        self.value().is_none()
+    }
+}
+
+/// A row type that wraps an inner row
+///
+/// This type only allows to access fields of the inner row, whose index is
+/// part of `range`.
+///
+/// Indexing via `usize` starts with 0 for this row type. The index is then shifted
+/// by `self.range.start` to match the corresponding field in the underlying row.
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct PartialRow<'a, R> {
+    inner: &'a R,
+    range: Range<usize>,
+}
+
+impl<'a, R> PartialRow<'a, R> {
+    #[doc(hidden)]
+    pub fn new(inner: &'a R, range: Range<usize>) -> Self {
+        Self { inner, range }
+    }
+}
+
+impl<'a, 'b, DB, R> Row<'a, DB> for PartialRow<'b, R>
+where
+    DB: Backend,
+    R: Row<'a, DB>,
+{
+    type Field = R::Field;
+    type InnerPartialRow = R;
+
+    fn field_count(&self) -> usize {
+        let inner_length = self.inner.field_count();
+        if self.range.start < inner_length {
+            std::cmp::min(inner_length - self.range.start, self.range.len())
+        } else {
+            0
+        }
+    }
+
+    fn get<I>(&self, idx: I) -> Option<Self::Field>
+    where
+        Self: RowIndex<I>,
+    {
+        let idx = self.idx(idx)?;
+        Some(self.inner.get(idx).unwrap())
+    }
+
+    fn partial_row(&self, range: Range<usize>) -> PartialRow<R> {
+        let range = (self.range.start + range.start)..(self.range.start + range.end);
+        PartialRow {
+            inner: self.inner,
+            range,
+        }
+    }
+}
+
+impl<'a, 'b, R> RowIndex<&'a str> for PartialRow<'b, R>
+where
+    R: RowIndex<&'a str>,
+{
+    fn idx(&self, idx: &'a str) -> Option<usize> {
+        let idx = self.inner.idx(idx)?;
+        if self.range.contains(&idx) {
+            Some(idx)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, R> RowIndex<usize> for PartialRow<'a, R>
+where
+    R: RowIndex<usize>,
+{
+    fn idx(&self, idx: usize) -> Option<usize> {
+        let idx = self.inner.idx(idx)? + self.range.start;
+        if self.range.contains(&idx) {
+            Some(idx)
+        } else {
+            None
+        }
+    }
 }
 
 /// Represents a row of a SQL query, where the values are accessed by name
@@ -44,26 +178,23 @@ pub trait NamedRow<DB: Backend> {
     ///
     /// If two or more fields in the query have the given name, the result of
     /// this function is undefined.
+    fn get<'a, ST, T>(&self, column_name: &'a str) -> deserialize::Result<T>
+    where
+        T: FromSql<ST, DB>;
+}
+
+impl<'a, R, DB> NamedRow<DB> for R
+where
+    R: Row<'a, DB>,
+    DB: Backend,
+{
     fn get<ST, T>(&self, column_name: &str) -> deserialize::Result<T>
     where
         T: FromSql<ST, DB>,
     {
-        let idx = self
-            .index_of(column_name)
-            .ok_or_else(|| format!("Column `{}` was not present in query", column_name).into());
-        let idx = match idx {
-            Ok(x) => x,
-            Err(e) => return Err(e),
-        };
-        let raw_value = self.get_raw_value(idx);
-        T::from_sql(raw_value)
+        let field = Row::get(self, column_name)
+            .ok_or_else(|| format!("Column `{}` was not present in query", column_name))?;
+
+        T::from_nullable_sql(field.value())
     }
-
-    #[doc(hidden)]
-    fn index_of(&self, column_name: &str) -> Option<usize>;
-    #[doc(hidden)]
-    fn get_raw_value(&self, index: usize) -> Option<backend::RawValue<DB>>;
-
-    /// Get a list of all field names in the current row
-    fn field_names(&self) -> Vec<&str>;
 }

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -68,7 +68,7 @@ pub trait Field<'a, DB: Backend> {
     /// The name of the current field
     ///
     /// Returns `None` if it's an unnamed field
-    fn field_name(&self) -> Option<&str>;
+    fn field_name(&self) -> Option<&'a str>;
 
     /// Get the value representing the current field in the raw representation
     /// as it is transmitted by the database
@@ -154,7 +154,7 @@ where
     R: RowIndex<usize>,
 {
     fn idx(&self, idx: usize) -> Option<usize> {
-        let idx = self.inner.idx(idx)? + self.range.start;
+        let idx = self.inner.idx(idx + self.range.start)?;
         if self.range.contains(&idx) {
             Some(idx)
         } else {

--- a/diesel/src/serialize.rs
+++ b/diesel/src/serialize.rs
@@ -145,7 +145,7 @@ where
 /// database, you should use `i32::to_sql(x, out)` instead of writing to `out`
 /// yourself.
 ///
-/// Any types which implement this trait should also `#[derive(AsExpression)]`.
+/// Any types which implement this trait should also [`#[derive(AsExpression)]`].
 ///
 /// ### Backend specific details
 ///
@@ -157,6 +157,7 @@ where
 /// - For third party backends, consult that backend's documentation.
 ///
 /// [`MysqlType`]: ../mysql/enum.MysqlType.html
+/// [`#[derive(AsExpression)]`]: ../expression/derive.AsExpression.html;
 ///
 /// ### Examples
 ///
@@ -165,12 +166,14 @@ where
 ///
 /// ```rust
 /// # use diesel::backend::Backend;
+/// # use diesel::expression::AsExpression;
 /// # use diesel::sql_types::*;
 /// # use diesel::serialize::{self, ToSql, Output};
 /// # use std::io::Write;
 /// #
 /// #[repr(i32)]
-/// #[derive(Debug, Clone, Copy)]
+/// #[derive(Debug, Clone, Copy, AsExpression)]
+/// #[sql_type = "Integer"]
 /// pub enum MyEnum {
 ///     A = 1,
 ///     B = 2,

--- a/diesel/src/sql_types/fold.rs
+++ b/diesel/src/sql_types/fold.rs
@@ -1,16 +1,16 @@
-use crate::sql_types::{self, NotNull};
+use crate::sql_types::{self, is_nullable, SingleValue, SqlType};
 
 /// Represents SQL types which can be used with `SUM` and `AVG`
-pub trait Foldable {
+pub trait Foldable: SingleValue {
     /// The SQL type of `sum(this_type)`
-    type Sum;
+    type Sum: SqlType + SingleValue;
     /// The SQL type of `avg(this_type)`
-    type Avg;
+    type Avg: SqlType + SingleValue;
 }
 
 impl<T> Foldable for sql_types::Nullable<T>
 where
-    T: Foldable + NotNull,
+    T: Foldable + SqlType<IsNull = is_nullable::NotNull>,
 {
     type Sum = T::Sum;
     type Avg = T::Avg;

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -501,7 +501,7 @@ pub use diesel_derives::SqlType;
 /// # Deriving
 ///
 /// This trait is automatically implemented by [`#[derive(SqlType)]`]
-/// by setting `IsNull` to [`is_nullable::NotNull`]
+/// which sets `IsNull` to [`is_nullable::NotNull`]
 ///
 /// [`#[derive(SqlType)]`]: derive.SqlType.html
 /// [`is_nullable::NotNull`]: is_nullable/struct.NotNull.html

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -20,6 +20,7 @@ mod ord;
 pub use self::fold::Foldable;
 pub use self::ord::SqlOrd;
 
+use crate::expression::TypedExpressionType;
 use crate::query_builder::QueryId;
 
 /// The boolean SQL type.
@@ -377,7 +378,14 @@ pub struct Json;
 ///
 /// - `Option<T>` for any `T` which implements `FromSql<ST>`
 #[derive(Debug, Clone, Copy, Default)]
-pub struct Nullable<ST: NotNull>(ST);
+pub struct Nullable<ST>(ST);
+
+impl<ST> SqlType for Nullable<ST>
+where
+    ST: SqlType,
+{
+    type IsNull = is_nullable::IsNullable;
+}
 
 #[cfg(feature = "postgres")]
 pub use crate::pg::types::sql_types::*;
@@ -404,12 +412,6 @@ pub trait HasSqlType<ST>: TypeMetadata {
     /// This method may use `lookup` to do dynamic runtime lookup. Implementors
     /// of this method should not do dynamic lookup unless absolutely necessary
     fn metadata(lookup: &Self::MetadataLookup) -> Self::TypeMetadata;
-
-    #[doc(hidden)]
-    #[cfg(feature = "mysql")]
-    fn mysql_row_metadata(out: &mut Vec<Self::TypeMetadata>, lookup: &Self::MetadataLookup) {
-        out.push(Self::metadata(lookup))
-    }
 }
 
 /// Information about how a backend stores metadata about given SQL types
@@ -427,15 +429,6 @@ pub trait TypeMetadata {
     type MetadataLookup;
 }
 
-/// A marker trait indicating that a SQL type is not null.
-///
-/// All SQL types must implement this trait.
-///
-/// # Deriving
-///
-/// This trait is automatically implemented by `#[derive(SqlType)]`
-pub trait NotNull {}
-
 /// Converts a type which may or may not be nullable into its nullable
 /// representation.
 pub trait IntoNullable {
@@ -445,12 +438,41 @@ pub trait IntoNullable {
     type Nullable;
 }
 
-impl<T: NotNull> IntoNullable for T {
+impl<T> IntoNullable for T
+where
+    T: SqlType<IsNull = is_nullable::NotNull> + SingleValue,
+{
     type Nullable = Nullable<T>;
 }
 
-impl<T: NotNull> IntoNullable for Nullable<T> {
-    type Nullable = Nullable<T>;
+impl<T> IntoNullable for Nullable<T>
+where
+    T: SqlType,
+{
+    type Nullable = Self;
+}
+
+/// Converts a type which may or may not be nullable into its not nullable
+/// representation.
+pub trait IntoNotNullable {
+    /// The not nullable representation of this type.
+    ///
+    /// For `Nullable<T>`, this will be `T` otherwise the type itself
+    type NotNullable;
+}
+
+impl<T> IntoNotNullable for T
+where
+    T: SqlType<IsNull = is_nullable::NotNull>,
+{
+    type NotNullable = T;
+}
+
+impl<T> IntoNotNullable for Nullable<T>
+where
+    T: SqlType,
+{
+    type NotNullable = T;
 }
 
 /// A marker trait indicating that a SQL type represents a single value, as
@@ -462,12 +484,149 @@ impl<T: NotNull> IntoNullable for Nullable<T> {
 ///
 /// # Deriving
 ///
-/// This trait is automatically implemented by `#[derive(SqlType)]`
-pub trait SingleValue {}
+/// This trait is automatically implemented by [`#[derive(SqlType)]`]
+///
+/// [`#[derive(SqlType)]`]: derive.SqlType.html
+pub trait SingleValue: SqlType {}
 
-impl<T: NotNull + SingleValue> SingleValue for Nullable<T> {}
+impl<T: SqlType + SingleValue> SingleValue for Nullable<T> {}
 
 #[doc(inline)]
 pub use diesel_derives::DieselNumericOps;
 #[doc(inline)]
 pub use diesel_derives::SqlType;
+
+/// A marker trait for SQL types
+///
+/// # Deriving
+///
+/// This trait is automatically implemented by [`#[derive(SqlType)]`]
+/// by setting `IsNull` to [`is_nullable::NotNull`]
+///
+/// [`#[derive(SqlType)]`]: derive.SqlType.html
+/// [`is_nullable::NotNull`]: is_nullable/struct.NotNull.html
+pub trait SqlType {
+    /// Is this type nullable?
+    ///
+    /// This type should always be one of the structs in the ['is_nullable`]
+    /// module. See the documentation of those structs for more details.
+    ///
+    /// ['is_nullable`]: is_nullable/index.html
+    type IsNull: OneIsNullable<is_nullable::IsNullable> + OneIsNullable<is_nullable::NotNull>;
+}
+
+/// Is one value of `IsNull` nullable?
+///
+/// You should never implement this trait.
+pub trait OneIsNullable<Other> {
+    /// See the trait documentation
+    type Out: OneIsNullable<is_nullable::IsNullable> + OneIsNullable<is_nullable::NotNull>;
+}
+
+/// Are both values of `IsNull` are nullable?
+pub trait AllAreNullable<Other> {
+    /// See the trait documentation
+    type Out: AllAreNullable<is_nullable::NotNull> + AllAreNullable<is_nullable::IsNullable>;
+}
+
+/// A type level constructor for maybe nullable types
+///
+/// Constructs either `Nullable<O>` (for `Self` == `is_nullable::IsNullable`)
+/// or `O` (for `Self` == `is_nullable::NotNull`)
+pub trait MaybeNullableType<O> {
+    /// See the trait documentation
+    type Out: SqlType + TypedExpressionType;
+}
+
+/// Possible values for `SqlType::IsNullable`
+pub mod is_nullable {
+    use super::*;
+
+    /// No, this type cannot be null as it is marked as `NOT NULL` at database level
+    ///
+    /// This should be choosen for basically all manual impls of `SqlType`
+    /// beside implementing your own `Nullable<>` wrapper type
+    #[derive(Debug, Clone, Copy)]
+    pub struct NotNull;
+
+    /// Yes, this type can be null
+    ///
+    /// The only diesel provided `SqlType` that uses this value is [`Nullable<T>`]
+    ///
+    /// [`Nullable<T>`]: ../struct.Nullable.html
+    #[derive(Debug, Clone, Copy)]
+    pub struct IsNullable;
+
+    impl OneIsNullable<NotNull> for NotNull {
+        type Out = NotNull;
+    }
+
+    impl OneIsNullable<IsNullable> for NotNull {
+        type Out = IsNullable;
+    }
+
+    impl OneIsNullable<NotNull> for IsNullable {
+        type Out = IsNullable;
+    }
+
+    impl OneIsNullable<IsNullable> for IsNullable {
+        type Out = IsNullable;
+    }
+
+    impl AllAreNullable<NotNull> for NotNull {
+        type Out = NotNull;
+    }
+
+    impl AllAreNullable<IsNullable> for NotNull {
+        type Out = NotNull;
+    }
+
+    impl AllAreNullable<NotNull> for IsNullable {
+        type Out = NotNull;
+    }
+
+    impl AllAreNullable<IsNullable> for IsNullable {
+        type Out = IsNullable;
+    }
+
+    impl<O> MaybeNullableType<O> for NotNull
+    where
+        O: SqlType + TypedExpressionType,
+    {
+        type Out = O;
+    }
+
+    impl<O> MaybeNullableType<O> for IsNullable
+    where
+        O: SqlType,
+        Nullable<O>: TypedExpressionType,
+    {
+        type Out = Nullable<O>;
+    }
+
+    /// Represents the output type of [`MaybeNullableType`](../trait.MaybeNullableType.html)
+    pub type MaybeNullable<N, T> = <N as MaybeNullableType<T>>::Out;
+
+    /// Represents the output type of [`OneIsNullable`](../trait.OneIsNullable.html)
+    /// for two given SQL types
+    pub type IsOneNullable<S1, S2> =
+        <IsSqlTypeNullable<S1> as OneIsNullable<IsSqlTypeNullable<S2>>>::Out;
+
+    /// Represents the output type of [`AllAreNullable`](../trait.AllAreNullable.html)
+    /// for two given SQL types
+    pub type AreAllNullable<S1, S2> =
+        <IsSqlTypeNullable<S1> as AllAreNullable<IsSqlTypeNullable<S2>>>::Out;
+
+    /// Represents if the SQL type is nullable or not
+    pub type IsSqlTypeNullable<T> = <T as SqlType>::IsNull;
+}
+
+/// A marker trait for accepting expressions of the type `Bool` and
+/// `Nullable<Bool>` in the same place
+pub trait BoolOrNullableBool {}
+
+impl BoolOrNullableBool for Bool {}
+impl BoolOrNullableBool for Nullable<Bool> {}
+
+#[doc(inline)]
+pub use crate::expression::expression_types::Untyped;

--- a/diesel/src/sql_types/ops.rs
+++ b/diesel/src/sql_types/ops.rs
@@ -36,33 +36,33 @@ use super::*;
 /// Represents SQL types which can be added.
 pub trait Add {
     /// The SQL type which can be added to this one
-    type Rhs;
+    type Rhs: SqlType;
     /// The SQL type of the result of adding `Rhs` to `Self`
-    type Output;
+    type Output: SqlType;
 }
 
 /// Represents SQL types which can be subtracted.
 pub trait Sub {
     /// The SQL type which can be subtracted from this one
-    type Rhs;
+    type Rhs: SqlType;
     /// The SQL type of the result of subtracting `Rhs` from `Self`
-    type Output;
+    type Output: SqlType;
 }
 
 /// Represents SQL types which can be multiplied.
 pub trait Mul {
     /// The SQL type which this can be multiplied by
-    type Rhs;
+    type Rhs: SqlType;
     /// The SQL type of the result of multiplying `Self` by `Rhs`
-    type Output;
+    type Output: SqlType;
 }
 
 /// Represents SQL types which can be divided.
 pub trait Div {
     /// The SQL type which this one can be divided by
-    type Rhs;
+    type Rhs: SqlType;
     /// The SQL type of the result of dividing `Self` by `Rhs`
-    type Output;
+    type Output: SqlType;
 }
 
 macro_rules! numeric_type {
@@ -145,9 +145,9 @@ impl Div for Interval {
 
 impl<T> Add for Nullable<T>
 where
-    T: Add + NotNull,
-    T::Rhs: NotNull,
-    T::Output: NotNull,
+    T: Add + SqlType<IsNull = is_nullable::NotNull>,
+    T::Rhs: SqlType<IsNull = is_nullable::NotNull>,
+    T::Output: SqlType<IsNull = is_nullable::NotNull>,
 {
     type Rhs = Nullable<T::Rhs>;
     type Output = Nullable<T::Output>;
@@ -155,9 +155,9 @@ where
 
 impl<T> Sub for Nullable<T>
 where
-    T: Sub + NotNull,
-    T::Rhs: NotNull,
-    T::Output: NotNull,
+    T: Sub + SqlType<IsNull = is_nullable::NotNull>,
+    T::Rhs: SqlType<IsNull = is_nullable::NotNull>,
+    T::Output: SqlType<IsNull = is_nullable::NotNull>,
 {
     type Rhs = Nullable<T::Rhs>;
     type Output = Nullable<T::Output>;
@@ -165,9 +165,9 @@ where
 
 impl<T> Mul for Nullable<T>
 where
-    T: Mul + NotNull,
-    T::Rhs: NotNull,
-    T::Output: NotNull,
+    T: Mul + SqlType<IsNull = is_nullable::NotNull>,
+    T::Rhs: SqlType<IsNull = is_nullable::NotNull>,
+    T::Output: SqlType<IsNull = is_nullable::NotNull>,
 {
     type Rhs = Nullable<T::Rhs>;
     type Output = Nullable<T::Output>;
@@ -175,9 +175,9 @@ where
 
 impl<T> Div for Nullable<T>
 where
-    T: Div + NotNull,
-    T::Rhs: NotNull,
-    T::Output: NotNull,
+    T: Div + SqlType<IsNull = is_nullable::NotNull>,
+    T::Rhs: SqlType<IsNull = is_nullable::NotNull>,
+    T::Output: SqlType<IsNull = is_nullable::NotNull>,
 {
     type Rhs = Nullable<T::Rhs>;
     type Output = Nullable<T::Output>;

--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -1,7 +1,7 @@
-use crate::sql_types::{self, NotNull};
+use crate::sql_types::{self, is_nullable, SqlType};
 
 /// Marker trait for types which can be used with `MAX` and `MIN`
-pub trait SqlOrd {}
+pub trait SqlOrd: SqlType {}
 
 impl SqlOrd for sql_types::SmallInt {}
 impl SqlOrd for sql_types::Integer {}
@@ -13,7 +13,7 @@ impl SqlOrd for sql_types::Date {}
 impl SqlOrd for sql_types::Interval {}
 impl SqlOrd for sql_types::Time {}
 impl SqlOrd for sql_types::Timestamp {}
-impl<T: SqlOrd + NotNull> SqlOrd for sql_types::Nullable<T> {}
+impl<T> SqlOrd for sql_types::Nullable<T> where T: SqlOrd + SqlType<IsNull = is_nullable::NotNull> {}
 
 #[cfg(feature = "postgres")]
 impl SqlOrd for sql_types::Timestamptz {}

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -45,7 +45,7 @@ impl Backend for Sqlite {
 }
 
 impl<'a> HasRawValue<'a> for Sqlite {
-    type RawValue = &'a SqliteValue;
+    type RawValue = SqliteValue<'a>;
 }
 
 impl TypeMetadata for Sqlite {

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -20,7 +20,7 @@ pub struct Sqlite;
 /// The variants of this struct determine what bytes are expected from
 /// `ToSql` impls.
 #[allow(missing_debug_implementations)]
-#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum SqliteType {
     /// Bind using `sqlite3_bind_blob`
     Binary,

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -71,7 +71,7 @@ pub(crate) fn build_sql_function_args<ArgsSqlType, Args>(
 where
     Args: Queryable<ArgsSqlType, Sqlite>,
 {
-    let mut row = FunctionRow { args };
+    let mut row = FunctionRow::new(args);
     let args_row = Args::Row::build_from_row(&mut row).map_err(Error::DeserializationError)?;
 
     Ok(Args::build(args_row))
@@ -100,7 +100,17 @@ where
 }
 
 struct FunctionRow<'a> {
+    column_count: usize,
     args: &'a [*mut ffi::sqlite3_value],
+}
+
+impl<'a> FunctionRow<'a> {
+    fn new(args: &'a [*mut ffi::sqlite3_value]) -> Self {
+        Self {
+            column_count: args.len(),
+            args,
+        }
+    }
 }
 
 impl<'a> Row<Sqlite> for FunctionRow<'a> {
@@ -118,7 +128,7 @@ impl<'a> Row<Sqlite> for FunctionRow<'a> {
     }
 
     fn column_count(&self) -> usize {
-        self.args.len()
+        self.column_count
     }
 
     fn column_name(&self) -> Option<&str> {

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -104,7 +104,7 @@ struct FunctionRow<'a> {
 }
 
 impl<'a> Row<Sqlite> for FunctionRow<'a> {
-    fn take(&mut self) -> Option<&SqliteValue> {
+    fn take(&mut self) -> Option<SqliteValue<'_>> {
         self.args.split_first().and_then(|(&first, rest)| {
             self.args = rest;
             unsafe { SqliteValue::new(first) }

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -121,7 +121,7 @@ impl<'a> Row<Sqlite> for FunctionRow<'a> {
         self.args.len()
     }
 
-    fn column_name(&self) -> &str {
-        unimplemented!()
+    fn column_name(&self) -> Option<&str> {
+        None
     }
 }

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -116,4 +116,12 @@ impl<'a> Row<Sqlite> for FunctionRow<'a> {
             .iter()
             .all(|&p| unsafe { SqliteValue::new(p) }.is_none())
     }
+
+    fn column_count(&self) -> usize {
+        self.args.len()
+    }
+
+    fn column_name(&self) -> &str {
+        unimplemented!()
+    }
 }

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -3,11 +3,12 @@ extern crate libsqlite3_sys as ffi;
 use super::raw::RawConnection;
 use super::serialized_value::SerializedValue;
 use super::{Sqlite, SqliteAggregateFunction, SqliteValue};
-use crate::deserialize::{FromSqlRow, Queryable, StaticallySizedRow};
+use crate::deserialize::{FromSqlRow, StaticallySizedRow};
 use crate::result::{DatabaseErrorKind, Error, QueryResult};
-use crate::row::Row;
+use crate::row::{Field, PartialRow, Row, RowIndex};
 use crate::serialize::{IsNull, Output, ToSql};
 use crate::sql_types::HasSqlType;
+use std::marker::PhantomData;
 
 pub fn register<ArgsSqlType, RetSqlType, Args, Ret, F>(
     conn: &RawConnection,
@@ -17,12 +18,11 @@ pub fn register<ArgsSqlType, RetSqlType, Args, Ret, F>(
 ) -> QueryResult<()>
 where
     F: FnMut(&RawConnection, Args) -> Ret + Send + 'static,
-    Args: Queryable<ArgsSqlType, Sqlite>,
-    Args::Row: StaticallySizedRow<ArgsSqlType, Sqlite>,
+    Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,
 {
-    let fields_needed = Args::Row::FIELD_COUNT;
+    let fields_needed = Args::FIELD_COUNT;
     if fields_needed > 127 {
         return Err(Error::DatabaseError(
             DatabaseErrorKind::UnableToSendCommand,
@@ -46,12 +46,11 @@ pub fn register_aggregate<ArgsSqlType, RetSqlType, Args, Ret, A>(
 ) -> QueryResult<()>
 where
     A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
-    Args: Queryable<ArgsSqlType, Sqlite>,
-    Args::Row: StaticallySizedRow<ArgsSqlType, Sqlite>,
+    Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,
 {
-    let fields_needed = Args::Row::FIELD_COUNT;
+    let fields_needed = Args::FIELD_COUNT;
     if fields_needed > 127 {
         return Err(Error::DatabaseError(
             DatabaseErrorKind::UnableToSendCommand,
@@ -71,12 +70,10 @@ pub(crate) fn build_sql_function_args<ArgsSqlType, Args>(
     args: &[*mut ffi::sqlite3_value],
 ) -> Result<Args, Error>
 where
-    Args: Queryable<ArgsSqlType, Sqlite>,
+    Args: FromSqlRow<ArgsSqlType, Sqlite>,
 {
-    let mut row = FunctionRow::new(args);
-    let args_row = Args::Row::build_from_row(&mut row).map_err(Error::DeserializationError)?;
-
-    Ok(Args::build(args_row))
+    let row = FunctionRow::new(args);
+    Args::build_from_row(&row).map_err(Error::DeserializationError)
 }
 
 pub(crate) fn process_sql_function_result<RetSqlType, Ret>(
@@ -101,39 +98,69 @@ where
     })
 }
 
+#[derive(Clone)]
 struct FunctionRow<'a> {
-    column_count: usize,
     args: &'a [*mut ffi::sqlite3_value],
 }
 
 impl<'a> FunctionRow<'a> {
     fn new(args: &'a [*mut ffi::sqlite3_value]) -> Self {
-        Self {
-            column_count: args.len(),
-            args,
-        }
+        Self { args }
     }
 }
 
-impl<'a> Row<Sqlite> for FunctionRow<'a> {
-    fn take(&mut self) -> Option<SqliteValue<'_>> {
-        self.args.split_first().and_then(|(&first, rest)| {
-            self.args = rest;
-            unsafe { SqliteValue::new(first) }
+impl<'a> Row<'a, Sqlite> for FunctionRow<'a> {
+    type Field = FunctionArgument<'a>;
+    type InnerPartialRow = Self;
+
+    fn field_count(&self) -> usize {
+        self.args.len()
+    }
+
+    fn get<I>(&self, idx: I) -> Option<Self::Field>
+    where
+        Self: crate::row::RowIndex<I>,
+    {
+        let idx = self.idx(idx)?;
+
+        self.args.get(idx).map(|arg| FunctionArgument {
+            arg: *arg,
+            p: PhantomData,
         })
     }
 
-    fn next_is_null(&self, count: usize) -> bool {
-        self.args[..count]
-            .iter()
-            .all(|&p| unsafe { SqliteValue::new(p) }.is_none())
+    fn partial_row(&self, range: std::ops::Range<usize>) -> PartialRow<Self::InnerPartialRow> {
+        PartialRow::new(self, range)
     }
+}
 
-    fn column_count(&self) -> usize {
-        self.column_count
+impl<'a> RowIndex<usize> for FunctionRow<'a> {
+    fn idx(&self, idx: usize) -> Option<usize> {
+        Some(idx)
     }
+}
 
-    fn column_name(&self) -> Option<&str> {
+impl<'a, 'b> RowIndex<&'a str> for FunctionRow<'b> {
+    fn idx(&self, _idx: &'a str) -> Option<usize> {
         None
+    }
+}
+
+struct FunctionArgument<'a> {
+    arg: *mut ffi::sqlite3_value,
+    p: PhantomData<&'a ()>,
+}
+
+impl<'a> Field<'a, Sqlite> for FunctionArgument<'a> {
+    fn field_name(&self) -> Option<&str> {
+        None
+    }
+
+    fn is_null(&self) -> bool {
+        self.value().is_none()
+    }
+
+    fn value(&self) -> Option<crate::backend::RawValue<'a, Sqlite>> {
+        unsafe { SqliteValue::new(self.arg) }
     }
 }

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -136,7 +136,11 @@ impl<'a> Row<'a, Sqlite> for FunctionRow<'a> {
 
 impl<'a> RowIndex<usize> for FunctionRow<'a> {
     fn idx(&self, idx: usize) -> Option<usize> {
-        Some(idx)
+        if idx < self.args.len() {
+            Some(idx)
+        } else {
+            None
+        }
     }
 }
 
@@ -152,7 +156,7 @@ struct FunctionArgument<'a> {
 }
 
 impl<'a> Field<'a, Sqlite> for FunctionArgument<'a> {
-    fn field_name(&self) -> Option<&str> {
+    fn field_name(&self) -> Option<&'a str> {
         None
     }
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -17,7 +17,7 @@ use self::statement_iterator::*;
 use self::stmt::{Statement, StatementUse};
 use super::SqliteAggregateFunction;
 use crate::connection::*;
-use crate::deserialize::{Queryable, QueryableByName};
+use crate::deserialize::{Queryable, QueryableByName, StaticallySizedRow};
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::*;
@@ -228,6 +228,7 @@ impl SqliteConnection {
     where
         F: FnMut(Args) -> Ret + Send + 'static,
         Args: Queryable<ArgsSqlType, Sqlite>,
+        Args::Row: StaticallySizedRow<ArgsSqlType, Sqlite>,
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {
@@ -247,6 +248,7 @@ impl SqliteConnection {
     where
         A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
         Args: Queryable<ArgsSqlType, Sqlite>,
+        Args::Row: StaticallySizedRow<ArgsSqlType, Sqlite>,
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -17,7 +17,8 @@ use self::statement_iterator::*;
 use self::stmt::{Statement, StatementUse};
 use super::SqliteAggregateFunction;
 use crate::connection::*;
-use crate::deserialize::{Queryable, QueryableByName, StaticallySizedRow};
+use crate::deserialize::{FromSqlRow, StaticallySizedRow};
+use crate::expression::QueryMetadata;
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::*;
@@ -71,28 +72,16 @@ impl Connection for SqliteConnection {
     }
 
     #[doc(hidden)]
-    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>>
+    fn load<T, U>(&self, source: T) -> QueryResult<Vec<U>>
     where
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
-        Self::Backend: HasSqlType<T::SqlType>,
-        U: Queryable<T::SqlType, Self::Backend>,
+        U: FromSqlRow<T::SqlType, Self::Backend>,
+        Self::Backend: QueryMetadata<T::SqlType>,
     {
         let mut statement = self.prepare_query(&source.as_query())?;
         let statement_use = StatementUse::new(&mut statement);
         let iter = StatementIterator::new(statement_use);
-        iter.collect()
-    }
-
-    #[doc(hidden)]
-    fn query_by_name<T, U>(&self, source: &T) -> QueryResult<Vec<U>>
-    where
-        T: QueryFragment<Self::Backend> + QueryId,
-        U: QueryableByName<Self::Backend>,
-    {
-        let mut statement = self.prepare_query(source)?;
-        let statement_use = StatementUse::new(&mut statement);
-        let iter = NamedStatementIterator::new(statement_use)?;
         iter.collect()
     }
 
@@ -227,8 +216,7 @@ impl SqliteConnection {
     ) -> QueryResult<()>
     where
         F: FnMut(Args) -> Ret + Send + 'static,
-        Args: Queryable<ArgsSqlType, Sqlite>,
-        Args::Row: StaticallySizedRow<ArgsSqlType, Sqlite>,
+        Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {
@@ -247,8 +235,7 @@ impl SqliteConnection {
     ) -> QueryResult<()>
     where
         A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
-        Args: Queryable<ArgsSqlType, Sqlite>,
-        Args::Row: StaticallySizedRow<ArgsSqlType, Sqlite>,
+        Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -9,7 +9,7 @@ use std::{mem, ptr, slice, str};
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::serialized_value::SerializedValue;
 use super::{Sqlite, SqliteAggregateFunction};
-use crate::deserialize::Queryable;
+use crate::deserialize::FromSqlRow;
 use crate::result::Error::DatabaseError;
 use crate::result::*;
 use crate::serialize::ToSql;
@@ -116,7 +116,7 @@ impl RawConnection {
     ) -> QueryResult<()>
     where
         A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
-        Args: Queryable<ArgsSqlType, Sqlite>,
+        Args: FromSqlRow<ArgsSqlType, Sqlite>,
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {
@@ -266,7 +266,7 @@ extern "C" fn run_aggregator_step_function<ArgsSqlType, RetSqlType, Args, Ret, A
     value_ptr: *mut *mut ffi::sqlite3_value,
 ) where
     A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
-    Args: Queryable<ArgsSqlType, Sqlite>,
+    Args: FromSqlRow<ArgsSqlType, Sqlite>,
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,
 {
@@ -336,7 +336,7 @@ extern "C" fn run_aggregator_final_function<ArgsSqlType, RetSqlType, Args, Ret, 
     ctx: *mut ffi::sqlite3_context,
 ) where
     A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
-    Args: Queryable<ArgsSqlType, Sqlite>,
+    Args: FromSqlRow<ArgsSqlType, Sqlite>,
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,
 {

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -113,15 +113,12 @@ impl Row<Sqlite> for SqliteRow {
             } else {
                 ffi::sqlite3_column_name(self.stmt.as_ptr(), self.next_col_index - 1)
             };
-            Some(
-                std::ffi::CStr::from_ptr(ptr)
-                    .to_str()
-                    .expect(
-                        "The Sqlite documentation states that this is UTF8. \
-                         If you see this error message something has gone \
-                         horribliy wrong. Please open an issue at the \
-                         diesel repository."),
-            )
+            Some(std::ffi::CStr::from_ptr(ptr).to_str().expect(
+                "The Sqlite documentation states that this is UTF8. \
+                 If you see this error message something has gone \
+                 horribliy wrong. Please open an issue at the \
+                 diesel repository.",
+            ))
         }
     }
 

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -105,6 +105,23 @@ impl Row<Sqlite> for SqliteRow {
             tpe == ffi::SQLITE_NULL
         })
     }
+
+    fn column_name(&self) -> &str {
+        unsafe {
+            let ptr = if self.next_col_index == 0 {
+                ffi::sqlite3_column_name(self.stmt.as_ptr(), 0)
+            } else {
+                ffi::sqlite3_column_name(self.stmt.as_ptr(), self.next_col_index - 1)
+            };
+            std::ffi::CStr::from_ptr(ptr)
+                .to_str()
+                .expect("Sqlite3 doc's say it's UTF8")
+        }
+    }
+
+    fn column_count(&self) -> usize {
+        unsafe { ffi::sqlite3_column_count(self.stmt.as_ptr()) as usize }
+    }
 }
 
 pub struct SqliteNamedRow<'a> {

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -106,16 +106,22 @@ impl Row<Sqlite> for SqliteRow {
         })
     }
 
-    fn column_name(&self) -> &str {
+    fn column_name(&self) -> Option<&str> {
         unsafe {
             let ptr = if self.next_col_index == 0 {
                 ffi::sqlite3_column_name(self.stmt.as_ptr(), 0)
             } else {
                 ffi::sqlite3_column_name(self.stmt.as_ptr(), self.next_col_index - 1)
             };
-            std::ffi::CStr::from_ptr(ptr)
-                .to_str()
-                .expect("Sqlite3 doc's say it's UTF8")
+            Some(
+                std::ffi::CStr::from_ptr(ptr)
+                    .to_str()
+                    .expect(
+                        "The Sqlite documentation states that this is UTF8. \
+                         If you see this error message something has gone \
+                         horribliy wrong. Please open an issue at the \
+                         diesel repository."),
+            )
         }
     }
 

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -26,7 +26,6 @@ pub struct SqliteRow<'a> {
 }
 
 impl<'a> SqliteValue<'a> {
-    #[allow(clippy::new_ret_no_self)]
     pub(crate) unsafe fn new(inner: *mut ffi::sqlite3_value) -> Option<Self> {
         NonNull::new(inner)
             .map(|value| SqliteValue {

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -152,7 +152,7 @@ pub struct SqliteField<'a> {
 }
 
 impl<'a> Field<'a, Sqlite> for SqliteField<'a> {
-    fn field_name(&self) -> Option<&str> {
+    fn field_name(&self) -> Option<&'a str> {
         column_name(self.stmt, self.col_idx)
     }
 

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use super::stmt::StatementUse;
-use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
+use crate::deserialize::FromSqlRow;
 use crate::result::Error::DeserializationError;
 use crate::result::QueryResult;
 use crate::sqlite::Sqlite;
@@ -23,7 +22,7 @@ impl<'a, ST, T> StatementIterator<'a, ST, T> {
 
 impl<'a, ST, T> Iterator for StatementIterator<'a, ST, T>
 where
-    T: Queryable<ST, Sqlite>,
+    T: FromSqlRow<ST, Sqlite>,
 {
     type Item = QueryResult<T>;
 
@@ -32,55 +31,6 @@ where
             Ok(row) => row,
             Err(e) => return Some(Err(e)),
         };
-        row.map(|mut row| {
-            T::Row::build_from_row(&mut row)
-                .map(T::build)
-                .map_err(DeserializationError)
-        })
-    }
-}
-
-pub struct NamedStatementIterator<'a, T> {
-    stmt: StatementUse<'a>,
-    column_indices: HashMap<&'a str, usize>,
-    _marker: PhantomData<T>,
-}
-
-impl<'a, T> NamedStatementIterator<'a, T> {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(stmt: StatementUse<'a>) -> QueryResult<Self> {
-        let column_indices = (0..stmt.num_fields())
-            .filter_map(|i| {
-                stmt.field_name(i).map(|column| {
-                    let column = column
-                        .to_str()
-                        .map_err(|e| DeserializationError(e.into()))?;
-                    Ok((column, i))
-                })
-            })
-            .collect::<QueryResult<_>>()?;
-        Ok(NamedStatementIterator {
-            stmt,
-            column_indices,
-            _marker: PhantomData,
-        })
-    }
-}
-
-impl<'a, T> Iterator for NamedStatementIterator<'a, T>
-where
-    T: QueryableByName<Sqlite>,
-{
-    type Item = QueryResult<T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let row = match self.stmt.step() {
-            Ok(row) => row,
-            Err(e) => return Some(Err(e)),
-        };
-        row.map(|row| {
-            let row = row.into_named(&self.column_indices);
-            T::build(&row).map_err(DeserializationError)
-        })
+        row.map(|row| T::build_from_row(&row).map_err(DeserializationError))
     }
 }

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -12,8 +12,8 @@ pub mod query_builder;
 
 pub use self::backend::{Sqlite, SqliteType};
 pub use self::connection::SqliteConnection;
-pub use self::query_builder::SqliteQueryBuilder;
 pub use self::connection::SqliteValue;
+pub use self::query_builder::SqliteQueryBuilder;
 
 /// Trait for the implementation of a SQLite aggregate function
 ///

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -13,6 +13,7 @@ pub mod query_builder;
 pub use self::backend::{Sqlite, SqliteType};
 pub use self::connection::SqliteConnection;
 pub use self::query_builder::SqliteQueryBuilder;
+pub use self::connection::SqliteValue;
 
 /// Trait for the implementation of a SQLite aggregate function
 ///

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -12,7 +12,7 @@ use crate::sqlite::Sqlite;
 const SQLITE_DATE_FORMAT: &str = "%F";
 
 impl FromSql<Date, Sqlite> for NaiveDate {
-    fn from_sql(value: Option<backend::RawValue<Sqlite>>) -> deserialize::Result<Self> {
+    fn from_sql(value: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let text_ptr = <*const str as FromSql<Date, Sqlite>>::from_sql(value)?;
         let text = unsafe { &*text_ptr };
         Self::parse_from_str(text, SQLITE_DATE_FORMAT).map_err(Into::into)
@@ -27,7 +27,7 @@ impl ToSql<Date, Sqlite> for NaiveDate {
 }
 
 impl FromSql<Time, Sqlite> for NaiveTime {
-    fn from_sql(value: Option<backend::RawValue<Sqlite>>) -> deserialize::Result<Self> {
+    fn from_sql(value: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let text_ptr = <*const str as FromSql<Date, Sqlite>>::from_sql(value)?;
         let text = unsafe { &*text_ptr };
         let valid_time_formats = &[
@@ -54,7 +54,7 @@ impl ToSql<Time, Sqlite> for NaiveTime {
 }
 
 impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
-    fn from_sql(value: Option<backend::RawValue<Sqlite>>) -> deserialize::Result<Self> {
+    fn from_sql(value: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let text_ptr = <*const str as FromSql<Date, Sqlite>>::from_sql(value)?;
         let text = unsafe { &*text_ptr };
 

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -15,7 +15,7 @@ mod chrono;
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Date, Sqlite> for *const str {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
 }
@@ -38,7 +38,7 @@ impl ToSql<sql_types::Date, Sqlite> for String {
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Time, Sqlite> for *const str {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
 }
@@ -61,7 +61,7 @@ impl ToSql<sql_types::Time, Sqlite> for String {
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Timestamp, Sqlite> for *const str {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
 }

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -15,7 +15,7 @@ mod chrono;
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Date, Sqlite> for *const str {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
 }
@@ -38,7 +38,7 @@ impl ToSql<sql_types::Date, Sqlite> for String {
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Time, Sqlite> for *const str {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
 }
@@ -61,7 +61,7 @@ impl ToSql<sql_types::Time, Sqlite> for String {
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Timestamp, Sqlite> for *const str {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         FromSql::<sql_types::Text, Sqlite>::from_sql(value)
     }
 }

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -15,8 +15,9 @@ use crate::sql_types;
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::VarChar, Sqlite> for *const str {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
-        let text = not_none!(value).read_text();
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        let text = value.read_text();
         Ok(text as *const _)
     }
 }
@@ -27,44 +28,45 @@ impl FromSql<sql_types::VarChar, Sqlite> for *const str {
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Binary, Sqlite> for *const [u8] {
-    fn from_sql(bytes: Option<&SqliteValue>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes).read_blob();
+    fn from_sql(bytes: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
+        let bytes = not_none!(bytes);
+        let bytes = bytes.read_blob();
         Ok(bytes as *const _)
     }
 }
 
 impl FromSql<sql_types::SmallInt, Sqlite> for i16 {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_integer() as i16)
     }
 }
 
 impl FromSql<sql_types::Integer, Sqlite> for i32 {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_integer())
     }
 }
 
 impl FromSql<sql_types::Bool, Sqlite> for bool {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_integer() != 0)
     }
 }
 
 impl FromSql<sql_types::BigInt, Sqlite> for i64 {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_long())
     }
 }
 
 impl FromSql<sql_types::Float, Sqlite> for f32 {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_double() as f32)
     }
 }
 
 impl FromSql<sql_types::Double, Sqlite> for f64 {
-    fn from_sql(value: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         Ok(not_none!(value).read_double())
     }
 }

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -15,8 +15,7 @@ use crate::sql_types;
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::VarChar, Sqlite> for *const str {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
         let text = value.read_text();
         Ok(text as *const _)
     }
@@ -28,46 +27,45 @@ impl FromSql<sql_types::VarChar, Sqlite> for *const str {
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
 impl FromSql<sql_types::Binary, Sqlite> for *const [u8] {
-    fn from_sql(bytes: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        let bytes = not_none!(bytes);
+    fn from_sql(bytes: SqliteValue<'_>) -> deserialize::Result<Self> {
         let bytes = bytes.read_blob();
         Ok(bytes as *const _)
     }
 }
 
 impl FromSql<sql_types::SmallInt, Sqlite> for i16 {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        Ok(not_none!(value).read_integer() as i16)
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
+        Ok(value.read_integer() as i16)
     }
 }
 
 impl FromSql<sql_types::Integer, Sqlite> for i32 {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        Ok(not_none!(value).read_integer())
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
+        Ok(value.read_integer())
     }
 }
 
 impl FromSql<sql_types::Bool, Sqlite> for bool {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        Ok(not_none!(value).read_integer() != 0)
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
+        Ok(value.read_integer() != 0)
     }
 }
 
 impl FromSql<sql_types::BigInt, Sqlite> for i64 {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        Ok(not_none!(value).read_long())
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
+        Ok(value.read_long())
     }
 }
 
 impl FromSql<sql_types::Float, Sqlite> for f32 {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        Ok(not_none!(value).read_double() as f32)
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
+        Ok(value.read_double() as f32)
     }
 }
 
 impl FromSql<sql_types::Double, Sqlite> for f64 {
-    fn from_sql(value: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
-        Ok(not_none!(value).read_double())
+    fn from_sql(value: SqliteValue<'_>) -> deserialize::Result<Self> {
+        Ok(value.read_double())
     }
 }
 

--- a/diesel/src/sqlite/types/numeric.rs
+++ b/diesel/src/sqlite/types/numeric.rs
@@ -8,7 +8,7 @@ use crate::sqlite::connection::SqliteValue;
 use crate::sqlite::Sqlite;
 
 impl FromSql<Numeric, Sqlite> for BigDecimal {
-    fn from_sql(bytes: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: SqliteValue<'_>) -> deserialize::Result<Self> {
         let data = <f64 as FromSql<Double, Sqlite>>::from_sql(bytes)?;
         Ok(data.into())
     }

--- a/diesel/src/sqlite/types/numeric.rs
+++ b/diesel/src/sqlite/types/numeric.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "bigdecimal")]
 
-extern crate bigdecimal;
-
-use self::bigdecimal::BigDecimal;
+use bigdecimal::BigDecimal;
 
 use crate::deserialize::{self, FromSql};
 use crate::sql_types::{Double, Numeric};
@@ -10,7 +8,7 @@ use crate::sqlite::connection::SqliteValue;
 use crate::sqlite::Sqlite;
 
 impl FromSql<Numeric, Sqlite> for BigDecimal {
-    fn from_sql(bytes: Option<&SqliteValue>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: Option<SqliteValue<'_>>) -> deserialize::Result<Self> {
         let data = <f64 as FromSql<Double, Sqlite>>::from_sql(bytes)?;
         Ok(data.into())
     }

--- a/diesel/src/type_impls/date_and_time.rs
+++ b/diesel/src/type_impls/date_and_time.rs
@@ -4,7 +4,7 @@ use crate::deserialize::FromSqlRow;
 use crate::expression::AsExpression;
 use std::time::SystemTime;
 
-#[derive(FromSqlRow, AsExpression)]
+#[derive(AsExpression, FromSqlRow)]
 #[diesel(foreign_derive)]
 #[sql_type = "crate::sql_types::Timestamp"]
 struct SystemTimeProxy(SystemTime);
@@ -17,24 +17,24 @@ mod chrono {
     use crate::expression::AsExpression;
     use crate::sql_types::{Date, Time, Timestamp};
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Date"]
     struct NaiveDateProxy(NaiveDate);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Time"]
     struct NaiveTimeProxy(NaiveTime);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Timestamp"]
     #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Timestamptz")]
     #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Datetime")]
     struct NaiveDateTimeProxy(NaiveDateTime);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Timestamptz")]
     struct DateTimeProxy<Tz: TimeZone>(DateTime<Tz>);

--- a/diesel/src/type_impls/decimal.rs
+++ b/diesel/src/type_impls/decimal.rs
@@ -8,7 +8,7 @@ mod bigdecimal {
     use crate::expression::AsExpression;
     use crate::sql_types::Numeric;
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Numeric"]
     struct BigDecimalProxy(BigDecimal);

--- a/diesel/src/type_impls/floats.rs
+++ b/diesel/src/type_impls/floats.rs
@@ -11,8 +11,7 @@ impl<DB> FromSql<sql_types::Float, DB> for f32
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: crate::backend::RawValue<DB>) -> deserialize::Result<Self> {
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 4,
@@ -37,8 +36,7 @@ impl<DB> FromSql<sql_types::Double, DB> for f64
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: crate::backend::RawValue<DB>) -> deserialize::Result<Self> {
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 8,

--- a/diesel/src/type_impls/integers.rs
+++ b/diesel/src/type_impls/integers.rs
@@ -11,8 +11,7 @@ impl<DB> FromSql<sql_types::SmallInt, DB> for i16
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: crate::backend::RawValue<DB>) -> deserialize::Result<Self> {
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 2,
@@ -43,8 +42,7 @@ impl<DB> FromSql<sql_types::Integer, DB> for i32
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: crate::backend::RawValue<DB>) -> deserialize::Result<Self> {
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 4,
@@ -74,8 +72,7 @@ impl<DB> FromSql<sql_types::BigInt, DB> for i64
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
-        let value = not_none!(value);
+    fn from_sql(value: crate::backend::RawValue<DB>) -> deserialize::Result<Self> {
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
             bytes.len() <= 8,

--- a/diesel/src/type_impls/json.rs
+++ b/diesel/src/type_impls/json.rs
@@ -6,7 +6,7 @@ use crate::sql_types::Json;
 #[cfg(feature = "postgres")]
 use crate::sql_types::Jsonb;
 
-#[derive(FromSqlRow, AsExpression)]
+#[derive(AsExpression, FromSqlRow)]
 #[diesel(foreign_derive)]
 #[sql_type = "Json"]
 #[cfg_attr(feature = "postgres", sql_type = "Jsonb")]

--- a/diesel/src/type_impls/mod.rs
+++ b/diesel/src/type_impls/mod.rs
@@ -6,4 +6,4 @@ mod integers;
 mod json;
 pub mod option;
 mod primitives;
-mod tuples;
+pub(crate) mod tuples;

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -87,15 +87,11 @@ where
     DB: Backend,
     ST: NotNull,
 {
-    const FIELDS_NEEDED: usize = T::FIELDS_NEEDED;
-
     fn build_from_row<R: crate::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
-        let fields_needed = Self::FIELDS_NEEDED;
-        if row.next_is_null(fields_needed) {
-            row.advance(fields_needed);
-            Ok(None)
-        } else {
-            T::build_from_row(row).map(Some)
+        match T::build_from_row(row) {
+            Ok(v) => Ok(Some(v)),
+            Err(e) if e.is::<UnexpectedNullError>() => Ok(None),
+            Err(e) => Err(e),
         }
     }
 }

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -1,33 +1,26 @@
 use std::io::Write;
 
 use crate::backend::{self, Backend};
-use crate::deserialize::{self, FromSql, FromSqlRow, Queryable, QueryableByName};
+use crate::deserialize::{self, FromSql, Queryable, QueryableByName};
 use crate::expression::bound::Bound;
 use crate::expression::*;
 use crate::query_builder::QueryId;
-use crate::result::UnexpectedNullError;
-use crate::row::NamedRow;
 use crate::serialize::{self, IsNull, Output, ToSql};
-use crate::sql_types::{HasSqlType, NotNull, Nullable};
+use crate::sql_types::{is_nullable, HasSqlType, Nullable, SingleValue, SqlType};
 
 impl<T, DB> HasSqlType<Nullable<T>> for DB
 where
     DB: Backend + HasSqlType<T>,
-    T: NotNull,
+    T: SqlType,
 {
     fn metadata(lookup: &DB::MetadataLookup) -> DB::TypeMetadata {
         <DB as HasSqlType<T>>::metadata(lookup)
-    }
-
-    #[cfg(feature = "mysql")]
-    fn mysql_row_metadata(out: &mut Vec<DB::TypeMetadata>, lookup: &DB::MetadataLookup) {
-        <DB as HasSqlType<T>>::mysql_row_metadata(out, lookup)
     }
 }
 
 impl<T> QueryId for Nullable<T>
 where
-    T: QueryId + NotNull,
+    T: QueryId + SqlType<IsNull = is_nullable::NotNull>,
 {
     type QueryId = T::QueryId;
 
@@ -38,60 +31,16 @@ impl<T, ST, DB> FromSql<Nullable<ST>, DB> for Option<T>
 where
     T: FromSql<ST, DB>,
     DB: Backend,
-    ST: NotNull,
+    ST: SqlType<IsNull = is_nullable::NotNull>,
 {
-    fn from_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
+        T::from_sql(bytes).map(Some)
+    }
+
+    fn from_nullable_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
         match bytes {
-            Some(_) => T::from_sql(bytes).map(Some),
+            Some(bytes) => T::from_sql(bytes).map(Some),
             None => Ok(None),
-        }
-    }
-}
-
-impl<T, ST, DB> Queryable<Nullable<ST>, DB> for Option<T>
-where
-    T: Queryable<ST, DB>,
-    DB: Backend,
-    Option<T::Row>: FromSqlRow<Nullable<ST>, DB>,
-    ST: NotNull,
-{
-    type Row = Option<T::Row>;
-
-    fn build(row: Self::Row) -> Self {
-        row.map(T::build)
-    }
-}
-
-impl<T, DB> QueryableByName<DB> for Option<T>
-where
-    T: QueryableByName<DB>,
-    DB: Backend,
-{
-    fn build<R: NamedRow<DB>>(row: &R) -> deserialize::Result<Self> {
-        match T::build(row) {
-            Ok(v) => Ok(Some(v)),
-            Err(e) => {
-                if e.is::<UnexpectedNullError>() {
-                    Ok(None)
-                } else {
-                    Err(e)
-                }
-            }
-        }
-    }
-}
-
-impl<T, ST, DB> FromSqlRow<Nullable<ST>, DB> for Option<T>
-where
-    T: FromSqlRow<ST, DB>,
-    DB: Backend,
-    ST: NotNull,
-{
-    fn build_from_row<R: crate::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
-        match T::build_from_row(row) {
-            Ok(v) => Ok(Some(v)),
-            Err(e) if e.is::<UnexpectedNullError>() => Ok(None),
-            Err(e) => Err(e),
         }
     }
 }
@@ -100,7 +49,7 @@ impl<T, ST, DB> ToSql<Nullable<ST>, DB> for Option<T>
 where
     T: ToSql<ST, DB>,
     DB: Backend,
-    ST: NotNull,
+    ST: SqlType<IsNull = is_nullable::NotNull>,
 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
         if let Some(ref value) = *self {
@@ -113,7 +62,8 @@ where
 
 impl<T, ST> AsExpression<Nullable<ST>> for Option<T>
 where
-    ST: NotNull,
+    ST: SqlType<IsNull = is_nullable::NotNull>,
+    Nullable<ST>: TypedExpressionType,
 {
     type Expression = Bound<Nullable<ST>, Self>;
 
@@ -124,12 +74,40 @@ where
 
 impl<'a, T, ST> AsExpression<Nullable<ST>> for &'a Option<T>
 where
-    ST: NotNull,
+    ST: SqlType<IsNull = is_nullable::NotNull>,
+    Nullable<ST>: TypedExpressionType,
 {
     type Expression = Bound<Nullable<ST>, Self>;
 
     fn as_expression(self) -> Self::Expression {
         Bound::new(self)
+    }
+}
+
+impl<T, DB> QueryableByName<DB> for Option<T>
+where
+    DB: Backend,
+    T: QueryableByName<DB>,
+{
+    fn build(row: &impl crate::row::NamedRow<DB>) -> deserialize::Result<Self> {
+        match T::build(row) {
+            Ok(v) => Ok(Some(v)),
+            Err(e) if e.is::<crate::result::UnexpectedNullError>() => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl<ST, T, DB> Queryable<ST, DB> for Option<T>
+where
+    ST: SingleValue<IsNull = is_nullable::IsNullable>,
+    DB: Backend,
+    Self: FromSql<ST, DB>,
+{
+    type Row = Self;
+
+    fn build(row: Self::Row) -> Self {
+        row
     }
 }
 

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -89,7 +89,7 @@ where
     DB: Backend,
     T: QueryableByName<DB>,
 {
-    fn build(row: &impl crate::row::NamedRow<DB>) -> deserialize::Result<Self> {
+    fn build<'a>(row: &impl crate::row::NamedRow<'a, DB>) -> deserialize::Result<Self> {
         match T::build(row) {
             Ok(v) => Ok(Some(v)),
             Err(e) if e.is::<crate::result::UnexpectedNullError>() => Ok(None),

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -2,42 +2,43 @@ use std::error::Error;
 use std::io::Write;
 
 use crate::backend::{self, Backend, BinaryRawValue};
-use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::deserialize::{self, FromSql, Queryable};
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::{
-    self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text,
+    self, BigInt, Binary, Bool, Double, Float, Integer, SingleValue, SmallInt, Text,
 };
 
 #[allow(dead_code)]
 mod foreign_impls {
     use super::*;
+    use crate::deserialize::FromSqlRow;
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Bool"]
     struct BoolProxy(bool);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::TinyInt")]
     struct I8Proxy(i8);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "SmallInt"]
     struct I16Proxy(i16);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Integer"]
     struct I32Proxy(i32);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "BigInt"]
     struct I64Proxy(i64);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[cfg_attr(
         feature = "mysql",
@@ -45,33 +46,33 @@ mod foreign_impls {
     )]
     struct U8Proxy(u8);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<SmallInt>")]
     struct U16Proxy(u16);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<Integer>")]
     #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Oid")]
     struct U32Proxy(u32);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<BigInt>")]
     struct U64Proxy(u64);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Float"]
     struct F32Proxy(f32);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Double"]
     struct F64Proxy(f64);
 
-    #[derive(FromSqlRow, AsExpression)]
+    #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
     #[sql_type = "Text"]
     #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Date")]
@@ -102,14 +103,12 @@ mod foreign_impls {
     struct BinarySliceProxy([u8]);
 }
 
-impl NotNull for () {}
-
 impl<ST, DB> FromSql<ST, DB> for String
 where
     DB: Backend,
     *const str: FromSql<ST, DB>,
 {
-    fn from_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
         let str_ptr = <*const str as FromSql<ST, DB>>::from_sql(bytes)?;
         // We know that the pointer impl will never return null
         let string = unsafe { &*str_ptr };
@@ -127,9 +126,8 @@ impl<DB> FromSql<sql_types::Text, DB> for *const str
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(value: crate::backend::RawValue<DB>) -> deserialize::Result<Self> {
         use std::str;
-        let value = not_none!(value);
         let string = str::from_utf8(DB::as_bytes(value))?;
         Ok(string as *const _)
     }
@@ -140,9 +138,8 @@ impl<DB> FromSql<sql_types::Text, DB> for *const str
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    default fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    default fn from_sql(value: crate::backend::RawValue<DB>) -> deserialize::Result<Self> {
         use std::str;
-        let value = not_none!(value);
         let string = str::from_utf8(DB::as_bytes(value))?;
         Ok(string as *const _)
     }
@@ -171,7 +168,7 @@ where
     DB: Backend,
     *const [u8]: FromSql<ST, DB>,
 {
-    fn from_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
         let slice_ptr = <*const [u8] as FromSql<ST, DB>>::from_sql(bytes)?;
         // We know that the pointer impl will never return null
         let bytes = unsafe { &*slice_ptr };
@@ -188,8 +185,8 @@ impl<DB> FromSql<sql_types::Binary, DB> for *const [u8]
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
-        Ok(DB::as_bytes(not_none!(bytes)) as *const _)
+    fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
+        Ok(DB::as_bytes(bytes) as *const _)
     }
 }
 
@@ -230,27 +227,17 @@ where
     DB: Backend,
     T::Owned: FromSql<ST, DB>,
 {
-    fn from_sql(bytes: Option<backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
         T::Owned::from_sql(bytes).map(Cow::Owned)
-    }
-}
-
-impl<'a, T: ?Sized, ST, DB> FromSqlRow<ST, DB> for Cow<'a, T>
-where
-    T: 'a + ToOwned,
-    DB: Backend,
-    Cow<'a, T>: FromSql<ST, DB>,
-{
-    fn build_from_row<R: crate::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
-        FromSql::<ST, DB>::from_sql(row.take())
     }
 }
 
 impl<'a, T: ?Sized, ST, DB> Queryable<ST, DB> for Cow<'a, T>
 where
     T: 'a + ToOwned,
+    ST: SingleValue,
     DB: Backend,
-    Self: FromSqlRow<ST, DB>,
+    Self: FromSql<ST, DB>,
 {
     type Row = Self;
 
@@ -260,12 +247,14 @@ where
 }
 
 use crate::expression::bound::Bound;
-use crate::expression::{AsExpression, Expression};
+use crate::expression::{AsExpression, Expression, TypedExpressionType};
+use sql_types::SqlType;
 
 impl<'a, T: ?Sized, ST> AsExpression<ST> for Cow<'a, T>
 where
     T: 'a + ToOwned,
     Bound<ST, Cow<'a, T>>: Expression<SqlType = ST>,
+    ST: SqlType + TypedExpressionType,
 {
     type Expression = Bound<ST, Self>;
 
@@ -278,6 +267,7 @@ impl<'a, 'b, T: ?Sized, ST> AsExpression<ST> for &'b Cow<'a, T>
 where
     T: 'a + ToOwned,
     Bound<ST, &'b T>: Expression<SqlType = ST>,
+    ST: SqlType + TypedExpressionType,
 {
     type Expression = Bound<ST, &'b T>;
 

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -306,6 +306,18 @@ macro_rules! tuple_impls {
                     )*
                 }
             }
+
+            impl<$($T,)* __DB> deserialize::QueryableByName< __DB> for ($($T,)*)
+            where __DB: Backend,
+            $($T: deserialize::QueryableByName<__DB>,)*
+            {
+                fn build<'a>(row: &impl NamedRow<'a, __DB>) -> deserialize::Result<Self> {
+                    Ok(($(
+                        <$T as deserialize::QueryableByName<__DB>>::build(row)?,
+                    )*))
+                }
+            }
+
         )+
     }
 }

--- a/diesel_cli/src/infer_schema_internals/data_structures.rs
+++ b/diesel_cli/src/infer_schema_internals/data_structures.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "uses_information_schema")]
 use diesel::backend::Backend;
-use diesel::deserialize::{FromSqlRow, Queryable};
+use diesel::deserialize::{FromStaticSqlRow, Queryable};
 #[cfg(feature = "sqlite")]
 use diesel::sqlite::Sqlite;
 
@@ -76,7 +76,7 @@ impl ColumnInformation {
 impl<ST, DB> Queryable<ST, DB> for ColumnInformation
 where
     DB: Backend + UsesInformationSchema,
-    (String, String, String): FromSqlRow<ST, DB>,
+    (String, String, String): FromStaticSqlRow<ST, DB>,
 {
     type Row = (String, String, String);
 
@@ -88,7 +88,7 @@ where
 #[cfg(feature = "sqlite")]
 impl<ST> Queryable<ST, Sqlite> for ColumnInformation
 where
-    (i32, String, String, bool, Option<String>, bool): FromSqlRow<ST, Sqlite>,
+    (i32, String, String, bool, Option<String>, bool): FromStaticSqlRow<ST, Sqlite>,
 {
     type Row = (i32, String, String, bool, Option<String>, bool);
 

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::error::Error;
 
 use diesel::backend::Backend;
-use diesel::deserialize::FromSql;
+use diesel::deserialize::{FromSql, FromSqlRow};
 use diesel::dsl::*;
-use diesel::expression::{is_aggregate, ValidGrouping};
+use diesel::expression::{is_aggregate, QueryMetadata, ValidGrouping};
 #[cfg(feature = "mysql")]
 use diesel::mysql::Mysql;
 #[cfg(feature = "postgres")]
@@ -78,7 +78,8 @@ mod information_schema {
             table_schema -> VarChar,
             table_name -> VarChar,
             column_name -> VarChar,
-            is_nullable -> VarChar,
+            #[sql_name = "is_nullable"]
+            __is_nullable -> VarChar,
             ordinal_position -> BigInt,
             udt_name -> VarChar,
             column_type -> VarChar,
@@ -126,6 +127,14 @@ pub fn get_table_data<'a, Conn>(
 where
     Conn: Connection,
     Conn::Backend: UsesInformationSchema,
+    ColumnInformation: FromSqlRow<
+        SqlTypeOf<(
+            columns::column_name,
+            <Conn::Backend as UsesInformationSchema>::TypeColumn,
+            columns::__is_nullable,
+        )>,
+        Conn::Backend,
+    >,
     String: FromSql<sql_types::Text, Conn::Backend>,
     Order<
         Filter<
@@ -135,7 +144,7 @@ where
                     (
                         columns::column_name,
                         <Conn::Backend as UsesInformationSchema>::TypeColumn,
-                        columns::is_nullable,
+                        columns::__is_nullable,
                     ),
                 >,
                 Eq<columns::table_name, &'a String>,
@@ -144,6 +153,7 @@ where
         >,
         columns::ordinal_position,
     >: QueryFragment<Conn::Backend>,
+    Conn::Backend: QueryMetadata<(sql_types::Text, sql_types::Text, sql_types::Text)>,
 {
     use self::information_schema::columns::dsl::*;
 
@@ -154,7 +164,7 @@ where
 
     let type_column = Conn::Backend::type_column();
     columns
-        .select((column_name, type_column, is_nullable))
+        .select((column_name, type_column, __is_nullable))
         .filter(table_name.eq(&table.sql_name))
         .filter(table_schema.eq(schema_name))
         .order(ordinal_position)
@@ -185,6 +195,7 @@ where
         >,
         key_column_usage::ordinal_position,
     >: QueryFragment<Conn::Backend>,
+    Conn::Backend: QueryMetadata<sql_types::Text>,
 {
     use self::information_schema::key_column_usage::dsl::*;
     use self::information_schema::table_constraints::constraint_type;
@@ -225,6 +236,7 @@ where
         >,
         Like<tables::table_type, &'static str>,
     >: QueryFragment<Conn::Backend>,
+    Conn::Backend: QueryMetadata<sql_types::Text>,
 {
     use self::information_schema::tables::dsl::*;
 

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -52,7 +52,7 @@ pub fn load_table_names(
         .select(name)
         .filter(name.not_like("\\_\\_%").escape('\\'))
         .filter(name.not_like("sqlite%"))
-        .filter(sql("type='table'"))
+        .filter(sql::<sql_types::Bool>("type='table'"))
         .order(name)
         .load::<String>(connection)?
         .into_iter()

--- a/diesel_cli/src/infer_schema_internals/table_data.rs
+++ b/diesel_cli/src/infer_schema_internals/table_data.rs
@@ -1,5 +1,5 @@
 use diesel::backend::Backend;
-use diesel::deserialize::{FromSqlRow, Queryable};
+use diesel::deserialize::{FromStaticSqlRow, Queryable};
 use std::fmt;
 use std::str::FromStr;
 
@@ -55,8 +55,8 @@ impl TableName {
 
 impl<ST, DB> Queryable<ST, DB> for TableName
 where
+    (String, String): FromStaticSqlRow<ST, DB>,
     DB: Backend,
-    (String, String): FromSqlRow<ST, DB>,
 {
     type Row = (String, String);
 

--- a/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use diesel::*;
-use diesel::dsl::count;
+use diesel::dsl::count_star;
 
 table! {
     users {
@@ -13,6 +13,6 @@ table! {
 fn main() {
     use self::users::dsl::*;
 
-    let source = users.select((id, count(users.star())));
+    let source = users.select((id, count_star()));
     //~^ ERROR MixedAggregates
 }

--- a/diesel_compile_tests/tests/compile-fail/filter_requires_bool_nonaggregate_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/filter_requires_bool_nonaggregate_expression.rs
@@ -14,7 +14,7 @@ fn main() {
     use diesel::dsl::sum;
 
     let _ = users::table.filter(users::name);
-    //~^ ERROR type mismatch resolving `<users::columns::name as diesel::Expression>::SqlType == diesel::sql_types::Bool`
+    //~^ ERROR the trait bound `diesel::sql_types::Text: diesel::sql_types::BoolOrNullableBool` is not satisfied
     let _ = users::table.filter(sum(users::id).eq(1));
     //~^ ERROR MixedAggregates
 }

--- a/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/compile-fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate diesel;
 
-use diesel::*;
-use diesel::sqlite::SqliteConnection;
 use diesel::backend::Backend;
 use diesel::sql_types::{Integer, VarChar};
+use diesel::sqlite::SqliteConnection;
+use diesel::deserialize::Queryable;
+use diesel::*;
 
 table! {
     users {
@@ -13,25 +14,12 @@ table! {
     }
 }
 
+#[derive(Queryable)]
 pub struct User {
     id: i32,
     name: String,
 }
 
-use diesel::deserialize::FromSqlRow;
-
-impl<DB: Backend> Queryable<(Integer, VarChar), DB> for User where
-    (i32, String): FromSqlRow<(Integer, VarChar), DB>,
-{
-    type Row = (i32, String);
-
-    fn build(row: Self::Row) -> Self {
-        User {
-            id: row.0,
-            name: row.1,
-        }
-    }
-}
 
 #[derive(Insertable)]
 #[table_name = "users"]

--- a/diesel_compile_tests/tests/compile-fail/join_with_explicit_on_requires_valid_boolean_expression.rs
+++ b/diesel_compile_tests/tests/compile-fail/join_with_explicit_on_requires_valid_boolean_expression.rs
@@ -32,5 +32,5 @@ fn main() {
     //~^ ERROR E0271
     // Invalid, type is not boolean
     let _ = users::table.inner_join(posts::table.on(users::id));
-    //~^ ERROR E0271
+    //~^ ERROR the trait bound `diesel::sql_types::Integer: diesel::sql_types::BoolOrNullableBool` is not satisfied [E0277]
 }

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -52,7 +52,6 @@ fn direct_joins() {
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR E0271
-    //~| ERROR E0271
 }
 
 fn nested_outer_joins_left_associative() {
@@ -74,7 +73,6 @@ fn nested_outer_joins_left_associative() {
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR E0271
-    //~| ERROR E0271
 }
 
 fn nested_mixed_joins_left_associative() {
@@ -95,7 +93,6 @@ fn nested_mixed_joins_left_associative() {
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR E0271
-    //~| ERROR E0271
 }
 
 fn nested_outer_joins_right_associative() {
@@ -116,7 +113,6 @@ fn nested_outer_joins_right_associative() {
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR E0271
-    //~| ERROR E0271
 }
 
 fn nested_mixed_joins_right_associative() {
@@ -137,5 +133,4 @@ fn nested_mixed_joins_right_associative() {
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR E0271
-    //~| ERROR E0271
 }

--- a/diesel_compile_tests/tests/ui/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
+++ b/diesel_compile_tests/tests/ui/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
@@ -20,6 +20,12 @@ error: All fields of tuple structs must be annotated with `#[column_name]`
 10 | struct Bar(i32, String);
    |            ^^^
 
+error: All fields of tuple structs must be annotated with `#[column_name]`
+  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:17
+   |
+10 | struct Bar(i32, String);
+   |                 ^^^^^^
+
 error: Cannot determine the SQL type of field
   --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:12
    |
@@ -27,12 +33,6 @@ error: Cannot determine the SQL type of field
    |            ^^^
    |
    = help: Your struct must either be annotated with `#[table_name = "foo"]` or have all of its fields annotated with `#[sql_type = "Integer"]`
-
-error: All fields of tuple structs must be annotated with `#[column_name]`
-  --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:17
-   |
-10 | struct Bar(i32, String);
-   |                 ^^^^^^
 
 error: Cannot determine the SQL type of field
   --> $DIR/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:17

--- a/diesel_compile_tests/tests/ui/queryable_type_missmatch.rs
+++ b/diesel_compile_tests/tests/ui/queryable_type_missmatch.rs
@@ -1,0 +1,71 @@
+extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        bio -> Nullable<Text>,
+    }
+}
+
+#[derive(Queryable)]
+struct User {
+    id: i32,
+    name: String,
+    bio: Option<String>
+}
+
+#[derive(Queryable)]
+struct UserWithToFewFields {
+    id: i32,
+    name: String,
+}
+
+#[derive(Queryable)]
+struct UserWithToManyFields {
+    id: i32,
+    name: String,
+    bio: Option<String>,
+    age: i32,
+}
+
+#[derive(Queryable)]
+struct UserWrongOrder {
+    name: String,
+    id: i32,
+    bio: Option<String>
+}
+
+#[derive(Queryable)]
+struct UserTypeMissmatch {
+    id: i32,
+    name: i32,
+    bio: Option<String>
+}
+
+#[derive(Queryable)]
+struct UserNullableTypeMissmatch {
+    id: i32,
+    name: String,
+    bio: Option<String>
+}
+
+fn test(conn: &PgConnection) {
+    // check that this works fine
+    let _ = users::table.load::<User>(conn);
+
+    let _ = users::table.load::<UserWithToFewFields>(conn);
+
+    let _ = users::table.load::<UserWithToManyFields>(conn);
+
+    let _ = users::table.load::<UserWrongOrder>(conn);
+
+    let _ = users::table.load::<UserTypeMissmatch>(conn);
+
+    let _ = users::table.load::<UserNullableTypeMissmatch>(conn);
+}
+
+
+fn main() {}

--- a/diesel_compile_tests/tests/ui/queryable_type_missmatch.stderr
+++ b/diesel_compile_tests/tests/ui/queryable_type_missmatch.stderr
@@ -1,0 +1,49 @@
+error[E0277]: the trait bound `UserWithToFewFields: diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+  --> $DIR/queryable_type_missmatch.rs:59:26
+   |
+59 |     let _ = users::table.load::<UserWithToFewFields>(conn);
+   |                          ^^^^ the trait `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `UserWithToFewFields`
+   |
+   = help: the following implementations were found:
+             <UserWithToFewFields as diesel::Queryable<(__ST0, __ST1), __DB>>
+   = note: required because of the requirements on the impl of `diesel::deserialize::FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWithToFewFields`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::LoadQuery<_, UserWithToFewFields>` for `users::table`
+
+error[E0277]: the trait bound `UserWithToManyFields: diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+  --> $DIR/queryable_type_missmatch.rs:61:26
+   |
+61 |     let _ = users::table.load::<UserWithToManyFields>(conn);
+   |                          ^^^^ the trait `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `UserWithToManyFields`
+   |
+   = help: the following implementations were found:
+             <UserWithToManyFields as diesel::Queryable<(__ST0, __ST1, __ST2, __ST3), __DB>>
+   = note: required because of the requirements on the impl of `diesel::deserialize::FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWithToManyFields`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::LoadQuery<_, UserWithToManyFields>` for `users::table`
+
+error[E0277]: the trait bound `(std::string::String, i32, std::option::Option<std::string::String>): diesel::deserialize::FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+  --> $DIR/queryable_type_missmatch.rs:63:26
+   |
+63 |     let _ = users::table.load::<UserWrongOrder>(conn);
+   |                          ^^^^ the trait `diesel::deserialize::FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `(std::string::String, i32, std::option::Option<std::string::String>)`
+   |
+   = help: the following implementations were found:
+             <(B, C, A) as diesel::deserialize::FromStaticSqlRow<(SB, SC, SA), __DB>>
+   = note: required because of the requirements on the impl of `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWrongOrder`
+   = note: required because of the requirements on the impl of `diesel::deserialize::FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWrongOrder`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::LoadQuery<_, UserWrongOrder>` for `users::table`
+
+error[E0277]: the trait bound `(i32, i32, std::option::Option<std::string::String>): diesel::deserialize::FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+  --> $DIR/queryable_type_missmatch.rs:65:26
+   |
+65 |     let _ = users::table.load::<UserTypeMissmatch>(conn);
+   |                          ^^^^ the trait `diesel::deserialize::FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `(i32, i32, std::option::Option<std::string::String>)`
+   |
+   = help: the following implementations were found:
+             <(B, C, A) as diesel::deserialize::FromStaticSqlRow<(SB, SC, SA), __DB>>
+   = note: required because of the requirements on the impl of `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserTypeMissmatch`
+   = note: required because of the requirements on the impl of `diesel::deserialize::FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserTypeMissmatch`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::LoadQuery<_, UserTypeMissmatch>` for `users::table`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_derives/src/diesel_numeric_ops.rs
+++ b/diesel_derives/src/diesel_numeric_ops.rs
@@ -22,10 +22,13 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
     Ok(wrap_in_dummy_mod(quote! {
         use diesel::expression::{ops, Expression, AsExpression};
         use diesel::sql_types::ops::{Add, Sub, Mul, Div};
+        use diesel::sql_types::{SqlType, SingleValue};
 
         impl #impl_generics ::std::ops::Add<__Rhs> for #struct_name #ty_generics
         #where_clause
+            Self: Expression,
             <Self as Expression>::SqlType: Add,
+            <<Self as Expression>::SqlType as Add>::Rhs: SqlType + SingleValue,
             __Rhs: AsExpression<<<Self as Expression>::SqlType as Add>::Rhs>,
         {
             type Output = ops::Add<Self, __Rhs::Expression>;
@@ -37,7 +40,9 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
 
         impl #impl_generics ::std::ops::Sub<__Rhs> for #struct_name #ty_generics
         #where_clause
+            Self: Expression,
             <Self as Expression>::SqlType: Sub,
+            <<Self as Expression>::SqlType as Sub>::Rhs: SqlType + SingleValue,
             __Rhs: AsExpression<<<Self as Expression>::SqlType as Sub>::Rhs>,
         {
             type Output = ops::Sub<Self, __Rhs::Expression>;
@@ -49,7 +54,9 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
 
         impl #impl_generics ::std::ops::Mul<__Rhs> for #struct_name #ty_generics
         #where_clause
+            Self: Expression,
             <Self as Expression>::SqlType: Mul,
+            <<Self as Expression>::SqlType as Mul>::Rhs: SqlType + SingleValue,
             __Rhs: AsExpression<<<Self as Expression>::SqlType as Mul>::Rhs>,
         {
             type Output = ops::Mul<Self, __Rhs::Expression>;
@@ -61,7 +68,9 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Di
 
         impl #impl_generics ::std::ops::Div<__Rhs> for #struct_name #ty_generics
         #where_clause
+            Self: Expression,
             <Self as Expression>::SqlType: Div,
+            <<Self as Expression>::SqlType as Div>::Rhs: SqlType + SingleValue,
             __Rhs: AsExpression<<<Self as Expression>::SqlType as Div>::Rhs>,
         {
             type Output = ops::Div<Self, __Rhs::Expression>;

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -26,7 +26,7 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
     let (impl_generics, _, where_clause) = item.generics.split_for_impl();
 
     Ok(wrap_in_dummy_mod(quote! {
-        use diesel::deserialize::{self, FromSql, FromSqlRow, Queryable};
+        use diesel::deserialize::{self, FromSql, FromSqlRow, Queryable, StaticallySizedRow};
 
         impl #impl_generics FromSqlRow<__ST, __DB> for #struct_ty
         #where_clause
@@ -47,5 +47,9 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
                 row
             }
         }
+
+        impl #impl_generics StaticallySizedRow<__ST, __DB> for #struct_ty
+        #where_clause
+        {}
     }))
 }

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -21,22 +21,15 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
             .push(parse_quote!(__DB: diesel::backend::Backend));
         where_clause
             .predicates
+            .push(parse_quote!(__ST: diesel::sql_types::SingleValue));
+        where_clause
+            .predicates
             .push(parse_quote!(Self: FromSql<__ST, __DB>));
     }
     let (impl_generics, _, where_clause) = item.generics.split_for_impl();
 
     Ok(wrap_in_dummy_mod(quote! {
-        use diesel::deserialize::{self, FromSql, FromSqlRow, Queryable, StaticallySizedRow};
-
-        impl #impl_generics FromSqlRow<__ST, __DB> for #struct_ty
-        #where_clause
-        {
-            fn build_from_row<R: diesel::row::Row<__DB>>(row: &mut R)
-                -> deserialize::Result<Self>
-            {
-                FromSql::<__ST, __DB>::from_sql(row.take())
-            }
-        }
+        use diesel::deserialize::{FromSql, Queryable};
 
         impl #impl_generics Queryable<__ST, __DB> for #struct_ty
         #where_clause
@@ -47,9 +40,5 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
                 row
             }
         }
-
-        impl #impl_generics StaticallySizedRow<__ST, __DB> for #struct_ty
-        #where_clause
-        {}
     }))
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -630,9 +630,9 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 ///     i32: FromSql<diesel::dsl::SqlTypeOf<users::id>, DB>,
 ///     String: FromSql<diesel::dsl::SqlTypeOf<users::name>, DB>,
 /// {
-///     fn build(row: &impl NamedRow<DB>) -> deserialize::Result<Self> {
-///         let id = row.get::<diesel::dsl::SqlTypeOf<users::id>, _>("id")?;
-///         let name = row.get::<diesel::dsl::SqlTypeOf<users::name>, _>("name")?;
+///     fn build<'a>(row: &impl NamedRow<'a, DB>) -> deserialize::Result<Self> {
+///         let id = NamedRow::get::<diesel::dsl::SqlTypeOf<users::id>, _>(row, "id")?;
+///         let name = NamedRow::get::<diesel::dsl::SqlTypeOf<users::name>, _>(row, "name")?;
 ///
 ///         Ok(Self { id, name })
 ///     }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -171,7 +171,7 @@ pub fn derive_diesel_numeric_ops(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, diesel_numeric_ops::derive)
 }
 
-/// Implements `FromSqlRow` and `Queryable`
+/// Implements `Queryable` for primitive types
 ///
 /// This derive is mostly useful to implement support deserializing
 /// into rust types not supported by diesel itself.
@@ -307,7 +307,7 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, query_id::derive)
 }
 
-/// Implements `Queryable`
+/// Implements `Queryable` to load the result of statically typed queries
 ///
 /// This trait can only be derived for structs, not enums.
 ///
@@ -331,12 +331,144 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///   into the field type, the implementation will deserialize into `Type`.
 ///   Then `Type` is converted via `.into()` into the field type. By default
 ///   this derive will deserialize directly into the field type
+///
+///
+/// # Examples
+///
+/// If we just want to map a query to our struct, we can use `derive`.
+///
+/// ```rust
+/// # extern crate diesel;
+/// # extern crate dotenv;
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// #
+/// #[derive(Queryable, PartialEq, Debug)]
+/// struct User {
+///     id: i32,
+///     name: String,
+/// }
+///
+/// # fn main() {
+/// #     run_test();
+/// # }
+/// #
+/// # fn run_test() -> QueryResult<()> {
+/// #     use schema::users::dsl::*;
+/// #     let connection = establish_connection();
+/// let first_user = users.first(&connection)?;
+/// let expected = User { id: 1, name: "Sean".into() };
+/// assert_eq!(expected, first_user);
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// If we want to do additional work during deserialization, we can use
+/// `deserialize_as` to use a different implementation.
+///
+/// ```rust
+/// # extern crate diesel;
+/// # extern crate dotenv;
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// #
+/// # use schema::users;
+/// # use diesel::backend::{self, Backend};
+/// # use diesel::deserialize::{Queryable, FromSql};
+/// # use diesel::sql_types::Text;
+/// #
+/// struct LowercaseString(String);
+///
+/// impl Into<String> for LowercaseString {
+///     fn into(self) -> String {
+///         self.0
+///     }
+/// }
+///
+/// impl<DB> Queryable<Text, DB> for LowercaseString
+/// where
+///     DB: Backend,
+///     String: FromSql<Text, DB>
+/// {
+///
+///     type Row = String;
+///
+///     fn build(s: String) -> Self {
+///         LowercaseString(s.to_lowercase())
+///     }
+/// }
+///
+/// #[derive(Queryable, PartialEq, Debug)]
+/// struct User {
+///     id: i32,
+///     #[diesel(deserialize_as = "LowercaseString")]
+///     name: String,
+/// }
+///
+/// # fn main() {
+/// #     run_test();
+/// # }
+/// #
+/// # fn run_test() -> QueryResult<()> {
+/// #     use schema::users::dsl::*;
+/// #     let connection = establish_connection();
+/// let first_user = users.first(&connection)?;
+/// let expected = User { id: 1, name: "sean".into() };
+/// assert_eq!(expected, first_user);
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// Alternatively, we can implement the trait for our struct manually.
+///
+/// ```rust
+/// # extern crate diesel;
+/// # extern crate dotenv;
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// #
+/// use schema::users;
+/// use diesel::deserialize::{Queryable, FromSqlRow};
+/// use diesel::row::Row;
+///
+/// # /*
+/// type DB = diesel::sqlite::Sqlite;
+/// # */
+///
+/// #[derive(PartialEq, Debug)]
+/// struct User {
+///     id: i32,
+///     name: String,
+/// }
+///
+/// impl Queryable<users::SqlType, DB> for User
+/// where
+///    (i32, String): FromSqlRow<users::SqlType, DB>,
+/// {
+///     type Row = (i32, String);
+///
+///     fn build((id, name): Self::Row) -> Self {
+///         User { id, name: name.to_lowercase() }
+///     }
+/// }
+///
+/// # fn main() {
+/// #     run_test();
+/// # }
+/// #
+/// # fn run_test() -> QueryResult<()> {
+/// #     use schema::users::dsl::*;
+/// #     let connection = establish_connection();
+/// let first_user = users.first(&connection)?;
+/// let expected = User { id: 1, name: "sean".into() };
+/// assert_eq!(expected, first_user);
+/// #     Ok(())
+/// # }
+/// ```
 #[proc_macro_derive(Queryable, attributes(column_name, diesel))]
 pub fn derive_queryable(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, queryable::derive)
 }
 
-/// Implements `QueryableByName`
+/// Implements `QueryableByName` for untyped sql queries, such as that one generated
+/// by `sql_query`
 ///
 /// To derive this trait, Diesel needs to know the SQL type of each field. You
 /// can do this by either annotating your struct with `#[table_name =
@@ -388,6 +520,137 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 /// * `#[diesel(embed)]`, specifies that the current field maps not only
 ///   single database column, but is a type that implements
 ///   `QueryableByName` on it's own
+///
+/// /// # Examples
+///
+/// If we just want to map a query to our struct, we can use `derive`.
+///
+/// ```rust
+/// # extern crate diesel;
+/// # extern crate dotenv;
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// # use schema::users;
+/// # use diesel::sql_query;
+/// #
+/// #[derive(QueryableByName, PartialEq, Debug)]
+/// #[table_name = "users"]
+/// struct User {
+///     id: i32,
+///     name: String,
+/// }
+///
+/// # fn main() {
+/// #     run_test();
+/// # }
+/// #
+/// # fn run_test() -> QueryResult<()> {
+/// #     let connection = establish_connection();
+/// let first_user = sql_query("SELECT * FROM users ORDER BY id LIMIT 1")
+///     .get_result(&connection)?;
+/// let expected = User { id: 1, name: "Sean".into() };
+/// assert_eq!(expected, first_user);
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// If we want to do additional work during deserialization, we can use
+/// `deserialize_as` to use a different implementation.
+///
+/// ```rust
+/// # extern crate diesel;
+/// # extern crate dotenv;
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// # use diesel::sql_query;
+/// # use schema::users;
+/// # use diesel::backend::{self, Backend};
+/// # use diesel::deserialize::{self, FromSql};
+/// #
+/// struct LowercaseString(String);
+///
+/// impl Into<String> for LowercaseString {
+///     fn into(self) -> String {
+///         self.0
+///     }
+/// }
+///
+/// impl<DB, ST> FromSql<ST, DB> for LowercaseString
+/// where
+///     DB: Backend,
+///     String: FromSql<ST, DB>,
+/// {
+///     fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
+///         String::from_sql(bytes)
+///             .map(|s| LowercaseString(s.to_lowercase()))
+///     }
+/// }
+///
+/// #[derive(QueryableByName, PartialEq, Debug)]
+/// #[table_name = "users"]
+/// struct User {
+///     id: i32,
+///     #[diesel(deserialize_as = "LowercaseString")]
+///     name: String,
+/// }
+///
+/// # fn main() {
+/// #     run_test();
+/// # }
+/// #
+/// # fn run_test() -> QueryResult<()> {
+/// #     let connection = establish_connection();
+/// let first_user = sql_query("SELECT * FROM users ORDER BY id LIMIT 1")
+///     .get_result(&connection)?;
+/// let expected = User { id: 1, name: "sean".into() };
+/// assert_eq!(expected, first_user);
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// The custom derive generates impls similar to the follownig one
+///
+/// ```rust
+/// # extern crate diesel;
+/// # extern crate dotenv;
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// # use schema::users;
+/// # use diesel::sql_query;
+/// # use diesel::deserialize::{self, QueryableByName, FromSql};
+/// # use diesel::row::NamedRow;
+/// # use diesel::backend::Backend;
+/// #
+/// #[derive(PartialEq, Debug)]
+/// struct User {
+///     id: i32,
+///     name: String,
+/// }
+///
+/// impl<DB> QueryableByName<DB> for User
+/// where
+///     DB: Backend,
+///     i32: FromSql<diesel::dsl::SqlTypeOf<users::id>, DB>,
+///     String: FromSql<diesel::dsl::SqlTypeOf<users::name>, DB>,
+/// {
+///     fn build(row: &impl NamedRow<DB>) -> deserialize::Result<Self> {
+///         let id = row.get::<diesel::dsl::SqlTypeOf<users::id>, _>("id")?;
+///         let name = row.get::<diesel::dsl::SqlTypeOf<users::name>, _>("name")?;
+///
+///         Ok(Self { id, name })
+///     }
+/// }
+///
+/// # fn main() {
+/// #     run_test();
+/// # }
+/// #
+/// # fn run_test() -> QueryResult<()> {
+/// #     let connection = establish_connection();
+/// let first_user = sql_query("SELECT * FROM users ORDER BY id LIMIT 1")
+///     .get_result(&connection)?;
+/// let expected = User { id: 1, name: "Sean".into() };
+/// assert_eq!(expected, first_user);
+/// #     Ok(())
+/// # }
+/// ```
 #[proc_macro_derive(QueryableByName, attributes(table_name, column_name, sql_type, diesel))]
 pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, queryable_by_name::derive)

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -9,11 +9,31 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     let model = Model::from_item(&item)?;
 
     let struct_name = &item.ident;
-    let field_expr = model
+    let fields = model.fields().iter().map(get_ident).collect::<Vec<_>>();
+    let field_names = model.fields().iter().map(|f| &f.name).collect::<Vec<_>>();
+
+    let initial_field_expr = model
         .fields()
         .iter()
-        .map(|f| field_expr(f, &model))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|f| {
+            if f.has_flag("embed") {
+                let field_ty = &f.ty;
+                Ok(quote!(<#field_ty as QueryableByName<__DB>>::build(
+                    row,
+                )?))
+            } else {
+                let name = f.column_name();
+                let field_ty = &f.ty;
+                let deserialize_ty = f.ty_for_deserialize()?;
+                Ok(quote!(
+                   {
+                       let field = row.get(stringify!(#name))?;
+                       <#deserialize_ty as Into<#field_ty>>::into(field)
+                   }
+                ))
+            }
+        })
+        .collect::<Result<Vec<_>, Diagnostic>>()?;
 
     let (_, ty_generics, ..) = item.generics.split_for_impl();
     let mut generics = item.generics.clone();
@@ -40,33 +60,34 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
 
     Ok(wrap_in_dummy_mod(quote! {
         use diesel::deserialize::{self, QueryableByName};
-        use diesel::row::NamedRow;
+        use diesel::row::{NamedRow};
+        use diesel::sql_types::Untyped;
 
         impl #impl_generics QueryableByName<__DB>
             for #struct_name #ty_generics
         #where_clause
         {
-            fn build<__R: NamedRow<__DB>>(row: &__R) -> deserialize::Result<Self> {
-                std::result::Result::Ok(Self {
-                    #(#field_expr,)*
+            fn build(row: &impl NamedRow<__DB>) -> deserialize::Result<Self>
+            {
+
+
+                #(
+                    let mut #fields = #initial_field_expr;
+                )*
+                deserialize::Result::Ok(Self {
+                    #(
+                        #field_names: #fields,
+                    )*
                 })
             }
         }
     }))
 }
 
-fn field_expr(field: &Field, model: &Model) -> Result<syn::FieldValue, Diagnostic> {
-    if field.has_flag("embed") {
-        Ok(field
-            .name
-            .assign(parse_quote!(QueryableByName::build(row)?)))
-    } else {
-        let column_name = field.column_name();
-        let ty = field.ty_for_deserialize()?;
-        let st = sql_type(field, model);
-        Ok(field
-            .name
-            .assign(parse_quote!(row.get::<#st, #ty>(stringify!(#column_name))?.into())))
+fn get_ident(field: &Field) -> Ident {
+    match &field.name {
+        FieldName::Named(n) => n.clone(),
+        FieldName::Unnamed(i) => Ident::new(&format!("field_{}", i.index), Span::call_site()),
     }
 }
 

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -27,7 +27,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
                 let deserialize_ty = f.ty_for_deserialize()?;
                 Ok(quote!(
                    {
-                       let field = row.get(stringify!(#name))?;
+                       let field = diesel::row::NamedRow::get(row, stringify!(#name))?;
                        <#deserialize_ty as Into<#field_ty>>::into(field)
                    }
                 ))
@@ -67,7 +67,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
             for #struct_name #ty_generics
         #where_clause
         {
-            fn build(row: &impl NamedRow<__DB>) -> deserialize::Result<Self>
+            fn build<'__a>(row: &impl NamedRow<'__a, __DB>) -> deserialize::Result<Self>
             {
 
 

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -141,7 +141,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
 
                 use diesel::sqlite::{Sqlite, SqliteConnection};
                 use diesel::serialize::ToSql;
-                use diesel::deserialize::Queryable;
+                use diesel::deserialize::{Queryable, StaticallySizedRow};
                 use diesel::sqlite::SqliteAggregateFunction;
                 use diesel::sql_types::IntoNullable;
             };
@@ -164,6 +164,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                             A: SqliteAggregateFunction<(#(#arg_name,)*)> + Send + 'static,
                             A::Output: ToSql<#return_type, Sqlite>,
                             (#(#arg_name,)*): Queryable<(#(#arg_type,)*), Sqlite>,
+                            <(#(#arg_name,)*) as Queryable<(#(#arg_type,)*), Sqlite>>::Row: StaticallySizedRow<(#(#arg_type,)*), Sqlite>,
                         {
                             conn.register_aggregate_function::<(#(#arg_type,)*), #return_type, _, _, A>(#sql_name)
                         }
@@ -189,6 +190,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                             A: SqliteAggregateFunction<#arg_name> + Send + 'static,
                             A::Output: ToSql<#return_type, Sqlite>,
                             #arg_name: Queryable<#arg_type, Sqlite>,
+                            <#arg_name as Queryable<#arg_type, Sqlite>>::Row: StaticallySizedRow<#arg_type, Sqlite>,
                             {
                                 conn.register_aggregate_function::<#arg_type, #return_type, _, _, A>(#sql_name)
                             }
@@ -219,7 +221,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
 
                 use diesel::sqlite::{Sqlite, SqliteConnection};
                 use diesel::serialize::ToSql;
-                use diesel::deserialize::Queryable;
+                use diesel::deserialize::{Queryable, StaticallySizedRow};
 
                 #[allow(dead_code)]
                 /// Registers an implementation for this function on the given connection
@@ -236,6 +238,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                 where
                     F: Fn(#(#arg_name,)*) -> Ret + Send + 'static,
                     (#(#arg_name,)*): Queryable<(#(#arg_type,)*), Sqlite>,
+                    <(#(#arg_name,)*) as Queryable<(#(#arg_type,)*), Sqlite>>::Row: StaticallySizedRow<(#(#arg_type,)*), Sqlite>,
                     Ret: ToSql<#return_type, Sqlite>,
                 {
                     conn.register_sql_function::<(#(#arg_type,)*), #return_type, _, _, _>(
@@ -261,6 +264,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                 where
                     F: FnMut(#(#arg_name,)*) -> Ret + Send + 'static,
                     (#(#arg_name,)*): Queryable<(#(#arg_type,)*), Sqlite>,
+                    <(#(#arg_name,)*) as Queryable<(#(#arg_type,)*), Sqlite>>::Row: StaticallySizedRow<(#(#arg_type,)*), Sqlite>,
                     Ret: ToSql<#return_type, Sqlite>,
                 {
                     conn.register_sql_function::<(#(#arg_type,)*), #return_type, _, _, _>(

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -71,8 +71,8 @@ fn mysql_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
                     for diesel::mysql::Mysql
                 #where_clause
                 {
-                    fn metadata(_: &()) -> diesel::mysql::MysqlType {
-                        diesel::mysql::MysqlType::#ty
+                    fn metadata(_: &()) -> std::option::Option<diesel::mysql::MysqlType> {
+                        std::option::Option::Some(diesel::mysql::MysqlType::#ty)
                     }
                 }
             })

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -13,10 +13,11 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     let pg_tokens = pg_tokens(&item);
 
     Ok(wrap_in_dummy_mod(quote! {
-        impl #impl_generics diesel::sql_types::NotNull
+        impl #impl_generics diesel::sql_types::SqlType
             for #struct_name #ty_generics
         #where_clause
         {
+            type IsNull = diesel::sql_types::is_nullable::NotNull;
         }
 
         impl #impl_generics diesel::sql_types::SingleValue
@@ -71,8 +72,8 @@ fn mysql_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
                     for diesel::mysql::Mysql
                 #where_clause
                 {
-                    fn metadata(_: &()) -> std::option::Option<diesel::mysql::MysqlType> {
-                        std::option::Option::Some(diesel::mysql::MysqlType::#ty)
+                    fn metadata(_: &()) -> diesel::mysql::MysqlType {
+                        diesel::mysql::MysqlType::#ty
                     }
                 }
             })

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -1,11 +1,12 @@
 use diesel::deserialize::FromSql;
 use diesel::expression::bound::Bound;
+use diesel::expression::QueryMetadata;
 use diesel::helper_types::{max, Limit, Select};
 use diesel::insertable::ColumnInsertValue;
 use diesel::prelude::*;
 use diesel::query_builder::{InsertStatement, QueryFragment, ValuesClause};
 use diesel::query_dsl::methods::{self, ExecuteDsl, LoadQuery};
-use diesel::sql_types::VarChar;
+use diesel::sql_types::{Nullable, VarChar};
 use std::collections::HashSet;
 use std::iter::FromIterator;
 
@@ -36,6 +37,7 @@ where
     __diesel_schema_migrations: methods::SelectDsl<version>,
     Select<__diesel_schema_migrations, version>: LoadQuery<T, String>,
     Limit<Select<__diesel_schema_migrations, max<version>>>: QueryFragment<T::Backend>,
+    T::Backend: QueryMetadata<Nullable<VarChar>>,
 {
     fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>> {
         __diesel_schema_migrations

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -37,8 +37,8 @@ impl ToSql<MyType, Pg> for MyEnum {
 }
 
 impl FromSql<MyType, Pg> for MyEnum {
-    fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
-        match not_none!(bytes).as_bytes() {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
             b"foo" => Ok(MyEnum::Foo),
             b"bar" => Ok(MyEnum::Bar),
             _ => Err("Unrecognized enum variant".into()),

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -131,7 +131,7 @@ fn now_can_be_used_as_nullable() {
     let nullable_timestamp = sql::<Nullable<Timestamp>>("CURRENT_TIMESTAMP");
     let result = select(nullable_timestamp.eq(now)).get_result(&connection());
 
-    assert_eq!(Ok(true), result);
+    assert_eq!(Ok(Some(true)), result);
 }
 
 #[test]

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -10,7 +10,9 @@ use crate::schema::{
 };
 use diesel::backend::Backend;
 use diesel::dsl::*;
+use diesel::expression::TypedExpressionType;
 use diesel::query_builder::*;
+use diesel::sql_types::SqlType;
 use diesel::*;
 
 #[test]
@@ -152,7 +154,10 @@ struct Arbitrary<T> {
     _marker: PhantomData<T>,
 }
 
-impl<T> Expression for Arbitrary<T> {
+impl<T> Expression for Arbitrary<T>
+where
+    T: SqlType + TypedExpressionType,
+{
     type SqlType = T;
 }
 
@@ -165,9 +170,9 @@ where
     }
 }
 
-impl<T, QS> SelectableExpression<QS> for Arbitrary<T> {}
+impl<T, QS> SelectableExpression<QS> for Arbitrary<T> where Self: Expression {}
 
-impl<T, QS> AppearsOnTable<QS> for Arbitrary<T> {}
+impl<T, QS> AppearsOnTable<QS> for Arbitrary<T> where Self: Expression {}
 
 fn arbitrary<T>() -> Arbitrary<T> {
     Arbitrary {

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -328,14 +328,14 @@ fn or_doesnt_mess_with_precedence_of_previous_statements() {
     let f = false.into_sql::<sql_types::Bool>();
     let count = users
         .filter(f)
-        .filter(f.or(true))
+        .filter(f.or(true.into_sql::<sql_types::Bool>()))
         .count()
         .first(&connection);
 
     assert_eq!(Ok(0), count);
 
     let count = users
-        .filter(f.or(f).and(f.or(true)))
+        .filter(f.or(f).and(f.or(true.into_sql::<sql_types::Bool>())))
         .count()
         .first(&connection);
 

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -324,7 +324,7 @@ fn select_left_join_right_side_with_non_null_inside() {
             users::id,
         ))
         .order_by((users::id.desc(), posts::id.asc()));
-    let actual_data: Vec<_> = source.load(&connection).unwrap();
+    let actual_data: Vec<(Option<(i32, String, String)>, i32)> = source.load(&connection).unwrap();
 
     assert_eq!(expected_data, actual_data);
 }

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -145,7 +145,7 @@ fn boolean_from_sql() {
 }
 
 #[test]
-fn boolean_treats_null_as_false_when_predicates_return_null() {
+fn nullable_boolean_from_sql() {
     let connection = connection();
     let one = Some(1).into_sql::<diesel::sql_types::Nullable<Integer>>();
     let query = select(one.eq(None::<i32>));

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -5,6 +5,7 @@ extern crate bigdecimal;
 extern crate chrono;
 
 use crate::schema::*;
+use diesel::deserialize::FromSqlRow;
 #[cfg(feature = "postgres")]
 use diesel::pg::Pg;
 use diesel::sql_types::*;
@@ -144,12 +145,11 @@ fn boolean_from_sql() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
 fn boolean_treats_null_as_false_when_predicates_return_null() {
     let connection = connection();
-    let one = Some(1).into_sql::<Nullable<Integer>>();
+    let one = Some(1).into_sql::<diesel::sql_types::Nullable<Integer>>();
     let query = select(one.eq(None::<i32>));
-    assert_eq!(Ok(false), query.first(&connection));
+    assert_eq!(Ok(Option::<bool>::None), query.first(&connection));
 }
 
 #[test]
@@ -670,16 +670,16 @@ fn pg_specific_option_to_sql() {
         "'t'::bool",
         Some(true)
     ));
-    assert!(!query_to_sql_equality::<Nullable<Bool>, Option<bool>>(
+    assert!(query_to_sql_equality::<Nullable<Bool>, Option<bool>>(
         "'f'::bool",
-        Some(true)
+        Some(false)
     ));
     assert!(query_to_sql_equality::<Nullable<Bool>, Option<bool>>(
         "NULL", None
     ));
-    assert!(!query_to_sql_equality::<Nullable<Bool>, Option<bool>>(
+    assert!(query_to_sql_equality::<Nullable<Bool>, Option<bool>>(
         "NULL::bool",
-        Some(false)
+        None
     ));
 }
 
@@ -1231,7 +1231,7 @@ fn third_party_crates_can_add_new_types() {
     }
 
     impl FromSql<MyInt, Pg> for i32 {
-        fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+        fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
             FromSql::<Integer, Pg>::from_sql(bytes)
         }
     }
@@ -1241,17 +1241,18 @@ fn third_party_crates_can_add_new_types() {
     assert_eq!(70_000, query_single_value::<MyInt, i32>("70000"));
 }
 
-fn query_single_value<T, U: Queryable<T, TestBackend>>(sql_str: &str) -> U
+fn query_single_value<T, U: FromSqlRow<T, TestBackend>>(sql_str: &str) -> U
 where
     TestBackend: HasSqlType<T>,
-    T: QueryId + SingleValue,
+    T: QueryId + SingleValue + SqlType,
 {
     use diesel::dsl::sql;
     let connection = connection();
     select(sql::<T>(sql_str)).first(&connection).unwrap()
 }
 
-use diesel::expression::{is_aggregate, AsExpression, ValidGrouping};
+use diesel::dsl::{And, AsExprOf, Eq, IsNull};
+use diesel::expression::{is_aggregate, AsExpression, SqlLiteral, ValidGrouping};
 use diesel::query_builder::{QueryFragment, QueryId};
 use std::fmt::Debug;
 
@@ -1261,7 +1262,16 @@ where
     U::Expression: SelectableExpression<(), SqlType = T>
         + ValidGrouping<(), IsAggregate = is_aggregate::Never>,
     U::Expression: QueryFragment<TestBackend> + QueryId,
-    T: QueryId + SingleValue,
+    T: QueryId + SingleValue + SqlType,
+    T::IsNull: OneIsNullable<T::IsNull, Out = T::IsNull>,
+    T::IsNull: MaybeNullableType<Bool>,
+    <T::IsNull as MaybeNullableType<Bool>>::Out: SqlType,
+    diesel::sql_types::is_nullable::NotNull: diesel::sql_types::AllAreNullable<
+        <<T::IsNull as MaybeNullableType<Bool>>::Out as SqlType>::IsNull,
+        Out = diesel::sql_types::is_nullable::NotNull,
+    >,
+    Eq<SqlLiteral<T>, U>: Expression<SqlType = <T::IsNull as MaybeNullableType<Bool>>::Out>,
+    And<IsNull<SqlLiteral<T>>, IsNull<AsExprOf<U, T>>>: Expression<SqlType = Bool>,
 {
     use diesel::dsl::sql;
     let connection = connection();
@@ -1272,7 +1282,7 @@ where
             .or(sql::<T>(sql_str).eq(value.clone())),
     );
     query
-        .get_result(&connection)
+        .get_result::<bool>(&connection)
         .expect(&format!("Error comparing {}, {:?}", sql_str, value))
 }
 

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -9,10 +9,11 @@ pub use crate::schema::{connection_without_transaction, TestConnection};
 pub use diesel::data_types::*;
 pub use diesel::result::Error;
 pub use diesel::serialize::ToSql;
-pub use diesel::sql_types::HasSqlType;
+pub use diesel::sql_types::{HasSqlType, SingleValue, SqlType};
 pub use diesel::*;
 
-use diesel::expression::{AsExpression, NonAggregate};
+use deserialize::FromSqlRow;
+use diesel::expression::{AsExpression, NonAggregate, TypedExpressionType};
 use diesel::query_builder::{QueryFragment, QueryId};
 #[cfg(feature = "postgres")]
 use std::collections::Bound;
@@ -23,10 +24,10 @@ thread_local! {
 
 pub fn test_type_round_trips<ST, T>(value: T) -> bool
 where
-    ST: QueryId,
+    ST: QueryId + SqlType + TypedExpressionType + SingleValue,
     <TestConnection as Connection>::Backend: HasSqlType<ST>,
     T: AsExpression<ST>
-        + Queryable<ST, <TestConnection as Connection>::Backend>
+        + FromSqlRow<ST, <TestConnection as Connection>::Backend>
         + PartialEq
         + Clone
         + ::std::fmt::Debug,

--- a/examples/postgres/advanced-blog-cli/src/post.rs
+++ b/examples/postgres/advanced-blog-cli/src/post.rs
@@ -14,6 +14,7 @@ pub struct Post {
     pub body: String,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+    #[diesel(deserialize_as = "Option<NaiveDateTime>")]
     pub status: Status,
 }
 
@@ -22,17 +23,11 @@ pub enum Status {
     Published { at: NaiveDateTime },
 }
 
-use diesel::deserialize::Queryable;
-use diesel::pg::Pg;
-use diesel::sql_types::{Nullable, Timestamp};
-
-impl Queryable<Nullable<Timestamp>, Pg> for Status {
-    type Row = Option<NaiveDateTime>;
-
-    fn build(row: Self::Row) -> Self {
-        match row {
-            Some(at) => Status::Published { at },
+impl Into<Status> for Option<NaiveDateTime> {
+    fn into(self) -> Status {
+        match self {
             None => Status::Draft,
+            Some(at) => Status::Published { at },
         }
     }
 }

--- a/examples/postgres/custom_types/src/main.rs
+++ b/examples/postgres/custom_types/src/main.rs
@@ -1,8 +1,5 @@
-#[macro_use]
-extern crate diesel;
-
+use self::schema::translations;
 use diesel::prelude::*;
-use schema::translations::{self, dsl};
 
 mod model;
 mod schema;
@@ -20,7 +17,7 @@ fn main() {
     let conn = PgConnection::establish(&database_url)
         .unwrap_or_else(|e| panic!("Error connecting to {}: {}", database_url, e));
 
-    let _ = diesel::insert_into(dsl::translations)
+    let _ = diesel::insert_into(translations::table)
         .values(&Translation {
             word_id: 1,
             translation_id: 1,
@@ -28,8 +25,12 @@ fn main() {
         })
         .execute(&conn);
 
-    let t = dsl::translations
-        .select((dsl::word_id, dsl::translation_id, dsl::language))
+    let t = translations::table
+        .select((
+            translations::word_id,
+            translations::translation_id,
+            translations::language,
+        ))
         .get_results::<Translation>(&conn)
         .expect("select");
     println!("{:?}", t);

--- a/examples/postgres/custom_types/src/model.rs
+++ b/examples/postgres/custom_types/src/model.rs
@@ -13,7 +13,7 @@ pub mod exports {
 #[postgres(type_name = "Language")]
 pub struct LanguageType;
 
-#[derive(Debug, FromSqlRow, AsExpression)]
+#[derive(Debug, AsExpression, FromSqlRow)]
 #[sql_type = "LanguageType"]
 pub enum Language {
     En,
@@ -33,8 +33,8 @@ impl ToSql<LanguageType, Pg> for Language {
 }
 
 impl FromSql<LanguageType, Pg> for Language {
-    fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {
-        match not_none!(bytes).as_bytes() {
+    fn from_sql(bytes: PgValue) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
             b"en" => Ok(Language::En),
             b"ru" => Ok(Language::Ru),
             b"de" => Ok(Language::De),

--- a/examples/postgres/custom_types/src/schema.rs
+++ b/examples/postgres/custom_types/src/schema.rs
@@ -1,4 +1,4 @@
-table! {
+diesel::table! {
     use diesel::sql_types::*;
     use crate::model::exports::*;
 


### PR DESCRIPTION
diesel_dynamic_query

This commit contains the following changes:
* Make SelectClause traits public to allow implementing a dynamic
select clause variant based on a vector instead of tuples like the
existing ones. This allows to construct dynamically sized select
clauses
* Add two methods to the `Row` traits to which allows to get more
information (current column name and column count) of the result
set. This is required to implement compatible result types for
dynamically sized select clauses