### PR TITLE
Add test for inserting null in nullable column with non null default

### DIFF
--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -18,6 +18,7 @@ cfg_if::cfg_if! {
             connection.execute("DROP TABLE IF EXISTS animals CASCADE").unwrap();
             connection.execute("DROP TABLE IF EXISTS posts CASCADE").unwrap();
             connection.execute("DROP TABLE IF EXISTS comments CASCADE").unwrap();
+            connection.execute("DROP TABLE IF EXISTS brands CASCADE").unwrap();
 
             connection
         }
@@ -61,6 +62,12 @@ cfg_if::cfg_if! {
                 (1, 'Great post'),
                 (2, 'Yay! I am learning Rust'),
                 (3, 'I enjoyed your post')").unwrap();
+
+            connection.execute("CREATE TABLE brands (
+                id SERIAL PRIMARY KEY,
+                color VARCHAR NOT NULL DEFAULT 'Green',
+                accent VARCHAR DEFAULT 'Blue'
+            )").unwrap();
 
             connection
         }
@@ -125,6 +132,7 @@ cfg_if::cfg_if! {
             connection.execute("DROP TABLE IF EXISTS animals CASCADE").unwrap();
             connection.execute("DROP TABLE IF EXISTS posts CASCADE").unwrap();
             connection.execute("DROP TABLE IF EXISTS comments CASCADE").unwrap();
+            connection.execute("DROP TABLE IF EXISTS brands CASCADE").unwrap();
 
             connection
         }
@@ -168,6 +176,12 @@ cfg_if::cfg_if! {
                 (1, 'Great post'),
                 (2, 'Yay! I am learning Rust'),
                 (3, 'I enjoyed your post')").unwrap();
+
+            connection.execute("CREATE TABLE brands (
+                id INTEGER PRIMARY KEY AUTO_INCREMENT,
+                color VARCHAR(255) NOT NULL DEFAULT 'Green',
+                accent VARCHAR(255) DEFAULT 'Blue'
+            )").unwrap();
 
             connection.begin_test_transaction().unwrap();
             connection
@@ -224,6 +238,15 @@ mod schema {
         users {
             id -> Integer,
             name -> VarChar,
+        }
+    }
+
+    #[cfg(not(feature = "sqlite"))]
+    table! {
+        brands {
+            id -> Integer,
+            color -> VarChar,
+            accent -> Nullable<VarChar>,
         }
     }
 

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -241,6 +241,105 @@ pub fn delete<T: IntoUpdateTarget>(source: T) -> DeleteStatement<T::Table, T::Wh
 /// # }
 /// ```
 ///
+/// ### Inserting default value for a column
+///
+/// You can use `Option<T>` to allow a column to be set to the default value when needed.
+///
+/// When the field is set to `None`, diesel inserts the default value on supported databases.
+/// When the field is set to `Some(..)`, diesel inserts the given value.
+///
+/// The column `color` in `brands` table is `NOT NULL DEFAULT 'Green'`.
+///
+/// ```rust
+/// # include!("../doctest_setup.rs");
+/// # #[cfg(not(feature = "sqlite"))]
+/// # use schema::brands;
+/// #
+/// # #[cfg(not(feature = "sqlite"))]
+/// #[derive(Insertable)]
+/// #[table_name = "brands"]
+/// struct NewBrand {
+///     color: Option<String>,
+/// }
+///
+/// # #[cfg(not(feature = "sqlite"))]
+/// # fn main() {
+/// #     use schema::brands::dsl::*;
+/// #     let connection = establish_connection();
+/// // Insert `Red`
+/// let new_brand = NewBrand { color: Some("Red".into()) };
+///
+/// diesel::insert_into(brands)
+///     .values(&new_brand)
+///     .execute(&connection)
+///     .unwrap();
+///
+/// // Insert the default color
+/// let new_brand = NewBrand { color: None };
+///
+/// diesel::insert_into(brands)
+///     .values(&new_brand)
+///     .execute(&connection)
+///     .unwrap();
+/// # }
+/// # #[cfg(feature = "sqlite")]
+/// # fn main() {}
+/// ```
+///
+/// ### Inserting default value for a nullable column
+///
+/// The column `accent` in `brands` table is `DEFAULT 'Green'`. It is a nullable column.
+///
+/// You can use `Option<Option<T>>` in this case.
+///
+/// When the field is set to `None`, diesel inserts the default value on supported databases.
+/// When the field is set to `Some(None)`, diesel inserts `NULL`.
+/// When the field is set to `Some(Some(..))` diesel inserts the given value.
+///
+/// ```rust
+/// # include!("../doctest_setup.rs");
+/// # #[cfg(not(feature = "sqlite"))]
+/// # use schema::brands;
+/// #
+/// # #[cfg(not(feature = "sqlite"))]
+/// #[derive(Insertable)]
+/// #[table_name = "brands"]
+/// struct NewBrand {
+///     accent: Option<Option<String>>,
+/// }
+///
+/// # #[cfg(not(feature = "sqlite"))]
+/// # fn main() {
+/// #     use schema::brands::dsl::*;
+/// #     let connection = establish_connection();
+/// // Insert `Red`
+/// let new_brand = NewBrand { accent: Some(Some("Red".into())) };
+///
+/// diesel::insert_into(brands)
+///     .values(&new_brand)
+///     .execute(&connection)
+///     .unwrap();
+///
+/// // Insert the default accent
+/// let new_brand = NewBrand { accent: None };
+///
+/// diesel::insert_into(brands)
+///     .values(&new_brand)
+///     .execute(&connection)
+///     .unwrap();
+///
+/// // Insert `NULL`
+/// let new_brand = NewBrand { accent: Some(None) };
+///
+/// diesel::insert_into(brands)
+///     .values(&new_brand)
+///     .execute(&connection)
+///     .unwrap();
+/// # }
+/// # #[cfg(feature = "sqlite")]
+/// # fn main() {}
+/// ```
+///
 /// ### Insert from select
 ///
 /// When inserting from a select statement,

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -94,6 +94,22 @@ impl NewUser {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Insertable)]
+#[table_name = "users"]
+pub struct DefaultColorUser {
+    pub name: String,
+    pub hair_color: Option<Option<String>>,
+}
+
+impl DefaultColorUser {
+    pub fn new(name: &str, hair_color: Option<Option<&str>>) -> Self {
+        Self {
+            name: name.to_string(),
+            hair_color: hair_color.map(|o| o.map(|s| s.to_string())),
+        }
+    }
+}
+
 #[derive(Insertable)]
 #[table_name = "posts"]
 pub struct NewPost {

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -36,6 +36,13 @@ impl<'a, T> Column<'a, T> {
         PrimaryKey(self)
     }
 
+    pub fn default(self, expr: &str) -> Default<Self> {
+        Default {
+            column: self,
+            value: expr,
+        }
+    }
+
     pub fn not_null(self) -> NotNull<Self> {
         NotNull(self)
     }


### PR DESCRIPTION
It looks like `Insertable` does support `DEFAULT` as you can see in the test [here]( https://github.com/diesel-rs/diesel/blob/master/diesel_tests/tests/insert.rs#L176-L182). It's  happening because of [this](https://github.com/diesel-rs/diesel/blob/master/diesel/src/insertable.rs#L246) line.

Also, `NULL` is inserted when `Option<Option<T>>` is set as `Some(None)` for a column with a non-null default. I have added a test to make sure this doesn't break.
