### PR TITLE
Make generated schema the same on all platforms

### DIFF
--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -176,22 +176,25 @@ where
     use self::information_schema::tables::dsl::*;
 
     let default_schema = Conn::Backend::default_schema(connection)?;
-    let schema_name = match schema_name {
+    let db_schema_name = match schema_name {
         Some(name) => name,
         None => &default_schema,
     };
 
     let mut table_names = tables
-        .select((table_name, table_schema))
-        .filter(table_schema.eq(schema_name))
+        .select(table_name)
+        .filter(table_schema.eq(db_schema_name))
         .filter(table_name.not_like("\\_\\_%"))
         .filter(table_type.like("BASE TABLE"))
-        .order(table_name)
-        .load::<TableName>(connection)?;
-    for table in &mut table_names {
-        table.strip_schema_if_matches(&default_schema);
-    }
-    Ok(table_names)
+        .load::<String>(connection)?;
+    table_names.sort_unstable();
+    Ok(table_names
+        .into_iter()
+        .map(|name| TableName {
+            name,
+            schema: schema_name.map(|schema| schema.to_owned()),
+        })
+        .collect())
 }
 
 #[allow(clippy::similar_names)]

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -133,7 +133,7 @@ where
     columns
         .select((column_name, type_column, is_nullable))
         .filter(table_name.eq(&table.name))
-        .filter(table_schema.eq(schema_name.as_ref()))
+        .filter(table_schema.eq(schema_name))
         .order(ordinal_position)
         .load(conn)
 }
@@ -160,7 +160,7 @@ where
         .select(column_name)
         .filter(constraint_name.eq_any(pk_query))
         .filter(table_name.eq(&table.name))
-        .filter(table_schema.eq(schema_name.as_ref()))
+        .filter(table_schema.eq(schema_name))
         .order(ordinal_position)
         .load(conn)
 }
@@ -177,10 +177,7 @@ where
     use self::information_schema::tables::dsl::*;
 
     let default_schema = Conn::Backend::default_schema(connection)?;
-    let db_schema_name = match schema_name {
-        Some(name) => name,
-        None => &default_schema,
-    };
+    let db_schema_name = schema_name.unwrap_or(&default_schema);
 
     let mut table_names = tables
         .select(table_name)
@@ -216,10 +213,7 @@ where
     use self::information_schema::table_constraints as tc;
 
     let default_schema = Conn::Backend::default_schema(connection)?;
-    let schema_name = match schema_name {
-        Some(name) => name,
-        None => &default_schema,
-    };
+    let schema_name = schema_name.unwrap_or(&default_schema);
 
     let constraint_names = tc::table
         .filter(tc::constraint_type.eq("FOREIGN KEY"))


### PR DESCRIPTION
Resolves #2202

It appears that the following query does not behave the same way on all platforms:
```sql
SELECT table_name, table_schema from information_schema.tables 
WHERE table_schema = 'your schema' AND table_type LIKE 'BASE TABLE' ORDER BY table_name;
```

The order changes depending on the platform and the version of postgres (more details [in the PostgreSQL bug mailing list](https://www.postgresql.org/message-id/11505.1571936496%40sss.pgh.pa.us)).

This query is used when generating the `schema.rs` in the Diesel CLI.
The fact the order changes depending on the platform creates issues when applying, say, an unified-diff patch to the schema afterwards.

This patch sorts the table names on the rust side so that the order of the tables will not depend on the collation of the `information_schema` table.

PostgreSQL >= 12 has *by default* on all platforms a collation of the `information_schema` table that results in the same generated `schema.rs`s as this patch enforces on all versions/platforms/configurations of Postgres, so this is a *one-shot* controlled somewhat-breaking change that is otherwise already happening *gradually* on all platforms.