### PR TITLE
Use `#[non_exhaustive]` instead of `__NonExhaustive` enum variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   represent everything it used to, so in some rare cases code changes may be
   required. See [the upgrade notes](#2-0-0-upgrade-non-aggregate) for details.
 
+* Various `__NonExhaustive` variants in different (error-) enums are replaced with
+  `#[non_exhaustive]`. If you matched on one of those variants explicitly you need to
+  introduce a wild card match instead.
+
 ### Fixed
 
 * Many types were incorrectly considered non-aggregate when they should not

--- a/diesel/src/migration/errors.rs
+++ b/diesel/src/migration/errors.rs
@@ -11,6 +11,7 @@ use crate::result;
 
 /// Errors that occur while preparing to run migrations
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum MigrationError {
     /// The migration directory wasn't found
     MigrationDirectoryNotFound(PathBuf),
@@ -22,9 +23,6 @@ pub enum MigrationError {
     UnknownMigrationVersion(String),
     /// No migrations had to be/ could be run
     NoMigrationRun,
-    ///
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 impl Error for MigrationError {}
@@ -51,7 +49,6 @@ impl fmt::Display for MigrationError {
                 f,
                 "No migrations have been run. Did you forget `diesel migration run`?"
             ),
-            MigrationError::__NonExhaustive => unreachable!(),
         }
     }
 }
@@ -81,6 +78,7 @@ impl From<io::Error> for MigrationError {
 /// Errors that occur while running migrations
 #[derive(Debug, PartialEq)]
 #[allow(clippy::enum_variant_names)]
+#[non_exhaustive]
 pub enum RunMigrationsError {
     /// A general migration error occured
     MigrationError(MigrationError),
@@ -88,9 +86,6 @@ pub enum RunMigrationsError {
     QueryError(result::Error),
     /// The provided migration was empty
     EmptyMigration,
-    ///
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 impl Error for RunMigrationsError {}
@@ -103,7 +98,6 @@ impl fmt::Display for RunMigrationsError {
             RunMigrationsError::EmptyMigration => {
                 write!(f, "Failed with: Attempted to run an empty migration.")
             }
-            RunMigrationsError::__NonExhaustive => unreachable!(),
         }
     }
 }

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -36,6 +36,7 @@ pub struct MysqlTypeMetadata {
 /// The null variant is omitted, as we will never prepare a statement in which
 /// one of the bind parameters can always be NULL
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
 pub enum MysqlType {
     /// Sets `buffer_type` to `MYSQL_TYPE_TINY`
     Tiny,

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display};
 ///
 /// This type is not intended to be exhaustively matched, and new variants may
 /// be added in the future without a major version bump.
+#[non_exhaustive]
 pub enum Error {
     /// The query contained a nul byte.
     ///
@@ -72,9 +73,6 @@ pub enum Error {
     /// Attempted to perform an operation that cannot be done inside a transaction
     /// when a transaction was already open.
     AlreadyInTransaction,
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -192,6 +190,7 @@ impl DatabaseErrorInformation for String {
 ///
 /// [`Connection::establish`]: ../connection/trait.Connection.html#tymethod.establish
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ConnectionError {
     /// The connection URL contained a `NUL` byte.
     InvalidCString(NulError),
@@ -206,8 +205,6 @@ pub enum ConnectionError {
     /// This variant is returned if an error occurred executing the query to set
     /// those options. Diesel will never affect global configuration.
     CouldntSetupConfiguration(Error),
-    #[doc(hidden)]
-    __Nonexhaustive, // Match against _ instead, more variants may be added in the future
 }
 
 /// A specialized result type for queries.
@@ -284,7 +281,6 @@ impl Display for Error {
                 f,
                 "Cannot perform this operation while a transaction is open",
             ),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -308,7 +304,6 @@ impl Display for ConnectionError {
             ConnectionError::BadConnection(ref s) => write!(f, "{}", s),
             ConnectionError::InvalidConnectionUrl(ref s) => write!(f, "{}", s),
             ConnectionError::CouldntSetupConfiguration(ref e) => e.fmt(f),
-            ConnectionError::__Nonexhaustive => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
This commit changes every occurrence of `__NonExhaustive` in our
public enums to `#[non_exhaustive]` to enforce non exhaustive
matching.

Additionally `MysqlType` is now also marked as `#[non_exhaustive]` as
we may want to add variants in future here as well.