### PR TITLE
Fix UnexpectedNullError when deserializing (NULL,NotNull) into Option

### DIFF
--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -59,6 +59,10 @@ impl<'a> Row<Mysql> for MysqlRow<'a> {
     fn next_is_null(&self, count: usize) -> bool {
         (0..count).all(|i| self.binds.field_data(self.col_idx + i).is_none())
     }
+
+    fn column_index(&self) -> usize {
+        self.col_idx
+    }
 }
 
 pub struct NamedStatementIterator<'a> {

--- a/diesel/src/pg/connection/row.rs
+++ b/diesel/src/pg/connection/row.rs
@@ -31,6 +31,10 @@ impl<'a> Row<Pg> for PgRow<'a> {
     fn next_is_null(&self, count: usize) -> bool {
         (0..count).all(|i| self.db_result.is_null(self.row_idx, self.col_idx + i))
     }
+
+    fn column_index(&self) -> usize {
+        self.col_idx
+    }
 }
 
 pub struct PgNamedRow<'a> {

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -19,6 +19,12 @@ pub trait Row<DB: Backend> {
     /// would all return `None`.
     fn next_is_null(&self, count: usize) -> bool;
 
+    /// Returns the index of the current column (next to be returned by take, zero based)
+    ///
+    /// May be used to skip the right number of fields when recovering for an `UnexpectedNullError` when
+    /// deserializing an `Option`
+    fn column_index(&self) -> usize;
+
     /// Skips the next `count` columns. This method must be called if you are
     /// choosing not to call `take` as a result of `next_is_null` returning
     /// `true`.

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -105,6 +105,10 @@ impl Row<Sqlite> for SqliteRow {
             tpe == ffi::SQLITE_NULL
         })
     }
+
+    fn column_index(&self) -> usize {
+        self.next_col_index as usize
+    }
 }
 
 pub struct SqliteNamedRow<'a> {

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -95,7 +95,16 @@ where
             row.advance(fields_needed);
             Ok(None)
         } else {
-            T::build_from_row(row).map(Some)
+            match T::build_from_row(row) {
+                Ok(v) => Ok(Some(v)),
+                Err(e) => {
+                    if e.is::<UnexpectedNullError>() {
+                        Ok(None)
+                    } else {
+                        Err(e)
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #2274

I'm not sure if this was originally a bug or not, but in any case as described on the issue, often the NotNull field (say, `zzz::some_nullable_thing.is_not_null()`) doesn't have any meaning if we couldn't left_join on the `zzz` table and select the NULL field (say, `zzz::id`).

This is why I'm very happy to not have access to the second field if the first field is NULL.

However I can't think of a scenario where I'd prefer a runtime error: cases where I could unintentionally "forget" a field should be covered by the typing after the query: "Why can't I get the value of this field? Oh it's because it was packed in this `Option`...)

This is why I beleive that this behaviour that ends up giving `Ok(None)` instead of `Err(DeserializationError(UnexpectedNullError))` is better.

~~Accorging to the tests this implementation seems to work properly, though I'm not sure why recovering from the error skips the proper amount of fields... Can anyone confirm that (and why) this indeed behaves as expected ? :)~~
EDIT: This indeed did not skip the proper amount of fields, and is now fixed.

Also open to any comments :)