### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,28 +21,29 @@ before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH
   - mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'travis'@'%';" -uroot
+  - rm rust-toolchain
 script:
 - |
-  rustc +$TRAVIS_RUST_VERSION --version &&
+  rustc --version &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-    (cd diesel && cargo +$TRAVIS_RUST_VERSION test --no-default-features --features "unstable extras $BACKEND")
+    (cd diesel && cargo test --no-default-features --features "unstable extras $BACKEND")
   else
-    (cd diesel && cargo +$TRAVIS_RUST_VERSION test --no-default-features --features "extras $BACKEND")
+    (cd diesel && cargo test --no-default-features --features "extras $BACKEND")
   fi &&
-  (cd diesel && cargo +$TRAVIS_RUST_VERSION test --no-default-features --features "extras with-deprecated $BACKEND") &&
-  (cd diesel_derives && cargo +$TRAVIS_RUST_VERSION test --features "diesel/$BACKEND") &&
+  (cd diesel && cargo test --no-default-features --features "extras with-deprecated $BACKEND") &&
+  (cd diesel_derives && cargo test --features "diesel/$BACKEND") &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-    (cd diesel_derives && cargo +$TRAVIS_RUST_VERSION test --features "diesel/unstable diesel/$BACKEND")
+    (cd diesel_derives && cargo test --features "diesel/unstable diesel/$BACKEND")
   fi &&
   (cd "examples/$BACKEND" && ./test_all) &&
-  (cd diesel_cli && cargo +$TRAVIS_RUST_VERSION test --no-default-features --features "$BACKEND") &&
-  (cd diesel_migrations/migrations_internals && cargo +$TRAVIS_RUST_VERSION test ) &&
-  (cd diesel_migrations/migrations_macros && cargo +$TRAVIS_RUST_VERSION test ) &&
-  (cd diesel_migrations/ && cargo +$TRAVIS_RUST_VERSION test  --features "$BACKEND diesel/$BACKEND" ) &&
+  (cd diesel_cli && cargo test --no-default-features --features "$BACKEND") &&
+  (cd diesel_migrations/migrations_internals && cargo test ) &&
+  (cd diesel_migrations/migrations_macros && cargo test ) &&
+  (cd diesel_migrations/ && cargo test  --features "$BACKEND diesel/$BACKEND" ) &&
   if [[ "$TRAVIS_RUST_VERSION" == nightly* ]]; then
-    (cd diesel_tests && cargo +$TRAVIS_RUST_VERSION test --no-default-features --features "unstable $BACKEND")
+    (cd diesel_tests && cargo test --no-default-features --features "unstable $BACKEND")
   else
-    (cd diesel_tests && cargo +$TRAVIS_RUST_VERSION test --no-default-features --features "$BACKEND")
+    (cd diesel_tests && cargo test --no-default-features --features "$BACKEND")
   fi
 matrix:
   allow_failures:
@@ -52,23 +53,23 @@ matrix:
     name: "Compile tests"
     env: RUSTFLAGS="--cap-lints=warn"
     script:
-    - (cd diesel_compile_tests && cargo +$TRAVIS_RUST_VERSION test)
+    - (cd diesel_compile_tests && cargo test)
   - rust: 1.36.0
     name: "Rustfmt && Clippy"
     script:
     - rustup component add rustfmt clippy
-    - cargo +$TRAVIS_RUST_VERSION clippy
-    - cargo +$TRAVIS_RUST_VERSION fmt --all -- --check
+    - cargo clippy
+    - cargo fmt --all -- --check
   - rust: stable
     name: "Bundled Sqlite"
     env:
     - SQLITE_DATABASE_URL=/tmp/test.db
     script:
-    - (cd diesel_cli && cargo +$TRAVIS_RUST_VERSION test --no-default-features --features "sqlite-bundled")
+    - (cd diesel_cli && cargo test --no-default-features --features "sqlite-bundled")
   - rust: 1.36.0
     name: "Minimal supported rust version == 1.36.0"
     script:
-    - cargo +$TRAVIS_RUST_VERSION check --all
+    - cargo check --all
 
 env:
   matrix:
@@ -88,7 +89,7 @@ env:
 after_success:
 - |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    (cd diesel && cargo +$TRAVIS_RUST_VERSION doc --features "postgres sqlite mysql extras")
+    (cd diesel && cargo doc --features "postgres sqlite mysql extras")
     mkdir diesel/target
     mv target/doc diesel/target/doc
     echo "docs.diesel.rs" > diesel/target/doc/CNAME


### PR DESCRIPTION
The build on master is currently broken. This is because the lockfile
created by Cargo in 1.41 is incompatible with earlier versions of Cargo.
Because the `test_all` files in the example directory aren't adding
`+$TRAVIS_RUST_VERSION`, our examples get run with the version specified
in `rust-toolchain` instead of the intended version for that piece of
the matrix.

Since everything in the main workspace uses a single lockfile, this
means that beta started breaking. We run the tests for the main crate
and derives first, which (correctly) runs on 1.41 and generates a
lockfile. When we then try to run the examples, they (incorrectly) use
the version in `rust-toolchain`, which cannot read the lockfile
generated by 1.41.

To fix this I just nuke the file before the build starts.