### PR TITLE
make ALL_MIGRATIONS public to allow users access to the migrations

### DIFF
--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -29,7 +29,7 @@ pub fn expand(path: String) -> proc_macro2::TokenStream {
             use self::diesel::connection::SimpleConnection;
             use std::io;
 
-            const ALL_MIGRATIONS: &[&Migration] = &[#(#migrations_expr),*];
+            pub const ALL_MIGRATIONS: &[&Migration] = &[#(#migrations_expr),*];
 
             struct EmbeddedMigration {
                 version: &'static str,


### PR DESCRIPTION
Hello!

We'd like to have a way for our programs to terminate if there are pending migrations, and we'd like to have the migrations bundled with our binary so that we don't have to package them separately and can have a single build artifact.

We would like to use code similar to https://github.com/diesel-rs/diesel/blob/master/diesel_migrations/migrations_internals/src/lib.rs#L194-L199 but for that we need access to the embedded migrations. 

Thank you!