### PR TITLE
Fix #2623

### DIFF
--- a/diesel_cli/src/infer_schema_internals/mysql.rs
+++ b/diesel_cli/src/infer_schema_internals/mysql.rs
@@ -53,6 +53,7 @@ pub fn load_foreign_key_constraints(
     let constraints = tc::table
         .filter(tc::constraint_type.eq("FOREIGN KEY"))
         .filter(tc::table_schema.eq(schema_name))
+        .filter(kcu::referenced_column_name.is_not_null())
         .inner_join(
             kcu::table.on(tc::constraint_schema
                 .eq(kcu::constraint_schema)

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -154,6 +154,11 @@ fn print_schema_with_unmappable_names_and_schema_name() {
 }
 
 #[test]
+fn print_schema_with_seperate_unique_constraint_and_foreign_key() {
+    test_print_schema("print_schema_regression_test_for_2623", vec![])
+}
+
+#[test]
 fn schema_file_is_relative_to_project_root() {
     let p = project("schema_file_is_relative_to_project_root")
         .folder("foo")

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/mysql/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/mysql/expected.rs
@@ -1,0 +1,21 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    tab_key1 (id) {
+        id -> Bigint,
+    }
+}
+
+diesel::table! {
+    tab_problem (id) {
+        id -> Bigint,
+        key1 -> Bigint,
+    }
+}
+
+diesel::joinable!(tab_problem -> tab_key1 (key1));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    tab_key1,
+    tab_problem,
+);

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/mysql/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/mysql/schema.sql
@@ -1,0 +1,14 @@
+CREATE TABLE tab_key1(
+    id bigint NOT NULL auto_increment,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+CREATE TABLE tab_problem (
+  id bigint NOT NULL auto_increment,
+  key1 bigint NOT NULL,
+
+  PRIMARY KEY (id),
+  UNIQUE (key1),
+  CONSTRAINT `key1` FOREIGN KEY (key1) REFERENCES tab_key1(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.rs
@@ -1,0 +1,21 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    tab1 (id) {
+        id -> Int8,
+    }
+}
+
+diesel::table! {
+    tab_problem (id) {
+        id -> Int8,
+        key1 -> Int8,
+    }
+}
+
+diesel::joinable!(tab_problem -> tab1 (key1));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    tab1,
+    tab_problem,
+);

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/schema.sql
@@ -1,0 +1,13 @@
+CREATE TABLE tab1(
+    id bigserial NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE tab_problem (
+  id bigserial NOT NULL,
+  key1 bigint NOT NULL,
+
+  PRIMARY KEY (id),
+  UNIQUE (key1),
+  CONSTRAINT "key1" FOREIGN KEY (key1) REFERENCES tab1(id)
+);

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/sqlite/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/sqlite/expected.rs
@@ -1,0 +1,21 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    tab_key1 (id) {
+        id -> Integer,
+    }
+}
+
+diesel::table! {
+    tab_problem (id) {
+        id -> Integer,
+        key1 -> BigInt,
+    }
+}
+
+diesel::joinable!(tab_problem -> tab_key1 (key1));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    tab_key1,
+    tab_problem,
+);

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/sqlite/schema.sql
@@ -1,0 +1,14 @@
+CREATE TABLE tab_key1(
+    id integer NOT NULL,
+    PRIMARY KEY (id)
+);
+
+
+CREATE TABLE tab_problem (
+  id integer NOT NULL,
+  key1 bigint NOT NULL,
+
+  PRIMARY KEY (id),
+  UNIQUE (key1),
+  CONSTRAINT `key1` FOREIGN KEY (key1) REFERENCES tab_key1(id)
+);


### PR DESCRIPTION
Mysql seems to store `UNIQUE` constrains in the same information schema
table as `FOREIGN KEY` constraints so we filter that out.