### PR TITLE
Clarify a bit the error message 'Unable to find migration version' - resolves #2719

### DIFF
--- a/diesel_migrations/src/errors.rs
+++ b/diesel_migrations/src/errors.rs
@@ -43,9 +43,10 @@ impl fmt::Display for MigrationError {
                  <timestamp>_<name_of_migration>, and it should only contain up.sql and down.sql."
             ),
             MigrationError::IoError(ref error) => write!(f, "{}", error),
-            MigrationError::UnknownMigrationVersion(_) => write!(
+            MigrationError::UnknownMigrationVersion(ref version) => write!(
                 f,
-                "Unable to find migration version to revert in the migrations directory."
+                "Unable to find migration version {} to revert in the migrations directory.",
+                version
             ),
             MigrationError::NoMigrationRun => write!(
                 f,


### PR DESCRIPTION
This change should help a bit devs who try to understand what is going wrong.