### PR TITLE
Upgrade dotenv to 0.15 [blocked on change to test suite]

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -36,7 +36,7 @@ r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 
 [dev-dependencies]
 cfg-if = "0.1.0"
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.11, <=0.15"
 quickcheck = "0.4"
 tempdir = "^0.3.4"
 

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 chrono = "0.4"
 clap = "2.27"
 diesel = { version = "~1.4.0", default-features = false }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.11, <=0.15"
 heck = "0.3.1"
 migrations_internals = "~1.4.0"
 serde = { version = "1.0.0", features = ["derive"] }

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "1"
 [dev-dependencies]
 cfg-if = "0.1.0"
 diesel = "1.4.0"
-dotenv = "0.10.0"
+dotenv = ">=0.11, <=0.15"
 
 [lib]
 proc-macro = true

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -14,7 +14,7 @@ migrations_macros = "~1.4.0"
 
 [dev-dependencies]
 diesel = { version = "1.4.0", default-features = false }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.11, <=0.15"
 cfg-if = "0.1.0"
 
 [features]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -16,7 +16,7 @@ assert_matches = "1.0.1"
 chrono = { version = "0.4" }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuidv07", "serde_json", "network-address", "numeric", "with-deprecated"] }
 diesel_migrations = { version = "1.4.0" }
-diesel_infer_schema = { version = "1.4.0" }
+diesel_infer_schema = { version = "1.4.0", default-features = false }
 dotenv = ">=0.11, <=0.15"
 quickcheck = { version = "0.4", features = ["unstable"] }
 uuid = { version = ">=0.7.0, <0.9.0" }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -9,7 +9,7 @@ autotests = false
 [build-dependencies]
 diesel = { path = "../diesel", default-features = false }
 diesel_migrations = { version = "1.4.0" }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.11, <=0.15"
 
 [dependencies]
 assert_matches = "1.0.1"
@@ -17,7 +17,7 @@ chrono = { version = "0.4" }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuidv07", "serde_json", "network-address", "numeric", "with-deprecated"] }
 diesel_migrations = { version = "1.4.0" }
 diesel_infer_schema = { version = "1.4.0" }
-dotenv = ">=0.8, <0.11"
+dotenv = ">=0.11, <=0.15"
 quickcheck = { version = "0.4", features = ["unstable"] }
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }

--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 bcrypt = "0.1.0"
 chrono = "0.4.0"
 diesel = { version = "1.4.0", features = ["postgres", "chrono"] }
-dotenv = "0.10.0"
+dotenv = ">=0.11, <=0.15"
 structopt = "0.1.6"
 structopt-derive = "0.1.6"
 tempfile = "2.2.0"

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "1.4.0", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = ">=0.11, <=0.15"


### PR DESCRIPTION
Trying to cargo install `diesel_cli` gave me compiler failures for `error_chain` and `dotenv`. I'm using a current nightly compiler.

This can be fixed by using a newer version of `dotenv`.