### PR TITLE
Allow non-static lifetime on boxed Migration

### DIFF
--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -21,7 +21,7 @@ pub trait Migration {
     }
 }
 
-impl Migration for Box<dyn Migration> {
+impl<'a> Migration for Box<dyn Migration + 'a> {
     fn version(&self) -> &str {
         (&**self).version()
     }


### PR DESCRIPTION
Box<dyn Trait> has an implied 'static lifetime. This allows for boxed Migration trait objects with a non-'static lifetime, such as for manual implementations of Migration that require an explicit lifetime.