### PR TITLE
Allow for multiple implementations of PgMetadataLookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   [`diesel::deserialize::Result<Self>`](https://docs.diesel.rs/master/diesel/deserialize/type.Result.html)
   instead of a `Self`.
 
+* `TypeMetadata::MetadataLookup` is now `?Sized`.
+
+* Multiple implementations of `Connection<Backend=Pg>` are now possible 
+  because of the new `PgMetadataLookup` trait.
+
+* For the `Pg` backend, `TypeMetadata::MetadataLookup` has changed to `dyn PgMetadataLookup`.
+
 ### Fixed
 
 * Many types were incorrectly considered non-aggregate when they should not

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -14,6 +14,8 @@ use crate::result::{DatabaseErrorKind, QueryResult};
 
 pub use self::metadata::{MysqlFieldMetadata, StatementMetadata};
 
+#[allow(dead_code)]
+// https://github.com/rust-lang/rust/issues/81658
 pub struct Statement {
     stmt: NonNull<ffi::MYSQL_STMT>,
     input_binds: Option<Binds>,

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -94,7 +94,7 @@ impl<'a> HasRawValue<'a> for Pg {
 
 impl TypeMetadata for Pg {
     type TypeMetadata = PgTypeMetadata;
-    type MetadataLookup = PgMetadataLookup;
+    type MetadataLookup = dyn PgMetadataLookup;
 }
 
 impl SupportsReturningClause for Pg {}

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -15,7 +15,7 @@ use self::stmt::Statement;
 use crate::connection::*;
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
-use crate::pg::{metadata_lookup::PgMetadataCache, Pg, PgMetadataLookup, TransactionBuilder};
+use crate::pg::{metadata_lookup::{PgMetadataCache}, Pg, TransactionBuilder};
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::ConnectionError::CouldntSetupConfiguration;
@@ -133,7 +133,7 @@ impl PgConnection {
         source: &T,
     ) -> QueryResult<(MaybeCached<Statement>, Vec<Option<Vec<u8>>>)> {
         let mut bind_collector = RawBytesBindCollector::<Pg>::new();
-        source.collect_binds(&mut bind_collector, PgMetadataLookup::new(self))?;
+        source.collect_binds(&mut bind_collector, self)?;
         let binds = bind_collector.binds;
         let metadata = bind_collector.metadata;
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -15,7 +15,7 @@ use self::stmt::Statement;
 use crate::connection::*;
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
-use crate::pg::{metadata_lookup::PgMetadataCache, Pg, TransactionBuilder};
+use crate::pg::{metadata_lookup::{PgMetadataCache, GetPgTypeMetadataCache}, Pg, TransactionBuilder};
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::ConnectionError::CouldntSetupConfiguration;
@@ -99,6 +99,12 @@ impl Connection for PgConnection {
     }
 }
 
+impl GetPgTypeMetadataCache for PgConnection {
+    fn get_metadata_cache(&self) -> &PgMetadataCache {
+        &self.metadata_cache
+    }
+}
+
 impl PgConnection {
     /// Build a transaction, specifying additional details such as isolation level
     ///
@@ -163,10 +169,6 @@ impl PgConnection {
         self.raw_connection
             .set_notice_processor(noop_notice_processor);
         Ok(())
-    }
-
-    pub(crate) fn get_metadata_cache(&self) -> &PgMetadataCache {
-        &self.metadata_cache
     }
 }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -16,7 +16,7 @@ use crate::connection::*;
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
 use crate::pg::{
-    metadata_lookup::{GetPgTypeMetadataCache, PgMetadataCache},
+    metadata_lookup::{GetPgMetadataCache, PgMetadataCache},
     Pg, TransactionBuilder,
 };
 use crate::query_builder::bind_collector::RawBytesBindCollector;
@@ -102,7 +102,7 @@ impl Connection for PgConnection {
     }
 }
 
-impl GetPgTypeMetadataCache for PgConnection {
+impl GetPgMetadataCache for PgConnection {
     fn get_metadata_cache(&self) -> &PgMetadataCache {
         &self.metadata_cache
     }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -15,10 +15,8 @@ use self::stmt::Statement;
 use crate::connection::*;
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
-use crate::pg::{
-    metadata_lookup::{GetPgMetadataCache, PgMetadataCache},
-    Pg, TransactionBuilder,
-};
+use crate::pg::metadata_lookup::{GetPgMetadataCache, PgMetadataCache};
+use crate::pg::{Pg, TransactionBuilder};
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::ConnectionError::CouldntSetupConfiguration;

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -15,7 +15,7 @@ use self::stmt::Statement;
 use crate::connection::*;
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
-use crate::pg::{metadata_lookup::{PgMetadataCache}, Pg, TransactionBuilder};
+use crate::pg::{metadata_lookup::PgMetadataCache, Pg, TransactionBuilder};
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::ConnectionError::CouldntSetupConfiguration;

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -15,7 +15,10 @@ use self::stmt::Statement;
 use crate::connection::*;
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
-use crate::pg::{metadata_lookup::{PgMetadataCache, GetPgTypeMetadataCache}, Pg, TransactionBuilder};
+use crate::pg::{
+    metadata_lookup::{GetPgTypeMetadataCache, PgMetadataCache},
+    Pg, TransactionBuilder,
+};
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
 use crate::result::ConnectionError::CouldntSetupConfiguration;

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -48,7 +48,7 @@ pub trait GetPgTypeMetadataCache {
     fn get_metadata_cache(&self) -> &PgMetadataCache;
 }
 
-fn lookup_type<T: Connection<Backend=Pg> + GetPgTypeMetadataCache>(
+fn lookup_type<T: Connection<Backend=Pg>>(
     cache_key: &PgMetadataCacheKey<'_>,
     conn: &T,
 ) -> QueryResult<InnerPgTypeMetadata> {

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -1,7 +1,7 @@
 #![allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
 
 use super::backend::{FailedToLookupTypeError, InnerPgTypeMetadata};
-use super::{PgTypeMetadata, Pg};
+use super::{Pg, PgTypeMetadata};
 use crate::prelude::*;
 
 use std::borrow::Cow;
@@ -19,7 +19,8 @@ pub trait PgMetadataLookup {
 }
 
 impl<T> PgMetadataLookup for T
-    where T: Connection<Backend=Pg> + GetPgTypeMetadataCache
+where
+    T: Connection<Backend = Pg> + GetPgTypeMetadataCache,
 {
     fn lookup_type(&self, type_name: &str, schema: Option<&str>) -> PgTypeMetadata {
         let metadata_cache = self.get_metadata_cache();
@@ -48,7 +49,7 @@ pub trait GetPgTypeMetadataCache {
     fn get_metadata_cache(&self) -> &PgMetadataCache;
 }
 
-fn lookup_type<T: Connection<Backend=Pg>>(
+fn lookup_type<T: Connection<Backend = Pg>>(
     cache_key: &PgMetadataCacheKey<'_>,
     conn: &T,
 ) -> QueryResult<InnerPgTypeMetadata> {

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -13,6 +13,9 @@ use std::collections::HashMap;
 /// Most connections do not have to implement this manually.
 /// It is much easier to implement [`GetPgMetadataCache`] for a type that implements `Connection<Backend=Pg>`.
 /// This will cause this trait to be auto implemented.
+///
+/// If this is implemented manually, make sure to use some sort of cache so that lookup
+/// don't cause a database query for types that have been seen before.
 pub trait PgMetadataLookup {
     /// Determine the type metadata for the given `type_name`
     ///
@@ -127,8 +130,12 @@ pub struct PgMetadataCache {
     cache: RefCell<HashMap<PgMetadataCacheKey<'static>, InnerPgTypeMetadata>>,
 }
 
+/// Cache for the [OIDs] of custom Postgres types
+///
+/// [OIDs]: https://www.postgresql.org/docs/current/static/datatype-oid.html
 impl PgMetadataCache {
-    pub(crate) fn new() -> Self {
+    /// Construct a new `PgMetadataCache`
+    pub fn new() -> Self {
         PgMetadataCache {
             cache: RefCell::new(HashMap::new()),
         }

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -124,21 +124,19 @@ impl<'a> PgMetadataCacheKey<'a> {
     }
 }
 
-/// Stores a cache for the OID of custom types
+/// Cache for the [OIDs] of custom Postgres types
+///
+/// [OIDs]: https://www.postgresql.org/docs/current/static/datatype-oid.html
 #[allow(missing_debug_implementations)]
+#[derive(Default)]
 pub struct PgMetadataCache {
     cache: RefCell<HashMap<PgMetadataCacheKey<'static>, InnerPgTypeMetadata>>,
 }
 
-/// Cache for the [OIDs] of custom Postgres types
-///
-/// [OIDs]: https://www.postgresql.org/docs/current/static/datatype-oid.html
 impl PgMetadataCache {
     /// Construct a new `PgMetadataCache`
     pub fn new() -> Self {
-        PgMetadataCache {
-            cache: RefCell::new(HashMap::new()),
-        }
+        Default::default()
     }
 
     /// Lookup the OID of a custom type

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -10,12 +10,9 @@ use std::collections::HashMap;
 
 /// Determines the OID of types at runtime
 ///
-/// Most connections do not have to implement this manually.
-/// It is much easier to implement [`GetPgMetadataCache`] for a type that implements `Connection<Backend=Pg>`.
-/// This will cause this trait to be auto implemented.
-///
-/// If this is implemented manually, make sure to use some sort of cache so that lookup
-/// don't cause a database query for types that have been seen before.
+/// Custom implementations of `Connection<Backend = Pg>` should not implement this trait directly.
+/// Instead `GetPgMetadataCache` should be implemented, afterwards the generic implementation will provide
+/// the necessary functions to perform the type lookup.
 pub trait PgMetadataLookup {
     /// Determine the type metadata for the given `type_name`
     ///
@@ -52,12 +49,12 @@ where
     }
 }
 
-/// Gets the [`PgMetadataCache`] for a `Connection<Backend=Pg>`
+/// Gets the `PgMetadataCache` for a `Connection<Backend=Pg>`
 /// so that the lookup of user defined types, or types which come from an extension can be cached.
 ///
-/// Implementing this trait for a `Connection<Backend=Pg>` will cause [`PgMetadataLookup`] to be auto implemented.
+/// Implementing this trait for a `Connection<Backend=Pg>` will cause `PgMetadataLookup` to be auto implemented.
 pub trait GetPgMetadataCache {
-    /// Get the [`PgMetadataCache`]
+    /// Get the `PgMetadataCache`
     fn get_metadata_cache(&self) -> &PgMetadataCache;
 }
 

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -17,11 +17,12 @@ mod value;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;
-pub use self::metadata_lookup::PgMetadataLookup;
 pub use self::query_builder::DistinctOnClause;
 pub use self::query_builder::PgQueryBuilder;
 pub use self::transaction::TransactionBuilder;
 pub use self::value::PgValue;
+#[doc(hidden)]
+pub use self::metadata_lookup::{PgMetadataLookup, GetPgMetadataCache, PgMetadataCache};
 #[doc(hidden)]
 #[cfg(all(feature = "with-deprecated", not(feature = "without-deprecated")))]
 #[deprecated(since = "2.0.0", note = "Use `diesel::upsert` instead")]

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -17,12 +17,12 @@ mod value;
 
 pub use self::backend::{Pg, PgTypeMetadata};
 pub use self::connection::PgConnection;
+#[doc(hidden)]
+pub use self::metadata_lookup::{GetPgMetadataCache, PgMetadataCache, PgMetadataLookup};
 pub use self::query_builder::DistinctOnClause;
 pub use self::query_builder::PgQueryBuilder;
 pub use self::transaction::TransactionBuilder;
 pub use self::value::PgValue;
-#[doc(hidden)]
-pub use self::metadata_lookup::{PgMetadataLookup, GetPgMetadataCache, PgMetadataCache};
 #[doc(hidden)]
 #[cfg(all(feature = "with-deprecated", not(feature = "without-deprecated")))]
 #[deprecated(since = "2.0.0", note = "Use `diesel::upsert` instead")]

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::io::Write;
 
 use crate::deserialize::{self, FromSql};
-use crate::pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
+use crate::pg::{Pg, PgTypeMetadata, PgValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::{Array, HasSqlType, Nullable};
 
@@ -11,7 +11,7 @@ impl<T> HasSqlType<Array<T>> for Pg
 where
     Pg: HasSqlType<T>,
 {
-    fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
+    fn metadata(lookup: &Self::MetadataLookup) -> PgTypeMetadata {
         match <Pg as HasSqlType<T>>::metadata(lookup).0 {
             Ok(tpe) => PgTypeMetadata::new(tpe.array_oid, 0),
             c @ Err(_) => PgTypeMetadata(c),

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use crate::deserialize::{self, FromSql, Queryable};
 use crate::expression::bound::Bound as SqlBound;
 use crate::expression::AsExpression;
-use crate::pg::{Pg, PgMetadataLookup, PgTypeMetadata, PgValue};
+use crate::pg::{Pg, PgTypeMetadata, PgValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::*;
 
@@ -159,37 +159,37 @@ where
 }
 
 impl HasSqlType<Int4range> for Pg {
-    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+    fn metadata(_: &Self::MetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata::new(3904, 3905)
     }
 }
 
 impl HasSqlType<Numrange> for Pg {
-    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+    fn metadata(_: &Self::MetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata::new(3906, 3907)
     }
 }
 
 impl HasSqlType<Tsrange> for Pg {
-    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+    fn metadata(_: &Self::MetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata::new(3908, 3909)
     }
 }
 
 impl HasSqlType<Tstzrange> for Pg {
-    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+    fn metadata(_: &Self::MetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata::new(3910, 3911)
     }
 }
 
 impl HasSqlType<Daterange> for Pg {
-    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+    fn metadata(_: &Self::MetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata::new(3912, 3913)
     }
 }
 
 impl HasSqlType<Int8range> for Pg {
-    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+    fn metadata(_: &Self::MetadataLookup) -> PgTypeMetadata {
         PgTypeMetadata::new(3926, 3927)
     }
 }

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -426,7 +426,7 @@ pub trait TypeMetadata {
     ///
     /// For most backends, which don't support user defined types, this will
     /// be `()`.
-    type MetadataLookup;
+    type MetadataLookup: ?Sized;
 }
 
 /// Converts a type which may or may not be nullable into its nullable

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -105,17 +105,17 @@ fn pg_tokens(item: &syn::DeriveInput) -> Option<proc_macro2::TokenStream> {
 
             let metadata_fn = match ty {
                 PgType::Fixed { oid, array_oid } => quote!(
-                    fn metadata(_: &PgMetadataLookup) -> PgTypeMetadata {
+                    fn metadata(_: &Self::MetadataLookup) -> PgTypeMetadata {
                         PgTypeMetadata::new(#oid, #array_oid)
                     }
                 ),
                 PgType::Lookup(type_name, Some(type_schema)) => quote!(
-                    fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
+                    fn metadata(lookup: &Self::MetadataLookup) -> PgTypeMetadata {
                         lookup.lookup_type(#type_name, Some(#type_schema))
                     }
                 ),
                 PgType::Lookup(type_name, None) => quote!(
-                    fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
+                    fn metadata(lookup: &Self::MetadataLookup) -> PgTypeMetadata {
                         lookup.lookup_type(#type_name, None)
                     }
                 ),

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -8,12 +8,14 @@ macro_rules! assert_sets_eq {
         let s1r: Vec<_> = set1.iter().filter(|&si| !set2.contains(si)).collect();
         assert!(
             s1r.len() == 0,
-            format!("left set contains items not found in right set: {:?}", s1r)
+            "left set contains items not found in right set: {:?}",
+            s1r
         );
         let s2r: Vec<_> = set2.iter().filter(|&si| !set1.contains(si)).collect();
         assert!(
             s2r.len() == 0,
-            format!("right set contains items not found in left set: {:?}", s2r)
+            "right set contains items not found in left set: {:?}",
+            s2r
         );
     };
 }


### PR DESCRIPTION
This is inspired by part of #2257. It is simpler and also removes some unsafe code. This will also allow for multiple implementations of `Connection`s for Postgres.