### PR TITLE
Implement where clauses on upsert for pg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target
 Cargo.lock
 !diesel_cli/Cargo.lock
 .env
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 !diesel_cli/Cargo.lock
 .env
+.DS_Store

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -74,6 +74,8 @@ pub type RawValue<'a, DB> = <DB as HasRawValue<'a>>::RawValue;
 pub trait SupportsReturningClause {}
 /// Does this backend support 'ON CONFLICT' clause?
 pub trait SupportsOnConflictClause {}
+/// Does this backend support 'WHERE' clauses on 'ON CONFLICT' clauses?
+pub trait SupportsOnConflictTargetDecorations {}
 /// Does this backend support the bare `DEFAULT` keyword?
 pub trait SupportsDefaultKeyword {}
 /// Does this backend use the standard `SAVEPOINT` syntax?

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -330,6 +330,8 @@ pub mod prelude {
     pub use crate::macros::prelude::*;
     #[doc(inline)]
     pub use crate::query_builder::AsChangeset;
+    #[doc(inline)]
+    pub use crate::query_builder::DecoratableTarget;
     #[doc(hidden)]
     pub use crate::query_dsl::GroupByDsl;
     #[doc(inline)]

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -45,5 +45,6 @@ impl TypeMetadata for Pg {
 
 impl SupportsReturningClause for Pg {}
 impl SupportsOnConflictClause for Pg {}
+impl SupportsOnConflictTargetDecorations for Pg {}
 impl SupportsDefaultKeyword for Pg {}
 impl UsesAnsiSavepointSyntax for Pg {}

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -31,9 +31,9 @@ mod select_statement;
 mod sql_query;
 mod update_statement;
 pub(crate) mod upsert;
-pub use self::upsert::on_conflict_target_decorations::DecoratableTarget;
 mod where_clause;
 
+pub use self::upsert::on_conflict_target_decorations::DecoratableTarget;
 pub use self::ast_pass::AstPass;
 pub use self::bind_collector::BindCollector;
 pub use self::debug_query::DebugQuery;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -33,7 +33,6 @@ mod update_statement;
 pub(crate) mod upsert;
 mod where_clause;
 
-pub use self::upsert::on_conflict_target_decorations::DecoratableTarget;
 pub use self::ast_pass::AstPass;
 pub use self::bind_collector::BindCollector;
 pub use self::debug_query::DebugQuery;
@@ -54,6 +53,7 @@ pub use self::sql_query::{BoxedSqlQuery, SqlQuery};
 pub use self::update_statement::{
     AsChangeset, BoxedUpdateStatement, IntoUpdateTarget, UpdateStatement, UpdateTarget,
 };
+pub use self::upsert::on_conflict_target_decorations::DecoratableTarget;
 
 pub use self::limit_clause::{LimitClause, NoLimitClause};
 pub use self::limit_offset_clause::{BoxedLimitOffsetClause, LimitOffsetClause};

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -31,6 +31,7 @@ mod select_statement;
 mod sql_query;
 mod update_statement;
 pub(crate) mod upsert;
+pub use upsert::on_conflict_target_decorations::DecoratableTarget;
 mod where_clause;
 
 pub use self::ast_pass::AstPass;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -31,7 +31,7 @@ mod select_statement;
 mod sql_query;
 mod update_statement;
 pub(crate) mod upsert;
-pub use upsert::on_conflict_target_decorations::DecoratableTarget;
+pub use self::upsert::on_conflict_target_decorations::DecoratableTarget;
 mod where_clause;
 
 pub use self::ast_pass::AstPass;

--- a/diesel/src/query_builder/upsert/mod.rs
+++ b/diesel/src/query_builder/upsert/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod into_conflict_clause;
 pub(crate) mod on_conflict_actions;
 pub(crate) mod on_conflict_clause;
 pub(crate) mod on_conflict_target;
+pub(crate) mod on_conflict_target_decorations;

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -1,20 +1,59 @@
 use crate::backend::{Backend, SupportsOnConflictClause};
-use crate::expression::operators::And;
 use crate::expression::Expression;
+use crate::query_builder::upsert::on_conflict_target::{ConflictTarget, NoConflictTarget};
 use crate::query_builder::where_clause::{NoWhereClause, WhereAnd, WhereClause};
 use crate::query_builder::{AstPass, QueryFragment, QueryResult};
-use crate::query_dsl::methods::FilterDsl;
 use crate::sql_types::Bool;
 
-pub struct UndecoratedConflictTarget<T>(pub T);
+pub trait UndecoratedConflictTarget {}
 
-#[derive(Debug)]
-pub struct FilteredConflictTarget<T, P> {
-    target: T,
-    where_clause: WhereClause<P>,
+impl UndecoratedConflictTarget for NoConflictTarget {}
+impl<T> UndecoratedConflictTarget for ConflictTarget<T> {}
+
+/// Interface to add information to conflict targets.
+/// Designed to be open for further additions to conflict targets like constraints
+pub trait DecoratableTarget<T, U, P> {
+    /// Output type of filter_target operation
+    type FilterOutput;
+    /// equivalent to filter of FilterDsl but aimed at conflict targets
+    fn filter_target(self, predicate: P) -> Self::FilterOutput;
 }
 
-impl<DB, T, U> QueryFragment<DB> for FilteredConflictTarget<T, U>
+#[derive(Debug)]
+pub struct DecoratedConflictTarget<T, U> {
+    target: T,
+    where_clause: U,
+}
+
+impl<T, P> DecoratableTarget<T, WhereClause<P>, P> for T
+where
+    P: Expression<SqlType = Bool>,
+    T: UndecoratedConflictTarget,
+{
+    type FilterOutput = DecoratedConflictTarget<T, WhereClause<P>>;
+    fn filter_target(self, predicate: P) -> Self::FilterOutput {
+        DecoratedConflictTarget {
+            target: self,
+            where_clause: NoWhereClause.and(predicate),
+        }
+    }
+}
+
+impl<T, U, P> DecoratableTarget<T, <U as WhereAnd<P>>::Output, P> for DecoratedConflictTarget<T, U>
+where
+    P: Expression<SqlType = Bool>,
+    U: WhereAnd<P>,
+{
+    type FilterOutput = DecoratedConflictTarget<T, <U as WhereAnd<P>>::Output>;
+    fn filter_target(self, predicate: P) -> Self::FilterOutput {
+        DecoratedConflictTarget {
+            target: self.target,
+            where_clause: self.where_clause.and(predicate),
+        }
+    }
+}
+
+impl<DB, T, U> QueryFragment<DB> for DecoratedConflictTarget<T, U>
 where
     T: QueryFragment<DB>,
     U: QueryFragment<DB>,
@@ -22,35 +61,8 @@ where
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         self.target.walk_ast(out.reborrow())?;
-        out.push_sql(" ");
+        // out.push_sql(" ");
         self.where_clause.walk_ast(out.reborrow())?;
         Ok(())
-    }
-}
-
-impl<T, Predicate> FilterDsl<Predicate> for UndecoratedConflictTarget<T>
-where
-    Predicate: Expression<SqlType = Bool>,
-{
-    type Output = FilteredConflictTarget<T, Predicate>;
-    fn filter(self, predicate: Predicate) -> Self::Output {
-        FilteredConflictTarget {
-            target: self.0,
-            where_clause: NoWhereClause.and(predicate),
-        }
-    }
-}
-
-impl<T, P1, P2> FilterDsl<P2> for FilteredConflictTarget<T, P1>
-where
-    P1: Expression<SqlType = Bool>,
-    P2: Expression<SqlType = Bool>,
-{
-    type Output = FilteredConflictTarget<T, And<P1, P2>>;
-    fn filter(self, predicate: P2) -> Self::Output {
-        FilteredConflictTarget {
-            target: self.target,
-            where_clause: self.where_clause.and(predicate),
-        }
     }
 }

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -63,7 +63,6 @@ where
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         self.target.walk_ast(out.reborrow())?;
-        // out.push_sql(" ");
         self.where_clause.walk_ast(out.reborrow())?;
         Ok(())
     }

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -12,7 +12,7 @@ impl<T> UndecoratedConflictTarget for ConflictTarget<T> {}
 
 /// Interface to add information to conflict targets.
 /// Designed to be open for further additions to conflict targets like constraints
