### PR TITLE
Fix #2140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   so non generic code does not require any change. For generic code you likely need to
   replace a trait bound on `Queryable<ST, DB>` with a trait bound on `FromSqlRow<ST, DB>`
   and a bound to `QueryableByName<DB>` with `FromSqlRow<Untyped, DB>`.
+  
+* Diesel's dsl now accept not nullable expressions in positions where nullable expressions 
+  are expected, without needing to call `.nullable()` explicitly
 
 
 ### Fixed
@@ -159,6 +162,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * We've refactored our type level representation of nullable values. This allowed us to
   fix multiple long standing bugs regarding the correct handling of nullable values in some
   corner cases (#104, #2274)
+  
+* Parenthesis are now inserted around all infix operations provided by diesel's `ExpressionMethods` traits
 
 ### Deprecated
 

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -108,7 +108,10 @@ where
     type InExpression = Many<T::Expression>;
 
     fn as_in_expression(self) -> Self::InExpression {
-        let expressions = self.into_iter().map(AsExpression::as_expression).collect();
+        let expressions = self
+            .into_iter()
+            .map(<T as AsExpression<ST>>::as_expression)
+            .collect();
         Many(expressions)
     }
 }

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -3,7 +3,7 @@ use super::{Expression, ValidGrouping};
 use crate::backend::Backend;
 use crate::query_builder::*;
 use crate::result::QueryResult;
