### PR TITLE
document `get_result` multi row result case

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -1200,6 +1200,9 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// it will implicitly add a `RETURNING *` to the query,
     /// unless a returning clause was already specified.
     ///
+    /// This method only returns the first row that was affected, even if more
+    /// rows are affected.
+    ///
     /// # Example
     ///
     /// ```rust


### PR DESCRIPTION
This PR introduces a small note on the `get_result` method. You could generate a query that matches multiple rows but the underlying `QueryResult` vector only returns the first result of the result set. A query could be created, because the use of  `get_result` won't append a `LIMIT 1;` to the SQL-query.


The issue #2446 discovered the behavior. 
For now it's only a documentation - I wasn't sure if the discussion was set on an `Err` if the result contains more than one row. (I could submit a PR or change this one if the `Err` is a welcome change  for Diesel v2)