### PR TITLE
Update major versions of dependencies

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -19,10 +19,11 @@ libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.17.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
-quickcheck = { version = "0.4", optional = true }
+quickcheck = { version = "0.9", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }
 time = { version = "0.1", optional = true }
-url = { version = "1.4.0", optional = true }
+url = { version = "2.1.0", optional = true }
+percent-encoding = { version = "2.1.0", optional = true }
 uuid = { version = ">=0.2.0, <0.7.0", optional = true, features = ["use_std"] }
 uuidv07 = { version = ">=0.7.0, <0.9.0", optional = true, package = "uuid"}
 ipnetwork = { version = ">=0.12.2, <0.16.0", optional = true }
@@ -35,9 +36,8 @@ r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 
 [dev-dependencies]
 cfg-if = "0.1.0"
-dotenv = ">=0.8, <0.11"
-quickcheck = "0.4"
-tempdir = "^0.3.4"
+dotenv = ">=0.8, <0.16"
+quickcheck = "0.9"
 
 [features]
 default = ["with-deprecated", "32-column-tables"]
@@ -50,7 +50,7 @@ huge-tables = ["64-column-tables"]
 128-column-tables = ["64-column-tables"]
 postgres = ["pq-sys", "bitflags", "diesel_derives/postgres"]
 sqlite = ["libsqlite3-sys", "diesel_derives/sqlite"]
-mysql = ["mysqlclient-sys", "url", "diesel_derives/mysql"]
+mysql = ["mysqlclient-sys", "url", "percent-encoding", "diesel_derives/mysql"]
 with-deprecated = []
 deprecated-time = ["time"]
 network-address = ["ipnetwork", "libc"]

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -1,6 +1,7 @@
+extern crate percent_encoding;
 extern crate url;
 
-use self::url::percent_encoding::percent_decode;
+use self::percent_encoding::percent_decode;
 use self::url::{Host, Url};
 use std::ffi::{CStr, CString};
 
