### PR TITLE
Note join extract struct not supported

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -355,6 +355,9 @@ pub trait QueryDsl: Sized {
     ///     INNER JOIN comments ON comments.user_id = users.id
     /// ```
     ///
+    /// **Note**: extracting structs directly like `(User, Post)` is not supported,
+    /// using `select` to extract the fields are still required.
+    ///
     /// [associations]: ../associations/index.html
     /// [`allow_tables_to_appear_in_same_query!`]: ../macro.allow_tables_to_appear_in_same_query.html
     ///


### PR DESCRIPTION
As I saw `(User, (Post, Comment))` in the docs, I thought using join to extract the original struct out without using `select` works, I spent some time trying it out and I believe it does not work. It would be better to tell others that `select` is still needed without letting them try it since it will fail during compilation time.

Or maybe we can explain this is due to ambiguity?