### PR TITLE
Allow some clauses to be public

### DIFF
--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use crate::backend::Backend;
 use crate::query_builder::*;
 use crate::result::QueryResult;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -13,7 +13,8 @@ mod ast_pass;
 pub mod bind_collector;
 mod debug_query;
 mod delete_statement;
-mod distinct_clause;
+#[doc(hidden)]
+pub mod distinct_clause;
 #[doc(hidden)]
 pub mod functions;
 mod group_by_clause;
@@ -31,7 +32,8 @@ mod select_statement;
 mod sql_query;
 mod update_statement;
 pub(crate) mod upsert;
-mod where_clause;
+#[doc(hidden)]
+pub mod where_clause;
 
 pub use self::ast_pass::AstPass;
 pub use self::bind_collector::BindCollector;

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use super::*;
 use crate::backend::Backend;
 use crate::expression::grouped::Grouped;


### PR DESCRIPTION
This is a blocker for the proc-macro based ORM I was talking about a few months ago.

```rust
let user: Option<User> = User::one().github_id(id).load().await?;
```

Basically, the proc macro adds methods for all columns using select clauses so that select statements can be used simply.

I am working on more stuff, but I wanted to send this first to make sure you are okay with making these public (even though they are hidden).