### PR TITLE
Update dotenv version

### DIFF
--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -13,7 +13,7 @@ path = "../diesel/"
 default-features = false
 
 [dev-dependencies]
-dotenv = "0.14"
+dotenv = "0.15"
 
 [[example]]
 name = "querying_basic_schemas"


### PR DESCRIPTION
Since all other crates use `dotenv = "0.15"`, I've updated dotenv version in `diesel_dynamic_schema`.