### PR TITLE
Add a few more compile fail tests for mixed selects

### DIFF
--- a/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
@@ -1,18 +1,29 @@
 #[macro_use]
 extern crate diesel;
 
-use diesel::*;
 use diesel::dsl::count_star;
+use diesel::sql_types::{Integer, Nullable};
+use diesel::*;
 
 table! {
     users {
         id -> Integer,
+        nullable_int_col -> Nullable<Integer>,
     }
 }
 
+sql_function!(fn f(x: Nullable<Integer>, y: Nullable<Integer>) -> Nullable<Integer>);
+
 fn main() {
     use self::users::dsl::*;
+    use diesel::dsl::max;
 
     let source = users.select((id, count_star()));
+    //~^ ERROR MixedAggregates
+
+    let source = users.select(nullable_int_col + max(nullable_int_col));
+    //~^ ERROR MixedAggregates
+
+    let source = users.select(f(nullable_int_col, max(nullable_int_col)));
     //~^ ERROR MixedAggregates
 }


### PR DESCRIPTION
Just adds the test cases from #1586 to our compile test suite to verify
that the `ValidGrouping<G>` rewrite fixed those issues.

Closes #1586