### PR TITLE
Implement `ValidGrouping<GB>` for more cases

### DIFF
--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -434,9 +434,9 @@ where
 
 impl<T, ST, DB> StaticallySizedRow<ST, DB> for T
 where
-    ST: SqlType + crate::type_impls::tuples::TupleSize,
+    ST: SqlType + crate::util::TupleSize,
     T: Queryable<ST, DB>,
     DB: Backend,
 {
-    const FIELD_COUNT: usize = <ST as crate::type_impls::tuples::TupleSize>::SIZE;
+    const FIELD_COUNT: usize = <ST as crate::util::TupleSize>::SIZE;
 }

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -444,6 +444,34 @@ impl<'a, T: ValidGrouping<GB> + ?Sized, GB> ValidGrouping<GB> for &'a T {
 #[doc(inline)]
 pub use diesel_derives::ValidGrouping;
 
+#[doc(hidden)]
+pub trait IsContainedInGroupBy<T> {
+    type Output;
+}
+
+#[doc(hidden)]
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+pub mod is_contained_in_group_by {
+    pub struct Yes;
+    pub struct No;
+
+    pub trait IsAny<O> {
+        type Output;
+    }
+
+    impl<T> IsAny<T> for Yes {
+        type Output = Yes;
+    }
+
+    impl IsAny<Yes> for No {
+        type Output = Yes;
+    }
+
+    impl IsAny<No> for No {
+        type Output = No;
+    }
+}
+
 /// Can two `IsAggregate` types appear in the same expression?
 ///
 /// You should never implement this trait. It will eventually become a trait

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -5,3 +5,7 @@ pub trait TupleAppend<T> {
 
     fn tuple_append(self, right: T) -> Self::Output;
 }
+
+pub trait TupleSize {
+    const SIZE: usize;
+}

--- a/diesel_compile_tests/tests/compile-fail/cannot_load_default_select_with_group_by.rs
+++ b/diesel_compile_tests/tests/compile-fail/cannot_load_default_select_with_group_by.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate diesel;
 
-use diesel::*;
 use diesel::dsl::count;
+use diesel::*;
 
 table! {
     users {
@@ -13,7 +13,8 @@ table! {
 
 fn main() {
     let conn = PgConnection::establish("").unwrap();
-    let _ = users::table.group_by(users::name)
+    let _ = users::table
+        .group_by(users::name)
         .load::<(i32, String)>(&conn);
-    //~^ ERROR ValidGrouping
+    //~^ ERROR IsContainedInGroupBy
 }

--- a/diesel_compile_tests/tests/compile-fail/select_requires_valid_grouping.rs
+++ b/diesel_compile_tests/tests/compile-fail/select_requires_valid_grouping.rs
@@ -1,0 +1,110 @@
+#[macro_use]
+extern crate diesel;
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> Text,
+        user_id -> Integer,
+    }
+}
+
+table! {
+    comments {
+        id -> Integer,
+        text -> Text,
+        post_id -> Integer,
+    }
+}
+
+joinable!(comments -> posts (post_id));
+joinable!(posts -> users (user_id));
+
+allow_tables_to_appear_in_same_query!(users, posts, comments);
+allow_columns_to_appear_in_same_group_by_clause!(
+    posts::title,
+    users::id,
+    posts::user_id,
+    users::name,
+    posts::id,
+    users::hair_color
+);
+
+fn main() {
+    use diesel::dsl;
+    // cases thas should compile
+
+    // A column appering in the group by clause should be considered valid for the select clause
+    let source = users::table.group_by(users::name).select(users::name);
+    // If the column appearing in the group by clause is the primary key, any column of that table is a
+    // valid group by clause
+    let source = users::table.group_by(users::id).select(users::name);
+    let source = users::table
+        .group_by(users::id)
+        .select((users::name, users::hair_color));
+    // It's valid to use a aggregate function on a column that does not appear in the group by clause)
+    let source = users::table
+        .group_by(users::name)
+        .select(dsl::max(users::id));
+    // If the group by clause consists of multiple columns it's fine for the select clause to contain
+    // any of those
+    let source = users::table
+        .group_by((users::name, users::hair_color))
+        .select(users::name);
+    let source = users::table
+        .group_by((users::name, users::hair_color))
+        .select(users::hair_color);
+    let source = users::table
+        .group_by((users::name, users::hair_color))
+        .select((users::name, users::hair_color));
+    // It's fine to select all columns of a table as long as the primary key appears in the group by clause
+    let source = users::table
+        .inner_join(posts::table)
+        .group_by(users::id)
+        .select(users::all_columns);
+    // This also work for group by clauses with multiple columns
+    let source = users::table
+        .inner_join(posts::table)
+        .group_by((users::id, posts::title))
+        .select((users::all_columns, posts::title));
+    let source = users::table
+        .inner_join(posts::table.inner_join(comments::table))
+        .group_by((users::id, posts::id))
+        .select((users::all_columns, posts::all_columns));
+
+    // cases that should fail to compile
+    let source = users::table.group_by(users::name).select(users::id);
+    //~^ ERROR IsContainedInGroupBy
+    let source = users::table
+        .group_by((users::name, users::hair_color))
+        .select(users::id);
+    //~^ ERROR IsContainedInGroupBy
+    let source = users::table
+        .group_by(users::name)
+        .select((users::name, users::id));
+    //~^ ERROR IsContainedInGroupBy
+    let source = users::table
+        .group_by((users::name, users::hair_color))
+        .select(users::id);
+    //~^ ERROR IsContainedInGroupBy
+    let source = users::table
+        .inner_join(posts::table)
+        .group_by((users::id, posts::title))
+        .select((users::all_columns, posts::id));
+    //~^ ERROR IsContainedInGroupBy
+    let source = users::table
+        .inner_join(posts::table.inner_join(comments::table))
+        .group_by((users::id, posts::id))
+        .select((users::all_columns, posts::all_columns, comments::id));
+    //~^ ERROR IsContainedInGroupBy
+    //~| E0277
+}

--- a/diesel_tests/tests/group_by.rs
+++ b/diesel_tests/tests/group_by.rs
@@ -23,6 +23,9 @@ fn group_by_generates_group_by_sql() {
         expected_sql,
         debug_query::<TestBackend, _>(&source).to_string()
     );
+    let conn = connection();
+
+    assert!(source.execute(&conn).is_ok());
 }
 
 #[test]
@@ -45,6 +48,10 @@ fn group_by_mixed_aggregate_column_and_aggregate_function() {
         expected_sql,
         debug_query::<TestBackend, _>(&source).to_string()
     );
+
+    let conn = connection();
+
+    assert!(source.execute(&conn).is_ok());
 }
 
 #[test]