-use crate::sql_types::{BigInt, DieselNumericOps, SingleValue, SqlType};
+use crate::sql_types::{BigInt, DieselNumericOps, Nullable, SingleValue, SqlType};
 
 sql_function! {
     /// Creates a SQL `COUNT` expression
@@ -25,7 +25,7 @@ sql_function! {
     /// # }
     /// ```
     #[aggregate]
-    fn count<T: SqlType + SingleValue>(expr: T) -> BigInt;
+    fn count<T: SqlType + SingleValue>(expr: Nullable<T>) -> BigInt;
 }
 
 /// Creates a SQL `COUNT(*)` expression

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,5 +1,5 @@
 use crate::expression::functions::sql_function;
-use crate::sql_types::Foldable;
+use crate::sql_types::{Foldable, Nullable};
 
 sql_function! {
     /// Represents a SQL `SUM` function. This function can only take types which are
@@ -18,7 +18,7 @@ sql_function! {
     /// # }
     /// ```
     #[aggregate]
-    fn sum<ST: Foldable>(expr: ST) -> ST::Sum;
+    fn sum<ST: Foldable>(expr: Nullable<ST>) -> ST::Sum;
 }
 
 sql_function! {
@@ -64,5 +64,5 @@ sql_function! {
     /// #     Ok(())
     /// # }
     #[aggregate]
-    fn avg<ST: Foldable>(expr: ST) -> ST::Avg;
+    fn avg<ST: Foldable>(expr: Nullable<ST>) -> ST::Avg;
 }

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,16 +1,16 @@
 use crate::expression::functions::sql_function;
-use crate::sql_types::{IntoNullable, SingleValue, SqlOrd, SqlType};
+use crate::sql_types::{IntoNullable, Nullable, SingleValue, SqlOrd, SqlType};
 
 pub trait SqlOrdAggregate: SingleValue {
     type Ret: SqlType + SingleValue;
 }
 
-impl<T> SqlOrdAggregate for T
+impl<ST> SqlOrdAggregate for ST
 where
-    T: SqlOrd + IntoNullable + SingleValue,
-    T::Nullable: SqlType + SingleValue,
+    ST: SqlOrd + SingleValue + IntoNullable,
+    ST::Nullable: SingleValue,
 {
-    type Ret = T::Nullable;
+    type Ret = <Self as IntoNullable>::Nullable;
 }
 
 sql_function! {
@@ -29,7 +29,7 @@ sql_function! {
     /// assert_eq!(Ok(Some(8)), animals.select(max(legs)).first(&connection));
     /// # }
     #[aggregate]
-    fn max<ST: SqlOrdAggregate>(expr: ST) -> ST::Ret;
+    fn max<ST: SqlOrdAggregate>(expr: Nullable<ST>) -> ST::Ret;
 }
 
 sql_function! {
@@ -48,5 +48,5 @@ sql_function! {
     /// assert_eq!(Ok(Some(4)), animals.select(min(legs)).first(&connection));
     /// # }
     #[aggregate]
-    fn min<ST: SqlOrdAggregate>(expr: ST) -> ST::Ret;
+    fn min<ST: SqlOrdAggregate>(expr: Nullable<ST>) -> ST::Ret;
 }

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -1,7 +1,8 @@
 use crate::backend::Backend;
-use crate::expression::coerce::Coerce;
 use crate::expression::functions::sql_function;
-use crate::expression::{AsExpression, Expression, ValidGrouping};
+#[cfg(feature = "postgres")]
+use crate::expression::{coerce::Coerce, AsExpression};
+use crate::expression::{Expression, ValidGrouping};
 use crate::query_builder::*;
 use crate::result::QueryResult;
 use crate::sql_types::*;
@@ -46,14 +47,6 @@ sql_function! {
     fn date(expr: Timestamp) -> Date;
 }
 
-impl AsExpression<Nullable<Timestamp>> for now {
-    type Expression = Coerce<now, Nullable<Timestamp>>;
-
-    fn as_expression(self) -> Self::Expression {
-        Coerce::new(self)
-    }
-}
-
 #[cfg(feature = "postgres")]
 impl AsExpression<Timestamptz> for now {
     type Expression = Coerce<now, Timestamptz>;
@@ -92,11 +85,3 @@ impl_selectable_expression!(today);
 
 operator_allowed!(today, Add, add);
 operator_allowed!(today, Sub, sub);
-
-impl AsExpression<Nullable<Date>> for today {
-    type Expression = Coerce<today, Nullable<Date>>;
-
-    fn as_expression(self) -> Self::Expression {
-        Coerce::new(self)
-    }
-}

--- a/diesel/src/expression/functions/helper_types.rs
+++ b/diesel/src/expression/functions/helper_types.rs
@@ -3,10 +3,10 @@
 use crate::dsl::{AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
 use crate::expression::operators;
-use crate::sql_types::Bool;
+use crate::sql_types::{Bool, Nullable};
 
 /// The return type of [`not(expr)`](../dsl/fn.not.html)
-pub type not<Expr> = operators::Not<Grouped<AsExprOf<Expr, Bool>>>;
+pub type not<Expr> = operators::Not<Grouped<AsExprOf<Expr, Nullable<Bool>>>>;
 
 /// The return type of [`max(expr)`](../dsl/fn.max.html)
 pub type max<Expr> = super::aggregate_ordering::max::HelperType<SqlTypeOf<Expr>, Expr>;

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -17,55 +17,63 @@ pub type AsExprOf<Item, Type> = <Item as AsExpression<Type>>::Expression;
 
 /// The return type of
 /// [`lhs.eq(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.eq)
-pub type Eq<Lhs, Rhs> = super::operators::Eq<Lhs, AsExpr<Rhs, Lhs>>;
+pub type Eq<Lhs, Rhs> = Grouped<super::operators::Eq<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of
 /// [`lhs.ne(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.ne)
-pub type NotEq<Lhs, Rhs> = super::operators::NotEq<Lhs, AsExpr<Rhs, Lhs>>;
+pub type NotEq<Lhs, Rhs> = Grouped<super::operators::NotEq<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of
 /// [`lhs.eq_any(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.eq_any)
-pub type EqAny<Lhs, Rhs> = In<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>;
+pub type EqAny<Lhs, Rhs> = Grouped<In<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>>;
 
 /// The return type of
 /// [`lhs.ne_any(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.ne_any)
-pub type NeAny<Lhs, Rhs> = NotIn<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>;
+pub type NeAny<Lhs, Rhs> =
+    Grouped<NotIn<Lhs, <Rhs as AsInExpression<SqlTypeOf<Lhs>>>::InExpression>>;
 
 /// The return type of
 /// [`expr.is_null()`](../expression_methods/trait.ExpressionMethods.html#method.is_null)
-pub type IsNull<Expr> = super::operators::IsNull<Expr>;
+pub type IsNull<Expr> = Grouped<super::operators::IsNull<Expr>>;
 
 /// The return type of
 /// [`expr.is_not_null()`](../expression_methods/trait.ExpressionMethods.html#method.is_not_null)
-pub type IsNotNull<Expr> = super::operators::IsNotNull<Expr>;
+pub type IsNotNull<Expr> = Grouped<super::operators::IsNotNull<Expr>>;
 
 /// The return type of
 /// [`lhs.gt(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.gt)
-pub type Gt<Lhs, Rhs> = super::operators::Gt<Lhs, AsExpr<Rhs, Lhs>>;
+pub type Gt<Lhs, Rhs> = Grouped<super::operators::Gt<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of
 /// [`lhs.ge(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.ge)
-pub type GtEq<Lhs, Rhs> = super::operators::GtEq<Lhs, AsExpr<Rhs, Lhs>>;
+pub type GtEq<Lhs, Rhs> = Grouped<super::operators::GtEq<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of
 /// [`lhs.lt(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.lt)
-pub type Lt<Lhs, Rhs> = super::operators::Lt<Lhs, AsExpr<Rhs, Lhs>>;
+pub type Lt<Lhs, Rhs> = Grouped<super::operators::Lt<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of
 /// [`lhs.le(rhs)`](../expression_methods/trait.ExpressionMethods.html#method.le)
-pub type LtEq<Lhs, Rhs> = super::operators::LtEq<Lhs, AsExpr<Rhs, Lhs>>;
+pub type LtEq<Lhs, Rhs> = Grouped<super::operators::LtEq<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of
 /// [`lhs.between(lower, upper)`](../expression_methods/trait.ExpressionMethods.html#method.between)
-pub type Between<Lhs, Lower, Upper> =
-    super::operators::Between<Lhs, super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>>;
+pub type Between<Lhs, Lower, Upper> = Grouped<
+    super::operators::Between<Lhs, super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>>,
+>;
 
 /// The return type of
 /// [`lhs.not_between(lower, upper)`](../expression_methods/trait.ExpressionMethods.html#method.not_between)
-pub type NotBetween<Lhs, Lower, Upper> = super::operators::NotBetween<
-    Lhs,
-    super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>,
+pub type NotBetween<Lhs, Lower, Upper> = Grouped<
+    super::operators::NotBetween<
+        Lhs,
+        super::operators::And<AsExpr<Lower, Lhs>, AsExpr<Upper, Lhs>>,
+    >,
 >;
+
+/// The return type of
+/// [`lhs.concat(rhs)`](../expression_methods/trait.TextExpressionMethods.html#method.concat)
+pub type Concat<Lhs, Rhs> = Grouped<super::operators::Concat<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of
 /// [`expr.desc()`](../expression_methods/trait.ExpressionMethods.html#method.desc)
@@ -81,23 +89,32 @@ pub type Nullable<Expr> = super::nullable::Nullable<Expr>;
 
 /// The return type of
 /// [`lhs.and(rhs)`](../expression_methods/trait.BoolExpressionMethods.html#method.and)
-pub type And<Lhs, Rhs> = super::operators::And<Lhs, AsExprOf<Rhs, sql_types::Bool>>;
+pub type And<Lhs, Rhs> = Grouped<super::operators::And<Nullable<Lhs>, AsExpr<Rhs, Nullable<Lhs>>>>;
 
 /// The return type of
 /// [`lhs.or(rhs)`](../expression_methods/trait.BoolExpressionMethods.html#method.or)
-pub type Or<Lhs, Rhs> = Grouped<super::operators::Or<Lhs, AsExprOf<Rhs, sql_types::Bool>>>;
+pub type Or<Lhs, Rhs> = Grouped<super::operators::Or<Lhs, AsExpr<Rhs, Nullable<Lhs>>>>;
 
 /// The return type of
 /// [`lhs.escape('x')`](../expression_methods/trait.EscapeExpressionMethods.html#method.escape)
-pub type Escape<Lhs> = super::operators::Escape<Lhs, AsExprOf<String, sql_types::VarChar>>;
+pub type Escape<Lhs> = Grouped<
+    super::operators::Escape<
+        <Lhs as crate::expression_methods::EscapeExpressionMethods>::TextExpression,
+        AsExprOf<String, sql_types::VarChar>,
+    >,
+>;
 
 /// The return type of
 /// [`lhs.like(rhs)`](../expression_methods/trait.TextExpressionMethods.html#method.like)
-pub type Like<Lhs, Rhs> = super::operators::Like<Lhs, AsExprOf<Rhs, sql_types::VarChar>>;
+pub type Like<Lhs, Rhs> = Grouped<super::operators::Like<Lhs, AsExprOf<Rhs, SqlTypeOf<Lhs>>>>;
 
 /// The return type of
 /// [`lhs.not_like(rhs)`](../expression_methods/trait.TextExpressionMethods.html#method.not_like)
-pub type NotLike<Lhs, Rhs> = super::operators::NotLike<Lhs, AsExprOf<Rhs, sql_types::VarChar>>;
+pub type NotLike<Lhs, Rhs> = Grouped<super::operators::NotLike<Lhs, AsExprOf<Rhs, SqlTypeOf<Lhs>>>>;
 
 #[doc(inline)]
 pub use super::functions::helper_types::*;
+
+#[doc(inline)]
+#[cfg(feature = "postgres")]
+pub use crate::pg::expression::helper_types::*;

--- a/diesel/src/expression/not.rs
+++ b/diesel/src/expression/not.rs
@@ -1,7 +1,7 @@
 use crate::expression::grouped::Grouped;
 use crate::expression::AsExpression;
 use crate::helper_types::not;
-use crate::sql_types::Bool;
+use crate::sql_types::{Bool, Nullable};
 
 /// Creates a SQL `NOT` expression
 ///
@@ -23,6 +23,9 @@ use crate::sql_types::Bool;
 /// assert_eq!(Ok(2), users_not_with_name.first(&connection));
 /// # }
 /// ```
-pub fn not<T: AsExpression<Bool>>(expr: T) -> not<T> {
+pub fn not<T>(expr: T) -> not<T>
+where
+    T: AsExpression<Nullable<Bool>>,
+{
     super::operators::Not::new(Grouped(expr.as_expression()))
 }

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -56,3 +56,5 @@ where
     T: SelectableExpression<QS::InnerJoin>,
 {
 }
+
+impl<T> SelectableExpression<()> for Nullable<T> where Self: AppearsOnTable<()> {}

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -421,7 +421,6 @@ macro_rules! diesel_prefix_operator {
 }
 
 infix_operator!(And, " AND ");
-infix_operator!(Between, " BETWEEN ");
 infix_operator!(Escape, " ESCAPE ");
 infix_operator!(Eq, " = ");
 infix_operator!(Gt, " > ");
@@ -429,9 +428,10 @@ infix_operator!(GtEq, " >= ");
 infix_operator!(Like, " LIKE ");
 infix_operator!(Lt, " < ");
 infix_operator!(LtEq, " <= ");
-infix_operator!(NotBetween, " NOT BETWEEN ");
 infix_operator!(NotEq, " != ");
 infix_operator!(NotLike, " NOT LIKE ");
+infix_operator!(Between, " BETWEEN ");
+infix_operator!(NotBetween, " NOT BETWEEN ");
 
 postfix_operator!(IsNull, " IS NULL");
 postfix_operator!(IsNotNull, " IS NOT NULL");
@@ -446,11 +446,16 @@ postfix_operator!(
     crate::expression::expression_types::NotSelectable
 );
 
-prefix_operator!(Not, "NOT ");
+prefix_operator!(
+    Not,
+    " NOT ",
+    crate::sql_types::Nullable<crate::sql_types::Bool>
+);
 
+use crate::backend::Backend;
 use crate::expression::{TypedExpressionType, ValidGrouping};
 use crate::insertable::{ColumnInsertValue, Insertable};
-use crate::query_builder::{QueryId, ValuesClause};
+use crate::query_builder::{QueryFragment, QueryId, ValuesClause};
 use crate::query_source::Column;
 use crate::sql_types::{
     is_nullable, AllAreNullable, Bool, DieselNumericOps, MaybeNullableType, SqlType,
@@ -504,11 +509,11 @@ where
 
 impl_selectable_expression!(Concat<L, R>);
 
-impl<L, R, DB> crate::query_builder::QueryFragment<DB> for Concat<L, R>
+impl<L, R, DB> QueryFragment<DB> for Concat<L, R>
 where
-    L: crate::query_builder::QueryFragment<DB>,
-    R: crate::query_builder::QueryFragment<DB>,
-    DB: crate::backend::Backend,
+    L: QueryFragment<DB>,
+    R: QueryFragment<DB>,
+    DB: Backend,
 {
     fn walk_ast(
         &self,

--- a/diesel/src/expression_methods/text_expression_methods.rs
+++ b/diesel/src/expression_methods/text_expression_methods.rs
@@ -1,3 +1,5 @@
+use crate::dsl;
+use crate::expression::grouped::Grouped;
 use crate::expression::operators::{Concat, Like, NotLike};
 use crate::expression::{AsExpression, Expression};
 use crate::sql_types::{Nullable, SqlType, Text};
@@ -54,12 +56,12 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// assert_eq!(Ok(expected_names), names);
     /// # }
     /// ```
-    fn concat<T>(self, other: T) -> Concat<Self, T::Expression>
+    fn concat<T>(self, other: T) -> dsl::Concat<Self, T>
     where
         Self::SqlType: SqlType,
         T: AsExpression<Self::SqlType>,
     {
-        Concat::new(self, other.as_expression())
+        Grouped(Concat::new(self, other.as_expression()))
     }
 
     /// Returns a SQL `LIKE` expression
@@ -90,12 +92,12 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn like<T>(self, other: T) -> Like<Self, T::Expression>
+    fn like<T>(self, other: T) -> dsl::Like<Self, T>
     where
         Self::SqlType: SqlType,
         T: AsExpression<Self::SqlType>,
     {
-        Like::new(self, other.as_expression())
+        Grouped(Like::new(self, other.as_expression()))
     }
 
     /// Returns a SQL `NOT LIKE` expression
@@ -126,12 +128,12 @@ pub trait TextExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn not_like<T>(self, other: T) -> NotLike<Self, T::Expression>
+    fn not_like<T>(self, other: T) -> dsl::NotLike<Self, T>
     where
         Self::SqlType: SqlType,
         T: AsExpression<Self::SqlType>,
     {
-        NotLike::new(self, other.as_expression())
+        Grouped(NotLike::new(self, other.as_expression()))
     }
 }
 

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::backend::{Backend, SupportsDefaultKeyword};
+use crate::expression::grouped::Grouped;
 use crate::expression::{AppearsOnTable, Expression};
 use crate::query_builder::{
     AstPass, InsertStatement, QueryFragment, UndecoratedInsertRecord, ValuesClause,
@@ -254,6 +255,28 @@ where
 
     fn values(self) -> Self::Values {
         self.as_ref().values()
+    }
+}
+
+impl<L, R, Tab> Insertable<Tab> for Grouped<crate::expression::operators::Eq<L, R>>
+where
+    crate::expression::operators::Eq<L, R>: Insertable<Tab>,
+{
+    type Values = <crate::expression::operators::Eq<L, R> as Insertable<Tab>>::Values;
+
+    fn values(self) -> Self::Values {
+        self.0.values()
+    }
+}
+
+impl<'a, L, R, Tab> Insertable<Tab> for &'a Grouped<crate::expression::operators::Eq<L, R>>
+where
+    &'a crate::expression::operators::Eq<L, R>: Insertable<Tab>,
+{
+    type Values = <&'a crate::expression::operators::Eq<L, R> as Insertable<Tab>>::Values;
+
+    fn values(self) -> Self::Values {
+        self.0.values()
     }
 }
 

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -141,7 +141,7 @@ where
     type Expression = <T as AsExpression<Array<ST>>>::Expression;
 
     fn as_expression(self) -> Self::Expression {
-        AsExpression::as_expression(self)
+        <T as AsExpression<Array<ST>>>::as_expression(self)
     }
 }
 

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,8 +1,44 @@
-use crate::dsl::AsExprOf;
+use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
+use crate::expression::grouped::Grouped;
 use crate::sql_types::VarChar;
 
 /// The return type of `lhs.ilike(rhs)`
-pub type ILike<Lhs, Rhs> = super::operators::ILike<Lhs, AsExprOf<Rhs, VarChar>>;
+pub type ILike<Lhs, Rhs> = Grouped<super::operators::ILike<Lhs, AsExprOf<Rhs, VarChar>>>;
 
 /// The return type of `lhs.not_ilike(rhs)`
-pub type NotILike<Lhs, Rhs> = super::operators::NotILike<Lhs, AsExprOf<Rhs, VarChar>>;
+pub type NotILike<Lhs, Rhs> = Grouped<super::operators::NotILike<Lhs, AsExprOf<Rhs, VarChar>>>;
+
+/// The return type of `lhs.is_not_distinct_from(rhs)`
+pub type IsNotDistinctFrom<Lhs, Rhs> =
+    Grouped<super::operators::IsNotDistinctFrom<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// The return type of `lhs.is_distinct_from(rhs)`
+pub type IsDistinctFrom<Lhs, Rhs> =
+    Grouped<super::operators::IsDistinctFrom<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// The return type of `lhs.overlaps_with(rhs)`
+pub type OverlapsWith<Lhs, Rhs> = Grouped<super::operators::OverlapsWith<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// The return type of `lhs.contains(rhs)` for array expressions
+pub type ArrayContains<Lhs, Rhs> = Grouped<super::operators::Contains<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// The return type of `lhs.contains(rhs)` for range expressions
+pub type RangeContains<Lhs, Rhs> = Grouped<
+    super::operators::Contains<
+        Lhs,
+        AsExprOf<Rhs, <SqlTypeOf<Lhs> as super::expression_methods::RangeHelper>::Inner>,
+    >,
+>;
+
+/// The return type of `lhs.is_contained_by(rhs)`
+pub type IsContainedBy<Lhs, Rhs> = Grouped<super::operators::IsContainedBy<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// The return type of `expr.nulls_first()`
+pub type NullsFirst<T> = super::operators::NullsFirst<T>;
+
+/// The return type of `expr.nulls_last()`
+pub type NullsLast<T> = super::operators::NullsLast<T>;
+
+/// The return type of `expr.at_time_zone(tz)`
+pub type AtTimeZone<Lhs, Rhs> =
+    Grouped<super::date_and_time::AtTimeZone<Lhs, AsExprOf<Rhs, VarChar>>>;

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -11,6 +11,7 @@ use std::marker::PhantomData;
 
 use super::returning_clause::*;
 use crate::backend::Backend;
+use crate::expression::grouped::Grouped;
 use crate::expression::operators::Eq;
 use crate::expression::{Expression, NonAggregate, SelectableExpression};
 use crate::insertable::*;
@@ -508,6 +509,13 @@ impl<T, Table> UndecoratedInsertRecord<Table> for Vec<T> where [T]: UndecoratedI
 impl<Lhs, Rhs> UndecoratedInsertRecord<Lhs::Table> for Eq<Lhs, Rhs> where Lhs: Column {}
 
 impl<Lhs, Rhs, Tab> UndecoratedInsertRecord<Tab> for Option<Eq<Lhs, Rhs>> where
+    Eq<Lhs, Rhs>: UndecoratedInsertRecord<Tab>
+{
+}
+
+impl<Lhs, Rhs> UndecoratedInsertRecord<Lhs::Table> for Grouped<Eq<Lhs, Rhs>> where Lhs: Column {}
+
+impl<Lhs, Rhs, Tab> UndecoratedInsertRecord<Tab> for Option<Grouped<Eq<Lhs, Rhs>>> where
     Eq<Lhs, Rhs>: UndecoratedInsertRecord<Tab>
 {
 }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -310,17 +310,17 @@ impl<T: Query> AsQuery for T {
 /// let debug = debug_query::<DB, _>(&query);
 /// # if cfg!(feature = "postgres") {
 /// #     assert_eq!(debug.to_string(), "SELECT \"users\".\"id\", \"users\".\"name\" \
-/// #         FROM \"users\" WHERE \"users\".\"id\" = $1 -- binds: [1]");
+/// #         FROM \"users\" WHERE (\"users\".\"id\" = $1) -- binds: [1]");
 /// # } else {
 /// assert_eq!(debug.to_string(), "SELECT `users`.`id`, `users`.`name` FROM `users` \
-///     WHERE `users`.`id` = ? -- binds: [1]");
+///     WHERE (`users`.`id` = ?) -- binds: [1]");
 /// # }
 ///
 /// let debug = format!("{:?}", debug);
 /// # if !cfg!(feature = "postgres") { // Escaping that string is a pain
 /// let expected = "Query { \
 ///     sql: \"SELECT `users`.`id`, `users`.`name` FROM `users` WHERE \
-///         `users`.`id` = ?\", \
+///         (`users`.`id` = ?)\", \
 ///     binds: [1] \
 /// }";
 /// assert_eq!(debug, expected);

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -1,4 +1,5 @@
 use crate::backend::Backend;
+use crate::expression::grouped::Grouped;
 use crate::expression::operators::Eq;
 use crate::expression::AppearsOnTable;
 use crate::query_builder::*;
@@ -45,6 +46,19 @@ where
             _column: self.left,
             expr: self.right,
         }
+    }
+}
+
+impl<Left, Right> AsChangeset for Grouped<Eq<Left, Right>>
+where
+    Eq<Left, Right>: AsChangeset,
+{
+    type Target = <Eq<Left, Right> as AsChangeset>::Target;
+
+    type Changeset = <Eq<Left, Right> as AsChangeset>::Changeset;
+
+    fn as_changeset(self) -> Self::Changeset {
+        self.0.as_changeset()
     }
 }
 

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::backend::Backend;
+use crate::expression::grouped::Grouped;
 use crate::expression::operators::{And, Or};
 use crate::expression::*;
 use crate::result::QueryResult;
@@ -88,10 +89,10 @@ where
     Predicate: Expression,
     Predicate::SqlType: BoolOrNullableBool,
 {
-    type Output = WhereClause<And<Expr, Predicate>>;
+    type Output = WhereClause<Grouped<And<Expr, Predicate>>>;
 
     fn and(self, predicate: Predicate) -> Self::Output {
-        WhereClause(And::new(self.0, predicate))
+        WhereClause(Grouped(And::new(self.0, predicate)))
     }
 }
 
@@ -102,10 +103,10 @@ where
     Predicate: Expression,
     Predicate::SqlType: BoolOrNullableBool,
 {
-    type Output = WhereClause<Or<Expr, Predicate>>;
+    type Output = WhereClause<Grouped<Or<Expr, Predicate>>>;
 
     fn or(self, predicate: Predicate) -> Self::Output {
-        WhereClause(Or::new(self.0, predicate))
+        WhereClause(Grouped(Or::new(self.0, predicate)))
     }
 }
 
@@ -165,7 +166,7 @@ where
         use self::BoxedWhereClause::Where;
 
         match self {
-            Where(where_clause) => Where(Box::new(And::new(where_clause, predicate))),
+            Where(where_clause) => Where(Box::new(Grouped(And::new(where_clause, predicate)))),
             BoxedWhereClause::None => Where(Box::new(predicate)),
         }
     }
@@ -180,7 +181,6 @@ where
 
     fn or(self, predicate: Predicate) -> Self::Output {
         use self::BoxedWhereClause::Where;
-        use crate::expression::grouped::Grouped;
 
         match self {
             Where(where_clause) => Where(Box::new(Grouped(Or::new(where_clause, predicate)))),

--- a/diesel/src/type_impls/option.rs
+++ b/diesel/src/type_impls/option.rs
@@ -60,12 +60,11 @@ where
     }
 }
 
-impl<T, ST> AsExpression<Nullable<ST>> for Option<T>
+impl<T, ST> AsExpression<ST> for Option<T>
 where
-    ST: SqlType<IsNull = is_nullable::NotNull>,
-    Nullable<ST>: TypedExpressionType,
+    ST: SqlType<IsNull = is_nullable::IsNullable> + SingleValue,
 {
-    type Expression = Bound<Nullable<ST>, Self>;
+    type Expression = Bound<ST, Self>;
 
     fn as_expression(self) -> Self::Expression {
         Bound::new(self)

--- a/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/compile-fail/right_side_of_left_join_requires_nullable.rs
@@ -51,7 +51,7 @@ fn direct_joins() {
     //~| ERROR E0277
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
-    //~^ ERROR E0271
+    //~^ ERROR E0277
 }
 
 fn nested_outer_joins_left_associative() {
@@ -72,7 +72,7 @@ fn nested_outer_joins_left_associative() {
     //~| ERROR E0277
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
-    //~^ ERROR E0271
+    //~^ ERROR E0277
 }
 
 fn nested_mixed_joins_left_associative() {
@@ -92,7 +92,7 @@ fn nested_mixed_joins_left_associative() {
     //~| ERROR E0277
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
-    //~^ ERROR E0271
+    //~^ ERROR E0277
 }
 
 fn nested_outer_joins_right_associative() {
@@ -112,7 +112,7 @@ fn nested_outer_joins_right_associative() {
     //~| ERROR E0277
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
-    //~^ ERROR E0271
+    //~^ ERROR E0277
 }
 
 fn nested_mixed_joins_right_associative() {
@@ -132,5 +132,5 @@ fn nested_mixed_joins_right_associative() {
     //~| ERROR E0277
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
-    //~^ ERROR E0271
+    //~^ ERROR E0277
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -849,12 +849,12 @@ pub fn derive_valid_grouping(input: TokenStream) -> TokenStream {
 /// #
 /// # table! { crates { id -> Integer, name -> VarChar, } }
 /// #
-/// use diesel::sql_types::Foldable;
+/// use diesel::sql_types::{Foldable, Nullable};
 ///
 /// sql_function! {
 ///     #[aggregate]
 ///     #[sql_name = "SUM"]
-///     fn sum<ST: Foldable>(expr: ST) -> ST::Sum;
+///     fn sum<ST: Foldable>(expr: Nullable<ST>) -> ST::Sum;
 /// }
 ///
 /// # fn main() {

--- a/diesel_tests/tests/debug/mod.rs
+++ b/diesel_tests/tests/debug/mod.rs
@@ -20,12 +20,12 @@ fn test_debug_output() {
     if cfg!(feature = "postgres") {
         assert_eq!(
             sql,
-            r#"UPDATE "users" SET "name" = $1 WHERE "users"."id" = $2 -- binds: ["new_name", 1]"#
+            r#"UPDATE "users" SET "name" = $1 WHERE ("users"."id" = $2) -- binds: ["new_name", 1]"#
         )
     } else {
         assert_eq!(
             sql,
-            r#"UPDATE `users` SET `name` = ? WHERE `users`.`id` = ? -- binds: ["new_name", 1]"#
+            r#"UPDATE `users` SET `name` = ? WHERE (`users`.`id` = ?) -- binds: ["new_name", 1]"#
         )
     }
 }
@@ -137,7 +137,7 @@ fn test_upsert() {
 
     assert_eq!(
         upsert_single_where_sql_display,
-        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, "black"]"#
+        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE ("users"."hair_color" = $5) DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, "black"]"#
     );
 
     let upsert_command_second_where = insert_into(users)
@@ -152,6 +152,6 @@ fn test_upsert() {
 
     assert_eq!(
         upsert_second_where_sql_display,
-        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE "users"."hair_color" = $5 AND "users"."name" = $6 DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, "black", "Sean"]"#
+        r#"INSERT INTO "users" ("name", "hair_color") VALUES ($1, $2), ($3, $4) ON CONFLICT ("hair_color") WHERE (("users"."hair_color" = $5) AND ("users"."name" = $6)) DO NOTHING -- binds: ["Sean", Some("black"), "Tess", None, "black", "Sean"]"#
     );
 }

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -460,3 +460,16 @@ fn test_arrays_b() {
 
     assert_eq!(value, vec![7, 14]);
 }
+
+#[test]
+fn test_operator_precedence() {
+    use self::numbers;
+
+    let connection = connection();
+    connection
+        .execute("INSERT INTO numbers (n) VALUES (2)")
+        .unwrap();
+    let source = numbers::table.select(numbers::n.gt(0).eq(true));
+
+    assert_eq!(Ok(true), source.first(&connection));
+}

--- a/diesel_tests/tests/group_by.rs
+++ b/diesel_tests/tests/group_by.rs
@@ -11,7 +11,7 @@ fn group_by_generates_group_by_sql() {
         .select(users::name)
         .filter(users::hair_color.is_null());
     let mut expected_sql = "SELECT `users`.`name` FROM `users` \
-                            WHERE `users`.`hair_color` IS NULL \
+                            WHERE (`users`.`hair_color` IS NULL) \
                             GROUP BY `users`.`name` \
                             -- binds: []"
         .to_string();
@@ -33,7 +33,7 @@ fn group_by_mixed_aggregate_column_and_aggregate_function() {
         .select((max(users::id), users::name))
         .filter(users::hair_color.is_null());
     let mut expected_sql = "SELECT max(`users`.`id`), `users`.`name` FROM `users` \
-                            WHERE `users`.`hair_color` IS NULL \
+                            WHERE (`users`.`hair_color` IS NULL) \
                             GROUP BY `users`.`name` \
                             -- binds: []"
         .to_string();
@@ -58,7 +58,7 @@ fn boxed_queries_have_group_by_method() {
         .select(users::name)
         .filter(users::hair_color.is_null());
     let mut expected_sql = "SELECT `users`.`name` FROM `users` \
-                            WHERE `users`.`hair_color` IS NULL \
+                            WHERE (`users`.`hair_color` IS NULL) \
                             GROUP BY `users`.`name` \
                             -- binds: []"
         .to_string();

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1251,27 +1251,21 @@ where
     select(sql::<T>(sql_str)).first(&connection).unwrap()
 }
 
-use diesel::dsl::{And, AsExprOf, Eq, IsNull};
+use diesel::dsl::Eq;
 use diesel::expression::{is_aggregate, AsExpression, SqlLiteral, ValidGrouping};
 use diesel::query_builder::{QueryFragment, QueryId};
 use std::fmt::Debug;
 
 fn query_to_sql_equality<T, U>(sql_str: &str, value: U) -> bool
 where
-    U: AsExpression<T> + Debug + Clone,
-    U::Expression: SelectableExpression<(), SqlType = T>
-        + ValidGrouping<(), IsAggregate = is_aggregate::Never>,
-    U::Expression: QueryFragment<TestBackend> + QueryId,
-    T: QueryId + SingleValue + SqlType,
-    T::IsNull: OneIsNullable<T::IsNull, Out = T::IsNull>,
-    T::IsNull: MaybeNullableType<Bool>,
-    <T::IsNull as MaybeNullableType<Bool>>::Out: SqlType,
-    diesel::sql_types::is_nullable::NotNull: diesel::sql_types::AllAreNullable<
-        <<T::IsNull as MaybeNullableType<Bool>>::Out as SqlType>::IsNull,
-        Out = diesel::sql_types::is_nullable::NotNull,
-    >,
-    Eq<SqlLiteral<T>, U>: Expression<SqlType = <T::IsNull as MaybeNullableType<Bool>>::Out>,
-    And<IsNull<SqlLiteral<T>>, IsNull<AsExprOf<U, T>>>: Expression<SqlType = Bool>,
+    U: AsExpression<T::Nullable> + Debug + Clone,
+    U::Expression: SelectableExpression<(), SqlType = T::Nullable>
+        + ValidGrouping<(), IsAggregate = is_aggregate::Never>
+        + QueryFragment<TestBackend>
+        + QueryId,
+    T: QueryId + SingleValue + SqlType + IntoNullable,
+    T::Nullable: SqlType + SingleValue,
+    Eq<SqlLiteral<T::Nullable>, U>: Expression<SqlType = Nullable<Bool>> + SelectableExpression<()>,
 {
     use diesel::dsl::sql;
     let connection = connection();
@@ -1279,11 +1273,12 @@ where
         sql::<T>(sql_str)
             .is_null()
             .and(value.clone().as_expression().is_null())
-            .or(sql::<T>(sql_str).eq(value.clone())),
+            .or(sql::<T::Nullable>(sql_str).eq(value.clone())),
     );
     query
-        .get_result::<bool>(&connection)
+        .get_result::<Option<bool>>(&connection)
         .expect(&format!("Error comparing {}, {:?}", sql_str, value))
+        .unwrap_or(false)
 }
 
 #[cfg(feature = "postgres")]

--- a/examples/postgres/all_about_updates/src/lib.rs
+++ b/examples/postgres/all_about_updates/src/lib.rs
@@ -63,7 +63,7 @@ fn examine_sql_from_publish_pending_posts() {
         .set(draft.eq(false));
     assert_eq!(
         "UPDATE \"posts\" SET \"draft\" = $1 \
-         WHERE \"posts\".\"publish_at\" < CURRENT_TIMESTAMP \
+         WHERE (\"posts\".\"publish_at\" < CURRENT_TIMESTAMP) \
          -- binds: [false]",
         debug_query(&query).to_string()
     );
@@ -86,7 +86,7 @@ fn examine_sql_from_publish_post() {
         visit_count: 0,
     };
     assert_eq!(
-        "UPDATE \"posts\" SET \"draft\" = $1 WHERE \"posts\".\"id\" = $2 \
+        "UPDATE \"posts\" SET \"draft\" = $1 WHERE (\"posts\".\"id\" = $2) \
          -- binds: [false, 1]",
         debug_query(&diesel::update(&post).set(posts::draft.eq(false))).to_string()
     );


### PR DESCRIPTION
Include parenthesis around every infix operation provided by one of the
`ExpressionMethod` traits.

It is not possible to include this directly into the `infix_operator!`
macro due several SQL constructs:

* `a LIKE b` can have optional `ESCAPE` clauses (same for `NOT LIKE`,
    `ILIKE` eg). Unconditionally putting a parenthesis around `(a LIKE b)` is no valid SQL
* `a BETWEEN l AND u` is implemented a set of two infix operators,
    `BETWEEN` and `AND`, so putting the parenthesis directly into the
    operator macro would lead to `x BETWEEN (l AND u)` which is not valid
    SQL

Instead I've opted for adding explicit parenthesis in the corresponding
`ExpressionMethod` (and similar traits implementations. As part of this
change I've changed all the return types there to use some type from
`diesel::dsl`, so that potential users have an easier time to figure out
what types to use if they have to write some where clause or something
like that.

While changing the return types to `diesel::dsl` types I noticed  and
fixed the following issues:

* Not all methods had an equivalent type in `diesel::dsl`, sometimes
    because it was missing, sometimes because the postgres specific types
    weren't correctly exported there. Both is fixed now
* Some types were not anymore compatible with the actual methods. A
    notable example is `dsl::And` and `BoolExpressionMethods::and` where the
    later returned a potentially nullable type depending on the input types,
    while the first was only valid for not nullable right sides. Fixing that
    was a bit more complicated:
* I've opted for making the return type of `BoolExpressionMethods::and`
          (and `or`) unconditonally nullable. This prevents having an explicit
         `ST` parameter on `dsl::And`
* This in turn requires that we accept a non nullable expression in
          places where a nullable expression is expected. Technically this
          was already possible, but would require explicitly calling
          `.nullable()` on affected expressions. Given that `.and()` and
          `.or()` are really common, that seemed not to be a good solution.
          As result I've changed the `AsExpression` impl for `T: Expression`
          in such a way that for any `T` with `T::SqlType: SqlType<IsNull =
          is_nullable::NotNull>` there is now an impl
          `AsExpression<Nullable<T::SqlType>>` so that such expressions are
          also accepted in nullable contexts.