### PR TITLE
Add support for dynamic select clauses to diesel_dynamic_schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,12 +253,11 @@ jobs:
           command: test
           args: --manifest-path diesel_tests/Cargo.toml --no-default-features --features "${{ matrix.backend }}"
 
-      - name: Run diesel_dynamic_schema tests"
-        if: matrix.backend == 'sqlite'
+      - name: Run diesel_dynamic_schema tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path diesel_dynamic_schema/Cargo.toml --no-default-features --features "diesel/${{ matrix.backend }}"
+          args: --manifest-path diesel_dynamic_schema/Cargo.toml --no-default-features --features "${{ matrix.backend }}"
 
       - name: Run rustdoc (nightly)
         if: matrix.run == 'nightly'

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -4,12 +4,16 @@ version = "1.0.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+autotests = false
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dependencies.diesel]
 version = "2.0.0"
 path = "../diesel/"
 default-features = false
+
+[dev-dependencies]
+dotenv = "0.14"
 
 [[example]]
 name = "querying_basic_schemas"
@@ -30,4 +34,9 @@ required-features = ["diesel/sqlite"]
 name = "integration_tests"
 path = "tests/lib.rs"
 harness = true
-required-features = ["diesel/sqlite"]
+
+[features]
+default = ["mysql"]
+postgres = ["diesel/postgres"]
+sqlite = ["diesel/sqlite"]
+mysql = ["diesel/mysql"]

