### PR TITLE
fix(diesel-cli): database subcommand ignores --migration-dir

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -265,11 +265,11 @@ fn create_config_file(matches: &ArgMatches) -> DatabaseResult<()> {
 fn run_database_command(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     match matches.subcommand() {
         ("setup", Some(args)) => {
-            let migrations_dir = migrations_dir(args).unwrap_or_else(handle_error);
+            let migrations_dir = migrations_dir(matches).unwrap_or_else(handle_error);
             database::setup_database(args, &migrations_dir)?;
         }
         ("reset", Some(args)) => {
-            let migrations_dir = migrations_dir(args).unwrap_or_else(handle_error);
+            let migrations_dir = migrations_dir(matches).unwrap_or_else(handle_error);
             database::reset_database(args, &migrations_dir)?;
             regenerate_schema_if_file_specified(matches)?;
         }

--- a/diesel_cli/tests/database_setup.rs
+++ b/diesel_cli/tests/database_setup.rs
@@ -85,6 +85,39 @@ fn database_abbreviated_as_db() {
 }
 
 #[test]
+fn database_setup_respects_migration_dir_by_arg_to_database() {
+    let p = project("database_setup_respects_migration_dir_by_arg_to_database")
+        .folder("foo")
+        .build();
+
+    let db = database(&p.database_url());
+
+    p.create_migration_in_directory(
+        "foo",
+        "12345_create_users_table",
+        "CREATE TABLE users ( id INTEGER )",
+        "DROP TABLE users",
+    );
+
+    // sanity check
+    assert!(!db.exists());
+
+    let result = p
+        .command("database")
+        .arg("--migration-dir=foo")
+        .arg("setup")
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(
+        result.stdout().contains("Running migration 12345"),
+        "Unexpected stdout {}",
+        result.stdout()
+    );
+    assert!(db.table_exists("users"));
+}
+
+#[test]
 fn database_setup_respects_migration_dir_by_arg() {
     let p = project("database_setup_respects_migration_dir_by_arg")
         .folder("foo")


### PR DESCRIPTION
The issue was the function that ran the database subcommands
was reading only the subcommand args i.e. the args to `setup`, `reset`
and not the args to the `database` subcommand.

Fixes issue #2225.