### PR TITLE
Bring back `HasSqlType::row_metadata` as this method is not only

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -72,7 +72,7 @@ impl Connection for MysqlConnection {
 
         let mut stmt = self.prepare_query(&source.as_query())?;
         let mut metadata = Vec::new();
-        Mysql::mysql_row_metadata(&mut metadata, &());
+        Mysql::row_metadata(&mut metadata, &());
         let results = unsafe { stmt.results(metadata)? };
         results.map(|mut row| {
             U::Row::build_from_row(&mut row)

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -404,8 +404,7 @@ pub trait HasSqlType<ST>: TypeMetadata {
     fn metadata(lookup: &Self::MetadataLookup) -> Self::TypeMetadata;
 
     #[doc(hidden)]
-    #[cfg(feature = "mysql")]
-    fn mysql_row_metadata(out: &mut Vec<Self::TypeMetadata>, lookup: &Self::MetadataLookup) {
+    fn row_metadata(out: &mut Vec<Self::TypeMetadata>, lookup: &Self::MetadataLookup) {
         out.push(Self::metadata(lookup))
     }
 }

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -19,9 +19,8 @@ where
         <DB as HasSqlType<T>>::metadata(lookup)
     }
 
-    #[cfg(feature = "mysql")]
-    fn mysql_row_metadata(out: &mut Vec<DB::TypeMetadata>, lookup: &DB::MetadataLookup) {
-        <DB as HasSqlType<T>>::mysql_row_metadata(out, lookup)
+    fn row_metadata(out: &mut Vec<DB::TypeMetadata>, lookup: &DB::MetadataLookup) {
+        <DB as HasSqlType<T>>::row_metadata(out, lookup)
     }
 }
 

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -29,9 +29,8 @@ macro_rules! tuple_impls {
                     unreachable!("Tuples should never implement `ToSql` directly");
                 }
 
-                #[cfg(feature = "mysql")]
-                fn mysql_row_metadata(out: &mut Vec<__DB::TypeMetadata>, lookup: &__DB::MetadataLookup) {
-                    $(<__DB as HasSqlType<$T>>::mysql_row_metadata(out, lookup);)+
+                fn row_metadata(out: &mut Vec<__DB::TypeMetadata>, lookup: &__DB::MetadataLookup) {
+                    $(<__DB as HasSqlType<$T>>::row_metadata(out, lookup);)+
                 }
             }
 


### PR DESCRIPTION
useful for the mysql backend

Fixes #1985