@@ -128,7 +129,27 @@ fn first_path_segment_is_treated_as_database() {
 
 #[test]
 fn userinfo_should_be_percent_decode() {
-    use self::url::percent_encoding::{utf8_percent_encode, USERINFO_ENCODE_SET};
+    use self::percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+    const USERINFO_ENCODE_SET: &AsciiSet = &CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'<')
+        .add(b'>')
+        .add(b'`')
+        .add(b'#')
+        .add(b'?')
+        .add(b'{')
+        .add(b'}')
+        .add(b'/')
+        .add(b':')
+        .add(b';')
+        .add(b'=')
+        .add(b'@')
+        .add(b'[')
+        .add(b'\\')
+        .add(b']')
+        .add(b'^')
+        .add(b'|');
 
     let username = "x#gfuL?4Zuj{n73m}eeJt0";
     let encoded_username = utf8_percent_encode(username, USERINFO_ENCODE_SET);

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,21 +19,20 @@ path = "src/main.rs"
 chrono = "0.4"
 clap = "2.27"
 diesel = { version = "~1.4.0", default-features = false }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.16"
 heck = "0.3.1"
 migrations_internals = "~1.4.0"
 serde = { version = "1.0.0", features = ["derive"] }
-tempfile = "3.0.0"
-toml = "0.4.6"
-url = { version = "1.4.0", optional = true }
+tempfile = "3.1.0"
+toml = "0.5.5"
+url = { version = "2.1.0", optional = true }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
 libsqlite3-sys = { version = ">=0.8.0, <0.17.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 
 [dev-dependencies]
-difference = "1.0"
-tempdir = "0.3.4"
-regex = "0.2"
-url = { version = "1.4.0" }
+difference = "2.0"
+regex = "1.3.0"
+url = { version = "2.1.0" }
 
 [features]
 default = ["postgres", "sqlite", "mysql"]

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -462,11 +462,11 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), Box<d
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use database_error::DatabaseError;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
 
     use std::fs;
     use std::path::PathBuf;
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn toml_directory_find_cargo_toml() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
         let toml_path = temp_path.join("Cargo.toml");
 
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn cargo_toml_not_found_if_no_cargo_toml() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
 
         assert_eq!(

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -6,7 +6,7 @@ extern crate url;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use tempfile::{Builder, TempDir};
 
 use super::command::TestCommand;
 
@@ -40,7 +40,7 @@ impl ProjectBuilder {
     }
 
     pub fn build(self) -> Project {
-        let tempdir = TempDir::new(&self.name).unwrap();
+        let tempdir = Builder::new().prefix(&self.name).tempdir().unwrap();
 
         File::create(tempdir.path().join("Cargo.toml")).unwrap();
 

--- a/diesel_cli/tests/tests.rs
+++ b/diesel_cli/tests/tests.rs
@@ -6,7 +6,7 @@ extern crate diesel;
 extern crate difference;
 extern crate migrations_internals;
 extern crate regex;
-extern crate tempdir;
+extern crate tempfile;
 
 mod completion_generation;
 mod database_drop;

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "1"
 [dev-dependencies]
 cfg-if = "0.1.0"
 diesel = "1.4.0"
-dotenv = "0.10.0"
+dotenv = "0.15.0"
 
 [lib]
 proc-macro = true

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -14,7 +14,7 @@ migrations_macros = "~1.4.0"
 
 [dev-dependencies]
 diesel = { version = "1.4.0", default-features = false }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.16"
 cfg-if = "0.1.0"
 
 [features]

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -11,7 +11,7 @@ diesel = { version = "~1.4.0", default-features = false }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
 
 [dev-dependencies]
-tempdir = "0.3.4"
+tempfile = "3.1.0"
 
 [features]
 default = []

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -381,16 +381,16 @@ pub fn search_for_migrations_directory(path: &Path) -> Result<PathBuf, Migration
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use super::*;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
     use std::fs;
 
     #[test]
     fn migration_directory_not_found_if_no_migration_dir_exists() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
 
         assert_eq!(
             Err(MigrationError::MigrationDirectoryNotFound),
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn migration_directory_defaults_to_pwd_slash_migrations() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
         let migrations_path = temp_path.join("migrations");
 
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn migration_directory_checks_parents() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
         let migrations_path = temp_path.join("migrations");
         let child_path = temp_path.join("child");

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -145,17 +145,17 @@ fn run_sql_from_file(conn: &dyn SimpleConnection, path: &Path) -> Result<(), Run
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use super::{valid_sql_migration_directory, version_from_path};
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
     use std::fs;
     use std::path::PathBuf;
 
     #[test]
     fn files_are_not_valid_sql_file_migrations() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let file_path = dir.path().join("12345");
 
         fs::File::create(&file_path).unwrap();
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn directory_containing_exactly_up_sql_and_down_sql_is_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn directory_containing_unknown_files_is_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn files_beginning_with_dot_are_allowed() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn empty_directory_is_not_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn directory_with_only_up_sql_is_not_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -14,7 +14,7 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-tempdir = "0.3.4"
+tempfile = "3.1.0"
 
 [lib]
 proc-macro = true

--- a/diesel_migrations/migrations_macros/src/migrations.rs
+++ b/diesel_migrations/migrations_macros/src/migrations.rs
@@ -32,16 +32,16 @@ fn resolve_migrations_directory(
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
     use super::resolve_migrations_directory;
     use std::fs;
     use std::path::Path;
 
     #[test]
     fn migrations_directory_resolved_relative_to_cargo_manifest_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/special_migrations")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo");
         let relative_path = Some(Path::new("special_migrations"));
@@ -58,7 +58,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_canonicalizes_result() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/migrations/bar")).unwrap();
         fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo/bar");
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_defaults_to_searching_migrations_path() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
         fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo/bar");
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_searches_src_migrations_if_present() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/src/migrations")).unwrap();
         fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo");
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_allows_no_parent_dir_for_cargo_manifest_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("special_migrations")).unwrap();
         let cargo_manifest_dir = tempdir.path().to_owned();
         let relative_path = Some(Path::new("special_migrations"));

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -9,7 +9,7 @@ autotests = false
 [build-dependencies]
 diesel = { path = "../diesel", default-features = false }
 diesel_migrations = { version = "1.4.0" }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.8, <0.16"
 
 [dependencies]
 assert_matches = "1.0.1"
@@ -18,7 +18,7 @@ diesel = { path = "../diesel", default-features = false, features = ["quickcheck
 diesel_migrations = { version = "1.4.0" }
 diesel_infer_schema = { version = "1.4.0" }
 dotenv = ">=0.8, <0.11"
-quickcheck = { version = "0.4", features = ["unstable"] }
+quickcheck = { version = "0.9", features = ["unstable"] }
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.16.0"

--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
-bcrypt = "0.1.0"
+bcrypt = "0.6.0"
 chrono = "0.4.0"
 diesel = { version = "1.4.0", features = ["postgres", "chrono"] }
-dotenv = "0.10.0"
+dotenv = "0.15.0"
 structopt = "0.1.6"
 structopt-derive = "0.1.6"
-tempfile = "2.2.0"
+tempfile = "3.1.0"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/examples/postgres/advanced-blog-cli/src/auth.rs
+++ b/examples/postgres/advanced-blog-cli/src/auth.rs
@@ -98,11 +98,11 @@ fn if_not_present<T>(
     res: Result<T, dotenv::Error>,
     on_not_present: AuthenticationError,
 ) -> Result<T, AuthenticationError> {
-    use dotenv::ErrorKind::EnvVar;
+    use dotenv::Error::EnvVar;
     use std::env::VarError::NotPresent;
 
     res.map_err(|e| match e {
-        dotenv::Error(EnvVar(NotPresent), _) => on_not_present,
+        EnvVar(NotPresent) => on_not_present,
         e => AuthenticationError::EnvironmentError(e),
     })
 }

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.15"


### PR DESCRIPTION
This updates all major versions of dependencies.

I wasn't able to update `structopt` in [examples/postgres/advanced-blog-cli/Cargo.toml](https://github.com/paolobarbolini/diesel/blob/e19fa752d0c2e8c4d3534421eafb9b96299a2228/examples/postgres/advanced-blog-cli/Cargo.toml) because the newer versions apparently don't allow setting `default_value` on `Option`.

I replaced `tempdir` with `tempfile` which was already being used in other parts of the code.

I wasn't able to run tests for all database backends so I'll rely on CI to find out if there are any problems left to fix.