### PR TITLE
Parse error from sqlite exec instead of returning `DatabaseErrorKind::Unknown`

### DIFF
--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -1,6 +1,6 @@
 extern crate libsqlite3_sys as ffi;
 
-use std::ffi::{CStr, CString, NulError};
+use std::ffi::{CString, NulError};
 use std::io::{stderr, Write};
 use std::os::raw as libc;
 use std::ptr::NonNull;
@@ -8,6 +8,7 @@ use std::{mem, ptr, slice, str};
 
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::serialized_value::SerializedValue;
+use super::stmt::ensure_sqlite_ok;
 use super::{Sqlite, SqliteAggregateFunction};
 use crate::deserialize::FromSqlRow;
 use crate::result::Error::DatabaseError;
@@ -62,27 +63,21 @@ impl RawConnection {
     }
 
     pub fn exec(&self, query: &str) -> QueryResult<()> {
-        let mut err_msg = ptr::null_mut();
         let query = CString::new(query)?;
         let callback_fn = None;
         let callback_arg = ptr::null_mut();
-        unsafe {
+        let result = unsafe {
             ffi::sqlite3_exec(
                 self.internal_connection.as_ptr(),
                 query.as_ptr(),
                 callback_fn,
                 callback_arg,
-                &mut err_msg,
-            );
-        }
+                ptr::null_mut(),
+            )
+        };
 
-        if err_msg.is_null() {
-            Ok(())
-        } else {
-            let msg = convert_to_string_and_free(err_msg);
-            let error_kind = DatabaseErrorKind::Unknown;
-            Err(DatabaseError(error_kind, Box::new(msg)))
-        }
+        ensure_sqlite_ok(result, self.internal_connection.as_ptr())?;
+        Ok(())
     }
 
     pub fn rows_affected_by_last_query(&self) -> usize {
@@ -233,16 +228,6 @@ impl Drop for RawConnection {
             }
         }
     }
-}
-
-fn convert_to_string_and_free(err_msg: *const libc::c_char) -> String {
-    let msg = unsafe {
-        let bytes = CStr::from_ptr(err_msg).to_bytes();
-        // sqlite is documented to return utf8 strings here
-        str::from_utf8_unchecked(bytes).into()
-    };
-    unsafe { ffi::sqlite3_free(err_msg as *mut libc::c_void) };
-    msg
 }
 
 enum SqliteCallbackError {

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -76,8 +76,7 @@ impl RawConnection {
             )
         };
 
-        ensure_sqlite_ok(result, self.internal_connection.as_ptr())?;
-        Ok(())
+        ensure_sqlite_ok(result, self.internal_connection.as_ptr())
     }
 
     pub fn rows_affected_by_last_query(&self) -> usize {

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -61,7 +61,10 @@ impl Statement {
     }
 }
 
-fn ensure_sqlite_ok(code: libc::c_int, raw_connection: *mut ffi::sqlite3) -> QueryResult<()> {
+pub(super) fn ensure_sqlite_ok(
+    code: libc::c_int,
+    raw_connection: *mut ffi::sqlite3,
+) -> QueryResult<()> {
     if code == ffi::SQLITE_OK {
         Ok(())
     } else {


### PR DESCRIPTION
Currently the `exec` function on SQLite only returns `DatabaseErrorKind::Unknown` and does not try to parse this error as seen in the `last_error` function from the [`diesel::sqlite::connection::stmt`](https://github.com/m-rots/diesel/blob/177290d82aa5bb5d7376389e7de5c886986ed11d/diesel/src/sqlite/connection/stmt.rs#L75) module.

With this pull request I simply re-use `ensure_sqlite_ok` from the `stmt` module to retrieve the extended result code. Retrieving the extended result code is needed as [SQLite only returns the primary result code for historic compatibility](https://www.sqlite.org/rescode.html#primary_result_codes_versus_extended_result_codes).

### Background
I stumbled upon the `DatabaseErrorKind::Unknown` while using `PRAGMA foreign_keys = ON` on the connection together with `DEFERRABLE INITIALLY DEFERRED` on a foreign key in the schema. Using this branch locally solved the issue for me, as Diesel now correctly returns `DatabaseErrorKind::ForeignKeyViolation`.

### Famous last words
- As I do not know your preferences regarding scoping, I simply added `pub(super)` to the `ensure_sqlite_ok` function.
- I'm unfamiliar with unsafe in Rust. Therefore, I do not know whether the `err_msg` in the exec function is freed when just using `ptr::null_mut()`.