### PR TITLE
Fix #2258

### DIFF
--- a/diesel/src/query_builder/debug_query.rs
+++ b/diesel/src/query_builder/debug_query.rs
@@ -16,7 +16,7 @@ use crate::backend::Backend;
 ///
 /// [`debug_query`]: ../fn.debug_query.html
 pub struct DebugQuery<'a, T: 'a, DB> {
-    query: &'a T,
+    pub(crate) query: &'a T,
     _marker: PhantomData<DB>,
 }
 

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -5,6 +5,8 @@ pub(crate) use self::column_list::ColumnList;
 pub(crate) use self::insert_from_select::InsertFromSelect;
 
 use std::any::*;
+#[cfg(feature = "sqlite")]
+use std::fmt::{self, Debug, Display};
 use std::marker::PhantomData;
 
 use super::returning_clause::*;
@@ -228,6 +230,62 @@ where
 }
 
 #[cfg(feature = "sqlite")]
+impl<'a, T, U, Op> Display for DebugQuery<'a, InsertStatement<T, BatchInsert<'a, U, T>, Op>, Sqlite>
+where
+    &'a U: Insertable<T>,
+    for<'b> DebugQuery<'b, InsertStatement<T, <&'a U as Insertable<T>>::Values, Op>, Sqlite>:
+        Display,
+    T: Copy,
+    Op: Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "BEGIN;")?;
+        for record in self.query.records.records {
+            let stmt = InsertStatement::new(
+                self.query.target,
+                record.values(),
+                self.query.operator,
+                self.query.returning,
+            );
+
+            writeln!(f, "{}", crate::debug_query::<Sqlite, _>(&stmt))?;
+        }
+        writeln!(f, "COMMIT;")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a, T, U, Op> Debug for DebugQuery<'a, InsertStatement<T, BatchInsert<'a, U, T>, Op>, Sqlite>
+where
+    &'a U: Insertable<T>,
+    for<'b> DebugQuery<'b, InsertStatement<T, <&'a U as Insertable<T>>::Values, Op>, Sqlite>:
+        Display,
+    T: Copy,
+    Op: Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut statements = Vec::with_capacity(self.query.records.records.len() + 2);
+        statements.push("BEGIN".into());
+        for record in self.query.records.records {
+            let stmt = InsertStatement::new(
+                self.query.target,
+                record.values(),
+                self.query.operator,
+                self.query.returning,
+            );
+            statements.push(format!("{}", crate::debug_query::<Sqlite, _>(&stmt)));
+        }
+        statements.push("COMMIT".into());
+
+        f.debug_struct("Query")
+            .field("sql", &statements)
+            .field("binds", &[] as &[i32; 0])
+            .finish()
+    }
+}
+
+#[cfg(feature = "sqlite")]
 impl<T, U, Op> ExecuteDsl<SqliteConnection>
     for InsertStatement<T, OwnedBatchInsert<ValuesClause<U, T>, T>, Op>
 where
@@ -246,6 +304,61 @@ where
             }
             Ok(result)
         })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a, T, U, Op> Display
+    for DebugQuery<'a, InsertStatement<T, OwnedBatchInsert<ValuesClause<U, T>, T>, Op>, Sqlite>
+where
+    for<'b> DebugQuery<'b, InsertStatement<T, &'b ValuesClause<U, T>, Op>, Sqlite>: Display,
+    T: Copy,
+    Op: Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "BEGIN;")?;
+        for value in &self.query.records.values {
+            let stmt = InsertStatement::new(
+                self.query.target,
+                value,
+                self.query.operator,
+                self.query.returning,
+            );
+
+            writeln!(f, "{}", crate::debug_query::<Sqlite, _>(&stmt))?;
+        }
+        writeln!(f, "COMMIT;")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a, T, U, Op> Debug
+    for DebugQuery<'a, InsertStatement<T, OwnedBatchInsert<ValuesClause<U, T>, T>, Op>, Sqlite>
+where
+    for<'b> DebugQuery<'b, InsertStatement<T, &'b ValuesClause<U, T>, Op>, Sqlite>: Display,
+    T: Copy,
+    Op: Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut statements = Vec::with_capacity(self.query.records.values.len() + 2);
+        statements.push("BEGIN".into());
+
+        for value in &self.query.records.values {
+            let stmt = InsertStatement::new(
+                self.query.target,
+                value,
+                self.query.operator,
+                self.query.returning,
+            );
+            statements.push(format!("{}", crate::debug_query::<Sqlite, _>(&stmt)));
+        }
+        statements.push("COMMIT".into());
+
+        f.debug_struct("Query")
+            .field("sql", &statements)
+            .field("binds", &[] as &[i32; 0])
+            .finish()
     }
 }
 

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -29,3 +29,89 @@ fn test_debug_output() {
         )
     }
 }
