### PR TITLE
Fix #1641

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   
 * Parenthesis are now inserted around all infix operations provided by diesel's `ExpressionMethods` traits
 
+* Queries containing a `distinct on` clause check now on compile time that a compatible order clause was set.
+
 ### Deprecated
 
 * `diesel_(prefix|postfix|infix)_operator!` have been deprecated. These macros

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,5 +1,6 @@
 use crate::backend::Backend;
 use crate::query_builder::*;
+use crate::query_dsl::order_dsl::ValidOrderingForDistinct;
 use crate::result::QueryResult;
 
 #[derive(Debug, Clone, Copy, QueryId)]
@@ -19,6 +20,9 @@ impl<DB: Backend> QueryFragment<DB> for DistinctClause {
         Ok(())
     }
 }
+
+impl<O> ValidOrderingForDistinct<NoDistinctClause> for O {}
+impl<O> ValidOrderingForDistinct<DistinctClause> for O {}
 
 #[cfg(feature = "postgres")]
 pub use crate::pg::DistinctOnClause;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -25,7 +25,7 @@ pub(crate) mod locking_clause;
 #[doc(hidden)]
 pub mod nodes;
 pub(crate) mod offset_clause;
-mod order_clause;
+pub(crate) mod order_clause;
 mod returning_clause;
 pub(crate) mod select_clause;
 mod select_statement;

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -22,6 +22,7 @@ use crate::query_builder::{
 };
 use crate::query_dsl::boxed_dsl::BoxedDsl;
 use crate::query_dsl::methods::*;
+use crate::query_dsl::order_dsl::ValidOrderingForDistinct;
 use crate::query_dsl::*;
 use crate::query_source::joins::{Join, JoinOn, JoinTo};
 use crate::query_source::QuerySource;
@@ -159,7 +160,7 @@ where
 impl<ST, F, S, D, W, O, LOf, G, LC, Expr> OrderDsl<Expr>
     for SelectStatement<F, S, D, W, O, LOf, G, LC>
 where
-    Expr: AppearsOnTable<F>,
+    Expr: AppearsOnTable<F> + ValidOrderingForDistinct<D>,
     Self: SelectQuery<SqlType = ST>,
     SelectStatement<F, S, D, W, OrderClause<Expr>, LOf, G, LC>: SelectQuery<SqlType = ST>,
 {

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -30,6 +30,7 @@ use crate::expression::subselect::ValidSubselect;
 use crate::expression::*;
 use crate::query_builder::limit_offset_clause::LimitOffsetClause;
 use crate::query_builder::{QueryId, SelectQuery};
+use crate::query_dsl::order_dsl::ValidOrderingForDistinct;
 use crate::query_source::joins::{AppendSelection, Inner, Join};
 use crate::query_source::*;
 use crate::result::QueryResult;
@@ -113,6 +114,7 @@ where
 impl<F, S, D, W, O, LOf, G, LC> SelectQuery for SelectStatement<F, S, D, W, O, LOf, G, LC>
 where
     S: SelectClauseExpression<F>,
+    O: ValidOrderingForDistinct<D>,
 {
     type SqlType = S::SelectClauseSqlType;
 }

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -3,8 +3,7 @@ use crate::dsl;
 use crate::expression::SelectableExpression;
 use crate::expression::TypedExpressionType;
 use crate::expression::ValidGrouping;
-use crate::query_builder::AsQuery;
-use crate::query_builder::SelectStatement;
+use crate::query_builder::{AsQuery, SelectStatement};
 use crate::query_source::Table;
 use crate::Expression;
 
@@ -57,6 +56,7 @@ impl<T, Selection> DistinctOnDsl<Selection> for T
 where
     Selection: SelectableExpression<T>,
     T: Table + AsQuery<Query = SelectStatement<T>>,
+    SelectStatement<T>: DistinctOnDsl<Selection>,
     T::DefaultSelection: Expression<SqlType = T::SqlType> + ValidGrouping<()>,
     T::SqlType: TypedExpressionType,
 {

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -38,7 +38,7 @@ pub mod load_dsl;
 mod locking_dsl;
 mod nullable_select_dsl;
 mod offset_dsl;
-mod order_dsl;
+pub(crate) mod order_dsl;
 #[doc(hidden)]
 pub mod positional_order_dsl;
 mod save_changes_dsl;
@@ -152,7 +152,10 @@ pub trait QueryDsl: Sized {
     ///     .execute(&connection)
     ///     .unwrap();
     /// let all_animals = animals.select((species, name, legs)).load(&connection);
-    /// let distinct_animals = animals.select((species, name, legs)).distinct_on(species).load(&connection);
+    /// let distinct_animals = animals
+    ///     .select((species, name, legs))
+    ///     .order_by((species, legs))
+    ///     .distinct_on(species).load(&connection);
     ///
     /// assert_eq!(Ok(vec![Animal::new("dog", Some("Jack"), 4),
     ///                    Animal::new("dog", None, 4),

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -56,3 +56,5 @@ where
         self.as_query().then_order_by(expr)
     }
 }
+
+pub trait ValidOrderingForDistinct<D> {}

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -316,6 +316,10 @@ macro_rules! tuple_impls {
                 }
             }
 
