### PR TITLE
Fix #2203

### DIFF
--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -215,7 +215,7 @@ where
             None => {
                 let sql = Self::construct_sql(source)?;
                 Ok(StatementCacheKey::Sql {
-                    sql: sql,
+                    sql,
                     bind_types: bind_types.into(),
                 })
             }

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -6,6 +6,7 @@ use super::query_builder::PgQueryBuilder;
 use super::{PgMetadataLookup, PgValue};
 use crate::backend::*;
 use crate::deserialize::Queryable;
+use crate::pg::metadata_lookup::PgMetadataCacheKey;
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::sql_types::TypeMetadata;
 
@@ -13,19 +14,72 @@ use crate::sql_types::TypeMetadata;
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Pg;
 
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Queryable)]
+pub(in crate::pg) struct InnerPgTypeMetadata {
+    pub oid: u32,
+    pub array_oid: u32,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub(in crate::pg) struct FailedToLookupTypeError(Box<PgMetadataCacheKey<'static>>);
+
+impl FailedToLookupTypeError {
+    pub(crate) fn new(cache_key: PgMetadataCacheKey<'static>) -> Self {
+        Self(Box::new(cache_key))
+    }
+}
+
+impl std::error::Error for FailedToLookupTypeError {}
+
+impl std::fmt::Display for FailedToLookupTypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(schema) = self.0.schema.as_ref() {
+            write!(
+                f,
+                "Failed to find a type oid for `{}`.`{}`",
+                schema, self.0.type_name
+            )
+        } else {
+            write!(f, "Failed to find a type oid for {}`", self.0.type_name)
+        }
+    }
+}
+
 /// The [OIDs] for a SQL type
 ///
 /// [OIDs]: https://www.postgresql.org/docs/current/static/datatype-oid.html
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default, Queryable)]
-pub struct PgTypeMetadata {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[must_use]
+pub struct PgTypeMetadata(pub(in crate::pg) Result<InnerPgTypeMetadata, FailedToLookupTypeError>);
+
+impl PgTypeMetadata {
+    /// Create a new instance of this type based on known constant [OIDs].
+    ///
+    /// Please refer to [PgMetadataLookup] for a way to query [OIDs]
+    /// of custom types at run time
+    ///
+    /// [OIDs]: https://www.postgresql.org/docs/current/static/datatype-oid.html
+    /// [PgMetadataLookup]: struct.PgMetadataLookup.html
+    pub fn new(type_oid: u32, array_oid: u32) -> Self {
+        Self(Ok(InnerPgTypeMetadata {
+            oid: type_oid,
+            array_oid,
+        }))
+    }
+
     /// The [OID] of `T`
     ///
     /// [OID]: https://www.postgresql.org/docs/current/static/datatype-oid.html
-    pub oid: u32,
+    pub fn oid(&self) -> Result<u32, impl std::error::Error + Send + Sync> {
+        self.0.as_ref().map(|i| i.oid).map_err(Clone::clone)
+    }
+
     /// The [OID] of `T[]`
     ///
     /// [OID]: https://www.postgresql.org/docs/current/static/datatype-oid.html
-    pub array_oid: u32,
+    pub fn array_oid(self) -> Result<u32, impl std::error::Error + Send + Sync> {
+        self.0.as_ref().map(|i| i.array_oid).map_err(Clone::clone)
+    }
 }
 
 impl Backend for Pg {

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -40,7 +40,7 @@ impl std::fmt::Display for FailedToLookupTypeError {
                 schema, self.0.type_name
             )
         } else {
-            write!(f, "Failed to find a type oid for {}`", self.0.type_name)
+            write!(f, "Failed to find a type oid for `{}`", self.0.type_name)
         }
     }
 }

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -57,7 +57,11 @@ impl Statement {
     ) -> QueryResult<Self> {
         let name = CString::new(name.unwrap_or(""))?;
         let sql = CString::new(sql)?;
-        let param_types_vec = param_types.iter().map(|x| x.oid).collect();
+        let param_types_vec = param_types
+            .iter()
+            .map(|x| x.oid())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
 
         let internal_result = unsafe {
             conn.raw_connection.prepare(

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -3,6 +3,7 @@
 use super::{PgConnection, PgTypeMetadata};
 use crate::prelude::*;
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -24,26 +25,87 @@ impl PgMetadataLookup {
     /// This function should only be used for user defined types, or types which
     /// come from an extension. This function may perform a SQL query to look
     /// up the type. For built-in types, a static OID should be preferred.
-    pub fn lookup_type(&self, type_name: &str) -> PgTypeMetadata {
+    pub fn lookup_type(&self, type_name: &str, schema: Option<&str>) -> PgTypeMetadata {
         let metadata_cache = self.conn.get_metadata_cache();
-        metadata_cache.lookup_type(type_name).unwrap_or_else(|| {
-            use self::pg_type::dsl::*;
+        let cache_key = PgMetadataCacheKey {
+            schema: schema.map(Cow::Borrowed),
+            type_name: Cow::Borrowed(type_name),
+        };
 
-            let type_metadata = pg_type
-                .select((oid, typarray))
-                .filter(typname.eq(type_name))
-                .first(&self.conn)
-                .unwrap_or_default();
-            metadata_cache.store_type(type_name, type_metadata);
-            type_metadata
+        metadata_cache.lookup_type(&cache_key).unwrap_or_else(|| {
+            let r = lookup_type(&cache_key, &self.conn);
+
+            match r {
+                Ok(type_metadata) => {
+                    metadata_cache.store_type(cache_key, type_metadata);
+                    type_metadata
+                }
+                Err(_e) => {
+                    eprintln!("Failed to find oid for type `{}`", type_name);
+                    // We return 0 as type oid here
+                    // because most of the time postgres
+                    // can figure out the type on its own
+                    PgTypeMetadata {
+                        oid: 0,
+                        array_oid: 0,
+                    }
+                }
+            }
         })
+    }
+}
+
+fn lookup_type(
+    cache_key: &PgMetadataCacheKey<'_>,
+    conn: &PgConnection,
+) -> QueryResult<PgTypeMetadata> {
+    let search_path: String;
+
+    let search_schema = if let Some(schema) = cache_key.schema.as_ref() {
+        vec![schema.as_ref()]
+    } else {
+        search_path = crate::dsl::sql("SHOW search_path").get_result::<String>(conn)?;
+
+        search_path
+            .split(',')
+            // skip the `$user` entry for now
+            .filter(|f| !f.starts_with("\"$"))
+            .map(|s| s.trim())
+            .collect()
+    };
+
+    let metadata = pg_type::table
+        .inner_join(pg_namespace::table)
+        .filter(pg_namespace::nspname.eq(crate::dsl::any(search_schema)))
+        .filter(pg_type::typname.eq(&cache_key.type_name))
+        .select((pg_type::oid, pg_type::typarray))
+        .first(conn)?;
+
+    Ok(metadata)
+}
+
+#[derive(Hash, PartialEq, Eq)]
+struct PgMetadataCacheKey<'a> {
+    schema: Option<Cow<'a, str>>,
+    type_name: Cow<'a, str>,
+}
+
+impl<'a> PgMetadataCacheKey<'a> {
+    fn as_owned(&self) -> PgMetadataCacheKey<'static> {
+        PgMetadataCacheKey {
+            schema: self
+                .schema
+                .as_ref()
+                .map(|schema| Cow::Owned(schema.as_ref().to_owned())),
+            type_name: Cow::Owned(self.type_name.as_ref().to_owned()),
+        }
     }
 }
 
 /// Stores a cache for the OID of custom types
 #[allow(missing_debug_implementations)]
 pub struct PgMetadataCache {
-    cache: RefCell<HashMap<String, PgTypeMetadata>>,
+    cache: RefCell<HashMap<PgMetadataCacheKey<'static>, PgTypeMetadata>>,
 }
 
 impl PgMetadataCache {
@@ -53,14 +115,14 @@ impl PgMetadataCache {
         }
     }
 
-    fn lookup_type(&self, type_name: &str) -> Option<PgTypeMetadata> {
+    fn lookup_type(&self, type_name: &PgMetadataCacheKey) -> Option<PgTypeMetadata> {
         Some(*self.cache.borrow().get(type_name)?)
     }
 
-    fn store_type(&self, type_name: &str, type_metadata: PgTypeMetadata) {
+    fn store_type(&self, type_name: PgMetadataCacheKey, type_metadata: PgTypeMetadata) {
         self.cache
             .borrow_mut()
-            .insert(type_name.to_owned(), type_metadata);
+            .insert(type_name.as_owned(), type_metadata);
     }
 }
 
@@ -69,5 +131,16 @@ table! {
         oid -> Oid,
         typname -> Text,
         typarray -> Oid,
+        typnamespace -> Oid,
     }
 }
+
+table! {
+    pg_namespace (oid) {
+        oid -> Oid,
+        nspname -> Text,
+    }
+}
+
+joinable!(pg_type -> pg_namespace(typnamespace));
+allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -91,13 +91,11 @@ struct PgMetadataCacheKey<'a> {
 }
 
 impl<'a> PgMetadataCacheKey<'a> {
-    fn as_owned(&self) -> PgMetadataCacheKey<'static> {
+    fn into_owned(self) -> PgMetadataCacheKey<'static> {
+        let PgMetadataCacheKey { schema, type_name } = self;
         PgMetadataCacheKey {
-            schema: self
-                .schema
-                .as_ref()
-                .map(|schema| Cow::Owned(schema.as_ref().to_owned())),
-            type_name: Cow::Owned(self.type_name.as_ref().to_owned()),
+            schema: schema.map(|s| Cow::Owned(s.into_owned())),
+            type_name: Cow::Owned(type_name.into_owned()),
         }
     }
 }
@@ -122,7 +120,7 @@ impl PgMetadataCache {
     fn store_type(&self, type_name: PgMetadataCacheKey, type_metadata: PgTypeMetadata) {
         self.cache
             .borrow_mut()
-            .insert(type_name.as_owned(), type_metadata);
+            .insert(type_name.into_owned(), type_metadata);
     }
 }
 

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -12,9 +12,9 @@ where
     Pg: HasSqlType<T>,
 {
     fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
-        PgTypeMetadata {
-            oid: <Pg as HasSqlType<T>>::metadata(lookup).array_oid,
-            array_oid: 0,
+        match <Pg as HasSqlType<T>>::metadata(lookup).0 {
+            Ok(tpe) => PgTypeMetadata::new(tpe.array_oid, 0),
+            c @ Err(_) => PgTypeMetadata(c),
         }
     }
 }
@@ -91,7 +91,7 @@ where
         out.write_i32::<NetworkEndian>(num_dimensions)?;
         let flags = 0;
         out.write_i32::<NetworkEndian>(flags)?;
-        let element_oid = Pg::metadata(out.metadata_lookup()).oid;
+        let element_oid = Pg::metadata(out.metadata_lookup()).oid()?;
         out.write_u32::<NetworkEndian>(element_oid)?;
         out.write_i32::<NetworkEndian>(self.len() as i32)?;
         let lower_bound = 1;

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -160,54 +160,36 @@ where
 
 impl HasSqlType<Int4range> for Pg {
     fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-        PgTypeMetadata {
-            oid: 3904,
-            array_oid: 3905,
-        }
+        PgTypeMetadata::new(3904, 3905)
     }
 }
 
 impl HasSqlType<Numrange> for Pg {
     fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-        PgTypeMetadata {
-            oid: 3906,
-            array_oid: 3907,
-        }
+        PgTypeMetadata::new(3906, 3907)
     }
 }
 
 impl HasSqlType<Tsrange> for Pg {
     fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-        PgTypeMetadata {
-            oid: 3908,
-            array_oid: 3909,
-        }
+        PgTypeMetadata::new(3908, 3909)
     }
 }
 
 impl HasSqlType<Tstzrange> for Pg {
     fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-        PgTypeMetadata {
-            oid: 3910,
-            array_oid: 3911,
-        }
+        PgTypeMetadata::new(3910, 3911)
     }
 }
 
 impl HasSqlType<Daterange> for Pg {
     fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-        PgTypeMetadata {
-            oid: 3912,
-            array_oid: 3913,
-        }
+        PgTypeMetadata::new(3912, 3913)
     }
 }
 
 impl HasSqlType<Int8range> for Pg {
     fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-        PgTypeMetadata {
-            oid: 3926,
-            array_oid: 3927,
-        }
+        PgTypeMetadata::new(3926, 3927)
     }
 }

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -103,7 +103,7 @@ macro_rules! tuple_impls {
                 out.write_i32::<NetworkEndian>($Tuple)?;
 
                 $(
-                    let oid = <Pg as HasSqlType<$ST>>::metadata(out.metadata_lookup()).oid;
+                    let oid = <Pg as HasSqlType<$ST>>::metadata(out.metadata_lookup()).oid()?;
                     out.write_u32::<NetworkEndian>(oid)?;
                     let is_null = self.$idx.to_sql(&mut buffer)?;
 

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -106,7 +106,7 @@ error[E0277]: the trait bound `{integer}: diesel::SelectableExpression<()>` is n
               <(A, B) as diesel::SelectableExpression<QS>>
               <(A, B, C) as diesel::SelectableExpression<QS>>
               <(A, B, C, D) as diesel::SelectableExpression<QS>>
-            and 108 others
+            and 124 others
     = note: required because of the requirements on the impl of `diesel::SelectableExpression<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
     = note: required because of the requirements on the impl of `diesel::SelectableExpression<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
     = note: required because of the requirements on the impl of `diesel::query_dsl::select_dsl::SelectDsl<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>` for `diesel::query_builder::SelectStatement<()>`
@@ -127,7 +127,7 @@ error[E0277]: the trait bound `{integer}: diesel::expression::ValidGrouping<()>`
               <(A, B) as diesel::expression::ValidGrouping<__GroupByClause>>
               <(A, B, C) as diesel::expression::ValidGrouping<__GroupByClause>>
               <(A, B, C, D) as diesel::expression::ValidGrouping<__GroupByClause>>
-            and 111 others
+            and 118 others
     = note: required because of the requirements on the impl of `diesel::expression::ValidGrouping<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
     = note: required because of the requirements on the impl of `diesel::expression::ValidGrouping<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
     = note: required because of the requirements on the impl of `diesel::query_dsl::select_dsl::SelectDsl<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>` for `diesel::query_builder::SelectStatement<()>`
@@ -143,7 +143,7 @@ error[E0277]: the trait bound `{integer}: diesel::SelectableExpression<()>` is n
              <(A, B) as diesel::SelectableExpression<QS>>
              <(A, B, C) as diesel::SelectableExpression<QS>>
              <(A, B, C, D) as diesel::SelectableExpression<QS>>
-           and 108 others
+           and 124 others
    = note: required because of the requirements on the impl of `diesel::SelectableExpression<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: required because of the requirements on the impl of `diesel::SelectableExpression<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
    = note: required because of the requirements on the impl of `diesel::query_builder::SelectClauseExpression<()>` for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>`
@@ -161,7 +161,7 @@ error[E0277]: the trait bound `{integer}: diesel::expression::ValidGrouping<()>`
              <(A, B) as diesel::expression::ValidGrouping<__GroupByClause>>
              <(A, B, C) as diesel::expression::ValidGrouping<__GroupByClause>>
              <(A, B, C, D) as diesel::expression::ValidGrouping<__GroupByClause>>
-           and 111 others
+           and 118 others
    = note: required because of the requirements on the impl of `diesel::expression::ValidGrouping<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: required because of the requirements on the impl of `diesel::expression::ValidGrouping<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
    = note: required because of the requirements on the impl of `diesel::query_builder::Query` for `diesel::query_builder::SelectStatement<(), diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>`
@@ -178,7 +178,7 @@ error[E0277]: the trait bound `{integer}: diesel::query_builder::QueryId` is not
              <() as diesel::query_builder::QueryId>
              <(A, B) as diesel::query_builder::QueryId>
              <(A, B, C) as diesel::query_builder::QueryId>
-           and 180 others
+           and 185 others
    = note: required because of the requirements on the impl of `diesel::query_builder::QueryId` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: required because of the requirements on the impl of `diesel::query_builder::QueryId` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
    = note: required because of the requirements on the impl of `diesel::query_builder::QueryId` for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>`
@@ -196,7 +196,7 @@ error[E0277]: the trait bound `{integer}: diesel::query_builder::QueryFragment<_
              <() as diesel::query_builder::QueryFragment<DB>>
              <(A, B) as diesel::query_builder::QueryFragment<__DB>>
              <(A, B, C) as diesel::query_builder::QueryFragment<__DB>>
-           and 211 others
+           and 215 others
    = note: required because of the requirements on the impl of `diesel::query_builder::QueryFragment<_>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: required because of the requirements on the impl of `for<'a> diesel::query_builder::QueryFragment<_>` for `&'a ({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: required because of the requirements on the impl of `diesel::query_builder::QueryFragment<_>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -220,7 +220,7 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              <(A, B) as diesel::Expression>
              <(A, B, C) as diesel::Expression>
              <(A, B, C, D) as diesel::Expression>
-           and 96 others
+           and 100 others
    = note: required because of the requirements on the impl of `diesel::expression::AsExpression<diesel::sql_types::Double>` for `{integer}`
    = note: required because of the requirements on the impl of `diesel::expression::AsExpressionList<diesel::sql_types::Double>` for `({integer}, f64)`
 

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              <(A, B) as diesel::Expression>
              <(A, B, C) as diesel::Expression>
              <(A, B, C, D) as diesel::Expression>
-           and 100 others
+           and 104 others
    = note: required because of the requirements on the impl of `diesel::Expression` for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>`
    = note: required because of the requirements on the impl of `diesel::Expression` for `diesel::expression::nullable::Nullable<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>`
    = note: required because of the requirements on the impl of `diesel::query_dsl::filter_dsl::FilterDsl<diesel::expression::nullable::Nullable<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>>` for `diesel::query_builder::SelectStatement<string_primary_key::table>`
@@ -46,6 +46,6 @@ error[E0277]: the trait bound `{integer}: diesel::expression::ValidGrouping<()>`
              <(A, B) as diesel::expression::ValidGrouping<__GroupByClause>>
              <(A, B, C) as diesel::expression::ValidGrouping<__GroupByClause>>
              <(A, B, C, D) as diesel::expression::ValidGrouping<__GroupByClause>>
-           and 117 others
+           and 124 others
    = note: required because of the requirements on the impl of `diesel::expression::ValidGrouping<()>` for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>`
    = note: required because of the requirements on the impl of `diesel::query_dsl::filter_dsl::FilterDsl<diesel::expression::nullable::Nullable<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>>` for `diesel::query_builder::SelectStatement<string_primary_key::table>`

--- a/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
+++ b/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
@@ -9,5 +9,5 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              <(A, B) as diesel::Expression>
              <(A, B, C) as diesel::Expression>
              <(A, B, C, D) as diesel::Expression>
-           and 100 others
+           and 104 others
    = note: required because of the requirements on the impl of `diesel::expression::AsExpression<diesel::sql_types::Text>` for `{integer}`

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -752,7 +752,7 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 /// You don't need to specify every backend,
 /// only the ones supported by your type.
 ///
-/// For PostgreSQL, add  `#[postgres(type_name = "pg_type_name")]`
+/// For PostgreSQL, add  `#[postgres(type_name = "pg_type_name", type_schema = "pg_schema_name")]`
 /// or `#[postgres(oid = "some_oid", array_oid = "some_oid")]` for
 /// builtin types.
 /// For MySQL, specify which variant of `MysqlType` should be used
@@ -764,9 +764,10 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 ///
 /// ## Type attributes
 ///
-/// * `#[postgres(type_name = "TypeName")]` specifies support for
-/// a postgresql type with the name `TypeName`. Prefer this variant
-/// for types with no stable OID (== everything but the builtin types)
+/// * `#[postgres(type_name = "TypeName", type_schema = "public")]` specifies support for
+/// a postgresql type with the name `TypeName` in the schema `public`. Prefer this variant
+/// for types with no stable OID (== everything but the builtin types). It's possible to leaf
+/// of the `type_schema` part. In that case diesel defaults to the default postgres search path.
 /// * `#[postgres(oid = 42, array_oid = 142)]`, specifies support for a
 /// postgresql type with the given `oid` and `array_oid`. This variant
 /// should only be used with types that have a stable OID.

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -106,10 +106,7 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
             let metadata_fn = match ty {
                 PgType::Fixed { oid, array_oid } => quote!(
                     fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
-                        PgTypeMetadata {
-                            oid: #oid,
-                            array_oid: #array_oid,
-                        }
+                        PgTypeMetadata::new(#oid, #array_oid)
                     }
                 ),
                 PgType::Lookup(type_name, Some(type_schema)) => quote!(

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -112,9 +112,14 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
                         }
                     }
                 ),
-                PgType::Lookup(type_name) => quote!(
+                PgType::Lookup(type_name, Some(type_schema)) => quote!(
                     fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
-                        lookup.lookup_type(#type_name)
+                        lookup.lookup_type(#type_name, Some(#type_schema))
+                    }
+                ),
+                PgType::Lookup(type_name, None) => quote!(
+                    fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
+                        lookup.lookup_type(#type_name, None)
                     }
                 ),
             };
@@ -133,9 +138,13 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
 }
 
 fn get_type_name(attr: &MetaItem) -> Result<Option<PgType>, Diagnostic> {
+    let schema = attr.nested_item("type_schema")?;
     Ok(attr.nested_item("type_name")?.map(|ty| {
-        attr.warn_if_other_options(&["type_name"]);
-        PgType::Lookup(ty.expect_str_value())
+        attr.warn_if_other_options(&["type_name", "type_schema"]);
+        PgType::Lookup(
+            ty.expect_str_value(),
+            schema.map(|schema| schema.expect_str_value()),
+        )
     }))
 }
 
@@ -155,5 +164,5 @@ fn get_oids(attr: &MetaItem) -> Result<Option<PgType>, Diagnostic> {
 
 enum PgType {
     Fixed { oid: u32, array_oid: u32 },
-    Lookup(String),
+    Lookup(String, Option<String>),
 }

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -84,3 +84,83 @@ fn custom_types_round_trip() {
         .unwrap();
     assert_eq!(data, inserted);
 }
+
+table! {
+    use diesel::sql_types::*;
+    use super::MyTypeInCustomSchema;
+    custom_schema.custom_types_with_custom_schema {
+        id -> Integer,
+        custom_enum -> MyTypeInCustomSchema,
+    }
+}
+
+#[derive(SqlType)]
+#[postgres(type_name = "my_type", type_schema = "custom_schema")]
+pub struct MyTypeInCustomSchema;
+
+#[derive(Debug, PartialEq, FromSqlRow, AsExpression)]
+#[sql_type = "MyTypeInCustomSchema"]
+pub enum MyEnumInCustomSchema {
+    Foo,
+    Bar,
+}
+
+impl ToSql<MyTypeInCustomSchema, Pg> for MyEnumInCustomSchema {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        match *self {
+            MyEnumInCustomSchema::Foo => out.write_all(b"foo")?,
+            MyEnumInCustomSchema::Bar => out.write_all(b"bar")?,
+        }
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<MyTypeInCustomSchema, Pg> for MyEnumInCustomSchema {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
+            b"foo" => Ok(MyEnumInCustomSchema::Foo),
+            b"bar" => Ok(MyEnumInCustomSchema::Bar),
+            _ => Err("Unrecognized enum variant".into()),
+        }
+    }
+}
+
+#[derive(Insertable, Queryable, Identifiable, Debug, PartialEq)]
+#[table_name = "custom_types_with_custom_schema"]
+struct HasCustomTypesInCustomSchema {
+    id: i32,
+    custom_enum: MyEnumInCustomSchema,
+}
+
+#[test]
+fn custom_types_in_custom_schema_round_trip() {
+    let data = vec![
+        HasCustomTypesInCustomSchema {
+            id: 1,
+            custom_enum: MyEnumInCustomSchema::Foo,
+        },
+        HasCustomTypesInCustomSchema {
+            id: 2,
+            custom_enum: MyEnumInCustomSchema::Bar,
+        },
+    ];
+    let connection = connection();
+    connection
+        .batch_execute(
+            r#"
+        CREATE SCHEMA IF NOT EXISTS custom_schema;
+        CREATE TYPE custom_schema.my_type AS ENUM ('foo', 'bar');
+        CREATE TABLE custom_schema.custom_types_with_custom_schema (
+            id SERIAL PRIMARY KEY,
+            custom_enum custom_schema.my_type NOT NULL
+        );
+    "#,
+        )
+        .unwrap();
+
+    let inserted = insert_into(custom_types_with_custom_schema::table)
+        .values(&data)
+        .get_results(&connection)
+        .unwrap();
+    assert_eq!(data, inserted);
+}


### PR DESCRIPTION
Custom postgres types could live in different schemas, so we need to
incorporate the corresponding schema in the lookup request. This commit
adds an optional parameter to `#[derive(SqlType)]` that allows to
configure the corresponding schema. Otherwise the default search path is used.