### PR TITLE
Make some fields of insertable public

### DIFF
--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -268,7 +268,7 @@ where
 
 #[derive(Debug, Clone, Copy)]
 pub struct BatchInsert<'a, T: 'a, Tab> {
-    pub(crate) records: &'a [T],
+    pub records: &'a [T],
     _marker: PhantomData<Tab>,
 }
 
@@ -295,7 +295,7 @@ where
 
 #[derive(Debug)]
 pub struct OwnedBatchInsert<V, Tab> {
-    pub(crate) values: Vec<V>,
+    pub values: Vec<V>,
     _marker: PhantomData<Tab>,
 }
 

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -448,7 +448,7 @@ where
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy)]
 pub struct ValuesClause<T, Tab> {
-    pub(crate) values: T,
+    pub values: T,
     _marker: PhantomData<Tab>,
 }
 


### PR DESCRIPTION
This allows custom backend implementation like diesel-oci to write
their own `QueryFragment` implementations for those structs