### PR TITLE
Add note clarifying that placeholder syntax is engine-dependent

### DIFF
--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -28,7 +28,10 @@ impl<Inner> SqlQuery<Inner> {
         SqlQuery { inner, query }
     }
 
-    /// Bind a value for use with this SQL query.
+    /// Bind a value for use with this SQL query. The given query should have
+    /// placeholders that vary based on the database type,
+    /// like [SQLite Parameters](https://sqlite.org/lang_expr.html#varparam) or
+    /// the [PostgreSQL PREPARE syntax](https://www.postgresql.org/docs/current/sql-prepare.html).
     ///
     /// # Safety
     ///

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -30,8 +30,9 @@ impl<Inner> SqlQuery<Inner> {
 
     /// Bind a value for use with this SQL query. The given query should have
     /// placeholders that vary based on the database type,
-    /// like [SQLite Parameters](https://sqlite.org/lang_expr.html#varparam) or
-    /// the [PostgreSQL PREPARE syntax](https://www.postgresql.org/docs/current/sql-prepare.html).
+    /// like [SQLite Parameters](https://sqlite.org/lang_expr.html#varparam) syntax,
+    /// the [PostgreSQL PREPARE syntax](https://www.postgresql.org/docs/current/sql-prepare.html),
+    /// or [MySQL bind syntax](https://dev.mysql.com/doc/refman/8.0/en/mysql-stmt-bind-param.html).
     ///
     /// # Safety
     ///

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -30,8 +30,8 @@ impl<Inner> SqlQuery<Inner> {
 
     /// Bind a value for use with this SQL query. The given query should have
     /// placeholders that vary based on the database type,
-    /// like [SQLite Parameters](https://sqlite.org/lang_expr.html#varparam) syntax,
-    /// the [PostgreSQL PREPARE syntax](https://www.postgresql.org/docs/current/sql-prepare.html),
+    /// like [SQLite Parameter](https://sqlite.org/lang_expr.html#varparam) syntax,
+    /// [PostgreSQL PREPARE syntax](https://www.postgresql.org/docs/current/sql-prepare.html),
     /// or [MySQL bind syntax](https://dev.mysql.com/doc/refman/8.0/en/mysql-stmt-bind-param.html).
     ///
     /// # Safety


### PR DESCRIPTION
I got a little lost in this example because it wasn't clear that the example was using SQLite as a backend, or that the query syntax (`?` placeholders) would be different for PostgreSQL. In hindsight this was obvious, but I figure it'd potentially save a future-me if the documentation noted up-front that this query syntax varied depending on the database type.