### PR TITLE
Bug/fix potential use after free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,14 @@ Key points:
 
 [2-0-migration]: FIXME write a migration guide
 
+## [1.4.6] - 2021-03-05
+
+### Fixed
+
+* Fixed a use-after-free issue in the `QueryableByName` implementation
+  of our `Sqlite` backend
+* Updated several dependencies
+
 ## [1.4.5] - 2020-06-09
 
 ### Fixed
@@ -1880,3 +1888,5 @@ Key points:
 [1.4.2]: https://github.com/diesel-rs/diesel/compare/v1.4.1...v1.4.2
 [1.4.3]: https://github.com/diesel-rs/diesel/compare/v1.4.2...v1.4.3
 [1.4.4]: https://github.com/diesel-rs/diesel/compare/v1.4.3...v1.4.4
+[1.4.5]: https://github.com/diesel-rs/diesel/compare/v1.4.4...v1.4.5
+[1.4.6]: https://github.com/diesel-rs/diesel/compare/v1.4.5...v1.4.6

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -83,7 +83,7 @@ impl Connection for SqliteConnection {
         Self::Backend: QueryMetadata<T::SqlType>,
     {
         let mut statement = self.prepare_query(&source.as_query())?;
-        let statement_use = StatementUse::new(&mut statement);
+        let statement_use = StatementUse::new(&mut statement, true);
         let iter = StatementIterator::new(statement_use);
         iter.collect()
     }
@@ -94,7 +94,7 @@ impl Connection for SqliteConnection {
         T: QueryFragment<Self::Backend> + QueryId,
     {
         let mut statement = self.prepare_query(source)?;
-        let mut statement_use = StatementUse::new(&mut statement);
+        let mut statement_use = StatementUse::new(&mut statement, false);
         statement_use.run()?;
         Ok(self.raw_connection.rows_affected_by_last_query())
     }

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -6,21 +6,21 @@ use crate::result::Error::DeserializationError;
 use crate::result::QueryResult;
 use crate::sqlite::Sqlite;
 
-pub struct StatementIterator<'a, ST, T> {
-    stmt: StatementUse<'a>,
+pub struct StatementIterator<'a: 'b, 'b, ST, T> {
+    stmt: StatementUse<'a, 'b>,
     _marker: PhantomData<(ST, T)>,
 }
 
-impl<'a, ST, T> StatementIterator<'a, ST, T> {
-    pub fn new(stmt: StatementUse<'a>) -> Self {
+impl<'a: 'b, 'b, ST, T> StatementIterator<'a, 'b, ST, T> {
+    pub fn new(stmt: StatementUse<'a, 'b>) -> Self {
         StatementIterator {
-            stmt: stmt,
+            stmt,
             _marker: PhantomData,
         }
     }
 }
 
-impl<'a, ST, T> Iterator for StatementIterator<'a, ST, T>
+impl<'a: 'b, 'b, ST, T> Iterator for StatementIterator<'a, 'b, ST, T>
 where
     T: FromSqlRow<ST, Sqlite>,
 {

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -175,13 +175,12 @@ impl<'a, 'b> StatementUse<'a, 'b> {
             );
             CStr::from_ptr(column_name)
         };
-        let name = name.to_str().expect(
+        name.to_str().expect(
             "The Sqlite documentation states that this is UTF8. \
              If you see this error message something has gone \
              horribliy wrong. Please open an issue at the \
              diesel repository.",
-        );
-        name
+        )
     }
 
     pub(in crate::sqlite::connection) fn column_count(&self) -> i32 {
@@ -203,7 +202,7 @@ impl<'a, 'b> StatementUse<'a, 'b> {
     where
         'b: 'c,
     {
-        self.column_names.get(idx as usize).map(|a| *a)
+        self.column_names.get(idx as usize).copied()
     }
 
     pub(in crate::sqlite::connection) fn value<'c>(


### PR DESCRIPTION
This is basically #2663 but targeting the master branch

> The returned string pointer is valid until either the prepared statement
> is destroyed by sqlite3_finalize() or until the statement is automatically
> reprepared by the first call to sqlite3_step() for a particular
> run or until the next call to sqlite3_column_name()
> or sqlite3_column_name16() on the same column.

As concequence this means we cannot just call `sqlite3_column_name` in
`Field::field_name()`. To fix this issue I decided to get all column
names pointers once after calling `step()` the first time and cache them
as part of the specific Statement instance. This introduces a lot of
lifetimes to be very explicit about what is valid for which time.