### PR TITLE
Fix #1988

### DIFF
--- a/diesel_compile_tests/tests/compile-fail/boxed_queries_and_group_by.rs
+++ b/diesel_compile_tests/tests/compile-fail/boxed_queries_and_group_by.rs
@@ -1,0 +1,98 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        user_id -> Integer,
+    }
+}
+
+joinable!(posts -> users (user_id));
+
+fn main() {
+    use diesel::dsl::*;
+
+    let conn = PgConnection::establish("connection-url").unwrap();
+
+    // a boxed query with group by just works
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed()
+        .load::<String>(&conn);
+
+    // it's fine to change the select clause afterwards as long as it is valid for the
+    // given group by clause
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed()
+        .select(users::name)
+        .load::<String>(&conn);
+
+    let mut q = users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed();
+
+    q = q.select(users::name);
+    q = q.filter(users::id.eq(42));
+    q = q.or_filter(users::id.eq(42));
+    q = q.order(users::id.asc());
+    q = q.then_order_by(users::id.asc());
+    q = q.distinct();
+    q = q.limit(42);
+    q = q.offset(42);
+
+    // cannot box a query with default select clause + a group by clause
+    users::table.group_by(users::name).into_boxed();
+    //~^ ERROR BoxedDsl
+
+    users::table
+        .group_by(users::name)
+        .select(users::id)
+        //~^ ERROR IsContainedInGroupBy
+        .into_boxed();
+    //~^ ERROR BoxedDsl
+
+    // you cannot call group by after boxing
+    users::table
+        .into_boxed()
+        .group_by(users::id)
+        //~^ ERROR no method named `group_by` found
+        .select(users::name)
+        .load::<String>(&conn);
+
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed()
+        .select(users::id)
+        //~^ ERROR IsContainedInGroupBy<users::columns::id>
+        .load::<i32>(&conn);
+
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed()
+        .inner_join(posts::table)
+        //~^ ERROR Table
+        //~| mismatched types
+        .load::<String>(&conn);
+
+    let mut a = users::table.into_boxed();
+
+    // this is a different type now
+    a = users::table.group_by(users::id).into_boxed();
+    //~^ ERROR mismatched types
+}

--- a/diesel_tests/tests/group_by.rs
+++ b/diesel_tests/tests/group_by.rs
@@ -55,14 +55,11 @@ fn group_by_mixed_aggregate_column_and_aggregate_function() {
 }
 
 #[test]
-// This test is a shim for a feature which is not sufficiently implemented. It
-// has been added as we have a user who needs a reasonable workaround, but this
-// functionality will change and this test is allowed to change post-1.0
 fn boxed_queries_have_group_by_method() {
     let source = users::table
-        .into_boxed::<TestBackend>()
         .group_by(users::name)
         .select(users::name)
+        .into_boxed::<TestBackend>()
         .filter(users::hair_color.is_null());
     let mut expected_sql = "SELECT `users`.`name` FROM `users` \
                             WHERE (`users`.`hair_color` IS NULL) \


### PR DESCRIPTION
Disallow calling `group_by` on boxed queries. Additionally we add a
generic parameter for already applied group by clauses to our query, so
that we can check if a newly applied select clause is valid for the
given group by clause.