### PR TITLE
doc correction for `Traversable`

### DIFF
--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -238,8 +238,8 @@ where
 
 /// Similar to `RefMut::map`, but for functions which return `Result`
 ///
-/// If we were in Haskell (and if `RefMut` were a functor), this would just be
-/// `sequenceA`.
+/// If we were in Haskell (and if `RefMut` were `Traversable`), this would just be
+/// `traverse`.
 fn refmut_map_result<T, U, F>(mut refmut: RefMut<T>, mapper: F) -> QueryResult<RefMut<U>>
 where
     F: FnOnce(&mut T) -> QueryResult<&mut U>,


### PR DESCRIPTION
This PR makes a small docs change related to Haskell type classes you mention. I provide an explanation below on how the `refmut_map_result` function is an implementation of `traverse`.

I read over the `refmut_map_result` function. It's given the arguments `RefMut<T>` and a function of type (essentially) `T -> QueryResult<U>` and returns a `QueryResult<RefMut<U>>`. Besides the arguments being flipped this reminded me of [`traverse`](http://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Traversable.html#v:traverse) in Haskell. Here's the type signature:

```haskell
traverse :: (Traversable t, Applicative f) => (a -> f b) -> t a -> f (t b)
```

The other change I made here was from
> if `RefMut` were a functor

to be instead

> if `RefMut` were `Traversable`

The previous wording makes me think that `RefMut` implements the functions in the `Functor` type class as though it were the `Functor` type class. Since `RefMut` is a type, I would assume it might have an instance of a particular type class, like `Traversable`. The implementation of `refmut_map_result` "traverses" the structure of the type and we don't have higher kinded types in Rust that make it so you can't combine results to create a type in the same way you can with Haskell's [`Applicative`](http://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Applicative.html), I thought it would make sense to say something that conveys `refmut_map_result` would be `traverse` if `RefMut` had an instance for `Traversable`.