### PR TITLE
Expose sqlite's sqlite3_create_collation()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * It is now possible to inspect the type of values returned from the database
   in such a way to support constructing a dynamic value depending on this type.
 
+* Added ability to create custom collation functions in SQLite.
 
 ### Removed
 

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -17,7 +17,7 @@ pub fn register<ArgsSqlType, RetSqlType, Args, Ret, F>(
     mut f: F,
 ) -> QueryResult<()>
 where
-    F: FnMut(&RawConnection, Args) -> Ret + Send + 'static,
+    F: FnMut(&RawConnection, Args) -> Ret + Send + 'static + std::panic::RefUnwindSafe,
     Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -45,8 +45,14 @@ pub fn register_aggregate<ArgsSqlType, RetSqlType, Args, Ret, A>(
     fn_name: &str,
 ) -> QueryResult<()>
 where
-    A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
-    Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
+    A: SqliteAggregateFunction<Args, Output = Ret>
+        + 'static
+        + Send
+        + std::panic::UnwindSafe
+        + std::panic::RefUnwindSafe,
+    Args: FromSqlRow<ArgsSqlType, Sqlite>
+        + StaticallySizedRow<ArgsSqlType, Sqlite>
+        + std::panic::UnwindSafe,
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,
 {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -215,8 +215,10 @@ impl SqliteConnection {
         mut f: F,
     ) -> QueryResult<()>
     where
-        F: FnMut(Args) -> Ret + Send + 'static,
-        Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
+        F: FnMut(Args) -> Ret + Send + 'static + std::panic::RefUnwindSafe,
+        Args: FromSqlRow<ArgsSqlType, Sqlite>
+            + StaticallySizedRow<ArgsSqlType, Sqlite>
+            + std::panic::UnwindSafe,
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -242,6 +242,48 @@ impl SqliteConnection {
         functions::register_aggregate::<_, _, _, _, A>(&self.raw_connection, fn_name)
     }
 
+    /// Register a collation function.
+    ///
+    /// `collation` must always return the same answer given the same inputs.
+    /// If `collation` panics and unwinds the stack, the process is aborted, since it is used
+    /// across a C FFI boundary, which cannot be unwound across.
+    ///
+    /// If the name is already registered it will be overwritten.
+    ///
+    /// This method will return an error if registering the function fails, either due to an
+    /// out-of-memory situation or because a collation with that name already exists and is
+    /// currently being used in parallel by a query.
+    ///
+    /// The collation needs to be specified when creating a table:
+    /// `CREATE TABLE my_table ( str TEXT COLLATE MY_COLLATION )`,
+    /// where `MY_COLLATION` corresponds to `collation_name`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     let conn = SqliteConnection::establish(":memory:").unwrap();
+    /// // sqlite NOCASE only works for ASCII characters,
+    /// // this collation allows handling UTF-8 (barring locale differences)
+    /// conn.register_collation("RUSTNOCASE", |rhs, lhs| {
+    ///     rhs.to_lowercase().cmp(&lhs.to_lowercase())
+    /// })
+    /// # }
+    /// ```
+    pub fn register_collation<F>(&self, collation_name: &str, collation: F) -> QueryResult<()>
+    where
+        F: Fn(&str, &str) -> std::cmp::Ordering + Send + 'static,
+    {
+        self.raw_connection
+            .register_collation_function(collation_name, collation)
+    }
+
     fn register_diesel_sql_functions(&self) -> QueryResult<()> {
         use crate::sql_types::{Integer, Text};
 
@@ -513,5 +555,76 @@ mod tests {
             .get_result::<Option<i32>>(&connection)
             .unwrap();
         assert_eq!(Some(3), result);
+    }
+
+    table! {
+        my_collation_example {
+            id -> Integer,
+            value -> Text,
+        }
+    }
+
+    #[test]
+    fn register_collation_function() {
+        use self::my_collation_example::dsl::*;
+
+        let connection = SqliteConnection::establish(":memory:").unwrap();
+
+        connection
+            .register_collation("RUSTNOCASE", |rhs, lhs| {
+                rhs.to_lowercase().cmp(&lhs.to_lowercase())
+            })
+            .unwrap();
+
+        connection
+            .execute(
+                "CREATE TABLE my_collation_example (id integer primary key autoincrement, value text collate RUSTNOCASE)",
+            )
+            .unwrap();
+        connection
+            .execute("INSERT INTO my_collation_example (value) VALUES ('foo'), ('FOo'), ('f00')")
+            .unwrap();
+
+        let result = my_collation_example
+            .filter(value.eq("foo"))
+            .select(value)
+            .load::<String>(&connection);
+        assert_eq!(
+            Ok(&["foo".to_owned(), "FOo".to_owned()][..]),
+            result.as_ref().map(|vec| vec.as_ref())
+        );
+
+        let result = my_collation_example
+            .filter(value.eq("FOO"))
+            .select(value)
+            .load::<String>(&connection);
+        assert_eq!(
+            Ok(&["foo".to_owned(), "FOo".to_owned()][..]),
+            result.as_ref().map(|vec| vec.as_ref())
+        );
+
+        let result = my_collation_example
+            .filter(value.eq("f00"))
+            .select(value)
+            .load::<String>(&connection);
+        assert_eq!(
+            Ok(&["f00".to_owned()][..]),
+            result.as_ref().map(|vec| vec.as_ref())
+        );
+
+        let result = my_collation_example
+            .filter(value.eq("F00"))
+            .select(value)
+            .load::<String>(&connection);
+        assert_eq!(
+            Ok(&["f00".to_owned()][..]),
+            result.as_ref().map(|vec| vec.as_ref())
+        );
+
+        let result = my_collation_example
+            .filter(value.eq("oof"))
+            .select(value)
+            .load::<String>(&connection);
+        assert_eq!(Ok(&[][..]), result.as_ref().map(|vec| vec.as_ref()));
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -234,8 +234,14 @@ impl SqliteConnection {
         fn_name: &str,
     ) -> QueryResult<()>
     where
-        A: SqliteAggregateFunction<Args, Output = Ret> + 'static + Send,
-        Args: FromSqlRow<ArgsSqlType, Sqlite> + StaticallySizedRow<ArgsSqlType, Sqlite>,
+        A: SqliteAggregateFunction<Args, Output = Ret>
+            + 'static
+            + Send
+            + std::panic::UnwindSafe
+            + std::panic::RefUnwindSafe,
+        Args: FromSqlRow<ArgsSqlType, Sqlite>
+            + StaticallySizedRow<ArgsSqlType, Sqlite>
+            + std::panic::UnwindSafe,
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -24,12 +24,19 @@ pub trait SqliteAggregateFunction<Args>: Default {
     /// The result type of the SQLite aggregate function
     type Output;
 
-    /// The `step()` method is called once for every record of the query
+    /// The `step()` method is called once for every record of the query.
+    ///
+    /// This is called through a C FFI, as such panics do not propagate to the caller. Panics are
+    /// caught and cause a return with an error value. The implementation must still ensure that
+    /// state remains in a valid state (refer to [`std::panic::UnwindSafe`] for a bit more detail).
     fn step(&mut self, args: Args);
 
     /// After the last row has been processed, the `finalize()` method is
     /// called to compute the result of the aggregate function. If no rows
     /// were processed `aggregator` will be `None` and `finalize()` can be
-    /// used to specify a default result
+    /// used to specify a default result.
+    ///
+    /// This is called through a C FFI, as such panics do not propagate to the caller. Panics are
+    /// caught and cause a return with an error value.
     fn finalize(aggregator: Option<Self>) -> Self::Output;
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -906,6 +906,17 @@ pub fn derive_valid_grouping(input: TokenStream) -> TokenStream {
 /// # }
 /// ```
 ///
+/// ## Panics
+///
+/// If an implementation of the custom function panics and unwinding is enabled, the panic is
+/// caught and the function returns to libsqlite with an error. It cannot propagate the panics due
+/// to the FFI bounary.
+/// The function or closure is internally wrapped in an
+/// [`AssertUnwindSafe`](std::panic::AssertUnwindSafe). Its implementation must take care of
+/// unwind-safety to avoid logic bugs on panic.
+///
+/// This also holds for [custom aggregate functions](#custom-aggregate-functions).
+///
 /// ## Custom Aggregate Functions
 ///
 /// Custom aggregate functions can be created in SQLite by adding an `#[aggregate]`

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -263,9 +263,10 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                     f: F,
                 ) -> QueryResult<()>
                 where
-                    F: Fn(#(#arg_name,)*) -> Ret + Send + 'static,
+                    F: Fn(#(#arg_name,)*) -> Ret + Send + 'static + ::std::panic::RefUnwindSafe,
                     (#(#arg_name,)*): FromSqlRow<(#(#arg_type,)*), Sqlite> +
-                        StaticallySizedRow<(#(#arg_type,)*), Sqlite>,
+                        StaticallySizedRow<(#(#arg_type,)*), Sqlite> +
+                        ::std::panic::UnwindSafe,
                     Ret: ToSql<#return_type, Sqlite>,
                 {
                     conn.register_sql_function::<(#(#arg_type,)*), #return_type, _, _, _>(
@@ -289,9 +290,10 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                     mut f: F,
                 ) -> QueryResult<()>
                 where
-                    F: FnMut(#(#arg_name,)*) -> Ret + Send + 'static,
+                    F: FnMut(#(#arg_name,)*) -> Ret + Send + 'static + ::std::panic::RefUnwindSafe,
                     (#(#arg_name,)*): FromSqlRow<(#(#arg_type,)*), Sqlite> +
-                        StaticallySizedRow<(#(#arg_type,)*), Sqlite>,
+                        StaticallySizedRow<(#(#arg_type,)*), Sqlite> +
+                        ::std::panic::UnwindSafe,
                     Ret: ToSql<#return_type, Sqlite>,
                 {
                     conn.register_sql_function::<(#(#arg_type,)*), #return_type, _, _, _>(

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -178,10 +178,15 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                             conn: &SqliteConnection
                         ) -> QueryResult<()>
                             where
-                            A: SqliteAggregateFunction<(#(#arg_name,)*)> + Send + 'static,
+                            A: SqliteAggregateFunction<(#(#arg_name,)*)>
+                                + Send
+                                + 'static
+                                + ::std::panic::UnwindSafe
+                                + ::std::panic::RefUnwindSafe,
                             A::Output: ToSql<#return_type, Sqlite>,
                             (#(#arg_name,)*): FromSqlRow<(#(#arg_type,)*), Sqlite> +
-                                StaticallySizedRow<(#(#arg_type,)*), Sqlite>,
+                                StaticallySizedRow<(#(#arg_type,)*), Sqlite> +
+                                ::std::panic::UnwindSafe,
                         {
                             conn.register_aggregate_function::<(#(#arg_type,)*), #return_type, _, _, A>(#sql_name)
                         }
@@ -204,10 +209,15 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
                             conn: &SqliteConnection
                         ) -> QueryResult<()>
                             where
-                            A: SqliteAggregateFunction<#arg_name> + Send + 'static,
+                            A: SqliteAggregateFunction<#arg_name>
+                                + Send
+                                + 'static
+                                + std::panic::UnwindSafe
+                                + std::panic::RefUnwindSafe,
                             A::Output: ToSql<#return_type, Sqlite>,
                             #arg_name: FromSqlRow<#arg_type, Sqlite> +
-                                StaticallySizedRow<#arg_type, Sqlite>,
+                                StaticallySizedRow<#arg_type, Sqlite> +
+                                ::std::panic::UnwindSafe,
                             {
                                 conn.register_aggregate_function::<#arg_type, #return_type, _, _, A>(#sql_name)
                             }


### PR DESCRIPTION
This PR adds `diesel::sqlite::SqliteConnection::register_collation()`, which wraps `sqlite3_create_collation_v2()` (ref https://sqlite.org/c3ref/create_collation.html).
The registered collations can be used via the `COLLATE`-constraint on table columns, as is demonstrated in the tests.