### PR TITLE
Allow to specialize `FromSql<Text>` impl for strings

### DIFF
--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -120,11 +120,25 @@ where
 /// impl in terms of `String`, but don't want to allocate. We have to return a
 /// raw pointer instead of a reference with a lifetime due to the structure of
 /// `FromSql`
+#[cfg(not(feature = "unstable"))]
 impl<DB> FromSql<sql_types::Text, DB> for *const str
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
     fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+        use std::str;
+        let value = not_none!(value);
+        let string = str::from_utf8(DB::as_bytes(value))?;
+        Ok(string as *const _)
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl<DB> FromSql<sql_types::Text, DB> for *const str
+where
+    DB: Backend + for<'a> BinaryRawValue<'a>,
+{
+    default fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         use std::str;
         let value = not_none!(value);
         let string = str::from_utf8(DB::as_bytes(value))?;


### PR DESCRIPTION
Again Oracle/liboci is strange… (It's nearly UTF-8, but with more `\0` 😱 )