### PR TITLE
pg: Add support for INET/CIDR-specific operators and functions

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -40,6 +40,7 @@ path = "../diesel_derives"
 [dev-dependencies]
 cfg-if = "0.1.10"
 dotenv = "0.15"
+ipnetwork = ">=0.12.2, <0.18.0"
 quickcheck = "0.9"
 
 [features]

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -124,6 +124,7 @@ macro_rules! __diesel_column {
 
         $crate::__diesel_generate_ops_impls_if_numeric!($column_name, $($Type)*);
         $crate::__diesel_generate_ops_impls_if_date_time!($column_name, $($Type)*);
+        $crate::__diesel_generate_ops_impls_if_network!($column_name, $($Type)*);
     }
 }
 

--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -86,3 +86,21 @@ macro_rules! __diesel_generate_ops_impls_if_date_time {
     ($column_name:ident, Timestamptz) => { date_time_expr!($column_name); };
     ($column_name:ident, $non_date_time_type:ty) => {};
 }
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! network_expr {
+    ($tpe:ty) => {
+        operator_allowed!($tpe, Add, add);
+        operator_allowed!($tpe, Sub, sub);
+    };
+}
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! __diesel_generate_ops_impls_if_network {
+    ($column_name:ident, Nullable<$($inner:tt)::*>) => { __diesel_generate_ops_impls_if_network!($column_name, $($inner)::*); };
+    ($column_name:ident, Cidr) => { network_expr!($column_name); };
+    ($column_name:ident, Inet) => { network_expr!($column_name); };
+    ($column_name:ident, $non_network_type:ty) => {};
+}

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -4,7 +4,7 @@ use super::operators::*;
 use crate::dsl;
 use crate::expression::grouped::Grouped;
 use crate::expression::{AsExpression, Expression, IntoSql, TypedExpressionType};
-use crate::sql_types::{Array, Bigint, Cidr, Inet, Nullable, Range, SqlType, Text};
+use crate::sql_types::{Array, Cidr, Inet, Nullable, Range, SqlType, Text};
 
 /// PostgreSQL specific methods which are present on all expressions.
 pub trait PgExpressionMethods: Expression + Sized {
@@ -1049,127 +1049,7 @@ pub trait PgNetExpressionMethods: Expression + Sized {
     {
         Grouped(OrNet::new(self, other.as_expression()))
     }
-}
 
-impl<T> PgNetExpressionMethods for T
-where
-    T: Expression,
-    T::SqlType: InetOrCidr,
-{
-}
-
-/// PostgreSQL specific methods present between CIDR/INET expressions and Bigint expressions
-pub trait PgNetAddExpressionMethods: Expression + Sized {
-    /// Creates a PostgreSQL `+` expression.
-    ///
-    /// This operator adds an offset to an address
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # include!("../../doctest_setup.rs");
-    /// #
-    /// # table! {
-    /// #     hosts {
-    /// #         id -> Integer,
-    /// #         address -> Inet,
-    /// #     }
-    /// # }
-    /// #
-    /// # fn main() {
-    /// #     run_test().unwrap();
-    /// # }
-    /// #
-    /// # fn run_test() -> QueryResult<()> {
-    /// #     use self::hosts::dsl::*;
-    /// #     use ipnetwork::IpNetwork;
-    /// #     use std::str::FromStr;
-    /// #     let conn = establish_connection();
-    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-    /// diesel::insert_into(hosts)
-    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
-    ///     .execute(&conn)?;
-    ///
-    /// let addr = hosts
-    ///     .select(address.add(10))
-    ///     .first::<IpNetwork>(&conn)?;
-    /// assert_eq!(addr, IpNetwork::from_str("10.0.2.13").unwrap());
-    /// #     Ok(())
-    /// # }
-    /// ```
-    fn add<T>(self, other: T) -> dsl::AddNet<Self, T>
-    where
-        T: AsExpression<Bigint>,
-    {
-        Grouped(AddNet::new(self, other.as_expression()))
-    }
-}
-
-impl<T> PgNetAddExpressionMethods for T
-where
-    T: Expression,
-    T::SqlType: InetOrCidr,
-{
-}
-
-/// PostgreSQL specific methods present between CIDR/INET expressions and Bigint expression
-pub trait PgNetSubExpressionMethods: Expression + Sized {
-    /// Creates a PostgreSQL `-` expression.
-    ///
-    /// This operator substracts an offset from an address
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # include!("../../doctest_setup.rs");
-    /// #
-    /// # table! {
-    /// #     hosts {
-    /// #         id -> Integer,
-    /// #         address -> Inet,
-    /// #     }
-    /// # }
-    /// #
-    /// # fn main() {
-    /// #     run_test().unwrap();
-    /// # }
-    /// #
-    /// # fn run_test() -> QueryResult<()> {
-    /// #     use self::hosts::dsl::*;
-    /// #     use ipnetwork::IpNetwork;
-    /// #     use std::str::FromStr;
-    /// #     let conn = establish_connection();
-    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-    /// diesel::insert_into(hosts)
-    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.53").unwrap())])
-    ///     .execute(&conn)?;
-    ///
-    /// let addr = hosts
-    ///     .select(address.sub(10))
-    ///     .first::<IpNetwork>(&conn)?;
-    /// assert_eq!(addr, IpNetwork::from_str("10.0.2.43").unwrap());
-    /// #     Ok(())
-    /// # }
-    /// ```
-    fn sub<T>(self, other: T) -> dsl::SubstractNet<Self, T>
-    where
-        T: AsExpression<Bigint>,
-    {
-        Grouped(SubstractNet::new(self, other.as_expression()))
-    }
-}
-
-impl<T> PgNetSubExpressionMethods for T
-where
-    T: Expression,
-    T::SqlType: InetOrCidr,
-{
-}
-
-/// PostgreSQL specific methods present between CIDR/INET expressions
-pub trait PgNetDiffExpressionMethods: Expression + Sized {
     /// Creates a PostgreSQL `-` expression.
     ///
     /// This operator substracts an address from an address to compute the distance between the two
@@ -1216,7 +1096,7 @@ pub trait PgNetDiffExpressionMethods: Expression + Sized {
     }
 }
 
-impl<T> PgNetDiffExpressionMethods for T
+impl<T> PgNetExpressionMethods for T
 where
     T: Expression,
     T::SqlType: InetOrCidr,
@@ -1224,7 +1104,7 @@ where
 }
 
 #[doc(hidden)]
