### PR TITLE
Fix #2368

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -568,6 +568,10 @@ use crate::query_builder::{QueryFragment, QueryId};
 /// This type has all of the additional traits you would want when using
 /// `Box<Expression>` as a single trait object.
 ///
+/// By default `BoxableExpression` is not usable in queries that have a custom
+/// group by clause. Setting the generic parameters `GB` and `IsAggregate` allows
+/// to configure the expression to be used with a specific group by clause.
+///
 /// This is typically used as the return type of a function.
 /// For cases where you want to dynamically construct a query,
 /// [boxing the query] is usually more ergonomic.
@@ -575,6 +579,8 @@ use crate::query_builder::{QueryFragment, QueryId};
 /// [boxing the query]: ../query_dsl/trait.QueryDsl.html#method.into_boxed
 ///
 /// # Examples
+///
+/// ## Usage without group by clause
 ///
 /// ```rust
 /// # include!("../doctest_setup.rs");
@@ -615,30 +621,103 @@ use crate::query_builder::{QueryFragment, QueryId};
 /// #     Ok(())
 /// # }
 /// ```
-pub trait BoxableExpression<QS, DB>
+///
+/// ## Allow usage with group by clause
+///
+/// ```rust
+/// # include!("../doctest_setup.rs");
+///
+/// # use schema::users;
+/// use diesel::sql_types::Text;
+/// use diesel::dsl;
+/// use diesel::expression::ValidGrouping;
+///
+/// # fn main() {
+/// #     run_test().unwrap();
+/// # }
+/// #
+/// # fn run_test() -> QueryResult<()> {
+/// #     let conn = establish_connection();
+/// enum NameOrConst {
+///     Name,
+///     Const(String),
+/// }
+///
+/// # /*
+/// type DB = diesel::sqlite::Sqlite;
+/// # */
+///
+/// fn selection<GB>(
+///     selection: NameOrConst
+/// ) -> Box<
+///     dyn BoxableExpression<
+///         users::table,
+///         DB,
+///         GB,
+///         <users::name as ValidGrouping<GB>>::IsAggregate,
+///         SqlType = Text
+///     >
+/// >
+/// where
+///     users::name: BoxableExpression<
+///             users::table,
+///             DB,
+///             GB,
+///             <users::name as ValidGrouping<GB>>::IsAggregate,
+///             SqlType = Text
+///         > + ValidGrouping<GB>,
+/// {
+///     match selection {
+///         NameOrConst::Name => Box::new(users::name),
+///         NameOrConst::Const(name) => Box::new(name.into_sql::<Text>()),
+///     }
+/// }
+///
+/// let user_one = users::table
+///     .select(selection(NameOrConst::Name))
+///     .first::<String>(&conn)?;
+/// assert_eq!(String::from("Sean"), user_one);
+///
+/// let with_name = users::table
+///     .group_by(users::name)
+///     .select(selection(NameOrConst::Const("Jane Doe".into())))
+///     .first::<String>(&conn)?;
+/// assert_eq!(String::from("Jane Doe"), with_name);
+/// #     Ok(())
+/// # }
+/// ```
+pub trait BoxableExpression<QS, DB, GB = (), IsAggregate = is_aggregate::No>
 where
     DB: Backend,
     Self: Expression,
     Self: SelectableExpression<QS>,
-    Self: ValidGrouping<(), IsAggregate = is_aggregate::No>,
     Self: QueryFragment<DB>,
 {
 }
 
-impl<QS, T, DB> BoxableExpression<QS, DB> for T
+impl<QS, T, DB, GB, IsAggregate> BoxableExpression<QS, DB, GB, IsAggregate> for T
 where
     DB: Backend,
     T: Expression,
     T: SelectableExpression<QS>,
-    T: ValidGrouping<(), IsAggregate = is_aggregate::No>,
+    T: ValidGrouping<GB>,
     T: QueryFragment<DB>,
+    T::IsAggregate: MixedAggregates<IsAggregate, Output = IsAggregate>,
 {
 }
 
