### PR TITLE
remove confusing panic messages from examples

### DIFF
--- a/examples/postgres/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/postgres/getting_started_step_3/src/bin/publish_post.rs
@@ -19,6 +19,6 @@ fn main() {
     let post = diesel::update(posts.find(id))
         .set(published.eq(true))
         .get_result::<Post>(&connection)
-        .unwrap_or_else(|_| panic!("Unable to find post {}", id));
+        .unwrap();
     println!("Published post {}", post.title);
 }

--- a/examples/sqlite/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/sqlite/getting_started_step_3/src/bin/publish_post.rs
@@ -18,7 +18,7 @@ fn main() {
     let _ = diesel::update(posts.find(id))
         .set(published.eq(true))
         .execute(&connection)
-        .unwrap_or_else(|_| panic!("Unable to find post {}", id));
+        .unwrap();
 
     let post: models::Post = posts
         .find(id)


### PR DESCRIPTION
The `publish_post` examples contained a confusing `panic!()` that
suggested the update statement would return an error, when a post to be
updated could not be found. In reality, however, that case results in an
`Ok(0)` value.

To avoid confusion, this commit replaces the panicking
`unwrap_or_else()` calls with a simpler `unwrap()`.