### PR TITLE
Some small refactorings

### DIFF
--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -36,10 +36,11 @@ impl fmt::Display for MigrationError {
                 f,
                 "Unable to find migrations directory in this directory or any parent directories."
             ),
-            MigrationError::UnknownMigrationFormat(_) => {
-                write!(f,"Invalid migration directory, the directory's name should be \
-                 <timestamp>_<name_of_migration>, and it should only contain up.sql and down.sql.")
-            }
+            MigrationError::UnknownMigrationFormat(_) => write!(
+                f,
+                "Invalid migration directory, the directory's name should be \
+                 <timestamp>_<name_of_migration>, and it should only contain up.sql and down.sql."
+            ),
             MigrationError::IoError(ref error) => write!(f, "{}", error),
             MigrationError::UnknownMigrationVersion(_) => write!(
                 f,

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -40,7 +40,7 @@ impl ConnectionOptions {
             Some(password) => Some(decode_into_cstring(password)?),
             None => None,
         };
-        let database = match url.path_segments().and_then(|mut iter| iter.nth(0)) {
+        let database = match url.path_segments().and_then(|mut iter| iter.next()) {
             Some("") | None => None,
             Some(segment) => Some(CString::new(segment.as_bytes())?),
         };

--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -4,7 +4,6 @@ use std::error::Error;
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
-use toml;
 
 use super::find_project_root;
 use print_schema;

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -85,7 +85,7 @@ pub fn load_foreign_key_constraints(
                 .collect())
         })
         .collect::<QueryResult<Vec<Vec<_>>>>()?;
-    Ok(rows.into_iter().flat_map(|x| x).collect())
+    Ok(rows.into_iter().flatten().collect())
 }
 
 pub fn get_table_data(

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -216,8 +216,7 @@ fn migrations_dir(matches: &ArgMatches) -> Result<PathBuf, MigrationError> {
                 Config::read(matches)
                     .unwrap_or_else(handle_error)
                     .migrations_directory?
-                    .dir
-                    .to_owned(),
+                    .dir,
             )
         });
 
@@ -248,7 +247,7 @@ fn create_migrations_dir(matches: &ArgMatches) -> DatabaseResult<PathBuf> {
         create_migrations_directory(&dir)?;
     }
 
-    Ok(dir.to_owned())
+    Ok(dir)
 }
 
 fn create_config_file(matches: &ArgMatches) -> DatabaseResult<()> {

--- a/diesel_derives/src/meta.rs
+++ b/diesel_derives/src/meta.rs
@@ -82,7 +82,7 @@ impl MetaItem {
     }
 
     pub fn ident_value(&self) -> Result<syn::Ident, Diagnostic> {
-        let maybe_attr = self.nested().ok().and_then(|mut n| n.nth(0));
+        let maybe_attr = self.nested().ok().and_then(|mut n| n.next());
         let maybe_path = maybe_attr.as_ref().and_then(|m| m.path().ok());
         match maybe_path {
             Some(x) => {

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -8,6 +8,12 @@ pub fn wrap_in_dummy_mod(item: TokenStream) -> TokenStream {
     quote! {
         #[allow(unused_imports)]
         const _: () = {
+            // This import is not actually redundant. When using diesel_derives
+            // inside of diesel, `diesel` doesn't exist as an extern crate, and
+            // to work around that it contains a private
+            // `mod diesel { pub use super::*; }` that this import will then
+            // refer to. In all other cases, this imports refers to the extern
+            // crate diesel.
             use diesel;
 
             #item

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -52,7 +52,7 @@ fn option_ty_arg(ty: &Type) -> Option<&Type> {
 pub fn ty_for_foreign_derive(item: &DeriveInput, flags: &MetaItem) -> Result<Type, Diagnostic> {
     if flags.has_flag("foreign_derive") {
         match item.data {
-            Data::Struct(ref body) => match body.fields.iter().nth(0) {
+            Data::Struct(ref body) => match body.fields.iter().next() {
                 Some(field) => Ok(field.ty.clone()),
                 None => Err(flags
                     .span()

--- a/diesel_migrations/migrations_internals/src/migration.rs
+++ b/diesel_migrations/migrations_internals/src/migration.rs
@@ -102,7 +102,7 @@ pub fn version_from_path(path: &Path) -> Result<String, MigrationError> {
         .unwrap_or_else(|| panic!("Can't get file name from path `{:?}`", path))
         .to_string_lossy()
         .split('_')
-        .nth(0)
+        .next()
         .map(|s| Ok(s.replace('-', "")))
         .unwrap_or_else(|| Err(MigrationError::UnknownMigrationFormat(path.to_path_buf())))
 }


### PR DESCRIPTION
I first thought I couldn't remove `use diesel;` because some crates didn't have `edition = "2018"` and started working on that. Then I realized the code the macros generate have to work in the 2015 edition so I probably can't remove the redundant import. (I still don't understand why things break *inside diesel* when I remove it, but that's not that important)

If you want me to split this PR or remove the first commit altogether, I'm fine with that.