### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -38,7 +38,6 @@ r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 cfg-if = "0.1.0"
 dotenv = ">=0.8, <0.11"
 quickcheck = "0.4"
-tempdir = "^0.3.4"
 
 [features]
 default = ["with-deprecated", "32-column-tables"]

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -31,7 +31,7 @@ libsqlite3-sys = { version = ">=0.8.0, <0.17.0", optional = true, features = ["m
 
 [dev-dependencies]
 difference = "1.0"
-tempdir = "0.3.4"
+tempfile = "3.0.0"
 regex = "0.2"
 url = { version = "2.1.0" }
 

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -466,11 +466,11 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), Box<d
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use database_error::DatabaseError;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
 
     use std::fs;
     use std::path::PathBuf;
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     fn toml_directory_find_cargo_toml() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
         let toml_path = temp_path.join("Cargo.toml");
 
@@ -494,7 +494,7 @@ mod tests {
 
     #[test]
     fn cargo_toml_not_found_if_no_cargo_toml() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
 
         assert_eq!(

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -6,7 +6,7 @@ extern crate url;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use tempfile::{Builder, TempDir};
 
 use super::command::TestCommand;
 
@@ -40,7 +40,7 @@ impl ProjectBuilder {
     }
 
     pub fn build(self) -> Project {
-        let tempdir = TempDir::new(&self.name).unwrap();
+        let tempdir = Builder::new().prefix(&self.name).tempdir().unwrap();
 
         File::create(tempdir.path().join("Cargo.toml")).unwrap();
 

--- a/diesel_cli/tests/tests.rs
+++ b/diesel_cli/tests/tests.rs
@@ -6,7 +6,7 @@ extern crate diesel;
 extern crate difference;
 extern crate migrations_internals;
 extern crate regex;
-extern crate tempdir;
+extern crate tempfile;
 
 mod completion_generation;
 mod database_drop;

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -11,7 +11,7 @@ diesel = { version = "~1.4.0", default-features = false }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
 
 [dev-dependencies]
-tempdir = "0.3.4"
+tempfile = "3.0.0"
 
 [features]
 default = []

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -391,16 +391,16 @@ pub fn search_for_migrations_directory(path: &Path) -> Result<PathBuf, Migration
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use super::*;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
     use std::fs;
 
     #[test]
     fn migration_directory_not_found_if_no_migration_dir_exists() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
 
         assert_eq!(
             Err(MigrationError::MigrationDirectoryNotFound),
@@ -410,7 +410,7 @@ mod tests {
 
     #[test]
     fn migration_directory_defaults_to_pwd_slash_migrations() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
         let migrations_path = temp_path.join("migrations");
 
@@ -424,7 +424,7 @@ mod tests {
 
     #[test]
     fn migration_directory_checks_parents() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let temp_path = dir.path().canonicalize().unwrap();
         let migrations_path = temp_path.join("migrations");
         let child_path = temp_path.join("child");

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -145,17 +145,17 @@ fn run_sql_from_file(conn: &dyn SimpleConnection, path: &Path) -> Result<(), Run
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
     use super::{valid_sql_migration_directory, version_from_path};
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
     use std::fs;
     use std::path::PathBuf;
 
     #[test]
     fn files_are_not_valid_sql_file_migrations() {
-        let dir = TempDir::new("diesel").unwrap();
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
         let file_path = dir.path().join("12345");
 
         fs::File::create(&file_path).unwrap();
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn directory_containing_exactly_up_sql_and_down_sql_is_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn directory_containing_unknown_files_is_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn files_beginning_with_dot_are_allowed() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn empty_directory_is_not_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn directory_with_only_up_sql_is_not_valid_migration_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         let folder = tempdir.path().join("12345");
 
         fs::create_dir(&folder).unwrap();

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -14,7 +14,7 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-tempdir = "0.3.4"
+tempfile = "3.0.0"
 
 [lib]
 proc-macro = true

--- a/diesel_migrations/migrations_macros/src/migrations.rs
+++ b/diesel_migrations/migrations_macros/src/migrations.rs
@@ -32,16 +32,16 @@ fn resolve_migrations_directory(
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::Builder;
     use super::resolve_migrations_directory;
     use std::fs;
     use std::path::Path;
 
     #[test]
     fn migrations_directory_resolved_relative_to_cargo_manifest_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/special_migrations")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo");
         let relative_path = Some(Path::new("special_migrations"));
@@ -58,7 +58,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_canonicalizes_result() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/migrations/bar")).unwrap();
         fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo/bar");
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_defaults_to_searching_migrations_path() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
         fs::create_dir_all(tempdir.path().join("foo/bar")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo/bar");
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_searches_src_migrations_if_present() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("foo/src/migrations")).unwrap();
         fs::create_dir_all(tempdir.path().join("foo/migrations")).unwrap();
         let cargo_manifest_dir = tempdir.path().join("foo");
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn migrations_directory_allows_no_parent_dir_for_cargo_manifest_dir() {
-        let tempdir = TempDir::new("diesel").unwrap();
+        let tempdir = Builder::new().prefix("diesel").tempdir().unwrap();
         fs::create_dir_all(tempdir.path().join("special_migrations")).unwrap();
         let cargo_manifest_dir = tempdir.path().to_owned();
         let relative_path = Some(Path::new("special_migrations"));


### PR DESCRIPTION
As can be read from the tempdir [README.md](https://github.com/rust-lang-deprecated/tempdir#deprecation-note), the crate has been deprecated after being merged into tempfile 3.0