### PR TITLE
Fix an utf8 issue

### DIFF
--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -106,7 +106,7 @@ fn last_error_message(conn: *const PGconn) -> String {
     unsafe {
         let error_ptr = PQerrorMessage(conn);
         let bytes = CStr::from_ptr(error_ptr).to_bytes();
-        str::from_utf8_unchecked(bytes).to_string()
+        String::from_utf8_lossy(bytes).to_string()
     }
 }
 

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -59,6 +59,8 @@ impl<'a> PgResult<'a> {
         unsafe {
             let count_char_ptr = PQcmdTuples(self.internal_result.as_ptr());
             let count_bytes = CStr::from_ptr(count_char_ptr).to_bytes();
+            // Using from_utf8_unchecked is ok here because, we've set the
+            // client encoding to utf8
             let count_str = str::from_utf8_unchecked(count_bytes);
             match count_str {
                 "" => 0,

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -133,6 +133,7 @@ impl Drop for RawConnection {
 fn convert_to_string_and_free(err_msg: *const libc::c_char) -> String {
     let msg = unsafe {
         let bytes = CStr::from_ptr(err_msg).to_bytes();
+        // sqlite is documented to return utf8 strings here
         str::from_utf8_unchecked(bytes).into()
     };
     unsafe { ffi::sqlite3_free(err_msg as *mut libc::c_void) };

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -35,6 +35,8 @@ impl SqliteValue {
             let ptr = ffi::sqlite3_value_text(self.value());
             let len = ffi::sqlite3_value_bytes(self.value());
             let bytes = slice::from_raw_parts(ptr as *const u8, len as usize);
+            // The string is guaranteed to be utf8 according to
+            // https://www.sqlite.org/c3ref/value_blob.html
             str::from_utf8_unchecked(bytes)
         }
     }


### PR DESCRIPTION
It was possible to reach `last_error_message` before we set the client
encoding to utf8. If there is some other default client encoding set,
this could lead to an corrupted string violating rust gurantees about
strings always being utf8.

Additionally I've checked the codebase for other occurrences of
`from_utf8_unchecked` and added comments there why they are
fine. Having a second (or third) look at them would be helpful.