### PR TITLE
Remove unused metadata field from `PgValue`

### DIFF
--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -9,15 +9,15 @@ use std::marker::PhantomData;
 
 /// The type returned by various [`Connection`](struct.Connection.html) methods.
 /// Acts as an iterator over `T`.
-pub struct Cursor<'a, ST, T> {
+pub struct Cursor<ST, T> {
     current_row: usize,
-    db_result: PgResult<'a>,
+    db_result: PgResult,
     _marker: PhantomData<(ST, T)>,
 }
 
-impl<'a, ST, T> Cursor<'a, ST, T> {
+impl<ST, T> Cursor<ST, T> {
     #[doc(hidden)]
-    pub fn new(db_result: PgResult<'a>) -> Self {
+    pub fn new(db_result: PgResult) -> Self {
         Cursor {
             current_row: 0,
             db_result,
@@ -26,7 +26,7 @@ impl<'a, ST, T> Cursor<'a, ST, T> {
     }
 }
 
-impl<'a, ST, T> Iterator for Cursor<'a, ST, T>
+impl<ST, T> Iterator for Cursor<ST, T>
 where
     T: Queryable<ST, Pg>,
 {
@@ -46,12 +46,12 @@ where
     }
 }
 
-pub struct NamedCursor<'a> {
-    pub(crate) db_result: PgResult<'a>,
+pub struct NamedCursor {
+    pub(crate) db_result: PgResult,
 }
 
-impl<'a> NamedCursor<'a> {
-    pub fn new(db_result: PgResult<'a>) -> Self {
+impl NamedCursor {
+    pub fn new(db_result: PgResult) -> Self {
         NamedCursor { db_result }
     }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -38,7 +38,7 @@ impl SimpleConnection for PgConnection {
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
         let query = CString::new(query)?;
         let inner_result = unsafe { self.raw_connection.exec(query.as_ptr()) };
-        PgResult::new(inner_result?, self)?;
+        PgResult::new(inner_result?)?;
         Ok(())
     }
 }

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -8,25 +8,20 @@ use std::{slice, str};
 
 use super::raw::RawResult;
 use super::row::PgRow;
-use pg::PgConnection;
 use result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
 
-pub struct PgResult<'a> {
+pub struct PgResult {
     internal_result: RawResult,
-    pub(crate) connection: &'a PgConnection,
 }
 
-impl<'a> PgResult<'a> {
+impl PgResult {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(internal_result: RawResult, connection: &'a PgConnection) -> QueryResult<Self> {
+    pub fn new(internal_result: RawResult) -> QueryResult<Self> {
         use self::ExecStatusType::*;
 
         let result_status = unsafe { PQresultStatus(internal_result.as_ptr()) };
         match result_status {
-            PGRES_COMMAND_OK | PGRES_TUPLES_OK => Ok(PgResult {
-                internal_result,
-                connection,
-            }),
+            PGRES_COMMAND_OK | PGRES_TUPLES_OK => Ok(PgResult { internal_result }),
             PGRES_EMPTY_QUERY => {
                 let error_message = "Received an empty query".to_string();
                 Err(Error::DatabaseError(

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -1,10 +1,10 @@
 use super::cursor::NamedCursor;
 use super::result::PgResult;
-use pg::{Pg, PgMetadataLookup, PgValue};
+use pg::{Pg, PgValue};
 use row::*;
 
 pub struct PgRow<'a> {
-    db_result: &'a PgResult<'a>,
+    db_result: &'a PgResult,
     row_idx: usize,
     col_idx: usize,
 }
@@ -25,11 +25,7 @@ impl<'a> Row<Pg> for PgRow<'a> {
         self.col_idx += 1;
         let raw = self.db_result.get(self.row_idx, current_idx)?;
 
-        Some(PgValue::new(
-            raw,
-            self.db_result.column_type(current_idx),
-            PgMetadataLookup::new(self.db_result.connection),
-        ))
+        Some(PgValue::new(raw, self.db_result.column_type(current_idx)))
     }
 
     fn next_is_null(&self, count: usize) -> bool {
@@ -38,7 +34,7 @@ impl<'a> Row<Pg> for PgRow<'a> {
 }
 
 pub struct PgNamedRow<'a> {
-    cursor: &'a NamedCursor<'a>,
+    cursor: &'a NamedCursor,
     idx: usize,
 }
 
@@ -51,11 +47,7 @@ impl<'a> PgNamedRow<'a> {
 impl<'a> NamedRow<Pg> for PgNamedRow<'a> {
     fn get_raw_value(&self, index: usize) -> Option<PgValue<'_>> {
         let raw = self.cursor.get_value(self.idx, index)?;
-        Some(PgValue::new(
-            raw,
-            self.cursor.db_result.column_type(index),
-            PgMetadataLookup::new(self.cursor.db_result.connection),
-        ))
+        Some(PgValue::new(raw, self.cursor.db_result.column_type(index)))
     }
 
     fn index_of(&self, column_name: &str) -> Option<usize> {

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -17,11 +17,11 @@ pub struct Statement {
 
 impl Statement {
     #[allow(clippy::ptr_arg)]
-    pub fn execute<'a>(
+    pub fn execute(
         &self,
-        conn: &'a PgConnection,
+        conn: &PgConnection,
         param_data: &Vec<Option<Vec<u8>>>,
-    ) -> QueryResult<PgResult<'a>> {
+    ) -> QueryResult<PgResult> {
         let params_pointer = param_data
             .iter()
             .map(|data| {
@@ -45,7 +45,7 @@ impl Statement {
             )
         };
 
-        PgResult::new(internal_res?, conn)
+        PgResult::new(internal_res?)
     }
 
     #[allow(clippy::ptr_arg)]
@@ -67,7 +67,7 @@ impl Statement {
                 param_types_to_ptr(Some(&param_types_vec)),
             )
         };
-        PgResult::new(internal_result?, conn)?;
+        PgResult::new(internal_result?)?;
 
         Ok(Statement {
             name,

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -49,11 +49,7 @@ where
                 } else {
                     let (elem_bytes, new_bytes) = bytes.split_at(elem_size as usize);
                     bytes = new_bytes;
-                    T::from_sql(Some(PgValue::new(
-                        elem_bytes,
-                        value.get_oid(),
-                        value.get_metadata_lookup(),
-                    )))
+                    T::from_sql(Some(PgValue::new(elem_bytes, value.get_oid())))
                 }
             })
             .collect()

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -89,11 +89,7 @@ where
             let elem_size = bytes.read_i32::<NetworkEndian>()?;
             let (elem_bytes, new_bytes) = bytes.split_at(elem_size as usize);
             bytes = new_bytes;
-            let value = T::from_sql(Some(PgValue::new(
-                elem_bytes,
-                value.get_oid(),
-                value.get_metadata_lookup(),
-            )))?;
+            let value = T::from_sql(Some(PgValue::new(elem_bytes, value.get_oid())))?;
 
             lower_bound = if flags.contains(RangeFlags::LB_INC) {
                 Bound::Included(value)
@@ -104,11 +100,7 @@ where
 
         if !flags.contains(RangeFlags::UB_INF) {
             let _size = bytes.read_i32::<NetworkEndian>()?;
-            let value = T::from_sql(Some(PgValue::new(
-                bytes,
-                value.get_oid(),
-                value.get_metadata_lookup(),
-            )))?;
+            let value = T::from_sql(Some(PgValue::new(bytes, value.get_oid())))?;
 
             upper_bound = if flags.contains(RangeFlags::UB_INC) {
                 Bound::Included(value)

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -54,7 +54,6 @@ macro_rules! tuple_impls {
                         $T::from_sql(Some(PgValue::new(
                             elem_bytes,
                             oid,
-                            value.get_metadata_lookup()
                         )))?
                     }
                 },)+);

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -1,4 +1,4 @@
-use super::{Pg, PgMetadataLookup};
+use super::Pg;
 use backend::BinaryRawValue;
 use std::num::NonZeroU32;
 use std::ops::Range;
@@ -9,7 +9,6 @@ use std::ops::Range;
 pub struct PgValue<'a> {
     raw_value: &'a [u8],
     type_oid: NonZeroU32,
-    metadata: Option<&'a PgMetadataLookup>,
 }
 
 impl<'a> BinaryRawValue<'a> for Pg {
@@ -24,19 +23,13 @@ impl<'a> PgValue<'a> {
         Self {
             raw_value,
             type_oid: NonZeroU32::new(42).unwrap(),
-            metadata: None,
         }
     }
 
-    pub(crate) fn new(
-        raw_value: &'a [u8],
-        type_oid: NonZeroU32,
-        metadata: &'a PgMetadataLookup,
-    ) -> Self {
+    pub(crate) fn new(raw_value: &'a [u8], type_oid: NonZeroU32) -> Self {
         Self {
             raw_value,
             type_oid,
-            metadata: Some(metadata),
         }
     }
 
@@ -48,11 +41,6 @@ impl<'a> PgValue<'a> {
     /// Get the type oid of this value
     pub fn get_oid(&self) -> NonZeroU32 {
         self.type_oid
-    }
-
-    /// Get a instance for type lookup
-    pub fn get_metadata_lookup(&self) -> &PgMetadataLookup {
-        self.metadata.expect("It's only not there for tests")
     }
 
     pub(crate) fn subslice(&self, range: Range<usize>) -> Self {


### PR DESCRIPTION
This was originally included in #2134 with the following comment:

> Additionally some type information are added to the postgresql value
> type. Those information may allow to do dynamic type conversations in
> future diesel versions.

While this may be useful in the future, we should wait until we have a
concrete use case for doing so. At the moment this means we have to
thread a `PgConnection` through various types that otherwise wouldn't
need to carry it, and are stabilizing an API that we aren't even sure
if/how we want to eventually use. Given that every use of `PgConnection`
complicates providing an async implementation, we should be more
conservative about speculative APIs like this.