### PR TITLE
Do not hard code the setup of the __diesel_schema_migrations table

### DIFF
--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -57,11 +57,10 @@ impl<'a> Migration for &'a dyn Migration {
 
 /// Create table statement for the `__diesel_schema_migrations` used
 /// used by the postgresql, sqlite and mysql backend
-pub const CREATE_MIGRATIONS_TABLE: &'static str =
-    "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (\
-     version VARCHAR(50) PRIMARY KEY NOT NULL,\
-     run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
-     )";
+pub const CREATE_MIGRATIONS_TABLE: &str = "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (\
+                                           version VARCHAR(50) PRIMARY KEY NOT NULL,\
+                                           run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
+                                           )";
 
 /// A trait indicating that a connection could be used to manage migrations
 ///

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -3,7 +3,8 @@
 mod errors;
 pub use self::errors::{MigrationError, RunMigrationsError};
 
-use connection::SimpleConnection;
+use connection::{Connection, SimpleConnection};
+use result::QueryResult;
 use std::path::Path;
 
 /// Represents a migration that interacts with diesel
@@ -51,5 +52,57 @@ impl<'a> Migration for &'a dyn Migration {
     }
     fn file_path(&self) -> Option<&Path> {
         (&**self).file_path()
+    }
+}
+
+/// Create table statement for the `__diesel_schema_migrations` used
+/// used by the postgresql, sqlite and mysql backend
+pub const CREATE_MIGRATIONS_TABLE: &'static str =
+    "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (\
+     version VARCHAR(50) PRIMARY KEY NOT NULL,\
+     run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
+     )";
+
+/// A trait indicating that a connection could be used to manage migrations
+///
+/// Only custom backend implementations need to think about this trait
+pub trait MigrationConnection: Connection {
+    /// Setup the following table:
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate diesel;
+    /// table! {
+    ///      __diesel_schema_migrations(version) {
+    ///          version -> Text,
+    ///          /// defaults to `CURRENT_TIMESTAMP`
+    ///          run_on -> Timestamp,
+    ///      }
+    /// }
+    /// # fn main() {}
+    /// ```
+    fn setup(&self) -> QueryResult<usize>;
+}
+
+#[cfg(feature = "postgres")]
+impl MigrationConnection for ::pg::PgConnection {
+    fn setup(&self) -> QueryResult<usize> {
+        use RunQueryDsl;
+        ::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl MigrationConnection for ::mysql::MysqlConnection {
+    fn setup(&self) -> QueryResult<usize> {
+        use RunQueryDsl;
+        ::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl MigrationConnection for ::sqlite::SqliteConnection {
+    fn setup(&self) -> QueryResult<usize> {
+        use RunQueryDsl;
+        ::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
     }
 }

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -57,10 +57,7 @@ impl<'a> Migration for &'a dyn Migration {
 
 /// Create table statement for the `__diesel_schema_migrations` used
 /// used by the postgresql, sqlite and mysql backend
-pub const CREATE_MIGRATIONS_TABLE: &str = "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (\
-                                           version VARCHAR(50) PRIMARY KEY NOT NULL,\
-                                           run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
-                                           )";
+pub const CREATE_MIGRATIONS_TABLE: &str = include_str!("setup_migration_table.sql");
 
 /// A trait indicating that a connection could be used to manage migrations
 ///

--- a/diesel/src/migration/setup_migration_table.sql
+++ b/diesel/src/migration/setup_migration_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (
+       version VARCHAR(50) PRIMARY KEY NOT NULL,
+       run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/diesel_migrations/migrations_internals/src/connection.rs
+++ b/diesel_migrations/migrations_internals/src/connection.rs
@@ -14,7 +14,7 @@ use super::schema::__diesel_schema_migrations::dsl::*;
 /// to wrap up some constraints which are meant to hold for *all* connections.
 /// This trait will go away at some point in the future. Any Diesel connection
 /// should be useable where this trait is required.
-pub trait MigrationConnection: Connection {
+pub trait MigrationConnection: diesel::migration::MigrationConnection {
     fn previously_run_migration_versions(&self) -> QueryResult<HashSet<String>>;
     fn latest_run_migration_version(&self) -> QueryResult<Option<String>>;
     fn insert_new_migration(&self, version: &str) -> QueryResult<()>;
@@ -22,7 +22,7 @@ pub trait MigrationConnection: Connection {
 
 impl<T> MigrationConnection for T
 where
-    T: Connection,
+    T: diesel::migration::MigrationConnection,
     String: FromSql<VarChar, T::Backend>,
     // FIXME: HRTB is preventing projecting on any associated types here
     for<'a> InsertStatement<

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -258,17 +258,8 @@ fn migration_with_version(
 }
 
 #[doc(hidden)]
-pub fn setup_database<Conn: Connection>(conn: &Conn) -> QueryResult<usize> {
-    create_schema_migrations_table_if_needed(conn)
-}
-
-fn create_schema_migrations_table_if_needed<Conn: Connection>(conn: &Conn) -> QueryResult<usize> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS __diesel_schema_migrations (\
-         version VARCHAR(50) PRIMARY KEY NOT NULL,\
-         run_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\
-         )",
-    )
+pub fn setup_database<Conn: MigrationConnection>(conn: &Conn) -> QueryResult<usize> {
+    conn.setup()
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Different backends (oracle…) could require a different sql comment
here. Similar to the r2d2 method we just provide a function where
everything could be easily handled.

Closes #1676