### PR TITLE
Enable using this library from git directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,3 @@ members = [
     "examples/sqlite/getting_started_step_2",
     "examples/sqlite/getting_started_step_3",
 ]
-
-[replace]
-"diesel:1.4.3" = { path = "diesel" }
-"diesel_derives:1.4.1" = { path = "diesel_derives" }
-"diesel_migrations:1.4.0" = { path = "diesel_migrations" }
-"migrations_internals:1.4.0" = { path = "diesel_migrations/migrations_internals" }
-"migrations_macros:1.4.1" = { path = "diesel_migrations/migrations_macros" }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.0"
-diesel_derives = "~1.4.0"
 chrono = { version = "0.4", optional = true }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.18.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
@@ -33,6 +32,10 @@ num-integer = { version = "0.1.32", optional = true }
 bigdecimal = { version = ">= 0.0.10, <= 0.1.0", optional = true }
 bitflags = { version = "1.0", optional = true }
 r2d2 = { version = ">= 0.8, < 0.9", optional = true }
+
+[dependencies.diesel_derives]
+version = "~1.4.0"
+path = "../diesel_derives"
 
 [dev-dependencies]
 cfg-if = "0.1.0"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,16 +19,23 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4"
 clap = "2.27"
-diesel = { version = "~1.4.0", default-features = false }
 dotenv = ">=0.8, <0.11"
 heck = "0.3.1"
-migrations_internals = "~1.4.0"
 serde = { version = "1.0.0", features = ["derive"] }
 tempfile = "3.0.0"
 toml = "0.4.6"
 url = { version = "2.1.0", optional = true }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
 libsqlite3-sys = { version = ">=0.8.0, <0.18.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+
+[dependencies.diesel]
+version = "~1.4.0"
+path = "../diesel"
+default-features = false
+
+[dependencies.migrations_internals]
+version = "~1.4.0"
+path = "../diesel_migrations/migrations_internals"
 
 [dev-dependencies]
 difference = "1.0"

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -16,8 +16,11 @@ proc-macro2 = "1"
 
 [dev-dependencies]
 cfg-if = "0.1.0"
-diesel = "1.4.0"
 dotenv = "0.10.0"
+
+[dev-dependencies.diesel]
+version = "~1.4.0"
+path = "../diesel"
 
 [lib]
 proc-macro = true

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -7,15 +7,22 @@ description = "Migration management for diesel"
 documentation = "https://docs.rs/crate/diesel_migrations"
 homepage = "https://diesel.rs"
 
+[dependencies.migrations_internals]
+version = "~1.4.0"
+path = "migrations_internals"
 
-[dependencies]
-migrations_internals = "~1.4.0"
-migrations_macros = "~1.4.0"
+[dependencies.migrations_macros]
+version = "~1.4.0"
+path = "migrations_macros"
 
 [dev-dependencies]
-diesel = { version = "1.4.0", default-features = false }
 dotenv = ">=0.8, <0.11"
 cfg-if = "0.1.0"
+
+[dev-dependencies.diesel]
+version = "~1.4.0"
+path = "../diesel"
+default-features = false
 
 [features]
 default = []

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -7,8 +7,12 @@ description = "Internal implementation of diesels migration mechanism"
 homepage = "https://diesel.rs"
 
 [dependencies]
-diesel = { version = "~1.4.0", default-features = false }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
+
+[dependencies.diesel]
+version = "~1.4.0"
+path = "../../diesel"
+default-features = false
 
 [dev-dependencies]
 tempfile = "3.0.0"

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -8,10 +8,13 @@ documentation = "https://docs.diesel.rs"
 homepage = "https://diesel.rs"
 
 [dependencies]
-migrations_internals = "~1.4.0"
 syn = { version = "1", features = ["extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
+
+[dependencies.migrations_internals]
+version = "~1.4.0"
+path = "../migrations_internals"
 
 [dev-dependencies]
 tempfile = "3.0.0"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2018"
 
 [build-dependencies]
 diesel = { path = "../diesel", default-features = false }
-diesel_migrations = { version = "1.4.0" }
+diesel_migrations = { path = "../diesel_migrations" }
 dotenv = ">=0.8, <0.11"
 
 [dependencies]
 assert_matches = "1.0.1"
 chrono = { version = "0.4" }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric", "with-deprecated"] }
-diesel_migrations = { version = "1.4.0" }
+diesel_migrations = { path = "../diesel_migrations" }
 diesel_infer_schema = { version = "1.4.0" }
 dotenv = ">=0.8, <0.11"
 quickcheck = { version = "0.4", features = ["unstable"] }


### PR DESCRIPTION
I love living on the edge 😄 

Unfortunately, I am unable to install `diesel_cli` from github directly because it would want `git` and `branch` in the versions. I hacked my way around it by installing from path after cloning the repo. Maybe, also adding `git` to these items would fix the issue? Or maybe replace `path` with `git`? Any experts?