### PR TITLE
Explain that not only the order of fields needed

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -266,7 +266,7 @@ pub trait QueryDsl: Sized {
     /// let join = users::table.left_join(posts::table);
     ///
     /// // By default, all columns from both tables are selected.
-    /// // Note, the structs must contain all the fields from original schemas in order.
+    /// // If no explicit select clause is used this means that the result type of this query must contain all fields from the original schema in order.
     /// let all_data = join.load::<(User, Option<Post>)>(&connection)?;
     /// let expected_data = vec![
     ///     (User::new(1, "Sean"), Some(Post::new(post_id, 1, "Sean's Post"))),
@@ -460,8 +460,8 @@ pub trait QueryDsl: Sized {
     ///     .execute(&connection)
     ///     .unwrap();
     ///
-    /// // It can load into struct as long as the struct contains all the
-    /// // fields in the schema in the same order without explicit select.
+    /// // By default, all columns from both tables are selected.
+    /// // If no explicit select clause is used this means that the result type of this query must contain all fields from the original schema in order.
     /// let data = users
     ///     .inner_join(posts.on(title.like(name.concat("%"))))
     ///     .load::<(User, Post)>(&connection); // type could be elided

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -265,7 +265,8 @@ pub trait QueryDsl: Sized {
     /// #         .first::<i32>(&connection)?;
     /// let join = users::table.left_join(posts::table);
     ///
-    /// // By default, all columns from both tables are selected
+    /// // By default, all columns from both tables are selected.
+    /// // Note, the structs must contain all the fields from original schemas in order.
     /// let all_data = join.load::<(User, Option<Post>)>(&connection)?;
     /// let expected_data = vec![
     ///     (User::new(1, "Sean"), Some(Post::new(post_id, 1, "Sean's Post"))),

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -266,7 +266,8 @@ pub trait QueryDsl: Sized {
     /// let join = users::table.left_join(posts::table);
     ///
     /// // By default, all columns from both tables are selected.
-    /// // If no explicit select clause is used this means that the result type of this query must contain all fields from the original schema in order.
+    /// // If no explicit select clause is used this means that the result
+    /// // type of this query must contain all fields from the original schema in order.
     /// let all_data = join.load::<(User, Option<Post>)>(&connection)?;
     /// let expected_data = vec![
     ///     (User::new(1, "Sean"), Some(Post::new(post_id, 1, "Sean's Post"))),
@@ -461,7 +462,9 @@ pub trait QueryDsl: Sized {
     ///     .unwrap();
     ///
     /// // By default, all columns from both tables are selected.
-    /// // If no explicit select clause is used this means that the result type of this query must contain all fields from the original schema in order.
+    /// // If no explicit select clause is used this means that the
+    /// // result type of this query must contain all fields from the
+    /// // original schema in order.
     /// let data = users
     ///     .inner_join(posts.on(title.like(name.concat("%"))))
     ///     .load::<(User, Post)>(&connection); // type could be elided

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -72,16 +72,16 @@ use diagnostic_shim::*;
 ///
 /// # Attributes
 ///
-/// ## Optional type attributes
+/// ## Optional container attributes
 ///
-/// * `#[table_name = "some_table"]`, specifies the table for which the
-/// current type is a changeset. Requires that `some_table` is in scope.
-/// If this attribute is not used, the type name converted to
-/// `snake_case` with an added `s` is used as table name
 /// * `#[changeset_options(treat_none_as_null = "true")]`, specifies that
 /// the derive should threat `None` values as `NULL`. By default
 /// `Option::<T>::None` is just skipped. To insert a `NULL` using default
 /// behavior use `Option::<Option<T>>::Some(None)`
+/// * `#[table_name = "some_table"]`, specifies the table for which the
+/// current type is a changeset. Requires that `some_table` is in scope.
+/// If this attribute is not used, the type name converted to
+/// `snake_case` with an added `s` is used as table name
 ///
 /// ## Optional field attributes
 ///
@@ -113,14 +113,18 @@ pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes:
 ///
-/// ## Required type attributes
+/// ## Required container attributes
 ///
 /// * `#[sql_type = "SqlType"]`, to specify the sql type of the
 ///  generated implementations. If the attribute exists multiple times
 ///  impls for each sql type are generated.
 ///
-/// ## Optional type attribute
+/// ## Optional container attributes
 ///
+/// * `#[table_name = "some_table"]`, specifies the table for which the
+/// current type is a changeset. Requires that `some_table` is in scope.
+/// If this attribute is not used, the type name converted to
+/// `snake_case` with an added `s` is used as table name
 /// * `#[diesel(not_sized)]`, to skip generating impls that require
 ///   that the type is `Sized`
 #[proc_macro_derive(AsExpression, attributes(diesel, sql_type))]
@@ -135,7 +139,7 @@ pub fn derive_as_expression(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// # Required type attributes
+/// # Required container attributes
 ///
 /// * `#[belongs_to(User)]`, to specify a child-to-parent relation ship
 /// between the current type and the specified parent type (`User`).
@@ -147,7 +151,7 @@ pub fn derive_as_expression(input: TokenStream) -> TokenStream {
 /// appended `_id` is used as foreign key name. (`user_id` in this example
 /// case)
 ///
-/// # Optional type attributes
+/// # Optional container attributes
 ///
 /// * `#[table_name = "some_table_name"]` specifies the table this
 ///    type belongs to. Requires that `some_table_name` is in scope.
@@ -203,7 +207,7 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// ## Optional type attributes
+/// ## Optional container attributes
 ///
 /// * `#[table_name = "some_table_name"]` specifies the table this
 ///    type belongs to. Requires that `some_table_name` is in scope.
@@ -212,8 +216,6 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 /// * `#[primary_key(id1, id2)]` to specify the struct field that
 ///    that corresponds to the primary key. If not used, `id` will be
 ///    assumed as primary key field
-///
-///
 #[proc_macro_derive(Identifiable, attributes(table_name, primary_key, column_name))]
 pub fn derive_identifiable(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, identifiable::derive)
@@ -251,7 +253,7 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// ## Optional type attributes
+/// ## Optional container attributes
 ///
 /// * `#[table_name = "some_table_name"]`, specifies the table this type
 /// is insertable into. Requires that `some_table_name` is in scope.
@@ -395,30 +397,9 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 /// This trait can only be derived for structs, not enums.
 ///
 /// **When this trait is derived, it will assume that __all fields on your
-/// struct__ is the same as __all fields in the query__, including the order.
-/// This means that field order is significant if you are using
-/// `#[derive(Queryable)]`. Field name has no effect. For example,
-///
-/// ```rust
-/// # extern crate diesel;
-/// # use diesel::prelude::*;
-/// table! {
-///     posts {
-///         id -> Integer,
-///         user_id -> Integer,
-///         title -> VarChar,
-///     }
-/// }
-///
-/// #[derive(Queryable, Debug)]
-/// pub struct Post {
-///     id: i32,
-///     user_id: i32,
-///     title: String,
-///     // this cannot be id, user_id (missing title)
-///     // this cannot be id, title, user_id (incorrect order)
-/// }
-/// ```
+/// struct__ is the same as __all fields in the query__, including the order
+/// and count. This means that field order is significant if you are using
+/// `#[derive(Queryable)]`. Field name has no effect.
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = "SomeType")]`. If this attribute is present, Diesel
@@ -432,14 +413,20 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// ## Optional field attributes:
+/// ## Optional container attributes
+///
+/// * `#[table_name = "some_table_name"]`, specifies the table this type
+/// is insertable into. Requires that `some_table_name` is in scope.
+/// If this attribute is not used, the type name converted to
+/// `snake_case` with an added `s` is used as table name
+///
+/// ## Optional field attributes
 ///
 /// * `#[diesel(deserialize_as = "Type")]`, instead of deserializing directly
 ///   into the field type, the implementation will deserialize into `Type`.
 ///   Then `Type` is converted via
 ///   [`.try_into`](https://doc.rust-lang.org/stable/std/convert/trait.TryInto.html#tymethod.try_into)
 ///   into the field type. By default this derive will deserialize directly into the field type
-///
 ///
 /// # Examples
 ///
@@ -614,6 +601,7 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 ///   the derive will use the sql type of the corresponding column.
 ///
 /// ## Field attributes
+///
 /// * `#[column_name = "some_column"]`, overrides the column name for
 ///    a given field. If not set, the name of the field is used as column
 ///    name. This attribute is required on tuple structs, if
@@ -842,7 +830,7 @@ pub fn derive_sql_type(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// ## Optional type attributes
+/// ## Optional container attributes
 ///
 /// * `#[diesel(aggregate)]` for cases where the type represents an aggregating
 ///   SQL expression

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -394,11 +394,31 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// This trait can only be derived for structs, not enums.
 ///
-/// **When this trait is derived, it will assume that __all fields on your struct__
-/// matches __all fields in the query__, including the order. This means that field
-/// order is significant if you are using `#[derive(Queryable)]`. Field name has
-/// no effect. Think `Eq`, if you have `a, b, c` in your schema, you need to have
-/// `a, b, c` in the struct derived, not `a, b` or `a, c, b`.**
+/// **When this trait is derived, it will assume that __all fields on your
+/// struct__ is the same as __all fields in the query__, including the order.
+/// This means that field order is significant if you are using
+/// `#[derive(Queryable)]`. Field name has no effect. For example,
+///
+/// ```rust
+/// # extern crate diesel;
+/// # use diesel::prelude::*;
+/// table! {
+///     posts {
+///         id -> Integer,
+///         user_id -> Integer,
+///         title -> VarChar,
+///     }
+/// }
+///
+/// #[derive(Queryable, Debug)]
+/// pub struct Post {
+///     id: i32,
+///     user_id: i32,
+///     title: String,
+///     // this cannot be id, user_id (missing title)
+///     // this cannot be id, title, user_id (incorrect order)
+/// }
+/// ```
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = "SomeType")]`. If this attribute is present, Diesel

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -396,10 +396,10 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// This trait can only be derived for structs, not enums.
 ///
-/// **When this trait is derived, it will assume that __all fields on your
-/// struct__ is the same as __all fields in the query__, including the order
-/// and count. This means that field order is significant if you are using
-/// `#[derive(Queryable)]`. Field name has no effect.
+/// **Note**: When this trait is derived, it will assume that __all fields on
+/// your struct__ is the same as __all fields in the query__, including the
+/// order and count. This means that field order is significant if you are
+/// using `#[derive(Queryable)]`. Field name has no effect.
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = "SomeType")]`. If this attribute is present, Diesel

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -397,7 +397,8 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 /// **When this trait is derived, it will assume that the order of fields on your
 /// struct match the order of the fields in the query. This means that field
 /// order is significant if you are using `#[derive(Queryable)]`. Field name has
-/// no effect.**
+/// no effect. In some cases, all the fields in the struct (including the order)
+/// must be exactly the same (like `Eq`) as the fields in the query.**
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = "SomeType")]`. If this attribute is present, Diesel

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -397,9 +397,9 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 /// This trait can only be derived for structs, not enums.
 ///
 /// **Note**: When this trait is derived, it will assume that __all fields on
-/// your struct__ is the same as __all fields in the query__, including the
-/// order and count. This means that field order is significant if you are
-/// using `#[derive(Queryable)]`. Field name has no effect.
+/// your struct__ matches __all fields in the query__, including the order and
+/// count. This means that field order is significant if you are using
+/// `#[derive(Queryable)]`. Field name has no effect.
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = "SomeType")]`. If this attribute is present, Diesel

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -409,12 +409,6 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// ## Optional container attributes
-///
-/// * `#[table_name = "some_table_name"]`, specifies the table this type
-/// is insertable into. Requires that `some_table_name` is in scope.
-/// If this attribute is not used, the type name converted to
-/// `snake_case` with an added `s` is used as table name
 ///
 /// ## Optional field attributes
 ///

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -395,7 +395,7 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 /// **Note**: When this trait is derived, it will assume that __all fields on
 /// your struct__ matches __all fields in the query__, including the order and
 /// count. This means that field order is significant if you are using
