### PR TITLE
Fix a broken link to Uuid

### DIFF
--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -181,7 +181,7 @@ pub mod sql_types {
     ///
     /// [`ToSql`]: ../../../serialize/trait.ToSql.html
     /// [`FromSql`]: ../../../deserialize/trait.FromSql.html
-    /// [Uuid]: https://doc.rust-lang.org/uuid/uuid/struct.Uuid.html
+    /// [Uuid]: https://docs.rs/uuid/*/uuid/struct.Uuid.html
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
     #[postgres(oid = "2950", array_oid = "2951")]
     pub struct Uuid;


### PR DESCRIPTION
Fixes a broken link in https://docs.diesel.rs/diesel/pg/types/sql_types/struct.Uuid.html.