### PR TITLE
[docs] Don't display has_many as an attribute.

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Associations in Diesel are always child-to-parent.
 //! You can declare an association between two records with `#[belongs_to]`.
-//! Unlike other ORMs, Diesel has no concept of `has_many`
+//! Unlike other ORMs, Diesel has no concept of `has many`
 //!
 //! ```rust
 //! # include!("../doctest_setup.rs");

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Associations in Diesel are always child-to-parent.
 //! You can declare an association between two records with `#[belongs_to]`.
-//! Unlike other ORMs, Diesel has no concept of `#[has_many`]
+//! Unlike other ORMs, Diesel has no concept of `has_many`
 //!
 //! ```rust
 //! # include!("../doctest_setup.rs");


### PR DESCRIPTION
The docs reads 
```
//! You can declare an association between two records with `#[belongs_to]`.
//! Unlike other ORMs, Diesel has no concept of `#[has_many`]
```
If there's no `has many` in Diesel, why use the argument syntax here?
I found it a little bit confusing when reading for the first time.