### PR TITLE
pg: Add support for INET/CIDR-specific operators and functions

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -36,6 +36,7 @@ r2d2 = { version = ">= 0.8, < 0.9", optional = true }
 [dev-dependencies]
 cfg-if = "0.1.0"
 dotenv = ">=0.8, <0.11"
+ipnetwork = ">=0.12.2, <0.17.0"
 quickcheck = "0.4"
 tempdir = "^0.3.4"
 

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -15,7 +15,7 @@ sql_function! {
     ///
     /// ```rust
     /// # #[macro_use] extern crate diesel;
-    /// # include!("../../doctest_setup.rs");
+    /// # include!("../doctest_setup.rs");
     /// # use diesel::dsl::*;
     /// #
     /// # fn main() {

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1,0 +1,52 @@
+//! PostgreSQL specific functions
+
+use sql_types::*;
+use super::expression_methods::InetOrCidr;
+
+sql_function! {
+    /// Creates an abbreviated display format as text.
+    fn abbrev<T: InetOrCidr>(addr: T) -> Text;
+}
+sql_function! {
+    /// Computes the broadcast address for the address's network.
+    fn broadcast<T: InetOrCidr>(addr: T) -> Inet;
+}
+sql_function! {
+    /// Returns the address's family: 4 for IPv4, 6 for IPv6.
+    fn family<T: InetOrCidr>(addr: T) -> Integer;
+}
+sql_function! {
+    /// Returns the IP address as text, ignoring the netmask.
+    fn host<T: InetOrCidr>(addr: T) -> Text;
+}
+sql_function! {
+    /// Computes the host mask for the address's network.
+    fn hostmask<T: InetOrCidr>(addr: T) -> Inet;
+}
+sql_function! {
+    /// Computes the smallest network that includes both of the given networks.
+    fn inet_merge<T: InetOrCidr, U: InetOrCidr>(a: T, b: U) -> Cidr;
+}
+sql_function! {
+    /// Tests whether the addresses belong to the same IP family.
+    fn inet_same_family<T: InetOrCidr, U: InetOrCidr>(a: T, b: U) -> Bool;
+}
+sql_function! {
+    /// Returns the netmask length in bits.
+    fn masklen<T: InetOrCidr>(addr: T) -> Integer;
+}
+sql_function! {
+    /// Computes the network mask for the address's network.
+    fn netmask<T: InetOrCidr>(addr: T) -> Inet;
+}
+sql_function! {
+    /// Returns the network part of the address, zeroing out whatever is to the right of the
+    /// netmask. (This is equivalent to casting the value to cidr.)
+    fn network(addr: Inet) -> Cidr;
+}
+sql_function! {
+    /// Sets the netmask length for an inet or cidr value.
+    /// For inet, the address part does not changes. For cidr, address bits to the right of the new
+    /// netmask are set to zero.
+    fn set_masklen<T: InetOrCidr>(addr: T, len: Integer) -> T;
+}

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -31,4 +31,7 @@ pub mod dsl {
     pub use super::array::array;
 
     pub use super::extensions::*;
+
+    #[cfg(not(feature = "sqlite"))]
+    pub use super::functions::*;
 }

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod array;
 pub mod array_comparison;
 pub(crate) mod expression_methods;
 pub mod extensions;
+#[cfg(not(feature = "sqlite"))]
+pub mod functions;
 #[doc(hidden)]
 pub mod helper_types;
 #[doc(hidden)]

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,4 +1,5 @@
 use pg::Pg;
+use sql_types::{Bigint, Inet};
 
 diesel_infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
 diesel_infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
@@ -9,3 +10,12 @@ diesel_infix_operator!(ILike, " ILIKE ", backend: Pg);
 diesel_infix_operator!(NotILike, " NOT ILIKE ", backend: Pg);
 diesel_postfix_operator!(NullsFirst, " NULLS FIRST", (), backend: Pg);
 diesel_postfix_operator!(NullsLast, " NULLS LAST", (), backend: Pg);
+diesel_infix_operator!(ContainsNet, " >> ", backend: Pg);
+diesel_infix_operator!(ContainsNetLoose, " >>= ", backend: Pg);
+diesel_infix_operator!(IsContainedByNet, " << ", backend: Pg);
+diesel_infix_operator!(IsContainedByNetLoose, " <<= ", backend: Pg);
+diesel_infix_operator!(AndNet, " & ", Inet, backend: Pg);
+diesel_infix_operator!(OrNet, " | ", Inet, backend: Pg);
+diesel_infix_operator!(AddNet, " + ", Inet, backend: Pg);
+diesel_infix_operator!(SubstractNet, " - ", Inet, backend: Pg);
+diesel_infix_operator!(DifferenceNet, " - ", Bigint, backend: Pg);


### PR DESCRIPTION
This PR adds support for postgresql-specific INET and CIDR types. In this PR, support is added in the query builder for:
- `<<`, `>>=`, etc operators
- `host`, `masklen`, ... functions