### PR TITLE
Add bind documentation to sql and sql_query functions

### DIFF
--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -238,7 +238,7 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// # }
 /// #
 /// # fn run_test_2() -> QueryResult<()> {
-/// #     use self::users::dsl::*;
+/// #     use crate::schema::users::dsl::*;
 /// #     use diesel::dsl::sql;
 /// #     use diesel::sql_types::{Bool, Integer, Text};
 /// #     let connection = establish_connection();

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -222,17 +222,28 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// ```rust
 /// # include!("../doctest_setup.rs");
 /// # fn main() {
+/// #     run_test_1().unwrap();
+/// #     run_test_2().unwrap();
+/// # }
+/// #
+/// # fn run_test_1() -> QueryResult<()> {
 /// #     use schema::users::dsl::*;
-/// #     use diesel::sql_types::{Bool, Integer, Text};
+/// #     use diesel::sql_types::Bool;
 /// use diesel::dsl::sql;
 /// #     let connection = establish_connection();
-/// let sean = (1, String::from("Sean"));
-/// assert_eq!(Ok(sean), users.filter(sql::<Bool>("name = 'Sean'")).first(&connection));
-///
-/// # let connection = establish_connection();
-/// # diesel::insert_into(users::table)
-/// #     .values(users::name.eq("Jim"))
-/// #     .execute(&connection).unwrap();
+/// let user = users.filter(sql::<Bool>("name = 'Sean'")).first(&connection)?;
+/// let expected = (1, String::from("Sean"));
+/// assert_eq!(expected, user);
+/// #     Ok(())
+/// # }
+/// #
+/// # fn run_test_2() -> QueryResult<()> {
+/// #     use schema::users;
+/// #     use diesel::sql_types::{Bool, Integer, Text};
+/// #     let connection = establish_connection();
+/// #     diesel::insert_into(users::table)
+/// #         .values(users::name.eq("Jim"))
+/// #         .execute(&connection).unwrap();
 /// let query = users
 ///     .select(name)
 ///     .filter(
@@ -244,6 +255,7 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 ///     .get_results(&connection);
 /// let expected = vec!["Tess".to_string()];
 /// assert_eq!(Ok(expected), query);
+/// #     Ok(())
 /// # }
 /// ```
 /// [`SqlLiteral::bind()`]: ../expression/struct.SqlLiteral.html#method.bind

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -226,9 +226,8 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// #     use diesel::sql_types::{Bool, Integer, Text};
 /// use diesel::dsl::sql;
 /// #     let connection = establish_connection();
-/// let user = users.filter(sql::<Bool>("name = 'Sean'")).first(&connection)?;
-/// let expected = (1, String::from("Sean"));
-/// assert_eq!(expected, user);
+/// let sean = (1, String::from("Sean"));
+/// assert_eq!(Ok(sean), users.filter(sql::<Bool>("name = 'Sean'")).first(&connection));
 ///
 /// let query = users
 ///     .select(name)

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -238,11 +238,12 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// # }
 /// #
 /// # fn run_test_2() -> QueryResult<()> {
-/// #     use schema::users;
+/// #     use self::users::dsl::*;
+/// #     use diesel::dsl::sql;
 /// #     use diesel::sql_types::{Bool, Integer, Text};
 /// #     let connection = establish_connection();
-/// #     diesel::insert_into(users::table)
-/// #         .values(users::name.eq("Jim"))
+/// #     diesel::insert_into(users)
+/// #         .values(name.eq("Jim"))
 /// #         .execute(&connection).unwrap();
 /// let query = users
 ///     .select(name)

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -243,7 +243,7 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// #     use diesel::sql_types::{Bool, Integer, Text};
 /// #     let connection = establish_connection();
 /// #     diesel::insert_into(users)
-/// #         .values(name.eq("Jim"))
+/// #         .values(name.eq("Ryan"))
 /// #         .execute(&connection).unwrap();
 /// let query = users
 ///     .select(name)

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -73,7 +73,7 @@ where
     ///
     /// ```rust
     /// # include!("../doctest_setup.rs");
-    ///
+    /// #
     /// # table! {
     /// #    users {
     /// #        id -> Integer,
@@ -125,7 +125,7 @@ where
     ///
     /// ```rust
     /// # include!("../doctest_setup.rs");
-    ///
+    /// #
     /// # table! {
     /// #    users {
     /// #        id -> Integer,
@@ -199,7 +199,7 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
     type IsAggregate = is_aggregate::Never;
 }
 
-/// Use literal SQL in the query builder
+/// Use literal SQL in the query builder.
 ///
 /// Available for when you truly cannot represent something using the expression
 /// DSL. You will need to provide the SQL type of the expression, in addition to
