### PR TITLE
Fix diesel-rs #2373 on v1.4.x

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -4,6 +4,7 @@ use std::mem;
 use std::os::raw as libc;
 
 use super::stmt::Statement;
+use crate::mysql::types::MYSQL_TIME;
 use mysql::MysqlType;
 use result::QueryResult;
 use sql_types::IsSigned;
@@ -238,7 +239,7 @@ fn known_buffer_size_for_ffi_type(tpe: ffi::enum_field_types) -> Option<usize> {
         t::MYSQL_TYPE_TIME
         | t::MYSQL_TYPE_DATE
         | t::MYSQL_TYPE_DATETIME
-        | t::MYSQL_TYPE_TIMESTAMP => Some(size_of::<ffi::MYSQL_TIME>()),
+        | t::MYSQL_TYPE_TIMESTAMP => Some(size_of::<MYSQL_TIME>()),
         _ => None,
     }
 }


### PR DESCRIPTION
As discussed in issue #2373, here is a WIP PR to backport the fix for the issues with MySql date/time types on v8.0 of the mysqlclient library.

I haven't been able to run the test locally, just compile the crate as part of another binary.

I'm not 100% sure about the conversion between the new and the `mysqlclient-sys` version of the MYSQL_TIME structs, but hopefully the CI test results and a bit of input will get it into a reasonable shape.