### PR TITLE
Make ConnectionManager implement Sync automatically

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -31,10 +31,8 @@ use crate::sql_types::HasSqlType;
 #[derive(Debug, Clone)]
 pub struct ConnectionManager<T> {
     database_url: String,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<fn() -> T>,
 }
-
-unsafe impl<T: Send + 'static> Sync for ConnectionManager<T> {}
 
 impl<T> ConnectionManager<T> {
     /// Returns a new connection manager,


### PR DESCRIPTION
By using `PhantomData<fn() -> T>` instead of `PhantomData<T>` for the type of the `_marker` field, this makes `ConnectionManager` implement `Sync` automatically, and means we can remove the `unsafe impl` of `Sync` for `ConnectionManager<T>`.