### PR TITLE
Update backend_installation mysql-apt-config version

### DIFF
--- a/guide_drafts/backend_installation.md
+++ b/guide_drafts/backend_installation.md
@@ -47,8 +47,8 @@ with various package managers.
 1. Install the following to add the MySQL APT repository.
 
     ```
-    wget https://dev.mysql.com/get/mysql-apt-config_0.8.7-1_all.deb
-    sudo dpkg -i mysql-apt-config_0.8.7-1_all.deb
+    wget https://dev.mysql.com/get/mysql-apt-config_0.8.15-1_all.deb
+    sudo dpkg -i mysql-apt-config_0.8.15-1_all.deb
     ```
 
     Select `<Ok>`.


### PR DESCRIPTION
In file [backend_installation.md](https://github.com/diesel-rs/diesel/blob/master/guide_drafts/backend_installation.md):

The version of 0.8.7 will lead to the EXPKEYSIG error when running ```sudo apt-get update```.

Update the dep file to the latest one.