### PR TITLE
Fix documentation for importing any and all in pg

### DIFF
--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -9,7 +9,7 @@ use crate::sql_types::Array;
 ///
 /// As with most bare functions, this is not exported by default. You can import
 /// it specifically from `diesel::pg::expression::dsl::any`, or glob import
-/// `diesel::dsl::*`.
+/// `diesel::dsl::any`.
 ///
 /// # Example
 ///

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -8,7 +8,7 @@ use crate::sql_types::Array;
 /// Creates a PostgreSQL `ANY` expression.
 ///
 /// As with most bare functions, this is not exported by default. You can import
-/// it specifically from `diesel::expression::any`, or glob import
+/// it specifically from `diesel::pg::expression::dsl::any`, or glob import
 /// `diesel::dsl::*`
 ///
 /// # Example
@@ -37,7 +37,8 @@ where
 /// Creates a PostgreSQL `ALL` expression.
 ///
 /// As with most bare functions, this is not exported by default. You can import
-/// it specifically as `diesel::dsl::all`.
+/// it specifically as `diesel::pg::expression::dsl::all`, or glob import
+/// `diesel::dsl::*`.
 ///
 /// # Example
 ///

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -38,7 +38,7 @@ where
 ///
 /// As with most bare functions, this is not exported by default. You can import
 /// it specifically as `diesel::pg::expression::dsl::all`, or glob import
-/// `diesel::dsl::*`.
+/// `diesel::dsl::all`.
 ///
 /// # Example
 ///

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -8,8 +8,7 @@ use crate::sql_types::Array;
 /// Creates a PostgreSQL `ANY` expression.
 ///
 /// As with most bare functions, this is not exported by default. You can import
-/// it specifically from `diesel::pg::expression::dsl::any`, or glob import
-/// `diesel::dsl::any`.
+/// it specifically from `diesel::pg::expression::dsl::any`, or `diesel::dsl::any`.
 ///
 /// # Example
 ///
@@ -37,8 +36,7 @@ where
 /// Creates a PostgreSQL `ALL` expression.
 ///
 /// As with most bare functions, this is not exported by default. You can import
-/// it specifically as `diesel::pg::expression::dsl::all`, or glob import
-/// `diesel::dsl::all`.
+/// it specifically as `diesel::pg::expression::dsl::all`, or `diesel::dsl::all`.
 ///
 /// # Example
 ///

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -9,7 +9,7 @@ use crate::sql_types::Array;
 ///
 /// As with most bare functions, this is not exported by default. You can import
 /// it specifically from `diesel::pg::expression::dsl::any`, or glob import
-/// `diesel::dsl::*`
+/// `diesel::dsl::*`.
 ///
 /// # Example
 ///


### PR DESCRIPTION
@weiznich I have now updated the documentations of importing `any` and `all` from `diesel/src/pg/expression/array_comparison.rs`. I wrote it as @ralpha suggested in the issue description. 

However, wouldn't it make more sense to offer `diesel::dsl::any` for the specific import? I'm asking because the original import documentation seemed unaware of `pg` as specific db backend. 

closes #2447 