### PR TITLE
Change MySQL's number handling to be more permissive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         rust: ["stable", "beta", "nightly"]
         backend: ["postgres", "sqlite", "mysql"]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `#[non_exhaustive]`. If you matched on one of those variants explicitly you need to
   introduce a wild card match instead.
 
+* The `TypeMetadata` type for `Mysql` changed to `MysqlType`
+
 ### Fixed
 
 * Many types were incorrectly considered non-aggregate when they should not
@@ -126,6 +128,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   See [the SQLite URI documentation] for additional details.
 
 [the SQLite URI documentation]: https://www.sqlite.org/uri.html
+
+* We've refactored our type translation layer for Mysql to handle more types now.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 [raw-value-2-0-0]: http://docs.diesel.rs/diesel/backend/type.RawValue.html
 
 * The type metadata for MySQL has been changed to include sign information. If
-  you are implementing `HasSqlType` for `Mysql` manually, or manipulating a
-  `Mysql::TypeMetadata`, you will need to take the new struct
-  `MysqlTypeMetadata` instead.
+  you are implementing `HasSqlType` for `Mysql` manually, you may need to adjust
+  your implementation to fully use the new unsigned variants in `MysqlType`
 
 * The minimal officially supported rustc version is now 1.40.0
 
@@ -94,7 +93,6 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   `#[non_exhaustive]`. If you matched on one of those variants explicitly you need to
   introduce a wild card match instead.
 
-* The `TypeMetadata` type for `Mysql` changed to `MysqlType`
 
 ### Fixed
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -43,7 +43,7 @@ dotenv = "0.15"
 quickcheck = "0.9"
 
 [features]
-default = ["mysql", "extras"]
+default = []
 extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address", "numeric", "r2d2"]
 unstable = ["diesel_derives/nightly"]
 large-tables = ["32-column-tables"]

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -43,7 +43,7 @@ dotenv = "0.15"
 quickcheck = "0.9"
 
 [features]
-default = []
+default = ["with-deprecated", "32-column-tables"]
 extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address", "numeric", "r2d2"]
 unstable = ["diesel_derives/nightly"]
 large-tables = ["32-column-tables"]

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -43,7 +43,7 @@ dotenv = "0.15"
 quickcheck = "0.9"
 
 [features]
-default = ["with-deprecated", "32-column-tables"]
+default = ["mysql", "extras"]
 extras = ["chrono", "serde_json", "uuid", "deprecated-time", "network-address", "numeric", "r2d2"]
 unstable = ["diesel_derives/nightly"]
 large-tables = ["32-column-tables"]
@@ -53,7 +53,7 @@ huge-tables = ["64-column-tables"]
 128-column-tables = ["64-column-tables"]
 postgres = ["pq-sys", "bitflags", "diesel_derives/postgres"]
 sqlite = ["libsqlite3-sys", "diesel_derives/sqlite"]
