### PR TITLE
Using chrono without the time 0.1 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Support for `pq-sys` < 0.4.0 has been removed.
 * Support for `mysqlclient-sys` < 0.2.0 has been removed.
 * Support for `time` types has been removed.
+* Support for `chrono` < 0.4.19 has been removed.
 * The `NonNull` for sql types has been removed in favour of the new `SqlType` trait.
 
 * `no_arg_sql_function!` has been deprecated without replacement.

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.0"
-chrono = { version = "0.4.1", optional = true }
+chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.21.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = "0.2.0", optional = true }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-chrono = "0.4.1"
+chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 clap = "2.27"
 dotenv = "0.15"
 heck = "0.3.1"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -15,7 +15,7 @@ dotenv = "0.15"
 
 [dependencies]
 assert_matches = "1.0.1"
-chrono = "0.4.1"
+chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric", "with-deprecated"] }
 diesel_migrations = { path = "../diesel_migrations" }
 dotenv = "0.15"

--- a/examples/mysql/all_about_inserts/Cargo.toml
+++ b/examples/mysql/all_about_inserts/Cargo.toml
@@ -9,7 +9,7 @@ diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql", "ch
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-chrono = "0.4"
+chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 
 [lib]
 doc = false

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bcrypt = "0.8.1"
-chrono = "0.4.0"
+chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres", "chrono"] }
 dotenv = "0.15"
 structopt = "0.3"

--- a/examples/sqlite/all_about_inserts/Cargo.toml
+++ b/examples/sqlite/all_about_inserts/Cargo.toml
@@ -9,7 +9,7 @@ diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite", "c
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-chrono = "0.4"
+chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 
 [lib]
 doc = false


### PR DESCRIPTION
Chrono has recently removed the time 0.1 dependency ([changelog](https://github.com/chronotope/chrono/blob/main/CHANGELOG.md#0416)). This makes it easy for diesel to remove the dependency too, by not using chrono's default, deprecated `oldtime` feature.