-/// `#[derive(Queryable)]`. Field name has no effect.
+/// `#[derive(Queryable)]`. __Field name has no effect__.
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = "SomeType")]`. If this attribute is present, Diesel

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -121,10 +121,6 @@ pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
 ///
 /// ## Optional container attributes
 ///
-/// * `#[table_name = "some_table"]`, specifies the table for which the
-/// current type is a changeset. Requires that `some_table` is in scope.
-/// If this attribute is not used, the type name converted to
-/// `snake_case` with an added `s` is used as table name
 /// * `#[diesel(not_sized)]`, to skip generating impls that require
 ///   that the type is `Sized`
 #[proc_macro_derive(AsExpression, attributes(diesel, sql_type))]

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -394,11 +394,11 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// This trait can only be derived for structs, not enums.
 ///
-/// **When this trait is derived, it will assume that the order of fields on your
-/// struct match the order of the fields in the query. This means that field
+/// **When this trait is derived, it will assume that __all fields on your struct__
+/// matches __all fields in the query__, including the order. This means that field
 /// order is significant if you are using `#[derive(Queryable)]`. Field name has
-/// no effect. In some cases, all the fields in the struct (including the order)
-/// must be exactly the same (like `Eq`) as the fields in the query.**
+/// no effect. Think `Eq`, if you have `a, b, c` in your schema, you need to have
+/// `a, b, c` in the struct derived, not `a, b` or `a, c, b`.**
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = "SomeType")]`. If this attribute is present, Diesel


### PR DESCRIPTION
Queryable need to match all the fields, not just the order but the number
**in some cases** (I don't know what case).

@weiznich @Mingun https://github.com/diesel-rs/diesel/pull/2627#issuecomment-765284022

I am confused myself about the behavior too, I only know in some cases it needs to be the same, after I read the docs I became more confused (since it works even when the number of fields is not the same but at least the order is the same), I tried my best to reduce the confusion saying that all the items needs to be the same.

At first I even thought this will do a smart job extracting the fields needed, like the struct being part of the schema.