### PR TITLE
Update `dotenv` to 0.15

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -39,7 +39,7 @@ path = "../diesel_derives"
 
 [dev-dependencies]
 cfg-if = "0.1.0"
-dotenv = ">=0.8, <0.11"
+dotenv = "0.15"
 quickcheck = "0.9"
 
 [features]

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4"
 clap = "2.27"
-dotenv = ">=0.8, <0.11"
+dotenv = "0.15"
 heck = "0.3.1"
 serde = { version = "1.0.0", features = ["derive"] }
 tempfile = "3.0.0"

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2 = "1"
 
 [dev-dependencies]
 cfg-if = "0.1.0"
-dotenv = "0.10.0"
+dotenv = "0.15"
 
 [dev-dependencies.diesel]
 version = "~2.0.0"

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -16,7 +16,7 @@ version = "~1.4.0"
 path = "migrations_macros"
 
 [dev-dependencies]
-dotenv = ">=0.8, <0.11"
+dotenv = "0.15"
 cfg-if = "0.1.0"
 
 [dev-dependencies.diesel]

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -18,7 +18,7 @@ path = "../migrations_internals"
 
 [dev-dependencies]
 tempfile = "3.0.0"
-dotenv = ">=0.8, <0.11"
+dotenv = "0.15"
 cfg-if = "0.1.0"
 
 [dev-dependencies.diesel]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2018"
 [build-dependencies]
 diesel = { path = "../diesel", default-features = false }
 diesel_migrations = { path = "../diesel_migrations" }
-dotenv = ">=0.8, <0.11"
+dotenv = "0.15"
 
 [dependencies]
 assert_matches = "1.0.1"
 chrono = { version = "0.4" }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric", "with-deprecated"] }
 diesel_migrations = { path = "../diesel_migrations" }
-dotenv = ">=0.8, <0.11"
+dotenv = "0.15"
 quickcheck = "0.9"
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }

--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 bcrypt = "0.1.0"
 chrono = "0.4.0"
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres", "chrono"] }
-dotenv = "0.10.0"
+dotenv = "0.15"
 structopt = "0.1.6"
 structopt-derive = "0.1.6"
 tempfile = "2.2.0"

--- a/examples/postgres/advanced-blog-cli/src/auth.rs
+++ b/examples/postgres/advanced-blog-cli/src/auth.rs
@@ -98,11 +98,10 @@ fn if_not_present<T>(
     res: Result<T, dotenv::Error>,
     on_not_present: AuthenticationError,
 ) -> Result<T, AuthenticationError> {
-    use dotenv::ErrorKind::EnvVar;
     use std::env::VarError::NotPresent;
 
     res.map_err(|e| match e {
-        dotenv::Error(EnvVar(NotPresent), _) => on_not_present,
+        dotenv::Error::EnvVar(NotPresent) => on_not_present,
         e => AuthenticationError::EnvironmentError(e),
     })
 }

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.15"

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Taryn Hill <taryn@phrohdoh.com>"]
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
-dotenv = "0.10"
+dotenv = "0.15"


### PR DESCRIPTION
Since we head 2.0 release, I think we could allow losing older dotenv support here.