+            #[cfg(feature = "postgres")]
+            impl<__D, $($T,)*> crate::query_dsl::order_dsl::ValidOrderingForDistinct<crate::pg::DistinctOnClause<__D>>
+                for crate::query_builder::order_clause::OrderClause<(__D, $($T,)*)> {}
+
         )+
     }
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
@@ -12,6 +12,14 @@ error[E0277]: the trait bound `posts::columns::id: diesel::SelectableExpression<
              <posts::columns::id as diesel::SelectableExpression<posts::table>>
    = note: required because of the requirements on the impl of `diesel::query_dsl::methods::DistinctOnDsl<posts::columns::id>` for `users::table`
 
+error[E0277]: the trait bound `(diesel::sql_types::Text, diesel::sql_types::Text): diesel::sql_types::SingleValue` is not satisfied
+  --> $DIR/distinct_on_allows_only_fields_of_table.rs:25:18
+   |
+25 |     posts::table.distinct_on((posts::name, users::name)).get_result(&connection);
+   |                  ^^^^^^^^^^^ the trait `diesel::sql_types::SingleValue` is not implemented for `(diesel::sql_types::Text, diesel::sql_types::Text)`
+   |
+   = note: required because of the requirements on the impl of `diesel::query_dsl::methods::DistinctOnDsl<(posts::columns::name, users::columns::name)>` for `diesel::query_builder::SelectStatement<posts::table>`
+
 error[E0277]: the trait bound `users::columns::name: diesel::SelectableExpression<posts::table>` is not satisfied
   --> $DIR/distinct_on_allows_only_fields_of_table.rs:25:30
    |

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
@@ -1,0 +1,86 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}
+
+fn main() {
+
+    // verify that we could use distinct on without order clause
+    let _ = users::table.distinct_on(users::name);
+
+    // verify that we could use distinct on with an order clause containing the same column
+    let _ = users::table.order_by(users::name).distinct_on(users::name);
+
+    // verify that we could use distinct on with an order clause that contains also a different column
+    let _ = users::table.order_by((users::name, users::id)).distinct_on(users::name);
+
+    // verify that this works also with `then_order_by`
+    let _ = users::table
+        .order_by(users::name)
+        .then_order_by(users::id)
+        .distinct_on(users::name);
+
+    // verify that this all works with boxed queries
+    let _ = users::table.distinct_on(users::name).into_boxed();
+    let _ = users::table
+        .order_by(users::name)
+        .distinct_on(users::name)
+        .into_boxed();
+    let _ = users::table
+        .order_by((users::name, users::id))
+        .distinct_on(users::name)
+        .into_boxed();
+    let _ = users::table
+        .order_by(users::name)
+        .then_order_by(users::id)
+        .distinct_on(users::name)
+        .into_boxed();
+
+    // compile fail section
+    // 
+    // we do not allow queries with order clauses that does not contain the distinct value
+    let _ = users::table.order_by(users::id).distinct_on(users::name);
+
+    // we do not allow queries where the distinct on expression is not the first expression
+    // in our order clause
+    let _ = users::table.order_by((users::id, users::name)).distinct_on(users::name);
+
+    // we cannot workaround that with `then_order_by`
+    let _ = users::table
+        .order_by(users::id)
+        .then_order_by(users::name)
+        .distinct_on(users::name);
+
+    // it's not possible to set a invalid order clause after we set
+    // the distinct on clause
+    let _ = users::table.distinct_on(users::name).order_by(users::id);
+
+    // we cannot box invalid queries
+    let _ = users::table.order_by(users::id).distinct_on(users::name).into_boxed();
+
+    let _ = users::table
+        .order_by((users::id, users::name))
+        .distinct_on(users::name)
+        .into_boxed();
+
+    // we cannot workaround that with `then_order_by`
+    let _ = users::table
+        .order_by(users::id)
+        .then_order_by(users::name)
+        .distinct_on(users::name)
+        .into_boxed();
+
+    // it's not possible to set a invalid order clause after we set
+    // the distinct on clause
+    let _ = users::table
+        .distinct_on(users::name)
+        .order_by(users::id)
+        .into_boxed();
+}

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -1,0 +1,81 @@
+error[E0308]: mismatched types
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:49:58
+   |
+49 |     let _ = users::table.order_by(users::id).distinct_on(users::name);
+   |                                                          ^^^^^^^^^^^ expected struct `users::columns::id`, found struct `users::columns::name`
+
+error[E0308]: mismatched types
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:53:73
+   |
+53 |     let _ = users::table.order_by((users::id, users::name)).distinct_on(users::name);
+   |                                                                         ^^^^^^^^^^^ expected struct `users::columns::id`, found struct `users::columns::name`
+
+error[E0308]: mismatched types
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:59:22
+   |
+59 |         .distinct_on(users::name);
+   |                      ^^^^^^^^^^^ expected struct `users::columns::id`, found struct `users::columns::name`
+
+error[E0277]: the trait bound `users::columns::id: diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not satisfied
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:63:60
+   |
+63 |     let _ = users::table.distinct_on(users::name).order_by(users::id);
+   |                                                            ^^^^^^^^^ the trait `diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not implemented for `users::columns::id`
+   |
+   = note: required because of the requirements on the impl of `diesel::query_dsl::methods::OrderDsl<users::columns::id>` for `diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::pg::DistinctOnClause<users::columns::name>>`
+
+error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<users::columns::id>: diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not satisfied
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:63:51
+   |
+63 |     let _ = users::table.distinct_on(users::name).order_by(users::id);
+   |                                                   ^^^^^^^^ the trait `diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<users::columns::id>`
+   |
+   = help: the following implementations were found:
+             <diesel::query_builder::order_clause::OrderClause<(T,)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<T>>>
+             <diesel::query_builder::order_clause::OrderClause<(__D, A)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<__D>>>
+             <diesel::query_builder::order_clause::OrderClause<(__D, A, B)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<__D>>>
+             <diesel::query_builder::order_clause::OrderClause<(__D, A, B, C)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<__D>>>
+           and 14 others
+   = note: required because of the requirements on the impl of `diesel::query_builder::SelectQuery` for `diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::pg::DistinctOnClause<users::columns::name>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<users::columns::id>>`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::methods::OrderDsl<users::columns::id>` for `diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::pg::DistinctOnClause<users::columns::name>>`
+
+error[E0308]: mismatched types
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:66:58
+   |
+66 |     let _ = users::table.order_by(users::id).distinct_on(users::name).into_boxed();
+   |                                                          ^^^^^^^^^^^ expected struct `users::columns::id`, found struct `users::columns::name`
+
+error[E0308]: mismatched types
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:70:22
+   |
+70 |         .distinct_on(users::name)
+   |                      ^^^^^^^^^^^ expected struct `users::columns::id`, found struct `users::columns::name`
+
+error[E0308]: mismatched types
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:77:22
+   |
+77 |         .distinct_on(users::name)
+   |                      ^^^^^^^^^^^ expected struct `users::columns::id`, found struct `users::columns::name`
+
+error[E0277]: the trait bound `users::columns::id: diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not satisfied
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:84:19
+   |
+84 |         .order_by(users::id)
+   |                   ^^^^^^^^^ the trait `diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not implemented for `users::columns::id`
+   |
+   = note: required because of the requirements on the impl of `diesel::query_dsl::methods::OrderDsl<users::columns::id>` for `diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::pg::DistinctOnClause<users::columns::name>>`
+
+error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<users::columns::id>: diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not satisfied
+  --> $DIR/distinct_on_requires_matching_order_clause.rs:84:10
+   |
+84 |         .order_by(users::id)
+   |          ^^^^^^^^ the trait `diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<users::columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<users::columns::id>`
+   |
+   = help: the following implementations were found:
+             <diesel::query_builder::order_clause::OrderClause<(T,)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<T>>>
+             <diesel::query_builder::order_clause::OrderClause<(__D, A)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<__D>>>
+             <diesel::query_builder::order_clause::OrderClause<(__D, A, B)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<__D>>>
+             <diesel::query_builder::order_clause::OrderClause<(__D, A, B, C)> as diesel::query_dsl::order_dsl::ValidOrderingForDistinct<diesel::pg::DistinctOnClause<__D>>>
+           and 14 others
+   = note: required because of the requirements on the impl of `diesel::query_builder::SelectQuery` for `diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::pg::DistinctOnClause<users::columns::name>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<users::columns::id>>`
+   = note: required because of the requirements on the impl of `diesel::query_dsl::methods::OrderDsl<users::columns::id>` for `diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::pg::DistinctOnClause<users::columns::name>>`

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
@@ -69,6 +69,7 @@ error[E0277]: the trait bound `diesel::query_builder::SelectStatement<diesel::qu
    |
    = help: the following implementations were found:
              <diesel::query_builder::SelectStatement<F, S, D, W, O, LOf, G> as diesel::query_dsl::methods::DistinctOnDsl<Selection>>
+   = note: required because of the requirements on the impl of `diesel::query_dsl::methods::DistinctOnDsl<_>` for `diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, diesel::query_builder::LimitOffsetClause<diesel::query_builder::NoLimitClause, diesel::query_builder::NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::locking_clause::LockingClause>`
 
 error[E0277]: the trait bound `users::columns::id: diesel::SelectableExpression<diesel::query_builder::SelectStatement<users::table, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, diesel::query_builder::LimitOffsetClause<diesel::query_builder::NoLimitClause, diesel::query_builder::NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::locking_clause::LockingClause>>` is not satisfied
   --> $DIR/select_for_update_cannot_be_mixed_with_some_clauses.rs:16:36


### PR DESCRIPTION
We enforce now that the order clause matches the corresponding
distinct_on clause. I've choosen to gate setting a distinct on clause on
having a corresponding order clause.