### PR TITLE
Update the test suite to the 2018 edition

### DIFF
--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 build = "build.rs"
 autotests = false
+edition = "2018"
 
 [build-dependencies]
 diesel = { path = "../diesel", default-features = false }

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -1,6 +1,6 @@
+use crate::schema::*;
 use diesel::sql_types::Text;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn association_where_struct_name_doesnt_match_table_name() {
@@ -133,7 +133,7 @@ mod associations_can_have_nullable_foreign_keys {
 // This module has no test functions, as it's only to test compilation.
 mod multiple_lifetimes_in_insertable_struct_definition {
     #![allow(dead_code)]
-    use schema::posts;
+    use crate::schema::posts;
 
     #[derive(Insertable)]
     #[table_name = "posts"]
@@ -145,7 +145,7 @@ mod multiple_lifetimes_in_insertable_struct_definition {
 
 mod lifetimes_with_names_other_than_a {
     #![allow(dead_code)]
-    use schema::posts;
+    use crate::schema::posts;
 
     #[derive(Insertable)]
     #[table_name = "posts"]
@@ -158,7 +158,7 @@ mod lifetimes_with_names_other_than_a {
 
 mod insertable_with_cow {
     #![allow(dead_code)]
-    use schema::posts;
+    use crate::schema::posts;
     use std::borrow::Cow;
 
     #[derive(Insertable)]
@@ -173,7 +173,7 @@ mod insertable_with_cow {
 mod custom_foreign_keys_are_respected_on_belongs_to {
     #![allow(dead_code)]
 
-    use schema::User;
+    use crate::schema::User;
 
     table! { special_posts { id -> Integer, author_id -> Integer, } }
 
@@ -187,7 +187,7 @@ mod custom_foreign_keys_are_respected_on_belongs_to {
 
 mod derive_identifiable_with_lifetime {
     #![allow(dead_code)]
-    use schema::posts;
+    use crate::schema::posts;
 
     #[derive(Identifiable)]
     pub struct Post<'a> {

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -1,5 +1,5 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn one_to_many_returns_query_source_for_association() {
@@ -38,10 +38,11 @@ fn eager_loading_associations_for_multiple_records() {
     assert_eq!(expected_data, users_and_posts);
 }
 
+#[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 mod eager_loading_with_string_keys {
+    use crate::schema::{connection, drop_table_cascade};
     use diesel::connection::SimpleConnection;
     use diesel::*;
-    use schema::{connection, drop_table_cascade};
 
     table! { users { id -> Text, } }
     table! { posts { id -> Text, user_id -> Text, } }
@@ -60,7 +61,6 @@ mod eager_loading_with_string_keys {
     }
 
     #[test]
-    #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
     fn eager_loading_associations_for_multiple_records() {
         let connection = connection();
         drop_table_cascade(&connection, "users");

--- a/diesel_tests/tests/bench.rs
+++ b/diesel_tests/tests/bench.rs
@@ -5,7 +5,10 @@
 #[macro_use]
 extern crate diesel;
 #[macro_use]
-extern crate diesel_proc_macro;
+extern crate diesel_infer_schema;
+#[cfg(feature = "sqlite")]
+#[macro_use]
+extern crate diesel_migrations;
 extern crate dotenv;
 extern crate test;
 
@@ -111,7 +114,7 @@ macro_rules! bench_medium_complex_query {
                 .unwrap();
 
             b.iter(|| {
-                use schema::users::dsl::*;
+                use crate::schema::users::dsl::*;
                 let target = users
                     .left_outer_join(posts::table)
                     .filter(hair_color.eq("black"))
@@ -136,7 +139,7 @@ macro_rules! bench_medium_complex_query {
                 .unwrap();
 
             b.iter(|| {
-                use schema::users::dsl::*;
+                use crate::schema::users::dsl::*;
                 let target = users
                     .left_outer_join(posts::table)
                     .filter(hair_color.eq("black"))
@@ -234,7 +237,7 @@ fn loading_associations_sequentially(b: &mut Bencher) {
             .unwrap()
             .grouped_by(&posts);
         let posts_and_comments = posts.into_iter().zip(comments).grouped_by(&users);
-        let result: Vec<(User, Vec<(Post, Vec<Comment>)>)> =
+        let _result: Vec<(User, Vec<(Post, Vec<Comment>)>)> =
             users.into_iter().zip(posts_and_comments).collect();
     })
 }

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -1,5 +1,6 @@
+#![cfg(not(feature = "mysql"))]
+use crate::schema::{connection_without_transaction, DropTable};
 use diesel::*;
-use schema::{connection_without_transaction, DropTable};
 
 table! {
     auto_time {
@@ -13,8 +14,8 @@ table! {
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 fn managing_updated_at_for_table() {
     use self::auto_time::dsl::*;
+    use crate::schema_dsl::*;
     use chrono::NaiveDateTime;
-    use schema_dsl::*;
     use std::{thread, time::Duration};
 
     // transactions have frozen time, so we can't use them

--- a/diesel_tests/tests/custom_schemas.rs
+++ b/diesel_tests/tests/custom_schemas.rs
@@ -1,5 +1,5 @@
+use crate::schema::connection;
 use diesel::*;
-use schema::connection;
 
 mod using_infer_schema {
     use super::*;

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::connection::SimpleConnection;
 use diesel::deserialize::{self, FromSql};
 use diesel::pg::{Pg, PgValue};
 use diesel::serialize::{self, IsNull, Output, ToSql};
 use diesel::*;
-use schema::*;
 use std::io::Write;
 
 table! {

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -1,9 +1,9 @@
+use crate::schema::TestBackend;
 use diesel::*;
-use schema::TestBackend;
 
 #[test]
 fn test_debug_count_output() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let sql = debug_query::<TestBackend, _>(&users.count()).to_string();
     if cfg!(feature = "postgres") {
         assert_eq!(sql, r#"SELECT COUNT(*) FROM "users" -- binds: []"#);
@@ -14,7 +14,7 @@ fn test_debug_count_output() {
 
 #[test]
 fn test_debug_output() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let command = update(users.filter(id.eq(1))).set(name.eq("new_name"));
     let sql = debug_query::<TestBackend, _>(&command).to_string();
     if cfg!(feature = "postgres") {
@@ -37,7 +37,7 @@ fn test_debug_batch_insert() {
     // This requires a separate impl because it's more than one sql statement that
     // is executed
 
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let values = vec![
         (name.eq("Sean"), hair_color.eq(Some("black"))),

--- a/diesel_tests/tests/delete.rs
+++ b/diesel_tests/tests/delete.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn delete_records() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection_with_sean_and_tess_in_users_table();
 
     let deleted_rows = delete(users.filter(name.eq("Sean"))).execute(&connection);
@@ -17,7 +17,7 @@ fn delete_records() {
 
 #[test]
 fn delete_single_record() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection_with_sean_and_tess_in_users_table();
     let data = users.load::<User>(&connection).unwrap();
     let sean = data[0].clone();
@@ -31,7 +31,7 @@ fn delete_single_record() {
 #[test]
 #[cfg(not(any(feature = "sqlite", feature = "mysql")))]
 fn return_deleted_records() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection_with_sean_and_tess_in_users_table();
 
     let deleted_name = delete(users.filter(name.eq("Sean")))

--- a/diesel_tests/tests/deserialization.rs
+++ b/diesel_tests/tests/deserialization.rs
@@ -1,5 +1,5 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 use std::borrow::Cow;
 
 #[derive(Queryable, PartialEq, Debug)]
@@ -10,7 +10,7 @@ struct CowUser<'a> {
 
 #[test]
 fn generated_queryable_allows_lifetimes() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection_with_sean_and_tess_in_users_table();
 
     let expected_user = CowUser {

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -3,7 +3,7 @@ use diesel::*;
 
 #[test]
 fn simple_distinct() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     connection
@@ -20,7 +20,7 @@ fn simple_distinct() {
 #[cfg(feature = "postgres")]
 #[test]
 fn distinct_on() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     connection

--- a/diesel_tests/tests/errors.rs
+++ b/diesel_tests/tests/errors.rs
@@ -1,7 +1,7 @@
+use crate::schema::*;
 use diesel::result::DatabaseErrorKind::{ForeignKeyViolation, UniqueViolation};
 use diesel::result::Error::DatabaseError;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn unique_constraints_are_detected() {

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -1,8 +1,9 @@
+use crate::schema::*;
+#[cfg(feature = "postgres")]
 use diesel::data_types::*;
 use diesel::dsl::*;
 use diesel::sql_types::Nullable;
 use diesel::*;
-use schema::{connection, TestConnection};
 
 table! {
     has_timestamps {
@@ -334,7 +335,7 @@ fn adding_interval_to_nullable_things() {
 
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 fn setup_test_table(conn: &TestConnection) {
-    use schema_dsl::*;
+    use crate::schema_dsl::*;
 
     create_table(
         "has_timestamps",

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -4,14 +4,14 @@ mod date_and_time;
 mod ops;
 
 use self::bigdecimal::BigDecimal;
+use crate::schema::users::dsl::*;
+use crate::schema::{
+    connection, connection_with_sean_and_tess_in_users_table, NewUser, TestBackend,
+};
 use diesel::backend::Backend;
 use diesel::dsl::*;
 use diesel::query_builder::*;
 use diesel::*;
-use schema::users::dsl::*;
-use schema::{
-    connection, connection_with_sean_and_tess_in_users_table, DropTable, NewUser, TestBackend,
-};
 
 #[test]
 fn test_count_counts_the_rows() {
@@ -81,6 +81,7 @@ table! {
 #[cfg(feature = "postgres")]
 fn test_min_max_of_array() {
     use self::number_arrays::dsl::*;
+    use crate::schema::DropTable;
 
     let connection = connection();
     connection
@@ -219,7 +220,7 @@ sql_function!(fn coalesce(x: sql_types::Nullable<sql_types::VarChar>, y: sql_typ
 
 #[test]
 fn function_with_multiple_arguments() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let new_users = vec![

--- a/diesel_tests/tests/expressions/ops.rs
+++ b/diesel_tests/tests/expressions/ops.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn adding_literal_to_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -19,7 +19,7 @@ fn adding_literal_to_column() {
 #[test]
 #[cfg(not(feature = "sqlite"))] // FIXME: Does SQLite provide a way to detect overflow?
 fn overflow_returns_an_error_but_does_not_panic() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let query_result = users.select(id + i32::max_value()).load::<i32>(&connection);
@@ -31,7 +31,7 @@ fn overflow_returns_an_error_but_does_not_panic() {
 
 #[test]
 fn adding_column_to_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -42,7 +42,7 @@ fn adding_column_to_column() {
 
 #[test]
 fn adding_multiple_times() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -53,7 +53,7 @@ fn adding_multiple_times() {
 
 #[test]
 fn subtracting_literal_from_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -64,7 +64,7 @@ fn subtracting_literal_from_column() {
 
 #[test]
 fn adding_then_subtracting() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -75,7 +75,7 @@ fn adding_then_subtracting() {
 
 #[test]
 fn multiplying_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -86,7 +86,7 @@ fn multiplying_column() {
 
 #[test]
 fn dividing_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -97,7 +97,7 @@ fn dividing_column() {
 
 #[test]
 fn test_adding_nullables() {
-    use schema::nullable_table::dsl::*;
+    use crate::schema::nullable_table::dsl::*;
     let connection = connection_with_nullable_table_data();
 
     let expected_data = vec![None, None, Some(2), Some(3), Some(2)];
@@ -117,7 +117,7 @@ fn test_adding_nullables() {
 
 #[test]
 fn test_subtracting_nullables() {
-    use schema::nullable_table::dsl::*;
+    use crate::schema::nullable_table::dsl::*;
     let connection = connection_with_nullable_table_data();
 
     let expected_data = vec![None, None, Some(0), Some(1), Some(0)];
@@ -137,7 +137,7 @@ fn test_subtracting_nullables() {
 
 #[test]
 fn test_multiplying_nullables() {
-    use schema::nullable_table::dsl::*;
+    use crate::schema::nullable_table::dsl::*;
     let connection = connection_with_nullable_table_data();
 
     let expected_data = vec![None, None, Some(3), Some(6), Some(3)];
@@ -157,7 +157,7 @@ fn test_multiplying_nullables() {
 
 #[test]
 fn test_dividing_nullables() {
-    use schema::nullable_table::dsl::*;
+    use crate::schema::nullable_table::dsl::*;
     let connection = connection_with_nullable_table_data();
 
     let expected_data = vec![None, None, Some(0), Some(1), Some(0)];
@@ -177,7 +177,7 @@ fn test_dividing_nullables() {
 
 #[test]
 fn mix_and_match_all_numeric_ops() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     connection

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -1,5 +1,5 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 macro_rules! assert_sets_eq {
     ($set1:expr, $set2:expr) => {
@@ -20,7 +20,7 @@ macro_rules! assert_sets_eq {
 
 #[test]
 fn filter_by_int_equality() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean_id = find_user_by_name("Sean", &connection).id;
@@ -39,7 +39,7 @@ fn filter_by_int_equality() {
 
 #[test]
 fn filter_by_string_equality() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -55,7 +55,7 @@ fn filter_by_string_equality() {
 
 #[test]
 fn filter_by_equality_on_nullable_columns() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data = vec![
@@ -82,7 +82,7 @@ fn filter_by_equality_on_nullable_columns() {
 
 #[test]
 fn filter_by_is_not_null_on_nullable_columns() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data = vec![
@@ -102,7 +102,7 @@ fn filter_by_is_not_null_on_nullable_columns() {
 
 #[test]
 fn filter_by_is_null_on_nullable_columns() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data = vec![
@@ -122,7 +122,7 @@ fn filter_by_is_null_on_nullable_columns() {
 
 #[test]
 fn filter_after_joining() {
-    use schema::users::name;
+    use crate::schema::users::name;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     connection
@@ -155,7 +155,7 @@ fn filter_after_joining() {
 
 #[test]
 fn select_then_filter() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
 
@@ -176,7 +176,7 @@ fn select_then_filter() {
 
 #[test]
 fn filter_then_select() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data = vec![NewUser::new("Sean", None), NewUser::new("Tess", None)];
@@ -210,7 +210,7 @@ fn filter_then_select() {
 
 #[test]
 fn filter_on_multiple_columns() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data: &[_] = &[
@@ -245,7 +245,7 @@ fn filter_on_multiple_columns() {
 
 #[test]
 fn filter_called_twice_means_same_thing_as_and() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data: &[_] = &[
@@ -302,7 +302,7 @@ fn filter_on_column_equality() {
 
 #[test]
 fn filter_with_or() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     insert_into(users)
@@ -322,7 +322,7 @@ fn filter_with_or() {
 
 #[test]
 fn or_doesnt_mess_with_precedence_of_previous_statements() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let f = false.into_sql::<sql_types::Bool>();
@@ -344,8 +344,8 @@ fn or_doesnt_mess_with_precedence_of_previous_statements() {
 
 #[test]
 fn not_does_not_affect_expressions_other_than_those_passed_to_it() {
+    use crate::schema::users::dsl::*;
     use diesel::dsl::not;
-    use schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let count = users
@@ -359,8 +359,8 @@ fn not_does_not_affect_expressions_other_than_those_passed_to_it() {
 
 #[test]
 fn not_affects_arguments_passed_when_they_contain_higher_operator_precedence() {
+    use crate::schema::users::dsl::*;
     use diesel::dsl::not;
-    use schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let count = users
@@ -427,7 +427,7 @@ fn filter_subselect_referencing_outer_table() {
 
 #[test]
 fn filter_subselect_with_boxed_query() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let conn = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &conn);
@@ -441,7 +441,7 @@ fn filter_subselect_with_boxed_query() {
 
 #[test]
 fn filter_subselect_with_nullable_column() {
-    use schema_dsl::*;
+    use crate::schema_dsl::*;
     table! {
         heros {
             id -> Integer,

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn filter_by_inequality() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = User::new(1, "Sean");
@@ -29,7 +29,7 @@ fn filter_by_inequality() {
 
 #[test]
 fn filter_by_gt() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_3_users();
     let tess = User::new(2, "Tess");
@@ -48,7 +48,7 @@ fn filter_by_gt() {
 
 #[test]
 fn filter_by_ge() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_3_users();
     let tess = User::new(2, "Tess");
@@ -67,7 +67,7 @@ fn filter_by_ge() {
 
 #[test]
 fn filter_by_lt() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_3_users();
     let sean = User::new(1, "Sean");
@@ -89,7 +89,7 @@ fn filter_by_lt() {
 
 #[test]
 fn filter_by_le() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_3_users();
     let sean = User::new(1, "Sean");
@@ -111,7 +111,7 @@ fn filter_by_le() {
 
 #[test]
 fn filter_by_between() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_3_users();
     let sean = User::new(1, "Sean");
@@ -138,7 +138,7 @@ fn filter_by_between() {
 
 #[test]
 fn filter_by_like() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data = vec![
@@ -176,7 +176,7 @@ fn filter_by_like() {
 #[test]
 #[cfg(feature = "postgres")]
 fn filter_by_ilike() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let data = vec![
@@ -214,8 +214,8 @@ fn filter_by_ilike() {
 #[test]
 #[cfg(feature = "postgres")]
 fn filter_by_any() {
+    use crate::schema::users::dsl::*;
     use diesel::dsl::any;
-    use schema::users::dsl::*;
 
     let connection = connection_with_3_users();
     let sean = User::new(1, "Sean");
@@ -244,7 +244,7 @@ fn filter_by_any() {
 
 #[test]
 fn filter_by_in() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_3_users();
     let sean = User::new(1, "Sean");

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn find() {
-    use schema::users::table as users;
+    use crate::schema::users::table as users;
 
     let connection = connection();
 
@@ -50,7 +50,7 @@ fn find_with_non_serial_pk() {
 
 #[test]
 fn find_with_composite_pk() {
-    use schema::followings::dsl::*;
+    use crate::schema::followings::dsl::*;
 
     let first_following = Following {
         user_id: 1,
@@ -95,7 +95,7 @@ fn find_with_composite_pk() {
 
 #[test]
 fn select_then_find() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = users.select(name).find(1).first(&connection);

--- a/diesel_tests/tests/group_by.rs
+++ b/diesel_tests/tests/group_by.rs
@@ -1,5 +1,5 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 // This test is a shim for a feature which is not sufficiently implemented. It

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -3,7 +3,7 @@ use diesel::*;
 
 #[test]
 fn insert_records() {
-    use schema::users::table as users;
+    use crate::schema::users::table as users;
     let connection = connection();
     let new_users: &[_] = &[
         NewUser::new("Sean", Some("Black")),
@@ -33,7 +33,7 @@ fn insert_records() {
 
 #[test]
 fn insert_records_as_vec() {
-    use schema::users::table as users;
+    use crate::schema::users::table as users;
     let connection = connection();
     let new_users = vec![
         NewUser::new("Sean", Some("Black")),
@@ -64,7 +64,7 @@ fn insert_records_as_vec() {
 #[test]
 #[cfg(not(any(feature = "sqlite", feature = "mysql")))]
 fn insert_records_using_returning_clause() {
-    use schema::users::table as users;
+    use crate::schema::users::table as users;
     let connection = connection();
     let new_users: &[_] = &[
         NewUser::new("Sean", Some("Black")),
@@ -94,7 +94,7 @@ fn insert_records_using_returning_clause() {
 #[test]
 #[cfg(not(any(feature = "sqlite", feature = "mysql")))]
 fn insert_records_with_custom_returning_clause() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     let new_users: &[_] = &[
@@ -118,8 +118,8 @@ fn insert_records_with_custom_returning_clause() {
 #[test]
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 fn batch_insert_with_defaults() {
-    use schema::users::table as users;
-    use schema_dsl::*;
+    use crate::schema::users::table as users;
+    use crate::schema_dsl::*;
 
     let connection = connection();
     drop_table_cascade(&connection, "users");
@@ -163,8 +163,8 @@ fn batch_insert_with_defaults() {
 #[test]
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 fn insert_with_defaults() {
-    use schema::users::table as users;
-    use schema_dsl::*;
+    use crate::schema::users::table as users;
+    use crate::schema_dsl::*;
 
     let connection = connection();
     drop_table_cascade(&connection, "users");
@@ -196,7 +196,7 @@ fn insert_with_defaults() {
 #[test]
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 fn insert_returning_count_returns_number_of_rows_inserted() {
-    use schema::users::table as users;
+    use crate::schema::users::table as users;
     let connection = connection();
     drop_table_cascade(&connection, "users");
     connection
@@ -245,7 +245,7 @@ struct BorrowedUser<'a> {
 
 #[test]
 fn insert_borrowed_content() {
-    use schema::users::table as users;
+    use crate::schema::users::table as users;
     let connection = connection();
     let new_users: &[_] = &[BorrowedUser { name: "Sean" }, BorrowedUser { name: "Tess" }];
     insert_into(users)
@@ -305,9 +305,9 @@ fn upsert_empty_slice() {
 #[test]
 #[cfg(feature = "postgres")]
 fn insert_only_default_values_with_returning() {
-    use schema::users::id;
-    use schema::users::table as users;
-    use schema_dsl::*;
+    use crate::schema::users::id;
+    use crate::schema::users::table as users;
+    use crate::schema_dsl::*;
     let connection = connection();
 
     drop_table_cascade(&connection, "users");
@@ -333,7 +333,7 @@ fn insert_only_default_values_with_returning() {
 
 #[test]
 fn insert_single_bare_value() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     insert_into(users)
@@ -348,7 +348,7 @@ fn insert_single_bare_value() {
 
 #[test]
 fn insert_single_bare_value_reference() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     insert_into(users)
@@ -363,7 +363,7 @@ fn insert_single_bare_value_reference() {
 
 #[test]
 fn insert_multiple_bare_values() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     let new_users = vec![name.eq("Sean"), name.eq("Tess")];
@@ -380,7 +380,7 @@ fn insert_multiple_bare_values() {
 
 #[test]
 fn insert_single_tuple() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     insert_into(users)
@@ -395,7 +395,7 @@ fn insert_single_tuple() {
 
 #[test]
 fn insert_single_tuple_reference() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     insert_into(users)
@@ -410,7 +410,7 @@ fn insert_single_tuple_reference() {
 
 #[test]
 fn insert_nested_tuples() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     insert_into(users)
@@ -425,7 +425,7 @@ fn insert_nested_tuples() {
 
 #[test]
 fn insert_mixed_tuple_and_insertable_struct() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     let new_user = NewUser::new("Sean", Some("Brown"));
@@ -441,7 +441,7 @@ fn insert_mixed_tuple_and_insertable_struct() {
 
 #[test]
 fn insert_multiple_tuples() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     let new_users = vec![
@@ -463,7 +463,7 @@ fn insert_multiple_tuples() {
 
 #[test]
 fn insert_optional_field_with_null() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     let new_users = vec![
@@ -486,8 +486,8 @@ fn insert_optional_field_with_null() {
 #[test]
 #[cfg(not(feature = "mysql"))]
 fn insert_optional_field_with_default() {
-    use schema::users::dsl::*;
-    use schema_dsl::*;
+    use crate::schema::users::dsl::*;
+    use crate::schema_dsl::*;
     let connection = connection();
     drop_table_cascade(&connection, "users");
     create_table(
@@ -521,8 +521,8 @@ fn insert_optional_field_with_default() {
 #[test]
 #[cfg(not(feature = "mysql"))]
 fn insert_all_default_fields() {
-    use schema::users::dsl::*;
-    use schema_dsl::*;
+    use crate::schema::users::dsl::*;
+    use crate::schema_dsl::*;
     let connection = connection();
     drop_table_cascade(&connection, "users");
     create_table(
@@ -556,7 +556,7 @@ fn insert_all_default_fields() {
 #[test]
 #[cfg(feature = "sqlite")]
 fn batch_insert_is_atomic_on_sqlite() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
 
     let new_users = vec![Some(name.eq("Sean")), None];

--- a/diesel_tests/tests/insert_from_select.rs
+++ b/diesel_tests/tests/insert_from_select.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn insert_from_table() {
-    use schema::posts::dsl::*;
+    use crate::schema::posts::dsl::*;
     let conn = connection_with_sean_and_tess_in_users_table();
     insert_into(posts)
         .values(users::table)
@@ -21,7 +21,7 @@ fn insert_from_table() {
 
 #[test]
 fn insert_from_table_reference() {
-    use schema::posts::dsl::*;
+    use crate::schema::posts::dsl::*;
     let conn = connection_with_sean_and_tess_in_users_table();
     insert_into(posts)
         .values(&users::table)
@@ -39,8 +39,8 @@ fn insert_from_table_reference() {
 
 #[test]
 fn insert_from_select() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     users
@@ -57,8 +57,8 @@ fn insert_from_select() {
 
 #[test]
 fn insert_from_select_reference() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     let select = users.select((id, name.concat(" says hi")));
@@ -75,8 +75,8 @@ fn insert_from_select_reference() {
 
 #[test]
 fn insert_from_boxed() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     users
@@ -94,8 +94,8 @@ fn insert_from_boxed() {
 
 #[test]
 fn insert_from_boxed_reference() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     let select = users.select((id, name.concat(" says hi"))).into_boxed();
@@ -113,8 +113,8 @@ fn insert_from_boxed_reference() {
 #[test]
 #[cfg(feature = "sqlite")]
 fn insert_or_ignore_with_select() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     sql_query("CREATE UNIQUE INDEX foo ON posts (user_id)")
@@ -140,8 +140,8 @@ fn insert_or_ignore_with_select() {
 #[test]
 #[cfg(feature = "sqlite")]
 fn insert_or_replace_with_select() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     sql_query("CREATE UNIQUE INDEX foo ON posts (user_id)")
@@ -169,8 +169,8 @@ fn insert_or_replace_with_select() {
 // We can't share the test with SQLite because it modifies
 // schema, but we can at least make sure the query is *syntactically* valid.
 fn insert_or_ignore_with_select() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
 
@@ -190,8 +190,8 @@ fn insert_or_ignore_with_select() {
 // We can't share the test with SQLite because it modifies
 // schema, but we can at least make sure the query is *syntactically* valid.
 fn insert_or_replace_with_select() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
 
@@ -209,8 +209,8 @@ fn insert_or_replace_with_select() {
 #[test]
 #[cfg(feature = "postgres")]
 fn on_conflict_do_nothing_with_select() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     sql_query("CREATE UNIQUE INDEX ON posts (title)")
@@ -235,8 +235,8 @@ fn on_conflict_do_nothing_with_select() {
 #[test]
 #[cfg(feature = "postgres")]
 fn on_conflict_do_update_with_select() {
-    use schema::posts::dsl::*;
-    use schema::users::dsl::{id, name, users};
+    use crate::schema::posts::dsl::*;
+    use crate::schema::users::dsl::{id, name, users};
 
     let conn = connection_with_sean_and_tess_in_users_table();
     sql_query("CREATE UNIQUE INDEX ON posts (title)")

--- a/diesel_tests/tests/internal_details.rs
+++ b/diesel_tests/tests/internal_details.rs
@@ -1,7 +1,8 @@
+#![cfg(not(feature = "mysql"))]
+use crate::schema::*;
 use diesel::dsl::sql;
 use diesel::sql_types::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 #[cfg(not(feature = "mysql"))] // ? IS NULL is invalid syntax for MySQL
@@ -15,9 +16,9 @@ fn bind_params_are_passed_for_null_when_not_inserting() {
 #[test]
 #[cfg(feature = "postgres")]
 fn query_which_cannot_be_transmitted_gives_proper_error_message() {
+    use crate::schema::comments::dsl::*;
     use diesel::result::DatabaseErrorKind::UnableToSendCommand;
     use diesel::result::Error::DatabaseError;
-    use schema::comments::dsl::*;
 
     // Create a query with 90000 binds, 2 binds per row
     let data: &[NewComment<'static>] = &[NewComment(1, "hi"); 45_000];

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -1,5 +1,5 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn belongs_to() {
@@ -302,7 +302,7 @@ fn select_right_side_with_nullable_column_first() {
 
 #[test]
 fn select_then_join() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection_with_sean_and_tess_in_users_table();
 
     connection

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "1024"]
-#![cfg_attr(feature = "postgres", deny(warnings))]
+#![deny(warnings)]
 
 #[macro_use]
 extern crate assert_matches;

--- a/diesel_tests/tests/macros.rs
+++ b/diesel_tests/tests/macros.rs
@@ -3,15 +3,15 @@
 // think we need to generically support creation of these functions, as it's
 // different enough in SQLite to avoid.
 #![cfg(feature = "postgres")]
+use crate::schema::*;
 use diesel::sql_types::{BigInt, VarChar};
 use diesel::*;
-use schema::*;
 
 sql_function!(fn my_lower(x: VarChar) -> VarChar);
 
 #[test]
 fn test_sql_function() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     connection

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn order_by_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let conn = connection();
     let data = vec![
@@ -42,7 +42,7 @@ fn order_by_column() {
 
 #[test]
 fn order_by_descending_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let conn = connection();
     let data = vec![

--- a/diesel_tests/tests/perf_details.rs
+++ b/diesel_tests/tests/perf_details.rs
@@ -1,7 +1,7 @@
+use crate::schema::posts::dsl::{posts, title};
+use crate::schema::users::dsl::*;
 use diesel::query_builder::AsQuery;
 use diesel::*;
-use schema::posts::dsl::{posts, title};
-use schema::users::dsl::*;
 use std::cmp::max;
 use std::mem;
 

--- a/diesel_tests/tests/raw_sql.rs
+++ b/diesel_tests/tests/raw_sql.rs
@@ -1,5 +1,5 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn execute_query_by_raw_sql() {

--- a/diesel_tests/tests/schema.rs
+++ b/diesel_tests/tests/schema.rs
@@ -1,6 +1,4 @@
 use diesel::*;
-use dotenv::dotenv;
-use std::env;
 
 #[cfg(all(feature = "postgres", feature = "backend_specific_database_url"))]
 infer_schema!("dotenv:PG_DATABASE_URL");
@@ -191,9 +189,8 @@ pub fn connection() -> TestConnection {
 
 #[cfg(feature = "postgres")]
 pub fn connection_without_transaction() -> TestConnection {
-    dotenv().ok();
-    let connection_url = env::var("PG_DATABASE_URL")
-        .or_else(|_| env::var("DATABASE_URL"))
+    let connection_url = dotenv::var("PG_DATABASE_URL")
+        .or_else(|_| dotenv::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     PgConnection::establish(&connection_url).unwrap()
 }
@@ -210,9 +207,8 @@ pub fn connection_without_transaction() -> TestConnection {
 
 #[cfg(feature = "mysql")]
 pub fn connection_without_transaction() -> TestConnection {
-    dotenv().ok();
-    let connection_url = env::var("MYSQL_DATABASE_URL")
-        .or_else(|_| env::var("DATABASE_URL"))
+    let connection_url = dotenv::var("MYSQL_DATABASE_URL")
+        .or_else(|_| dotenv::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     MysqlConnection::establish(&connection_url).unwrap()
 }
@@ -241,7 +237,7 @@ pub fn drop_table_cascade(connection: &TestConnection, table: &str) {
         .unwrap();
 }
 
-#[cfg(not(feature = "sqlite"))]
+#[cfg(feature = "postgres")]
 pub fn drop_table_cascade(connection: &TestConnection, table: &str) {
     connection
         .execute(&format!("DROP TABLE {} CASCADE", table))

--- a/diesel_tests/tests/schema_dsl/mod.rs
+++ b/diesel_tests/tests/schema_dsl/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "postgres"), allow(dead_code))]
+
 mod functions;
 mod structures;
 

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -74,7 +74,6 @@ use diesel::mysql::Mysql;
 use diesel::pg::Pg;
 use diesel::query_builder::*;
 use diesel::result::QueryResult;
-use diesel::sql_types::Integer;
 #[cfg(feature = "sqlite")]
 use diesel::sqlite::Sqlite;
 
@@ -171,7 +170,7 @@ impl<Col> QueryId for AutoIncrement<Col> {
 }
 
 #[cfg(feature = "postgres")]
-impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, Integer>>> {
+impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, diesel::sql_types::Integer>>> {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         out.push_identifier((self.0).0.name)?;

--- a/diesel_tests/tests/schema_inference.rs
+++ b/diesel_tests/tests/schema_inference.rs
@@ -3,8 +3,8 @@ extern crate chrono;
 #[cfg(feature = "sqlite")]
 mod sqlite {
     use super::chrono::*;
+    use crate::schema::*;
     use diesel::*;
-    use schema::*;
 
     #[derive(Queryable, PartialEq, Debug, Insertable)]
     #[table_name = "infer_all_the_ints"]
@@ -192,9 +192,9 @@ mod sqlite {
 #[cfg(feature = "postgres")]
 mod postgres {
     use super::chrono::*;
+    use crate::schema::*;
     use diesel::data_types::PgNumeric;
     use diesel::*;
-    use schema::*;
     use std::collections::Bound;
 
     #[derive(Queryable, PartialEq, Debug, Insertable)]
@@ -241,8 +241,8 @@ mod postgres {
 
 #[cfg(feature = "mysql")]
 mod mysql {
+    use crate::schema::*;
     use diesel::*;
-    use schema::*;
 
     #[derive(Insertable)]
     #[table_name = "all_the_blobs"]
@@ -292,8 +292,8 @@ mod mysql {
 
 #[test]
 fn columns_named_as_reserved_keywords_are_renamed() {
+    use crate::schema::*;
     use diesel::*;
-    use schema::*;
 
     #[derive(Queryable, Insertable, Debug, PartialEq)]
     #[table_name = "with_keywords"]

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -1,11 +1,10 @@
 use super::schema::*;
-use diesel::connection::SimpleConnection;
+use crate::schema_dsl::*;
 use diesel::*;
-use schema_dsl::*;
 
 #[test]
 fn selecting_basic_data() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     connection
@@ -22,7 +21,7 @@ fn selecting_basic_data() {
 
 #[test]
 fn selecting_a_struct() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
     let connection = connection();
     connection
         .execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
@@ -35,7 +34,7 @@ fn selecting_a_struct() {
 
 #[test]
 fn with_safe_select() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     connection
@@ -71,7 +70,7 @@ fn with_select_sql() {
 
 #[test]
 fn selecting_nullable_followed_by_non_null() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     connection
@@ -87,7 +86,7 @@ fn selecting_nullable_followed_by_non_null() {
 
 #[test]
 fn selecting_expression_with_bind_param() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection();
     connection
@@ -163,7 +162,7 @@ fn selecting_columns_with_different_definition_order() {
 
 #[test]
 fn selection_using_subselect() {
-    use schema::posts::dsl::*;
+    use crate::schema::posts::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let ids: Vec<i32> = users::table.select(users::id).load(&connection).unwrap();
@@ -220,6 +219,7 @@ table! {
 #[test]
 fn select_for_update_locks_selected_rows() {
     use self::users_select_for_update::dsl::*;
+    use diesel::connection::SimpleConnection;
     use std::mem::drop;
     use std::sync::mpsc;
     use std::thread;

--- a/diesel_tests/tests/transactions.rs
+++ b/diesel_tests/tests/transactions.rs
@@ -1,6 +1,6 @@
+use crate::schema::*;
 use diesel::result::Error;
 use diesel::*;
-use schema::*;
 
 #[test]
 #[cfg(not(feature = "sqlite"))] // FIXME: This test is only valid when operating on a file and not :memory:
@@ -113,7 +113,7 @@ fn test_transaction_panics_on_error() {
 }
 
 fn setup_test_table(connection: &TestConnection, table_name: &str) {
-    use schema_dsl::*;
+    use crate::schema_dsl::*;
     create_table(table_name, (integer("id").primary_key().auto_increment(),))
         .execute(connection)
         .unwrap();

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -4,13 +4,13 @@
 extern crate bigdecimal;
 extern crate chrono;
 
-use diesel::deserialize::FromSql;
+use crate::schema::*;
 #[cfg(feature = "postgres")]
 use diesel::pg::Pg;
 use diesel::sql_types::*;
 use diesel::*;
-use schema::*;
 
+#[cfg(any(feature = "postgres", feature = "mysql"))]
 use quickcheck::quickcheck;
 
 table! {
@@ -374,8 +374,22 @@ fn f32_from_sql() {
 }
 
 #[test]
+#[cfg(any(feature = "mysql", feature = "sqlite"))]
+fn f32_from_sql() {
+    assert_eq!(0.0, query_single_value::<Float, f32>("0.0"));
+    assert_eq!(0.5, query_single_value::<Float, f32>("0.5"));
+    // MySQL has no way to represent NaN or Infinity as a literal
+    #[cfg(feature = "sqlite")]
+    {
+        assert_eq!(f32::INFINITY, query_single_value::<Float, f32>("9e999"));
+        assert_eq!(-f32::INFINITY, query_single_value::<Float, f32>("-9e999"));
+        // SQLite has no way to represent NaN
+    }
+}
+
+#[test]
 #[cfg(feature = "postgres")]
-fn f32_to_sql_float() {
+fn f32_to_sql() {
     assert!(query_to_sql_equality::<Float, f32>("0.0::real", 0.0));
     assert!(query_to_sql_equality::<Float, f32>("0.5::real", 0.5));
     assert!(query_to_sql_equality::<Float, f32>("'NaN'::real", f32::NAN));
@@ -397,6 +411,26 @@ fn f32_to_sql_float() {
         "'-Infinity'::real",
         1.0
     ));
+}
+
+#[test]
+#[cfg(any(feature = "mysql", feature = "sqlite"))]
+fn f32_to_sql() {
+    assert!(query_to_sql_equality::<Float, f32>("0.0", 0.0));
+    assert!(query_to_sql_equality::<Float, f32>("0.5", 0.5));
+    // While MySQL will correctly round trip SELECT ? when the bind param is
+    // NaN or Infinity, any attempt to insert those values into a row will
+    // result in an error, and we have no way to write SELECT ? = NaN,
+    // so those cases are untested.
+    #[cfg(feature = "sqlite")]
+    {
+        assert!(query_to_sql_equality::<Float, f32>("9e999", f32::INFINITY));
+        assert!(query_to_sql_equality::<Float, f32>(
+            "-9e999",
+            -f32::INFINITY
+        ));
+        // SQLite has no way to represent NaN
+    }
 }
 
 #[test]
@@ -423,8 +457,22 @@ fn f64_from_sql() {
 }
 
 #[test]
+#[cfg(any(feature = "mysql", feature = "sqlite"))]
+fn f64_from_sql() {
+    assert_eq!(0.0, query_single_value::<Double, f64>("0.0"));
+    assert_eq!(0.5, query_single_value::<Double, f64>("0.5"));
+    // MySQL has no way to represent NaN or Infinity as a literal
+    #[cfg(feature = "sqlite")]
+    {
+        assert_eq!(f64::INFINITY, query_single_value::<Double, f64>("9e999"));
+        assert_eq!(-f64::INFINITY, query_single_value::<Double, f64>("-9e999"));
+        // SQLite has no way to represent NaN
+    }
+}
+
+#[test]
 #[cfg(feature = "postgres")]
-fn f64_to_sql_float() {
+fn f64_to_sql() {
     assert!(query_to_sql_equality::<Double, f64>(
         "0.0::double precision",
         0.0
@@ -461,6 +509,26 @@ fn f64_to_sql_float() {
         "'-Infinity'::double precision",
         1.0
     ));
+}
+
+#[test]
+#[cfg(any(feature = "mysql", feature = "sqlite"))]
+fn f64_to_sql() {
+    assert!(query_to_sql_equality::<Double, f64>("0.0", 0.0));
+    assert!(query_to_sql_equality::<Double, f64>("0.5", 0.5));
+    // While MySQL will correctly round trip SELECT ? when the bind param is
+    // NaN or Infinity, any attempt to insert those values into a row will
+    // result in an error, and we have no way to write SELECT ? = NaN,
+    // so those cases are untested.
+    #[cfg(feature = "sqlite")]
+    {
+        assert!(query_to_sql_equality::<Double, f64>("9e999", f64::INFINITY));
+        assert!(query_to_sql_equality::<Double, f64>(
+            "-9e999",
+            -f64::INFINITY
+        ));
+        // SQLite has no way to represent NaN
+    }
 }
 
 #[test]
@@ -1128,6 +1196,7 @@ fn text_array_can_be_assigned_to_varchar_array_column() {
 #[test]
 #[cfg(feature = "postgres")]
 fn third_party_crates_can_add_new_types() {
+    use diesel::deserialize::FromSql;
     use diesel::pg::PgValue;
 
     #[derive(Debug, Clone, Copy, QueryId, SqlType)]

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -2,18 +2,19 @@
 extern crate bigdecimal;
 extern crate chrono;
 
-use self::chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use self::chrono::*;
 pub use quickcheck::quickcheck;
 
+pub use crate::schema::{connection_without_transaction, TestConnection};
 pub use diesel::data_types::*;
 pub use diesel::result::Error;
 pub use diesel::serialize::ToSql;
 pub use diesel::sql_types::HasSqlType;
 pub use diesel::*;
-pub use schema::{connection_without_transaction, TestConnection};
 
 use diesel::expression::AsExpression;
 use diesel::query_builder::{QueryFragment, QueryId};
+#[cfg(feature = "postgres")]
 use std::collections::Bound;
 
 thread_local! {
@@ -262,6 +263,10 @@ mod pg_types {
         let tstz2 = mk_datetime((data.2, data.3));
         mk_bounds((tstz1, tstz2))
     }
+
+    pub fn mk_datetime(data: (i64, u32)) -> DateTime<Utc> {
+        DateTime::from_utc(mk_naive_datetime(data), Utc)
+    }
 }
 
 #[cfg(feature = "mysql")]
@@ -295,10 +300,6 @@ pub fn mk_naive_datetime(data: (i64, u32)) -> NaiveDateTime {
 
 pub fn mk_naive_time(data: (u32, u32)) -> NaiveTime {
     NaiveTime::from_num_seconds_from_midnight(data.0, data.1 / 1000)
-}
-
-pub fn mk_datetime(data: (i64, u32)) -> DateTime<Utc> {
-    DateTime::from_utc(mk_naive_datetime(data), Utc)
 }
 
 #[cfg(any(feature = "postgres", feature = "mysql"))]

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -1,9 +1,9 @@
+use crate::schema::*;
 use diesel::*;
-use schema::*;
 
 #[test]
 fn test_updating_single_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     update(users)
@@ -18,7 +18,7 @@ fn test_updating_single_column() {
 
 #[test]
 fn test_updating_single_column_of_single_row() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
@@ -35,7 +35,7 @@ fn test_updating_single_column_of_single_row() {
 
 #[test]
 fn test_updating_nullable_column() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
@@ -66,7 +66,7 @@ fn test_updating_nullable_column() {
 
 #[test]
 fn test_updating_multiple_columns() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
@@ -84,7 +84,7 @@ fn test_updating_multiple_columns() {
 #[test]
 #[cfg(not(any(feature = "sqlite", feature = "mysql")))]
 fn update_returning_struct() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
@@ -99,7 +99,7 @@ fn update_returning_struct() {
 #[test]
 #[cfg(not(any(feature = "sqlite", feature = "mysql")))]
 fn update_with_custom_returning_clause() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
@@ -114,7 +114,7 @@ fn update_with_custom_returning_clause() {
 
 #[test]
 fn update_with_struct_as_changes() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
@@ -132,7 +132,7 @@ fn update_with_struct_as_changes() {
 
 #[test]
 fn save_on_struct_with_primary_key_changes_that_struct() {
-    use schema::users::dsl::*;
+    use crate::schema::users::dsl::*;
 
     let connection = connection_with_sean_and_tess_in_users_table();
     let sean = find_user_by_name("Sean", &connection);
@@ -268,10 +268,10 @@ fn upsert_with_no_changes_executes_do_nothing_owned() {
 #[test]
 #[cfg(feature = "postgres")]
 fn upsert_with_sql_literal_for_target() {
+    use crate::schema::users::dsl::*;
     use diesel::dsl::sql;
     use diesel::pg::upsert::*;
     use diesel::sql_types::Text;
-    use schema::users::dsl::*;
 
     let connection = connection();
     // This index needs to happen before the insert or we'll get a deadlock


### PR DESCRIPTION
Because `cargo fix --edition` also fixes any warnings, which would
remove a bunch of dead code if run for sqlite or mysql, I went ahead and
fixed the warnings for those backends figuring it'd take less time than
fixing the 2018 edition errors for those backends manually (spoiler: it
wasnt)

The warnings for those backends were 100% related to dead code, mostly
unused imports. For the most part, fixing these was just moving imports
where they were actually used, or cfging them. In one case I fixed the
unused imports by adding some missing tests for float
seralization/deserializion on SQLite and MySQL. This was a bit funky
since neither have a way to specify the type of a float literal, nor do
they have a way to specify NaN or Infinity (though SQLite will coerce an
out of range number to infinity). For the `schema_dsl` module, I stuck
the slightly odd `#[cfg_attr(not(feature = "postgres"),
allow(dead_code))]`. This is because going through that module and
annotating what schema creation methods are used by what backends just
isn't worth the time. We do want to warn if something is *actually*
unused though, so I'm assuming that if it's used at all it's used by at
least PG.

The benchmarks haven't built for ~2 years... They build again now.