### PR TITLE
feat: bump to libsqlite3-sys 0.17, no other changes

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.0"
 diesel_derives = "~1.4.0"
 chrono = { version = "0.4", optional = true }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.17.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.18.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
 quickcheck = { version = "0.4", optional = true }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -27,7 +27,7 @@ tempfile = "3.0.0"
 toml = "0.4.6"
 url = { version = "2.1.0", optional = true }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
-libsqlite3-sys = { version = ">=0.8.0, <0.17.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.18.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 
 [dev-dependencies]
 difference = "1.0"


### PR DESCRIPTION
New `libsqlite3-sys` is out, released 2019-12-13 and has a patch release.

Everything seems to work on linux.

Most of the changes seem to be around the `bundled` feature, which we don't expose (yet?): https://github.com/jgallagher/rusqlite/commits/master/libsqlite3-sys