### PR TITLE
Added getters for dynamic tables, columns and schemas

### DIFF
--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -25,6 +25,16 @@ impl<T, U, ST> Column<T, U, ST> {
             _sql_type: PhantomData,
         }
     }
+
+    /// Gets a reference to the table of the column.
+    pub fn table(&self) -> &T {
+        &self.table
+    }
+
+    /// Gets the name of the column, as provided on creation.
+    pub fn name(&self) -> &U {
+        &self.name
+    }
 }
 
 impl<T, U, ST> QueryId for Column<T, U, ST> {

--- a/diesel_dynamic_schema/src/schema.rs
+++ b/diesel_dynamic_schema/src/schema.rs
@@ -19,4 +19,9 @@ impl<T> Schema<T> {
     {
         Table::with_schema(self.name.clone(), name)
     }
+
+    /// Gets the name of the schema, as specified on creation.
+    pub fn name(&self) -> &T {
+        &self.name
+    }
 }

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -35,6 +35,11 @@ impl<T, U> Table<T, U> {
     {
         Column::new(self.clone(), name)
     }
+
+    /// Gets the name of the table, as especified on creation.
+    pub fn name(&self) -> &T {
+        &self.name
+    }
 }
 
 impl<T, U> QuerySource for Table<T, U>


### PR DESCRIPTION
This PR adds getters for dynamic tables, coluns and schemas in `diesel_dynamic_schema`, in order to allow retrieving the table, colum and schema names, and the table of a column, if the original information is no longer available.

This was previously merged here: https://github.com/GiGainfosystems/diesel-dynamic-schema/pull/3, but it seems it was not added to the `diesel` repo.