### PR TITLE
Properly decrement transaction_depth on a successful rollback from a serialization/read-only failure

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -38,6 +38,7 @@ version = "~2.0.0"
 path = "../diesel_derives"
 
 [dev-dependencies]
+assert_matches = "1.0.1"
 cfg-if = "0.1.0"
 dotenv = ">=0.8, <0.11"
 quickcheck = "0.4"

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -38,7 +38,6 @@ version = "~2.0.0"
 path = "../diesel_derives"
 
 [dev-dependencies]
-assert_matches = "1.0.1"
 cfg-if = "0.1.0"
 dotenv = ">=0.8, <0.11"
 quickcheck = "0.4"

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -147,6 +147,7 @@ where
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "postgres")]
     macro_rules! matches {
         ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )?) => {
             match $expression {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -27,7 +27,7 @@ use crate::sql_types::HasSqlType;
 #[allow(missing_debug_implementations)]
 pub struct PgConnection {
     pub(crate) raw_connection: RawConnection,
-    transaction_manager: AnsiTransactionManager,
+    pub(crate) transaction_manager: AnsiTransactionManager,
     statement_cache: StatementCache<Pg, Statement>,
     metadata_cache: PgMetadataCache,
 }

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -53,9 +53,14 @@ cfg_if! {
 
 #[cfg(feature = "postgres")]
 pub fn pg_connection() -> PgConnection {
-    let conn = PgConnection::establish(&pg_database_url()).unwrap();
+    let conn = pg_connection_no_transaction();
     conn.begin_test_transaction().unwrap();
     conn
+}
+
+#[cfg(feature = "postgres")]
+pub fn pg_connection_no_transaction() -> PgConnection {
+    PgConnection::establish(&pg_database_url()).unwrap()
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
This iterates on PR #2364 - the logic in that PR wasn't decrementing the transaction_depth on a successful rollback, because change_transaction_depth was always using the Ok/Err value of the initial COMMIT, which was always Err. This PR changes it to use the Ok/Err value of the ROLLBACK, but still return an Err from the function if the commit failed.

This logic is a little thorny and repetitive in the use of change_transaction_depth, there may be a better way to represent it.

cc @Ten0 