### PR TITLE
Update macOS MySQL version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - '0.[0-9]+.x'
       - '1.[0-9]+.x'
 
-
 name: CI Tests
 
 jobs:
@@ -127,11 +126,11 @@ jobs:
           brew services start mysql &&
           brew services stop mysql;sleep 3;brew services start mysql &&
           sleep 2 &&
-          /usr/local/Cellar/mysql/8.0.19_1/bin/mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'localhost';" -uroot
+          /usr/local/Cellar/mysql/8.0.21/bin/mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'localhost';" -uroot
           echo '::set-env name=MYSQL_DATABASE_URL::mysql://root@localhost/diesel_test'
           echo '::set-env name=MYSQL_EXAMPLE_DATABASE_URL::mysql://root@localhost/diesel_example'
           echo '::set-env name=MYSQL_UNIT_TEST_DATABASE_URL::mysql://root@localhost/diesel_unit_test'
-          echo '::set-env name=MYSQLCLIENT_LIB_DIR::/usr/local/Cellar/mysql/8.0.19_1/lib'
+          echo '::set-env name=MYSQLCLIENT_LIB_DIR::/usr/local/Cellar/mysql/8.0.21/lib'
 
       - name: Install sqlite (Windows)
         if: runner.os == 'Windows' && matrix.backend == 'sqlite'


### PR DESCRIPTION
[The latest homebrew formula pulls 8.0.21](https://formulae.brew.sh/formula/) and it breaks our CI. This just updates the number to unblock other PRs but it'd be great if we could stop hard-coding it as a follow-up work.