### PR TITLE
Issue 786 mysql ssl support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
+* `MysqlConnection::establish` is able to initiate SSL connection. The database URL should contain `ssl_mode` parameter with a value of the [MySQL client command option `--ssl-mode`](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode) if desired.
+
 * `Connection` and `SimpleConnection` traits are implemented for a broader range
   of `r2d2::PooledConnection<M>` types when the `r2d2` feature is enabled.
 
@@ -80,7 +82,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Support for `uuid` version < 0.7.0 has been removed.
 * Support for `bigdecimal` < 0.0.13 has been removed.
 * Support for `pq-sys` < 0.4.0 has been removed.
-* Support for `mysqlclient-sys` < 0.2.0 has been removed.
+* Support for `mysqlclient-sys` < 0.2.5 has been removed.
 * Support for `time` types has been removed.
 * Support for `chrono` < 0.4.19 has been removed.
 * The `NonNull` trait for sql types has been removed in favour of the new `SqlType` trait.

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.24.0", optional = true, features = ["bundled_bindings"] }
-mysqlclient-sys = { version = "0.2.0", optional = true }
+mysqlclient-sys = { version = "0.2.2", optional = true }
 pq-sys = { version = "0.4.0", optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.24.0", optional = true, features = ["bundled_bindings"] }
-mysqlclient-sys = { version = "0.2.2", optional = true }
+mysqlclient-sys = { version = "0.2.5", optional = true }
 pq-sys = { version = "0.4.0", optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -56,6 +56,13 @@ impl Connection for MysqlConnection {
     type Backend = Mysql;
     type TransactionManager = AnsiTransactionManager;
 
+    /// Establishes a new connection to the MySQL database
+    /// `database_url` may be enhanced by GET parameters
+    /// `mysql://[user[:password]@]host/database_name[?unix_socket=socket-path&ssl_mode=SSL_MODE*]`
+    ///
+    /// * `unix_socket` excepts the path to the unix socket
+    /// * `ssl_mode` expects a value defined for MySQL client command option `--ssl-mode`
+    /// See <https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode>
     fn establish(database_url: &str) -> ConnectionResult<Self> {
         use crate::result::ConnectionError::CouldntSetupConfiguration;
 

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -48,13 +48,8 @@ impl RawConnection {
         let unix_socket = connection_options.unix_socket();
         let client_flags = connection_options.client_flags();
 
-        #[cfg(not(windows))]
-        // allow single_match because compiler complains about if after cfg
-        // error: attributes are not yet allowed on `if` expressions
-        #[allow(clippy::single_match)]
-        match connection_options.ssl_mode() {
-            Some(ssl_mode) => self.set_ssl_mode(ssl_mode),
-            _ => (),
+        if let Some(ssl_mode) = connection_options.ssl_mode() {
+            self.set_ssl_mode(ssl_mode)
         }
 
         unsafe {
@@ -190,7 +185,6 @@ impl RawConnection {
         self.did_an_error_occur()
     }
 
-    #[cfg(not(windows))]
     fn set_ssl_mode(&self, ssl_mode: mysqlclient_sys::mysql_ssl_mode) {
         let v = ssl_mode as u32;
         let v_ptr: *const u32 = &v;

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -48,11 +48,13 @@ impl RawConnection {
         let unix_socket = connection_options.unix_socket();
         let client_flags = connection_options.client_flags();
 
-        if connection_options.ssl_mode().is_some() {
-            let ssl_mode = connection_options
-                .ssl_mode()
-                .expect("Failure on unwrapping ssl_mode");
-            self.set_ssl_mode(ssl_mode)
+        #[cfg(not(windows))]
+        // allow single_match because compiler complains about if after cfg
+        // error: attributes are not yet allowed on `if` expressions
+        #[allow(clippy::single_match)]
+        match connection_options.ssl_mode() {
+            Some(ssl_mode) => self.set_ssl_mode(ssl_mode),
+            _ => (),
         }
 
         unsafe {
@@ -188,6 +190,7 @@ impl RawConnection {
         self.did_an_error_occur()
     }
 
+    #[cfg(not(windows))]
     fn set_ssl_mode(&self, ssl_mode: mysqlclient_sys::mysql_ssl_mode) {
         let v = ssl_mode as u32;
         let v_ptr: *const u32 = &v;

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -48,6 +48,13 @@ impl RawConnection {
         let unix_socket = connection_options.unix_socket();
         let client_flags = connection_options.client_flags();
 
+        if connection_options.ssl_mode().is_some() {
+            let ssl_mode = connection_options
+                .ssl_mode()
+                .expect("Failure on unwrapping ssl_mode");
+            self.set_ssl_mode(ssl_mode)
+        }
+
         unsafe {
             // Make sure you don't use the fake one!
             ffi::mysql_real_connect(
@@ -179,6 +186,19 @@ impl RawConnection {
     fn next_result(&self) -> QueryResult<()> {
         unsafe { ffi::mysql_next_result(self.0.as_ptr()) };
         self.did_an_error_occur()
+    }
+
+    fn set_ssl_mode(&self, ssl_mode: mysqlclient_sys::mysql_ssl_mode) {
+        let v = ssl_mode as u32;
+        let v_ptr: *const u32 = &v;
+        let n = ptr::NonNull::new(v_ptr as *mut u32).expect("NonNull::new failed");
+        unsafe {
+            mysqlclient_sys::mysql_options(
+                self.0.as_ptr(),
+                mysqlclient_sys::mysql_option::MYSQL_OPT_SSL_MODE,
+                n.as_ptr() as *const std::ffi::c_void,
+            )
+        };
     }
 }
 

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -8,7 +8,6 @@ use std::ffi::{CStr, CString};
 
 use crate::result::{ConnectionError, ConnectionResult};
 
-#[cfg(not(windows))]
 use mysqlclient_sys::mysql_ssl_mode;
 
 bitflags::bitflags! {
@@ -49,7 +48,6 @@ pub struct ConnectionOptions {
     port: Option<u16>,
     unix_socket: Option<CString>,
     client_flags: CapabilityFlags,
-    #[cfg(not(windows))]
     ssl_mode: Option<mysql_ssl_mode>,
 }
 
@@ -78,7 +76,6 @@ impl ConnectionOptions {
             _ => None,
         };
 
-        #[cfg(not(windows))]
         let ssl_mode = match query_pairs.get("ssl_mode") {
             Some(v) => {
                 let ssl_mode = match v.to_lowercase().as_str() {
@@ -125,7 +122,6 @@ impl ConnectionOptions {
             port: url.port(),
             unix_socket: unix_socket,
             client_flags: client_flags,
-            #[cfg(not(windows))]
             ssl_mode: ssl_mode,
         })
     }
@@ -158,7 +154,6 @@ impl ConnectionOptions {
         self.client_flags
     }
 
-    #[cfg(not(windows))]
     pub fn ssl_mode(&self) -> Option<mysql_ssl_mode> {
         self.ssl_mode
     }
@@ -298,7 +293,6 @@ fn unix_socket_tests() {
     );
 }
 
-#[cfg(not(windows))]
 #[test]
 fn ssl_mode() {
     let ssl_mode = |url| ConnectionOptions::parse(url).unwrap().ssl_mode();

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 
 use crate::result::{ConnectionError, ConnectionResult};
+
+#[cfg(not(windows))]
 use mysqlclient_sys::mysql_ssl_mode;
 
 bitflags::bitflags! {
@@ -47,6 +49,7 @@ pub struct ConnectionOptions {
     port: Option<u16>,
     unix_socket: Option<CString>,
     client_flags: CapabilityFlags,
+    #[cfg(not(windows))]
     ssl_mode: Option<mysql_ssl_mode>,
 }
 
@@ -75,6 +78,7 @@ impl ConnectionOptions {
             _ => None,
         };
 
+        #[cfg(not(windows))]
         let ssl_mode = match query_pairs.get("ssl_mode") {
             Some(v) => {
                 let ssl_mode = match v.to_lowercase().as_str() {
@@ -121,6 +125,7 @@ impl ConnectionOptions {
             port: url.port(),
             unix_socket: unix_socket,
             client_flags: client_flags,
+            #[cfg(not(windows))]
             ssl_mode: ssl_mode,
         })
     }
@@ -153,6 +158,7 @@ impl ConnectionOptions {
         self.client_flags
     }
 
+    #[cfg(not(windows))]
     pub fn ssl_mode(&self) -> Option<mysql_ssl_mode> {
         self.ssl_mode
     }
@@ -292,6 +298,7 @@ fn unix_socket_tests() {
     );
 }
 
+#[cfg(not(windows))]
 #[test]
 fn ssl_mode() {
     let ssl_mode = |url| ConnectionOptions::parse(url).unwrap().ssl_mode();


### PR DESCRIPTION
This PR aims to add ssl connection support for MySQL backend, which is requested in the issue #786 .
At this stage it allow setting of mysql option `MYSQL_OPT_SSL_MODE` only.
The connection could be established  with `MYSQL_OPT_SSL_MODE` set to `SSL_MODE_DISABLED`, `SSL_MODE_PREFERRED` and `SSL_MODE_REQUIRED`.

Tested with
`DATABASE_URL='mysql://***?ssl_mode=(disabled|required|preferred)' cargo test --manifest-path diesel/Cargo.toml --features mysql --no-default-features mysql`

https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html
https://dev.mysql.com/doc/c-api/8.0/en/c-api-encrypted-connections.html