### PR TITLE
Support `#[diesel(serialize_as)]` on fields of `Insertable` structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for PostgreSQL's `SIMILAR TO` and `NOT SIMILAR TO`.
 
+* Added `#[diesel(serialize_as)]` analogous to `#[diesel(deserialize_as)]`. This allows
+  customization of the serialization behaviour of `Insertable` structs.
+
 ### Removed
 
 * All previously deprecated items have been removed.

--- a/diesel_compile_tests/tests/ui/embed_and_serialize_as_cannot_be_mixed.rs
+++ b/diesel_compile_tests/tests/ui/embed_and_serialize_as_cannot_be_mixed.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users (id) {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Text,
+    }
+}
+
+#[derive(Insertable)]
+#[table_name = "users"]
+struct NameAndHairColor<'a> {
+    name: &'a str,
+    hair_color: &'a str,
+}
+
+#[derive(Insertable)]
+struct User<'a> {
+    id: i32,
+    #[diesel(embed, serialize_as = "SomeType")] // to test the compile error, this type doesn't need to exist
+    name_and_hair_color: NameAndHairColor<'a>,
+}
+
+fn main() {
+
+}

--- a/diesel_compile_tests/tests/ui/embed_and_serialize_as_cannot_be_mixed.stderr
+++ b/diesel_compile_tests/tests/ui/embed_and_serialize_as_cannot_be_mixed.stderr
@@ -1,0 +1,8 @@
+error: `#[diesel(embed)]` cannot be combined with `#[diesel(serialize_as)]`
+  --> $DIR/embed_and_serialize_as_cannot_be_mixed.rs:22:7
+   |
+22 |     #[diesel(embed, serialize_as = "SomeType")] // to test the compile error, this type doesn't need to exist
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -12,8 +12,8 @@ pub struct Field {
     pub name: FieldName,
     pub span: Span,
     pub sql_type: Option<syn::Type>,
+    pub flags: MetaItem,
     column_name_from_attribute: Option<syn::Ident>,
-    flags: MetaItem,
 }
 
 impl Field {
@@ -67,6 +67,15 @@ impl Field {
 
     pub fn has_flag(&self, flag: &str) -> bool {
         self.flags.has_flag(flag)
+    }
+
+    pub fn ty_for_serialize(&self) -> Result<Option<syn::Type>, Diagnostic> {
+        if let Some(meta) = self.flags.nested_item("serialize_as")? {
+            let ty = meta.ty_value()?;
+            Ok(Some(ty))
+        } else {
+            Ok(None)
+        }
     }
 
     pub fn ty_for_deserialize(&self) -> Result<Cow<syn::Type>, Diagnostic> {

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -26,33 +26,46 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     impl_generics.params.push(parse_quote!('insert));
     let (impl_generics, ..) = impl_generics.split_for_impl();
 
-    let (direct_field_ty, direct_field_assign): (Vec<_>, Vec<_>) = model
-        .fields()
-        .iter()
-        .map(|f| {
-            (
-                (field_ty(f, table_name, None)),
-                (field_expr(f, table_name, None)),
-            )
-        })
-        .unzip();
+    let mut generate_borrowed_insert = true;
 
-    let (ref_field_ty, ref_field_assign): (Vec<_>, Vec<_>) = model
-        .fields()
-        .iter()
-        .map(|f| {
-            (
-                (field_ty(f, table_name, Some(quote!(&'insert)))),
-                (field_expr(f, table_name, Some(quote!(&)))),
-            )
-        })
-        .unzip();
+    let mut direct_field_ty = Vec::with_capacity(model.fields().len());
+    let mut direct_field_assign = Vec::with_capacity(model.fields().len());
+    let mut ref_field_ty = Vec::with_capacity(model.fields().len());
+    let mut ref_field_assign = Vec::with_capacity(model.fields().len());
 
-    Ok(wrap_in_dummy_mod(quote! {
-        use diesel::insertable::Insertable;
-        use diesel::query_builder::UndecoratedInsertRecord;
-        use diesel::prelude::*;
+    for field in model.fields() {
+        let serialize_as = field.ty_for_serialize()?;
+        let embed = field.has_flag("embed");
 
+        match (serialize_as, embed) {
+            (None, true) => {
+                direct_field_ty.push(field_ty_embed(field, None));
+                direct_field_assign.push(field_expr_embed(field, None));
+                ref_field_ty.push(field_ty_embed(field, Some(quote!(&'insert))));
+                ref_field_assign.push(field_expr_embed(field, Some(quote!(&))));
+            }
+            (None, false) => {
+                direct_field_ty.push(field_ty(field, table_name, None));
+                direct_field_assign.push(field_expr(field, table_name, None));
+                ref_field_ty.push(field_ty(field, table_name, Some(quote!(&'insert))));
+                ref_field_assign.push(field_expr(field, table_name, Some(quote!(&))));
+            }
+            (Some(ty), false) => {
+                direct_field_ty.push(field_ty_serialize_as(field, table_name, &ty));
+                direct_field_assign.push(field_expr_serialize_as(field, table_name, &ty));
+
+                generate_borrowed_insert = false; // as soon as we hit one field with #[diesel(serialize_as)] there is no point in generating the impl of Insertable for borrowed structs
+            }
+            (Some(_), true) => {
+                return Err(field
+                    .flags
+                    .span()
+                    .error("`#[diesel(embed)]` cannot be combined with `#[diesel(serialize_as)]`"))
+            }
+        }
+    }
+
+    let insert_owned = quote! {
         impl #impl_generics Insertable<#table_name::table> for #struct_name #ty_generics
             #where_clause
         {
@@ -62,24 +75,76 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
                 (#(#direct_field_assign,)*).values()
             }
         }
+    };
 
-        impl #impl_generics Insertable<#table_name::table>
-            for &'insert #struct_name #ty_generics
-        #where_clause
-        {
-            type Values = <(#(#ref_field_ty,)*) as Insertable<#table_name::table>>::Values;
+    let insert_borrowed = if generate_borrowed_insert {
+        quote! {
+            impl #impl_generics Insertable<#table_name::table>
+                for &'insert #struct_name #ty_generics
+            #where_clause
+            {
+                type Values = <(#(#ref_field_ty,)*) as Insertable<#table_name::table>>::Values;
 
-            fn values(self) -> Self::Values {
-                (#(#ref_field_assign,)*).values()
+                fn values(self) -> Self::Values {
+                    (#(#ref_field_assign,)*).values()
+                }
+            }
+
+            impl #impl_generics UndecoratedInsertRecord<#table_name::table>
+                for #struct_name #ty_generics
+            #where_clause
+            {
             }
         }
+    } else {
+        quote! {}
+    };
 
-        impl #impl_generics UndecoratedInsertRecord<#table_name::table>
-            for #struct_name #ty_generics
-        #where_clause
-        {
-        }
+    Ok(wrap_in_dummy_mod(quote! {
+        use diesel::insertable::Insertable;
+        use diesel::query_builder::UndecoratedInsertRecord;
+        use diesel::prelude::*;
+
+        #insert_owned
+
+        #insert_borrowed
     }))
+}
+
+fn field_ty_embed(field: &Field, lifetime: Option<proc_macro2::TokenStream>) -> syn::Type {
+    let field_ty = &field.ty;
+
+    parse_quote!(#lifetime #field_ty)
+}
+
+fn field_expr_embed(field: &Field, lifetime: Option<proc_macro2::TokenStream>) -> syn::Expr {
+    let field_access = field.name.access();
+
+    parse_quote!(#lifetime self#field_access)
+}
+
+fn field_ty_serialize_as(field: &Field, table_name: &syn::Ident, ty: &syn::Type) -> syn::Type {
+    let inner_ty = inner_of_option_ty(&ty);
+    let column_name = field.column_name();
+
+    parse_quote!(
+        std::option::Option<diesel::dsl::Eq<
+            #table_name::#column_name,
+            #inner_ty,
+        >>
+    )
+}
+
+fn field_expr_serialize_as(field: &Field, table_name: &syn::Ident, ty: &syn::Type) -> syn::Expr {
+    let field_access = field.name.access();
+    let column_name = field.column_name();
+    let column: syn::Expr = parse_quote!(#table_name::#column_name);
+
+    if is_option_ty(&ty) {
+        parse_quote!(self#field_access.map(|x| #column.eq(::std::convert::Into::<#ty>::into(x))))
+    } else {
+        parse_quote!(std::option::Option::Some(#column.eq(::std::convert::Into::<#ty>::into(self#field_access))))
+    }
 }
 
 fn field_ty(
@@ -87,19 +152,15 @@ fn field_ty(
     table_name: &syn::Ident,
     lifetime: Option<proc_macro2::TokenStream>,
 ) -> syn::Type {
-    if field.has_flag("embed") {
-        let field_ty = &field.ty;
-        parse_quote!(#lifetime #field_ty)
-    } else {
-        let inner_ty = inner_of_option_ty(&field.ty);
-        let column_name = field.column_name();
-        parse_quote!(
-            std::option::Option<diesel::dsl::Eq<
-                #table_name::#column_name,
-                #lifetime #inner_ty,
-            >>
-        )
-    }
+    let inner_ty = inner_of_option_ty(&field.ty);
+    let column_name = field.column_name();
+
+    parse_quote!(
+        std::option::Option<diesel::dsl::Eq<
+            #table_name::#column_name,
+            #lifetime #inner_ty,
+        >>
+    )
 }
 
 fn field_expr(
@@ -108,19 +169,15 @@ fn field_expr(
     lifetime: Option<proc_macro2::TokenStream>,
 ) -> syn::Expr {
     let field_access = field.name.access();
-    if field.has_flag("embed") {
-        parse_quote!(#lifetime self#field_access)
-    } else {
-        let column_name = field.column_name();
-        let column: syn::Expr = parse_quote!(#table_name::#column_name);
-        if is_option_ty(&field.ty) {
-            if lifetime.is_some() {
-                parse_quote!(self#field_access.as_ref().map(|x| #column.eq(x)))
-            } else {
-                parse_quote!(self#field_access.map(|x| #column.eq(x)))
-            }
+    let column_name = field.column_name();
+    let column: syn::Expr = parse_quote!(#table_name::#column_name);
+    if is_option_ty(&field.ty) {
+        if lifetime.is_some() {
+            parse_quote!(self#field_access.as_ref().map(|x| #column.eq(x)))
         } else {
-            parse_quote!(std::option::Option::Some(#column.eq(#lifetime self#field_access)))
+            parse_quote!(self#field_access.map(|x| #column.eq(x)))
         }
+    } else {
+        parse_quote!(std::option::Option::Some(#column.eq(#lifetime self#field_access)))
     }
 }

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -41,6 +41,7 @@ mod schema;
 mod schema_dsl;
 mod schema_inference;
 mod select;
+mod serialize_as;
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 mod transactions;
 mod types;

--- a/diesel_tests/tests/serialize_as.rs
+++ b/diesel_tests/tests/serialize_as.rs
@@ -1,0 +1,52 @@
+use crate::schema::*;
+use diesel::backend::Backend;
+use diesel::serialize::{Output, ToSql};
+use diesel::*;
+use std::io::Write;
+
+#[derive(Debug, FromSqlRow, AsExpression)]
+#[sql_type = "sql_types::Text"]
+struct UppercaseString(pub String);
+
+impl From<String> for UppercaseString {
+    fn from(s: String) -> Self {
+        UppercaseString(s.to_uppercase())
+    }
+}
+
+impl<DB> ToSql<sql_types::Text, DB> for UppercaseString
+where
+    DB: Backend,
+    String: ToSql<sql_types::Text, DB>,
+{
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+        self.0.to_sql(out)
+    }
+}
+
+#[derive(Insertable, PartialEq, Debug)]
+#[table_name = "users"]
+struct InsertableUser {
+    #[diesel(serialize_as = "UppercaseString")]
+    name: String,
+}
+
+#[test]
+fn serialization_can_be_customized() {
+    use crate::schema::users::dsl::*;
+    let connection = connection();
+
+    let user = InsertableUser {
+        name: "thomas".to_string(),
+    };
+
+    diesel::insert_into(users)
+        .values(user)
+        .execute(&connection)
+        .unwrap();
+
+    assert_eq!(
+        Ok("THOMAS".to_string()),
+        users.select(name).first(&connection)
+    );
+}


### PR DESCRIPTION
Similar to how `#[diesel(deserialize_as)]` can be used for `Queryable`
structs to customize which type is being constructed, we add support
for doing the same thing for `Insertable` structs.

The conversion happens using the std trait `Into` which takes ownership
during conversion. As such, as soon as any field within an `Insertable`
struct has a `#[diesel(serialize_as)]` attribute, we no longer generate
an implementation of `Insertable` for borrowed versions of this struct.

Fields annotated with `#[diesel(serialize_as)]` are also incompatible
with `#[diesel(embed)]`. Using both on the same field will result in
a compile-error.

Resolves https://github.com/diesel-rs/diesel/issues/2344.