-impl<'a, QS, ST, DB> QueryId for dyn BoxableExpression<QS, DB, SqlType = ST> + 'a {
+impl<'a, QS, ST, DB, GB, IsAggregate> QueryId
+    for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + 'a
+{
     type QueryId = ();
 
     const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a, QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
+    for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + 'a
+{
+    type IsAggregate = IsAggregate;
 }
 
 /// Converts a tuple of values into a tuple of Diesel expressions.

--- a/diesel_compile_tests/tests/compile-fail/valid_grouping_and_boxed_expressions.rs
+++ b/diesel_compile_tests/tests/compile-fail/valid_grouping_and_boxed_expressions.rs
@@ -1,0 +1,120 @@
+extern crate diesel;
+
+use diesel::expression::{is_aggregate, MixedAggregates, ValidGrouping};
+use diesel::pg::Pg;
+use diesel::prelude::*;
+use diesel::sql_types::{Integer, Nullable};
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+fn some_ungrouped_expression(
+    something: bool,
+) -> Box<dyn BoxableExpression<users::table, Pg, SqlType = Integer>> {
+    if something {
+        Box::new(5.into_sql::<Integer>())
+    } else {
+        Box::new(users::id)
+    }
+}
+
+fn maybe_grouped<GB>(
+    something: bool,
+) -> Box<
+    dyn BoxableExpression<
+        users::table,
+        Pg,
+        GB,
+        <users::id as ValidGrouping<GB>>::IsAggregate,
+        SqlType = Integer,
+    >,
+>
+where
+    users::id: BoxableExpression<
+            users::table,
+            Pg,
+            GB,
+            <users::id as ValidGrouping<GB>>::IsAggregate,
+            SqlType = Integer,
+        > + ValidGrouping<GB>,
+{
+    if something {
+        Box::new(5.into_sql::<Integer>())
+    } else {
+        Box::new(users::id)
+    }
+}
+
+fn something_that_is_aggregate<GB>(
+) -> Box<dyn BoxableExpression<users::table, Pg, GB, is_aggregate::Yes, SqlType = Nullable<Integer>>>
+where
+    diesel::dsl::count<users::id>: BoxableExpression<users::table, Pg, GB, is_aggregate::Yes>,
+{
+    Box::new(diesel::dsl::max(users::id))
+}
+
+fn main() {
+    let conn = PgConnection::establish("connection_string").unwrap();
+
+    // it's fine to pass this to some query without group clause
+    users::table
+        .select(some_ungrouped_expression(true))
+        .load::<i32>(&conn);
+
+    // this fails because there is explicitly no group by clause
+    users::table
+        .group_by(users::id)
+        .select(some_ungrouped_expression(true))
+        //~^ ERROR ValidGrouping
+        .load::<i32>(&conn);
+    //~^ ERROR ValidGrouping
+
+    // it's fine to pass this to some query without group by clause
+    // rustc should infer the correct bounds here
+    users::table.select(maybe_grouped(false)).load::<i32>(&conn);
+
+    // it's also fine to pass this to some query with a matching
+    // group by clause
+    users::table
+        .group_by(users::id)
+        .select(maybe_grouped(true))
+        .load::<i32>(&conn);
+
+    // this fails because of an incompatible group by clause
+    users::table
+        .group_by(users::name)
+        .select(maybe_grouped(true))
+        //~^ ERROR ValidGrouping
+        .load::<i32>(&conn);
+
+    // aggregated expressions work to
+    users::table
+        .select(something_that_is_aggregate())
+        .load::<Option<i32>>(&conn);
+
+    // also with a group by clause
+    users::table
+        .group_by(users::name)
+        .select(something_that_is_aggregate())
+        .load::<Option<i32>>(&conn);
+
+    // but we cannot mix a aggregated expression with an non aggregate one
+    users::table
+        .select((
+            //~^ ERROR MixedAggregates
+            something_that_is_aggregate(),
+            some_ungrouped_expression(false),
+        ))
+        .load::<(Option<i32>, i32)>(&conn);
+    //~^ ERROR MixedAggregates
+
+    // using two potential aggregated expressions works
+    users::table
+        .group_by(users::id)
+        .select((something_that_is_aggregate(), maybe_grouped(true)))
+        .load::<(Option<i32>, i32)>(&conn);
+}


### PR DESCRIPTION
Allow using mixed aggregate expressions as `BoxableExpression`. We do
this by making `BoxableExpression` explicitly generic over the group by
clause and the aggregate expression. For use cases where no group by
clause is required those parameters are set by default, otherwise they
need to be supplied by the user.

It would be great to get some feedback from @diesel-rs/reviewers here on the proposed API