### PR TITLE
Migrate the main crate to the 2018 edition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 ### Added
 
 * `NonAggregate` can now be derived for simple cases.
+
 * `Connection` and `SimpleConnection` traits are implemented for a broader range
   of `r2d2::PooledConnection<M>` types when the `r2d2` feature is enabled.
 
@@ -18,14 +19,13 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * All expression methods can now be called on expressions of nullable types.
 
 * Added `BoxedSqlQuery`. This allows users to do a variable amount of `.sql` or
-
   `.bind` calls without changing the underlying type.
 
 * Added `.sql` to `SqlQuery` and `UncheckedBind` to allow appending SQL code to
-
   an existing query.
 
-
+* The `MacAddr` SQL type can now be used without enabling the `network-address`
+  feature.
 
 ### Removed
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel"
 keywords = ["orm", "database", "blockchain", "sql"]
 categories = ["database"]
+edition = "2018"
 
 [dependencies]
 byteorder = "1.0"

--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -1,9 +1,9 @@
 use super::{HasTable, Identifiable};
-use dsl::{Eq, EqAny, Filter, FindBy};
-use expression::array_comparison::AsInExpression;
-use expression::AsExpression;
-use prelude::*;
-use query_dsl::methods::FilterDsl;
+use crate::dsl::{Eq, EqAny, Filter, FindBy};
+use crate::expression::array_comparison::AsInExpression;
+use crate::expression::AsExpression;
+use crate::prelude::*;
+use crate::query_dsl::methods::FilterDsl;
 
 use std::borrow::Borrow;
 use std::hash::Hash;

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -31,7 +31,7 @@
 //! #
 //! # fn run_test() -> QueryResult<()> {
 //! #     let connection = establish_connection();
-//! #     use users::dsl::*;
+//! #     use self::users::dsl::*;
 //! let user = users.find(2).get_result::<User>(&connection)?;
 //! let users_post = Post::belonging_to(&user)
 //!     .first(&connection)?;
@@ -118,7 +118,7 @@
 //! # }
 //! #
 //! # fn main() {
-//! #   use users::dsl::*;
+//! #   use self::users::dsl::*;
 //! #   let connection = establish_connection();
 //! #
 //! let user = users.find(1).first::<User>(&connection).expect("Error loading user");
@@ -178,8 +178,8 @@
 //! #
 //! # fn run_test() -> QueryResult<()> {
 //! #     let connection = establish_connection();
-//! #     use users::dsl::*;
-//! #     use posts::dsl::{posts, title};
+//! #     use self::users::dsl::*;
+//! #     use self::posts::dsl::{posts, title};
 //! let sean = users.filter(name.eq("Sean")).first::<User>(&connection)?;
 //! let tess = users.filter(name.eq("Tess")).first::<User>(&connection)?;
 //!
@@ -357,7 +357,7 @@ mod belongs_to;
 
 use std::hash::Hash;
 
-use query_source::Table;
+use crate::query_source::Table;
 
 pub use self::belongs_to::{BelongsTo, GroupedBy};
 

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -2,9 +2,9 @@
 
 use byteorder::ByteOrder;
 
-use query_builder::bind_collector::BindCollector;
-use query_builder::QueryBuilder;
-use sql_types::{self, HasSqlType};
+use crate::query_builder::bind_collector::BindCollector;
+use crate::query_builder::QueryBuilder;
+use crate::sql_types::{self, HasSqlType};
 
 /// A database backend
 ///

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -5,11 +5,11 @@ mod transaction_manager;
 
 use std::fmt::Debug;
 
-use backend::Backend;
-use deserialize::{Queryable, QueryableByName};
-use query_builder::{AsQuery, QueryFragment, QueryId};
-use result::*;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::result::*;
+use crate::sql_types::HasSqlType;
 
 #[doc(hidden)]
 pub use self::statement_cache::{MaybeCached, StatementCache, StatementCacheKey};

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -98,9 +98,9 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -1,6 +1,6 @@
-use backend::UsesAnsiSavepointSyntax;
-use connection::{Connection, SimpleConnection};
-use result::QueryResult;
+use crate::backend::UsesAnsiSavepointSyntax;
+use crate::connection::{Connection, SimpleConnection};
+use crate::result::QueryResult;
 
 /// Manages the internal transaction state for a connection.
 ///