-pub trait DecoratableTarget<T, U, P> {
+pub trait DecoratableTarget<U, P> {
     /// Output type of filter_target operation
     type FilterOutput;
     /// equivalent to filter of FilterDsl but aimed at conflict targets
@@ -25,7 +25,7 @@ pub struct DecoratedConflictTarget<T, U> {
     where_clause: U,
 }
 
-impl<T, P> DecoratableTarget<T, WhereClause<P>, P> for T
+impl<T, P> DecoratableTarget<WhereClause<P>, P> for T
 where
     P: Expression,
     P::SqlType: BoolOrNullableBool,
@@ -40,7 +40,7 @@ where
     }
 }
 
-impl<T, U, P> DecoratableTarget<T, <U as WhereAnd<P>>::Output, P> for DecoratedConflictTarget<T, U>
+impl<T, U, P> DecoratableTarget<<U as WhereAnd<P>>::Output, P> for DecoratedConflictTarget<T, U>
 where
     P: Expression,
     P::SqlType: BoolOrNullableBool,

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -32,7 +32,7 @@ where
     T: UndecoratedConflictTarget,
 {
     type FilterOutput = DecoratedConflictTarget<T, WhereClause<P>>;
-    
+
     fn filter_target(self, predicate: P) -> Self::FilterOutput {
         DecoratedConflictTarget {
             target: self,

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -32,6 +32,7 @@ where
     T: UndecoratedConflictTarget,
 {
     type FilterOutput = DecoratedConflictTarget<T, WhereClause<P>>;
+    
     fn filter_target(self, predicate: P) -> Self::FilterOutput {
         DecoratedConflictTarget {
             target: self,
@@ -47,6 +48,7 @@ where
     U: WhereAnd<P>,
 {
     type FilterOutput = DecoratedConflictTarget<T, <U as WhereAnd<P>>::Output>;
+
     fn filter_target(self, predicate: P) -> Self::FilterOutput {
         DecoratedConflictTarget {
             target: self.target,

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -3,7 +3,7 @@ use crate::expression::Expression;
 use crate::query_builder::upsert::on_conflict_target::{ConflictTarget, NoConflictTarget};
 use crate::query_builder::where_clause::{NoWhereClause, WhereAnd, WhereClause};
 use crate::query_builder::{AstPass, QueryFragment, QueryResult};
-use crate::sql_types::Bool;
+use crate::sql_types::BoolOrNullableBool;
 
 pub trait UndecoratedConflictTarget {}
 
@@ -27,7 +27,8 @@ pub struct DecoratedConflictTarget<T, U> {
 
 impl<T, P> DecoratableTarget<T, WhereClause<P>, P> for T
 where
-    P: Expression<SqlType = Bool>,
+    P: Expression,
+    P::SqlType: BoolOrNullableBool,
     T: UndecoratedConflictTarget,
 {
     type FilterOutput = DecoratedConflictTarget<T, WhereClause<P>>;
@@ -41,7 +42,8 @@ where
 
 impl<T, U, P> DecoratableTarget<T, <U as WhereAnd<P>>::Output, P> for DecoratedConflictTarget<T, U>
 where
-    P: Expression<SqlType = Bool>,
+    P: Expression,
+    P::SqlType: BoolOrNullableBool,
     U: WhereAnd<P>,
 {
     type FilterOutput = DecoratedConflictTarget<T, <U as WhereAnd<P>>::Output>;

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -12,7 +12,7 @@ impl<T> UndecoratedConflictTarget for ConflictTarget<T> {}
 
 /// Interface to add information to conflict targets.
 /// Designed to be open for further additions to conflict targets like constraints
-pub trait DecoratableTarget<U, P> {
+pub trait DecoratableTarget<P> {
     /// Output type of filter_target operation
     type FilterOutput;
     /// equivalent to filter of FilterDsl but aimed at conflict targets
@@ -25,7 +25,7 @@ pub struct DecoratedConflictTarget<T, U> {
     where_clause: U,
 }
 
-impl<T, P> DecoratableTarget<WhereClause<P>, P> for T
+impl<T, P> DecoratableTarget<P> for T
 where
     P: Expression,
     P::SqlType: BoolOrNullableBool,
@@ -40,7 +40,7 @@ where
     }
 }
 
-impl<T, U, P> DecoratableTarget<<U as WhereAnd<P>>::Output, P> for DecoratedConflictTarget<T, U>
+impl<T, U, P> DecoratableTarget<P> for DecoratedConflictTarget<T, U>
 where
     P: Expression,
     P::SqlType: BoolOrNullableBool,

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -1,0 +1,56 @@
+use crate::backend::{Backend, SupportsOnConflictClause};
+use crate::expression::operators::And;
+use crate::expression::Expression;
+use crate::query_builder::where_clause::{NoWhereClause, WhereAnd, WhereClause};
+use crate::query_builder::{AstPass, QueryFragment, QueryResult};
+use crate::query_dsl::methods::FilterDsl;
+use crate::sql_types::Bool;
+
+pub struct UndecoratedConflictTarget<T>(pub T);
+
+#[derive(Debug)]
+pub struct FilteredConflictTarget<T, P> {
+    target: T,
+    where_clause: WhereClause<P>,
+}
+
+impl<DB, T, U> QueryFragment<DB> for FilteredConflictTarget<T, U>
+where
+    T: QueryFragment<DB>,
+    U: QueryFragment<DB>,
+    DB: Backend + SupportsOnConflictClause,
+{
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        self.target.walk_ast(out.reborrow())?;
+        out.push_sql(" ");
+        self.where_clause.walk_ast(out.reborrow())?;
+        Ok(())
+    }
+}
+
+impl<T, Predicate> FilterDsl<Predicate> for UndecoratedConflictTarget<T>
+where
+    Predicate: Expression<SqlType = Bool>,
+{
+    type Output = FilteredConflictTarget<T, Predicate>;
+    fn filter(self, predicate: Predicate) -> Self::Output {
+        FilteredConflictTarget {
+            target: self.0,
+            where_clause: NoWhereClause.and(predicate),
+        }
+    }
+}
+
+impl<T, P1, P2> FilterDsl<P2> for FilteredConflictTarget<T, P1>
+where
+    P1: Expression<SqlType = Bool>,
+    P2: Expression<SqlType = Bool>,
+{
+    type Output = FilteredConflictTarget<T, And<P1, P2>>;
+    fn filter(self, predicate: P2) -> Self::Output {
+        FilteredConflictTarget {
+            target: self.target,
+            where_clause: self.where_clause.and(predicate),
+        }
+    }
+}

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -1,4 +1,4 @@
-use crate::backend::{Backend, SupportsOnConflictClause};
+use crate::backend::{Backend, SupportsOnConflictClause, SupportsOnConflictTargetDecorations};
 use crate::expression::Expression;
 use crate::query_builder::upsert::on_conflict_target::{ConflictTarget, NoConflictTarget};
 use crate::query_builder::where_clause::{NoWhereClause, WhereAnd, WhereClause};
@@ -59,7 +59,7 @@ impl<DB, T, U> QueryFragment<DB> for DecoratedConflictTarget<T, U>
 where
     T: QueryFragment<DB>,
     U: QueryFragment<DB>,
-    DB: Backend + SupportsOnConflictClause,
+    DB: Backend + SupportsOnConflictClause + SupportsOnConflictTargetDecorations,
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         self.target.walk_ast(out.reborrow())?;

--- a/diesel/src/upsert/mod.rs
+++ b/diesel/src/upsert/mod.rs
@@ -16,6 +16,7 @@ use crate::query_builder::upsert::on_conflict_actions::Excluded;
 
 mod on_conflict_extension;
 
+pub use self::on_conflict_extension::DecoratableTarget;
 pub use self::on_conflict_extension::*;
 #[cfg(feature = "postgres")]
 pub use crate::pg::query_builder::on_constraint::*;

--- a/diesel/src/upsert/on_conflict_extension.rs
+++ b/diesel/src/upsert/on_conflict_extension.rs
@@ -202,13 +202,13 @@ where
     }
 }
 
-impl<Stmt, T, U, P> DecoratableTarget<U, P> for IncompleteOnConflict<Stmt, T>
+impl<Stmt, T, P> DecoratableTarget<P> for IncompleteOnConflict<Stmt, T>
 where
     P: Expression,
     P::SqlType: BoolOrNullableBool,
-    T: DecoratableTarget<U, P>,
+    T: DecoratableTarget<P>,
 {
-    type FilterOutput = IncompleteOnConflict<Stmt, <T as DecoratableTarget<U, P>>::FilterOutput>;
+    type FilterOutput = IncompleteOnConflict<Stmt, <T as DecoratableTarget<P>>::FilterOutput>;
     fn filter_target(self, predicate: P) -> Self::FilterOutput {
         IncompleteOnConflict {
             stmt: self.stmt,

--- a/diesel/src/upsert/on_conflict_extension.rs
+++ b/diesel/src/upsert/on_conflict_extension.rs
@@ -202,13 +202,13 @@ where
     }
 }
 
-impl<Stmt, T, U, P> DecoratableTarget<T, U, P> for IncompleteOnConflict<Stmt, T>
+impl<Stmt, T, U, P> DecoratableTarget<U, P> for IncompleteOnConflict<Stmt, T>
 where
     P: Expression,
     P::SqlType: BoolOrNullableBool,
-    T: DecoratableTarget<T, U, P>,
+    T: DecoratableTarget<U, P>,
 {
-    type FilterOutput = IncompleteOnConflict<Stmt, <T as DecoratableTarget<T, U, P>>::FilterOutput>;
+    type FilterOutput = IncompleteOnConflict<Stmt, <T as DecoratableTarget<U, P>>::FilterOutput>;
     fn filter_target(self, predicate: P) -> Self::FilterOutput {
         IncompleteOnConflict {
             stmt: self.stmt,

--- a/diesel/src/upsert/on_conflict_extension.rs
+++ b/diesel/src/upsert/on_conflict_extension.rs
@@ -6,7 +6,7 @@ use crate::query_builder::upsert::on_conflict_target::*;
 pub use crate::query_builder::upsert::on_conflict_target_decorations::DecoratableTarget;
 use crate::query_builder::{AsChangeset, InsertStatement, UndecoratedInsertRecord};
 use crate::query_source::QuerySource;
-use crate::sql_types::Bool;
+use crate::sql_types::BoolOrNullableBool;
 
 impl<T, U, Op, Ret> InsertStatement<T, U, Op, Ret>
 where
@@ -204,7 +204,8 @@ where
 
 impl<Stmt, T, U, P> DecoratableTarget<T, U, P> for IncompleteOnConflict<Stmt, T>
 where
-    P: Expression<SqlType = Bool>,
+    P: Expression,
+    P::SqlType: BoolOrNullableBool,
     T: DecoratableTarget<T, U, P>,
 {
     type FilterOutput = IncompleteOnConflict<Stmt, <T as DecoratableTarget<T, U, P>>::FilterOutput>;

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -127,15 +127,31 @@ fn test_upsert() {
         (name.eq("Tess"), hair_color.eq(None::<&str>)),
     ];
 
-    let upsert_command = insert_into(users)
+    let upsert_command_single_where = insert_into(users)
         .values(values)
         .on_conflict(hair_color)
         .filter_target(hair_color.eq(Some("black")))
         .do_nothing();
-    let upsert_sql_display = debug_query::<TestBackend, _>(&upsert_command).to_string();
+    let upsert_single_where_sql_display =
+        debug_query::<TestBackend, _>(&upsert_command_single_where).to_string();
 
     assert_eq!(
-        upsert_sql_display,
+        upsert_single_where_sql_display,
         r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, Some("black")]"#
     );
+
+    // let upsert_command_second_where = insert_into(users)
+    //     .values(values)
+    //     .on_conflict(hair_color)
+    //     .filter_target(name.eq(Some("Sean")))
+    //     .filter_target(hair_color.eq(Some("black")))
+    //     .do_nothing();
+
+    // let upsert_second_where_sql_display =
+    //     debug_query::<TestBackend, _>(&upsert_command_second_where).to_string();
+
+    // assert_eq!(
+    //     upsert_second_where_sql_display,
+    //     r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 and WHERE "users"."name" = $6 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, Some("black"), Some("Sean")]"#
+    // );
 }

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -128,30 +128,30 @@ fn test_upsert() {
     ];
 
     let upsert_command_single_where = insert_into(users)
-        .values(values)
+        .values(&values)
         .on_conflict(hair_color)
-        .filter_target(hair_color.eq(Some("black")))
+        .filter_target(hair_color.eq("black"))
         .do_nothing();
     let upsert_single_where_sql_display =
         debug_query::<TestBackend, _>(&upsert_command_single_where).to_string();
 
     assert_eq!(
         upsert_single_where_sql_display,
-        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, Some("black")]"#
+        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, "black"]"#
     );
 
-    // let upsert_command_second_where = insert_into(users)
-    //     .values(values)
-    //     .on_conflict(hair_color)
-    //     .filter_target(name.eq(Some("Sean")))
-    //     .filter_target(hair_color.eq(Some("black")))
-    //     .do_nothing();
+    let upsert_command_second_where = insert_into(users)
+        .values(&values)
+        .on_conflict(hair_color)
+        .filter_target(hair_color.eq("black"))
+        .filter_target(name.eq("Sean"))
+        .do_nothing();
 
-    // let upsert_second_where_sql_display =
-    //     debug_query::<TestBackend, _>(&upsert_command_second_where).to_string();
+    let upsert_second_where_sql_display =
+        debug_query::<TestBackend, _>(&upsert_command_second_where).to_string();
 
-    // assert_eq!(
-    //     upsert_second_where_sql_display,
-    //     r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 and WHERE "users"."name" = $6 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, Some("black"), Some("Sean")]"#
-    // );
+    assert_eq!(
+        upsert_second_where_sql_display,
+        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 AND "users"."name" = $6 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, "black", "Sean"]"#
+    );
 }

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -1,5 +1,4 @@
 use crate::schema::TestBackend;
-use diesel::upsert::DecoratableTarget;
 use diesel::*;
 
 #[test]
@@ -131,7 +130,7 @@ fn test_upsert() {
     let upsert_command = insert_into(users)
         .values(values)
         .on_conflict(hair_color)
-        .filter_target(hair_color.eq(Some("black")))
+        .filter_target(hair_color.eq("black"))
         .do_nothing();
     let upsert_sql_display = debug_query::<TestBackend, _>(&upsert_command).to_string();
 

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -130,7 +130,7 @@ fn test_upsert() {
     let upsert_command = insert_into(users)
         .values(values)
         .on_conflict(hair_color)
-        .filter_target(hair_color.eq("black"))
+        .filter_target(hair_color.eq(Some("black")))
         .do_nothing();
     let upsert_sql_display = debug_query::<TestBackend, _>(&upsert_command).to_string();
 

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -1,4 +1,5 @@
 use crate::schema::TestBackend;
+use diesel::upsert::DecoratableTarget;
 use diesel::*;
 
 #[test]
@@ -130,13 +131,12 @@ fn test_upsert() {
     let upsert_command = insert_into(users)
         .values(values)
         .on_conflict(hair_color)
-        .filter(hair_color.eq(Some("black")))
+        .filter_target(hair_color.eq(Some("black")))
         .do_nothing();
     let upsert_sql_display = debug_query::<TestBackend, _>(&upsert_command).to_string();
-    // let upsert_sql_debug = format!("{:?}", debug_query::<TestBackend, _>(&upsert_command));
 
     assert_eq!(
         upsert_sql_display,
-        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE hair_color="black" DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None]"#
+        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, Some("black")]"#
     );
 }


### PR DESCRIPTION
closes #2430 

Hey all! Since this here is my first ever PR written in Rust I'm especially keen on getting feedback for things that someone better at Rust would do totally different. 

There are to issues with which I would need expert help anyway: 

* I have explicitly imported the `DecoratableTarget` trait inside `diesel_tests/tests/debug/mod.rs because I failed exporting it properly to be part of a `use diesel::**` statement. You can see my failed attempts in `diesel/src/query_builder/mod.rs` and others. If you could help me get these exports right I could remove that explicit `use diesel::upsert::DecoratableTarget;` in `diesel_tests/tests/debug/mod.rs`
* I have only tested that the debug string will show the expected statement `"ON CONFLICT (...) WHERE ..."`. What other test scenarios would you like to have me cover in order to make sure it works. 