-/// Marker trait used to implement `PgNet*ExpressionMethods` on the appropriate types.
+/// Marker trait used to implement `PgNetExpressionMethods` on the appropriate types.
 pub trait InetOrCidr {}
 
 impl InetOrCidr for Inet {}

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -621,7 +621,6 @@ pub trait PgRangeExpressionMethods: Expression + Sized {
     /// # Example
     ///
     /// ```rust
-    /// # #[macro_use] extern crate diesel;
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # table! {
@@ -694,8 +693,6 @@ pub trait PgNetExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -754,8 +751,6 @@ pub trait PgNetExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -814,8 +809,6 @@ pub trait PgNetExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -874,8 +867,6 @@ pub trait PgNetExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -929,8 +920,6 @@ pub trait PgNetExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -989,8 +978,6 @@ pub trait PgNetExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -1038,8 +1025,6 @@ pub trait PgNetExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -1097,8 +1082,6 @@ pub trait PgNetAddExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -1156,8 +1139,6 @@ pub trait PgNetSubExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {
@@ -1215,8 +1196,6 @@ pub trait PgNetDiffExpressionMethods: Expression + Sized {
      * # Example
      *
      * ```rust
-     * # #[macro_use] extern crate diesel;
-     * # extern crate ipnetwork;
      * # include!("../../doctest_setup.rs");
      * #
      * # table! {

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -4,7 +4,7 @@ use super::operators::*;
 use crate::dsl;
 use crate::expression::grouped::Grouped;
 use crate::expression::{AsExpression, Expression, IntoSql, TypedExpressionType};
-use crate::sql_types::{Array, Nullable, Range, SqlType, Text};
+use crate::sql_types::{Array, Bigint, Cidr, Inet, Nullable, Range, SqlType, Text};
 
 /// PostgreSQL specific methods which are present on all expressions.
 pub trait PgExpressionMethods: Expression + Sized {
@@ -683,3 +683,592 @@ where
     T::SqlType: RangeOrNullableRange,
 {
 }
+
+/// PostgreSQL specific methods present between CIDR/INET expressions
+pub trait PgNetExpressionMethods: Expression + Sized {
+    /**
+     * Creates a PostgreSQL `>>` expression.
+     *
+     * This operator returns wether a subnet strictly contains another subnet or address.
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.contains(IpNetwork::from_str("10.0.2.5").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1, 2], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.contains(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![2], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.contains(IpNetwork::from_str("10.0.3.31").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![2], my_hosts);
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn contains<T>(self, other: T) -> dsl::ContainsNet<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(ContainsNet::new(self, other.as_expression()))
+    }
+
+    /**
+     * Creates a PostgreSQL `>>=` expression.
+     *
+     * This operator returns wether a subnet contains or is equal to another subnet.
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.2.5").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1, 2], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1, 2], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.3.31").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![2], my_hosts);
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn contains_or_eq<T>(self, other: T) -> dsl::ContainsNetLoose<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(ContainsNetLoose::new(self, other.as_expression()))
+    }
+
+    /**
+     * Creates a PostgreSQL `<<` expression.
+     *
+     * This operator returns wether a subnet or address is strictly contained by another subnet.
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.is_contained_by(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(my_hosts.len(), 0);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.is_contained_by(IpNetwork::from_str("10.0.3.31/23").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.is_contained_by(IpNetwork::from_str("10.0.3.31/22").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1, 2], my_hosts);
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn is_contained_by<T>(self, other: T) -> dsl::IsContainedByNet<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(IsContainedByNet::new(self, other.as_expression()))
+    }
+
+    /**
+     * Creates a PostgreSQL `>>=` expression.
+     *
+     * This operator returns wether a subnet is contained by or equal to another subnet.
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.is_contained_by_or_eq(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.is_contained_by_or_eq(IpNetwork::from_str("10.0.3.31/23").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1, 2], my_hosts);
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn is_contained_by_or_eq<T>(self, other: T) -> dsl::IsContainedByNetLoose<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(IsContainedByNetLoose::new(self, other.as_expression()))
+    }
+
+    /**
+     * Creates a PostgreSQL `&&` expression.
+     *
+     * This operator returns wether a subnet contains or is contained by another subnet.
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.overlaps_with(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1, 2], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.overlaps_with(IpNetwork::from_str("10.0.3.31/24").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![2], my_hosts);
+     *
+     * let my_hosts = hosts.select(id)
+     *     .filter(address.overlaps_with(IpNetwork::from_str("10.0.3.31/23").unwrap()))
+     *     .load::<i32>(&conn)?;
+     * assert_eq!(vec![1, 2], my_hosts);
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn overlaps_with<T>(self, other: T) -> dsl::OverlapsWithNet<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(OverlapsWith::new(self, other.as_expression()))
+    }
+
+    /**
+     * Creates a PostgreSQL `&` expression.
+     *
+     * This operator computes the bitwise AND between two network addresses.
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let addr = hosts
+     *     .select(address.and(IpNetwork::from_str("0.0.0.255").unwrap()))
+     *     .first::<IpNetwork>(&conn)?;
+     * assert_eq!(addr, IpNetwork::from_str("0.0.0.3").unwrap());
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn and<T>(self, other: T) -> dsl::AndNet<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(AndNet::new(self, other.as_expression()))
+    }
+
+    /**
+     * Creates a PostgreSQL `|` expression.
+     *
+     * This operator computes the bitwise OR between two network addresses.
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let addr = hosts
+     *     .select(address.or(IpNetwork::from_str("0.0.0.255").unwrap()))
+     *     .first::<IpNetwork>(&conn)?;
+     * assert_eq!(addr, IpNetwork::from_str("10.0.2.255").unwrap());
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn or<T>(self, other: T) -> dsl::OrNet<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(OrNet::new(self, other.as_expression()))
+    }
+}
+
+impl<T> PgNetExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: InetOrCidr,
+{
+}
+
+/// PostgreSQL specific methods present between CIDR/INET expressions and Bigint expressions
+pub trait PgNetAddExpressionMethods: Expression + Sized {
+    /**
+     * Creates a PostgreSQL `+` expression.
+     *
+     * This operator adds an offset to an address
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let addr = hosts
+     *     .select(address.add(10))
+     *     .first::<IpNetwork>(&conn)?;
+     * assert_eq!(addr, IpNetwork::from_str("10.0.2.13").unwrap());
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn add<T>(self, other: T) -> dsl::AddNet<Self, T>
+    where
+        T: AsExpression<Bigint>,
+    {
+        Grouped(AddNet::new(self, other.as_expression()))
+    }
+}
+
+impl<T> PgNetAddExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: InetOrCidr,
+{
+}
+
+/// PostgreSQL specific methods present between CIDR/INET expressions and Bigint expression
+pub trait PgNetSubExpressionMethods: Expression + Sized {
+    /**
+     * Creates a PostgreSQL `-` expression.
+     *
+     * This operator substracts an offset from an address
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.53").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let addr = hosts
+     *     .select(address.sub(10))
+     *     .first::<IpNetwork>(&conn)?;
+     * assert_eq!(addr, IpNetwork::from_str("10.0.2.43").unwrap());
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn sub<T>(self, other: T) -> dsl::SubstractNet<Self, T>
+    where
+        T: AsExpression<Bigint>,
+    {
+        Grouped(SubstractNet::new(self, other.as_expression()))
+    }
+}
+
+impl<T> PgNetSubExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: InetOrCidr,
+{
+}
+
+/// PostgreSQL specific methods present between CIDR/INET expressions
+pub trait PgNetDiffExpressionMethods: Expression + Sized {
+    /**
+     * Creates a PostgreSQL `-` expression.
+     *
+     * This operator substracts an address from an address to compute the distance between the two
+     *
+     * # Example
+     *
+     * ```rust
+     * # #[macro_use] extern crate diesel;
+     * # extern crate ipnetwork;
+     * # include!("../../doctest_setup.rs");
+     * #
+     * # table! {
+     * #     hosts {
+     * #         id -> Integer,
+     * #         address -> Inet,
+     * #     }
+     * # }
+     * #
+     * # fn main() {
+     * #     run_test().unwrap();
+     * # }
+     * #
+     * # fn run_test() -> QueryResult<()> {
+     * #     use self::hosts::dsl::*;
+     * #     use ipnetwork::IpNetwork;
+     * #     use std::str::FromStr;
+     * #     let conn = establish_connection();
+     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+     * diesel::insert_into(hosts)
+     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.53").unwrap())])
+     *     .execute(&conn)?;
+     *
+     * let offset = hosts
+     *     .select(address.diff(IpNetwork::from_str("10.0.2.42").unwrap()))
+     *     .first::<i64>(&conn)?;
+     * assert_eq!(offset, 11);
+     * #     Ok(())
+     * # }
+     * ```
+     */
+    fn diff<T>(self, other: T) -> dsl::DifferenceNet<Self, T>
+    where
+        T: AsExpression<Inet>,
+    {
+        Grouped(DifferenceNet::new(self, other.as_expression()))
+    }
+}
+
+impl<T> PgNetDiffExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: InetOrCidr,
+{
+}
+
+#[doc(hidden)]
+/// Marker trait used to implement `PgNet*ExpressionMethods` on the appropriate types.
+pub trait InetOrCidr {}
+
+impl InetOrCidr for Inet {}
+impl InetOrCidr for Cidr {}
+impl InetOrCidr for Nullable<Inet> {}
+impl InetOrCidr for Nullable<Cidr> {}

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -685,57 +685,55 @@ where
 
 /// PostgreSQL specific methods present between CIDR/INET expressions
 pub trait PgNetExpressionMethods: Expression + Sized {
-    /**
-     * Creates a PostgreSQL `>>` expression.
-     *
-     * This operator returns wether a subnet strictly contains another subnet or address.
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
-     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.contains(IpNetwork::from_str("10.0.2.5").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1, 2], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.contains(IpNetwork::from_str("10.0.2.5/24").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![2], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.contains(IpNetwork::from_str("10.0.3.31").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![2], my_hosts);
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `>>` expression.
+    ///
+    /// This operator returns wether a subnet strictly contains another subnet or address.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+    ///                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.contains(IpNetwork::from_str("10.0.2.5").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.contains(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![2], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.contains(IpNetwork::from_str("10.0.3.31").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![2], my_hosts);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn contains<T>(self, other: T) -> dsl::ContainsNet<Self, T>
     where
         T: AsExpression<Inet>,
@@ -743,57 +741,55 @@ pub trait PgNetExpressionMethods: Expression + Sized {
         Grouped(ContainsNet::new(self, other.as_expression()))
     }
 
-    /**
-     * Creates a PostgreSQL `>>=` expression.
-     *
-     * This operator returns wether a subnet contains or is equal to another subnet.
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
-     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.2.5").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1, 2], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.2.5/24").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1, 2], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.3.31").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![2], my_hosts);
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `>>=` expression.
+    ///
+    /// This operator returns wether a subnet contains or is equal to another subnet.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+    ///                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.2.5").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.contains_or_eq(IpNetwork::from_str("10.0.3.31").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![2], my_hosts);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn contains_or_eq<T>(self, other: T) -> dsl::ContainsNetLoose<Self, T>
     where
         T: AsExpression<Inet>,
@@ -801,57 +797,55 @@ pub trait PgNetExpressionMethods: Expression + Sized {
         Grouped(ContainsNetLoose::new(self, other.as_expression()))
     }
 
-    /**
-     * Creates a PostgreSQL `<<` expression.
-     *
-     * This operator returns wether a subnet or address is strictly contained by another subnet.
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
-     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.is_contained_by(IpNetwork::from_str("10.0.2.5/24").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(my_hosts.len(), 0);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.is_contained_by(IpNetwork::from_str("10.0.3.31/23").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.is_contained_by(IpNetwork::from_str("10.0.3.31/22").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1, 2], my_hosts);
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `<<` expression.
+    ///
+    /// This operator returns wether a subnet or address is strictly contained by another subnet.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+    ///                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.is_contained_by(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(my_hosts.len(), 0);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.is_contained_by(IpNetwork::from_str("10.0.3.31/23").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.is_contained_by(IpNetwork::from_str("10.0.3.31/22").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2], my_hosts);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn is_contained_by<T>(self, other: T) -> dsl::IsContainedByNet<Self, T>
     where
         T: AsExpression<Inet>,
@@ -859,52 +853,50 @@ pub trait PgNetExpressionMethods: Expression + Sized {
         Grouped(IsContainedByNet::new(self, other.as_expression()))
     }
 
-    /**
-     * Creates a PostgreSQL `>>=` expression.
-     *
-     * This operator returns wether a subnet is contained by or equal to another subnet.
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
-     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.is_contained_by_or_eq(IpNetwork::from_str("10.0.2.5/24").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.is_contained_by_or_eq(IpNetwork::from_str("10.0.3.31/23").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1, 2], my_hosts);
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `>>=` expression.
+    ///
+    /// This operator returns wether a subnet is contained by or equal to another subnet.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+    ///                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.is_contained_by_or_eq(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.is_contained_by_or_eq(IpNetwork::from_str("10.0.3.31/23").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2], my_hosts);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn is_contained_by_or_eq<T>(self, other: T) -> dsl::IsContainedByNetLoose<Self, T>
     where
         T: AsExpression<Inet>,
@@ -912,57 +904,55 @@ pub trait PgNetExpressionMethods: Expression + Sized {
         Grouped(IsContainedByNetLoose::new(self, other.as_expression()))
     }
 
-    /**
-     * Creates a PostgreSQL `&&` expression.
-     *
-     * This operator returns wether a subnet contains or is contained by another subnet.
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
-     *                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.overlaps_with(IpNetwork::from_str("10.0.2.5/24").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1, 2], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.overlaps_with(IpNetwork::from_str("10.0.3.31/24").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![2], my_hosts);
-     *
-     * let my_hosts = hosts.select(id)
-     *     .filter(address.overlaps_with(IpNetwork::from_str("10.0.3.31/23").unwrap()))
-     *     .load::<i32>(&conn)?;
-     * assert_eq!(vec![1, 2], my_hosts);
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `&&` expression.
+    ///
+    /// This operator returns wether a subnet contains or is contained by another subnet.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3/24").unwrap()),
+    ///                  address.eq(IpNetwork::from_str("10.0.3.4/23").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.overlaps_with(IpNetwork::from_str("10.0.2.5/24").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.overlaps_with(IpNetwork::from_str("10.0.3.31/24").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![2], my_hosts);
+    ///
+    /// let my_hosts = hosts.select(id)
+    ///     .filter(address.overlaps_with(IpNetwork::from_str("10.0.3.31/23").unwrap()))
+    ///     .load::<i32>(&conn)?;
+    /// assert_eq!(vec![1, 2], my_hosts);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn overlaps_with<T>(self, other: T) -> dsl::OverlapsWithNet<Self, T>
     where
         T: AsExpression<Inet>,
@@ -970,46 +960,44 @@ pub trait PgNetExpressionMethods: Expression + Sized {
         Grouped(OverlapsWith::new(self, other.as_expression()))
     }
 
-    /**
-     * Creates a PostgreSQL `&` expression.
-     *
-     * This operator computes the bitwise AND between two network addresses.
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let addr = hosts
-     *     .select(address.and(IpNetwork::from_str("0.0.0.255").unwrap()))
-     *     .first::<IpNetwork>(&conn)?;
-     * assert_eq!(addr, IpNetwork::from_str("0.0.0.3").unwrap());
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `&` expression.
+    ///
+    /// This operator computes the bitwise AND between two network addresses.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let addr = hosts
+    ///     .select(address.and(IpNetwork::from_str("0.0.0.255").unwrap()))
+    ///     .first::<IpNetwork>(&conn)?;
+    /// assert_eq!(addr, IpNetwork::from_str("0.0.0.3").unwrap());
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn and<T>(self, other: T) -> dsl::AndNet<Self, T>
     where
         T: AsExpression<Inet>,
@@ -1017,46 +1005,44 @@ pub trait PgNetExpressionMethods: Expression + Sized {
         Grouped(AndNet::new(self, other.as_expression()))
     }
 
-    /**
-     * Creates a PostgreSQL `|` expression.
-     *
-     * This operator computes the bitwise OR between two network addresses.
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let addr = hosts
-     *     .select(address.or(IpNetwork::from_str("0.0.0.255").unwrap()))
-     *     .first::<IpNetwork>(&conn)?;
-     * assert_eq!(addr, IpNetwork::from_str("10.0.2.255").unwrap());
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `|` expression.
+    ///
+    /// This operator computes the bitwise OR between two network addresses.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let addr = hosts
+    ///     .select(address.or(IpNetwork::from_str("0.0.0.255").unwrap()))
+    ///     .first::<IpNetwork>(&conn)?;
+    /// assert_eq!(addr, IpNetwork::from_str("10.0.2.255").unwrap());
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn or<T>(self, other: T) -> dsl::OrNet<Self, T>
     where
         T: AsExpression<Inet>,
@@ -1074,46 +1060,44 @@ where
 
 /// PostgreSQL specific methods present between CIDR/INET expressions and Bigint expressions
 pub trait PgNetAddExpressionMethods: Expression + Sized {
-    /**
-     * Creates a PostgreSQL `+` expression.
-     *
-     * This operator adds an offset to an address
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let addr = hosts
-     *     .select(address.add(10))
-     *     .first::<IpNetwork>(&conn)?;
-     * assert_eq!(addr, IpNetwork::from_str("10.0.2.13").unwrap());
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `+` expression.
+    ///
+    /// This operator adds an offset to an address
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.3").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let addr = hosts
+    ///     .select(address.add(10))
+    ///     .first::<IpNetwork>(&conn)?;
+    /// assert_eq!(addr, IpNetwork::from_str("10.0.2.13").unwrap());
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn add<T>(self, other: T) -> dsl::AddNet<Self, T>
     where
         T: AsExpression<Bigint>,
@@ -1131,46 +1115,44 @@ where
 
 /// PostgreSQL specific methods present between CIDR/INET expressions and Bigint expression
 pub trait PgNetSubExpressionMethods: Expression + Sized {
-    /**
-     * Creates a PostgreSQL `-` expression.
-     *
-     * This operator substracts an offset from an address
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.53").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let addr = hosts
-     *     .select(address.sub(10))
-     *     .first::<IpNetwork>(&conn)?;
-     * assert_eq!(addr, IpNetwork::from_str("10.0.2.43").unwrap());
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `-` expression.
+    ///
+    /// This operator substracts an offset from an address
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.53").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let addr = hosts
+    ///     .select(address.sub(10))
+    ///     .first::<IpNetwork>(&conn)?;
+    /// assert_eq!(addr, IpNetwork::from_str("10.0.2.43").unwrap());
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn sub<T>(self, other: T) -> dsl::SubstractNet<Self, T>
     where
         T: AsExpression<Bigint>,
@@ -1188,46 +1170,44 @@ where
 
 /// PostgreSQL specific methods present between CIDR/INET expressions
 pub trait PgNetDiffExpressionMethods: Expression + Sized {
-    /**
-     * Creates a PostgreSQL `-` expression.
-     *
-     * This operator substracts an address from an address to compute the distance between the two
-     *
-     * # Example
-     *
-     * ```rust
-     * # include!("../../doctest_setup.rs");
-     * #
-     * # table! {
-     * #     hosts {
-     * #         id -> Integer,
-     * #         address -> Inet,
-     * #     }
-     * # }
-     * #
-     * # fn main() {
-     * #     run_test().unwrap();
-     * # }
-     * #
-     * # fn run_test() -> QueryResult<()> {
-     * #     use self::hosts::dsl::*;
-     * #     use ipnetwork::IpNetwork;
-     * #     use std::str::FromStr;
-     * #     let conn = establish_connection();
-     * #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
-     * #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
-     * diesel::insert_into(hosts)
-     *     .values(vec![address.eq(IpNetwork::from_str("10.0.2.53").unwrap())])
-     *     .execute(&conn)?;
-     *
-     * let offset = hosts
-     *     .select(address.diff(IpNetwork::from_str("10.0.2.42").unwrap()))
-     *     .first::<i64>(&conn)?;
-     * assert_eq!(offset, 11);
-     * #     Ok(())
-     * # }
-     * ```
-     */
+    /// Creates a PostgreSQL `-` expression.
+    ///
+    /// This operator substracts an address from an address to compute the distance between the two
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     hosts {
+    /// #         id -> Integer,
+    /// #         address -> Inet,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::hosts::dsl::*;
+    /// #     use ipnetwork::IpNetwork;
+    /// #     use std::str::FromStr;
+    /// #     let conn = establish_connection();
+    /// #     conn.execute("DROP TABLE IF EXISTS hosts").unwrap();
+    /// #     conn.execute("CREATE TABLE hosts (id SERIAL PRIMARY KEY, address INET NOT NULL)").unwrap();
+    /// diesel::insert_into(hosts)
+    ///     .values(vec![address.eq(IpNetwork::from_str("10.0.2.53").unwrap())])
+    ///     .execute(&conn)?;
+    ///
+    /// let offset = hosts
+    ///     .select(address.diff(IpNetwork::from_str("10.0.2.42").unwrap()))
+    ///     .first::<i64>(&conn)?;
+    /// assert_eq!(offset, 11);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn diff<T>(self, other: T) -> dsl::DifferenceNet<Self, T>
     where
         T: AsExpression<Inet>,

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -43,7 +43,7 @@ sql_function! {
 sql_function! {
     /// Returns the network part of the address, zeroing out whatever is to the right of the
     /// netmask. (This is equivalent to casting the value to cidr.)
-    fn network(addr: Inet) -> Cidr;
+    fn network<T: InetOrCidr + SingleValue>(addr: T) -> Cidr;
 }
 sql_function! {
     /// Sets the netmask length for an inet or cidr value.

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1,0 +1,53 @@
+//! PostgreSQL specific functions
+
+use super::expression_methods::InetOrCidr;
+use crate::expression::functions::sql_function;
+use crate::sql_types::*;
+
+sql_function! {
+    /// Creates an abbreviated display format as text.
+    fn abbrev<T: InetOrCidr + SingleValue>(addr: T) -> Text;
+}
+sql_function! {
+    /// Computes the broadcast address for the address's network.
+    fn broadcast<T: InetOrCidr + SingleValue>(addr: T) -> Inet;
+}
+sql_function! {
+    /// Returns the address's family: 4 for IPv4, 6 for IPv6.
+    fn family<T: InetOrCidr + SingleValue>(addr: T) -> Integer;
+}
+sql_function! {
+    /// Returns the IP address as text, ignoring the netmask.
+    fn host<T: InetOrCidr + SingleValue>(addr: T) -> Text;
+}
+sql_function! {
+    /// Computes the host mask for the address's network.
+    fn hostmask<T: InetOrCidr + SingleValue>(addr: T) -> Inet;
+}
+sql_function! {
+    /// Computes the smallest network that includes both of the given networks.
+    fn inet_merge<T: InetOrCidr + SingleValue, U: InetOrCidr + SingleValue>(a: T, b: U) -> Cidr;
+}
+sql_function! {
+    /// Tests whether the addresses belong to the same IP family.
+    fn inet_same_family<T: InetOrCidr + SingleValue, U: InetOrCidr + SingleValue>(a: T, b: U) -> Bool;
+}
+sql_function! {
+    /// Returns the netmask length in bits.
+    fn masklen<T: InetOrCidr + SingleValue>(addr: T) -> Integer;
+}
+sql_function! {
+    /// Computes the network mask for the address's network.
+    fn netmask<T: InetOrCidr + SingleValue>(addr: T) -> Inet;
+}
+sql_function! {
+    /// Returns the network part of the address, zeroing out whatever is to the right of the
+    /// netmask. (This is equivalent to casting the value to cidr.)
+    fn network(addr: Inet) -> Cidr;
+}
+sql_function! {
+    /// Sets the netmask length for an inet or cidr value.
+    /// For inet, the address part does not changes. For cidr, address bits to the right of the new
+    /// netmask are set to zero.
+    fn set_masklen<T: InetOrCidr + SingleValue>(addr: T, len: Integer) -> T;
+}

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,6 +1,6 @@
 use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
-use crate::sql_types::{Bigint, Inet, VarChar};
+use crate::sql_types::{Inet, VarChar};
 
 /// The return type of `lhs.ilike(rhs)`
 pub type ILike<Lhs, Rhs> = Grouped<super::operators::ILike<Lhs, AsExprOf<Rhs, VarChar>>>;
@@ -74,13 +74,6 @@ pub type AndNet<Lhs, Rhs> = Grouped<super::operators::AndNet<Lhs, AsExprOf<Rhs, 
 
 /// The return type of `lsh.or(rhs)`
 pub type OrNet<Lhs, Rhs> = Grouped<super::operators::OrNet<Lhs, AsExprOf<Rhs, Inet>>>;
-
-/// The return type of `lsh.add(rhs)`
-pub type AddNet<Lhs, Rhs> = Grouped<super::operators::AddNet<Lhs, AsExprOf<Rhs, Bigint>>>;
-
-/// The return type of `lsh.sub(rhs)`
-pub type SubstractNet<Lhs, Rhs> =
-    Grouped<super::operators::SubstractNet<Lhs, AsExprOf<Rhs, Bigint>>>;
 
 /// The return type of `lsh.diff(rhs)`
 pub type DifferenceNet<Lhs, Rhs> =

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,6 +1,6 @@
 use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
-use crate::sql_types::VarChar;
+use crate::sql_types::{Bigint, Inet, VarChar};
 
 /// The return type of `lhs.ilike(rhs)`
 pub type ILike<Lhs, Rhs> = Grouped<super::operators::ILike<Lhs, AsExprOf<Rhs, VarChar>>>;
@@ -49,3 +49,39 @@ pub type NullsLast<T> = super::operators::NullsLast<T>;
 /// The return type of `expr.at_time_zone(tz)`
 pub type AtTimeZone<Lhs, Rhs> =
     Grouped<super::date_and_time::AtTimeZone<Lhs, AsExprOf<Rhs, VarChar>>>;
+
+/// The return type of `lsh.contains(rhs)`
+pub type ContainsNet<Lhs, Rhs> = Grouped<super::operators::ContainsNet<Lhs, AsExprOf<Rhs, Inet>>>;
+
+/// The return type of `lsh.contains_or_eq(rhs)`
+pub type ContainsNetLoose<Lhs, Rhs> =
+    Grouped<super::operators::ContainsNetLoose<Lhs, AsExprOf<Rhs, Inet>>>;
+
+/// The return type of `lsh.is_contained_by(rhs)`
+pub type IsContainedByNet<Lhs, Rhs> =
+    Grouped<super::operators::IsContainedByNet<Lhs, AsExprOf<Rhs, Inet>>>;
+
+/// The return type of `lsh.is_contained_by_or_eq(rhs)`
+pub type IsContainedByNetLoose<Lhs, Rhs> =
+    Grouped<super::operators::IsContainedByNetLoose<Lhs, AsExprOf<Rhs, Inet>>>;
+
+/// The return type of `lhs.overlaps_with(rhs)`
+pub type OverlapsWithNet<Lhs, Rhs> =
+    Grouped<super::operators::OverlapsWith<Lhs, AsExprOf<Rhs, Inet>>>;
+
+/// The return type of `lsh.and(rhs)`
+pub type AndNet<Lhs, Rhs> = Grouped<super::operators::AndNet<Lhs, AsExprOf<Rhs, Inet>>>;
+
+/// The return type of `lsh.or(rhs)`
+pub type OrNet<Lhs, Rhs> = Grouped<super::operators::OrNet<Lhs, AsExprOf<Rhs, Inet>>>;
+
+/// The return type of `lsh.add(rhs)`
+pub type AddNet<Lhs, Rhs> = Grouped<super::operators::AddNet<Lhs, AsExprOf<Rhs, Bigint>>>;
+
+/// The return type of `lsh.sub(rhs)`
+pub type SubstractNet<Lhs, Rhs> =
+    Grouped<super::operators::SubstractNet<Lhs, AsExprOf<Rhs, Bigint>>>;
+
+/// The return type of `lsh.diff(rhs)`
+pub type DifferenceNet<Lhs, Rhs> =
+    Grouped<super::operators::DifferenceNet<Lhs, AsExprOf<Rhs, Inet>>>;

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod array;
 pub mod array_comparison;
 pub(crate) mod expression_methods;
 pub mod extensions;
+#[cfg(not(feature = "sqlite"))]
+pub mod functions;
 #[doc(hidden)]
 pub mod helper_types;
 #[doc(hidden)]
@@ -29,4 +31,7 @@ pub mod dsl {
     pub use super::array::array;
 
     pub use super::extensions::*;
+
+    #[cfg(not(feature = "sqlite"))]
+    pub use super::functions::*;
 }

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod array;
 pub mod array_comparison;
 pub(crate) mod expression_methods;
 pub mod extensions;
-#[cfg(not(feature = "sqlite"))]
 pub mod functions;
 #[doc(hidden)]
 pub mod helper_types;

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -1,5 +1,6 @@
 use crate::expression::expression_types::NotSelectable;
 use crate::pg::Pg;
+use crate::sql_types::{Bigint, Inet};
 
 infix_operator!(IsDistinctFrom, " IS DISTINCT FROM ", backend: Pg);
 infix_operator!(IsNotDistinctFrom, " IS NOT DISTINCT FROM ", backend: Pg);
@@ -12,3 +13,12 @@ infix_operator!(SimilarTo, " SIMILAR TO ", backend: Pg);
 infix_operator!(NotSimilarTo, " NOT SIMILAR TO ", backend: Pg);
 postfix_operator!(NullsFirst, " NULLS FIRST", NotSelectable, backend: Pg);
 postfix_operator!(NullsLast, " NULLS LAST", NotSelectable, backend: Pg);
+infix_operator!(ContainsNet, " >> ", backend: Pg);
+infix_operator!(ContainsNetLoose, " >>= ", backend: Pg);
+infix_operator!(IsContainedByNet, " << ", backend: Pg);
+infix_operator!(IsContainedByNetLoose, " <<= ", backend: Pg);
+infix_operator!(AndNet, " & ", Inet, backend: Pg);
+infix_operator!(OrNet, " | ", Inet, backend: Pg);
+infix_operator!(AddNet, " + ", Inet, backend: Pg);
+infix_operator!(SubstractNet, " - ", Inet, backend: Pg);
+infix_operator!(DifferenceNet, " - ", Bigint, backend: Pg);

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -19,6 +19,4 @@ infix_operator!(IsContainedByNet, " << ", backend: Pg);
 infix_operator!(IsContainedByNetLoose, " <<= ", backend: Pg);
 infix_operator!(AndNet, " & ", Inet, backend: Pg);
 infix_operator!(OrNet, " | ", Inet, backend: Pg);
-infix_operator!(AddNet, " + ", Inet, backend: Pg);
-infix_operator!(SubstractNet, " - ", Inet, backend: Pg);
 infix_operator!(DifferenceNet, " - ", Bigint, backend: Pg);

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -478,7 +478,7 @@ pub mod sql_types {
 mod ops {
     use super::sql_types::*;
     use crate::sql_types::ops::*;
-    use crate::sql_types::Interval;
+    use crate::sql_types::{Bigint, Cidr, Inet, Interval};
 
     impl Add for Timestamptz {
         type Rhs = Interval;
@@ -488,5 +488,25 @@ mod ops {
     impl Sub for Timestamptz {
         type Rhs = Interval;
         type Output = Timestamptz;
+    }
+
+    impl Add for Cidr {
+        type Rhs = Bigint;
+        type Output = Inet;
+    }
+
+    impl Add for Inet {
+        type Rhs = Bigint;
+        type Output = Inet;
+    }
+
+    impl Sub for Cidr {
+        type Rhs = Bigint;
+        type Output = Inet;
+    }
+
+    impl Sub for Inet {
+        type Rhs = Bigint;
+        type Output = Inet;
     }
 }


### PR DESCRIPTION
This PR adds support for postgresql-specific INET and CIDR types. In this PR, support is added in the query builder for:
- `<<`, `>>=`, etc operators
- `host`, `masklen`, ... functions

This is #2565 but for Diesel master.