### PR TITLE
Add docs to sql_function macro for functions without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,10 @@ Key points:
   NonAggregate` no longer implies `(OtherType, T): NonAggregate`.
   - With `feature = "unstable"`, `(T, OtherType): NonAggregate` is still implied.
 
+- In diesel v1.4 sql functions without arguments used the `no_arg_sql_function!` macro,
+  which has since been deprecated. The new `sql_function!` macro supports functions without
+  arguments.
+
 [2-0-migration]: FIXME write a migration guide
 
 ## [1.4.5] - 2020-06-09

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -863,6 +863,25 @@ pub fn derive_valid_grouping(input: TokenStream) -> TokenStream {
 /// # }
 /// ```
 ///
+/// # SQL Functions without Arguments
+///
+/// A common example is ordering a query using the `RANDOM()` sql function,
+/// which can be implemented using `sql_function!` like this:
+///
+/// ```rust
+/// # extern crate diesel;
+/// # use diesel::*;
+/// #
+/// # table! { crates { id -> Integer, name -> VarChar, } }
+/// #
+/// sql_function!(fn random() -> Text);
+///
+/// # fn main() {
+/// # use self::crates::dsl::*;
+/// crates.order(random());
+/// # }
+/// ```
+///
 /// # Use with SQLite
 ///
 /// On most backends, the implementation of the function is defined in a


### PR DESCRIPTION
I was looking to port ordering by random from v1.4 to master branch. I left a comment for others and it was recommended I add the `random` example to the docs: https://github.com/diesel-rs/diesel/pull/1987#issuecomment-703584356

Please let me know if you would like more detail, and if so, where you would like any! Thanks for the great project! :) 