### PR TITLE
Updated ipnetwork dependency to 0.18.0

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { version = ">=0.8.0, <2.0", optional = true }
 url = { version = "2.1.0", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 uuid = { version = ">=0.7.0, <0.9.0", optional = true}
-ipnetwork = { version = ">=0.12.2, <0.18.0", optional = true }
+ipnetwork = { version = ">=0.12.2, <0.19.0", optional = true }
 num-bigint = { version = ">=0.2.0, <0.4.0", optional = true }
 num-traits = { version = "0.2.0", optional = true }
 num-integer = { version = "0.1.39", optional = true }
@@ -40,7 +40,7 @@ path = "../diesel_derives"
 [dev-dependencies]
 cfg-if = "1"
 dotenv = "0.15"
-ipnetwork = ">=0.12.2, <0.18.0"
+ipnetwork = ">=0.12.2, <0.19.0"
 quickcheck = "0.9"
 
 [features]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -22,7 +22,7 @@ dotenv = "0.15"
 quickcheck = "0.9"
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
-ipnetwork = ">=0.12.2, <0.18.0"
+ipnetwork = ">=0.12.2, <0.19.0"
 bigdecimal = ">= 0.0.13, < 0.3.0"
 rand = "0.7"
 


### PR DESCRIPTION
The `ipnetwork` crate just released a new version (0.18.0). By looking at the changes, there shouldn't be anything that is not backwards compatible, so this adds the new version to the list of supported versions by `diesel`.