@@ -208,6 +208,8 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// This function is intended for use when you need a small bit of raw SQL in
 /// your query. If you want to write the entire query using raw SQL, use
 /// [`sql_query`](../fn.sql_query.html) instead.
+///
+/// Query parameters can be bound into the literal SQL using [`SqlLiteral::bind()`].
 ///
 /// # Safety
 ///
@@ -220,20 +222,28 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// ```rust
 /// # include!("../doctest_setup.rs");
 /// # fn main() {
-/// #     run_test().unwrap();
-/// # }
-/// #
-/// # fn run_test() -> QueryResult<()> {
 /// #     use schema::users::dsl::*;
-/// #     use diesel::sql_types::Bool;
+/// #     use diesel::sql_types::{Bool, Integer, Text};
 /// use diesel::dsl::sql;
 /// #     let connection = establish_connection();
 /// let user = users.filter(sql::<Bool>("name = 'Sean'")).first(&connection)?;
 /// let expected = (1, String::from("Sean"));
 /// assert_eq!(expected, user);
-/// #     Ok(())
+///
+/// let query = users
+///     .select(name)
+///     .filter(
+///         sql::<Bool>("id > ")
+///         .bind::<Integer,_>(1)
+///         .sql(" AND name <> ")
+///         .bind::<Text, _>("Ryan")
+///     )
+///     .get_results(&connection);
+/// let expected = vec!["Tess".to_string()];
+/// assert_eq!(Ok(expected), query);
 /// # }
 /// ```
+/// [`SqlLiteral::bind()`]: ../expression/struct.SqlLiteral.html#method.bind
 pub fn sql<ST>(sql: &str) -> SqlLiteral<ST>
 where
     ST: TypedExpressionType,
@@ -245,7 +255,7 @@ where
 #[must_use = "Queries are only executed when calling `load`, `get_result`, or similar."]
 /// Returned by the [`SqlLiteral::bind()`] method when binding a value to a fragment of SQL.
 ///
-/// [`bind()`]: ./struct.SqlLiteral.html#method.bind
+/// [`SqlLiteral::bind()`]: ./struct.SqlLiteral.html#method.bind
 pub struct UncheckedBind<Query, Value> {
     query: Query,
     value: Value,
@@ -259,7 +269,7 @@ where
         UncheckedBind { query, value }
     }
 
-    /// Use literal SQL in the query builder
+    /// Use literal SQL in the query builder.
     ///
     /// This function is intended for use when you need a small bit of raw SQL in
     /// your query. If you want to write the entire query using raw SQL, use
@@ -275,7 +285,7 @@ where
     ///
     /// ```rust
     /// # include!("../doctest_setup.rs");
