### PR TITLE
Fix Linux_mysql job failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,8 +104,7 @@ jobs:
       RUST_TEST_THREADS: 1
     setup:
       - bash: |
-          sudo apt-get update &&
-          sudo apt-get -y install mysql-server libmysqlclient-dev &&
+          sudo systemctl start mysql.service &&
           mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'localhost';" -uroot -proot
         displayName: Install mysql
 


### PR DESCRIPTION
This PR fixes the test failures of the 'Linux_mysql' jobs on Azure.

Because the MySQL server is already installed, `apt install mysql-server`, which would start `mysql.service` at the end of the installation, does nothing.

The fix here is to simply launch the server manually.