### PR TITLE
Json support for MySQL

### DIFF
--- a/diesel/src/mysql/types/json.rs
+++ b/diesel/src/mysql/types/json.rs
@@ -1,0 +1,20 @@
+use deserialize::{self, FromSql};
+use mysql::{Mysql, MysqlValue};
+use serialize::{self, IsNull, Output, ToSql};
+use sql_types::*;
+use std::io::Write;
+
+impl FromSql<Json, Mysql> for serde_json::Value {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        serde_json::from_slice(value.as_bytes()).map_err(Into::into)
+    }
+}
+
+impl ToSql<Json, Mysql> for serde_json::Value {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
+        serde_json::to_writer(out, self)
+            .map(|_| IsNull::No)
+            .map_err(Into::into)
+    }
+}

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "chrono")]
 mod date_and_time;
+#[cfg(feature = "serde_json")]
+mod json;
 mod numeric;
 
 use byteorder::WriteBytesExt;

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -12,11 +12,11 @@ use sql_types;
 #[allow(dead_code)]
 mod foreign_derives {
     use super::serde_json;
-    use sql_types::{Json, Jsonb};
+    use sql_types::Jsonb;
 
-    #[derive(FromSqlRow, AsExpression)]
+    /// Deriving AsExpression only, FromSqlRow for serde_json::Value is already derived in src/sql_types/mod.rs
+    #[derive(AsExpression)]
     #[diesel(foreign_derive)]
-    #[sql_type = "Json"]
     #[sql_type = "Jsonb"]
     struct SerdeJsonValueProxy(serde_json::Value);
 }

--- a/diesel/src/sql_types/json.rs
+++ b/diesel/src/sql_types/json.rs
@@ -1,0 +1,33 @@
+/// The JSON SQL type.  This type can only be used with `feature =
+/// "serde_json"`
+///
+/// Normally you should prefer [`Jsonb`](struct.Jsonb.html) instead, for the reasons
+/// discussed there.
+///
+/// ### [`ToSql`] impls
+///
+/// - [`serde_json::Value`]
+///
+/// ### [`FromSql`] impls
+///
+/// - [`serde_json::Value`]
+///
+/// [`ToSql`]: ../../../serialize/trait.ToSql.html
+/// [`FromSql`]: ../../../deserialize/trait.FromSql.html
+/// [`serde_json::Value`]: ../../../../serde_json/value/enum.Value.html
+#[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
+#[postgres(oid = "114", array_oid = "199")]
+#[sqlite_type = "Text"]
+#[mysql_type = "String"]
+#[cfg(feature = "serde_json")]
+pub struct Json;
+
+#[allow(dead_code)]
+mod foreign_derives {
+    use super::Json;
+
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(foreign_derive)]
+    #[sql_type = "Json"]
+    struct SerdeJsonValueProxy(serde_json::Value);
+}

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -16,6 +16,11 @@
 mod fold;
 pub mod ops;
 mod ord;
+#[cfg(feature = "serde_json")]
+mod json;
+
+#[cfg(feature = "serde_json")]
+pub use self::json::Json;
 
 pub use self::fold::Foldable;
 pub use self::ord::SqlOrd;

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -328,6 +328,28 @@ fn u64_from_sql() {
 }
 
 #[test]
+#[cfg(feature = "mysql")]
+fn mysql_json_array_from_sql() {
+    assert_eq!(
+        serde_json::to_value(vec![true, false, true]).unwrap(),
+        query_single_value::<Json, serde_json::Value>("JSON_ARRAY(true, false, true)")
+    );
+    assert_eq!(
+        serde_json::to_value(vec![1, 2, 3]).unwrap(),
+        query_single_value::<Json, serde_json::Value>("JSON_ARRAY(1, 2, 3)")
+    );
+    assert_eq!(
+        serde_json::to_value(vec![
+            "Hello".to_string(),
+            "".to_string(),
+            "world".to_string()
+        ])
+        .unwrap(),
+        query_single_value::<Json, serde_json::Value>("JSON_ARRAY('Hello', '', 'world')")
+    );
+}
+
+#[test]
 #[cfg(feature = "postgres")]
 fn i64_from_sql() {
     assert_eq!(0, query_single_value::<BigInt, i64>("0::int8"));


### PR DESCRIPTION
Add Json support for MySQL.

Because there is a name conflict with the pg's Json type, I moved it into the common `sql_types` module, while kept the `Jsonb` type in pg.