-    ///
+    /// #
     /// # table! {
     /// #    users {
     /// #        id -> Integer,

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -229,6 +229,10 @@ impl<ST, T, GB> ValidGrouping<GB> for SqlLiteral<ST, T> {
 /// let sean = (1, String::from("Sean"));
 /// assert_eq!(Ok(sean), users.filter(sql::<Bool>("name = 'Sean'")).first(&connection));
 ///
+/// # let connection = establish_connection();
+/// # diesel::insert_into(users::table)
+/// #     .values(users::name.eq("Jim"))
+/// #     .execute(&connection).unwrap();
 /// let query = users
 ///     .select(name)
 ///     .filter(

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -512,7 +512,13 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 /// supported by the query builder. Unlike most queries in Diesel, `sql_query`
 /// will deserialize its data by name, not by index. That means that you cannot
 /// deserialize into a tuple, and structs which you deserialize from this
-/// function will need to have `#[derive(QueryableByName)]`
+/// function will need to have `#[derive(QueryableByName)]`.
+///
+/// This function is intended for use when you want to write the entire query
+/// using raw SQL. If you only need a small bit of raw SQL in your query, use
+/// [`sql`](./dsl/fn.sql.html) instead.
+///
+/// Query parameters can be bound into the raw query using [`SqlQuery::bind()`].
 ///
 /// # Safety
 ///
@@ -521,7 +527,7 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 /// that the given type is correct. If your query returns a column of an
 /// unexpected type, the result may have the wrong value, or return an error.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```rust
 /// # include!("../doctest_setup.rs");
@@ -537,6 +543,7 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 /// #
 /// # fn main() {
 /// #     use diesel::sql_query;
+/// #     use diesel::sql_types::{Integer, Text};
 /// #
 /// #     let connection = establish_connection();
 /// let users = sql_query("SELECT * FROM users ORDER BY id")
@@ -546,8 +553,23 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 ///     User { id: 2, name: "Tess".into() },
 /// ];
 /// assert_eq!(Ok(expected_users), users);
+///
+/// # #[cfg(feature = "postgres")]
+/// # let users = sql_query("SELECT * FROM users WHERE id > $1 AND name != $2");
+/// # #[cfg(not(feature = "postgres"))]
+/// let users = sql_query("SELECT * FROM users WHERE id > ? AND name <> ?")
+/// # ;
+/// # let users = users
+///     .bind::<Integer, _>(1)
+///     .bind::<Text, _>("Tess")
+///     .get_results(&connection);
+/// let expected_users = vec![
+///     User { id: 3, name: "Jim".into() },
+/// ];
+/// assert_eq!(Ok(expected_users), users);
 /// # }
 /// ```
+/// [`SqlQuery::bind()`]: query_builder/struct.SqlQuery.html#method.bind
 pub fn sql_query<T: Into<String>>(query: T) -> SqlQuery<()> {
     SqlQuery::new((), query.into())
 }

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -542,6 +542,11 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 /// # }
 /// #
 /// # fn main() {
+/// #     run_test_1().unwrap();
+/// #     run_test_2().unwrap();
+/// # }
+/// #
+/// # fn run_test_1() -> QueryResult<()> {
 /// #     use diesel::sql_query;
 /// #     use diesel::sql_types::{Integer, Text};
 /// #
@@ -553,17 +558,23 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 ///     User { id: 2, name: "Tess".into() },
 /// ];
 /// assert_eq!(Ok(expected_users), users);
+/// #     Ok(())
+/// # }
 ///
-/// # let connection = establish_connection();
-/// # diesel::insert_into(users::table)
-/// #     .values(users::name.eq("Jim"))
-/// #     .execute(&connection).unwrap();
-/// # #[cfg(feature = "postgres")]
-/// # let users = sql_query("SELECT * FROM users WHERE id > $1 AND name != $2");
-/// # #[cfg(not(feature = "postgres"))]
+/// # fn run_test_2() -> QueryResult<()> {
+/// #     use diesel::sql_query;
+/// #     use diesel::sql_types::{Integer, Text};
+/// #
+/// #     let connection = establish_connection();
+/// #     diesel::insert_into(users::table)
+/// #         .values(users::name.eq("Jim"))
+/// #         .execute(&connection).unwrap();
+/// #     #[cfg(feature = "postgres")]
+/// #     let users = sql_query("SELECT * FROM users WHERE id > $1 AND name != $2");
+/// #     #[cfg(not(feature = "postgres"))]
 /// let users = sql_query("SELECT * FROM users WHERE id > ? AND name <> ?")
 /// # ;
-/// # let users = users
+/// let users = users
 ///     .bind::<Integer, _>(1)
 ///     .bind::<Text, _>("Tess")
 ///     .get_results(&connection);
@@ -571,6 +582,7 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 ///     User { id: 3, name: "Jim".into() },
 /// ];
 /// assert_eq!(Ok(expected_users), users);
+/// #     Ok(())
 /// # }
 /// ```
 /// [`SqlQuery::bind()`]: query_builder/struct.SqlQuery.html#method.bind

--- a/diesel/src/query_builder/functions.rs
+++ b/diesel/src/query_builder/functions.rs
@@ -554,6 +554,10 @@ pub fn replace_into<T>(target: T) -> IncompleteInsertStatement<T, Replace> {
 /// ];
 /// assert_eq!(Ok(expected_users), users);
 ///
+/// # let connection = establish_connection();
+/// # diesel::insert_into(users::table)
+/// #     .values(users::name.eq("Jim"))
+/// #     .execute(&connection).unwrap();
 /// # #[cfg(feature = "postgres")]
 /// # let users = sql_query("SELECT * FROM users WHERE id > $1 AND name != $2");
 /// # #[cfg(not(feature = "postgres"))]

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -190,6 +190,9 @@ impl<Query, Value, ST> UncheckedBind<Query, Value, ST> {
     /// #     use diesel::sql_types::{Integer, Text};
     /// #
     /// #     let connection = establish_connection();
+    /// #     diesel::insert_into(users::table)
+    /// #         .values(users::name.eq("Jim"))
+    /// #         .execute(&connection).unwrap();
     /// # #[cfg(feature = "postgres")]
     /// # let users = sql_query("SELECT * FROM users WHERE id > $1 AND name != $2");
     /// # #[cfg(not(feature = "postgres"))]


### PR DESCRIPTION
This is a followup from a discussion in the gitter.im channel.

* `sql` and `sql_query` each get a link to their respective `bind` functions and an example containing usage of `bind`.
* `SqlLiteral::bind`'s `UncheckedBind` struct had a broken link back to `SqlLiteral::bind` so I fixed that.
* Since `sql` already links to `sql_query`, I crosslinked `sql_query` back to `sql`.
* I'm not sure why `SqlQuery::bind`'s `UncheckedBind` struct doesn't get documented by cargo, but I added documentation comments to it anyway.