### PR TITLE
Update bcrypt to 0.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,4 +388,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all
+          # This example pulls generic-array v0.14.1 that cannot compile with rustc 1.40.0.
+          # We could exclude it as it won't affect our MSRV.
+          args: --all --exclude=advanced-blog-cli

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 edition = "2018"
 
 [dependencies]
-bcrypt = "0.2.0"
+bcrypt = "0.8.1"
 chrono = "0.4.0"
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres", "chrono"] }
 dotenv = "0.15"


### PR DESCRIPTION
bcrypt 0.8.1 is out timely :)
Fixes #2436 