@@ -67,4 +74,116 @@ fn boxed_queries_have_group_by_method() {
     }
 
     assert_eq!(expected_sql, debug_query(&source).to_string());
+
+    let conn = connection();
+
+    assert!(source.execute(&conn).is_ok());
+}
+
+#[test]
+fn check_group_by_primary_key_allows_other_columns_in_select_clause() {
+    let source = users::table
+        .group_by(users::id)
+        .select(users::name)
+        .filter(users::hair_color.is_null());
+
+    let mut expected_sql = "SELECT `users`.`name` FROM `users` \
+                            WHERE (`users`.`hair_color` IS NULL) \
+                            GROUP BY `users`.`id` \
+                            -- binds: []"
+        .to_string();
+
+    if cfg!(feature = "postgres") {
+        expected_sql = expected_sql.replace('`', "\"");
+    }
+
+    assert_eq!(expected_sql, debug_query(&source).to_string());
+
+    let conn = connection();
+
+    assert!(source.execute(&conn).is_ok());
+}
+
+#[test]
+fn check_group_by_multiple_columns_in_group_by_clause_single_select() {
+    let source = users::table
+        .group_by((users::name, users::hair_color))
+        .select(users::name)
+        .filter(users::id.nullable().is_null());
+
+    let mut expected_sql = "SELECT `users`.`name` \
+                            FROM `users` WHERE (`users`.`id` IS NULL) \
+                            GROUP BY `users`.`name`, `users`.`hair_color` \
+                            -- binds: []"
+        .to_string();
+
+    if cfg!(feature = "postgres") {
+        expected_sql = expected_sql.replace('`', "\"");
+    }
+
+    assert_eq!(expected_sql, debug_query(&source).to_string());
+
+    let conn = connection();
+
+    assert!(source.execute(&conn).is_ok());
+}
+
+#[test]
+fn check_group_by_multiple_columns_in_group_by_clause_complex_select() {
+    let source = users::table
+        .group_by((users::name, users::hair_color))
+        .select((users::name, users::hair_color, diesel::dsl::max(users::id)))
+        .filter(users::id.nullable().is_null());
+
+    let mut expected_sql = "SELECT `users`.`name`, `users`.`hair_color`, max(`users`.`id`) \
+                            FROM `users` WHERE (`users`.`id` IS NULL) \
+                            GROUP BY `users`.`name`, `users`.`hair_color` \
+                            -- binds: []"
+        .to_string();
+
+    if cfg!(feature = "postgres") {
+        expected_sql = expected_sql.replace('`', "\"");
+    }
+
+    assert_eq!(expected_sql, debug_query(&source).to_string());
+
+    let conn = connection();
+
+    assert!(source.execute(&conn).is_ok());
+}
+
+diesel::allow_columns_to_appear_in_same_group_by_clause!(
+    posts::id,
+    users::id,
+    posts::title,
+    users::name
+);
+
+#[test]
+fn check_group_by_multiple_tables() {
+    let source = users::table
+        .inner_join(posts::table.inner_join(comments::table))
+        .group_by((users::id, posts::id))
+        .select((users::name, posts::title, diesel::dsl::count(comments::id)))
+        .filter(comments::text.nullable().is_null());
+
+    let mut expected_sql = "SELECT `users`.`name`, `posts`.`title`, count(`comments`.`id`) \
+                            FROM (`users` \
+                            INNER JOIN (`posts` \
+                            INNER JOIN `comments` ON (`comments`.`post_id` = `posts`.`id`)) \
+                            ON (`posts`.`user_id` = `users`.`id`)) \
+                            WHERE (`comments`.`text` IS NULL) \
+                            GROUP BY `users`.`id`, `posts`.`id` \
+                            -- binds: []"
+        .to_string();
+
+    if cfg!(feature = "postgres") {
+        expected_sql = expected_sql.replace('`', "\"");
+    }
+
+    assert_eq!(expected_sql, debug_query(&source).to_string());
+
+    let conn = connection();
+
+    assert!(source.execute(&conn).is_ok());
 }


### PR DESCRIPTION
This commit adds support for more kinds of `GROUP BY` clauses.

* We implement now `ValidGrouping<table::primary_key, IsAggregate = Yey>` for each column
of that table, as according to the postgres documentation it is
sufficient to have only the primary key in the group by clause
* We provide a basic infrastructure to handle `GROUP BY` clauses
consisting of more than one column by introducing a
`IsContainedInGroupBy` helper trait. It is currently used to check if a
column is part of a composite `GROUP BY` clause by checking if the
corresponding tuple contains this column. As basic requirement an  `impl
IsContainedInGroupBy<column_a> for column_b { type Output = No; }` is
required for each pair `column_a` and `column_b` that should be allowed
to appear together in a `GROUP BY` clause. This is automatically
implemented for all columns belonging to one table. For cross table
cases the `allow_columns_to_appear_in_same_group_by_clause!` macro is
provided. (This macros just skips the default per table generated
impls). As future extension we may want to generate a call to that macro
for all columns in a generated schema, after checking the impact on
compile times of having that much impls.
* Additionally this commit adds a bunch of test cases that cover the old
and new allowed usecases of `GROUP BY` clauses

Fixes #2370, CC #210