@@ -68,7 +68,7 @@ impl AnsiTransactionManager {
     where
         Conn: SimpleConnection,
     {
-        use result::Error::AlreadyInTransaction;
+        use crate::result::Error::AlreadyInTransaction;
 
         if self.transaction_depth.get() == 0 {
             self.change_transaction_depth(1, conn.batch_execute(sql))

--- a/diesel/src/data_types.rs
+++ b/diesel/src/data_types.rs
@@ -4,4 +4,4 @@
 //! all backend specific data structures when compiled against that
 //! backend.
 #[cfg(feature = "postgres")]
-pub use pg::data_types::*;
+pub use crate::pg::data_types::*;

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -3,8 +3,8 @@
 use std::error::Error;
 use std::result;
 
-use backend::{self, Backend};
-use row::{NamedRow, Row};
+use crate::backend::{self, Backend};
+use crate::row::{NamedRow, Row};
 
 /// A specialized result type representing the result of deserializing
 /// a value from the database.

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::subselect::Subselect;
-use expression::*;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Bool;
+use crate::backend::Backend;
+use crate::expression::subselect::Subselect;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
 
 #[derive(Debug, Copy, Clone, QueryId, NonAggregate)]
 pub struct In<T, U> {
@@ -92,7 +92,7 @@ where
 impl_selectable_expression!(In<T, U>);
 impl_selectable_expression!(NotIn<T, U>);
 
-use query_builder::{BoxedSelectStatement, SelectStatement};
+use crate::query_builder::{BoxedSelectStatement, SelectStatement};
 
 pub trait AsInExpression<T> {
     type InExpression: MaybeEmpty + Expression<SqlType = T>;

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -1,11 +1,11 @@
 use std::marker::PhantomData;
 
 use super::*;
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
-use serialize::ToSql;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::serialize::ToSql;
+use crate::sql_types::HasSqlType;
 
 #[derive(Debug, Clone, Copy, DieselNumericOps)]
 pub struct Bound<T, U> {

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use expression::*;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone, QueryId, DieselNumericOps)]
 #[doc(hidden)]

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,8 +1,8 @@
 use super::Expression;
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::BigInt;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::BigInt;
 
 sql_function! {
     /// Creates a SQL `COUNT` expression

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::subselect::Subselect;
-use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Bool;
+use crate::backend::Backend;
+use crate::expression::subselect::Subselect;
+use crate::expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
 
 /// Creates a SQL `EXISTS` expression.
 ///

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,4 +1,4 @@
-use sql_types::Foldable;
+use crate::sql_types::Foldable;
 
 sql_function! {
     /// Represents a SQL `SUM` function. This function can only take types which are
@@ -47,7 +47,7 @@ sql_function! {
     /// # #[cfg(all(feature = "numeric", any(feature = "postgres", not(feature = "sqlite"))))]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use bigdecimal::BigDecimal;
-    /// #     use numbers::dsl::*;
+    /// #     use self::numbers::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("DROP TABLE IF EXISTS numbers")?;
     /// #     conn.execute("CREATE TABLE numbers (number INTEGER)")?;

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,4 +1,4 @@
-use sql_types::{IntoNullable, SqlOrd};
+use crate::sql_types::{IntoNullable, SqlOrd};
 
 sql_function! {
     /// Represents a SQL `MAX` function. This function can only take types which are

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::coerce::Coerce;
-use expression::{AsExpression, Expression};
-use query_builder::*;
-use result::QueryResult;
-use sql_types::*;
+use crate::backend::Backend;
+use crate::expression::coerce::Coerce;
+use crate::expression::{AsExpression, Expression};
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::*;
 
 /// Represents the SQL `CURRENT_TIMESTAMP` constant. This is equivalent to the
 /// `NOW()` function on backends that support it.

--- a/diesel/src/expression/functions/helper_types.rs
+++ b/diesel/src/expression/functions/helper_types.rs
@@ -1,9 +1,9 @@
 #![allow(non_camel_case_types)]
 
-use dsl::{AsExprOf, SqlTypeOf};
-use expression::grouped::Grouped;
-use expression::operators;
-use sql_types::Bool;
+use crate::dsl::{AsExprOf, SqlTypeOf};
+use crate::expression::grouped::Grouped;
+use crate::expression::operators;
+use crate::sql_types::Bool;
 
 /// The return type of [`not(expr)`](../dsl/fn.not.html)
 pub type not<Expr> = operators::Not<Grouped<AsExprOf<Expr, Bool>>>;

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -1,7 +1,7 @@
-use backend::Backend;
-use expression::Expression;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::Expression;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone, QueryId, Default, DieselNumericOps, NonAggregate)]
 pub struct Grouped<T>(pub T);

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -4,7 +4,7 @@
 use super::array_comparison::{AsInExpression, In, NotIn};
 use super::grouped::Grouped;
 use super::{AsExpression, Expression};
-use sql_types;
+use crate::sql_types;
 
 /// The SQL type of an expression
 pub type SqlTypeOf<Expr> = <Expr as Expression>::SqlType;

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -49,7 +49,7 @@ pub mod subselect;
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 pub mod dsl {
-    use dsl::SqlTypeOf;
+    use crate::dsl::SqlTypeOf;
 
     #[doc(inline)]
     pub use super::count::*;
@@ -67,7 +67,7 @@ pub mod dsl {
     pub use super::sql_literal::sql;
 
     #[cfg(feature = "postgres")]
-    pub use pg::expression::dsl::*;
+    pub use crate::pg::expression::dsl::*;
 
     /// The return type of [`count(expr)`](../dsl/fn.count.html)
     pub type count<Expr> = super::count::count::HelperType<SqlTypeOf<Expr>, Expr>;
@@ -82,8 +82,8 @@ pub mod dsl {
 #[doc(inline)]
 pub use self::sql_literal::{SqlLiteral, UncheckedBind};
 
-use backend::Backend;
-use dsl::AsExprOf;
+use crate::backend::Backend;
+use crate::dsl::AsExprOf;
 
 /// Represents a typed fragment of SQL.
 ///
@@ -291,7 +291,7 @@ impl<T: NonAggregate + ?Sized> NonAggregate for Box<T> {}
 
 impl<'a, T: NonAggregate + ?Sized> NonAggregate for &'a T {}
 
-use query_builder::{QueryFragment, QueryId};
+use crate::query_builder::{QueryFragment, QueryId};
 
 /// Helper trait used when boxing expressions.
 ///

--- a/diesel/src/expression/not.rs
+++ b/diesel/src/expression/not.rs
@@ -1,7 +1,7 @@
-use expression::grouped::Grouped;
-use expression::AsExpression;
-use helper_types::not;
-use sql_types::Bool;
+use crate::expression::grouped::Grouped;
+use crate::expression::AsExpression;
+use crate::helper_types::not;
+use crate::sql_types::Bool;
 
 /// Creates a SQL `NOT` expression
 ///

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::*;
-use query_builder::*;
-use query_source::Table;
-use result::QueryResult;
-use sql_types::IntoNullable;
+use crate::backend::Backend;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::query_source::Table;
+use crate::result::QueryResult;
+use crate::sql_types::IntoNullable;
 
 #[derive(Debug, Copy, Clone, DieselNumericOps, NonAggregate)]
 pub struct Nullable<T>(T);

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -380,9 +380,9 @@ postfix_operator!(Desc, " DESC", ());
 
 prefix_operator!(Not, "NOT ");
 
-use insertable::{ColumnInsertValue, Insertable};
-use query_builder::ValuesClause;
-use query_source::Column;
+use crate::insertable::{ColumnInsertValue, Insertable};
+use crate::query_builder::ValuesClause;
+use crate::query_source::Column;
 
 impl<T, U> Insertable<T::Table> for Eq<T, U>
 where
@@ -420,23 +420,23 @@ impl<L, R> Concat<L, R> {
     }
 }
 
-impl<L, R, ST> ::expression::Expression for Concat<L, R>
+impl<L, R, ST> crate::expression::Expression for Concat<L, R>
 where
-    L: ::expression::Expression<SqlType = ST>,
-    R: ::expression::Expression<SqlType = ST>,
+    L: crate::expression::Expression<SqlType = ST>,
+    R: crate::expression::Expression<SqlType = ST>,
 {
     type SqlType = ST;
 }
 
 impl_selectable_expression!(Concat<L, R>);
 
-impl<L, R, DB> ::query_builder::QueryFragment<DB> for Concat<L, R>
+impl<L, R, DB> crate::query_builder::QueryFragment<DB> for Concat<L, R>
 where
-    L: ::query_builder::QueryFragment<DB>,
-    R: ::query_builder::QueryFragment<DB>,
-    DB: ::backend::Backend,
+    L: crate::query_builder::QueryFragment<DB>,
+    R: crate::query_builder::QueryFragment<DB>,
+    DB: crate::backend::Backend,
 {
-    fn walk_ast(&self, mut out: ::query_builder::AstPass<DB>) -> ::result::QueryResult<()> {
+    fn walk_ast(&self, mut out: crate::query_builder::AstPass<DB>) -> crate::result::QueryResult<()> {
         // Those brackets are required because mysql is broken
         // https://github.com/diesel-rs/diesel/issues/2133#issuecomment-517432317
         out.push_sql("(");

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -436,7 +436,10 @@ where
     R: crate::query_builder::QueryFragment<DB>,
     DB: crate::backend::Backend,
 {
-    fn walk_ast(&self, mut out: crate::query_builder::AstPass<DB>) -> crate::result::QueryResult<()> {
+    fn walk_ast(
+        &self,
+        mut out: crate::query_builder::AstPass<DB>,
+    ) -> crate::result::QueryResult<()> {
         // Those brackets are required because mysql is broken
         // https://github.com/diesel-rs/diesel/issues/2133#issuecomment-517432317
         out.push_sql("(");

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -1,8 +1,8 @@
-use backend::Backend;
-use expression::{Expression, NonAggregate};
-use query_builder::*;
-use result::QueryResult;
-use sql_types;
+use crate::backend::Backend;
+use crate::expression::{Expression, NonAggregate};
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types;
 
 macro_rules! numeric_operation {
     ($name:ident, $op:expr) => {

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use expression::*;
-use query_builder::*;
-use query_dsl::RunQueryDsl;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::query_dsl::RunQueryDsl;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, DieselNumericOps)]
 #[must_use = "Queries are only executed when calling `load`, `get_result`, or similar."]

--- a/diesel/src/expression/subselect.rs
+++ b/diesel/src/expression/subselect.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use expression::array_comparison::MaybeEmpty;
-use expression::*;
-use query_builder::*;
-use result::QueryResult;
+use crate::expression::array_comparison::MaybeEmpty;
+use crate::expression::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone, QueryId)]
 pub struct Subselect<T, ST> {

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -1,7 +1,7 @@
-use expression::grouped::Grouped;
-use expression::operators::{And, Or};
-use expression::{AsExpression, Expression};
-use sql_types::{Bool, Nullable};
+use crate::expression::grouped::Grouped;
+use crate::expression::operators::{And, Or};
+use crate::expression::{AsExpression, Expression};
+use crate::sql_types::{Bool, Nullable};
 
 /// Methods present on boolean expressions
 pub trait BoolExpressionMethods: Expression + Sized {

--- a/diesel/src/expression_methods/eq_all.rs
+++ b/diesel/src/expression_methods/eq_all.rs
@@ -1,7 +1,7 @@
-use expression::operators::And;
-use expression::Expression;
-use expression_methods::*;
-use sql_types::Bool;
+use crate::expression::operators::And;
+use crate::expression::Expression;
+use crate::expression_methods::*;
+use crate::sql_types::Bool;
 
 /// This method is used by `FindDsl` to work with tuples. Because we cannot
 /// express this without specialization or overlapping impls, it is brute force

--- a/diesel/src/expression_methods/escape_expression_methods.rs
+++ b/diesel/src/expression_methods/escape_expression_methods.rs
@@ -1,7 +1,7 @@
-use dsl::AsExprOf;
-use expression::operators::{Escape, Like, NotLike};
-use expression::IntoSql;
-use sql_types::VarChar;
+use crate::dsl::AsExprOf;
+use crate::expression::operators::{Escape, Like, NotLike};
+use crate::expression::IntoSql;
+use crate::sql_types::VarChar;
 
 /// Adds the `escape` method to `LIKE` and `NOT LIKE`. This is used to specify
 /// the escape character for the pattern.

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -1,7 +1,7 @@
-use expression::array_comparison::{AsInExpression, In, NotIn};
-use expression::operators::*;
-use expression::{nullable, AsExpression, Expression};
-use sql_types::SingleValue;
+use crate::expression::array_comparison::{AsInExpression, In, NotIn};
+use crate::expression::operators::*;
+use crate::expression::{nullable, AsExpression, Expression};
+use crate::sql_types::SingleValue;
 
 /// Methods present on all expressions, except tuples
 pub trait ExpressionMethods: Expression + Sized {

--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -23,4 +23,4 @@ pub use self::text_expression_methods::TextExpressionMethods;
 
 #[cfg(feature = "postgres")]
 #[doc(inline)]
-pub use pg::expression::expression_methods::*;
+pub use crate::pg::expression::expression_methods::*;

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -1,6 +1,6 @@
-use expression::operators::{Concat, Like, NotLike};
-use expression::{AsExpression, Expression};
-use sql_types::{Nullable, Text};
+use crate::expression::operators::{Concat, Like, NotLike};
+use crate::expression::{AsExpression, Expression};
+use crate::sql_types::{Nullable, Text};
 
 /// Methods present on text expressions
 pub trait TextExpressionMethods: Expression + Sized {

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -1,14 +1,14 @@
 use std::marker::PhantomData;
 
-use backend::{Backend, SupportsDefaultKeyword};
-use expression::{AppearsOnTable, Expression};
-use query_builder::{
+use crate::backend::{Backend, SupportsDefaultKeyword};
+use crate::expression::{AppearsOnTable, Expression};
+use crate::query_builder::{
     AstPass, InsertStatement, QueryFragment, UndecoratedInsertRecord, ValuesClause,
 };
-use query_source::{Column, Table};
-use result::QueryResult;
+use crate::query_source::{Column, Table};
+use crate::result::QueryResult;
 #[cfg(feature = "sqlite")]
-use sqlite::Sqlite;
+use crate::sqlite::Sqlite;
 
 /// Represents that a structure can be used to insert a new row into the
 /// database. This is automatically implemented for `&[T]` and `&Vec<T>` for
@@ -82,7 +82,7 @@ pub trait Insertable<T> {
     where
         Self: Sized,
     {
-        ::insert_into(table).values(self)
+        crate::insert_into(table).values(self)
     }
 }
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -181,13 +181,13 @@ pub mod dsl {
     //! generically to be included in prelude, but are often used when using Diesel.
 
     #[doc(inline)]
-    pub use helper_types::*;
+    pub use crate::helper_types::*;
 
     #[doc(inline)]
-    pub use expression::dsl::*;
+    pub use crate::expression::dsl::*;
 
     #[doc(inline)]
-    pub use query_builder::functions::{
+    pub use crate::query_builder::functions::{
         delete, insert_into, insert_or_ignore_into, replace_into, select, sql_query, update,
     };
 }
@@ -209,7 +209,7 @@ pub mod helper_types {
     use super::query_source::joins;
 
     #[doc(inline)]
-    pub use expression::helper_types::*;
+    pub use crate::expression::helper_types::*;
 
     /// Represents the return type of `.select(selection)`
     pub type Select<Source, Selection> = <Source as SelectDsl<Selection>>::Output;
@@ -292,42 +292,42 @@ pub mod helper_types {
 
 pub mod prelude {
     //! Re-exports important traits and types. Meant to be glob imported when using Diesel.
-    pub use associations::{GroupedBy, Identifiable};
-    pub use connection::Connection;
+    pub use crate::associations::{GroupedBy, Identifiable};
+    pub use crate::connection::Connection;
     #[deprecated(
         since = "1.1.0",
         note = "Explicitly `use diesel::deserialize::Queryable"
     )]
-    pub use deserialize::Queryable;
-    pub use expression::{
+    pub use crate::deserialize::Queryable;
+    pub use crate::expression::{
         AppearsOnTable, BoxableExpression, Expression, IntoSql, SelectableExpression,
     };
-    pub use expression_methods::*;
+    pub use crate::expression_methods::*;
     #[doc(inline)]
-    pub use insertable::Insertable;
+    pub use crate::insertable::Insertable;
     #[doc(hidden)]
-    pub use query_dsl::GroupByDsl;
-    pub use query_dsl::{BelongingToDsl, JoinOnDsl, QueryDsl, RunQueryDsl, SaveChangesDsl};
+    pub use crate::query_dsl::GroupByDsl;
+    pub use crate::query_dsl::{BelongingToDsl, JoinOnDsl, QueryDsl, RunQueryDsl, SaveChangesDsl};
 
-    pub use query_source::{Column, JoinTo, QuerySource, Table};
-    pub use result::{ConnectionError, ConnectionResult, OptionalExtension, QueryResult};
+    pub use crate::query_source::{Column, JoinTo, QuerySource, Table};
+    pub use crate::result::{ConnectionError, ConnectionResult, OptionalExtension, QueryResult};
 
     #[cfg(feature = "mysql")]
-    pub use mysql::MysqlConnection;
+    pub use crate::mysql::MysqlConnection;
     #[cfg(feature = "postgres")]
-    pub use pg::PgConnection;
+    pub use crate::pg::PgConnection;
     #[cfg(feature = "sqlite")]
-    pub use sqlite::SqliteConnection;
+    pub use crate::sqlite::SqliteConnection;
 }
 
-pub use prelude::*;
+pub use crate::prelude::*;
 #[doc(inline)]
-pub use query_builder::debug_query;
+pub use crate::query_builder::debug_query;
 #[doc(inline)]
-pub use query_builder::functions::{
+pub use crate::query_builder::functions::{
     delete, insert_into, insert_or_ignore_into, replace_into, select, sql_query, update,
 };
-pub use result::Error::NotFound;
+pub use crate::result::Error::NotFound;
 
 pub(crate) mod diesel {
     pub use super::*;

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -162,17 +162,17 @@ macro_rules! __diesel_column {
 /// which types to import.
 ///
 /// ```
-/// #[macro_use] extern crate diesel;
-/// # /*
-/// extern crate diesel_full_text_search;
-/// # */
+/// # #[macro_use] extern crate diesel;
 /// # mod diesel_full_text_search {
 /// #     pub struct TsVector;
 /// # }
 ///
 /// table! {
 ///     use diesel::sql_types::*;
+/// #    use crate::diesel_full_text_search::*;
+/// # /*
 ///     use diesel_full_text_search::*;
+/// # */
 ///
 ///     posts {
 ///         id -> Integer,
@@ -1069,7 +1069,7 @@ mod tuples;
 
 #[cfg(test)]
 mod tests {
-    use prelude::*;
+    use crate::prelude::*;
 
     table! {
         foo.bars {
@@ -1084,8 +1084,8 @@ mod tests {
     }
 
     table! {
-        use sql_types::*;
-        use macros::tests::my_types::*;
+        use crate::sql_types::*;
+        use crate::macros::tests::my_types::*;
 
         table_with_custom_types {
             id -> Integer,
@@ -1094,8 +1094,8 @@ mod tests {
     }
 
     table! {
-        use sql_types::*;
-        use macros::tests::my_types::*;
+        use crate::sql_types::*;
+        use crate::macros::tests::my_types::*;
 
         /// Table documentation
         ///
@@ -1112,17 +1112,17 @@ mod tests {
     #[test]
     #[cfg(feature = "postgres")]
     fn table_with_custom_schema() {
-        use pg::Pg;
+        use crate::pg::Pg;
         let expected_sql = r#"SELECT "foo"."bars"."baz" FROM "foo"."bars" -- binds: []"#;
         assert_eq!(
             expected_sql,
-            &::debug_query::<Pg, _>(&bars::table.select(bars::baz)).to_string()
+            &crate::debug_query::<Pg, _>(&bars::table.select(bars::baz)).to_string()
         );
     }
 
     table! {
-        use sql_types;
-        use sql_types::*;
+        use crate::sql_types;
+        use crate::sql_types::*;
 
         table_with_arbitrarily_complex_types {
             id -> sql_types::Integer,
@@ -1153,41 +1153,41 @@ mod tests {
     #[test]
     #[cfg(feature = "postgres")]
     fn table_with_column_renaming_postgres() {
-        use pg::Pg;
+        use crate::pg::Pg;
         let expected_sql =
             r#"SELECT "foo"."id", "foo"."type", "foo"."bleh" FROM "foo" WHERE "foo"."type" = $1 -- binds: [1]"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Pg, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
+            crate::debug_query::<Pg, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "mysql")]
     fn table_with_column_renaming_mysql() {
-        use mysql::Mysql;
+        use crate::mysql::Mysql;
         let expected_sql =
             r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Mysql, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
+            crate::debug_query::<Mysql, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "sqlite")]
     fn table_with_column_renaming_sqlite() {
-        use sqlite::Sqlite;
+        use crate::sqlite::Sqlite;
         let expected_sql =
             r#"SELECT `foo`.`id`, `foo`.`type`, `foo`.`bleh` FROM `foo` WHERE `foo`.`type` = ? -- binds: [1]"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Sqlite, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
+            crate::debug_query::<Sqlite, _>(&foo::table.filter(foo::mytype.eq(1))).to_string()
         );
     }
 
     table!(
-        use sql_types::*;
+        use crate::sql_types::*;
 
         /// Some documentation
         #[sql_name="mod"]
@@ -1200,33 +1200,33 @@ mod tests {
     #[test]
     #[cfg(feature = "postgres")]
     fn table_renaming_postgres() {
-        use pg::Pg;
+        use crate::pg::Pg;
         let expected_sql = r#"SELECT "mod"."id" FROM "mod" -- binds: []"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Pg, _>(&bar::table.select(bar::id)).to_string()
+            crate::debug_query::<Pg, _>(&bar::table.select(bar::id)).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "mysql")]
     fn table_renaming_mysql() {
-        use mysql::Mysql;
+        use crate::mysql::Mysql;
         let expected_sql = r#"SELECT `mod`.`id` FROM `mod` -- binds: []"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Mysql, _>(&bar::table.select(bar::id)).to_string()
+            crate::debug_query::<Mysql, _>(&bar::table.select(bar::id)).to_string()
         );
     }
 
     #[test]
     #[cfg(feature = "sqlite")]
     fn table_renaming_sqlite() {
-        use sqlite::Sqlite;
+        use crate::sqlite::Sqlite;
         let expected_sql = r#"SELECT `mod`.`id` FROM `mod` -- binds: []"#;
         assert_eq!(
             expected_sql,
-            ::debug_query::<Sqlite, _>(&bar::table.select(bar::id)).to_string()
+            crate::debug_query::<Sqlite, _>(&bar::table.select(bar::id)).to_string()
         );
     }
 }

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::{fmt, io};
 
-use result;
+use crate::result;
 
 /// Errors that occur while preparing to run migrations
 #[derive(Debug)]

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -3,8 +3,8 @@
 mod errors;
 pub use self::errors::{MigrationError, RunMigrationsError};
 
-use connection::{Connection, SimpleConnection};
-use result::QueryResult;
+use crate::connection::{Connection, SimpleConnection};
+use crate::result::QueryResult;
 use std::path::Path;
 
 /// Represents a migration that interacts with diesel
@@ -80,25 +80,25 @@ pub trait MigrationConnection: Connection {
 }
 
 #[cfg(feature = "postgres")]
-impl MigrationConnection for ::pg::PgConnection {
+impl MigrationConnection for crate::pg::PgConnection {
     fn setup(&self) -> QueryResult<usize> {
-        use RunQueryDsl;
-        ::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
+        use crate::RunQueryDsl;
+        crate::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
     }
 }
 
 #[cfg(feature = "mysql")]
-impl MigrationConnection for ::mysql::MysqlConnection {
+impl MigrationConnection for crate::mysql::MysqlConnection {
     fn setup(&self) -> QueryResult<usize> {
-        use RunQueryDsl;
-        ::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
+        use crate::RunQueryDsl;
+        crate::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
     }
 }
 
 #[cfg(feature = "sqlite")]
-impl MigrationConnection for ::sqlite::SqliteConnection {
+impl MigrationConnection for crate::sqlite::SqliteConnection {
     fn setup(&self) -> QueryResult<usize> {
-        use RunQueryDsl;
-        ::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
+        use crate::RunQueryDsl;
+        crate::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
     }
 }

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -4,9 +4,9 @@ use byteorder::NativeEndian;
 
 use super::query_builder::MysqlQueryBuilder;
 use super::MysqlValue;
-use backend::*;
-use query_builder::bind_collector::RawBytesBindCollector;
-use sql_types::TypeMetadata;
+use crate::backend::*;
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::sql_types::TypeMetadata;
 
 /// The MySQL backend
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -4,8 +4,8 @@ use std::mem;
 use std::os::raw as libc;
 
 use super::stmt::Statement;
-use mysql::{MysqlType, MysqlTypeMetadata, MysqlValue};
-use result::QueryResult;
+use crate::mysql::{MysqlType, MysqlTypeMetadata, MysqlValue};
+use crate::result::QueryResult;
 
 pub struct Binds {
     data: Vec<BindData>,
@@ -201,7 +201,7 @@ impl BindData {
     }
 
     fn did_numeric_overflow_occur(&self) -> QueryResult<()> {
-        use result::Error::DeserializationError;
+        use crate::result::Error::DeserializationError;
 
         if self.is_truncated() && self.is_fixed_size_buffer() {
             Err(DeserializationError(

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -7,12 +7,12 @@ use self::raw::RawConnection;
 use self::stmt::Statement;
 use self::url::ConnectionOptions;
 use super::backend::Mysql;
-use connection::*;
-use deserialize::{Queryable, QueryableByName};
-use query_builder::bind_collector::RawBytesBindCollector;
-use query_builder::*;
-use result::*;
-use sql_types::HasSqlType;
+use crate::connection::*;
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::query_builder::*;
+use crate::result::*;
+use crate::sql_types::HasSqlType;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 /// A connection to a MySQL database. Connection URLs should be in the form
@@ -37,7 +37,7 @@ impl Connection for MysqlConnection {
     type TransactionManager = AnsiTransactionManager;
 
     fn establish(database_url: &str) -> ConnectionResult<Self> {
-        use result::ConnectionError::CouldntSetupConfiguration;
+        use crate::result::ConnectionError::CouldntSetupConfiguration;
 
         let raw_connection = RawConnection::new();
         let connection_options = ConnectionOptions::parse(database_url)?;
@@ -67,8 +67,8 @@ impl Connection for MysqlConnection {
         Self::Backend: HasSqlType<T::SqlType>,
         U: Queryable<T::SqlType, Self::Backend>,
     {
-        use deserialize::FromSqlRow;
-        use result::Error::DeserializationError;
+        use crate::deserialize::FromSqlRow;
+        use crate::result::Error::DeserializationError;
 
         let mut stmt = self.prepare_query(&source.as_query())?;
         let mut metadata = Vec::new();
@@ -87,7 +87,7 @@ impl Connection for MysqlConnection {
         T: QueryFragment<Self::Backend> + QueryId,
         U: QueryableByName<Self::Backend>,
     {
-        use result::Error::DeserializationError;
+        use crate::result::Error::DeserializationError;
 
         let mut stmt = self.prepare_query(source)?;
         let results = unsafe { stmt.named_results()? };

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -7,7 +7,7 @@ use std::sync::Once;
 
 use super::stmt::Statement;
 use super::url::ConnectionOptions;
-use result::{ConnectionError, ConnectionResult, QueryResult};
+use crate::result::{ConnectionError, ConnectionResult, QueryResult};
 
 pub struct RawConnection(NonNull<ffi::MYSQL>);
 
@@ -134,8 +134,8 @@ impl RawConnection {
     }
 
     fn did_an_error_occur(&self) -> QueryResult<()> {
-        use result::DatabaseErrorKind;
-        use result::Error::DatabaseError;
+        use crate::result::DatabaseErrorKind;
+        use crate::result::Error::DatabaseError;
 
         let error_message = self.last_error_message();
         if error_message.is_empty() {

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use super::{ffi, libc, Binds, Statement, StatementMetadata};
-use mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
-use result::QueryResult;
-use row::*;
+use crate::mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
+use crate::result::QueryResult;
+use crate::row::*;
 
 pub struct StatementIterator<'a> {
     stmt: &'a mut Statement,

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -10,8 +10,8 @@ use std::ptr::NonNull;
 use self::iterator::*;
 use self::metadata::*;
 use super::bind::Binds;
-use mysql::MysqlTypeMetadata;
-use result::{DatabaseErrorKind, QueryResult};
+use crate::mysql::MysqlTypeMetadata;
+use crate::result::{DatabaseErrorKind, QueryResult};
 
 pub struct Statement {
     stmt: NonNull<ffi::MYSQL_STMT>,
@@ -115,7 +115,7 @@ impl Statement {
     }
 
     fn metadata(&self) -> QueryResult<StatementMetadata> {
-        use result::Error::DeserializationError;
+        use crate::result::Error::DeserializationError;
 
         let result_ptr = unsafe { ffi::mysql_stmt_result_metadata(self.stmt.as_ptr()).as_mut() };
         self.did_an_error_occur()?;
@@ -125,7 +125,7 @@ impl Statement {
     }
 
     fn did_an_error_occur(&self) -> QueryResult<()> {
-        use result::Error::DatabaseError;
+        use crate::result::Error::DatabaseError;
 
         let error_message = self.last_error_message();
         if error_message.is_empty() {

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -5,7 +5,7 @@ use self::percent_encoding::percent_decode;
 use self::url::{Host, Url};
 use std::ffi::{CStr, CString};
 
-use result::{ConnectionError, ConnectionResult};
+use crate::result::{ConnectionError, ConnectionResult};
 
 pub struct ConnectionOptions {
     host: Option<CString>,

--- a/diesel/src/mysql/query_builder/mod.rs
+++ b/diesel/src/mysql/query_builder/mod.rs
@@ -1,6 +1,6 @@
 use super::backend::Mysql;
-use query_builder::QueryBuilder;
-use result::QueryResult;
+use crate::query_builder::QueryBuilder;
+use crate::result::QueryResult;
 
 mod query_fragment_impls;
 

--- a/diesel/src/mysql/query_builder/query_fragment_impls.rs
+++ b/diesel/src/mysql/query_builder/query_fragment_impls.rs
@@ -1,7 +1,7 @@
-use mysql::Mysql;
-use query_builder::locking_clause::{ForShare, ForUpdate, NoModifier, NoWait, SkipLocked};
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
+use crate::mysql::Mysql;
+use crate::query_builder::locking_clause::{ForShare, ForUpdate, NoModifier, NoWait, SkipLocked};
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
 
 impl QueryFragment<Mysql> for ForUpdate {
     fn walk_ast(&self, mut out: AstPass<Mysql>) -> QueryResult<()> {

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -6,10 +6,10 @@ use std::io::Write;
 use std::os::raw as libc;
 use std::{mem, ptr, slice};
 
-use deserialize::{self, FromSql};
-use mysql::{Mysql, MysqlValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{Date, Datetime, Time, Timestamp};
+use crate::deserialize::{self, FromSql};
+use crate::mysql::{Mysql, MysqlValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{Date, Datetime, Time, Timestamp};
 
 macro_rules! mysql_time_impls {
     ($ty:ty) => {
@@ -153,10 +153,10 @@ mod tests {
     use self::chrono::{Duration, NaiveDate, NaiveTime, Utc};
     use self::dotenv::dotenv;
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::{Date, Datetime, Time, Timestamp};
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::{Date, Datetime, Time, Timestamp};
 
     fn connection() -> MysqlConnection {
         dotenv().ok();

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -7,10 +7,10 @@ mod numeric;
 use byteorder::WriteBytesExt;
 use std::io::Write;
 
-use deserialize::{self, FromSql};
-use mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::*;
+use crate::deserialize::{self, FromSql};
+use crate::mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::*;
 
 impl ToSql<TinyInt, Mysql> for i8 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {

--- a/diesel/src/mysql/types/numeric.rs
+++ b/diesel/src/mysql/types/numeric.rs
@@ -5,11 +5,11 @@ pub mod bigdecimal {
     use self::bigdecimal::BigDecimal;
     use std::io::prelude::*;
 
-    use backend;
-    use deserialize::{self, FromSql};
-    use mysql::Mysql;
-    use serialize::{self, IsNull, Output, ToSql};
-    use sql_types::{Binary, Numeric};
+    use crate::backend;
+    use crate::deserialize::{self, FromSql};
+    use crate::mysql::Mysql;
+    use crate::serialize::{self, IsNull, Output, ToSql};
+    use crate::sql_types::{Binary, Numeric};
 
     impl ToSql<Numeric, Mysql> for BigDecimal {
         fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -1,5 +1,5 @@
 use super::Mysql;
-use backend::BinaryRawValue;
+use crate::backend::BinaryRawValue;
 
 /// Raw mysql value as received from the database
 #[derive(Copy, Clone, Debug)]

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -4,10 +4,10 @@ use byteorder::NetworkEndian;
 
 use super::query_builder::PgQueryBuilder;
 use super::{PgMetadataLookup, PgValue};
-use backend::*;
-use deserialize::Queryable;
-use query_builder::bind_collector::RawBytesBindCollector;
-use sql_types::{Oid, TypeMetadata};
+use crate::backend::*;
+use crate::deserialize::Queryable;
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::sql_types::{Oid, TypeMetadata};
 
 /// The PostgreSQL backend
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/diesel/src/pg/connection/cursor.rs
+++ b/diesel/src/pg/connection/cursor.rs
@@ -1,9 +1,9 @@
 use super::result::PgResult;
 use super::row::PgNamedRow;
-use deserialize::{FromSqlRow, Queryable, QueryableByName};
-use pg::Pg;
-use result::Error::DeserializationError;
-use result::QueryResult;
+use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
+use crate::pg::Pg;
+use crate::result::Error::DeserializationError;
+use crate::result::QueryResult;
 
 use std::marker::PhantomData;
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -12,14 +12,14 @@ use self::cursor::*;
 use self::raw::RawConnection;
 use self::result::PgResult;
 use self::stmt::Statement;
-use connection::*;
-use deserialize::{Queryable, QueryableByName};
-use pg::{metadata_lookup::PgMetadataCache, Pg, PgMetadataLookup, TransactionBuilder};
-use query_builder::bind_collector::RawBytesBindCollector;
-use query_builder::*;
-use result::ConnectionError::CouldntSetupConfiguration;
-use result::*;
-use sql_types::HasSqlType;
+use crate::connection::*;
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::pg::{metadata_lookup::PgMetadataCache, Pg, PgMetadataLookup, TransactionBuilder};
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::query_builder::*;
+use crate::result::ConnectionError::CouldntSetupConfiguration;
+use crate::result::*;
+use crate::sql_types::HasSqlType;
 
 /// The connection string expected by `PgConnection::establish`
 /// should be a PostgreSQL connection string, as documented at
@@ -189,15 +189,15 @@ mod tests {
     use std::env;
 
     use super::*;
-    use dsl::sql;
-    use prelude::*;
-    use sql_types::{Integer, VarChar};
+    use crate::dsl::sql;
+    use crate::prelude::*;
+    use crate::sql_types::{Integer, VarChar};
 
     #[test]
     fn prepared_statements_are_cached() {
         let connection = connection();
 
-        let query = ::select(1.into_sql::<Integer>());
+        let query = crate::select(1.into_sql::<Integer>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -208,8 +208,8 @@ mod tests {
     fn queries_with_identical_sql_but_different_types_are_cached_separately() {
         let connection = connection();
 
-        let query = ::select(1.into_sql::<Integer>());
-        let query2 = ::select("hi".into_sql::<VarChar>());
+        let query = crate::select(1.into_sql::<Integer>());
+        let query2 = crate::select("hi".into_sql::<VarChar>());
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(Ok("hi".to_string()), query2.get_result(&connection));
@@ -220,8 +220,8 @@ mod tests {
     fn queries_with_identical_types_and_sql_but_different_bind_types_are_cached_separately() {
         let connection = connection();
 
-        let query = ::select(1.into_sql::<Integer>()).into_boxed::<Pg>();
-        let query2 = ::select("hi".into_sql::<VarChar>()).into_boxed::<Pg>();
+        let query = crate::select(1.into_sql::<Integer>()).into_boxed::<Pg>();
+        let query2 = crate::select("hi".into_sql::<VarChar>()).into_boxed::<Pg>();
 
         assert_eq!(0, connection.statement_cache.len());
         assert_eq!(Ok(1), query.get_result(&connection));
@@ -236,8 +236,8 @@ mod tests {
         let connection = connection();
 
         let hi = "HI".into_sql::<VarChar>();
-        let query = ::select(hi).into_boxed::<Pg>();
-        let query2 = ::select(lower(hi)).into_boxed::<Pg>();
+        let query = crate::select(hi).into_boxed::<Pg>();
+        let query2 = crate::select(lower(hi)).into_boxed::<Pg>();
 
         assert_eq!(0, connection.statement_cache.len());
         assert_eq!(Ok("HI".to_string()), query.get_result(&connection));
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn queries_with_sql_literal_nodes_are_not_cached() {
         let connection = connection();
-        let query = ::select(sql::<Integer>("1"));
+        let query = crate::select(sql::<Integer>("1"));
 
         assert_eq!(Ok(1), query.get_result(&connection));
         assert_eq!(0, connection.statement_cache.len());

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -8,7 +8,7 @@ use std::os::raw as libc;
 use std::ptr::NonNull;
 use std::{ptr, str};
 
-use result::*;
+use crate::result::*;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct RawConnection {

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -8,7 +8,7 @@ use std::{slice, str};
 
 use super::raw::RawResult;
 use super::row::PgRow;
-use result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
+use crate::result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
 
 pub struct PgResult {
     internal_result: RawResult,

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -1,7 +1,7 @@
 use super::cursor::NamedCursor;
 use super::result::PgResult;
-use pg::{Pg, PgValue};
-use row::*;
+use crate::pg::{Pg, PgValue};
+use crate::row::*;
 
 pub struct PgRow<'a> {
     db_result: &'a PgResult,

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -5,8 +5,8 @@ use std::os::raw as libc;
 use std::ptr;
 
 use super::result::PgResult;
-use pg::{PgConnection, PgTypeMetadata};
-use result::QueryResult;
+use crate::pg::{PgConnection, PgTypeMetadata};
+use crate::result::QueryResult;
 
 pub use super::raw::RawConnection;
 

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::{
+use crate::backend::Backend;
+use crate::expression::{
     AppearsOnTable, AsExpressionList, Expression, NonAggregate, SelectableExpression,
 };
-use query_builder::{AstPass, QueryFragment};
-use sql_types;
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::sql_types;
 use std::marker::PhantomData;
 
 /// An ARRAY[...] literal.
@@ -69,7 +69,7 @@ where
     DB: Backend,
     for<'a> &'a T: QueryFragment<DB>,
 {
-    fn walk_ast(&self, mut out: AstPass<DB>) -> ::result::QueryResult<()> {
+    fn walk_ast(&self, mut out: AstPass<DB>) -> crate::result::QueryResult<()> {
         out.push_sql("ARRAY[");
         QueryFragment::walk_ast(&&self.elements, out.reborrow())?;
         out.push_sql("]");

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -1,9 +1,9 @@
-use expression::subselect::Subselect;
-use expression::{AsExpression, Expression};
-use pg::Pg;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Array;
+use crate::expression::subselect::Subselect;
+use crate::expression::{AsExpression, Expression};
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Array;
 
 /// Creates a PostgreSQL `ANY` expression.
 ///

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -1,8 +1,8 @@
-use expression::Expression;
-use pg::Pg;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::{Date, NotNull, Nullable, Timestamp, Timestamptz, VarChar};
+use crate::expression::Expression;
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::{Date, NotNull, Nullable, Timestamp, Timestamptz, VarChar};
 
 /// Marker trait for types which are valid in `AT TIME ZONE` expressions
 pub trait DateTimeLike {}

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -1,8 +1,8 @@
 //! PostgreSQL specific expression methods
 
 use super::operators::*;
-use expression::{AsExpression, Expression};
-use sql_types::{Array, Nullable, Text};
+use crate::expression::{AsExpression, Expression};
+use crate::sql_types::{Array, Nullable, Text};
 
 /// PostgreSQL specific methods which are present on all expressions.
 pub trait PgExpressionMethods: Expression + Sized {
@@ -64,7 +64,7 @@ pub trait PgExpressionMethods: Expression + Sized {
 impl<T: Expression> PgExpressionMethods for T {}
 
 use super::date_and_time::{AtTimeZone, DateTimeLike};
-use sql_types::VarChar;
+use crate::sql_types::VarChar;
 
 /// PostgreSQL specific methods present on timestamp expressions.
 pub trait PgTimestampExpressionMethods: Expression + Sized {
@@ -82,8 +82,6 @@ pub trait PgTimestampExpressionMethods: Expression + Sized {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # #[cfg(feature = "chrono")]
-    /// # extern crate chrono;
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
@@ -98,7 +96,7 @@ pub trait PgTimestampExpressionMethods: Expression + Sized {
     /// #
     /// # #[cfg(all(feature = "postgres", feature = "chrono"))]
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use timestamps::dsl::*;
+    /// #     use self::timestamps::dsl::*;
     /// #     use chrono::*;
     /// #     let connection = establish_connection();
     /// #     connection.execute("CREATE TABLE timestamps (\"timestamp\"
@@ -316,7 +314,7 @@ pub trait ArrayOrNullableArray {}
 impl<T> ArrayOrNullableArray for Array<T> {}
 impl<T> ArrayOrNullableArray for Nullable<Array<T>> {}
 
-use expression::operators::{Asc, Desc};
+use crate::expression::operators::{Asc, Desc};
 
 /// PostgreSQL expression methods related to sorting.
 ///

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -1,6 +1,6 @@
 use std::ops::Mul;
 
-use data_types::PgInterval;
+use crate::data_types::PgInterval;
 
 /// A DSL added to integers and `f64` to construct PostgreSQL intervals.
 ///
@@ -243,10 +243,10 @@ mod tests {
     use self::quickcheck::quickcheck;
 
     use super::*;
-    use data_types::PgInterval;
-    use dsl::sql;
-    use prelude::*;
-    use {select, sql_types};
+    use crate::data_types::PgInterval;
+    use crate::dsl::sql;
+    use crate::prelude::*;
+    use crate::{select, sql_types};
 
     thread_local! {
         static CONN: PgConnection = {

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,5 +1,5 @@
-use dsl::AsExprOf;
-use sql_types::VarChar;
+use crate::dsl::AsExprOf;
+use crate::sql_types::VarChar;
 
 /// The return type of `lhs.ilike(rhs)`
 pub type ILike<Lhs, Rhs> = super::operators::ILike<Lhs, AsExprOf<Rhs, VarChar>>;

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,4 +1,4 @@
-use pg::Pg;
+use crate::pg::Pg;
 
 infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
 infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -1,7 +1,7 @@
 #![allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
 
 use super::{PgConnection, PgTypeMetadata};
-use prelude::*;
+use crate::prelude::*;
 
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -1,8 +1,8 @@
-use expression::SelectableExpression;
-use pg::Pg;
-use query_builder::{AstPass, QueryFragment, SelectQuery, SelectStatement};
-use query_dsl::methods::DistinctOnDsl;
-use result::QueryResult;
+use crate::expression::SelectableExpression;
+use crate::pg::Pg;
+use crate::query_builder::{AstPass, QueryFragment, SelectQuery, SelectStatement};
+use crate::query_dsl::methods::DistinctOnDsl;
+use crate::result::QueryResult;
 
 /// Represents `DISTINCT ON (...)`
 #[derive(Debug, Clone, Copy, QueryId)]

--- a/diesel/src/pg/query_builder/mod.rs
+++ b/diesel/src/pg/query_builder/mod.rs
@@ -1,6 +1,6 @@
 use super::backend::Pg;
-use query_builder::QueryBuilder;
-use result::QueryResult;
+use crate::query_builder::QueryBuilder;
+use crate::result::QueryResult;
 
 mod distinct_on;
 mod query_fragment_impls;

--- a/diesel/src/pg/query_builder/query_fragment_impls.rs
+++ b/diesel/src/pg/query_builder/query_fragment_impls.rs
@@ -1,9 +1,9 @@
-use pg::Pg;
-use query_builder::locking_clause::{
+use crate::pg::Pg;
+use crate::query_builder::locking_clause::{
     ForKeyShare, ForNoKeyUpdate, ForShare, ForUpdate, NoModifier, NoWait, SkipLocked,
 };
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
 
 impl QueryFragment<Pg> for ForUpdate {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {

--- a/diesel/src/pg/serialize/write_tuple.rs
+++ b/diesel/src/pg/serialize/write_tuple.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
-use pg::Pg;
-use serialize::{self, Output};
+use crate::pg::Pg;
+use crate::serialize::{self, Output};
 
 /// Helper trait for writing tuples as named composite types
 ///

--- a/diesel/src/pg/transaction.rs
+++ b/diesel/src/pg/transaction.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
-use backend::Backend;
-use connection::TransactionManager;
-use pg::Pg;
-use prelude::*;
-use query_builder::{AstPass, QueryBuilder, QueryFragment};
-use result::Error;
+use crate::backend::Backend;
+use crate::connection::TransactionManager;
+use crate::pg::Pg;
+use crate::prelude::*;
+use crate::query_builder::{AstPass, QueryBuilder, QueryFragment};
+use crate::result::Error;
 
 /// Used to build a transaction, specifying additional details.
 ///

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -2,10 +2,10 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::fmt;
 use std::io::Write;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{Array, HasSqlType, Nullable};
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{Array, HasSqlType, Nullable};
 
 impl<T> HasSqlType<Array<T>> for Pg
 where
@@ -56,8 +56,8 @@ where
     }
 }
 
-use expression::bound::Bound;
-use expression::AsExpression;
+use crate::expression::bound::Bound;
+use crate::expression::AsExpression;
 
 macro_rules! array_as_expression {
     ($ty:ty, $sql_type:ty) => {

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -8,10 +8,10 @@ use self::chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTim
 use std::io::Write;
 
 use super::{PgDate, PgTime, PgTimestamp};
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, Output, ToSql};
-use sql_types::{Date, Time, Timestamp, Timestamptz};
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types::{Date, Time, Timestamp, Timestamptz};
 
 // Postgres timestamps start from January 1st 2000.
 fn pg_epoch() -> NaiveDateTime {
@@ -132,10 +132,10 @@ mod tests {
     use self::chrono::{Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};
     use self::dotenv::dotenv;
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::{Date, Time, Timestamp, Timestamptz};
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::{Date, Time, Timestamp, Timestamptz};
 
     fn connection() -> PgConnection {
         dotenv().ok();

--- a/diesel/src/pg/types/date_and_time/deprecated_time.rs
+++ b/diesel/src/pg/types/date_and_time/deprecated_time.rs
@@ -4,10 +4,10 @@ use std::io::Write;
 
 use self::time::{Duration, Timespec};
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
 
 #[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
@@ -44,10 +44,10 @@ mod tests {
     use self::dotenv::dotenv;
     use self::time::{Duration, Timespec};
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::Timestamp;
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::Timestamp;
 
     fn connection() -> PgConnection {
         dotenv().ok();

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 use std::ops::Add;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{self, Date, Interval, Time, Timestamp, Timestamptz};
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{self, Date, Interval, Time, Timestamp, Timestamptz};
 
 #[cfg(feature = "chrono")]
 mod chrono;

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
 
 fn pg_epoch() -> SystemTime {
     let thirty_years = Duration::from_secs(946_684_800);
@@ -64,10 +64,10 @@ mod tests {
     use self::dotenv::dotenv;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::Timestamp;
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::Timestamp;
 
     fn connection() -> PgConnection {
         dotenv().ok();

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -2,10 +2,10 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -1,10 +1,10 @@
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl FromSql<sql_types::Oid, Pg> for u32 {
     fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -4,15 +4,15 @@ extern crate serde_json;
 
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 #[allow(dead_code)]
 mod foreign_derives {
     use super::serde_json;
-    use sql_types::{Json, Jsonb};
+    use crate::sql_types::{Json, Jsonb};
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]

--- a/diesel/src/pg/types/mac_addr.rs
+++ b/diesel/src/pg/types/mac_addr.rs
@@ -43,4 +43,3 @@ fn macaddr_roundtrip() {
         FromSql::from_sql(Some(PgValue::for_test(bytes.as_ref()))).unwrap();
     assert_eq!(input_address, output_address);
 }
-

--- a/diesel/src/pg/types/mac_addr.rs
+++ b/diesel/src/pg/types/mac_addr.rs
@@ -1,0 +1,46 @@
+use std::convert::TryInto;
+use std::io::prelude::*;
+
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::MacAddr;
+
+#[allow(dead_code)]
+mod foreign_derives {
+    use super::*;
+
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(foreign_derive)]
+    #[sql_type = "MacAddr"]
+    struct ByteArrayProxy([u8; 6]);
+}
+
+impl FromSql<MacAddr, Pg> for [u8; 6] {
+    fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        value
+            .as_bytes()
+            .try_into()
+            .map_err(|_| "invalid network address format: input isn't 6 bytes.".into())
+    }
+}
+
+impl ToSql<MacAddr, Pg> for [u8; 6] {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        out.write_all(&self[..])
+            .map(|_| IsNull::No)
+            .map_err(Into::into)
+    }
+}
+
+#[test]
+fn macaddr_roundtrip() {
+    let mut bytes = Output::test();
+    let input_address = [0x52, 0x54, 0x00, 0xfb, 0xc6, 0x16];
+    ToSql::<MacAddr, Pg>::to_sql(&input_address, &mut bytes).unwrap();
+    let output_address: [u8; 6] =
+        FromSql::from_sql(Some(PgValue::for_test(bytes.as_ref()))).unwrap();
+    assert_eq!(input_address, output_address);
+}
+

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -3,10 +3,10 @@
 use std::io::prelude::*;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, Output, ToSql};
-use sql_types::{BigInt, Money};
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types::{BigInt, Money};
 
 /// Money is represented in Postgres as a 64 bit signed integer.  This struct is a dumb wrapper
 /// type, meant only to indicate the integer's meaning.  The fractional precision of the value is

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -11,11 +11,11 @@ mod bigdecimal {
     use self::num_traits::{Signed, ToPrimitive, Zero};
     use std::io::prelude::*;
 
-    use deserialize::{self, FromSql};
-    use pg::data_types::PgNumeric;
-    use pg::{Pg, PgValue};
-    use serialize::{self, Output, ToSql};
-    use sql_types::Numeric;
+    use crate::deserialize::{self, FromSql};
+    use crate::pg::data_types::PgNumeric;
+    use crate::pg::{Pg, PgValue};
+    use crate::serialize::{self, Output, ToSql};
+    use crate::sql_types::Numeric;
 
     use std::convert::{TryFrom, TryInto};
     use std::error::Error;

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -1,9 +1,9 @@
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl FromSql<sql_types::Bool, Pg> for bool {
     fn from_sql(bytes: Option<PgValue<'_>>) -> deserialize::Result<Self> {

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -2,12 +2,12 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::Bound;
 use std::io::Write;
 
-use deserialize::{self, FromSql, FromSqlRow, Queryable};
-use expression::bound::Bound as SqlBound;
-use expression::AsExpression;
-use pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::*;
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::expression::bound::Bound as SqlBound;
+use crate::expression::AsExpression;
+use crate::pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::*;
 
 // https://github.com/postgres/postgres/blob/113b0045e20d40f726a0a30e33214455e4f1385e/src/include/utils/rangetypes.h#L35-L43
 bitflags! {
@@ -69,7 +69,7 @@ impl<T, ST> FromSqlRow<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     (Bound<T>, Bound<T>): FromSql<Range<ST>, Pg>,
 {
-    fn build_from_row<R: ::row::Row<Pg>>(row: &mut R) -> deserialize::Result<Self> {
+    fn build_from_row<R: crate::row::Row<Pg>>(row: &mut R) -> deserialize::Result<Self> {
         FromSql::<Range<ST>, Pg>::from_sql(row.take())
     }
 }

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -2,14 +2,14 @@ use byteorder::*;
 use std::io::Write;
 use std::num::NonZeroU32;
 
-use deserialize::{self, FromSql, FromSqlRow, Queryable};
-use expression::{AppearsOnTable, AsExpression, Expression, SelectableExpression};
-use pg::{Pg, PgValue};
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
-use row::Row;
-use serialize::{self, IsNull, Output, ToSql, WriteTuple};
-use sql_types::{HasSqlType, Record};
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::expression::{AppearsOnTable, AsExpression, Expression, SelectableExpression};
+use crate::pg::{Pg, PgValue};
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
+use crate::row::Row;
+use crate::serialize::{self, IsNull, Output, ToSql, WriteTuple};
+use crate::sql_types::{HasSqlType, Record};
 
 macro_rules! tuple_impls {
     ($(
@@ -173,10 +173,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dsl::sql;
-    use prelude::*;
-    use sql_types::*;
-    use test_helpers::*;
+    use crate::dsl::sql;
+    use crate::prelude::*;
+    use crate::sql_types::*;
+    use crate::test_helpers::*;
 
     #[test]
     fn record_deserializes_correctly() {
@@ -205,11 +205,11 @@ mod tests {
         let conn = pg_connection();
 
         let tup = sql::<Record<(Integer, Text)>>("(1, 'hi')");
-        let res = ::select(tup.eq((1, "hi"))).get_result(&conn);
+        let res = crate::select(tup.eq((1, "hi"))).get_result(&conn);
         assert_eq!(Ok(true), res);
 
         let tup = sql::<Record<(Record<(Integer, Text)>, Integer)>>("((2, 'bye'::text), 3)");
-        let res = ::select(tup.eq(((2, "bye"), 3))).get_result(&conn);
+        let res = crate::select(tup.eq(((2, "bye"), 3))).get_result(&conn);
         assert_eq!(Ok(true), res);
 
         let tup = sql::<
@@ -218,7 +218,7 @@ mod tests {
                 Nullable<Integer>,
             )>,
         >("((4, NULL::text), NULL::int4)");
-        let res = ::select(tup.is_not_distinct_from(((Some(4), None::<&str>), None::<i32>)))
+        let res = crate::select(tup.is_not_distinct_from(((Some(4), None::<&str>), None::<i32>)))
             .get_result(&conn);
         assert_eq!(Ok(true), res);
     }
@@ -241,11 +241,11 @@ mod tests {
 
         let conn = pg_connection();
 
-        ::sql_query("CREATE TYPE my_type AS (i int4, t text)")
+        crate::sql_query("CREATE TYPE my_type AS (i int4, t text)")
             .execute(&conn)
             .unwrap();
         let sql = sql::<Bool>("(1, 'hi')::my_type = ").bind::<MyType, _>(MyStruct(1, "hi"));
-        let res = ::select(sql).get_result(&conn);
+        let res = crate::select(sql).get_result(&conn);
         assert_eq!(Ok(true), res);
     }
 }

--- a/diesel/src/pg/types/uuid_v0_7.rs
+++ b/diesel/src/pg/types/uuid_v0_7.rs
@@ -2,10 +2,10 @@ extern crate uuidv07 as uuid;
 
 use std::io::prelude::*;
 
-use deserialize::{self, FromSql};
-use pg::{Pg, PgValue};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::Uuid;
+use crate::deserialize::{self, FromSql};
+use crate::pg::{Pg, PgValue};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::Uuid;
 
 #[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]

--- a/diesel/src/pg/upsert/on_conflict_actions.rs
+++ b/diesel/src/pg/upsert/on_conflict_actions.rs
@@ -1,8 +1,8 @@
-use expression::{AppearsOnTable, Expression};
-use pg::Pg;
-use query_builder::*;
-use query_source::*;
-use result::QueryResult;
+use crate::expression::{AppearsOnTable, Expression};
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::query_source::*;
+use crate::result::QueryResult;
 
 /// Represents `excluded.column` in an `ON CONFLICT DO UPDATE` clause.
 pub fn excluded<T>(excluded: T) -> Excluded<T> {

--- a/diesel/src/pg/upsert/on_conflict_clause.rs
+++ b/diesel/src/pg/upsert/on_conflict_clause.rs
@@ -1,9 +1,9 @@
 use super::on_conflict_actions::*;
 use super::on_conflict_target::*;
-use insertable::*;
-use pg::Pg;
-use query_builder::*;
-use result::QueryResult;
+use crate::insertable::*;
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy)]

--- a/diesel/src/pg/upsert/on_conflict_extension.rs
+++ b/diesel/src/pg/upsert/on_conflict_extension.rs
@@ -1,8 +1,8 @@
 use super::on_conflict_actions::*;
 use super::on_conflict_clause::*;
 use super::on_conflict_target::*;
-use query_builder::{AsChangeset, InsertStatement, UndecoratedInsertRecord};
-use query_source::QuerySource;
+use crate::query_builder::{AsChangeset, InsertStatement, UndecoratedInsertRecord};
+use crate::query_source::QuerySource;
 
 impl<T, U, Op, Ret> InsertStatement<T, U, Op, Ret>
 where
@@ -20,7 +20,7 @@ where
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Sean", };
@@ -46,7 +46,7 @@ where
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Sean", };
@@ -82,7 +82,7 @@ where
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// conn.execute("CREATE UNIQUE INDEX users_name ON users (name)").unwrap();
@@ -131,7 +131,7 @@ where
     /// # }
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// use diesel::pg::upsert::*;
     ///
     /// #     let conn = establish_connection();
@@ -221,7 +221,7 @@ impl<Stmt, Target> IncompleteOnConflict<Stmt, Target> {
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Pascal" };
@@ -249,7 +249,7 @@ impl<Stmt, Target> IncompleteOnConflict<Stmt, Target> {
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let conn = establish_connection();
     /// #     conn.execute("TRUNCATE TABLE users").unwrap();
     /// let user = User { id: 1, name: "Pascal" };
@@ -277,7 +277,7 @@ impl<Stmt, Target> IncompleteOnConflict<Stmt, Target> {
     /// # include!("on_conflict_docs_setup.rs");
     /// #
     /// # fn main() {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// use diesel::pg::upsert::excluded;
     ///
     /// #     let conn = establish_connection();

--- a/diesel/src/pg/upsert/on_conflict_target.rs
+++ b/diesel/src/pg/upsert/on_conflict_target.rs
@@ -1,8 +1,8 @@
-use expression::SqlLiteral;
-use pg::Pg;
-use query_builder::*;
-use query_source::Column;
-use result::QueryResult;
+use crate::expression::SqlLiteral;
+use crate::pg::Pg;
+use crate::query_builder::*;
+use crate::query_source::Column;
+use crate::result::QueryResult;
 
 /// Used to specify the constraint name for an upsert statement in the form `ON
 /// CONFLICT ON CONSTRAINT`. Note that `constraint_name` must be the name of a
@@ -15,7 +15,7 @@ use result::QueryResult;
 /// # include!("on_conflict_docs_setup.rs");
 /// #
 /// # fn main() {
-/// #     use users::dsl::*;
+/// #     use self::users::dsl::*;
 /// use diesel::pg::upsert::*;
 ///
 /// #     let conn = establish_connection();

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -1,5 +1,5 @@
 use super::Pg;
-use backend::BinaryRawValue;
+use crate::backend::BinaryRawValue;
 use std::num::NonZeroU32;
 use std::ops::Range;
 

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -1,10 +1,10 @@
 use std::{fmt, mem};
 
-use backend::Backend;
-use query_builder::{BindCollector, QueryBuilder};
-use result::QueryResult;
-use serialize::ToSql;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::query_builder::{BindCollector, QueryBuilder};
+use crate::result::QueryResult;
+use crate::serialize::ToSql;
+use crate::sql_types::HasSqlType;
 
 #[allow(missing_debug_implementations)]
 /// The primary type used when walking a Diesel AST during query execution.

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -1,10 +1,10 @@
 //! Types related to managing bind parameters during query construction.
 
-use backend::Backend;
-use result::Error::SerializationError;
-use result::QueryResult;
-use serialize::{IsNull, Output, ToSql};
-use sql_types::{HasSqlType, TypeMetadata};
+use crate::backend::Backend;
+use crate::result::Error::SerializationError;
+use crate::result::QueryResult;
+use crate::serialize::{IsNull, Output, ToSql};
+use crate::sql_types::{HasSqlType, TypeMetadata};
 
 /// A type which manages serializing bind parameters during query construction.
 ///

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -4,8 +4,8 @@ macro_rules! simple_clause {
     };
 
     ($no_clause:ident, $clause:ident, $sql:expr, backend_bounds = $($backend_bounds:ident),*) => {
-        use backend::Backend;
-        use result::QueryResult;
+        use crate::backend::Backend;
+        use crate::result::QueryResult;
         use super::{QueryFragment, AstPass};
 
         #[derive(Debug, Clone, Copy, QueryId)]

--- a/diesel/src/query_builder/debug_query.rs
+++ b/diesel/src/query_builder/debug_query.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::mem;
 
 use super::{AstPass, QueryBuilder, QueryFragment};
-use backend::Backend;
+use crate::backend::Backend;
 
 /// A struct that implements `fmt::Display` and `fmt::Debug` to show the SQL
 /// representation of a query.

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -1,13 +1,13 @@
-use backend::Backend;
-use dsl::{Filter, IntoBoxed};
-use expression::{AppearsOnTable, SelectableExpression};
-use query_builder::returning_clause::*;
-use query_builder::where_clause::*;
-use query_builder::*;
-use query_dsl::methods::{BoxedDsl, FilterDsl};
-use query_dsl::RunQueryDsl;
-use query_source::Table;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::dsl::{Filter, IntoBoxed};
+use crate::expression::{AppearsOnTable, SelectableExpression};
+use crate::query_builder::returning_clause::*;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::*;
+use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
+use crate::query_dsl::RunQueryDsl;
+use crate::query_source::Table;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 #[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,6 +1,6 @@
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct NoDistinctClause;
@@ -21,4 +21,4 @@ impl<DB: Backend> QueryFragment<DB> for DistinctClause {
 }
 
 #[cfg(feature = "postgres")]
-pub use pg::DistinctOnClause;
+pub use crate::pg::DistinctOnClause;

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -3,9 +3,9 @@ use super::insert_statement::{Insert, InsertOrIgnore, Replace};
 use super::{
     IncompleteInsertStatement, IntoUpdateTarget, SelectStatement, SqlQuery, UpdateStatement,
 };
-use dsl::Select;
-use expression::Expression;
-use query_dsl::methods::SelectDsl;
+use crate::dsl::Select;
+use crate::expression::Expression;
+use crate::query_dsl::methods::SelectDsl;
 
 /// Creates an `UPDATE` statement.
 ///
@@ -59,7 +59,7 @@ use query_dsl::methods::SelectDsl;
 /// #
 /// # #[cfg(feature = "postgres")]
 /// # fn main() {
-/// # use users::dsl::*;
+/// # use self::users::dsl::*;
 /// # let connection = establish_connection();
 /// # connection.execute("DROP TABLE users").unwrap();
 /// # connection.execute("CREATE TABLE users (

--- a/diesel/src/query_builder/insert_statement/column_list.rs
+++ b/diesel/src/query_builder/insert_statement/column_list.rs
@@ -1,7 +1,7 @@
-use backend::Backend;
-use query_builder::*;
-use query_source::Column;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::query_source::Column;
+use crate::result::QueryResult;
 
 /// Represents the column list for use in an insert statement.
 ///

--- a/diesel/src/query_builder/insert_statement/insert_from_select.rs
+++ b/diesel/src/query_builder/insert_statement/insert_from_select.rs
@@ -1,8 +1,8 @@
-use backend::Backend;
-use expression::{Expression, NonAggregate, SelectableExpression};
-use insertable::*;
-use query_builder::*;
-use query_source::Table;
+use crate::backend::Backend;
+use crate::expression::{Expression, NonAggregate, SelectableExpression};
+use crate::insertable::*;
+use crate::query_builder::*;
+use crate::query_source::Table;
 
 /// Represents `(Columns) SELECT FROM ...` for use in an `INSERT` statement
 #[derive(Debug, Clone, Copy)]

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -8,20 +8,20 @@ use std::any::*;
 use std::marker::PhantomData;
 
 use super::returning_clause::*;
-use backend::Backend;
-use expression::operators::Eq;
-use expression::{Expression, NonAggregate, SelectableExpression};
-use insertable::*;
+use crate::backend::Backend;
+use crate::expression::operators::Eq;
+use crate::expression::{Expression, NonAggregate, SelectableExpression};
+use crate::insertable::*;
 #[cfg(feature = "mysql")]
-use mysql::Mysql;
-use query_builder::*;
+use crate::mysql::Mysql;
+use crate::query_builder::*;
 #[cfg(feature = "sqlite")]
-use query_dsl::methods::ExecuteDsl;
-use query_dsl::RunQueryDsl;
-use query_source::{Column, Table};
-use result::QueryResult;
+use crate::query_dsl::methods::ExecuteDsl;
+use crate::query_dsl::RunQueryDsl;
+use crate::query_source::{Column, Table};
+use crate::result::QueryResult;
 #[cfg(feature = "sqlite")]
-use sqlite::{Sqlite, SqliteConnection};
+use crate::sqlite::{Sqlite, SqliteConnection};
 
 /// The structure returned by [`insert_into`].
 ///
@@ -62,7 +62,7 @@ impl<T, Op> IncompleteInsertStatement<T, Op> {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::insert_into;
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let connection = connection_no_data();
     /// connection.execute("CREATE TABLE users (
     ///     name VARCHAR(255) NOT NULL DEFAULT 'Sean',
@@ -210,7 +210,7 @@ where
     Op: Copy,
 {
     fn execute(query: Self, conn: &SqliteConnection) -> QueryResult<usize> {
-        use connection::Connection;
+        use crate::connection::Connection;
         conn.transaction(|| {
             let mut result = 0;
             for record in query.records.records {
@@ -236,7 +236,7 @@ where
     Op: Copy,
 {
     fn execute(query: Self, conn: &SqliteConnection) -> QueryResult<usize> {
-        use connection::Connection;
+        use crate::connection::Connection;
         conn.transaction(|| {
             let mut result = 0;
             for value in query.records.values {
@@ -430,7 +430,7 @@ where
     #[cfg(feature = "mysql")]
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         // This can be less hacky once stabilization lands
-        if TypeId::of::<DB>() == TypeId::of::<::mysql::Mysql>() {
+        if TypeId::of::<DB>() == TypeId::of::<crate::mysql::Mysql>() {
             out.push_sql("() VALUES ()");
         } else {
             out.push_sql("DEFAULT VALUES");

--- a/diesel/src/query_builder/locking_clause.rs
+++ b/diesel/src/query_builder/locking_clause.rs
@@ -1,6 +1,6 @@
-use backend::Backend;
-use query_builder::{AstPass, QueryFragment};
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::{AstPass, QueryFragment};
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct NoLockingClause;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -52,8 +52,8 @@ pub(crate) use self::insert_statement::ColumnList;
 
 use std::error::Error;
 
-use backend::Backend;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::result::QueryResult;
 
 #[doc(hidden)]
 pub type Binds = Vec<Option<Vec<u8>>>;

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -1,6 +1,6 @@
-use backend::Backend;
-use query_builder::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::query_builder::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Identifier<'a>(pub &'a str);

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -118,7 +118,7 @@ mod tests {
     use std::any::TypeId;
 
     use super::QueryId;
-    use prelude::*;
+    use crate::prelude::*;
 
     table! {
         users {

--- a/diesel/src/query_builder/returning_clause.rs
+++ b/diesel/src/query_builder/returning_clause.rs
@@ -1,4 +1,4 @@
-use backend::SupportsReturningClause;
+use crate::backend::SupportsReturningClause;
 
 simple_clause!(
     NoReturningClause,

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -1,7 +1,7 @@
-use backend::Backend;
-use expression::{Expression, SelectableExpression};
-use query_builder::*;
-use query_source::QuerySource;
+use crate::backend::Backend;
+use crate::expression::{Expression, SelectableExpression};
+use crate::query_builder::*;
+use crate::query_source::QuerySource;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct DefaultSelectClause;

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -1,24 +1,24 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use dsl::AsExprOf;
-use expression::subselect::ValidSubselect;
-use expression::*;
-use insertable::Insertable;
-use query_builder::distinct_clause::DistinctClause;
-use query_builder::group_by_clause::GroupByClause;
-use query_builder::insert_statement::InsertFromSelect;
-use query_builder::limit_clause::LimitClause;
-use query_builder::offset_clause::OffsetClause;
-use query_builder::order_clause::OrderClause;
-use query_builder::where_clause::*;
-use query_builder::*;
-use query_dsl::methods::*;
-use query_dsl::*;
-use query_source::joins::*;
-use query_source::{QuerySource, Table};
-use result::QueryResult;
-use sql_types::{BigInt, Bool, NotNull, Nullable};
+use crate::backend::Backend;
+use crate::dsl::AsExprOf;
+use crate::expression::subselect::ValidSubselect;
+use crate::expression::*;
+use crate::insertable::Insertable;
+use crate::query_builder::distinct_clause::DistinctClause;
+use crate::query_builder::group_by_clause::GroupByClause;
+use crate::query_builder::insert_statement::InsertFromSelect;
+use crate::query_builder::limit_clause::LimitClause;
+use crate::query_builder::offset_clause::OffsetClause;
+use crate::query_builder::order_clause::OrderClause;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::*;
+use crate::query_dsl::methods::*;
+use crate::query_dsl::*;
+use crate::query_source::joins::*;
+use crate::query_source::{QuerySource, Table};
+use crate::result::QueryResult;
+use crate::sql_types::{BigInt, Bool, NotNull, Nullable};
 
 #[allow(missing_debug_implementations)]
 pub struct BoxedSelectStatement<'a, ST, QS, DB> {

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -1,27 +1,27 @@
 use super::BoxedSelectStatement;
-use associations::HasTable;
-use backend::Backend;
-use dsl::AsExprOf;
-use expression::nullable::Nullable;
-use expression::*;
-use insertable::Insertable;
-use query_builder::distinct_clause::*;
-use query_builder::group_by_clause::*;
-use query_builder::insert_statement::InsertFromSelect;
-use query_builder::limit_clause::*;
-use query_builder::locking_clause::*;
-use query_builder::offset_clause::*;
-use query_builder::order_clause::*;
-use query_builder::select_clause::*;
-use query_builder::update_statement::*;
-use query_builder::where_clause::*;
-use query_builder::{AsQuery, Query, QueryFragment, SelectQuery, SelectStatement};
-use query_dsl::boxed_dsl::BoxedDsl;
-use query_dsl::methods::*;
-use query_dsl::*;
-use query_source::joins::{Join, JoinOn, JoinTo};
-use query_source::QuerySource;
-use sql_types::{BigInt, Bool};
+use crate::associations::HasTable;
+use crate::backend::Backend;
+use crate::dsl::AsExprOf;
+use crate::expression::nullable::Nullable;
+use crate::expression::*;
+use crate::insertable::Insertable;
+use crate::query_builder::distinct_clause::*;
+use crate::query_builder::group_by_clause::*;
+use crate::query_builder::insert_statement::InsertFromSelect;
+use crate::query_builder::limit_clause::*;
+use crate::query_builder::locking_clause::*;
+use crate::query_builder::offset_clause::*;
+use crate::query_builder::order_clause::*;
+use crate::query_builder::select_clause::*;
+use crate::query_builder::update_statement::*;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::{AsQuery, Query, QueryFragment, SelectQuery, SelectStatement};
+use crate::query_dsl::boxed_dsl::BoxedDsl;
+use crate::query_dsl::methods::*;
+use crate::query_dsl::*;
+use crate::query_source::joins::{Join, JoinOn, JoinTo};
+use crate::query_source::QuerySource;
+use crate::sql_types::{BigInt, Bool};
 
 impl<F, S, D, W, O, L, Of, G, LC, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On>
     for SelectStatement<F, S, D, W, O, L, Of, G, LC>
@@ -136,9 +136,9 @@ where
     }
 }
 
-use dsl::Filter;
-use expression_methods::EqAll;
-use query_source::Table;
+use crate::dsl::Filter;
+use crate::expression_methods::EqAll;
+use crate::query_source::Table;
 
 impl<F, S, D, W, O, L, Of, G, LC, PK> FindDsl<PK> for SelectStatement<F, S, D, W, O, L, Of, G, LC>
 where
@@ -207,7 +207,7 @@ where
     Expr: Expression,
     Self: OrderDsl<Expr>,
 {
-    type Output = ::dsl::Order<Self, Expr>;
+    type Output = crate::dsl::Order<Self, Expr>;
 
     fn then_order_by(self, expr: Expr) -> Self::Output {
         self.order_by(expr)

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -25,13 +25,13 @@ use super::order_clause::NoOrderClause;
 use super::select_clause::*;
 use super::where_clause::*;
 use super::{AstPass, Query, QueryFragment};
-use backend::Backend;
-use expression::subselect::ValidSubselect;
-use expression::*;
-use query_builder::SelectQuery;
-use query_source::joins::{AppendSelection, Inner, Join};
-use query_source::*;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::subselect::ValidSubselect;
+use crate::expression::*;
+use crate::query_builder::SelectQuery;
+use crate::query_source::joins::{AppendSelection, Inner, Join};
+use crate::query_source::*;
+use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 #[doc(hidden)]

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -1,13 +1,13 @@
 use std::marker::PhantomData;
 
-use backend::Backend;
-use connection::Connection;
-use deserialize::QueryableByName;
-use query_builder::{AstPass, QueryFragment, QueryId};
-use query_dsl::{LoadQuery, RunQueryDsl};
-use result::QueryResult;
-use serialize::ToSql;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::connection::Connection;
+use crate::deserialize::QueryableByName;
+use crate::query_builder::{AstPass, QueryFragment, QueryId};
+use crate::query_dsl::{LoadQuery, RunQueryDsl};
+use crate::result::QueryResult;
+use crate::serialize::ToSql;
+use crate::sql_types::HasSqlType;
 
 #[derive(Debug, Clone)]
 #[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -1,9 +1,9 @@
-use backend::Backend;
-use expression::operators::Eq;
-use expression::AppearsOnTable;
-use query_builder::*;
-use query_source::{Column, QuerySource};
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::expression::operators::Eq;
+use crate::expression::AppearsOnTable;
+use crate::query_builder::*;
+use crate::query_source::{Column, QuerySource};
+use crate::result::QueryResult;
 
 /// Types which can be passed to
 /// [`update.set`](struct.UpdateStatement.html#method.set).

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -4,17 +4,17 @@ pub mod target;
 pub use self::changeset::AsChangeset;
 pub use self::target::{IntoUpdateTarget, UpdateTarget};
 
-use backend::Backend;
-use dsl::{Filter, IntoBoxed};
-use expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
-use query_builder::returning_clause::*;
-use query_builder::where_clause::*;
-use query_builder::*;
-use query_dsl::methods::{BoxedDsl, FilterDsl};
-use query_dsl::RunQueryDsl;
-use query_source::Table;
-use result::Error::QueryBuilderError;
-use result::QueryResult;
+use crate::backend::Backend;
+use crate::dsl::{Filter, IntoBoxed};
+use crate::expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
+use crate::query_builder::returning_clause::*;
+use crate::query_builder::where_clause::*;
+use crate::query_builder::*;
+use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
+use crate::query_dsl::RunQueryDsl;
+use crate::query_source::Table;
+use crate::result::Error::QueryBuilderError;
+use crate::result::QueryResult;
 
 impl<T, U> UpdateStatement<T, U, SetNotCalled> {
     pub(crate) fn new(target: UpdateTarget<T, U>) -> Self {

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -1,7 +1,7 @@
-use associations::{HasTable, Identifiable};
-use dsl::Find;
-use query_dsl::methods::FindDsl;
-use query_source::Table;
+use crate::associations::{HasTable, Identifiable};
+use crate::dsl::Find;
+use crate::query_dsl::methods::FindDsl;
+use crate::query_source::Table;
 
 #[doc(hidden)]
 #[derive(Debug)]

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -1,11 +1,11 @@
 use super::*;
-use backend::Backend;
-use dsl::Or;
-use expression::operators::And;
-use expression::*;
-use expression_methods::*;
-use result::QueryResult;
-use sql_types::Bool;
+use crate::backend::Backend;
+use crate::dsl::Or;
+use crate::expression::operators::And;
+use crate::expression::*;
+use crate::expression_methods::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
 
 /// Add `Predicate` to the current `WHERE` clause, joining with `AND` if
 /// applicable.
@@ -176,8 +176,8 @@ where
 
     fn or(self, predicate: Predicate) -> Self::Output {
         use self::BoxedWhereClause::Where;
-        use expression::grouped::Grouped;
-        use expression::operators::Or;
+        use crate::expression::grouped::Grouped;
+        use crate::expression::operators::Or;
 
         match self {
             Where(where_clause) => Where(Box::new(Grouped(Or::new(where_clause, predicate)))),

--- a/diesel/src/query_dsl/belonging_to_dsl.rs
+++ b/diesel/src/query_dsl/belonging_to_dsl.rs
@@ -28,8 +28,8 @@
 /// #
 /// # fn run_test() -> QueryResult<()> {
 /// #     let connection = establish_connection();
-/// #     use users::dsl::*;
-/// #     use posts::dsl::{posts, title};
+/// #     use self::users::dsl::*;
+/// #     use self::posts::dsl::{posts, title};
 /// let sean = users.filter(name.eq("Sean")).first::<User>(&connection)?;
 /// let tess = users.filter(name.eq("Tess")).first::<User>(&connection)?;
 ///

--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -1,5 +1,5 @@
-use query_builder::AsQuery;
-use query_source::Table;
+use crate::query_builder::AsQuery;
+use crate::query_source::Table;
 
 /// The `into_boxed` method
 ///

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "postgres")]
-use expression::SelectableExpression;
-use query_source::Table;
+use crate::expression::SelectableExpression;
+use crate::query_source::Table;
 
 /// The `distinct` method
 ///

--- a/diesel/src/query_dsl/filter_dsl.rs
+++ b/diesel/src/query_dsl/filter_dsl.rs
@@ -1,6 +1,6 @@
-use dsl::{Filter, OrFilter};
-use expression_methods::*;
-use query_source::*;
+use crate::dsl::{Filter, OrFilter};
+use crate::expression_methods::*;
+use crate::query_source::*;
 
 /// The `filter` method
 ///

--- a/diesel/src/query_dsl/group_by_dsl.rs
+++ b/diesel/src/query_dsl/group_by_dsl.rs
@@ -1,6 +1,6 @@
-use expression::Expression;
-use query_builder::{AsQuery, Query};
-use query_source::Table;
+use crate::expression::Expression;
+use crate::query_builder::{AsQuery, Query};
+use crate::query_source::Table;
 
 /// This trait is not yet part of Diesel's public API. It may change in the
 /// future without a major version bump.

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -1,6 +1,6 @@
-use query_builder::AsQuery;
-use query_source::joins::OnClauseWrapper;
-use query_source::{JoinTo, QuerySource, Table};
+use crate::query_builder::AsQuery;
+use crate::query_source::joins::OnClauseWrapper;
+use crate::query_source::{JoinTo, QuerySource, Table};
 
 #[doc(hidden)]
 /// `JoinDsl` support trait to emulate associated type constructors

--- a/diesel/src/query_dsl/limit_dsl.rs
+++ b/diesel/src/query_dsl/limit_dsl.rs
@@ -1,4 +1,4 @@
-use query_source::Table;
+use crate::query_source::Table;
 
 /// The `limit` method
 ///

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,10 +1,10 @@
 use super::RunQueryDsl;
-use backend::Backend;
-use connection::Connection;
-use deserialize::Queryable;
-use query_builder::{AsQuery, QueryFragment, QueryId};
-use result::QueryResult;
-use sql_types::HasSqlType;
+use crate::backend::Backend;
+use crate::connection::Connection;
+use crate::deserialize::Queryable;
+use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::result::QueryResult;
+use crate::sql_types::HasSqlType;
 
 /// The `load` method
 ///

--- a/diesel/src/query_dsl/locking_dsl.rs
+++ b/diesel/src/query_dsl/locking_dsl.rs
@@ -1,5 +1,5 @@
-use query_builder::AsQuery;
-use query_source::Table;
+use crate::query_builder::AsQuery;
+use crate::query_source::Table;
 
 /// Methods related to locking select statements
 ///

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -13,14 +13,14 @@
 //! [`QueryDsl`]: trait.QueryDsl.html
 //! [`RunQueryDsl`]: trait.RunQueryDsl.html
 
-use backend::Backend;
-use connection::Connection;
-use expression::count::CountStar;
-use expression::Expression;
-use helper_types::*;
-use query_builder::locking_clause as lock;
-use query_source::{joins, Table};
-use result::{first_or_not_found, QueryResult};
+use crate::backend::Backend;
+use crate::connection::Connection;
+use crate::expression::count::CountStar;
+use crate::expression::Expression;
+use crate::helper_types::*;
+use crate::query_builder::locking_clause as lock;
+use crate::query_source::{joins, Table};
+use crate::result::{first_or_not_found, QueryResult};
 
 mod belonging_to_dsl;
 #[doc(hidden)]
@@ -310,7 +310,7 @@ pub trait QueryDsl: Sized {
     where
         Self: methods::SelectDsl<CountStar>,
     {
-        use dsl::count_star;
+        use crate::dsl::count_star;
 
         QueryDsl::select(self, count_star())
     }
@@ -698,7 +698,7 @@ pub trait QueryDsl: Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     diesel::delete(users).execute(&connection)?;
     /// #     diesel::insert_into(users)
@@ -748,7 +748,7 @@ pub trait QueryDsl: Sized {
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use users::dsl::*;
+    /// #     use self::users::dsl::*;
     /// #     let connection = establish_connection();
     /// #     diesel::delete(users).execute(&connection)?;
     /// #     diesel::insert_into(users)

--- a/diesel/src/query_dsl/offset_dsl.rs
+++ b/diesel/src/query_dsl/offset_dsl.rs
@@ -1,4 +1,4 @@
-use query_source::Table;
+use crate::query_source::Table;
 
 /// The `offset` method
 ///

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -1,5 +1,5 @@
-use expression::Expression;
-use query_source::Table;
+use crate::expression::Expression;
+use crate::query_source::Table;
 
 /// The `order` method
 ///

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -1,17 +1,17 @@
-use associations::HasTable;
+use crate::associations::HasTable;
 #[cfg(any(feature = "sqlite", feature = "mysql"))]
-use associations::Identifiable;
-use connection::Connection;
+use crate::associations::Identifiable;
+use crate::connection::Connection;
 #[cfg(any(feature = "sqlite", feature = "mysql"))]
-use dsl::Find;
+use crate::dsl::Find;
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-use dsl::Update;
-use query_builder::{AsChangeset, IntoUpdateTarget};
+use crate::dsl::Update;
+use crate::query_builder::{AsChangeset, IntoUpdateTarget};
 #[cfg(any(feature = "sqlite", feature = "mysql"))]
-use query_dsl::methods::{ExecuteDsl, FindDsl};
+use crate::query_dsl::methods::{ExecuteDsl, FindDsl};
 #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-use query_dsl::{LoadQuery, RunQueryDsl};
-use result::QueryResult;
+use crate::query_dsl::{LoadQuery, RunQueryDsl};
+use crate::result::QueryResult;
 
 /// A trait defining how to update a record and fetch the updated entry
 /// on a certain backend.
@@ -29,7 +29,7 @@ pub trait UpdateAndFetchResults<Changes, Output>: Connection {
 }
 
 #[cfg(feature = "postgres")]
-use pg::PgConnection;
+use crate::pg::PgConnection;
 
 #[cfg(feature = "postgres")]
 impl<Changes, Output> UpdateAndFetchResults<Changes, Output> for PgConnection
@@ -38,12 +38,12 @@ where
     Update<Changes, Changes>: LoadQuery<PgConnection, Output>,
 {
     fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
-        ::update(changeset).set(changeset).get_result(self)
+        crate::update(changeset).set(changeset).get_result(self)
     }
 }
 
 #[cfg(feature = "sqlite")]
-use sqlite::SqliteConnection;
+use crate::sqlite::SqliteConnection;
 
 #[cfg(feature = "sqlite")]
 impl<Changes, Output> UpdateAndFetchResults<Changes, Output> for SqliteConnection
@@ -55,13 +55,13 @@ where
     Find<Changes::Table, Changes::Id>: LoadQuery<SqliteConnection, Output>,
 {
     fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
-        ::update(changeset).set(changeset).execute(self)?;
+        crate::update(changeset).set(changeset).execute(self)?;
         Changes::table().find(changeset.id()).get_result(self)
     }
 }
 
 #[cfg(feature = "mysql")]
-use mysql::MysqlConnection;
+use crate::mysql::MysqlConnection;
 
 #[cfg(feature = "mysql")]
 impl<Changes, Output> UpdateAndFetchResults<Changes, Output> for MysqlConnection
@@ -73,7 +73,7 @@ where
     Find<Changes::Table, Changes::Id>: LoadQuery<MysqlConnection, Output>,
 {
     fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
-        ::update(changeset).set(changeset).execute(self)?;
+        crate::update(changeset).set(changeset).execute(self)?;
         Changes::table().find(changeset.id()).get_result(self)
     }
 }
@@ -112,7 +112,7 @@ where
 /// # }
 /// #
 /// # fn run_test() -> QueryResult<()> {
-/// #     use animals::dsl::*;
+/// #     use self::animals::dsl::*;
 /// #     let connection = establish_connection();
 /// let form = AnimalForm { id: 2, name: "Super scary" };
 /// let changed_animal = form.save_changes(&connection)?;

--- a/diesel/src/query_dsl/select_dsl.rs
+++ b/diesel/src/query_dsl/select_dsl.rs
@@ -1,5 +1,5 @@
-use expression::Expression;
-use query_source::Table;
+use crate::expression::Expression;
+use crate::query_source::Table;
 
 /// The `select` method
 ///

--- a/diesel/src/query_dsl/single_value_dsl.rs
+++ b/diesel/src/query_dsl/single_value_dsl.rs
@@ -1,9 +1,9 @@
 use super::methods::LimitDsl;
-use dsl::Limit;
-use expression::grouped::Grouped;
-use expression::subselect::Subselect;
-use query_builder::SelectQuery;
-use sql_types::{IntoNullable, SingleValue};
+use crate::dsl::Limit;
+use crate::expression::grouped::Grouped;
+use crate::expression::subselect::Subselect;
+use crate::query_builder::SelectQuery;
+use crate::sql_types::{IntoNullable, SingleValue};
 
 /// The `single_value` method
 ///

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -1,13 +1,13 @@
 use super::{AppearsInFromClause, Plus, QuerySource};
-use backend::Backend;
-use expression::grouped::Grouped;
-use expression::nullable::Nullable;
-use expression::SelectableExpression;
-use prelude::*;
-use query_builder::*;
-use result::QueryResult;
-use sql_types::Bool;
-use util::TupleAppend;
+use crate::backend::Backend;
+use crate::expression::grouped::Grouped;
+use crate::expression::nullable::Nullable;
+use crate::expression::SelectableExpression;
+use crate::prelude::*;
+use crate::query_builder::*;
+use crate::result::QueryResult;
+use crate::sql_types::Bool;
+use crate::util::TupleAppend;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 /// A query source representing the join between two tables

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -7,8 +7,8 @@
 pub mod joins;
 mod peano_numbers;
 
-use expression::{Expression, NonAggregate, SelectableExpression};
-use query_builder::*;
+use crate::expression::{Expression, NonAggregate, SelectableExpression};
+use crate::query_builder::*;
 
 pub use self::joins::JoinTo;
 pub use self::peano_numbers::*;

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -16,12 +16,12 @@ use std::convert::Into;
 use std::fmt;
 use std::marker::PhantomData;
 
-use backend::UsesAnsiSavepointSyntax;
-use connection::{AnsiTransactionManager, SimpleConnection};
-use deserialize::{Queryable, QueryableByName};
-use prelude::*;
-use query_builder::{AsQuery, QueryFragment, QueryId};
-use sql_types::HasSqlType;
+use crate::backend::UsesAnsiSavepointSyntax;
+use crate::connection::{AnsiTransactionManager, SimpleConnection};
+use crate::deserialize::{Queryable, QueryableByName};
+use crate::prelude::*;
+use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::sql_types::HasSqlType;
 
 /// An r2d2 connection manager for use with Diesel.
 ///
@@ -54,7 +54,7 @@ pub enum Error {
     ConnectionError(ConnectionError),
 
     /// An error occurred pinging the database
-    QueryError(::result::Error),
+    QueryError(crate::result::Error),
 }
 
 impl fmt::Display for Error {
@@ -82,21 +82,21 @@ pub trait R2D2Connection: Connection {
 }
 
 #[cfg(feature = "postgres")]
-impl R2D2Connection for ::pg::PgConnection {
+impl R2D2Connection for crate::pg::PgConnection {
     fn ping(&self) -> QueryResult<()> {
         self.execute("SELECT 1").map(|_| ())
     }
 }
 
 #[cfg(feature = "mysql")]
-impl R2D2Connection for ::mysql::MysqlConnection {
+impl R2D2Connection for crate::mysql::MysqlConnection {
     fn ping(&self) -> QueryResult<()> {
         self.execute("SELECT 1").map(|_| ())
     }
 }
 
 #[cfg(feature = "sqlite")]
-impl R2D2Connection for ::sqlite::SqliteConnection {
+impl R2D2Connection for crate::sqlite::SqliteConnection {
     fn ping(&self) -> QueryResult<()> {
         self.execute("SELECT 1").map(|_| ())
     }
@@ -188,8 +188,8 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
-    use r2d2::*;
-    use test_helpers::*;
+    use crate::r2d2::*;
+    use crate::test_helpers::*;
 
     #[test]
     fn establish_basic_connection() {
@@ -235,8 +235,8 @@ mod tests {
 
     #[test]
     fn pooled_connection_impls_connection() {
-        use select;
-        use sql_types::Text;
+        use crate::select;
+        use crate::sql_types::Text;
 
         let manager = ConnectionManager::<TestConnection>::new(database_url());
         let pool = Pool::builder()

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -1,7 +1,7 @@
 //! Contains the `Row` trait
 
-use backend::{self, Backend};
-use deserialize::{self, FromSql};
+use crate::backend::{self, Backend};
+use crate::deserialize::{self, FromSql};
 
 /// Represents a single database row.
 /// Apps should not need to concern themselves with this trait.

--- a/diesel/src/serialize.rs
+++ b/diesel/src/serialize.rs
@@ -6,11 +6,11 @@ use std::io::{self, Write};
 use std::ops::{Deref, DerefMut};
 use std::result;
 
-use backend::Backend;
-use sql_types::TypeMetadata;
+use crate::backend::Backend;
+use crate::sql_types::TypeMetadata;
 
 #[cfg(feature = "postgres")]
-pub use pg::serialize::*;
+pub use crate::pg::serialize::*;
 
 /// A specialized result type representing the result of serializing
 /// a value for the database.

--- a/diesel/src/sql_types/fold.rs
+++ b/diesel/src/sql_types/fold.rs
@@ -1,4 +1,4 @@
-use sql_types::{self, NotNull};
+use crate::sql_types::{self, NotNull};
 
 /// Represents SQL types which can be used with `SUM` and `AVG`
 pub trait Foldable {

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -356,10 +356,10 @@ pub struct Timestamp;
 pub struct Nullable<ST: NotNull>(ST);
 
 #[cfg(feature = "postgres")]
-pub use pg::types::sql_types::*;
+pub use crate::pg::types::sql_types::*;
 
 #[cfg(feature = "mysql")]
-pub use mysql::types::*;
+pub use crate::mysql::types::*;
 
 /// Indicates that a SQL type exists for a backend.
 ///

--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -1,4 +1,4 @@
-use sql_types::{self, NotNull};
+use crate::sql_types::{self, NotNull};
 
 /// Marker trait for types which can be used with `MAX` and `MIN`
 pub trait SqlOrd {}

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -3,9 +3,9 @@ use byteorder::NativeEndian;
 
 use super::connection::SqliteValue;
 use super::query_builder::SqliteQueryBuilder;
-use backend::*;
-use query_builder::bind_collector::RawBytesBindCollector;
-use sql_types::TypeMetadata;
+use crate::backend::*;
+use crate::query_builder::bind_collector::RawBytesBindCollector;
+use crate::sql_types::TypeMetadata;
 
 /// The SQLite backend
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -3,11 +3,11 @@ extern crate libsqlite3_sys as ffi;
 use super::raw::RawConnection;
 use super::serialized_value::SerializedValue;
 use super::{Sqlite, SqliteValue};
-use deserialize::{FromSqlRow, Queryable};
-use result::{DatabaseErrorKind, Error, QueryResult};
-use row::Row;
-use serialize::{IsNull, Output, ToSql};
-use sql_types::HasSqlType;
+use crate::deserialize::{FromSqlRow, Queryable};
+use crate::result::{DatabaseErrorKind, Error, QueryResult};
+use crate::row::Row;
+use crate::serialize::{IsNull, Output, ToSql};
+use crate::sql_types::HasSqlType;
 
 pub fn register<ArgsSqlType, RetSqlType, Args, Ret, F>(
     conn: &RawConnection,

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -7,8 +7,8 @@ use std::ptr::NonNull;
 use std::{mem, ptr, slice, str};
 
 use super::serialized_value::SerializedValue;
-use result::Error::DatabaseError;
-use result::*;
+use crate::result::Error::DatabaseError;
+use crate::result::*;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct RawConnection {

--- a/diesel/src/sqlite/connection/serialized_value.rs
+++ b/diesel/src/sqlite/connection/serialized_value.rs
@@ -3,7 +3,7 @@ extern crate libsqlite3_sys as ffi;
 use std::os::raw as libc;
 use std::ptr::{self, NonNull};
 
-use sqlite::SqliteType;
+use crate::sqlite::SqliteType;
 
 pub struct SerializedValue {
     pub ty: SqliteType,

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -5,8 +5,8 @@ use std::os::raw as libc;
 use std::ptr::NonNull;
 use std::{slice, str};
 
-use row::*;
-use sqlite::Sqlite;
+use crate::row::*;
+use crate::sqlite::Sqlite;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct SqliteValue {

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use super::stmt::StatementUse;
-use deserialize::{FromSqlRow, Queryable, QueryableByName};
-use result::Error::DeserializationError;
-use result::QueryResult;
-use sqlite::Sqlite;
+use crate::deserialize::{FromSqlRow, Queryable, QueryableByName};
+use crate::result::Error::DeserializationError;
+use crate::result::QueryResult;
+use crate::sqlite::Sqlite;
 
 pub struct StatementIterator<'a, ST, T> {
     stmt: StatementUse<'a>,

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -8,9 +8,9 @@ use std::ptr::{self, NonNull};
 use super::raw::RawConnection;
 use super::serialized_value::SerializedValue;
 use super::sqlite_value::SqliteRow;
-use result::Error::DatabaseError;
-use result::*;
-use sqlite::SqliteType;
+use crate::result::Error::DatabaseError;
+use crate::result::*;
+use crate::sqlite::SqliteType;
 
 pub struct Statement {
     inner_statement: NonNull<ffi::sqlite3_stmt>,

--- a/diesel/src/sqlite/query_builder/mod.rs
+++ b/diesel/src/sqlite/query_builder/mod.rs
@@ -1,8 +1,8 @@
 //! The SQLite query builder
 
 use super::backend::Sqlite;
-use query_builder::QueryBuilder;
-use result::QueryResult;
+use crate::query_builder::QueryBuilder;
+use crate::result::QueryResult;
 
 /// Constructs SQL queries for use with the SQLite backend
 #[allow(missing_debug_implementations)]

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -3,11 +3,11 @@ extern crate chrono;
 use self::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use std::io::Write;
 
-use backend;
-use deserialize::{self, FromSql};
-use serialize::{self, Output, ToSql};
-use sql_types::{Date, Text, Time, Timestamp};
-use sqlite::Sqlite;
+use crate::backend;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types::{Date, Text, Time, Timestamp};
+use crate::sqlite::Sqlite;
 
 const SQLITE_DATE_FORMAT: &str = "%F";
 
@@ -111,10 +111,10 @@ mod tests {
     use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
     use self::dotenv::dotenv;
 
-    use dsl::{now, sql};
-    use prelude::*;
-    use select;
-    use sql_types::{Text, Time, Timestamp};
+    use crate::dsl::{now, sql};
+    use crate::prelude::*;
+    use crate::select;
+    use crate::sql_types::{Text, Time, Timestamp};
 
     sql_function!(fn datetime(x: Text) -> Timestamp);
     sql_function!(fn time(x: Text) -> Time);

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 
-use deserialize::{self, FromSql};
-use serialize::{self, Output, ToSql};
-use sql_types;
-use sqlite::connection::SqliteValue;
-use sqlite::Sqlite;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
+use crate::sqlite::connection::SqliteValue;
+use crate::sqlite::Sqlite;
 
 #[cfg(feature = "chrono")]
 mod chrono;

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -5,9 +5,9 @@ use std::io::prelude::*;
 
 use super::connection::SqliteValue;
 use super::Sqlite;
-use deserialize::{self, FromSql};
-use serialize::{self, Output, ToSql};
-use sql_types;
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, Output, ToSql};
+use crate::sql_types;
 
 /// The returned pointer is *only* valid for the lifetime to the argument of
 /// `from_sql`. This impl is intended for uses where you want to write a new

--- a/diesel/src/sqlite/types/numeric.rs
+++ b/diesel/src/sqlite/types/numeric.rs
@@ -4,10 +4,10 @@ extern crate bigdecimal;
 
 use self::bigdecimal::BigDecimal;
 
-use deserialize::{self, FromSql};
-use sql_types::{Double, Numeric};
-use sqlite::connection::SqliteValue;
-use sqlite::Sqlite;
+use crate::deserialize::{self, FromSql};
+use crate::sql_types::{Double, Numeric};
+use crate::sqlite::connection::SqliteValue;
+use crate::sqlite::Sqlite;
 
 impl FromSql<Numeric, Sqlite> for BigDecimal {
     fn from_sql(bytes: Option<&SqliteValue>) -> deserialize::Result<Self> {

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -1,6 +1,6 @@
 extern crate dotenv;
 
-use prelude::*;
+use crate::prelude::*;
 
 cfg_if! {
     if #[cfg(feature = "sqlite")] {

--- a/diesel/src/type_impls/date_and_time.rs
+++ b/diesel/src/type_impls/date_and_time.rs
@@ -4,14 +4,14 @@ use std::time::SystemTime;
 
 #[derive(FromSqlRow, AsExpression)]
 #[diesel(foreign_derive)]
-#[sql_type = "::sql_types::Timestamp"]
+#[sql_type = "crate::sql_types::Timestamp"]
 struct SystemTimeProxy(SystemTime);
 
 #[cfg(feature = "chrono")]
 mod chrono {
     extern crate chrono;
     use self::chrono::*;
-    use sql_types::{Date, Time, Timestamp};
+    use crate::sql_types::{Date, Time, Timestamp};
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
@@ -26,12 +26,12 @@ mod chrono {
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
     #[sql_type = "Timestamp"]
-    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Timestamptz")]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Datetime")]
+    #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Timestamptz")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Datetime")]
     struct NaiveDateTimeProxy(NaiveDateTime);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Timestamptz")]
+    #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Timestamptz")]
     struct DateTimeProxy<Tz: TimeZone>(DateTime<Tz>);
 }

--- a/diesel/src/type_impls/decimal.rs
+++ b/diesel/src/type_impls/decimal.rs
@@ -4,7 +4,7 @@
 mod bigdecimal {
     extern crate bigdecimal;
     use self::bigdecimal::BigDecimal;
-    use sql_types::Numeric;
+    use crate::sql_types::Numeric;
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]

--- a/diesel/src/type_impls/floats.rs
+++ b/diesel/src/type_impls/floats.rs
@@ -2,16 +2,16 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use backend::{Backend, BinaryRawValue};
-use deserialize::{self, FromSql};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::backend::{Backend, BinaryRawValue};
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl<DB> FromSql<sql_types::Float, DB> for f32
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
@@ -37,7 +37,7 @@ impl<DB> FromSql<sql_types::Double, DB> for f64
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let mut bytes = DB::as_bytes(value);
         debug_assert!(

--- a/diesel/src/type_impls/integers.rs
+++ b/diesel/src/type_impls/integers.rs
@@ -2,16 +2,16 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::io::prelude::*;
 
-use backend::{Backend, BinaryRawValue};
-use deserialize::{self, FromSql};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types;
+use crate::backend::{Backend, BinaryRawValue};
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
 
 impl<DB> FromSql<sql_types::SmallInt, DB> for i16
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
@@ -43,7 +43,7 @@ impl<DB> FromSql<sql_types::Integer, DB> for i32
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let mut bytes = DB::as_bytes(value);
         debug_assert!(
@@ -74,7 +74,7 @@ impl<DB> FromSql<sql_types::BigInt, DB> for i64
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         let value = not_none!(value);
         let mut bytes = DB::as_bytes(value);
         debug_assert!(

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -1,14 +1,14 @@
 use std::io::Write;
 
-use backend::{self, Backend};
-use deserialize::{self, FromSql, FromSqlRow, Queryable, QueryableByName};
-use expression::bound::Bound;
-use expression::*;
-use query_builder::QueryId;
-use result::UnexpectedNullError;
-use row::NamedRow;
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{HasSqlType, NotNull, Nullable};
+use crate::backend::{self, Backend};
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable, QueryableByName};
+use crate::expression::bound::Bound;
+use crate::expression::*;
+use crate::query_builder::QueryId;
+use crate::result::UnexpectedNullError;
+use crate::row::NamedRow;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{HasSqlType, NotNull, Nullable};
 
 impl<T, DB> HasSqlType<Nullable<T>> for DB
 where
@@ -89,7 +89,7 @@ where
 {
     const FIELDS_NEEDED: usize = T::FIELDS_NEEDED;
 
-    fn build_from_row<R: ::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
+    fn build_from_row<R: crate::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
         let fields_needed = Self::FIELDS_NEEDED;
         if row.next_is_null(fields_needed) {
             row.advance(fields_needed);
@@ -138,9 +138,9 @@ where
 }
 
 #[cfg(all(test, feature = "postgres"))]
-use pg::Pg;
+use crate::pg::Pg;
 #[cfg(all(test, feature = "postgres"))]
-use sql_types;
+use crate::sql_types;
 
 #[test]
 #[cfg(feature = "postgres")]

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -138,7 +138,7 @@ impl<DB> FromSql<sql_types::Text, DB> for *const str
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    default fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    default fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         use std::str;
         let value = not_none!(value);
         let string = str::from_utf8(DB::as_bytes(value))?;

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -1,10 +1,10 @@
 use std::error::Error;
 use std::io::Write;
 
-use backend::{self, Backend, BinaryRawValue};
-use deserialize::{self, FromSql, FromSqlRow, Queryable};
-use serialize::{self, IsNull, Output, ToSql};
-use sql_types::{self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text};
+use crate::backend::{self, Backend, BinaryRawValue};
+use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::{self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text};
 
 #[allow(dead_code)]
 mod foreign_impls {
@@ -17,7 +17,7 @@ mod foreign_impls {
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::TinyInt")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::TinyInt")]
     struct I8Proxy(i8);
 
     #[derive(FromSqlRow, AsExpression)]
@@ -39,24 +39,24 @@ mod foreign_impls {
     #[diesel(foreign_derive)]
     #[cfg_attr(
         feature = "mysql",
-        sql_type = "::sql_types::Unsigned<::sql_types::TinyInt>"
+        sql_type = "crate::sql_types::Unsigned<crate::sql_types::TinyInt>"
     )]
     struct U8Proxy(u8);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<SmallInt>")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<SmallInt>")]
     struct U16Proxy(u16);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<Integer>")]
-    #[cfg_attr(feature = "postgres", sql_type = "::sql_types::Oid")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<Integer>")]
+    #[cfg_attr(feature = "postgres", sql_type = "crate::sql_types::Oid")]
     struct U32Proxy(u32);
 
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
-    #[cfg_attr(feature = "mysql", sql_type = "::sql_types::Unsigned<BigInt>")]
+    #[cfg_attr(feature = "mysql", sql_type = "crate::sql_types::Unsigned<BigInt>")]
     struct U64Proxy(u64);
 
     #[derive(FromSqlRow, AsExpression)]
@@ -72,17 +72,17 @@ mod foreign_impls {
     #[derive(FromSqlRow, AsExpression)]
     #[diesel(foreign_derive)]
     #[sql_type = "Text"]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Date")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Time")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Timestamp")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Date")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Time")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Timestamp")]
     struct StringProxy(String);
 
     #[derive(AsExpression)]
     #[diesel(foreign_derive, not_sized)]
     #[sql_type = "Text"]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Date")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Time")]
-    #[cfg_attr(feature = "sqlite", sql_type = "::sql_types::Timestamp")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Date")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Time")]
+    #[cfg_attr(feature = "sqlite", sql_type = "crate::sql_types::Timestamp")]
     struct StrProxy(str);
 
     #[derive(FromSqlRow)]
@@ -125,7 +125,7 @@ impl<DB> FromSql<sql_types::Text, DB> for *const str
 where
     DB: Backend + for<'a> BinaryRawValue<'a>,
 {
-    fn from_sql(value: Option<::backend::RawValue<DB>>) -> deserialize::Result<Self> {
+    fn from_sql(value: Option<crate::backend::RawValue<DB>>) -> deserialize::Result<Self> {
         use std::str;
         let value = not_none!(value);
         let string = str::from_utf8(DB::as_bytes(value))?;
@@ -239,7 +239,7 @@ where
     DB: Backend,
     Cow<'a, T>: FromSql<ST, DB>,
 {
-    fn build_from_row<R: ::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
+    fn build_from_row<R: crate::row::Row<DB>>(row: &mut R) -> deserialize::Result<Self> {
         FromSql::<ST, DB>::from_sql(row.take())
     }
 }
@@ -257,8 +257,8 @@ where
     }
 }
 
-use expression::bound::Bound;
-use expression::{AsExpression, Expression};
+use crate::expression::bound::Bound;
+use crate::expression::{AsExpression, Expression};
 
 impl<'a, T: ?Sized, ST> AsExpression<ST> for Cow<'a, T>
 where

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -4,7 +4,9 @@ use std::io::Write;
 use crate::backend::{self, Backend, BinaryRawValue};
 use crate::deserialize::{self, FromSql, FromSqlRow, Queryable};
 use crate::serialize::{self, IsNull, Output, ToSql};
-use crate::sql_types::{self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text};
+use crate::sql_types::{
+    self, BigInt, Binary, Bool, Double, Float, Integer, NotNull, SmallInt, Text,
+};
 
 #[allow(dead_code)]
 mod foreign_impls {

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -1,18 +1,18 @@
 use std::error::Error;
 
-use associations::BelongsTo;
-use backend::Backend;
-use deserialize::{self, FromSqlRow, Queryable, QueryableByName};
-use expression::{
+use crate::associations::BelongsTo;
+use crate::backend::Backend;
+use crate::deserialize::{self, FromSqlRow, Queryable, QueryableByName};
+use crate::expression::{
     AppearsOnTable, AsExpression, AsExpressionList, Expression, NonAggregate, SelectableExpression,
 };
-use insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
-use query_builder::*;
-use query_source::*;
-use result::QueryResult;
-use row::*;
-use sql_types::{HasSqlType, NotNull};
-use util::TupleAppend;
+use crate::insertable::{CanInsertInSingleQuery, InsertValues, Insertable};
+use crate::query_builder::*;
+use crate::query_source::*;
+use crate::result::QueryResult;
+use crate::row::*;
+use crate::sql_types::{HasSqlType, NotNull};
+use crate::util::TupleAppend;
 
 macro_rules! tuple_impls {
     ($(


### PR DESCRIPTION
Note that this does not make any idiom adjustments, nor does it make the
crate usable without `#[macro_use] extern crate diesel;`. This is the
result of running `cargo fix --edition`, fixing the broken code it
generated, and then manually fixing the doctests.

As part of this I noticed a few doctests that expected the `extras`
feature to be able to run. I fixed those, and also realized that the
`Macaddr` type's impls are hidden behind the `network-address` feature
for no real reason.