### PR TITLE
Mention the order of select and group_by

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -836,8 +836,8 @@ pub trait QueryDsl: Sized {
 
     /// Sets the `group by` clause of a query.
     ///
-    /// **Note:** Queries having a `group by` clause require a custom select clause.
-    /// Use `QueryDsl::select()` to specify one
+    /// **Note:** Queries having a `group by` clause require a custom select clause _after_ it.
+    /// Use `QueryDsl::select()` to specify one.
     ///
     /// If there was already a group by clause, it will be overridden.
     /// Ordering by multiple columns can be achieved by passing a tuple of those


### PR DESCRIPTION
select can only be used after group_by, but not before it

```rust
let query = comments::table
    .group_by((comments::user_id, comments::post_id))
    .select((comments::user_id, comments::post_id, count(comments::id)));
```

I tried flipping `group_by` and `select` and found that it does not work (I expected this) but it wasn't mentioned in the docs.