### PR TITLE
allow paths in #[table_name]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,9 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   be compatible with the rewrite, but code calling into `diesel_migrations` requires an update.
   See the [migration guide](#2-0-0-upgrade-migrations) for details.
 
+* The `#[table_name]` attribute for derive macros can now refer to any path and is no
+  longer limited to identifiers from the current scope.
+
 ### Fixed
 
 * Many types were incorrectly considered non-aggregate when they should not

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -15,7 +15,7 @@ use crate::sqlite::Sqlite;
 /// database. This is automatically implemented for `&[T]` and `&Vec<T>` for
 /// inserting more than one record.
 ///
-/// This trait can be [derived](Insertable)
+/// This trait can be [derived](derive@Insertable)
 pub trait Insertable<T> {
     /// The `VALUES` clause to insert these records
     ///

--- a/diesel_compile_tests/tests/fail/as_changeset_missing_table_import.stderr
+++ b/diesel_compile_tests/tests/fail/as_changeset_missing_table_import.stderr
@@ -11,5 +11,3 @@ error[E0433]: failed to resolve: use of undeclared crate or module `users`
    |
 11 | #[table_name = "users"]
    |                ^^^^^^^ use of undeclared crate or module `users`
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/insertable_bad_table_name.rs
+++ b/diesel_compile_tests/tests/fail/insertable_bad_table_name.rs
@@ -1,0 +1,52 @@
+#[macro_use]
+extern crate diesel;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+#[derive(Insertable)]
+#[table_name = "self::users"]
+struct UserOk {
+    id: i32,
+}
+
+#[derive(Insertable)]
+#[table_name(self::users)]
+struct UserWarn {
+    id: i32,
+}
+
+#[derive(Insertable)]
+#[table_name]
+struct UserError1 {
+    id: i32,
+}
+
+#[derive(Insertable)]
+#[table_name = true]
+struct UserError2 {
+    id: i32,
+}
+
+#[derive(Insertable)]
+#[table_name = ""]
+struct UserError3 {
+    id: i32,
+}
+
+#[derive(Insertable)]
+#[table_name = "not a path"]
+struct UserError4 {
+    id: i32,
+}
+
+#[derive(Insertable)]
+#[table_name = "does::not::exist"]
+struct UserError5 {
+    id: i32,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/fail/insertable_bad_table_name.stderr
+++ b/diesel_compile_tests/tests/fail/insertable_bad_table_name.stderr
@@ -1,0 +1,35 @@
+warning: The form `table_name(value)` is deprecated. Use `table_name = "value"` instead
+  --> $DIR/insertable_bad_table_name.rs:17:3
+   |
+17 | #[table_name(self::users)]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `table_name` must be in the form `table_name = "value"`
+  --> $DIR/insertable_bad_table_name.rs:23:3
+   |
+23 | #[table_name]
+   |   ^^^^^^^^^^
+
+error: `table_name` must be in the form `table_name = "value"`
+  --> $DIR/insertable_bad_table_name.rs:29:3
+   |
+29 | #[table_name = true]
+   |   ^^^^^^^^^^^^^^^^^
+
+error: `` is not a valid path
+  --> $DIR/insertable_bad_table_name.rs:35:16
+   |
+35 | #[table_name = ""]
+   |                ^^
+
+error: `not a path` is not a valid path
+  --> $DIR/insertable_bad_table_name.rs:41:16
+   |
+41 | #[table_name = "not a path"]
+   |                ^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared crate or module `does`
+  --> $DIR/insertable_bad_table_name.rs:47:16
+   |
+47 | #[table_name = "does::not::exist"]
+   |                ^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `does`

--- a/diesel_compile_tests/tests/fail/insertable_missing_table_or_column.stderr
+++ b/diesel_compile_tests/tests/fail/insertable_missing_table_or_column.stderr
@@ -11,8 +11,6 @@ error[E0433]: failed to resolve: use of undeclared crate or module `posts`
    |
 16 | #[table_name = "posts"]
    |                ^^^^^^^ use of undeclared crate or module `posts`
-   |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `name` in module `users`
   --> $DIR/insertable_missing_table_or_column.rs:24:5

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -88,7 +88,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
 
 fn field_changeset_ty(
     field: &Field,
-    table_name: &syn::Ident,
+    table_name: &syn::Path,
     treat_none_as_null: bool,
     lifetime: Option<proc_macro2::TokenStream>,
 ) -> syn::Type {
@@ -104,7 +104,7 @@ fn field_changeset_ty(
 
 fn field_changeset_expr(
     field: &Field,
-    table_name: &syn::Ident,
+    table_name: &syn::Path,
     treat_none_as_null: bool,
     lifetime: Option<proc_macro2::TokenStream>,
 ) -> syn::Expr {

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -3,6 +3,7 @@ use proc_macro2::Span;
 use syn;
 
 use field::*;
+use meta::path_to_string;
 use model::*;
 use util::*;
 
@@ -14,7 +15,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
             .error("Cannot derive Insertable for unit structs")
             .help(format!(
                 "Use `insert_into({}::table).default_values()` if you want `DEFAULT VALUES`",
-                model.table_name()
+                path_to_string(&model.table_name())
             )));
     }
 
@@ -123,7 +124,7 @@ fn field_expr_embed(field: &Field, lifetime: Option<proc_macro2::TokenStream>) -
     parse_quote!(#lifetime self#field_access)
 }
 
-fn field_ty_serialize_as(field: &Field, table_name: &syn::Ident, ty: &syn::Type) -> syn::Type {
+fn field_ty_serialize_as(field: &Field, table_name: &syn::Path, ty: &syn::Type) -> syn::Type {
     let inner_ty = inner_of_option_ty(&ty);
     let column_name = field.column_name();
 
@@ -135,7 +136,7 @@ fn field_ty_serialize_as(field: &Field, table_name: &syn::Ident, ty: &syn::Type)
     )
 }
 
-fn field_expr_serialize_as(field: &Field, table_name: &syn::Ident, ty: &syn::Type) -> syn::Expr {
+fn field_expr_serialize_as(field: &Field, table_name: &syn::Path, ty: &syn::Type) -> syn::Expr {
     let field_access = field.name.access();
     let column_name = field.column_name();
     let column: syn::Expr = parse_quote!(#table_name::#column_name);
@@ -149,7 +150,7 @@ fn field_expr_serialize_as(field: &Field, table_name: &syn::Ident, ty: &syn::Typ
 
 fn field_ty(
     field: &Field,
-    table_name: &syn::Ident,
+    table_name: &syn::Path,
     lifetime: Option<proc_macro2::TokenStream>,
 ) -> syn::Type {
     let inner_ty = inner_of_option_ty(&field.ty);
@@ -165,7 +166,7 @@ fn field_ty(
 
 fn field_expr(
     field: &Field,
-    table_name: &syn::Ident,
+    table_name: &syn::Path,
     lifetime: Option<proc_macro2::TokenStream>,
 ) -> syn::Expr {
     let field_access = field.name.access();

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -76,7 +76,7 @@ use diagnostic_shim::*;
 /// `Option::<T>::None` is just skipped. To insert a `NULL` using default
 /// behavior use `Option::<Option<T>>::Some(None)`
 /// * `#[table_name = "path::to::table"]`, specifies a path to the table for which the
-/// current type is a changeset.
+/// current type is a changeset. The path is relative to the current module.
 /// If this attribute is not used, the type name converted to
 /// `snake_case` with an added `s` is used as table name.
 ///
@@ -147,7 +147,7 @@ pub fn derive_as_expression(input: TokenStream) -> TokenStream {
 /// # Optional container attributes
 ///
 /// * `#[table_name = "path::to::table"]` specifies a path to the table this
-///    type belongs to.
+///    type belongs to. The path is relative to the current module.
 ///    If this attribute is not used, the type name converted to
 ///    `snake_case` with an added `s` is used as table name.
 ///
@@ -199,7 +199,7 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 /// ## Optional container attributes
 ///
 /// * `#[table_name = "path::to::table"]` specifies a path to the table this
-///    type belongs to.
+///    type belongs to. The path is relative to the current module.
 ///    If this attribute is not used, the type name converted to
 ///    `snake_case` with an added `s` is used as table name
 /// * `#[primary_key(id1, id2)]` to specify the struct field that
@@ -243,7 +243,7 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 /// ## Optional container attributes
 ///
 /// * `#[table_name = "path::to::table"]`, specifies a path to the table this type
-/// is insertable into.
+/// is insertable into. The path is relative to the current module.
 /// If this attribute is not used, the type name converted to
 /// `snake_case` with an added `s` is used as table name
 ///
@@ -573,9 +573,10 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 ///
 /// ## Type attributes
 ///
-/// * `#[table_name = "some_table"]`, to specify that this type contains
-///   columns for the specified table. If no field attributes are specified
-///   the derive will use the sql type of the corresponding column.
+/// * `#[table_name = "path::to::table"]`, to specify that this type contains
+///   columns for the specified table. The path is relative to the current module.
+///   If no field attributes are specified the derive will use the sql type of
+///   the corresponding column.
 ///
 /// ## Field attributes
 ///

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -54,8 +54,8 @@ use diagnostic_shim::*;
 /// Implements `AsChangeset`
 ///
 /// To implement `AsChangeset` this derive needs to know the corresponding table
-/// type. By default it uses the `snake_case` type name with an added `s`.
-/// In this case the module for that table must be in scope.
+/// type. By default it uses the `snake_case` type name with an added `s` from
+/// the current scope.
 /// It is possible to change this default by using `#[table_name = "something"]`.
 ///
 /// If a field name of your struct differs
@@ -75,10 +75,10 @@ use diagnostic_shim::*;
 /// the derive should threat `None` values as `NULL`. By default
 /// `Option::<T>::None` is just skipped. To insert a `NULL` using default
 /// behavior use `Option::<Option<T>>::Some(None)`
-/// * `#[table_name = "some_table"]`, specifies the table for which the
+/// * `#[table_name = "path::to::table"]`, specifies a path to the table for which the
 /// current type is a changeset.
 /// If this attribute is not used, the type name converted to
-/// `snake_case` with an added `s` is used as table name
+/// `snake_case` with an added `s` is used as table name.
 ///
 /// ## Optional field attributes
 ///
@@ -146,15 +146,15 @@ pub fn derive_as_expression(input: TokenStream) -> TokenStream {
 ///
 /// # Optional container attributes
 ///
-/// * `#[table_name = "some_table_name"]` specifies the table this
+/// * `#[table_name = "path::to::table"]` specifies a path to the table this
 ///    type belongs to.
 ///    If this attribute is not used, the type name converted to
-///    `snake_case` with an added `s` is used as table name
+///    `snake_case` with an added `s` is used as table name.
 ///
 /// # Optional field attributes
 ///
-/// * `#[column_name = "some_table_name"]`, overrides the column the current
-/// field maps to to `some_table_name`. By default the field name is used
+/// * `#[column_name = "some_column_name"]`, overrides the column the current
+/// field maps to to `some_column_name`. By default the field name is used
 /// as column name. Only useful for the foreign key field.
 ///
 #[proc_macro_derive(Associations, attributes(belongs_to, column_name, table_name))]
@@ -185,13 +185,12 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 /// If it's not, you can put `#[primary_key(your_id)]` on your struct.
 /// If you have a composite primary key, the syntax is `#[primary_key(id1, id2)]`.
 ///
-/// By default, `#[derive(Identifiable)]` will assume that your table
-/// name is the plural form of your struct name.
+/// By default, `#[derive(Identifiable)]` will assume that your table is
+/// in scope and its name is the plural form of your struct name.
 /// Diesel uses very simple pluralization rules.
 /// It only adds an `s` to the end, and converts `CamelCase` to `snake_case`.
-/// If your table name does not follow this convention
-/// or the plural form isn't just an `s`,
-/// you can specify the table name with `#[table_name = "some_table_name"]`.
+/// If your table name does not follow this convention or is not in scope,
+/// you can specify a path to the table with `#[table_name = "path::to::table"]`.
 /// Our rules for inferring table names is considered public API.
 /// It will never change without a major version bump.
 ///
@@ -199,7 +198,7 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 ///
 /// ## Optional container attributes
 ///
-/// * `#[table_name = "some_table_name"]` specifies the table this
+/// * `#[table_name = "path::to::table"]` specifies a path to the table this
 ///    type belongs to.
 ///    If this attribute is not used, the type name converted to
 ///    `snake_case` with an added `s` is used as table name
@@ -214,8 +213,8 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 /// Implements `Insertable`
 ///
 /// To implement `Insertable` this derive needs to know the corresponding table
-/// type. By default it uses the `snake_case` type name with an added `s`.
-/// In this case the module for that table must be in scope.
+/// type. By default it uses the `snake_case` type name with an added `s`
+/// from the current scope.
 /// It is possible to change this default by using `#[table_name = "something"]`.
 ///
 /// If a field name of your
@@ -243,15 +242,15 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 ///
 /// ## Optional container attributes
 ///
-/// * `#[table_name = "some_table_name"]`, specifies the table this type
+/// * `#[table_name = "path::to::table"]`, specifies a path to the table this type
 /// is insertable into.
 /// If this attribute is not used, the type name converted to
 /// `snake_case` with an added `s` is used as table name
 ///
 /// ## Optional field attributes
 ///
-/// * `#[column_name = "some_table_name"]`, overrides the column the current
-/// field maps to `some_table_name`. By default the field name is used
+/// * `#[column_name = "some_column_name"]`, overrides the column the current
+/// field maps to `some_column_name`. By default the field name is used
 /// as column name
 /// * `#[diesel(embed)]`, specifies that the current field maps not only
 /// to single database field, but is a struct that implements `Insertable`

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -55,10 +55,8 @@ use diagnostic_shim::*;
 ///
 /// To implement `AsChangeset` this derive needs to know the corresponding table
 /// type. By default it uses the `snake_case` type name with an added `s`.
+/// In this case the module for that table must be in scope.
 /// It is possible to change this default by using `#[table_name = "something"]`.
-/// In both cases the module for that table must be in scope.
-/// For example, to derive this for a struct called `User`, you will
-/// likely need a line such as `use schema::users;`
 ///
 /// If a field name of your struct differs
 /// from the name of the corresponding column, you can annotate the field with
@@ -78,7 +76,7 @@ use diagnostic_shim::*;
 /// `Option::<T>::None` is just skipped. To insert a `NULL` using default
 /// behavior use `Option::<Option<T>>::Some(None)`
 /// * `#[table_name = "some_table"]`, specifies the table for which the
-/// current type is a changeset. Requires that `some_table` is in scope.
+/// current type is a changeset.
 /// If this attribute is not used, the type name converted to
 /// `snake_case` with an added `s` is used as table name
 ///
@@ -149,7 +147,7 @@ pub fn derive_as_expression(input: TokenStream) -> TokenStream {
 /// # Optional container attributes
 ///
 /// * `#[table_name = "some_table_name"]` specifies the table this
-///    type belongs to. Requires that `some_table_name` is in scope.
+///    type belongs to.
 ///    If this attribute is not used, the type name converted to
 ///    `snake_case` with an added `s` is used as table name
 ///
@@ -194,9 +192,6 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 /// If your table name does not follow this convention
 /// or the plural form isn't just an `s`,
 /// you can specify the table name with `#[table_name = "some_table_name"]`.
-/// In both cases the module for that table must be in scope.
-/// For example, to derive this for a struct called `User`, you will
-/// likely need a line such as `use schema::users;`
 /// Our rules for inferring table names is considered public API.
 /// It will never change without a major version bump.
 ///
@@ -205,7 +200,7 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 /// ## Optional container attributes
 ///
 /// * `#[table_name = "some_table_name"]` specifies the table this
-///    type belongs to. Requires that `some_table_name` is in scope.
+///    type belongs to.
 ///    If this attribute is not used, the type name converted to
 ///    `snake_case` with an added `s` is used as table name
 /// * `#[primary_key(id1, id2)]` to specify the struct field that
@@ -220,10 +215,8 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 ///
 /// To implement `Insertable` this derive needs to know the corresponding table
 /// type. By default it uses the `snake_case` type name with an added `s`.
+/// In this case the module for that table must be in scope.
 /// It is possible to change this default by using `#[table_name = "something"]`.
-/// In both cases the module for that table must be in scope.
-/// For example, to derive this for a struct called `User`, you will
-/// likely need a line such as `use schema::users;`
 ///
 /// If a field name of your
 /// struct differs from the name of the corresponding column,
@@ -251,7 +244,7 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 /// ## Optional container attributes
 ///
 /// * `#[table_name = "some_table_name"]`, specifies the table this type
-/// is insertable into. Requires that `some_table_name` is in scope.
+/// is insertable into.
 /// If this attribute is not used, the type name converted to
 /// `snake_case` with an added `s` is used as table name
 ///
@@ -559,10 +552,6 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 /// "some_table"]` (in which case the SQL type will be
 /// `diesel::dsl::SqlTypeOf<table_name::column_name>`), or by annotating each
 /// field with `#[sql_type = "SomeType"]`.
-///
-/// If you are using `#[table_name]`, the module for that table must be in
-/// scope. For example, to derive this for a struct called `User`, you will
-/// likely need a line such as `use schema::users;`
 ///
 /// If the name of a field on your struct is different than the column in your
 /// `table!` declaration, or if you are deriving this trait on a tuple struct,

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -82,6 +82,33 @@ fn with_explicit_table_name() {
 }
 
 #[test]
+fn with_path_in_table_name() {
+    #[derive(AsChangeset)]
+    #[table_name = "crate::schema::users"]
+    struct UserForm {
+        name: String,
+        hair_color: String,
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm {
+            name: String::from("Jim"),
+            hair_color: String::from("blue"),
+        })
+        .execute(&connection)
+        .unwrap();
+
+    let expected = vec![
+        (1, String::from("Jim"), Some(String::from("blue"))),
+        (2, String::from("Tess"), Some(String::from("brown"))),
+    ];
+    let actual = users::table.order(users::id).load(&connection);
+    assert_eq!(Ok(expected), actual);
+}
+
+#[test]
 fn with_lifetime() {
     #[derive(AsChangeset)]
     #[table_name = "users"]

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -35,6 +35,20 @@ fn tuple_struct() {
     assert_eq!(Ok(MyStruct(1, 2)), data);
 }
 
+#[test]
+fn struct_with_path_in_name() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, QueryableByName)]
+    #[table_name = "self::my_structs"]
+    struct MyStruct {
+        foo: i32,
+        bar: i32,
+    }
+
+    let conn = connection();
+    let data = sql_query("SELECT 1 AS foo, 2 AS bar").get_result(&conn);
+    assert_eq!(Ok(MyStruct { foo: 1, bar: 2 }), data);
+}
+
 // FIXME: Test usage with renamed columns
 
 #[test]


### PR DESCRIPTION
This pull request allows any path as the argument for the `#[table_name]` attribute instead of just identifiers.
This way the table module no longer needs to be imported to derive traits like `Insertable`.
```rust
mod schema {
    diesel::table! {
        users {
            id -> Integer,
            name -> Text,
        }
    }
}

use diesel::Insertable;

#[derive(Insertable)]
#[table_name = "schema::users"]
pub struct User {
    pub id: i32,
    pub name: String,
}
```