### PR TITLE
Introduce `QueryBuilder::push_bind_param_value_only`

### DIFF
--- a/diesel/src/pg/query_builder/mod.rs
+++ b/diesel/src/pg/query_builder/mod.rs
@@ -36,12 +36,38 @@ impl QueryBuilder<Pg> for PgQueryBuilder {
     }
 
     fn push_bind_param(&mut self) {
-        self.bind_idx += 1;
+        self.push_bind_param_value_only();
         self.sql += "$";
         itoa::fmt(&mut self.sql, self.bind_idx).expect("int formating does not fail");
+    }
+
+    fn push_bind_param_value_only(&mut self) {
+        self.bind_idx += 1;
     }
 
     fn finish(self) -> String {
         self.sql
     }
+}
+
+#[test]
+fn check_sql_query_increments_bind_count() {
+    use crate::query_builder::{AstPass, QueryFragment};
+    use crate::sql_types::*;
+
+    let query = crate::sql_query("SELECT $1, $2, $3")
+        .bind::<Integer, _>(42)
+        .bind::<Integer, _>(3)
+        .bind::<Integer, _>(342);
+
+    let mut query_builder = PgQueryBuilder::default();
+
+    {
+        let ast_pass = AstPass::<crate::pg::Pg>::to_sql(&mut query_builder);
+
+        query.walk_ast(ast_pass).unwrap();
+    }
+
+    assert_eq!(query_builder.bind_idx, 3);
+    assert_eq!(query_builder.sql, "SELECT $1, $2, $3");
 }

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -219,6 +219,9 @@ where
         use self::AstPassInternals::*;
         match self.internals {
             CollectBinds { .. } | DebugBinds(..) => self.push_bind_param(bind)?,
+            ToSql(ref mut out) => {
+                out.push_bind_param_value_only();
+            }
             _ => {}
         }
         Ok(())

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -91,6 +91,10 @@ pub trait QueryBuilder<DB: Backend> {
     /// constructed.
     fn push_bind_param(&mut self);
 
+    /// Increases the internal counter for bind parameters without adding the
+    /// bind parameter itself to the query
+    fn push_bind_param_value_only(&mut self) {}
+
     /// Returns the constructed SQL query.
     fn finish(self) -> String;
 }


### PR DESCRIPTION
This is the last missing piece to allow code to abstract both, over
queries generated by `sql_query` and queries constructed using diesels
query dsl.

To quote from the original issue:

> The fix for this is basically to add a (default empty impl for backwards compat) function to QueryBuilder which is informed when push_bind_param_value_only is called, which increments the bind counter and does nothing else. Importantly, this means that it would be valid to add more bind params through the query builder after the SqlQuery is walked, but not before. So SELECT * FROM ({sql_query}) LIMIT $1 is fine, SELECT *, $1 FROM ({sql_query}) is not -- or at least the query passed to it needs to be aware that its indexes need to start from 2.

> We could theoretically detect this at runtime by erroring if push_bind_param_value_only is called after push_bind_param. We could even do this only for PG. I opted not to in my (unopened) PR both for simplicity, and because having a sql_query which is expected to be passed to some other combinator like paginate on use is completely valid, so I don't want to make writing these queries with all hand-written SQL starting at $2 impossible.

> I also don't think this vector for misuse is particularly common. This interaction is only when writing generic code that abstracts over entire queries. That means by definition it's going to be wrapping that query in a subselect as part of the FROM clause or a CTE. While there are reasons you could have a bind param in front of that, it's substantially less common than having it after.

Fixes #2150