### PR TITLE
Upgrade to the latest bigdecimal version

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -29,7 +29,7 @@ ipnetwork = { version = ">=0.12.2, <0.17.0", optional = true }
 num-bigint = { version = ">=0.1.41, <0.3", optional = true }
 num-traits = { version = "0.2", optional = true }
 num-integer = { version = "0.1.32", optional = true }
-bigdecimal = { version = ">= 0.0.10, <= 0.1.2", optional = true }
+bigdecimal = { version = ">= 0.0.10, < 0.2.0", optional = true }
 bitflags = { version = "1.0", optional = true }
 r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -29,7 +29,7 @@ ipnetwork = { version = ">=0.12.2, <0.17.0", optional = true }
 num-bigint = { version = ">=0.1.41, <0.3", optional = true }
 num-traits = { version = "0.2", optional = true }
 num-integer = { version = "0.1.32", optional = true }
-bigdecimal = { version = ">= 0.0.10, <= 0.1.0", optional = true }
+bigdecimal = { version = ">= 0.0.10, <= 0.1.2", optional = true }
 bitflags = { version = "1.0", optional = true }
 r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -22,7 +22,7 @@ quickcheck = "0.9"
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.17.0"
-bigdecimal = ">= 0.0.10, <= 0.1.2"
+bigdecimal = ">= 0.0.10, < 0.2.0"
 
 [features]
 default = []

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -22,7 +22,7 @@ quickcheck = "0.9"
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.17.0"
-bigdecimal = ">= 0.0.10, <= 0.1.0"
+bigdecimal = ">= 0.0.10, <= 0.1.2"
 
 [features]
 default = []


### PR DESCRIPTION
I followed the same convention of limiting the patch version so this won't upgrade automatically. It doesn't look like bigdecimal has frequent releases anyway.

Here is the diff for bigdecimal: https://github.com/akubera/bigdecimal-rs/compare/v0.1.0...v0.1.2

fixes #2402