### PR TITLE
`impl<T> fmt::Debug for r2d2::ConnectionManager<T>`

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -27,10 +27,16 @@ use crate::query_builder::{AsQuery, QueryFragment, QueryId};
 /// See the [r2d2 documentation] for usage examples.
 ///
 /// [r2d2 documentation]: ../../r2d2
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ConnectionManager<T> {
     database_url: String,
     _marker: PhantomData<T>,
+}
+
+impl<T> fmt::Debug for ConnectionManager<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ConnectionManager<{}>", std::any::type_name::<T>())
+    }
 }
 
 unsafe impl<T: Send + 'static> Sync for ConnectionManager<T> {}


### PR DESCRIPTION
The debug message of `ConnectionManager<PgConnection>` now looks like:
```rust
ConnectionManager<diesel::pg::connection::PgConnection>
```
and the one of `Pool<ConnectionManager<PgConnection>>>` like:
```rust
Pool {
    state: State {
        connections: 10,
        idle_connections: 10,
    },
    config: Config {
        max_size: 10,
        min_idle: None,
        test_on_check_out: true,
        max_lifetime: Some(
            1800s,
        ),
        idle_timeout: Some(
            600s,
        ),
        connection_timeout: 30s,
        error_handler: LoggingErrorHandler,
        event_handler: NopEventHandler,
        connection_customizer: NopConnectionCustomizer,
    },
    manager: ConnectionManager<diesel::pg::connection::PgConnection>,
}
```

Fixes #2567 