### PR TITLE
Additional `DatabaseErrorKind` variants

### DIFF
--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -147,7 +147,7 @@ impl Statement {
             1062 | 1586 | 1859 => DatabaseErrorKind::UniqueViolation,
             1216 | 1217 | 1451 | 1452 | 1830 | 1834 => DatabaseErrorKind::ForeignKeyViolation,
             1792 => DatabaseErrorKind::ReadOnlyTransaction,
-            1048 => DatabaseErrorKind::NotNullViolation,
+            1048 | 1364 => DatabaseErrorKind::NotNullViolation,
             3819 => DatabaseErrorKind::CheckViolation,
             _ => DatabaseErrorKind::__Unknown,
         }

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -141,7 +141,7 @@ impl Statement {
     fn last_error_type(&self) -> DatabaseErrorKind {
         let last_error_number = unsafe { ffi::mysql_stmt_errno(self.stmt.as_ptr()) };
         // These values are not exposed by the C API, but are documented
-        // at https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+        // at https://dev.mysql.com/doc/refman/8.0/en/server-error-reference.html
         // and are from the ANSI SQLSTATE standard
         match last_error_number {
             1062 | 1586 | 1859 => DatabaseErrorKind::UniqueViolation,

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -147,6 +147,8 @@ impl Statement {
             1062 | 1586 | 1859 => DatabaseErrorKind::UniqueViolation,
             1216 | 1217 | 1451 | 1452 | 1830 | 1834 => DatabaseErrorKind::ForeignKeyViolation,
             1792 => DatabaseErrorKind::ReadOnlyTransaction,
+            1048 => DatabaseErrorKind::NotNullViolation,
+            3819 => DatabaseErrorKind::CheckViolation,
             _ => DatabaseErrorKind::__Unknown,
         }
     }

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -42,6 +42,10 @@ impl PgResult {
                         Some(error_codes::READ_ONLY_TRANSACTION) => {
                             DatabaseErrorKind::ReadOnlyTransaction
                         }
+                        Some(error_codes::NOT_NULL_VIOLATION) => {
+                            DatabaseErrorKind::NotNullViolation
+                        }
+                        Some(error_codes::CHECK_VIOLATION) => DatabaseErrorKind::CheckViolation,
                         _ => DatabaseErrorKind::__Unknown,
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
@@ -182,4 +186,6 @@ mod error_codes {
     pub const FOREIGN_KEY_VIOLATION: &str = "23503";
     pub const SERIALIZATION_FAILURE: &str = "40001";
     pub const READ_ONLY_TRANSACTION: &str = "25006";
+    pub const NOT_NULL_VIOLATION: &str = "23502";
+    pub const CHECK_VIOLATION: &str = "23514";
 }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -113,6 +113,12 @@ pub enum DatabaseErrorKind {
     /// to lock the rows.
     ReadOnlyTransaction,
 
+    /// A not null constraint was violated.
+    NotNullViolation,
+
+    /// A check constraint was violated.
+    CheckViolation,
+
     #[doc(hidden)]
     __Unknown, // Match against _ instead, more variants may be added in the future
 }

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -103,6 +103,8 @@ fn last_error(raw_connection: *mut ffi::sqlite3) -> Error {
             DatabaseErrorKind::UniqueViolation
         }
         ffi::SQLITE_CONSTRAINT_FOREIGNKEY => DatabaseErrorKind::ForeignKeyViolation,
+        ffi::SQLITE_CONSTRAINT_NOTNULL => DatabaseErrorKind::NotNullViolation,
+        ffi::SQLITE_CONSTRAINT_CHECK => DatabaseErrorKind::CheckViolation,
         _ => DatabaseErrorKind::__Unknown,
     };
     DatabaseError(error_kind, error_information)

--- a/diesel_tests/tests/errors.rs
+++ b/diesel_tests/tests/errors.rs
@@ -1,7 +1,7 @@
 use crate::schema::*;
-use diesel::result::DatabaseErrorKind::{
-    CheckViolation, ForeignKeyViolation, NotNullViolation, UniqueViolation,
-};
+#[cfg(not(feature = "mysql"))]
+use diesel::result::DatabaseErrorKind::CheckViolation;
+use diesel::result::DatabaseErrorKind::{ForeignKeyViolation, NotNullViolation, UniqueViolation};
 use diesel::result::Error::DatabaseError;
 use diesel::*;
 
@@ -225,6 +225,8 @@ fn not_null_constraints_correct_column_name() {
 }
 
 #[test]
+#[cfg(not(feature = "mysql"))]
+/// MySQL < 8.0.16 doesn't enforce check constraints
 fn check_constraints_are_detected() {
     let connection = connection();
 

--- a/diesel_tests/tests/errors.rs
+++ b/diesel_tests/tests/errors.rs
@@ -225,7 +225,7 @@ fn not_null_constraints_correct_column_name() {
 }
 
 #[test]
-fn check_constraints_constraints_are_detected() {
+fn check_constraints_are_detected() {
     let connection = connection();
 
     insert_into(users::table)

--- a/migrations/mysql/2020-02-18-111430_create_pokes/down.sql
+++ b/migrations/mysql/2020-02-18-111430_create_pokes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE pokes;

--- a/migrations/mysql/2020-02-18-111430_create_pokes/up.sql
+++ b/migrations/mysql/2020-02-18-111430_create_pokes/up.sql
@@ -1,0 +1,5 @@
+create table pokes (
+    user_id INTEGER PRIMARY KEY NOT NULL REFERENCES users(id),
+    poke_count INTEGER NOT NULL,
+    CONSTRAINT pokes_poke_count_check CHECK (poke_count > 0)
+);

--- a/migrations/postgresql/2020-02-18-111430_create_pokes/down.sql
+++ b/migrations/postgresql/2020-02-18-111430_create_pokes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE pokes;

--- a/migrations/postgresql/2020-02-18-111430_create_pokes/up.sql
+++ b/migrations/postgresql/2020-02-18-111430_create_pokes/up.sql
@@ -1,0 +1,5 @@
+create table pokes (
+    user_id INTEGER PRIMARY KEY NOT NULL REFERENCES users(id),
+    poke_count INTEGER NOT NULL,
+    CONSTRAINT pokes_poke_count_check CHECK (poke_count > 0)
+);

--- a/migrations/sqlite/2020-02-18-111430_create_pokes/down.sql
+++ b/migrations/sqlite/2020-02-18-111430_create_pokes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE pokes;

--- a/migrations/sqlite/2020-02-18-111430_create_pokes/up.sql
+++ b/migrations/sqlite/2020-02-18-111430_create_pokes/up.sql
@@ -1,0 +1,5 @@
+create table pokes (
+    user_id INTEGER PRIMARY KEY NOT NULL REFERENCES users(id),
+    poke_count INTEGER NOT NULL,
+    CONSTRAINT pokes_poke_count_check CHECK (poke_count > 0)
+);


### PR DESCRIPTION
Introduces additional [`DatabaseErrorKind`](https://github.com/PhilipTrauner/diesel/blob/5d7cfb69ca8251db7447898341029c3d314db4de/diesel/src/result.rs#L87) variants (`NotNullViolation`, `CheckViolation`), their respective Postgres and MySQL error codes, and extends the error matching function of each supported database.