+
+#[test]
+fn test_debug_batch_insert() {
+    // This test ensures that we've implemented `debug_query` for batch insert
+    // on sqlite
+    // This requires a separate impl because it's more than one sql statement that
+    // is executed
+
+    use schema::users::dsl::*;
+
+    let values = vec![
+        (name.eq("Sean"), hair_color.eq(Some("black"))),
+        (name.eq("Tess"), hair_color.eq(None::<&str>)),
+    ];
+    let borrowed_command = insert_into(users).values(&values);
+    let borrowed_sql_display = debug_query::<TestBackend, _>(&borrowed_command).to_string();
+    let borrowed_sql_debug = format!("{:?}", debug_query::<TestBackend, _>(&borrowed_command));
+
+    let owned_command = insert_into(users).values(values);
+    let owned_sql_display = debug_query::<TestBackend, _>(&owned_command).to_string();
+    let owned_sql_debug = format!("{:?}", debug_query::<TestBackend, _>(&owned_command));
+
+    if cfg!(feature = "postgres") {
+        assert_eq!(
+            borrowed_sql_display,
+            r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) -- binds: ["Sean", Some("black"), "Tess", None]"#
+        );
+        assert_eq!(
+            borrowed_sql_debug,
+            r#"Query { sql: "INSERT INTO \"users\" (\"name\", \"hair_color\") VALUES ($1, $2), ($3, $4)", binds: ["Sean", Some("black"), "Tess", None] }"#
+        );
+
+        assert_eq!(
+            owned_sql_display,
+            r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) -- binds: ["Sean", Some("black"), "Tess", None]"#
+        );
+        assert_eq!(
+            owned_sql_debug,
+            r#"Query { sql: "INSERT INTO \"users\" (\"name\", \"hair_color\") VALUES ($1, $2), ($3, $4)", binds: ["Sean", Some("black"), "Tess", None] }"#
+        );
+    } else if cfg!(feature = "sqlite") {
+        assert_eq!(
+            borrowed_sql_display,
+            r#"BEGIN;
+INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: ["Sean", Some("black")]
+INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: ["Tess", None]
+COMMIT;
+"#
+        );
+        assert_eq!(
+            borrowed_sql_debug,
+            r#"Query { sql: ["BEGIN", "INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: [\"Sean\", Some(\"black\")]", "INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: [\"Tess\", None]", "COMMIT"], binds: [] }"#
+        );
+
+        assert_eq!(
+            owned_sql_display,
+            r#"BEGIN;
+INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: ["Sean", Some("black")]
+INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: ["Tess", None]
+COMMIT;
+"#
+        );
+        assert_eq!(
+            owned_sql_debug,
+            r#"Query { sql: ["BEGIN", "INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: [\"Sean\", Some(\"black\")]", "INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?) -- binds: [\"Tess\", None]", "COMMIT"], binds: [] }"#
+        );
+    } else {
+        assert_eq!(
+            borrowed_sql_display,
+            r#"INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?), (?, ?) -- binds: ["Sean", Some("black"), "Tess", None]"#
+        );
+        assert_eq!(
+            borrowed_sql_debug,
+            r#"Query { sql: "INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?), (?, ?)", binds: ["Sean", Some("black"), "Tess", None] }"#
+        );
+
+        assert_eq!(
+            owned_sql_display,
+            r#"INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?), (?, ?) -- binds: ["Sean", Some("black"), "Tess", None]"#
+        );
+        assert_eq!(
+            owned_sql_debug,
+            r#"Query { sql: "INSERT INTO `users` (`name`, `hair_color`) VALUES (?, ?), (?, ?)", binds: ["Sean", Some("black"), "Tess", None] }"#
+        );
+    }
+}


### PR DESCRIPTION
Manual implement `Display`/`Debug` for batch insert statements on
sqlite. The generic impl for `QueryFragment` does not work here
because we've faked batch inserts on sqlite (sqlite does not actual
support them) by just doing an insert per item inside a transaction.