-mysql = ["mysqlclient-sys", "url", "percent-encoding", "diesel_derives/mysql"]
+mysql = ["mysqlclient-sys", "url", "percent-encoding", "diesel_derives/mysql", "bitflags"]
 with-deprecated = []
 deprecated-time = ["time"]
 network-address = ["ipnetwork", "libc"]

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -50,6 +50,8 @@ pub enum MysqlType {
     Float,
     /// Sets `buffer_type` to `MYSQL_TYPE_DOUBLE`
     Double,
+    /// Sets `buffer_type` to `MYSQL_TYPE_NEWDECIMAL`
+    Numeric,
     /// Sets `buffer_type` to `MYSQL_TYPE_TIME`
     Time,
     /// Sets `buffer_type` to `MYSQL_TYPE_DATE`

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -58,6 +58,8 @@ pub enum MysqlType {
     Set,
     ///
     Enum,
+    ///
+    Json,
 }
 
 impl Backend for Mysql {

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -12,42 +12,28 @@ use crate::sql_types::TypeMetadata;
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Mysql;
 
-/// The full type metadata for MySQL
-///
-/// This includes the type of the value, and whether it is signed.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub struct MysqlTypeMetadata {
-    /// The underlying data type
-    ///
-    /// Affects the `buffer_type` sent to libmysqlclient
-    pub data_type: MysqlType,
-
-    /// Is this type signed?
-    ///
-    /// Affects the `is_unsigned` flag sent to libmysqlclient
-    pub is_unsigned: bool,
-}
-
 #[allow(missing_debug_implementations)]
-/// Represents the possible forms a bind parameter can be transmitted as.
-/// Each variant represents one of the forms documented at
-/// <https://dev.mysql.com/doc/refman/5.7/en/c-api-prepared-statement-type-codes.html>
-///
-/// The null variant is omitted, as we will never prepare a statement in which
-/// one of the bind parameters can always be NULL
+/// Represents the possible types, that can be transmitted as via the
+/// Mysql wire protocol
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub enum MysqlType {
-    /// Sets `buffer_type` to `MYSQL_TYPE_TINY`
+    ///
     Tiny,
+    /// Sets
+    UnsignedTiny,
     /// Sets `buffer_type` to `MYSQL_TYPE_SHORT`
     Short,
-    /// Sets `buffer_type` to `MYSQL_TYPE_INT24`
-    Medium,
+    ///
+    UnsignedShort,
     /// Sets `buffer_type` to `MYSQL_TYPE_LONG`
     Long,
+    ///
+    UnsignedLong,
     /// Sets `buffer_type` to `MYSQL_TYPE_LONGLONG`
     LongLong,
+    ///
+    UnsignedLongLong,
     /// Sets `buffer_type` to `MYSQL_TYPE_FLOAT`
     Float,
     /// Sets `buffer_type` to `MYSQL_TYPE_DOUBLE`
@@ -68,6 +54,10 @@ pub enum MysqlType {
     Blob,
     /// Sets `buffer_type` to `MYSQL_TYPE_BIT`
     Bit,
+    ///
+    Set,
+    ///
+    Enum,
 }
 
 impl Backend for Mysql {
@@ -81,7 +71,7 @@ impl<'a> HasRawValue<'a> for Mysql {
 }
 
 impl TypeMetadata for Mysql {
-    type TypeMetadata = MysqlTypeMetadata;
+    type TypeMetadata = MysqlType;
     type MetadataLookup = ();
 }
 

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -42,6 +42,8 @@ pub enum MysqlType {
     Tiny,
     /// Sets `buffer_type` to `MYSQL_TYPE_SHORT`
     Short,
+    /// Sets `buffer_type` to `MYSQL_TYPE_INT24`
+    Medium,
     /// Sets `buffer_type` to `MYSQL_TYPE_LONG`
     Long,
     /// Sets `buffer_type` to `MYSQL_TYPE_LONGLONG`
@@ -64,6 +66,8 @@ pub enum MysqlType {
     String,
     /// Sets `buffer_type` to `MYSQL_TYPE_BLOB`
     Blob,
+    /// Sets `buffer_type` to `MYSQL_TYPE_BIT`
+    Bit,
 }
 
 impl Backend for Mysql {

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -13,50 +13,52 @@ use crate::sql_types::TypeMetadata;
 pub struct Mysql;
 
 #[allow(missing_debug_implementations)]
-/// Represents the possible types, that can be transmitted as via the
+/// Represents possible types, that can be transmitted as via the
 /// Mysql wire protocol
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub enum MysqlType {
-    ///
+    /// A 8 bit signed integer
     Tiny,
-    /// Sets
+    /// A 8 bit unsigned integer
     UnsignedTiny,
-    /// Sets `buffer_type` to `MYSQL_TYPE_SHORT`
+    /// A 16 bit signed integer
     Short,
-    ///
+    /// A 16 bit unsigned integer
     UnsignedShort,
-    /// Sets `buffer_type` to `MYSQL_TYPE_LONG`
+    /// A 32 bit signed integer
     Long,
-    ///
+    /// A 32 bit unsigned integer
     UnsignedLong,
-    /// Sets `buffer_type` to `MYSQL_TYPE_LONGLONG`
+    /// A 64 bit signed integer
     LongLong,
-    ///
+    /// A 64 bit unsigned integer
     UnsignedLongLong,
-    /// Sets `buffer_type` to `MYSQL_TYPE_FLOAT`
+    /// A 32 bit floating point number
     Float,
-    /// Sets `buffer_type` to `MYSQL_TYPE_DOUBLE`
+    /// A 64 bit floating point number
     Double,
-    /// Sets `buffer_type` to `MYSQL_TYPE_NEWDECIMAL`
+    /// A fixed point decimal value
     Numeric,
-    /// Sets `buffer_type` to `MYSQL_TYPE_TIME`
+    /// A datatype to store a time value
     Time,
-    /// Sets `buffer_type` to `MYSQL_TYPE_DATE`
+    /// A datatype to store a date value
     Date,
-    /// Sets `buffer_type` to `MYSQL_TYPE_DATETIME`
+    /// A datatype containing timestamp values ranging from
+    /// '1000-01-01 00:00:00' to '9999-12-31 23:59:59'.
     DateTime,
-    /// Sets `buffer_type` to `MYSQL_TYPE_TIMESTAMP`
+    /// A datatype containing timestamp values ranging from
+    /// 1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC.
     Timestamp,
-    /// Sets `buffer_type` to `MYSQL_TYPE_STRING`
+    /// A datatype for string values
     String,
-    /// Sets `buffer_type` to `MYSQL_TYPE_BLOB`
+    /// A datatype containing binary large objects
     Blob,
-    /// Sets `buffer_type` to `MYSQL_TYPE_BIT`
+    /// A value containing a set of bit's
     Bit,
-    ///
+    /// A user defined set type
     Set,
-    ///
+    /// A user defined enum type
     Enum,
 }
 

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -58,8 +58,6 @@ pub enum MysqlType {
     Set,
     ///
     Enum,
-    ///
-    Json,
 }
 
 impl Backend for Mysql {

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -83,8 +83,8 @@ impl Binds {
 
     pub fn field_data(&self, idx: usize) -> Option<MysqlValue<'_>> {
         let data = &self.data[idx];
-        let tpe = data.tpe.into();
         self.data[idx].bytes().map(|bytes| {
+            let tpe = data.tpe.into();
             MysqlValue::new(
                 bytes,
                 MysqlTypeMetadata {
@@ -266,7 +266,11 @@ impl From<ffi::enum_field_types> for MysqlType {
             | MYSQL_TYPE_LONG_BLOB => MysqlType::Blob,
             MYSQL_TYPE_DECIMAL | MYSQL_TYPE_NEWDECIMAL => MysqlType::Numeric,
             // Null value
-            MYSQL_TYPE_NULL |
+            MYSQL_TYPE_NULL => unreachable!(
+                "We ensure at the call side that we do not hit this type here. \
+                 If you ever see this error, something has gone very wrong. \
+                 Please open a issue at the diesel github repo in this case"
+            ),
             // bit type
             // same encoding as string
             MYSQL_TYPE_BIT |
@@ -289,7 +293,7 @@ impl From<ffi::enum_field_types> for MysqlType {
             MYSQL_TYPE_NEWDATE
             | MYSQL_TYPE_TIME2
             | MYSQL_TYPE_DATETIME2
-            | MYSQL_TYPE_TIMESTAMP2 => panic!(
+            | MYSQL_TYPE_TIMESTAMP2 => unreachable!(
                 "The mysql documentation states that this types are \
                  only used on server side, so if you see this error \
                  something has gone wrong. Please open a issue at \

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -7,6 +7,7 @@ use super::stmt::Statement;
 use crate::mysql::{MysqlType, MysqlTypeMetadata, MysqlValue};
 use crate::result::QueryResult;
 
+#[derive(Debug)]
 pub struct Binds {
     data: Vec<BindData>,
 }
@@ -29,7 +30,16 @@ impl Binds {
     pub fn from_output_types(types: Vec<MysqlTypeMetadata>) -> Self {
         let data = types
             .into_iter()
-            .map(|metadata| (metadata.data_type.into(), metadata.is_unsigned as _))
+            .map(|metadata| {
+                (
+                    metadata.data_type.into(),
+                    if metadata.is_unsigned {
+                        Flags::UNSIGNED_FLAG
+                    } else {
+                        Flags::empty()
+                    },
+                )
+            })
             .map(BindData::for_output)
             .collect();
 
@@ -39,7 +49,12 @@ impl Binds {
     pub fn from_result_metadata(fields: &[ffi::MYSQL_FIELD]) -> Self {
         let data = fields
             .iter()
-            .map(|field| (field.type_, is_field_unsigned(field)))
+            .map(|field| {
+                (
+                    field.type_,
+                    Flags::from_bits(field.flags).expect("No unknown flags"),
+                )
+            })
             .map(BindData::for_output)
             .collect();
 
@@ -89,24 +104,51 @@ impl Binds {
                 bytes,
                 MysqlTypeMetadata {
                     data_type: tpe,
-                    is_unsigned: data.is_unsigned != 0,
+                    is_unsigned: data.flags.contains(Flags::UNSIGNED_FLAG),
                 },
             )
         })
     }
 }
 
+bitflags::bitflags! {
+    struct Flags: u32 {
+        const NOT_NULL_FLAG = 1;
+        const PRI_KEY_FAG = 2;
+        const UNIQUE_KEY_FLAG = 4;
+        const MULTIPLE_KEY_FLAG = 8;
+        const BLOB_FLAG = 16;
+        const UNSIGNED_FLAG = 32;
+        const ZEROFILL_FLAG = 64;
+        const BINARY_FLAG = 128;
+        const ENUM_FLAG = 256;
+        const AUTO_INCREMENT_FLAG = 512;
+        const TIMESTAMP_FLAG = 1024;
+        const SET_FLAG = 2048;
+        const NO_DEFAULT_VALUE_FLAG = 4096;
+        const ON_UPDATE_NOW_FLAG = 8192;
+        const NUM_FLAG = 32768;
+        const PART_KEY_FLAG = 16384;
+        const GROUP_FLAG = 32768;
+        const UNIQUE_FLAG = 65536;
+        const BINCMP_FLAG = 130172;
+        const GET_FIXED_FIELDS_FLAG = (1<<18);
+        const FIELD_IN_PART_FUNC_FLAG = (1 << 19);
+    }
+}
+
+#[derive(Debug)]
 struct BindData {
     tpe: ffi::enum_field_types,
     bytes: Vec<u8>,
     length: libc::c_ulong,
+    flags: Flags,
     is_null: ffi::my_bool,
     is_truncated: Option<ffi::my_bool>,
-    is_unsigned: ffi::my_bool,
 }
 
 impl BindData {
-    fn for_input(tpe: MysqlType, is_unsigned: ffi::my_bool, data: Option<Vec<u8>>) -> Self {
+    fn for_input(tpe: MysqlType, is_unsigned: bool, data: Option<Vec<u8>>) -> Self {
         let is_null = if data.is_none() { 1 } else { 0 };
         let bytes = data.unwrap_or_default();
         let length = bytes.len() as libc::c_ulong;
@@ -117,11 +159,15 @@ impl BindData {
             length,
             is_null,
             is_truncated: None,
-            is_unsigned,
+            flags: if is_unsigned {
+                Flags::UNSIGNED_FLAG
+            } else {
+                Flags::empty()
+            },
         }
     }
 
-    fn for_output((tpe, is_unsigned): (ffi::enum_field_types, ffi::my_bool)) -> Self {
+    fn for_output((tpe, flags): (ffi::enum_field_types, Flags)) -> Self {
         let bytes = known_buffer_size_for_ffi_type(tpe)
             .map(|len| vec![0; len])
             .unwrap_or_default();
@@ -133,7 +179,7 @@ impl BindData {
             length,
             is_null: 0,
             is_truncated: Some(0),
-            is_unsigned,
+            flags,
         }
     }
 
@@ -167,7 +213,7 @@ impl BindData {
         bind.buffer_length = self.bytes.capacity() as libc::c_ulong;
         bind.length = &mut self.length;
         bind.is_null = &mut self.is_null;
-        bind.is_unsigned = self.is_unsigned;
+        bind.is_unsigned = self.flags.contains(Flags::UNSIGNED_FLAG) as ffi::my_bool;
 
         if let Some(ref mut is_truncated) = self.is_truncated {
             bind.error = is_truncated;
@@ -225,6 +271,7 @@ impl From<MysqlType> for ffi::enum_field_types {
         match tpe {
             MysqlType::Tiny => MYSQL_TYPE_TINY,
             MysqlType::Short => MYSQL_TYPE_SHORT,
+            MysqlType::Medium => MYSQL_TYPE_INT24,
             MysqlType::Long => MYSQL_TYPE_LONG,
             MysqlType::LongLong => MYSQL_TYPE_LONGLONG,
             MysqlType::Float => MYSQL_TYPE_FLOAT,
@@ -236,6 +283,7 @@ impl From<MysqlType> for ffi::enum_field_types {
             MysqlType::String => MYSQL_TYPE_STRING,
             MysqlType::Blob => MYSQL_TYPE_BLOB,
             MysqlType::Numeric => MYSQL_TYPE_NEWDECIMAL,
+            MysqlType::Bit => MYSQL_TYPE_BIT,
         }
     }
 }
@@ -251,7 +299,8 @@ impl From<ffi::enum_field_types> for MysqlType {
         match tpe {
             MYSQL_TYPE_TINY => MysqlType::Tiny,
             MYSQL_TYPE_YEAR | MYSQL_TYPE_SHORT => MysqlType::Short,
-            MYSQL_TYPE_INT24 | MYSQL_TYPE_LONG => MysqlType::Long,
+            MYSQL_TYPE_INT24 => MysqlType::Medium,
+            MYSQL_TYPE_LONG => MysqlType::Long,
             MYSQL_TYPE_LONGLONG => MysqlType::LongLong,
             MYSQL_TYPE_FLOAT => MysqlType::Float,
             MYSQL_TYPE_DOUBLE => MysqlType::Double,
@@ -259,7 +308,13 @@ impl From<ffi::enum_field_types> for MysqlType {
             MYSQL_TYPE_DATE => MysqlType::Date,
             MYSQL_TYPE_DATETIME => MysqlType::DateTime,
             MYSQL_TYPE_TIMESTAMP => MysqlType::Timestamp,
-            MYSQL_TYPE_VAR_STRING | MYSQL_TYPE_VARCHAR | MYSQL_TYPE_STRING => MysqlType::String,
+            MYSQL_TYPE_BIT => MysqlType::Bit,
+            MYSQL_TYPE_ENUM
+            | MYSQL_TYPE_SET
+            | MYSQL_TYPE_JSON
+            | MYSQL_TYPE_VAR_STRING
+            | MYSQL_TYPE_VARCHAR
+            | MYSQL_TYPE_STRING => MysqlType::String,
             MYSQL_TYPE_BLOB
             | MYSQL_TYPE_TINY_BLOB
             | MYSQL_TYPE_MEDIUM_BLOB
@@ -271,25 +326,14 @@ impl From<ffi::enum_field_types> for MysqlType {
                  If you ever see this error, something has gone very wrong. \
                  Please open a issue at the diesel github repo in this case"
             ),
-            // bit type
-            // same encoding as string
-            MYSQL_TYPE_BIT |
-            // enum type
-            // same encoding as string
-            MYSQL_TYPE_ENUM |
-            // set type
-            // same encoding as string
-            MYSQL_TYPE_SET |
             // spatial type
             // same encoding as string
-            MYSQL_TYPE_GEOMETRY |
-            // json type, only available on newer mysql versions
-            // same encoding as string
-            MYSQL_TYPE_JSON => unimplemented!(
+            MYSQL_TYPE_GEOMETRY => unimplemented!(
                 "Hit currently unsupported type, those variants should \
                  probably be variants of MysqlType or at least be mapped \
                  to one of the existing types"
             ),
+
             MYSQL_TYPE_NEWDATE
             | MYSQL_TYPE_TIME2
             | MYSQL_TYPE_DATETIME2
@@ -320,7 +364,955 @@ fn known_buffer_size_for_ffi_type(tpe: ffi::enum_field_types) -> Option<usize> {
     }
 }
 
-fn is_field_unsigned(field: &ffi::MYSQL_FIELD) -> ffi::my_bool {
-    const UNSIGNED_FLAG: libc::c_uint = 32;
-    (field.flags & UNSIGNED_FLAG > 0) as _
+#[allow(warnings)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+
+    use super::{MysqlTypeMetadata, MysqlValue};
+    use crate::deserialize::FromSql;
+    use crate::mysql::connection::stmt::iterator::NamedStatementIterator;
+    use crate::sql_types::*;
+
+    fn to_value<ST, T>(
+        bind: &BindData,
+    ) -> Result<T, Box<(dyn std::error::Error + Send + Sync + 'static)>>
+    where
+        T: FromSql<ST, crate::mysql::Mysql> + std::fmt::Debug,
+    {
+        let meta = MysqlTypeMetadata {
+            data_type: bind.tpe.into(),
+            is_unsigned: bind.flags.contains(Flags::UNSIGNED_FLAG),
+        };
+
+        let value = MysqlValue::new(&bind.bytes, meta);
+        dbg!(T::from_sql(Some(value)))
+    }
+
+    #[test]
+    fn check_all_the_types() {
+        let conn = crate::test_helpers::connection();
+
+        conn.execute("DROP TABLE IF EXISTS all_mysql_types CASCADE")
+            .unwrap();
+        conn.execute(
+            "CREATE TABLE all_mysql_types (
+                    tiny_int TINYINT NOT NULL,
+                    small_int SMALLINT NOT NULL,
+                    medium_int MEDIUMINT NOT NULL,
+                    int_col INTEGER NOT NULL,
+                    big_int BIGINT NOT NULL,
+                    unsigned_int INTEGER UNSIGNED NOT NULL,
+                    zero_fill_int INTEGER ZEROFILL NOT NULL,
+                    numeric_col NUMERIC(20,5) NOT NULL,
+                    decimal_col DECIMAL(20,5) NOT NULL,
+                    float_col FLOAT NOT NULL,
+                    double_col DOUBLE NOT NULL,
+                    bit_col BIT(8) NOT NULL,
+                    date_col DATE NOT NULL,
+                    date_time DATETIME NOT NULL,
+                    timestamp_col TIMESTAMP NOT NULL,
+                    time_col TIME NOT NULL,
+                    year_col YEAR NOT NULL,
+                    char_col CHAR(30) NOT NULL,
+                    varchar_col VARCHAR(30) NOT NULL,
+                    binary_col BINARY(30) NOT NULL,
+                    varbinary_col VARBINARY(30) NOT NULL,
+                    blob_col BLOB NOT NULL,
+                    text_col TEXT NOT NULL,
+                    enum_col ENUM('red', 'green', 'blue') NOT NULL,
+                    set_col SET('one', 'two') NOT NULL,
+                    geom GEOMETRY NOT NULL,
+                    point_col POINT NOT NULL,
+                    linestring_col LINESTRING NOT NULL,
+                    polygon_col POLYGON NOT NULL,
+                    multipoint_col MULTIPOINT NOT NULL,
+                    multilinestring_col MULTILINESTRING NOT NULL,
+                    multipolygon_col MULTIPOLYGON NOT NULL,
+                    geometry_collection GEOMETRYCOLLECTION NOT NULL,
+                    json_col JSON NOT NULL
+            )",
+        )
+        .unwrap();
+        conn
+            .execute(
+                "INSERT INTO all_mysql_types VALUES (
+                    0, -- tiny_int
+                    1, -- small_int
+                    2, -- medium_int
+                    3, -- int_col
+                    -5, -- big_int
+                    42, -- unsigned_int
+                    1, -- zero_fill_int
+                    -999.999, -- numeric_col,
+                    3.14, -- decimal_col,
+                    1.23, -- float_col
+                    4.5678, -- double_col
+                    b'10101010', -- bit_col
+                    '1000-01-01', -- date_col
+                    '9999-12-31 12:34:45.012345', -- date_time
+                    '2020-01-01 10:10:10', -- timestamp_col
+                    '23:01:01', -- time_col
+                    2020, -- year_col
+                    'abc', -- char_col
+                    'foo', -- varchar_col
+                    'a ', -- binary_col
+                    'a ', -- varbinary_col
+                    'binary', -- blob_col
+                    'some text whatever', -- text_col
+                    'red', -- enum_col
+                    'one', -- set_col
+                    ST_GeomFromText('POINT(1 1)'), -- geom
+                    ST_PointFromText('POINT(1 1)'), -- point_col
+                    ST_LineStringFromText('LINESTRING(0 0,1 1,2 2)'), -- linestring_col
+                    ST_PolygonFromText('POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7, 5 5))'), -- polygon_col
+                    ST_MultiPointFromText('MULTIPOINT(0 0,10 10,10 20,20 20)'), -- multipoint_col
+                    ST_MultiLineStringFromText('MULTILINESTRING((10 48,10 21,10 0),(16 0,16 23,16 48))'), -- multilinestring_col
+                    ST_MultiPolygonFromText('MULTIPOLYGON(((28 26,28 0,84 0,84 42,28 26),(52 18,66 23,73 9,48 6,52 18)),((59 18,67 18,67 13,59 13,59 18)))'), -- multipolygon_col
+                    ST_GeomCollFromText('GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,1 1,2 2,3 3,4 4))'), -- geometry_collection
+                    '{\"key1\": \"value1\", \"key2\": \"value2\"}' -- json_col
+)",
+            )
+            .unwrap();
+
+        let mut stmt = conn
+            .prepare_query(&crate::sql_query(
+                "SELECT
+                    tiny_int, small_int, medium_int, int_col,
+                    big_int, unsigned_int, zero_fill_int,
+                    numeric_col, decimal_col, float_col, double_col, bit_col,
+                    date_col, date_time, timestamp_col, time_col, year_col,
+                    char_col, varchar_col, binary_col, varbinary_col, blob_col,
+                    text_col, enum_col, set_col, ST_AsText(geom), ST_AsText(point_col), ST_AsText(linestring_col),
+                    ST_AsText(polygon_col), ST_AsText(multipoint_col), ST_AsText(multilinestring_col),
+                    ST_AsText(multipolygon_col), ST_AsText(geometry_collection), json_col
+                 FROM all_mysql_types",
+            ))
+            .unwrap();
+
+        let results = unsafe { stmt.named_results().unwrap() };
+
+        let NamedStatementIterator {
+            stmt,
+            mut output_binds,
+            metadata,
+        } = results;
+
+        crate::mysql::connection::stmt::iterator::populate_row_buffers(stmt, &mut output_binds)
+            .unwrap();
+
+        let results: Vec<(BindData, &ffi::st_mysql_field)> = output_binds
+            .data
+            .into_iter()
+            .zip(metadata.fields())
+            .collect::<Vec<_>>();
+
+        macro_rules! matches {
+            ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )?) => {
+                match $expression {
+                    $( $pattern )|+ $( if $guard )? => true,
+                    _ => false
+                }
+            }
+        }
+
+        let tiny_int_col = &results[0].0;
+        assert_eq!(tiny_int_col.tpe, ffi::enum_field_types::MYSQL_TYPE_TINY);
+        assert!(tiny_int_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!tiny_int_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<TinyInt, i8>(tiny_int_col), Ok(0)));
+
+        let small_int_col = &results[1].0;
+        assert_eq!(small_int_col.tpe, ffi::enum_field_types::MYSQL_TYPE_SHORT);
+        assert!(small_int_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!small_int_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<SmallInt, i16>(small_int_col), Ok(1)));
+
+        let medium_int_col = &results[2].0;
+        assert_eq!(medium_int_col.tpe, ffi::enum_field_types::MYSQL_TYPE_INT24);
+        assert!(medium_int_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!medium_int_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<Integer, i32>(medium_int_col), Ok(2)));
+
+        let int_col = &results[3].0;
+        assert_eq!(int_col.tpe, ffi::enum_field_types::MYSQL_TYPE_LONG);
+        assert!(int_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!int_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<Integer, i32>(int_col), Ok(3)));
+
+        let big_int_col = &results[4].0;
+        assert_eq!(big_int_col.tpe, ffi::enum_field_types::MYSQL_TYPE_LONGLONG);
+        assert!(big_int_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!big_int_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<TinyInt, i8>(big_int_col), Ok(-5)));
+
+        let unsigned_int_col = &results[5].0;
+        assert_eq!(unsigned_int_col.tpe, ffi::enum_field_types::MYSQL_TYPE_LONG);
+        assert!(unsigned_int_col.flags.contains(Flags::NUM_FLAG));
+        assert!(unsigned_int_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(
+            to_value::<Unsigned<Integer>, u32>(unsigned_int_col),
+            Ok(42)
+        ));
+
+        let zero_fill_int_col = &results[6].0;
+        assert_eq!(
+            zero_fill_int_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_LONG
+        );
+        assert!(zero_fill_int_col.flags.contains(Flags::NUM_FLAG));
+        assert!(zero_fill_int_col.flags.contains(Flags::ZEROFILL_FLAG));
+        assert!(matches!(to_value::<Integer, i32>(zero_fill_int_col), Ok(1)));
+
+        let numeric_col = &results[7].0;
+        assert_eq!(
+            numeric_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_NEWDECIMAL
+        );
+        assert!(numeric_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!numeric_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert_eq!(
+            to_value::<Numeric, bigdecimal::BigDecimal>(numeric_col).unwrap(),
+            bigdecimal::BigDecimal::from(-999.999)
+        );
+
+        let decimal_col = &results[8].0;
+        assert_eq!(
+            decimal_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_NEWDECIMAL
+        );
+        assert!(decimal_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!decimal_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert_eq!(
+            to_value::<Numeric, bigdecimal::BigDecimal>(decimal_col).unwrap(),
+            bigdecimal::BigDecimal::from(3.14)
+        );
+
+        let float_col = &results[9].0;
+        assert_eq!(float_col.tpe, ffi::enum_field_types::MYSQL_TYPE_FLOAT);
+        assert!(float_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!float_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<Float, f32>(float_col), Ok(1.23)));
+
+        let double_col = &results[10].0;
+        assert_eq!(double_col.tpe, ffi::enum_field_types::MYSQL_TYPE_DOUBLE);
+        assert!(double_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!double_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<Double, f64>(double_col), Ok(4.5678)));
+
+        let bit_col = &results[11].0;
+        assert_eq!(bit_col.tpe, ffi::enum_field_types::MYSQL_TYPE_BIT);
+        assert!(!bit_col.flags.contains(Flags::NUM_FLAG));
+        assert!(bit_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(!bit_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Blob, Vec<u8>>(bit_col).unwrap(), vec![170]);
+
+        let date_col = &results[12].0;
+        assert_eq!(date_col.tpe, ffi::enum_field_types::MYSQL_TYPE_DATE);
+        assert!(!date_col.flags.contains(Flags::TIMESTAMP_FLAG));
+        assert!(!date_col.flags.contains(Flags::NUM_FLAG));
+        assert_eq!(
+            to_value::<Date, chrono::NaiveDate>(date_col).unwrap(),
+            chrono::NaiveDate::from_ymd_opt(1000, 1, 1).unwrap(),
+        );
+
+        let date_time_col = &results[13].0;
+        assert_eq!(
+            date_time_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_DATETIME
+        );
+        assert!(!date_time_col.flags.contains(Flags::TIMESTAMP_FLAG));
+        assert!(!date_time_col.flags.contains(Flags::NUM_FLAG));
+        assert_eq!(
+            to_value::<Datetime, chrono::NaiveDateTime>(date_time_col).unwrap(),
+            chrono::NaiveDateTime::parse_from_str("9999-12-31 12:34:45", "%Y-%m-%d %H:%M:%S")
+                .unwrap()
+        );
+
+        let timestamp_col = &results[14].0;
+        assert_eq!(
+            timestamp_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_TIMESTAMP
+        );
+        assert!(timestamp_col.flags.contains(Flags::TIMESTAMP_FLAG));
+        assert!(!timestamp_col.flags.contains(Flags::NUM_FLAG));
+        assert_eq!(
+            to_value::<Datetime, chrono::NaiveDateTime>(timestamp_col).unwrap(),
+            chrono::NaiveDateTime::parse_from_str("2020-01-01 10:10:10", "%Y-%m-%d %H:%M:%S")
+                .unwrap()
+        );
+
+        let time_col = &results[15].0;
+        assert_eq!(time_col.tpe, ffi::enum_field_types::MYSQL_TYPE_TIME);
+        assert!(!time_col.flags.contains(Flags::TIMESTAMP_FLAG));
+        assert!(!time_col.flags.contains(Flags::NUM_FLAG));
+        assert_eq!(
+            to_value::<Time, chrono::NaiveTime>(time_col).unwrap(),
+            chrono::NaiveTime::from_hms(23, 01, 01)
+        );
+
+        let year_col = &results[16].0;
+        assert_eq!(year_col.tpe, ffi::enum_field_types::MYSQL_TYPE_YEAR);
+        assert!(!year_col.flags.contains(Flags::TIMESTAMP_FLAG));
+        assert!(year_col.flags.contains(Flags::NUM_FLAG));
+        assert!(year_col.flags.contains(Flags::UNSIGNED_FLAG));
+        assert!(matches!(to_value::<SmallInt, i16>(year_col), Ok(2020)));
+
+        let char_col = &results[17].0;
+        assert_eq!(char_col.tpe, ffi::enum_field_types::MYSQL_TYPE_STRING);
+        assert!(!char_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!char_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!char_col.flags.contains(Flags::SET_FLAG));
+        assert!(!char_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!char_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(char_col).unwrap(), "abc");
+
+        let varchar_col = &results[18].0;
+        assert_eq!(
+            varchar_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_VAR_STRING
+        );
+        assert!(!varchar_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!varchar_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!varchar_col.flags.contains(Flags::SET_FLAG));
+        assert!(!varchar_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!varchar_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(varchar_col).unwrap(), "foo");
+
+        let binary_col = &results[19].0;
+        assert_eq!(binary_col.tpe, ffi::enum_field_types::MYSQL_TYPE_STRING);
+        assert!(!binary_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!binary_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!binary_col.flags.contains(Flags::SET_FLAG));
+        assert!(!binary_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(binary_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Blob, Vec<u8>>(binary_col).unwrap(),
+            b"a \0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+        );
+
+        let varbinary_col = &results[20].0;
+        assert_eq!(
+            varbinary_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_VAR_STRING
+        );
+        assert!(!varbinary_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!varbinary_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!varbinary_col.flags.contains(Flags::SET_FLAG));
+        assert!(!varbinary_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(varbinary_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Blob, Vec<u8>>(varbinary_col).unwrap(), b"a ");
+
+        let blob_col = &results[21].0;
+        assert_eq!(blob_col.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!blob_col.flags.contains(Flags::NUM_FLAG));
+        assert!(blob_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!blob_col.flags.contains(Flags::SET_FLAG));
+        assert!(!blob_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(blob_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Blob, Vec<u8>>(blob_col).unwrap(), b"binary");
+
+        let text_col = &results[22].0;
+        assert_eq!(text_col.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!text_col.flags.contains(Flags::NUM_FLAG));
+        assert!(text_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!text_col.flags.contains(Flags::SET_FLAG));
+        assert!(!text_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!text_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(text_col).unwrap(),
+            "some text whatever"
+        );
+
+        let enum_col = &results[23].0;
+        assert_eq!(enum_col.tpe, ffi::enum_field_types::MYSQL_TYPE_STRING);
+        assert!(!enum_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!enum_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!enum_col.flags.contains(Flags::SET_FLAG));
+        assert!(enum_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!enum_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(enum_col).unwrap(), "red");
+
+        let set_col = &results[24].0;
+        assert_eq!(set_col.tpe, ffi::enum_field_types::MYSQL_TYPE_STRING);
+        assert!(!set_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!set_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(set_col.flags.contains(Flags::SET_FLAG));
+        assert!(!set_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!set_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(set_col).unwrap(), "one");
+
+        let geom = &results[25].0;
+        assert_eq!(geom.tpe, ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB);
+        assert!(!geom.flags.contains(Flags::NUM_FLAG));
+        assert!(!geom.flags.contains(Flags::BLOB_FLAG));
+        assert!(!geom.flags.contains(Flags::SET_FLAG));
+        assert!(!geom.flags.contains(Flags::ENUM_FLAG));
+        assert!(!geom.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(geom).unwrap(), "POINT(1 1)");
+
+        let point_col = &results[26].0;
+        assert_eq!(point_col.tpe, ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB);
+        assert!(!point_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!point_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!point_col.flags.contains(Flags::SET_FLAG));
+        assert!(!point_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!point_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(point_col).unwrap(), "POINT(1 1)");
+
+        let linestring_col = &results[27].0;
+        assert_eq!(
+            linestring_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB
+        );
+        assert!(!linestring_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!linestring_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!linestring_col.flags.contains(Flags::SET_FLAG));
+        assert!(!linestring_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!linestring_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(linestring_col).unwrap(),
+            "LINESTRING(0 0,1 1,2 2)"
+        );
+
+        let polygon_col = &results[28].0;
+        assert_eq!(polygon_col.tpe, ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB);
+        assert!(!polygon_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::SET_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(polygon_col).unwrap(),
+            "POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5))"
+        );
+
+        let multipoint_col = &results[29].0;
+        assert_eq!(
+            multipoint_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB
+        );
+        assert!(!multipoint_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!multipoint_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!multipoint_col.flags.contains(Flags::SET_FLAG));
+        assert!(!multipoint_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!multipoint_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(multipoint_col).unwrap(),
+            "MULTIPOINT(0 0,10 10,10 20,20 20)"
+        );
+
+        let multilinestring_col = &results[30].0;
+        assert_eq!(
+            multilinestring_col.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB
+        );
+        assert!(!multilinestring_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!multilinestring_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!multilinestring_col.flags.contains(Flags::SET_FLAG));
+        assert!(!multilinestring_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!multilinestring_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(multilinestring_col).unwrap(),
+            "MULTILINESTRING((10 48,10 21,10 0),(16 0,16 23,16 48))"
+        );
+
+        let polygon_col = &results[31].0;
+        assert_eq!(polygon_col.tpe, ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB);
+        assert!(!polygon_col.flags.contains(Flags::NUM_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::SET_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(!polygon_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(polygon_col).unwrap(),
+            "MULTIPOLYGON(((28 26,28 0,84 0,84 42,28 26),(52 18,66 23,73 9,48 6,52 18)),((59 18,67 18,67 13,59 13,59 18)))"
+        );
+
+        let geometry_collection = &results[32].0;
+        assert_eq!(
+            geometry_collection.tpe,
+            ffi::enum_field_types::MYSQL_TYPE_LONG_BLOB
+        );
+        assert!(!geometry_collection.flags.contains(Flags::NUM_FLAG));
+        assert!(!geometry_collection.flags.contains(Flags::BLOB_FLAG));
+        assert!(!geometry_collection.flags.contains(Flags::SET_FLAG));
+        assert!(!geometry_collection.flags.contains(Flags::ENUM_FLAG));
+        assert!(!geometry_collection.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(geometry_collection).unwrap(),
+            "GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,1 1,2 2,3 3,4 4))"
+        );
+
+        let json_col = &results[33].0;
+        assert_eq!(json_col.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!json_col.flags.contains(Flags::NUM_FLAG));
+        assert!(json_col.flags.contains(Flags::BLOB_FLAG));
+        assert!(!json_col.flags.contains(Flags::SET_FLAG));
+        assert!(!json_col.flags.contains(Flags::ENUM_FLAG));
+        assert!(json_col.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(json_col).unwrap(),
+            "{\"key1\": \"value1\", \"key2\": \"value2\"}"
+        );
+    }
+
+    fn query_single_table(
+        query: &'static str,
+        conn: &MysqlConnection,
+        bind_tpe: ffi::enum_field_types,
+    ) -> BindData {
+        let mut stmt: Statement = conn.raw_connection.prepare(query).unwrap();
+
+        let bind = BindData::for_output((bind_tpe, Flags::UNSIGNED_FLAG));
+
+        let mut binds = Binds { data: vec![bind] };
+
+        crate::mysql::connection::stmt::iterator::execute_statement(&mut stmt, &mut binds).unwrap();
+
+        crate::mysql::connection::stmt::iterator::populate_row_buffers(&stmt, &mut binds).unwrap();
+
+        binds.data.remove(0)
+    }
+
+    fn input_bind(
+        query: &'static str,
+        conn: &MysqlConnection,
+        id: i32,
+        (field, tpe): (Vec<u8>, ffi::enum_field_types),
+    ) {
+        let mut stmt = conn.raw_connection.prepare(query).unwrap();
+        let length = field.len() as _;
+
+        let json_bind = BindData {
+            tpe,
+            bytes: field,
+            length,
+            flags: Flags::empty(),
+            is_null: 0,
+            is_truncated: None,
+        };
+
+        let bytes = id.to_be_bytes().to_vec();
+        let length = bytes.len() as _;
+
+        let id_bind = BindData {
+            tpe: ffi::enum_field_types::MYSQL_TYPE_LONG,
+            bytes,
+            length,
+            flags: Flags::empty(),
+            is_null: 0,
+            is_truncated: None,
+        };
+
+        let mut binds = Binds {
+            data: vec![id_bind, json_bind],
+        };
+
+        binds.with_mysql_binds(|bind_ptr| unsafe {
+            ffi::mysql_stmt_bind_param(stmt.stmt.as_ptr(), bind_ptr);
+        });
+
+        stmt.did_an_error_occur().unwrap();
+
+        let mut out_binds = Binds { data: vec![] };
+
+        unsafe {
+            stmt.execute().unwrap();
+        }
+    }
+
+    #[test]
+    fn check_json_bind() {
+        let conn: MysqlConnection = crate::test_helpers::connection();
+
+        table! {
+            json_test {
+                id -> Integer,
+                json_field -> Text,
+            }
+        }
+
+        conn.execute("DROP TABLE IF EXISTS json_test CASCADE")
+            .unwrap();
+
+        conn.execute("CREATE TABLE json_test(id INTEGER PRIMARY KEY, json_field JSON NOT NULL)")
+            .unwrap();
+
+        conn.execute("INSERT INTO json_test(id, json_field) VALUES (1, '{\"key1\": \"value1\", \"key2\": \"value2\"}')").unwrap();
+
+        let json_col_as_json = query_single_table(
+            "SELECT json_field FROM json_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_JSON,
+        );
+
+        assert_eq!(json_col_as_json.tpe, ffi::enum_field_types::MYSQL_TYPE_JSON);
+        assert!(!json_col_as_json.flags.contains(Flags::NUM_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::BLOB_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::SET_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::ENUM_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&json_col_as_json).unwrap(),
+            "{\"key1\": \"value1\", \"key2\": \"value2\"}"
+        );
+
+        let json_col_as_text = query_single_table(
+            "SELECT json_field FROM json_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(json_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!json_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&json_col_as_text).unwrap(),
+            "{\"key1\": \"value1\", \"key2\": \"value2\"}"
+        );
+        assert_eq!(json_col_as_json.bytes, json_col_as_text.bytes);
+
+        conn.execute("DELETE FROM json_test").unwrap();
+
+        input_bind(
+            "INSERT INTO json_test(id, json_field) VALUES (?, ?)",
+            &conn,
+            41,
+            (
+                b"{\"abc\": 42}".to_vec(),
+                ffi::enum_field_types::MYSQL_TYPE_JSON,
+            ),
+        );
+
+        let json_col_as_json = query_single_table(
+            "SELECT json_field FROM json_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_JSON,
+        );
+
+        assert_eq!(json_col_as_json.tpe, ffi::enum_field_types::MYSQL_TYPE_JSON);
+        assert!(!json_col_as_json.flags.contains(Flags::NUM_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::BLOB_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::SET_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::ENUM_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&json_col_as_json).unwrap(),
+            "{\"abc\": 42}"
+        );
+
+        let json_col_as_text = query_single_table(
+            "SELECT json_field FROM json_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(json_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!json_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&json_col_as_text).unwrap(),
+            "{\"abc\": 42}"
+        );
+        assert_eq!(json_col_as_json.bytes, json_col_as_text.bytes);
+
+        conn.execute("DELETE FROM json_test").unwrap();
+
+        input_bind(
+            "INSERT INTO json_test(id, json_field) VALUES (?, ?)",
+            &conn,
+            41,
+            (
+                b"{\"abca\": 42}".to_vec(),
+                ffi::enum_field_types::MYSQL_TYPE_BLOB,
+            ),
+        );
+
+        let json_col_as_json = query_single_table(
+            "SELECT json_field FROM json_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_JSON,
+        );
+
+        assert_eq!(json_col_as_json.tpe, ffi::enum_field_types::MYSQL_TYPE_JSON);
+        assert!(!json_col_as_json.flags.contains(Flags::NUM_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::BLOB_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::SET_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::ENUM_FLAG));
+        assert!(!json_col_as_json.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&json_col_as_json).unwrap(),
+            "{\"abca\": 42}"
+        );
+
+        let json_col_as_text = query_single_table(
+            "SELECT json_field FROM json_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(json_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!json_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!json_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&json_col_as_text).unwrap(),
+            "{\"abca\": 42}"
+        );
+        assert_eq!(json_col_as_json.bytes, json_col_as_text.bytes);
+    }
+
+    #[test]
+    fn check_enum_bind() {
+        let conn: MysqlConnection = crate::test_helpers::connection();
+
+        conn.execute("DROP TABLE IF EXISTS enum_test CASCADE")
+            .unwrap();
+
+        conn.execute("CREATE TABLE enum_test(id INTEGER PRIMARY KEY, enum_field ENUM('red', 'green', 'blue') NOT NULL)")
+            .unwrap();
+
+        conn.execute("INSERT INTO enum_test(id, enum_field) VALUES (1, 'green')")
+            .unwrap();
+
+        let enum_col_as_enum: BindData = query_single_table(
+            "SELECT enum_field FROM enum_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_ENUM,
+        );
+
+        assert_eq!(enum_col_as_enum.tpe, ffi::enum_field_types::MYSQL_TYPE_ENUM);
+        assert!(!enum_col_as_enum.flags.contains(Flags::NUM_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::BLOB_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::SET_FLAG));
+        assert!(enum_col_as_enum.flags.contains(Flags::ENUM_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&enum_col_as_enum).unwrap(),
+            "green"
+        );
+
+        let enum_col_as_text = query_single_table(
+            "SELECT enum_field FROM enum_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(enum_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!enum_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(enum_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(
+            to_value::<Text, String>(&enum_col_as_text).unwrap(),
+            "green"
+        );
+        assert_eq!(enum_col_as_enum.bytes, enum_col_as_text.bytes);
+
+        conn.execute("DELETE FROM enum_test").unwrap();
+
+        input_bind(
+            "INSERT INTO enum_test(id, enum_field) VALUES (?, ?)",
+            &conn,
+            41,
+            (b"blue".to_vec(), ffi::enum_field_types::MYSQL_TYPE_ENUM),
+        );
+
+        let enum_col_as_enum = query_single_table(
+            "SELECT enum_field FROM enum_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_ENUM,
+        );
+
+        assert_eq!(enum_col_as_enum.tpe, ffi::enum_field_types::MYSQL_TYPE_ENUM);
+        assert!(!enum_col_as_enum.flags.contains(Flags::NUM_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::BLOB_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::SET_FLAG));
+        assert!(enum_col_as_enum.flags.contains(Flags::ENUM_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&enum_col_as_enum).unwrap(), "blue");
+
+        let enum_col_as_text = query_single_table(
+            "SELECT enum_field FROM enum_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(enum_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!enum_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(enum_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&enum_col_as_text).unwrap(), "blue");
+        assert_eq!(enum_col_as_enum.bytes, enum_col_as_text.bytes);
+
+        conn.execute("DELETE FROM enum_test").unwrap();
+
+        input_bind(
+            "INSERT INTO enum_test(id, enum_field) VALUES (?, ?)",
+            &conn,
+            41,
+            (b"red".to_vec(), ffi::enum_field_types::MYSQL_TYPE_BLOB),
+        );
+
+        let enum_col_as_enum = query_single_table(
+            "SELECT enum_field FROM enum_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_ENUM,
+        );
+
+        assert_eq!(enum_col_as_enum.tpe, ffi::enum_field_types::MYSQL_TYPE_ENUM);
+        assert!(!enum_col_as_enum.flags.contains(Flags::NUM_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::BLOB_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::SET_FLAG));
+        assert!(enum_col_as_enum.flags.contains(Flags::ENUM_FLAG));
+        assert!(!enum_col_as_enum.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&enum_col_as_enum).unwrap(), "red");
+
+        let enum_col_as_text = query_single_table(
+            "SELECT enum_field FROM enum_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(enum_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!enum_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!enum_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&enum_col_as_text).unwrap(), "red");
+        assert_eq!(enum_col_as_enum.bytes, enum_col_as_text.bytes);
+    }
+
+    #[test]
+    fn check_set_bind() {
+        let conn: MysqlConnection = crate::test_helpers::connection();
+
+        conn.execute("DROP TABLE IF EXISTS set_test CASCADE")
+            .unwrap();
+
+        conn.execute("CREATE TABLE set_test(id INTEGER PRIMARY KEY, set_field SET('red', 'green', 'blue') NOT NULL)")
+            .unwrap();
+
+        conn.execute("INSERT INTO set_test(id, set_field) VALUES (1, 'green')")
+            .unwrap();
+
+        let set_col_as_set: BindData = query_single_table(
+            "SELECT set_field FROM set_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_SET,
+        );
+
+        assert_eq!(set_col_as_set.tpe, ffi::enum_field_types::MYSQL_TYPE_ENUM);
+        assert!(!set_col_as_set.flags.contains(Flags::NUM_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::BLOB_FLAG));
+        assert!(set_col_as_set.flags.contains(Flags::SET_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::ENUM_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&set_col_as_set).unwrap(), "green");
+
+        let set_col_as_text = query_single_table(
+            "SELECT set_field FROM enum_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(set_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!set_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(set_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&set_col_as_text).unwrap(), "green");
+        assert_eq!(set_col_as_set.bytes, set_col_as_text.bytes);
+
+        conn.execute("DELETE FROM set_test").unwrap();
+
+        input_bind(
+            "INSERT INTO set_test(id, set_field) VALUES (?, ?)",
+            &conn,
+            41,
+            (b"blue".to_vec(), ffi::enum_field_types::MYSQL_TYPE_SET),
+        );
+
+        let set_col_as_set = query_single_table(
+            "SELECT set_field FROM set_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_SET,
+        );
+
+        assert_eq!(set_col_as_set.tpe, ffi::enum_field_types::MYSQL_TYPE_SET);
+        assert!(!set_col_as_set.flags.contains(Flags::NUM_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::BLOB_FLAG));
+        assert!(set_col_as_set.flags.contains(Flags::SET_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::ENUM_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&set_col_as_set).unwrap(), "blue");
+
+        let set_col_as_text = query_single_table(
+            "SELECT set_field FROM set_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(set_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!set_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(set_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&set_col_as_text).unwrap(), "blue");
+        assert_eq!(set_col_as_set.bytes, set_col_as_text.bytes);
+
+        conn.execute("DELETE FROM set_test").unwrap();
+
+        input_bind(
+            "INSERT INTO set_test(id, set_field) VALUES (?, ?)",
+            &conn,
+            41,
+            (b"red".to_vec(), ffi::enum_field_types::MYSQL_TYPE_BLOB),
+        );
+
+        let set_col_as_set = query_single_table(
+            "SELECT set_field FROM set_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_SET,
+        );
+
+        assert_eq!(set_col_as_set.tpe, ffi::enum_field_types::MYSQL_TYPE_SET);
+        assert!(!set_col_as_set.flags.contains(Flags::NUM_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::BLOB_FLAG));
+        assert!(set_col_as_set.flags.contains(Flags::SET_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::ENUM_FLAG));
+        assert!(!set_col_as_set.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&set_col_as_set).unwrap(), "red");
+
+        let set_col_as_text = query_single_table(
+            "SELECT set_field FROM set_test",
+            &conn,
+            ffi::enum_field_types::MYSQL_TYPE_BLOB,
+        );
+
+        assert_eq!(set_col_as_text.tpe, ffi::enum_field_types::MYSQL_TYPE_BLOB);
+        assert!(!set_col_as_text.flags.contains(Flags::NUM_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::BLOB_FLAG));
+        assert!(set_col_as_text.flags.contains(Flags::SET_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::ENUM_FLAG));
+        assert!(!set_col_as_text.flags.contains(Flags::BINARY_FLAG));
+        assert_eq!(to_value::<Text, String>(&set_col_as_text).unwrap(), "red");
+        assert_eq!(set_col_as_set.bytes, set_col_as_text.bytes);
+    }
 }

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -7,7 +7,6 @@ use crate::mysql::types::MYSQL_TIME;
 use crate::mysql::{MysqlType, MysqlValue};
 use crate::result::QueryResult;
 
-#[derive(Debug)]
 pub struct Binds {
     data: Vec<BindData>,
 }
@@ -124,7 +123,6 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Debug)]
 struct BindData {
     tpe: ffi::enum_field_types,
     bytes: Vec<u8>,

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -114,7 +114,7 @@ bitflags::bitflags! {
         const PART_KEY_FLAG = 16384;
         const GROUP_FLAG = 32768;
         const UNIQUE_FLAG = 65536;
-        const BINCMP_FLAG = 130172;
+        const BINCMP_FLAG = 130_172;
         const GET_FIXED_FIELDS_FLAG = (1<<18);
         const FIELD_IN_PART_FUNC_FLAG = (1 << 19);
     }
@@ -448,6 +448,7 @@ mod tests {
         dbg!(T::from_sql(Some(value)))
     }
 
+    #[cfg(feature = "extras")]
     #[test]
     fn check_all_the_types() {
         let conn = crate::test_helpers::connection();

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -4,6 +4,7 @@ use std::mem;
 use std::os::raw as libc;
 
 use super::stmt::Statement;
+use crate::mysql::types::MYSQL_TIME;
 use crate::mysql::{MysqlType, MysqlValue};
 use crate::result::QueryResult;
 
@@ -421,7 +422,7 @@ fn known_buffer_size_for_ffi_type(tpe: ffi::enum_field_types) -> Option<usize> {
         t::MYSQL_TYPE_TIME
         | t::MYSQL_TYPE_DATE
         | t::MYSQL_TYPE_DATETIME
-        | t::MYSQL_TYPE_TIMESTAMP => Some(size_of::<ffi::MYSQL_TIME>()),
+        | t::MYSQL_TYPE_TIMESTAMP => Some(size_of::<MYSQL_TIME>()),
         _ => None,
     }
 }

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -262,7 +262,6 @@ impl From<MysqlType> for (ffi::enum_field_types, Flags) {
             MysqlType::Blob => MYSQL_TYPE_BLOB,
             MysqlType::Numeric => MYSQL_TYPE_NEWDECIMAL,
             MysqlType::Bit => MYSQL_TYPE_BIT,
-            MysqlType::Json => MYSQL_TYPE_JSON,
             MysqlType::UnsignedTiny => {
                 flags = Flags::UNSIGNED_FLAG;
                 MYSQL_TYPE_TINY
@@ -320,7 +319,9 @@ impl From<(ffi::enum_field_types, Flags)> for MysqlType {
             MYSQL_TYPE_DATE => MysqlType::Date,
             MYSQL_TYPE_DATETIME => MysqlType::DateTime,
             MYSQL_TYPE_TIMESTAMP => MysqlType::Timestamp,
-            MYSQL_TYPE_JSON => MysqlType::Json,
+            // Treat json as string because even mysql 8.0
+            // throws errors sometimes if we use json for json
+            MYSQL_TYPE_JSON => MysqlType::String,
 
             // The documentation states that
             // MYSQL_TYPE_STRING is used for enums and sets

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -62,9 +62,9 @@ impl<'a> Row<Mysql> for MysqlRow<'a> {
 }
 
 pub struct NamedStatementIterator<'a> {
-    stmt: &'a mut Statement,
-    output_binds: Binds,
-    metadata: StatementMetadata,
+    pub(crate) stmt: &'a mut Statement,
+    pub(crate) output_binds: Binds,
+    pub(crate) metadata: StatementMetadata,
 }
 
 #[allow(clippy::should_implement_trait)] // don't need `Iterator` here
@@ -121,7 +121,7 @@ impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
     }
 }
 
-fn execute_statement(stmt: &mut Statement, binds: &mut Binds) -> QueryResult<()> {
+pub(in crate::mysql::connection) fn execute_statement(stmt: &mut Statement, binds: &mut Binds) -> QueryResult<()> {
     unsafe {
         binds.with_mysql_binds(|bind_ptr| stmt.bind_result(bind_ptr))?;
         stmt.execute()?;
@@ -129,7 +129,7 @@ fn execute_statement(stmt: &mut Statement, binds: &mut Binds) -> QueryResult<()>
     Ok(())
 }
 
-fn populate_row_buffers(stmt: &Statement, binds: &mut Binds) -> QueryResult<Option<()>> {
+pub(crate) fn populate_row_buffers(stmt: &Statement, binds: &mut Binds) -> QueryResult<Option<()>> {
     let next_row_result = unsafe { ffi::mysql_stmt_fetch(stmt.stmt.as_ptr()) };
     match next_row_result as libc::c_uint {
         ffi::MYSQL_NO_DATA => Ok(None),

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use super::{ffi, libc, Binds, Statement, StatementMetadata};
-use crate::mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
+use crate::mysql::{Mysql, MysqlType, MysqlValue};
 use crate::result::QueryResult;
 use crate::row::*;
 
@@ -13,7 +13,7 @@ pub struct StatementIterator<'a> {
 #[allow(clippy::should_implement_trait)] // don't neet `Iterator` here
 impl<'a> StatementIterator<'a> {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(stmt: &'a mut Statement, types: Vec<MysqlTypeMetadata>) -> QueryResult<Self> {
+    pub fn new(stmt: &'a mut Statement, types: Vec<MysqlType>) -> QueryResult<Self> {
         let mut output_binds = Binds::from_output_types(types);
 
         execute_statement(stmt, &mut output_binds)?;

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -121,7 +121,10 @@ impl<'a> NamedRow<Mysql> for NamedMysqlRow<'a> {
     }
 }
 
-pub(in crate::mysql::connection) fn execute_statement(stmt: &mut Statement, binds: &mut Binds) -> QueryResult<()> {
+pub(in crate::mysql::connection) fn execute_statement(
+    stmt: &mut Statement,
+    binds: &mut Binds,
+) -> QueryResult<()> {
     unsafe {
         binds.with_mysql_binds(|bind_ptr| stmt.bind_result(bind_ptr))?;
         stmt.execute()?;

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -1,6 +1,6 @@
 extern crate mysqlclient_sys as ffi;
 
-mod iterator;
+pub(super) mod iterator;
 mod metadata;
 
 use std::ffi::CStr;
@@ -14,7 +14,7 @@ use crate::mysql::MysqlTypeMetadata;
 use crate::result::{DatabaseErrorKind, QueryResult};
 
 pub struct Statement {
-    stmt: NonNull<ffi::MYSQL_STMT>,
+    pub(super) stmt: NonNull<ffi::MYSQL_STMT>,
     input_binds: Option<Binds>,
 }
 
@@ -124,7 +124,7 @@ impl Statement {
             .ok_or_else(|| DeserializationError("No metadata exists".into()))
     }
 
-    fn did_an_error_occur(&self) -> QueryResult<()> {
+    pub(super) fn did_an_error_occur(&self) -> QueryResult<()> {
         use crate::result::Error::DatabaseError;
 
         let error_message = self.last_error_message();

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -10,7 +10,7 @@ use std::ptr::NonNull;
 use self::iterator::*;
 use self::metadata::*;
 use super::bind::Binds;
-use crate::mysql::MysqlTypeMetadata;
+use crate::mysql::MysqlType;
 use crate::result::{DatabaseErrorKind, QueryResult};
 
 pub struct Statement {
@@ -39,7 +39,7 @@ impl Statement {
 
     pub fn bind<Iter>(&mut self, binds: Iter) -> QueryResult<()>
     where
-        Iter: IntoIterator<Item = (MysqlTypeMetadata, Option<Vec<u8>>)>,
+        Iter: IntoIterator<Item = (MysqlType, Option<Vec<u8>>)>,
     {
         let mut input_binds = Binds::from_input_data(binds);
         input_binds.with_mysql_binds(|bind_ptr| {
@@ -74,7 +74,7 @@ impl Statement {
     /// be called on this statement.
     pub unsafe fn results(
         &mut self,
-        types: Vec<MysqlTypeMetadata>,
+        types: Vec<MysqlType>,
     ) -> QueryResult<StatementIterator> {
         StatementIterator::new(self, types)
     }

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -72,10 +72,7 @@ impl Statement {
     /// This function should be called instead of `execute` for queries which
     /// have a return value. After calling this function, `execute` can never
     /// be called on this statement.
-    pub unsafe fn results(
-        &mut self,
-        types: Vec<MysqlType>,
-    ) -> QueryResult<StatementIterator> {
+    pub unsafe fn results(&mut self, types: Vec<MysqlType>) -> QueryResult<StatementIterator> {
         StatementIterator::new(self, types)
     }
 

--- a/diesel/src/mysql/mod.rs
+++ b/diesel/src/mysql/mod.rs
@@ -11,7 +11,7 @@ mod value;
 mod query_builder;
 pub mod types;
 
-pub use self::backend::{Mysql, MysqlType, MysqlTypeMetadata};
+pub use self::backend::{Mysql, MysqlType};
 pub use self::connection::MysqlConnection;
 pub use self::query_builder::MysqlQueryBuilder;
 pub use self::value::{MysqlValue, NumericRepresentation};

--- a/diesel/src/mysql/mod.rs
+++ b/diesel/src/mysql/mod.rs
@@ -14,4 +14,4 @@ pub mod types;
 pub use self::backend::{Mysql, MysqlType, MysqlTypeMetadata};
 pub use self::connection::MysqlConnection;
 pub use self::query_builder::MysqlQueryBuilder;
-pub use self::value::MysqlValue;
+pub use self::value::{MysqlValue, NumericRepresentation};

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -1,11 +1,10 @@
-extern crate chrono;
-extern crate mysqlclient_sys as ffi;
-
-use self::chrono::*;
+use chrono::*;
+use mysqlclient_sys as ffi;
 use std::io::Write;
 use std::os::raw as libc;
 use std::{mem, slice};
 
+use super::MYSQL_TIME;
 use crate::deserialize::{self, FromSql};
 use crate::mysql::{Mysql, MysqlValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
@@ -13,18 +12,18 @@ use crate::sql_types::{Date, Datetime, Time, Timestamp};
 
 macro_rules! mysql_time_impls {
     ($ty:ty) => {
-        impl ToSql<$ty, Mysql> for ffi::MYSQL_TIME {
+        impl ToSql<$ty, Mysql> for MYSQL_TIME {
             fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
                 let bytes = unsafe {
-                    let bytes_ptr = self as *const ffi::MYSQL_TIME as *const u8;
-                    slice::from_raw_parts(bytes_ptr, mem::size_of::<ffi::MYSQL_TIME>())
+                    let bytes_ptr = self as *const MYSQL_TIME as *const u8;
+                    slice::from_raw_parts(bytes_ptr, mem::size_of::<MYSQL_TIME>())
                 };
                 out.write_all(bytes)?;
                 Ok(IsNull::No)
             }
         }
 
-        impl FromSql<$ty, Mysql> for ffi::MYSQL_TIME {
+        impl FromSql<$ty, Mysql> for MYSQL_TIME {
             fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
                 let data = not_none!(value);
                 data.time_value()
@@ -52,7 +51,7 @@ impl FromSql<Datetime, Mysql> for NaiveDateTime {
 
 impl ToSql<Timestamp, Mysql> for NaiveDateTime {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
-        let mysql_time = ffi::MYSQL_TIME {
+        let mysql_time = MYSQL_TIME {
             year: self.year() as libc::c_uint,
             month: self.month() as libc::c_uint,
             day: self.day() as libc::c_uint,
@@ -60,17 +59,18 @@ impl ToSql<Timestamp, Mysql> for NaiveDateTime {
             minute: self.minute() as libc::c_uint,
             second: self.second() as libc::c_uint,
             second_part: libc::c_ulong::from(self.timestamp_subsec_micros()),
-            neg: 0,
+            neg: false,
             time_type: ffi::enum_mysql_timestamp_type::MYSQL_TIMESTAMP_DATETIME,
+            time_zone_displacement: 0,
         };
 
-        <ffi::MYSQL_TIME as ToSql<Timestamp, Mysql>>::to_sql(&mysql_time, out)
+        <MYSQL_TIME as ToSql<Timestamp, Mysql>>::to_sql(&mysql_time, out)
     }
 }
 
 impl FromSql<Timestamp, Mysql> for NaiveDateTime {
     fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-        let mysql_time = <ffi::MYSQL_TIME as FromSql<Timestamp, Mysql>>::from_sql(bytes)?;
+        let mysql_time = <MYSQL_TIME as FromSql<Timestamp, Mysql>>::from_sql(bytes)?;
 
         NaiveDate::from_ymd_opt(
             mysql_time.year as i32,
@@ -91,7 +91,7 @@ impl FromSql<Timestamp, Mysql> for NaiveDateTime {
 
 impl ToSql<Time, Mysql> for NaiveTime {
     fn to_sql<W: Write>(&self, out: &mut serialize::Output<W, Mysql>) -> serialize::Result {
-        let mysql_time = ffi::MYSQL_TIME {
+        let mysql_time = MYSQL_TIME {
             hour: self.hour() as libc::c_uint,
             minute: self.minute() as libc::c_uint,
             second: self.second() as libc::c_uint,
@@ -99,17 +99,18 @@ impl ToSql<Time, Mysql> for NaiveTime {
             month: 0,
             second_part: 0,
             year: 0,
-            neg: 0,
+            neg: false,
             time_type: ffi::enum_mysql_timestamp_type::MYSQL_TIMESTAMP_TIME,
+            time_zone_displacement: 0,
         };
 
-        <ffi::MYSQL_TIME as ToSql<Time, Mysql>>::to_sql(&mysql_time, out)
+        <MYSQL_TIME as ToSql<Time, Mysql>>::to_sql(&mysql_time, out)
     }
 }
 
 impl FromSql<Time, Mysql> for NaiveTime {
     fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-        let mysql_time = <ffi::MYSQL_TIME as FromSql<Time, Mysql>>::from_sql(bytes)?;
+        let mysql_time = <MYSQL_TIME as FromSql<Time, Mysql>>::from_sql(bytes)?;
         NaiveTime::from_hms_opt(
             mysql_time.hour as u32,
             mysql_time.minute as u32,
@@ -121,7 +122,7 @@ impl FromSql<Time, Mysql> for NaiveTime {
 
 impl ToSql<Date, Mysql> for NaiveDate {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
-        let mysql_time = ffi::MYSQL_TIME {
+        let mysql_time = MYSQL_TIME {
             year: self.year() as libc::c_uint,
             month: self.month() as libc::c_uint,
             day: self.day() as libc::c_uint,
@@ -129,17 +130,18 @@ impl ToSql<Date, Mysql> for NaiveDate {
             minute: 0,
             second: 0,
             second_part: 0,
-            neg: 0,
+            neg: false,
             time_type: ffi::enum_mysql_timestamp_type::MYSQL_TIMESTAMP_DATE,
+            time_zone_displacement: 0,
         };
 
-        <ffi::MYSQL_TIME as ToSql<Date, Mysql>>::to_sql(&mysql_time, out)
+        <MYSQL_TIME as ToSql<Date, Mysql>>::to_sql(&mysql_time, out)
     }
 }
 
 impl FromSql<Date, Mysql> for NaiveDate {
     fn from_sql(bytes: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
-        let mysql_time = <ffi::MYSQL_TIME as FromSql<Date, Mysql>>::from_sql(bytes)?;
+        let mysql_time = <MYSQL_TIME as FromSql<Date, Mysql>>::from_sql(bytes)?;
         NaiveDate::from_ymd_opt(
             mysql_time.year as i32,
             mysql_time.month as u32,

--- a/diesel/src/mysql/types/json.rs
+++ b/diesel/src/mysql/types/json.rs
@@ -1,0 +1,20 @@
+use crate::mysql::{Mysql, MysqlValue};
+use crate::deserialize::{self, FromSql};
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types;
+use std::io::prelude::*;
+
+impl FromSql<sql_types::Json, Mysql> for serde_json::Value {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        serde_json::from_slice(value.as_bytes()).map_err(|_| "Invalid Json".into())
+    }
+}
+
+impl ToSql<sql_types::Json, MysqlValue> for serde_json::Value {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, MysqlValue>) -> serialize::Result {
+        serde_json::to_writer(out, self)
+            .map(|_| IsNull::No)
+            .map_err(Into::into)
+    }
+}

--- a/diesel/src/mysql/types/json.rs
+++ b/diesel/src/mysql/types/json.rs
@@ -32,7 +32,7 @@ fn some_json_from_sql() {
     use crate::mysql::MysqlType;
     let input_json = b"true";
     let output_json: serde_json::Value = FromSql::<sql_types::Json, Mysql>::from_sql(Some(
-        MysqlValue::new(input_json, MysqlType::Json),
+        MysqlValue::new(input_json, MysqlType::String),
     ))
     .unwrap();
     assert_eq!(output_json, serde_json::Value::Bool(true));
@@ -42,7 +42,7 @@ fn some_json_from_sql() {
 fn bad_json_from_sql() {
     use crate::mysql::MysqlType;
     let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Json, Mysql>::from_sql(Some(
-        MysqlValue::new(b"boom", MysqlType::Json),
+        MysqlValue::new(b"boom", MysqlType::String),
     ));
     assert_eq!(uuid.unwrap_err().to_string(), "Invalid Json");
 }

--- a/diesel/src/mysql/types/json.rs
+++ b/diesel/src/mysql/types/json.rs
@@ -1,5 +1,5 @@
-use crate::mysql::{Mysql, MysqlValue};
 use crate::deserialize::{self, FromSql};
+use crate::mysql::{Mysql, MysqlValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types;
 use std::io::prelude::*;
@@ -11,10 +11,47 @@ impl FromSql<sql_types::Json, Mysql> for serde_json::Value {
     }
 }
 
-impl ToSql<sql_types::Json, MysqlValue> for serde_json::Value {
-    fn to_sql<W: Write>(&self, out: &mut Output<W, MysqlValue>) -> serialize::Result {
+impl ToSql<sql_types::Json, Mysql> for serde_json::Value {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
         serde_json::to_writer(out, self)
             .map(|_| IsNull::No)
             .map_err(Into::into)
     }
+}
+
+#[test]
+fn json_to_sql() {
+    let mut bytes = Output::test();
+    let test_json = serde_json::Value::Bool(true);
+    ToSql::<sql_types::Json, Mysql>::to_sql(&test_json, &mut bytes).unwrap();
+    assert_eq!(bytes, b"true");
+}
+
+#[test]
+fn some_json_from_sql() {
+    use crate::mysql::MysqlType;
+    let input_json = b"true";
+    let output_json: serde_json::Value = FromSql::<sql_types::Json, Mysql>::from_sql(Some(
+        MysqlValue::new(input_json, MysqlType::Json),
+    ))
+    .unwrap();
+    assert_eq!(output_json, serde_json::Value::Bool(true));
+}
+
+#[test]
+fn bad_json_from_sql() {
+    use crate::mysql::MysqlType;
+    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Json, Mysql>::from_sql(Some(
+        MysqlValue::new(b"boom", MysqlType::Json),
+    ));
+    assert_eq!(uuid.unwrap_err().to_string(), "Invalid Json");
+}
+
+#[test]
+fn no_json_from_sql() {
+    let uuid: Result<serde_json::Value, _> = FromSql::<sql_types::Json, Mysql>::from_sql(None);
+    assert_eq!(
+        uuid.unwrap_err().to_string(),
+        "Unexpected null for non-null column"
+    );
 }

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "chrono")]
 mod date_and_time;
 mod numeric;
+mod primitives;
 
 use byteorder::WriteBytesExt;
 use std::io::Write;

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -9,7 +9,7 @@ use byteorder::WriteBytesExt;
 use std::io::Write;
 
 use crate::deserialize::{self, FromSql};
-use crate::mysql::{Mysql, MysqlTypeMetadata, MysqlValue};
+use crate::mysql::{Mysql, MysqlType, MysqlValue};
 use crate::query_builder::QueryId;
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::ops::*;
@@ -130,15 +130,27 @@ impl FromSql<Bool, Mysql> for bool {
     }
 }
 
-impl<ST> HasSqlType<Unsigned<ST>> for Mysql
-where
-    Mysql: HasSqlType<ST>,
-{
-    fn metadata(lookup: &()) -> MysqlTypeMetadata {
-        MysqlTypeMetadata {
-            is_unsigned: true,
-            ..<Mysql as HasSqlType<ST>>::metadata(lookup)
-        }
+impl HasSqlType<Unsigned<TinyInt>> for Mysql {
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedTiny
+    }
+}
+
+impl HasSqlType<Unsigned<SmallInt>> for Mysql {
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedShort
+    }
+}
+
+impl HasSqlType<Unsigned<Integer>> for Mysql {
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedLong
+    }
+}
+
+impl HasSqlType<Unsigned<BigInt>> for Mysql {
+    fn metadata(_lookup: &()) -> MysqlType {
+        MysqlType::UnsignedLongLong
     }
 }
 

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -4,6 +4,8 @@
 mod date_and_time;
 mod numeric;
 mod primitives;
+#[cfg(featuer = "serde_json")]
+mod json;
 
 use byteorder::WriteBytesExt;
 use std::io::Write;

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -19,6 +19,11 @@ use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::ops::*;
 use crate::sql_types::*;
 
+// A internal helper type
+// This type also exists in mysqlclient_sys
+// but the definition changed over time
+// to remain backward compatible with old mysqlclient_sys
+// version we just have our own copy here
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct MYSQL_TIME {

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -4,7 +4,7 @@
 mod date_and_time;
 mod numeric;
 mod primitives;
-#[cfg(featuer = "serde_json")]
+#[cfg(feature = "serde_json")]
 mod json;
 
 use byteorder::WriteBytesExt;

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -8,7 +8,9 @@ mod numeric;
 mod primitives;
 
 use byteorder::WriteBytesExt;
+use mysqlclient_sys as ffi;
 use std::io::Write;
+use std::os::raw as libc;
 
 use crate::deserialize::{self, FromSql};
 use crate::mysql::{Mysql, MysqlType, MysqlValue};
@@ -16,6 +18,21 @@ use crate::query_builder::QueryId;
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::ops::*;
 use crate::sql_types::*;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MYSQL_TIME {
+    pub year: libc::c_uint,
+    pub month: libc::c_uint,
+    pub day: libc::c_uint,
+    pub hour: libc::c_uint,
+    pub minute: libc::c_uint,
+    pub second: libc::c_uint,
+    pub second_part: libc::c_ulong,
+    pub neg: bool,
+    pub time_type: ffi::enum_mysql_timestamp_type,
+    pub time_zone_displacement: libc::c_int,
+}
 
 impl ToSql<TinyInt, Mysql> for i8 {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -2,10 +2,10 @@
 
 #[cfg(feature = "chrono")]
 mod date_and_time;
-mod numeric;
-mod primitives;
 #[cfg(feature = "serde_json")]
 mod json;
+mod numeric;
+mod primitives;
 
 use byteorder::WriteBytesExt;
 use std::io::Write;

--- a/diesel/src/mysql/types/primitives.rs
+++ b/diesel/src/mysql/types/primitives.rs
@@ -1,0 +1,116 @@
+use std::str;
+
+use crate::deserialize::{self, FromSql};
+use crate::mysql::{Mysql, MysqlValue};
+use crate::sql_types::{BigInt, Binary, Double, Float, Integer, SmallInt, Text};
+
+impl FromSql<SmallInt, Mysql> for i16 {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        use crate::mysql::NumericRepresentation::*;
+
+        let data = not_none!(value);
+        match data.numeric_value()? {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x),
+            Medium(x) => Ok(x as Self),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x as Self),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => {
+                let string = str::from_utf8(bytes)?;
+                let integer_portion = string.split('.').nth(0).unwrap_or_default();
+                Ok(integer_portion.parse()?)
+            }
+        }
+    }
+}
+
+impl FromSql<Integer, Mysql> for i32 {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        use crate::mysql::NumericRepresentation::*;
+
+        let data = not_none!(value);
+        match data.numeric_value()? {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x as Self),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => {
+                let string = str::from_utf8(bytes)?;
+                let integer_portion = string.split('.').nth(0).unwrap_or_default();
+                Ok(integer_portion.parse()?)
+            }
+        }
+    }
+}
+
+impl FromSql<BigInt, Mysql> for i64 {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        use crate::mysql::NumericRepresentation::*;
+
+        let data = not_none!(value);
+        match data.numeric_value()? {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x.into()),
+            Big(x) => Ok(x),
+            Float(x) => Ok(x as Self),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => {
+                let string = str::from_utf8(bytes)?;
+                let integer_portion = string.split('.').nth(0).unwrap_or_default();
+                Ok(integer_portion.parse()?)
+            }
+        }
+    }
+}
+
+impl FromSql<Float, Mysql> for f32 {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        use crate::mysql::NumericRepresentation::*;
+
+        let data = not_none!(value);
+        match data.numeric_value()? {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x as Self),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x),
+            Double(x) => Ok(x as Self),
+            Decimal(bytes) => Ok(str::from_utf8(bytes)?.parse()?),
+        }
+    }
+}
+
+impl FromSql<Double, Mysql> for f64 {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        use crate::mysql::NumericRepresentation::*;
+
+        let data = not_none!(value);
+        match data.numeric_value()? {
+            Tiny(x) => Ok(x.into()),
+            Small(x) => Ok(x.into()),
+            Medium(x) => Ok(x.into()),
+            Big(x) => Ok(x as Self),
+            Float(x) => Ok(x.into()),
+            Double(x) => Ok(x),
+            Decimal(bytes) => Ok(str::from_utf8(bytes)?.parse()?),
+        }
+    }
+}
+
+impl FromSql<Text, Mysql> for String {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        String::from_utf8(value.as_bytes().into()).map_err(Into::into)
+    }
+}
+
+impl FromSql<Binary, Mysql> for Vec<u8> {
+    fn from_sql(value: Option<MysqlValue<'_>>) -> deserialize::Result<Self> {
+        let value = not_none!(value);
+        Ok(value.as_bytes().into())
+    }
+}

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -1,25 +1,79 @@
-use super::Mysql;
-use crate::backend::BinaryRawValue;
+use super::{MysqlType, MysqlTypeMetadata};
+use crate::deserialize;
+use mysqlclient_sys as ffi;
+use std::error::Error;
 
 /// Raw mysql value as received from the database
 #[derive(Copy, Clone, Debug)]
 pub struct MysqlValue<'a> {
     raw: &'a [u8],
+    tpe: MysqlTypeMetadata,
 }
 
 impl<'a> MysqlValue<'a> {
-    pub(crate) fn new(raw: &'a [u8]) -> Self {
-        Self { raw }
+    pub(crate) fn new(raw: &'a [u8], tpe: MysqlTypeMetadata) -> Self {
+        Self { raw, tpe }
     }
 
     /// Get the underlying raw byte representation
     pub fn as_bytes(&self) -> &[u8] {
         self.raw
     }
+
+    /// Checks that the type code is valid, and interprets the data as a
+    /// `MYSQL_TIME` pointer
+    pub(crate) fn time_value(&self) -> deserialize::Result<ffi::MYSQL_TIME> {
+        match self.tpe.data_type {
+            MysqlType::Time | MysqlType::Date | MysqlType::DateTime | MysqlType::Timestamp => {
+                Ok(*unsafe { &*(self.raw as *const _ as *const ffi::MYSQL_TIME) })
+            }
+            _ => Err(self.invalid_type_code("timestamp")),
+        }
+    }
+
+    /// Returns the numeric representation of this value, based on the type code.
+    /// Returns an error if the type code is not numeric.
+    pub(crate) fn numeric_value(&self) -> deserialize::Result<NumericRepresentation> {
+        use self::NumericRepresentation::*;
+        use std::convert::TryInto;
+
+        Ok(match self.tpe.data_type {
+            MysqlType::Tiny => Tiny(self.raw[0] as i8),
+            MysqlType::Short => Small(i16::from_ne_bytes(self.raw.try_into()?)),
+            MysqlType::Long => Medium(i32::from_ne_bytes(self.raw.try_into()?)),
+            MysqlType::LongLong => Big(i64::from_ne_bytes(self.raw.try_into()?)),
+            MysqlType::Float => Float(f32::from_ne_bytes(self.raw.try_into()?)),
+            MysqlType::Double => Double(f64::from_ne_bytes(self.raw.try_into()?)),
+
+            MysqlType::Numeric => Decimal(self.raw),
+            _ => return Err(self.invalid_type_code("number")),
+        })
+    }
+
+    fn invalid_type_code(&self, expected: &str) -> Box<dyn Error + Send + Sync> {
+        format!(
+            "Invalid representation received for {}: {:?}",
+            expected, self.tpe
+        )
+        .into()
+    }
 }
 
-impl<'a> BinaryRawValue<'a> for Mysql {
-    fn as_bytes(value: Self::RawValue) -> &'a [u8] {
-        value.raw
-    }
+/// Represents all possible forms MySQL transmits integers
+#[derive(Debug, Clone, Copy)]
+pub enum NumericRepresentation<'a> {
+    /// Correponds to `MYSQL_TYPE_TINY`
+    Tiny(i8),
+    /// Correponds to `MYSQL_TYPE_SHORT`
+    Small(i16),
+    /// Correponds to `MYSQL_TYPE_INT24` and `MYSQL_TYPE_LONG`
+    Medium(i32),
+    /// Correponds to `MYSQL_TYPE_LONGLONG`
+    Big(i64),
+    /// Correponds to `MYSQL_TYPE_FLOAT`
+    Float(f32),
+    /// Correponds to `MYSQL_TYPE_DOUBLE`
+    Double(f64),
+    /// Correponds to `MYSQL_TYPE_DECIMAL` and `MYSQL_TYPE_NEWDECIMAL`
+    Decimal(&'a [u8]),
 }

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -50,7 +50,7 @@ impl<'a> MysqlValue<'a> {
         Ok(match self.tpe.data_type {
             MysqlType::Tiny => Tiny(self.raw[0] as i8),
             MysqlType::Short => Small(i16::from_ne_bytes(self.raw.try_into()?)),
-            MysqlType::Long => Medium(i32::from_ne_bytes(self.raw.try_into()?)),
+            MysqlType::Medium | MysqlType::Long => Medium(i32::from_ne_bytes(self.raw.try_into()?)),
             MysqlType::LongLong => Big(i64::from_ne_bytes(self.raw.try_into()?)),
             MysqlType::Float => Float(f32::from_ne_bytes(self.raw.try_into()?)),
             MysqlType::Double => Double(f64::from_ne_bytes(self.raw.try_into()?)),
@@ -71,6 +71,7 @@ impl<'a> MysqlValue<'a> {
 
 /// Represents all possible forms MySQL transmits integers
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum NumericRepresentation<'a> {
     /// Correponds to `MYSQL_TYPE_TINY`
     Tiny(i8),

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -22,6 +22,7 @@ impl<'a> MysqlValue<'a> {
 
     /// Checks that the type code is valid, and interprets the data as a
     /// `MYSQL_TIME` pointer
+    #[allow(dead_code)]
     pub(crate) fn time_value(&self) -> deserialize::Result<ffi::MYSQL_TIME> {
         match self.tpe.data_type {
             MysqlType::Time | MysqlType::Date | MysqlType::DateTime | MysqlType::Timestamp => {

--- a/diesel/src/pg/types/json.rs
+++ b/diesel/src/pg/types/json.rs
@@ -9,20 +9,6 @@ use crate::pg::{Pg, PgValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types;
 
-#[allow(dead_code)]
-mod foreign_derives {
-    use super::serde_json;
-    use crate::deserialize::FromSqlRow;
-    use crate::expression::AsExpression;
-    use crate::sql_types::{Json, Jsonb};
-
-    #[derive(FromSqlRow, AsExpression)]
-    #[diesel(foreign_derive)]
-    #[sql_type = "Json"]
-    #[sql_type = "Jsonb"]
-    struct SerdeJsonValueProxy(serde_json::Value);
-}
-
 impl FromSql<sql_types::Json, Pg> for serde_json::Value {
     fn from_sql(value: Option<PgValue<'_>>) -> deserialize::Result<Self> {
         let value = not_none!(value);

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -196,27 +196,6 @@ pub mod sql_types {
     #[doc(hidden)]
     pub type Bpchar = crate::sql_types::VarChar;
 
-    /// The JSON SQL type.  This type can only be used with `feature =
-    /// "serde_json"`
-    ///
-    /// Normally you should prefer [`Jsonb`](struct.Jsonb.html) instead, for the reasons
-    /// discussed there.
-    ///
-    /// ### [`ToSql`] impls
-    ///
-    /// - [`serde_json::Value`]
-    ///
-    /// ### [`FromSql`] impls
-    ///
-    /// - [`serde_json::Value`]
-    ///
-    /// [`ToSql`]: ../../../serialize/trait.ToSql.html
-    /// [`FromSql`]: ../../../deserialize/trait.FromSql.html
-    /// [`serde_json::Value`]: ../../../../serde_json/value/enum.Value.html
-    #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
-    #[postgres(oid = "114", array_oid = "199")]
-    pub struct Json;
-
     /// The `jsonb` SQL type.  This type can only be used with `feature =
     /// "serde_json"`
     ///

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -341,6 +341,28 @@ pub struct Time;
 #[mysql_type = "Timestamp"]
 pub struct Timestamp;
 
+/// The JSON SQL type.  This type can only be used with `feature =
+/// "serde_json"`
+///
+/// Normally you should prefer [`Jsonb`](struct.Jsonb.html) instead, for the reasons
+/// discussed there.
+///
+/// ### [`ToSql`] impls
+///
+/// - [`serde_json::Value`]
+///
+/// ### [`FromSql`] impls
+///
+/// - [`serde_json::Value`]
+///
+/// [`ToSql`]: /serialize/trait.ToSql.html
+/// [`FromSql`]: /deserialize/trait.FromSql.html
+/// [`serde_json::Value`]: /../serde_json/value/enum.Value.html
+#[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
+#[postgres(oid = "114", array_oid = "199")]
+#[mysql_type = "Json"]
+pub struct Json;
+
 /// The nullable SQL type.
 ///
 /// This wraps another SQL type to indicate that it can be null.

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -178,7 +178,7 @@ pub type Float8 = Double;
 /// [`bigdecimal::BigDecimal`]: /bigdecimal/struct.BigDecimal.html
 #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
 #[postgres(oid = "1700", array_oid = "1231")]
-#[mysql_type = "String"]
+#[mysql_type = "Numeric"]
 #[sqlite_type = "Double"]
 pub struct Numeric;
 

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -344,8 +344,8 @@ pub struct Timestamp;
 /// The JSON SQL type.  This type can only be used with `feature =
 /// "serde_json"`
 ///
-/// Normally you should prefer [`Jsonb`](struct.Jsonb.html) instead, for the reasons
-/// discussed there.
+/// For postgresql you should normally prefer [`Jsonb`](struct.Jsonb.html) instead,
+/// for the reasons discussed there.
 ///
 /// ### [`ToSql`] impls
 ///

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -360,7 +360,7 @@ pub struct Timestamp;
 /// [`serde_json::Value`]: /../serde_json/value/enum.Value.html
 #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
 #[postgres(oid = "114", array_oid = "199")]
-#[mysql_type = "Json"]
+#[mysql_type = "String"]
 pub struct Json;
 
 /// The nullable SQL type.

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -37,9 +37,9 @@ cfg_if! {
         }
 
         pub fn database_url() -> String {
-            dbg!(dotenv::var("MYSQL_UNIT_TEST_DATABASE_URL")
+            dotenv::var("MYSQL_UNIT_TEST_DATABASE_URL")
                 .or_else(|_| dotenv::var("DATABASE_URL"))
-                .expect("DATABASE_URL must be set in order to run tests"))
+                .expect("DATABASE_URL must be set in order to run tests")
         }
     } else {
         compile_error!(

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -37,9 +37,9 @@ cfg_if! {
         }
 
         pub fn database_url() -> String {
-            dotenv::var("MYSQL_UNIT_TEST_DATABASE_URL")
+            dbg!(dotenv::var("MYSQL_UNIT_TEST_DATABASE_URL")
                 .or_else(|_| dotenv::var("DATABASE_URL"))
-                .expect("DATABASE_URL must be set in order to run tests")
+                .expect("DATABASE_URL must be set in order to run tests"))
         }
     } else {
         compile_error!(

--- a/diesel/src/type_impls/json.rs
+++ b/diesel/src/type_impls/json.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+use crate::deserialize::FromSqlRow;
+use crate::expression::AsExpression;
+use crate::sql_types::Json;
+#[cfg(feature = "postgres")]
+use crate::sql_types::Jsonb;
+
+#[derive(FromSqlRow, AsExpression)]
+#[diesel(foreign_derive)]
+#[sql_type = "Json"]
+#[cfg_attr(feature = "postgres", sql_type = "Jsonb")]
+struct SerdeJsonValueProxy(serde_json::Value);

--- a/diesel/src/type_impls/mod.rs
+++ b/diesel/src/type_impls/mod.rs
@@ -5,3 +5,5 @@ mod integers;
 pub mod option;
 mod primitives;
 mod tuples;
+#[cfg(all(feature = "serde_json", any(feature = "postgresql", feature = "mysql")))]
+mod json;

--- a/diesel/src/type_impls/mod.rs
+++ b/diesel/src/type_impls/mod.rs
@@ -2,8 +2,8 @@ mod date_and_time;
 mod decimal;
 pub mod floats;
 mod integers;
+#[cfg(all(feature = "serde_json", any(feature = "postgres", feature = "mysql")))]
+mod json;
 pub mod option;
 mod primitives;
 mod tuples;
-#[cfg(all(feature = "serde_json", any(feature = "postgres", feature = "mysql")))]
-mod json;

--- a/diesel/src/type_impls/mod.rs
+++ b/diesel/src/type_impls/mod.rs
@@ -5,5 +5,5 @@ mod integers;
 pub mod option;
 mod primitives;
 mod tuples;
-#[cfg(all(feature = "serde_json", any(feature = "postgresql", feature = "mysql")))]
+#[cfg(all(feature = "serde_json", any(feature = "postgres", feature = "mysql")))]
 mod json;

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -71,11 +71,8 @@ fn mysql_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
                     for diesel::mysql::Mysql
                 #where_clause
                 {
-                    fn metadata(_: &()) -> diesel::mysql::MysqlTypeMetadata {
-                        diesel::mysql::MysqlTypeMetadata {
-                            data_type: diesel::mysql::MysqlType::#ty,
-                            is_unsigned: false,
-                        }
+                    fn metadata(_: &()) -> diesel::mysql::MysqlType {
+                        diesel::mysql::MysqlType::#ty
                     }
                 }
             })

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -1,22 +1,12 @@
+use diesel::sql_types::Integer;
 use diesel::*;
 
 use helpers::connection;
 
-#[cfg(feature = "mysql")]
-type IntSql = ::diesel::sql_types::BigInt;
-#[cfg(feature = "mysql")]
-type IntRust = i64;
-
-#[cfg(not(feature = "mysql"))]
-type IntSql = ::diesel::sql_types::Integer;
-#[cfg(not(feature = "mysql"))]
-type IntRust = i32;
-
 table! {
-    use super::IntSql;
     my_structs (foo) {
-        foo -> IntSql,
-        bar -> IntSql,
+        foo -> Integer,
+        bar -> Integer,
     }
 }
 
@@ -25,8 +15,8 @@ fn named_struct_definition() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct MyStruct {
-        foo: IntRust,
-        bar: IntRust,
+        foo: i32,
+        bar: i32,
     }
 
     let conn = connection();
@@ -38,10 +28,7 @@ fn named_struct_definition() {
 fn tuple_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
-    struct MyStruct(
-        #[column_name = "foo"] IntRust,
-        #[column_name = "bar"] IntRust,
-    );
+    struct MyStruct(#[column_name = "foo"] i32, #[column_name = "bar"] i32);
 
     let conn = connection();
     let data = sql_query("SELECT 1 AS foo, 2 AS bar").get_result(&conn);
@@ -54,10 +41,10 @@ fn tuple_struct() {
 fn struct_with_no_table() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     struct MyStructNamedSoYouCantInferIt {
-        #[sql_type = "IntSql"]
-        foo: IntRust,
-        #[sql_type = "IntSql"]
-        bar: IntRust,
+        #[sql_type = "Integer"]
+        foo: i32,
+        #[sql_type = "Integer"]
+        bar: i32,
     }
 
     let conn = connection();
@@ -70,7 +57,7 @@ fn embedded_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct A {
-        foo: IntRust,
+        foo: i32,
         #[diesel(embed)]
         b: B,
     }
@@ -78,7 +65,7 @@ fn embedded_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct B {
-        bar: IntRust,
+        bar: i32,
     }
 
     let conn = connection();
@@ -97,7 +84,7 @@ fn embedded_option() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct A {
-        foo: IntRust,
+        foo: i32,
         #[diesel(embed)]
         b: Option<B>,
     }
@@ -105,7 +92,7 @@ fn embedded_option() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
     #[table_name = "my_structs"]
     struct B {
-        bar: IntRust,
+        bar: i32,
     }
 
     let conn = connection();

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -23,6 +23,7 @@ uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.17.0"
 bigdecimal = ">= 0.0.13, < 0.2.0"
+rand = "0.7"
 
 [features]
 default = []

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -354,6 +354,28 @@ fn i64_to_sql_bigint() {
     ));
 }
 
+#[test]
+#[cfg(feature = "mysql")]
+fn mysql_json_from_sql() {
+    let query = "'true'";
+    let expected_value = serde_json::Value::Bool(true);
+    assert_eq!(
+        expected_value,
+        query_single_value::<Json, serde_json::Value>(query)
+    );
+}
+
+#[test]
+#[cfg(feature = "mysql")]
+fn mysql_json_to_sql_json() {
+    let expected_value = "'false'";
+    let value = serde_json::Value::Bool(false);
+    assert!(query_to_sql_equality::<Json, serde_json::Value>(
+        expected_value,
+        value
+    ));
+}
+
 use std::{f32, f64};
 
 #[test]

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -363,11 +363,7 @@ impl quickcheck::Arbitrary for SerdeWrapper {
 fn arbitrary_serde<G: quickcheck::Gen>(g: &mut G, depth: usize) -> serde_json::Value {
     use rand::distributions::Alphanumeric;
     use rand::Rng;
-    let variant = match g.gen_range(0, 6) {
-        4 | 5 if depth > 0 => g.gen_range(0, 4),
-        i => i,
-    };
-    match variant {
+    match g.gen_range(0, if depth > 0 { 4 } else { 6 }) {
         0 => serde_json::Value::Null,
         1 => serde_json::Value::Bool(g.gen()),
         2 => {

--- a/examples/postgres/custom_types/src/model.rs
+++ b/examples/postgres/custom_types/src/model.rs
@@ -1,5 +1,8 @@
-use diesel::pg::PgValue;
+use diesel::deserialize::{self, FromSql, FromSqlRow};
+use diesel::expression::AsExpression;
+use diesel::pg::{Pg, PgValue};
 use diesel::serialize::{self, IsNull, Output, ToSql};
+use diesel::sql_types::SqlType;
 use std::io::Write;
 
 pub mod exports {
@@ -28,9 +31,6 @@ impl ToSql<LanguageType, Pg> for Language {
         Ok(IsNull::No)
     }
 }
-
-use diesel::deserialize::{self, FromSql};
-use diesel::pg::Pg;
 
 impl FromSql<LanguageType, Pg> for Language {
     fn from_sql(bytes: Option<PgValue>) -> deserialize::Result<Self> {


### PR DESCRIPTION
MySQL is a bit more... lax with types than other backends. It's very
easy to accidentally get a 64 bit integer or decimal when other backends
would continue to give you a 32 bit integer. Right now we're relying on
conversion happening in `libmysqlclient` for `query_by_index`. If we
ever want to dump `libmysqlclient`, we will need to move those
conversions into Diesel.

However, I've opted to do this in such a way that it affects `sql_query`
as well. Right now there are many differences between what our query
builder says and what MySQL does. (32 bit addition/subtraction returns
64 bit, 32 bit multiplication/division/sum return decimal). Ideally you
should be able to have a struct that derives both `Queryable` and
`QueryableByName`, and have that work with the same query built using
the query builder or `sql_query`.

In order for that to happen, we can't do the conversions until we hit
`FromSql`, since for `sql_query` that is the first and only time we
learn what the expected type is.


This is basically a rebase of #1457.  I've adjusted the code to now already existing `MysqlValue` type. Additionally we now also have a lifetime on that type, so that we can just use `&[u8]` as raw value there, instead of the unsafe pointer/cell stuff. I've opted into not having the ffi type enum in `MysqlValue`, because we want to expose that type as part of #2182 and that would restrict possible implementations of the mysql backend to such ones that use `libmysqlclient`. 
Additionally I've added a `#[non_exhaustive]` (requires rust 1.40) to the `MysqlType` enum and removed some unneed unsafe code from the date/time type conversations.

