### PR TITLE
Feature/allow more generic connections

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -212,6 +212,29 @@ where
     }
 }
 
+impl<M> crate::migration::MigrationConnection for PooledConnection<M>
+where
+    M: ManageConnection,
+    M::Connection: crate::migration::MigrationConnection,
+    Self: Connection,
+{
+    fn setup(&self) -> QueryResult<usize> {
+        (&**self).setup()
+    }
+}
+
+impl<Changes, Output, M> crate::query_dsl::UpdateAndFetchResults<Changes, Output>
+    for PooledConnection<M>
+where
+    M: ManageConnection,
+    M::Connection: crate::query_dsl::UpdateAndFetchResults<Changes, Output>,
+    Self: Connection,
+{
+    fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
+        (&**self).update_and_fetch(changeset)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -16,8 +16,7 @@ use std::convert::Into;
 use std::fmt;
 use std::marker::PhantomData;
 
-use crate::backend::UsesAnsiSavepointSyntax;
-use crate::connection::{AnsiTransactionManager, SimpleConnection};
+use crate::connection::{SimpleConnection, TransactionManager};
 use crate::deserialize::{Queryable, QueryableByName};
 use crate::prelude::*;
 use crate::query_builder::{AsQuery, QueryFragment, QueryId};
@@ -128,12 +127,10 @@ where
 impl<M> Connection for PooledConnection<M>
 where
     M: ManageConnection,
-    M::Connection:
-        Connection<TransactionManager = AnsiTransactionManager> + R2D2Connection + Send + 'static,
-    <M::Connection as Connection>::Backend: UsesAnsiSavepointSyntax,
+    M::Connection: Connection + R2D2Connection + Send + 'static,
 {
     type Backend = <M::Connection as Connection>::Backend;
-    type TransactionManager = <M::Connection as Connection>::TransactionManager;
+    type TransactionManager = PooledConnectionTransactionManager<M>;
 
     fn establish(_: &str) -> ConnectionResult<Self> {
         Err(ConnectionError::BadConnection(String::from(
@@ -171,7 +168,47 @@ where
     }
 
     fn transaction_manager(&self) -> &Self::TransactionManager {
-        (&**self).transaction_manager()
+        // This is actually fine because we have an #[repr(transparent)]
+        // on LoggingTransactionManager, which means the layout is the same
+        // as the inner type
+        // See the ref-cast crate for a longer version: https://github.com/dtolnay/ref-cast
+        unsafe {
+            &*((&**self).transaction_manager() as *const _ as *const Self::TransactionManager)
+        }
+    }
+}
+
+#[doc(hidden)]
+#[repr(transparent)]
+#[allow(missing_debug_implementations)]
+pub struct PooledConnectionTransactionManager<M>
+where
+    M: ManageConnection,
+    M::Connection: Connection,
+{
+    inner: <M::Connection as Connection>::TransactionManager,
+}
+
+impl<M> TransactionManager<PooledConnection<M>> for PooledConnectionTransactionManager<M>
+where
+    M: ManageConnection,
+    PooledConnection<M>: Connection,
+    M::Connection: Connection,
+{
+    fn begin_transaction(&self, conn: &PooledConnection<M>) -> QueryResult<()> {
+        self.inner.begin_transaction(&**conn)
+    }
+
+    fn rollback_transaction(&self, conn: &PooledConnection<M>) -> QueryResult<()> {
+        self.inner.rollback_transaction(&**conn)
+    }
+
+    fn commit_transaction(&self, conn: &PooledConnection<M>) -> QueryResult<()> {
+        self.inner.commit_transaction(&**conn)
+    }
+
+    fn get_transaction_depth(&self) -> u32 {
+        self.inner.get_transaction_depth()
     }
 }
 


### PR DESCRIPTION
This PR contains a bunch of changes that allow to use generic connection wrappers in more places:

* We make the connection impl for `PooledConnection` more generic, so that we also support connection impls now that don't use `AnsiTransactionManager` (for example the `OciConnection` form `diesel_oci`)
* Implement a few more connection related traits for `PooledConnection` to unblock using that specific functionality
* Make the `ExecuteDsl` impl for batch inserts on sqlite more generic. This fixes #1822 