### PR TITLE
Generalize creating a `BoxedWhereClause`

### DIFF
--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -59,8 +59,8 @@ where
     }
 }
 
-impl<DB> Into<BoxedWhereClause<'static, DB>> for NoWhereClause {
-    fn into(self) -> BoxedWhereClause<'static, DB> {
+impl<'a, DB> Into<BoxedWhereClause<'a, DB>> for NoWhereClause {
+    fn into(self) -> BoxedWhereClause<'a, DB> {
         BoxedWhereClause::None
     }
 }


### PR DESCRIPTION
This commit generalizes the creating of a boxed where clause from an
empty where clause in such a way that this works for any lifetime
instead only for static lifetimes. This is required to write
`dsl::IntoBoxed<some::table>` for general queries that may contain a
restriction on their lifetime. (For example because of they contain a
`.eq_any(some_borrowed_array)` expression)