### PR TITLE
Fix changelog after d2af2263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,9 +131,6 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   so non generic code does not require any change. For generic code you likely need to
   replace a trait bound on `Queryable<ST, DB>` with a trait bound on `FromSqlRow<ST, DB>`
   and a bound to `QueryableByName<DB>` with `FromSqlRow<Untyped, DB>`.
-  
-* Diesel's dsl now accept not nullable expressions in positions where nullable expressions 
-  are expected, without needing to call `.nullable()` explicitly
 
 * CLI flags of `only-tables` and `except-tables` are now interpreted as regular expressions.
   Similary, `only_tabels` and `except_tables` in `diesel.toml` are treated as regular expressions.


### PR DESCRIPTION
d2af2263c71fb836201346dd798a2cec6e67f27b had to roll back the impl of `AsExpression<Nullable<sql_types::Bool>>` for `E: AsExpression<sql_types::Bool>`, to allow for more type inference, but forgot to remove the corresponding line in the changelog.