### PR TITLE
Allow to box selectstatements containing boxable expressions

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -769,6 +769,7 @@ where
     Self: Expression,
     Self: SelectableExpression<QS>,
     Self: QueryFragment<DB>,
+    Self: Send,
 {
 }
 
@@ -779,6 +780,7 @@ where
     T: SelectableExpression<QS>,
     T: ValidGrouping<GB>,
     T: QueryFragment<DB>,
+    T: Send,
     T::IsAggregate: MixedAggregates<IsAggregate, Output = IsAggregate>,
 {
 }

--- a/diesel_tests/tests/boxed_queries.rs
+++ b/diesel_tests/tests/boxed_queries.rs
@@ -159,3 +159,20 @@ fn boxed_queries_implement_or_filter() {
     ];
     assert_eq!(Ok(expected), data);
 }
+
+#[test]
+fn can_box_query_with_boxable_expression() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    let expr: Box<dyn BoxableExpression<_, _, SqlType = _>> = Box::new(users::name.eq("Sean")) as _;
+
+    let data = users::table.into_boxed().filter(expr).load(&connection);
+    let expected = vec![find_user_by_name("Sean", &connection)];
+    assert_eq!(Ok(expected), data);
+
+    let expr: Box<dyn BoxableExpression<_, _, SqlType = _>> = Box::new(users::name.eq("Sean")) as _;
+
+    let data = users::table.filter(expr).into_boxed().load(&connection);
+    let expected = vec![find_user_by_name("Sean", &connection)];
+    assert_eq!(Ok(expected), data);
+}


### PR DESCRIPTION
There was a missing `Send` bound there