--- a/diesel_dynamic_schema/src/dynamic_select.rs
+++ b/diesel_dynamic_schema/src/dynamic_select.rs
@@ -1,0 +1,102 @@
+use diesel::backend::Backend;
+use diesel::expression::{is_aggregate, NonAggregate, ValidGrouping};
+use diesel::query_builder::{
+    AstPass, IntoBoxedSelectClause, QueryFragment, QueryId, SelectClauseExpression,
+    SelectClauseQueryFragment,
+};
+use diesel::sql_types::Untyped;
+use diesel::{AppearsOnTable, Expression, QueryResult, SelectableExpression};
+use std::marker::PhantomData;
+
+/// Represents a dynamically sized select clause
+#[allow(missing_debug_implementations)]
+pub struct DynamicSelectClause<'a, DB, QS> {
+    selects: Vec<Box<dyn QueryFragment<DB> + Send + 'a>>,
+    p: PhantomData<QS>,
+}
+
+impl<'a, DB, QS> QueryId for DynamicSelectClause<'a, DB, QS> {
+    const HAS_STATIC_QUERY_ID: bool = false;
+    type QueryId = ();
+}
+
+impl<'a, DB, QS> Default for DynamicSelectClause<'a, DB, QS> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a, DB, QS> DynamicSelectClause<'a, DB, QS> {
+    /// Constructs a new dynamically sized select clause without any fields
+    pub fn new() -> Self {
+        Self {
+            selects: Vec::new(),
+            p: PhantomData,
+        }
+    }
+
+    /// Adds the field to the dynamically sized select clause
+    pub fn add_field<F>(&mut self, field: F)
+    where
+        F: QueryFragment<DB> + SelectableExpression<QS> + NonAggregate + Send + 'a,
+        DB: Backend,
+    {
+        self.selects.push(Box::new(field))
+    }
+}
+
+impl<'a, DB, QS> AppearsOnTable<QS> for DynamicSelectClause<'a, DB, QS> where Self: Expression {}
+
+impl<'a, DB, QS> SelectableExpression<QS> for DynamicSelectClause<'a, DB, QS> where
+    Self: AppearsOnTable<QS>
+{
+}
+
+impl<'a, QS, DB> Expression for DynamicSelectClause<'a, DB, QS> {
+    type SqlType = Untyped;
+}
+
+impl<'a, QS, DB> SelectClauseQueryFragment<QS, DB> for DynamicSelectClause<'a, QS, DB>
+where
+    DB: Backend,
+    Self: QueryFragment<DB>,
+{
+    fn walk_ast(&self, _source: &QS, pass: AstPass<DB>) -> QueryResult<()> {
+        <Self as QueryFragment<DB>>::walk_ast(self, pass)
+    }
+}
+
+impl<'a, DB, QS> QueryFragment<DB> for DynamicSelectClause<'a, DB, QS>
+where
+    DB: Backend,
+{
+    fn walk_ast(&self, mut pass: AstPass<DB>) -> QueryResult<()> {
+        let mut first = true;
+        for s in &self.selects {
+            if first {
+                first = false;
+            } else {
+                pass.push_sql(", ");
+            }
+            s.walk_ast(pass.reborrow())?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a, DB, QS> IntoBoxedSelectClause<'a, DB, QS> for DynamicSelectClause<'a, DB, QS>
+where
+    QS: Send,
+    Self: 'a + QueryFragment<DB> + SelectClauseExpression<QS>,
+    DB: Backend,
+{
+    type SqlType = Untyped;
+
+    fn into_boxed(self, _source: &QS) -> Box<dyn QueryFragment<DB> + Send + 'a> {
+        Box::new(self)
+    }
+}
+
+impl<'a, DB, QS> ValidGrouping<()> for DynamicSelectClause<'a, DB, QS> {
+    type IsAggregate = is_aggregate::No;
+}

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -1,0 +1,464 @@
+//! This module provides a container that allows to receive a dynamically
+//! specified number of fields from the database.
+//!
+//!
+//! ```rust
+//! # mod connection_setup {
+//! #     include!("../tests/connection_setup.rs");
+//! # }
+//! # use diesel::prelude::*;
+//! # use diesel::sql_types::{Untyped};
+//! # use diesel_dynamic_schema::{table, DynamicSelectClause};
+//! # use diesel_dynamic_schema::dynamic_value::*;
+//! # use diesel::dsl::sql_query;
+//! # use diesel::deserialize::{self, FromSql};
+//! #
+//! # #[derive(PartialEq, Debug)]
+//! # enum MyDynamicValue {
+//! #     String(String),
+//! #     Integer(i32),
+//! # }
+//! #
+//! # #[cfg(feature = "postgres")]
+//! # impl FromSql<Any, diesel::pg::Pg> for MyDynamicValue {
+//! #     fn from_sql(value: diesel::pg::PgValue) -> deserialize::Result<Self> {
+//! #         use diesel::pg::Pg;
+//! #         use std::num::NonZeroU32;
+//! #
+//! #         const VARCHAR_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1043) };
+//! #         const TEXT_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(25) };
+//! #         const INTEGER_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(23) };
+//! #
+//! #         match value.get_oid() {
+//! #             VARCHAR_OID | TEXT_OID => {
+//! #                 <String as FromSql<diesel::sql_types::Text, Pg>>::from_sql(value)
+//! #                     .map(MyDynamicValue::String)
+//! #             }
+//! #             INTEGER_OID => <i32 as FromSql<diesel::sql_types::Integer, Pg>>::from_sql(value)
+//! #                 .map(MyDynamicValue::Integer),
+//! #             e => Err(format!("Unknown type: {}", e).into()),
+//! #         }
+//! #     }
+//! # }
+//! #
+//! # #[cfg(feature = "sqlite")]
+//! # impl FromSql<Any, diesel::sqlite::Sqlite> for MyDynamicValue {
+//! #     fn from_sql(value: diesel::sqlite::SqliteValue) -> deserialize::Result<Self> {
+//! #         use diesel::sqlite::{Sqlite, SqliteType};
+//! #         match value.value_type() {
+//! #             Some(SqliteType::Text) => {
+//! #                 <String as FromSql<diesel::sql_types::Text, Sqlite>>::from_sql(value)
+//! #                     .map(MyDynamicValue::String)
+//! #             }
+//! #             Some(SqliteType::Long) => {
+//! #                 <i32 as FromSql<diesel::sql_types::Integer, Sqlite>>::from_sql(value)
+//! #                     .map(MyDynamicValue::Integer)
+//! #             }
+//! #             _ => Err("Unknown data type".into()),
+//! #         }
+//! #     }
+//! # }
+//! #
+//! # #[cfg(feature = "mysql")]
+//! # impl FromSql<Any, diesel::mysql::Mysql> for MyDynamicValue {
+//! #    fn from_sql(value: diesel::mysql::MysqlValue) -> deserialize::Result<Self> {
+//! #         use diesel::mysql::{Mysql, MysqlType};
+//! #         match value.value_type() {
+//! #              MysqlType::String => {
+//! #                  <String as FromSql<diesel::sql_types::Text, Mysql>>::from_sql(value)
+//! #                      .map(MyDynamicValue::String)
+//! #              }
+//! #              MysqlType::Long => <i32 as FromSql<diesel::sql_types::Integer, Mysql>>::from_sql(value)
+//! #                 .map(MyDynamicValue::Integer),
+//! #             e => Err(format!("Unknown data type: {:?}", e).into()),
+//! #         }
+//! #     }
+//! # }
+//! #
+//! # fn result_main() -> QueryResult<()> {
+//! #
+//! # let conn = connection_setup::establish_connection();
+//! #
+//! # // Create some example data by using typical SQL statements.
+//! # connection_setup::create_user_table(&conn);
+//! # // Create some example data by using typical SQL statements.
+//! # connection_setup::create_user_table(&conn);
+//! # sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn)?;
+//!
+//!     let users = diesel_dynamic_schema::table("users");
+//!     let id = users.column::<Untyped, _>("id");
+//!     let name = users.column::<Untyped, _>("name");
+//!
+//!     let mut select = DynamicSelectClause::new();
+//!
+//!     select.add_field(id);
+//!     select.add_field(name);
+//!
+//!     let actual_data: Vec<DynamicRow<NamedField<MyDynamicValue>>> =
+//!         users.select(select).load(&conn)?;
+//!
+//!     assert_eq!(
+//!         actual_data[0]["name"],
+//!         MyDynamicValue::String("Sean".into())
+//!     );
+//!     assert_eq!(
+//!         actual_data[0][1],
+//!         NamedField {
+//!             name: "name".into(),
+//!             value: MyDynamicValue::String("Sean".into())
+//!         }
+//!     );
+//!
+//! # Ok(())
+//! # }
+//! # result_main().unwrap()
+//! ```
+//!
+//! It is required to provide your own inner type to hold the actual database value.
+//!
+//! ```rust
+//! # use diesel_dynamic_schema::dynamic_value::Any;
+//! # use diesel::deserialize::{self, FromSql};
+//! #
+//! #[derive(PartialEq, Debug)]
+//! enum MyDynamicValue {
+//!    String(String),
+//!    Integer(i32),
+//! }
+//!
+//! # #[cfg(feature = "postgres")]
+//! impl FromSql<Any, diesel::pg::Pg> for MyDynamicValue {
+//!    fn from_sql(value: diesel::pg::PgValue) -> deserialize::Result<Self> {
+//!        use diesel::pg::Pg;
+//!        use std::num::NonZeroU32;
+//!
+//!        const VARCHAR_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1043) };
+//!        const TEXT_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(25) };
+//!        const INTEGER_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(23) };
+//!
+//!        match value.get_oid() {
+//!            VARCHAR_OID | TEXT_OID => {
+//!                <String as FromSql<diesel::sql_types::Text, Pg>>::from_sql(value)
+//!                    .map(MyDynamicValue::String)
+//!            }
+//!            INTEGER_OID => <i32 as FromSql<diesel::sql_types::Integer, Pg>>::from_sql(value)
+//!                .map(MyDynamicValue::Integer),
+//!            e => Err(format!("Unknown type: {}", e).into()),
+//!        }
+//!    }
+//! }
+//! ```
+
+use diesel::backend::Backend;
+use diesel::deserialize::{self, FromSql};
+use diesel::expression::{QueryMetadata, TypedExpressionType};
+use diesel::row::{Field, NamedRow, Row};
+use diesel::QueryableByName;
+use std::iter::FromIterator;
+use std::ops::Index;
+
+/// A marker type used to indicate that
+/// the provided `FromSql` impl does handle
+/// any passed database value, independently
+/// from the actual value kind
+pub struct Any;
+
+impl TypedExpressionType for Any {}
+
+#[cfg(feature = "postgres")]
+impl QueryMetadata<Any> for diesel::pg::Pg {
+    fn row_metadata(_lookup: &Self::MetadataLookup, out: &mut Vec<Option<Self::TypeMetadata>>) {
+        out.push(None)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl QueryMetadata<Any> for diesel::sqlite::Sqlite {
+    fn row_metadata(_lookup: &Self::MetadataLookup, out: &mut Vec<Option<Self::TypeMetadata>>) {
+        out.push(None)
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl QueryMetadata<Any> for diesel::mysql::Mysql {
+    fn row_metadata(_lookup: &Self::MetadataLookup, out: &mut Vec<Option<Self::TypeMetadata>>) {
+        out.push(None)
+    }
+}
+
+/// A dynamically sized container that allows to receive
+/// a not at compile time known number of columns from the database
+#[derive(Debug)]
+pub struct DynamicRow<I> {
+    values: Vec<I>,
+}
+
+/// A helper struct used as field type in `DynamicRow`
+/// to also return the name of the field along with the
+/// value
+#[derive(Debug, PartialEq)]
+pub struct NamedField<I> {
+    /// Name of the field
+    pub name: String,
+    /// Actual field value
+    pub value: I,
+}
+
+impl<I> FromIterator<I> for DynamicRow<I> {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = I>,
+    {
+        DynamicRow {
+            values: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl<I> DynamicRow<I> {
+    /// Get the field value at the provided row index
+    ///
+    /// Returns `None` if the index is outside the bounds of the row
+    pub fn get(&self, index: usize) -> Option<&I> {
+        self.values.get(index)
+    }
+
+    /// Get the number of fields in the current row
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Check if the current row is empty
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Create a new dynamic row from an existing database row
+    ///
+    /// This function is mostly useful for third party backends adding
+    /// support for `diesel_dynamic_schema`
+    pub fn from_row<'a, DB>(row: &impl Row<'a, DB>) -> deserialize::Result<Self>
+    where
+        DB: Backend,
+        I: FromSql<Any, DB>,
+    {
+        let data = (0..row.field_count())
+            .map(|i| {
+                let field = Row::get(row, i).expect("We checked the field count above");
+
+                I::from_nullable_sql(field.value())
+            })
+            .collect::<deserialize::Result<_>>()?;
+
+        Ok(Self { values: data })
+    }
+}
+
+impl<I> DynamicRow<NamedField<I>> {
+    /// Get the field value by the provided field name
+    ///
+    /// Returns `None` if the field with the specified name is not found.
+    /// If there are multiple fields with the same name, the behaviour
+    /// of this function is unspecified.
+    pub fn get_by_name<S: AsRef<str>>(&self, name: S) -> Option<&I> {
+        self.values
+            .iter()
+            .find(|f| f.name == name.as_ref())
+            .map(|f| &f.value)
+    }
+}
+
+impl<I> DynamicRow<NamedField<Option<I>>> {
+    /// Create a new dynamic row instance with corresponding field information from the given
+    /// database row
+    ///
+    /// This function is mostly useful for third party backends adding
+    /// support for `diesel_dynamic_schema`
+    pub fn from_nullable_row<'a, DB>(row: &impl Row<'a, DB>) -> deserialize::Result<Self>
+    where
+        DB: Backend,
+        I: FromSql<Any, DB>,
+    {
+        let data = (0..row.field_count())
+            .map(|i| {
+                let field = Row::get(row, i).expect("We checked the field count above");
+
+                let value = match I::from_nullable_sql(field.value()) {
+                    Ok(o) => Some(o),
+                    Err(e) if e.is::<diesel::result::UnexpectedNullError>() => None,
+                    Err(e) => return Err(e),
+                };
+
+                Ok(NamedField {
+                    name: field
+                        .field_name()
+                        .ok_or("Try to load an unnamed field")?
+                        .to_owned(),
+                    value,
+                })
+            })
+            .collect::<deserialize::Result<Vec<_>>>()?;
+        Ok(DynamicRow { values: data })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<I> QueryableByName<diesel::pg::Pg> for DynamicRow<I>
+where
+    I: FromSql<Any, diesel::pg::Pg>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, diesel::pg::Pg>) -> deserialize::Result<Self> {
+        Self::from_row(row)
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<I> QueryableByName<diesel::mysql::Mysql> for DynamicRow<I>
+where
+    I: FromSql<Any, diesel::mysql::Mysql>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, diesel::mysql::Mysql>) -> deserialize::Result<Self> {
+        Self::from_row(row)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<I> QueryableByName<diesel::sqlite::Sqlite> for DynamicRow<I>
+where
+    I: FromSql<Any, diesel::sqlite::Sqlite>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, diesel::sqlite::Sqlite>) -> deserialize::Result<Self> {
+        Self::from_row(row)
+    }
+}
+
+impl<I, DB> QueryableByName<DB> for DynamicRow<Option<I>>
+where
+    DB: Backend,
+    I: FromSql<Any, DB>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, DB>) -> deserialize::Result<Self> {
+        let data = (0..row.field_count())
+            .map(|i| {
+                let field = Row::get(row, i).expect("We checked the field count above");
+
+                match I::from_nullable_sql(field.value()) {
+                    Ok(o) => Ok(Some(o)),
+                    Err(e) if e.is::<diesel::result::UnexpectedNullError>() => Ok(None),
+                    Err(e) => Err(e),
+                }
+            })
+            .collect::<deserialize::Result<_>>()?;
+
+        Ok(Self { values: data })
+    }
+}
+
+impl<I, DB> QueryableByName<DB> for DynamicRow<NamedField<I>>
+where
+    DB: Backend,
+    I: FromSql<Any, DB>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, DB>) -> deserialize::Result<Self> {
+        let data = (0..row.field_count())
+            .map(|i| {
+                let field = Row::get(row, i).expect("We checked the field count above");
+
+                let value = I::from_nullable_sql(field.value())?;
+
+                Ok(NamedField {
+                    name: field
+                        .field_name()
+                        .ok_or("Try to load an unnamed field")?
+                        .to_owned(),
+                    value,
+                })
+            })
+            .collect::<deserialize::Result<Vec<_>>>()?;
+        Ok(DynamicRow { values: data })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<I> QueryableByName<diesel::pg::Pg> for DynamicRow<NamedField<Option<I>>>
+where
+    I: FromSql<Any, diesel::pg::Pg>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, diesel::pg::Pg>) -> deserialize::Result<Self> {
+        Self::from_nullable_row(row)
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl<I> QueryableByName<diesel::mysql::Mysql> for DynamicRow<NamedField<Option<I>>>
+where
+    I: FromSql<Any, diesel::mysql::Mysql>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, diesel::mysql::Mysql>) -> deserialize::Result<Self> {
+        Self::from_nullable_row(row)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<I> QueryableByName<diesel::sqlite::Sqlite> for DynamicRow<NamedField<Option<I>>>
+where
+    I: FromSql<Any, diesel::sqlite::Sqlite>,
+{
+    fn build<'a>(row: &impl NamedRow<'a, diesel::sqlite::Sqlite>) -> deserialize::Result<Self> {
+        Self::from_nullable_row(row)
+    }
+}
+
+impl<I> Index<usize> for DynamicRow<I> {
+    type Output = I;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.values[index]
+    }
+}
+
+impl<'a, I> Index<&'a str> for DynamicRow<NamedField<I>> {
+    type Output = I;
+
+    fn index(&self, field_name: &'a str) -> &Self::Output {
+        self.values
+            .iter()
+            .find(|f| f.name == field_name)
+            .map(|f| &f.value)
+            .expect("Field not found")
+    }
+}
+
+impl<'a, I> Index<&'a String> for DynamicRow<NamedField<I>> {
+    type Output = I;
+
+    fn index(&self, field_name: &'a String) -> &Self::Output {
+        self.index(field_name as &str)
+    }
+}
+
+impl<I> Index<String> for DynamicRow<NamedField<I>> {
+    type Output = I;
+
+    fn index(&self, field_name: String) -> &Self::Output {
+        self.index(&field_name)
+    }
+}
+
+impl<V> IntoIterator for DynamicRow<V> {
+    type Item = V;
+    type IntoIter = <Vec<V> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter()
+    }
+}
+
+impl<'a, V> IntoIterator for &'a DynamicRow<V> {
+    type Item = &'a V;
+    type IntoIter = <&'a Vec<V> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter()
+    }
+}

--- a/diesel_dynamic_schema/src/lib.rs
+++ b/diesel_dynamic_schema/src/lib.rs
@@ -27,18 +27,22 @@
 //! when using this crate.
 //!
 //! ```rust
+//! # mod connection_setup {
+//! #     include!("../tests/connection_setup.rs");
+//! # }
+//! # use connection_setup::establish_connection;
 //! # use diesel::prelude::*;
 //! # use diesel::sql_types::{Integer, Text};
-//! # use diesel::sqlite::SqliteConnection;
 //! # use diesel_dynamic_schema::table;
 //! # use diesel::dsl::sql_query;
 //! #
+//! #
 //! # fn result_main() -> QueryResult<()> {
 //! #
-//! # let conn = SqliteConnection::establish(":memory:").unwrap();
+//! # let conn = establish_connection();
 //! #
 //! # // Create some example data by using typical SQL statements.
-//! # sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn)?;
+//! # connection_setup::create_user_table(&conn);
 //! # sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn)?;
 //! #
 //! // Use diesel-dynamic-schema to create a table and columns.
@@ -72,13 +76,13 @@
 //! [gitter.im/diesel-rs/diesel](https://gitter.im/diesel-rs/diesel)
 
 // Built-in Lints
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 #![deny(warnings)]
-
-extern crate diesel;
 
 mod column;
 mod dummy_expression;
+mod dynamic_select;
+pub mod dynamic_value;
 mod schema;
 mod table;
 
@@ -90,6 +94,9 @@ pub use schema::Schema;
 
 /// A database table.
 pub use table::Table;
+
+#[doc(inline)]
+pub use self::dynamic_select::DynamicSelectClause;
 
 /// Create a new [`Table`](struct.Table.html) with the given name.
 ///

--- a/diesel_dynamic_schema/tests/connection_setup.rs
+++ b/diesel_dynamic_schema/tests/connection_setup.rs
@@ -1,0 +1,67 @@
+#[cfg(feature = "postgres")]
+pub fn create_user_table(conn: &diesel::PgConnection) {
+    use diesel::*;
+
+    diesel::sql_query("CREATE TABLE IF NOT EXISTS users (id Serial PRIMARY KEY, name TEXT NOT NULL DEFAULT '', hair_color TEXT)")
+        .execute(conn)
+        .unwrap();
+}
+
+#[cfg(feature = "sqlite")]
+pub fn create_user_table(conn: &diesel::SqliteConnection) {
+    use diesel::*;
+
+    diesel::sql_query("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL DEFAULT '', hair_color TEXT)")
+        .execute(conn)
+        .unwrap();
+}
+
+#[cfg(feature = "mysql")]
+pub fn create_user_table(conn: &diesel::MysqlConnection) {
+    use diesel::*;
+
+    diesel::sql_query("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTO_INCREMENT, name TEXT NOT NULL, hair_color TEXT)")
+        .execute(conn)
+        .unwrap();
+    diesel::sql_query("DELETE FROM users")
+        .execute(conn)
+        .unwrap();
+}
+
+#[cfg(feature = "sqlite")]
+pub fn establish_connection() -> diesel::SqliteConnection {
+    use diesel::*;
+
+    SqliteConnection::establish(":memory:").unwrap()
+}
+
+#[cfg(feature = "postgres")]
+pub fn establish_connection() -> diesel::PgConnection {
+    use diesel::*;
+
+    let conn = PgConnection::establish(
+        &dotenv::var("DATABASE_URL")
+            .or_else(|_| dotenv::var("PG_DATABASE_URL"))
+            .expect("Set either `DATABASE_URL` or `PG_DATABASE_URL`"),
+    )
+    .unwrap();
+
+    conn.begin_test_transaction().unwrap();
+    conn
+}
+
+#[cfg(feature = "mysql")]
+pub fn establish_connection() -> diesel::MysqlConnection {
+    use diesel::*;
+
+    let conn = MysqlConnection::establish(
+        &dotenv::var("DATABASE_URL")
+            .or_else(|_| dotenv::var("MYSQL_DATABASE_URL"))
+            .expect("Set either `DATABASE_URL` or `MYSQL_DATABASE_URL`"),
+    )
+    .unwrap();
+
+    conn.begin_test_transaction().unwrap();
+
+    conn
+}

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -1,0 +1,205 @@
+use diesel::deserialize::*;
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::*;
+use diesel_dynamic_schema::dynamic_value::*;
+use diesel_dynamic_schema::DynamicSelectClause;
+
+#[derive(PartialEq, Debug)]
+enum MyDynamicValue {
+    String(String),
+    Integer(i32),
+}
+
+#[cfg(feature = "postgres")]
+impl FromSql<Any, diesel::pg::Pg> for MyDynamicValue {
+    fn from_sql(value: diesel::pg::PgValue) -> Result<Self> {
+        use diesel::pg::Pg;
+        use std::num::NonZeroU32;
+
+        const VARCHAR_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1043) };
+        const TEXT_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(25) };
+        const INTEGER_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(23) };
+
+        match value.get_oid() {
+            VARCHAR_OID | TEXT_OID => {
+                <String as FromSql<diesel::sql_types::Text, Pg>>::from_sql(value)
+                    .map(MyDynamicValue::String)
+            }
+            INTEGER_OID => <i32 as FromSql<diesel::sql_types::Integer, Pg>>::from_sql(value)
+                .map(MyDynamicValue::Integer),
+            e => Err(format!("Unknown type: {}", e).into()),
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl FromSql<Any, diesel::sqlite::Sqlite> for MyDynamicValue {
+    fn from_sql(value: diesel::sqlite::SqliteValue) -> Result<Self> {
+        use diesel::sqlite::{Sqlite, SqliteType};
+        match value.value_type() {
+            Some(SqliteType::Text) => {
+                <String as FromSql<diesel::sql_types::Text, Sqlite>>::from_sql(value)
+                    .map(MyDynamicValue::String)
+            }
+            Some(SqliteType::Long) => {
+                <i32 as FromSql<diesel::sql_types::Integer, Sqlite>>::from_sql(value)
+                    .map(MyDynamicValue::Integer)
+            }
+            _ => Err("Unknown data type".into()),
+        }
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl FromSql<Any, diesel::mysql::Mysql> for MyDynamicValue {
+    fn from_sql(value: diesel::mysql::MysqlValue) -> Result<Self> {
+        use diesel::mysql::{Mysql, MysqlType};
+        match value.value_type() {
+            MysqlType::String => {
+                <String as FromSql<diesel::sql_types::Text, Mysql>>::from_sql(value)
+                    .map(MyDynamicValue::String)
+            }
+            MysqlType::Long => <i32 as FromSql<diesel::sql_types::Integer, Mysql>>::from_sql(value)
+                .map(MyDynamicValue::Integer),
+            e => Err(format!("Unknown data type: {:?}", e).into()),
+        }
+    }
+}
+
+#[test]
+fn dynamic_query() {
+    let connection = super::establish_connection();
+    crate::create_user_table(&connection);
+    sql_query("INSERT INTO users (name, hair_color) VALUES ('Sean', 'black'), ('Tess', 'black')")
+        .execute(&connection)
+        .unwrap();
+
+    let users = diesel_dynamic_schema::table("users");
+    let id = users.column::<Untyped, _>("id");
+    let name = users.column::<Untyped, _>("name");
+    let hair_color = users.column::<Untyped, _>("hair_color");
+
+    let mut select = DynamicSelectClause::new();
+
+    select.add_field(id);
+    select.add_field(name);
+    select.add_field(hair_color);
+
+    let actual_data: Vec<DynamicRow<NamedField<MyDynamicValue>>> =
+        users.select(select).load(&connection).unwrap();
+
+    assert_eq!(
+        actual_data[0]["name"],
+        MyDynamicValue::String("Sean".into())
+    );
+    assert_eq!(
+        actual_data[0][1],
+        NamedField {
+            name: "name".into(),
+            value: MyDynamicValue::String("Sean".into())
+        }
+    );
+    assert_eq!(
+        actual_data[1]["name"],
+        MyDynamicValue::String("Tess".into())
+    );
+    assert_eq!(
+        actual_data[1][1],
+        NamedField {
+            name: "name".into(),
+            value: MyDynamicValue::String("Tess".into())
+        }
+    );
+    assert_eq!(
+        actual_data[0]["hair_color"],
+        MyDynamicValue::String("black".into())
+    );
+    assert_eq!(
+        actual_data[0][2],
+        NamedField {
+            name: "hair_color".into(),
+            value: MyDynamicValue::String("black".into())
+        }
+    );
+    assert_eq!(
+        actual_data[1]["hair_color"],
+        MyDynamicValue::String("black".into())
+    );
+    assert_eq!(
+        actual_data[1][2],
+        NamedField {
+            name: "hair_color".into(),
+            value: MyDynamicValue::String("black".into())
+        }
+    );
+
+    let mut select = DynamicSelectClause::new();
+
+    select.add_field(id);
+    select.add_field(name);
+    select.add_field(hair_color);
+
+    let actual_data: Vec<DynamicRow<MyDynamicValue>> =
+        users.select(select).load(&connection).unwrap();
+
+    assert_eq!(actual_data[0][1], MyDynamicValue::String("Sean".into()));
+    assert_eq!(actual_data[1][1], MyDynamicValue::String("Tess".into()));
+    assert_eq!(actual_data[0][2], MyDynamicValue::String("black".into()));
+    assert_eq!(actual_data[1][2], MyDynamicValue::String("black".into()));
+}
+
+#[test]
+fn mixed_value_query() {
+    use diesel::dsl::sql;
+
+    let connection = crate::establish_connection();
+    crate::create_user_table(&connection);
+    sql_query("INSERT INTO users (id, name, hair_color) VALUES (42, 'Sean', 'black'), (43, 'Tess', 'black')")
+        .execute(&connection)
+        .unwrap();
+
+    let users = diesel_dynamic_schema::table("users");
+    let id = users.column::<Integer, _>("id");
+
+    let (id, row) = users
+        .select((id, sql::<Untyped>("name, hair_color")))
+        .first::<(i32, DynamicRow<NamedField<MyDynamicValue>>)>(&connection)
+        .unwrap();
+
+    assert_eq!(id, 42);
+    assert_eq!(row["name"], MyDynamicValue::String("Sean".into()));
+    assert_eq!(row["hair_color"], MyDynamicValue::String("black".into()));
+}
+
+#[test]
+fn nullable_dynamic_value() {
+    use diesel::dsl::sql;
+
+    let connection = crate::establish_connection();
+    crate::create_user_table(&connection);
+    sql_query("INSERT INTO users (name, hair_color) VALUES ('Sean', 'dark'), ('Tess', NULL)")
+        .execute(&connection)
+        .unwrap();
+
+    let users = diesel_dynamic_schema::table("users");
+
+    let result = users
+        .select(sql::<Untyped>("hair_color"))
+        .load::<DynamicRow<Option<MyDynamicValue>>>(&connection)
+        .unwrap();
+
+    assert_eq!(result[0][0], Some(MyDynamicValue::String("dark".into())));
+    assert_eq!(result[1][0], None);
+
+    let result = users
+        .select(sql::<Untyped>("hair_color"))
+        .load::<DynamicRow<NamedField<Option<MyDynamicValue>>>>(&connection)
+        .unwrap();
+
+    assert_eq!(
+        result[0]["hair_color"],
+        Some(MyDynamicValue::String("dark".into()))
+    );
+    assert_eq!(result[1]["hair_color"], None);
+}

--- a/diesel_dynamic_schema/tests/lib.rs
+++ b/diesel_dynamic_schema/tests/lib.rs
@@ -2,70 +2,85 @@ extern crate diesel;
 extern crate diesel_dynamic_schema;
 
 use diesel::sql_types::*;
-use diesel::sqlite::Sqlite;
 use diesel::*;
 use diesel_dynamic_schema::{schema, table};
+
+mod dynamic_values;
+
+mod connection_setup;
+
+use connection_setup::{create_user_table, establish_connection};
+
+#[cfg(feature = "postgres")]
+type Backend = diesel::pg::Pg;
+#[cfg(feature = "mysql")]
+type Backend = diesel::mysql::Mysql;
+#[cfg(feature = "sqlite")]
+type Backend = diesel::sqlite::Sqlite;
 
 #[test]
 fn querying_basic_schemas() {
     let conn = establish_connection();
-    sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT)")
-        .execute(&conn)
-        .unwrap();
-    sql_query("INSERT INTO users DEFAULT VALUES")
+    create_user_table(&conn);
+    sql_query("INSERT INTO users(name) VALUES ('Sean')")
         .execute(&conn)
         .unwrap();
 
     let users = table("users");
-    let id = users.column::<Integer, _>("id");
-    let ids = users.select(id).load::<i32>(&conn);
-    assert_eq!(Ok(vec![1]), ids);
+    let name = users.column::<Text, _>("name");
+    let names = users.select(name).load::<String>(&conn);
+    assert_eq!(Ok(vec!["Sean".into()]), names);
 }
 
 #[test]
 fn querying_multiple_types() {
     let conn = establish_connection();
-    sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)")
-        .execute(&conn)
-        .unwrap();
+    create_user_table(&conn);
     sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
         .execute(&conn)
         .unwrap();
 
     let users = table("users");
-    let id = users.column::<Integer, _>("id");
+    let hair_color = users.column::<Nullable<Text>, _>("hair_color");
     let name = users.column::<Text, _>("name");
-    let users = users.select((id, name)).load::<(i32, String)>(&conn);
-    assert_eq!(Ok(vec![(1, "Sean".into()), (2, "Tess".into())]), users);
+    let users = users
+        .select((name, hair_color))
+        .load::<(String, Option<String>)>(&conn);
+    assert_eq!(
+        Ok(vec![("Sean".into(), None), ("Tess".into(), None)]),
+        users
+    );
 }
 
 #[test]
 fn columns_used_in_where_clause() {
     let conn = establish_connection();
-    sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)")
-        .execute(&conn)
-        .unwrap();
+    create_user_table(&conn);
     sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
         .execute(&conn)
         .unwrap();
 
     let users = table("users");
-    let id = users.column::<Integer, _>("id");
     let name = users.column::<Text, _>("name");
     let users = users
-        .select((id, name))
+        .select(name)
         .filter(name.eq("Sean"))
-        .load::<(i32, String)>(&conn);
-    assert_eq!(Ok(vec![(1, "Sean".into())]), users);
+        .load::<String>(&conn);
+
+    assert_eq!(Ok(vec!["Sean".into()]), users);
 }
 
 #[test]
 fn providing_custom_schema_name() {
     let table = schema("information_schema").table("users");
-    let sql = debug_query::<Sqlite, _>(&table);
-    assert_eq!("`information_schema`.`users` -- binds: []", sql.to_string());
-}
+    let sql = debug_query::<Backend, _>(&table);
 
-fn establish_connection() -> SqliteConnection {
-    SqliteConnection::establish(":memory:").unwrap()
+    #[cfg(feature = "postgres")]
+    assert_eq!(
+        r#""information_schema"."users" -- binds: []"#,
+        sql.to_string()
+    );
+
+    #[cfg(not(feature = "postgres"))]
+    assert_eq!("`information_schema`.`users` -- binds: []", sql.to_string());
 }


### PR DESCRIPTION
This commit adds support for constructing dynamic select clauses and
receiving values into a dynamically sized container. I've opted for
requiring a user provided type as value type in the dynamically sized
`DynamicRow<I>` container, because that type needs to handle all
possible values that can appear in the loaded row. The requirements for
such type are normally highly dependent on the actual use case,
therefore we do not provide a "covers all cases" container type yet. The
implementation leave open the possibility to add such a container type
by just setting a default type for the generic paramater there.

See the added test cases and documentation for examples how to use this feature.