### PR TITLE
Implement `To/FromSql` for `IpAddr` enum

### DIFF
--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -3,7 +3,7 @@ extern crate libc;
 
 use self::ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use std::io::prelude::*;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::deserialize::{self, FromSql, FromSqlRow};
 use crate::pg::{Pg, PgValue};
@@ -54,6 +54,76 @@ macro_rules! assert_or_error {
             return err!($msg);
         }
     };
+}
+
+impl FromSql<Inet, Pg> for IpAddr {
+    fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
+        // https://github.com/postgres/postgres/blob/55c3391d1e6a201b5b891781d21fe682a8c64fe6/src/include/utils/inet.h#L23-L28
+        let bytes = value.as_bytes();
+        assert_or_error!(4 <= bytes.len(), "input is too short.");
+        let af = bytes[0];
+        let prefix = bytes[1];
+        let net_type = bytes[2];
+        let len = bytes[3];
+        assert_or_error!(
+            net_type == 0,
+            format!("returned type isn't a {}", stringify!($ty))
+        );
+        if af == PGSQL_AF_INET {
+            assert_or_error!(bytes.len() == 8);
+            assert_or_error!(len == 4, "the data isn't the size of ipv4");
+            assert_or_error!(prefix == 32, "the data isn't a single ipv4 address");
+            let b = &bytes[4..];
+            let addr = Ipv4Addr::new(b[0], b[1], b[2], b[3]);
+            Ok(IpAddr::V4(addr))
+        } else if af == PGSQL_AF_INET6 {
+            assert_or_error!(bytes.len() == 20);
+            assert_or_error!(len == 16, "the data isn't the size of ipv6");
+            assert_or_error!(prefix == 128, "the data isn't a single ipv6 address");
+            let b = &bytes[4..];
+            let addr = Ipv6Addr::from([
+                b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12],
+                b[13], b[14], b[15],
+            ]);
+            Ok(IpAddr::V6(addr))
+        } else {
+            err!()
+        }
+    }
+}
+
+impl ToSql<Inet, Pg> for IpAddr {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        let net_type = 0;
+        match *self {
+            IpAddr::V4(ref net) => {
+                let mut data = [0u8; 8];
+                let af = PGSQL_AF_INET;
+                let prefix = 32;
+                let len: u8 = 4;
+                let addr = net.octets();
+                data[0] = af;
+                data[1] = prefix;
+                data[2] = net_type;
+                data[3] = len;
+                data[4..].copy_from_slice(&addr);
+                out.write_all(&data).map(|_| IsNull::No).map_err(Into::into)
+            }
+            IpAddr::V6(ref net) => {
+                let mut data = [0u8; 20];
+                let af = PGSQL_AF_INET6;
+                let prefix = 128;
+                let len: u8 = 16;
+                let addr = net.octets();
+                data[0] = af;
+                data[1] = prefix;
+                data[2] = net_type;
+                data[3] = len;
+                data[4..].copy_from_slice(&addr);
+                out.write_all(&data).map(|_| IsNull::No).map_err(Into::into)
+            }
+        }
+    }
 }
 
 macro_rules! impl_Sql {
@@ -136,6 +206,11 @@ impl_Sql!(Cidr, 1);
 
 #[test]
 fn v4address_to_sql() {
+    let mut bytes = Output::test();
+    let test_address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    ToSql::<Inet, Pg>::to_sql(&test_address, &mut bytes).unwrap();
+    assert_eq!(bytes, vec![PGSQL_AF_INET, 32, 0, 4, 127, 0, 0, 1]);
+
     macro_rules! test_to_sql {
         ($ty:ty, $net_type:expr) => {
             let mut bytes = Output::test();
@@ -152,6 +227,13 @@ fn v4address_to_sql() {
 
 #[test]
 fn some_v4address_from_sql() {
+    let input_address = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let mut bytes = Output::test();
+    ToSql::<Inet, Pg>::to_sql(&input_address, &mut bytes).unwrap();
+    let output_address: IpAddr =
+        FromSql::<Inet, Pg>::from_sql(PgValue::for_test(bytes.as_ref())).unwrap();
+    assert_eq!(input_address, output_address);
+
     macro_rules! test_some_address_from_sql {
         ($ty:tt) => {
             let input_address =
@@ -170,6 +252,35 @@ fn some_v4address_from_sql() {
 
 #[test]
 fn v6address_to_sql() {
+    let mut bytes = Output::test();
+    let test_address = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    ToSql::<Inet, Pg>::to_sql(&test_address, &mut bytes).unwrap();
+    assert_eq!(
+        bytes,
+        vec![
+            PGSQL_AF_INET6,
+            128,
+            0,
+            16,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+        ]
+    );
+
     macro_rules! test_to_sql {
         ($ty:ty, $net_type:expr) => {
             let mut bytes = Output::test();
@@ -210,6 +321,13 @@ fn v6address_to_sql() {
 
 #[test]
 fn some_v6address_from_sql() {
+    let input_address = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    let mut bytes = Output::test();
+    ToSql::<Inet, Pg>::to_sql(&input_address, &mut bytes).unwrap();
+    let output_address: IpAddr =
+        FromSql::<Inet, Pg>::from_sql(PgValue::for_test(bytes.as_ref())).unwrap();
+    assert_eq!(input_address, output_address);
+
     macro_rules! test_some_address_from_sql {
         ($ty:tt) => {
             let input_address =
@@ -228,6 +346,13 @@ fn some_v6address_from_sql() {
 
 #[test]
 fn bad_address_from_sql() {
+    let address: Result<IpAddr, _> =
+        FromSql::<Inet, Pg>::from_sql(PgValue::for_test(&[7, PGSQL_AF_INET, 0]));
+    assert_eq!(
+        address.unwrap_err().to_string(),
+        "invalid network address format. input is too short."
+    );
+
     macro_rules! bad_address_from_sql {
         ($ty:tt) => {
             let address: Result<IpNetwork, _> =
@@ -245,6 +370,12 @@ fn bad_address_from_sql() {
 
 #[test]
 fn no_address_from_sql() {
+    let address: Result<IpAddr, _> = FromSql::<Inet, Pg>::from_nullable_sql(None);
+    assert_eq!(
+        address.unwrap_err().to_string(),
+        "Unexpected null for non-null column"
+    );
+
     macro_rules! test_no_address_from_sql {
         ($ty:ty) => {
             let address: Result<IpNetwork, _> = FromSql::<$ty, Pg>::from_nullable_sql(None);


### PR DESCRIPTION
https://github.com/diesel-rs/diesel/pull/749 implemented `Inet` support for Postgres using the `ipnetwork` crate. This PR adds support for `std::net::IpAddr` too.

The `Inet` type in Postgres supports including a subnet mask (see https://www.postgresql.org/docs/current/datatype-net-types.html), which the `IpAddr` enum does not support. For the simple use case of saving plain IP addresses to the database that does not seem necessary though, since we can assume a subnet mask of 32 for IPv4 addresses and 128 for IPv6, which corresponds to a full IP address without a subnet. When reading from the database I've added `assert_or_error!()` calls that check if the subnet mask length corresponds to the two values above.

Ideally this would mean that we could avoid the extra `network-address` feature flag when only supporting `std::net::IpAddr`, but unfortunately we still need the `libc` dependency to get access to `AF_INET`.