### PR TITLE
re-export the `chrono` crate from diesel

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -142,6 +142,9 @@ pub mod macros;
 #[macro_use]
 extern crate cfg_if;
 
+#[cfg(feature = "chrono")]
+pub extern crate chrono;
+
 #[cfg(test)]
 pub mod test_helpers;
 


### PR DESCRIPTION
This allows the user to use the same version of `chrono` that Diesel ships with. The user avoids another direct dependency that could be another version or a not-compatible version of `chrono`. On the other hand, re-exporting could cause a breaking change through `chrono` to the user.

The re-export is guarded with a feature flag and uses the already known `chrono` feature flag.

