### PR TITLE
Ran cargo-diet to reduce download size from crates.io

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/diesel-rs/diesel"
 keywords = ["diesel", "migrations", "cli"]
 autotests = false
 edition = "2018"
+include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [[bin]]
 name = "diesel"

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://diesel.rs/guides/"
 homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel/tree/master/diesel_derives"
 autotests = false
+include = ["src/**/*", "LICENSE-*"]
 
 [dependencies]
 syn = { version = "1.0.1", features = ["full", "fold"] }

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dependencies.diesel]
 version = "2.0.0"


### PR DESCRIPTION
This just runs `cargo-diet` in order to remove tests and examples from the crates.io packages. They are not needed to compile, and removing them reduces download time (and therefore compile time). This is especially the case on places with a bad or slow Internet connection.

The results of the diet are the following:

**diesel_cli:**
```
Saved 47% or 117.8 KB in 118 files (of 248.4 KB and 141 files in entire crate)
```

**diesel_derives:**
```
Saved 23% or 35.6 KB in 9 files (of 156.7 KB and 32 files in entire crate)
```

**diesel_dynamic_schema:**
```
Saved 21% or 6.4 KB in 4 files (of 29.6 KB and 13 files in entire crate)
```