### PR TITLE
Allow `unused_parens` temporarily

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -1,3 +1,4 @@
+#![allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
 #![cfg_attr(rustfmt, rustfmt_skip)] // https://github.com/rust-lang-nursery/rustfmt/issues/2755
 
 #[macro_export]

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -67,7 +67,7 @@ where
 impl<T, ST, DB> QueryFragment<DB> for ArrayLiteral<T, ST>
 where
     DB: Backend,
-    for<'a> (&'a T): QueryFragment<DB>,
+    for<'a> &'a T: QueryFragment<DB>,
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> ::result::QueryResult<()> {
         out.push_sql("ARRAY[");

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -1,3 +1,5 @@
+#![allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
+
 use super::{PgConnection, PgTypeMetadata};
 use prelude::*;
 

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -113,6 +113,7 @@ impl<DB> QueryId for dyn QueryFragment<DB> {
 }
 
 #[cfg(test)]
+#[allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
 mod tests {
     use std::any::TypeId;
 

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -126,7 +126,10 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         ("pending", Some(_)) => {
             let database_url = database::database_url(matches);
             let dir = migrations_dir(matches).unwrap_or_else(handle_error);
-            let result = call_with_conn!(database_url, migrations::any_pending_migrations_in_directory(&dir))?;
+            let result = call_with_conn!(
+                database_url,
+                migrations::any_pending_migrations_in_directory(&dir)
+            )?;
             println!("{:?}", result);
         }
         ("generate", Some(args)) => {

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -182,7 +182,10 @@ where
     any_pending_migrations_in_directory(conn, &migrations_dir)
 }
 
-pub fn any_pending_migrations_in_directory<Conn>(conn: &Conn, migrations_dir: &Path) -> Result<bool, RunMigrationsError>
+pub fn any_pending_migrations_in_directory<Conn>(
+    conn: &Conn,
+    migrations_dir: &Path,
+) -> Result<bool, RunMigrationsError>
 where
     Conn: MigrationConnection,
 {

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -1,5 +1,5 @@
-use schema::*;
 use diesel::*;
+use schema::*;
 
 #[test]
 fn belongs_to() {

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -1,4 +1,4 @@
-use super::schema::*;
+use schema::*;
 use diesel::*;
 
 #[test]
@@ -678,13 +678,13 @@ fn connection_with_fixture_data_for_multitable_joins() -> (TestConnection, TestD
         .order(posts::id)
         .load::<Post>(&connection)
         .unwrap();
-    let new_comments = vec![
+    let new_comments: &[NewComment<'static>] = &[
         NewComment(posts[0].id, "First Comment"),
         NewComment(posts[2].id, "Second Comment"),
         NewComment(posts[0].id, "Third Comment"),
     ];
     insert_into(comments::table)
-        .values(&new_comments)
+        .values(new_comments)
         .execute(&connection)
         .unwrap();
 


### PR DESCRIPTION
It's annoying on CI so we should allow this lint temporarily, I think.