### PR TITLE
dependency on 'ipnetwork' updated to include latest (0.15.0) crate

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -25,7 +25,7 @@ time = { version = "0.1", optional = true }
 url = { version = "1.4.0", optional = true }
 uuid = { version = ">=0.2.0, <0.7.0", optional = true, features = ["use_std"] }
 uuidv07 = { version = "0.7.0", optional = true, package = "uuid"}
-ipnetwork = { version = ">=0.12.2, <0.14.0", optional = true }
+ipnetwork = { version = ">=0.12.2, <0.16.0", optional = true }
 num-bigint = { version = ">=0.1.41, <0.3", optional = true }
 num-traits = { version = "0.2", optional = true }
 num-integer = { version = "0.1.32", optional = true }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -21,7 +21,7 @@ dotenv = ">=0.8, <0.11"
 quickcheck = { version = "0.4", features = ["unstable"] }
 uuid = { version = ">=0.2.0, <0.7.0" }
 serde_json = { version=">=0.9, <2.0" }
-ipnetwork = ">=0.12.2, <0.14.0"
+ipnetwork = ">=0.12.2, <0.16.0"
 bigdecimal = ">= 0.0.10, <= 0.1.0"
 
 [features]


### PR DESCRIPTION
Including latest version of 'ipnetwork' in an application was giving error. Updated this dependency in 'diesel'. This fixed the issue.