### PR TITLE
Use migration directory during pending CLI command

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -125,7 +125,8 @@ fn run_migration_command(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         }
         ("pending", Some(_)) => {
             let database_url = database::database_url(matches);
-            let result = call_with_conn!(database_url, migrations::any_pending_migrations)?;
+            let dir = migrations_dir(matches).unwrap_or_else(handle_error);
+            let result = call_with_conn!(database_url, migrations::any_pending_migrations_in_directory(&dir))?;
             println!("{:?}", result);
         }
         ("generate", Some(args)) => {

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -179,6 +179,13 @@ where
     Conn: MigrationConnection,
 {
     let migrations_dir = find_migrations_directory()?;
+    any_pending_migrations_in_directory(conn, &migrations_dir)
+}
+
+pub fn any_pending_migrations_in_directory<Conn>(conn: &Conn, migrations_dir: &Path) -> Result<bool, RunMigrationsError>
+where
+    Conn: MigrationConnection,
+{
     let all_migrations = migrations_in_directory(&migrations_dir)?;
     setup_database(conn)?;
     let already_run = conn.previously_run_migration_versions()?;


### PR DESCRIPTION
The diesel_cli migration pending wasn't using the
`--migration-dir <MIGRATION_DIRECTORY>` option. We now use it at
parameter of any_pending_migrations in the CLI.