### PR TITLE
Feature/selectable v2

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -9,6 +9,7 @@ use crate::backend::Backend;
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
 use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::query_dsl::load_dsl::CompatibleType;
 use crate::result::*;
 
 #[doc(hidden)]
@@ -180,12 +181,13 @@ pub trait Connection: SimpleConnection + Send {
     fn execute(&self, query: &str) -> QueryResult<usize>;
 
     #[doc(hidden)]
-    fn load<T, U>(&self, source: T) -> QueryResult<Vec<U>>
+    fn load<T, U, ST>(&self, source: T) -> QueryResult<Vec<U>>
     where
         Self: Sized,
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
-        U: FromSqlRow<T::SqlType, Self::Backend>,
+        T::SqlType: CompatibleType<U, Self::Backend, SqlType = ST>,
+        U: FromSqlRow<ST, Self::Backend>,
         Self::Backend: QueryMetadata<T::SqlType>;
 
     #[doc(hidden)]

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -391,7 +391,12 @@ pub trait FromStaticSqlRow<ST, DB: Backend>: Sized {
 pub trait SqlTypeOrSelectable {}
 
 impl<ST> SqlTypeOrSelectable for ST where ST: SqlType + SingleValue {}
-impl<U> SqlTypeOrSelectable for SelectBy<U> where U: Selectable {}
+impl<U, DB> SqlTypeOrSelectable for SelectBy<U, DB>
+where
+    U: Selectable<DB>,
+    DB: Backend,
+{
+}
 
 impl<T, ST, DB> FromSqlRow<ST, DB> for T
 where

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -403,27 +403,36 @@ where
 /// #     Ok(())
 /// # }
 /// ```
-pub trait Selectable {
+pub trait Selectable<DB: Backend> {
     /// The expression you'd like to select.
     ///
     /// This is typically a tuple of corresponding to the table columns of your struct's fields.
-    type Expression: Expression;
+    type SelectExpression: Expression;
 
     /// Construct an instance of the expression
-    fn new_expression() -> Self::Expression;
+    fn construct_selection() -> Self::SelectExpression;
 }
 
 #[doc(inline)]
 pub use diesel_derives::Selectable;
 
 /// TODO
-pub trait SelectableHelper: Selectable + Sized {
+pub trait SelectableHelper<DB: Backend>: Selectable<DB> + Sized {
     /// TODO
-    fn as_select() -> select_by::SelectBy<Self>;
+    fn as_select() -> select_by::SelectBy<Self, DB>;
+
+    /// TODO
+    fn as_returning() -> select_by::SelectBy<Self, DB> {
+        Self::as_select()
+    }
 }
 
-impl<T: Selectable> SelectableHelper for T {
-    fn as_select() -> select_by::SelectBy<Self> {
+impl<T, DB> SelectableHelper<DB> for T
+where
+    T: Selectable<DB>,
+    DB: Backend,
+{
+    fn as_select() -> select_by::SelectBy<Self, DB> {
         select_by::SelectBy::new()
     }
 }

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -324,10 +324,10 @@ where
 ///
 /// Types which implement `Selectable` represent the select clause of a SQL query.
 /// Use [`SelectableHelper::as_select()`] to construct the select clause. Once you
-/// called `.select(YourType::as_select())` we enforce at type system level that you
+/// called `.select(YourType::as_select())` we enforce at the type system level that you
 /// use the same type to load the query result into.
 ///
-/// The constructed select clause can contain abitary expressions comming from different
+/// The constructed select clause can contain arbitrary expressions coming from different
 /// tables. The corresponding [derive](derive@Selectable) provides a simple way to
 /// construct a select clause matching fields to the corresponding table columns.
 ///

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -49,6 +49,18 @@ impl<T: QueryId> QueryId for Nullable<T> {
     const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
 }
 
+impl<T> Selectable for Option<T>
+where
+    T: Selectable,
+    Nullable<T::Expression>: Expression,
+{
+    type Expression = Nullable<T::Expression>;
+
+    fn new_expression() -> Self::Expression {
+        Nullable::new(T::new_expression())
+    }
+}
+
 impl<T, QS> SelectableExpression<QS> for Nullable<T>
 where
     Self: AppearsOnTable<QS>,

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -49,15 +49,16 @@ impl<T: QueryId> QueryId for Nullable<T> {
     const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
 }
 
-impl<T> Selectable for Option<T>
+impl<T, DB> Selectable<DB> for Option<T>
 where
-    T: Selectable,
-    Nullable<T::Expression>: Expression,
+    DB: Backend,
+    T: Selectable<DB>,
+    Nullable<T::SelectExpression>: Expression,
 {
-    type Expression = Nullable<T::Expression>;
+    type SelectExpression = Nullable<T::SelectExpression>;
 
-    fn new_expression() -> Self::Expression {
-        Nullable::new(T::new_expression())
+    fn construct_selection() -> Self::SelectExpression {
+        Nullable::new(T::construct_selection())
     }
 }
 

--- a/diesel/src/expression/select_by.rs
+++ b/diesel/src/expression/select_by.rs
@@ -1,0 +1,88 @@
+use crate::backend::Backend;
+use crate::expression::{
+    AppearsOnTable, Expression, QueryMetadata, Selectable, SelectableExpression,
+    TypedExpressionType, ValidGrouping,
+};
+use crate::query_builder::*;
+use crate::result::QueryResult;
+
+#[derive(Debug, Default)]
+pub struct SelectBy<T>(std::marker::PhantomData<T>);
+
+impl<T> Clone for SelectBy<T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl<T> Copy for SelectBy<T> {}
+
+impl<T, E> QueryId for SelectBy<T>
+where
+    T: Selectable<Expression = E>,
+    E: QueryId + Expression,
+{
+    type QueryId = E::QueryId;
+
+    const HAS_STATIC_QUERY_ID: bool = E::HAS_STATIC_QUERY_ID;
+}
+
+impl<T> SelectBy<T> {
+    pub(crate) fn new() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T, E> Expression for SelectBy<T>
+where
+    T: Selectable<Expression = E>,
+    E: QueryId + Expression,
+{
+    type SqlType = SelectBy<T>;
+}
+
+impl<T> TypedExpressionType for SelectBy<T> {}
+
+impl<T, GB, E> ValidGrouping<GB> for SelectBy<T>
+where
+    T: Selectable<Expression = E>,
+    E: Expression + ValidGrouping<GB>,
+{
+    type IsAggregate = E::IsAggregate;
+}
+
+impl<T, DB> QueryMetadata<SelectBy<T>> for DB
+where
+    DB: Backend,
+{
+    fn row_metadata(_: &Self::MetadataLookup, out: &mut Vec<Option<Self::TypeMetadata>>) {
+        out.push(None)
+    }
+}
+
+impl<T, DB> QueryFragment<DB> for SelectBy<T>
+where
+    T: Selectable,
+    T::Expression: QueryFragment<DB>,
+    DB: Backend,
+{
+    fn walk_ast(&self, out: AstPass<DB>) -> QueryResult<()> {
+        T::new_expression().walk_ast(out)
+    }
+}
+
+impl<T, QS> SelectableExpression<QS> for SelectBy<T>
+where
+    T: Selectable,
+    T::Expression: SelectableExpression<QS>,
+    Self: AppearsOnTable<QS>,
+{
+}
+
+impl<T, QS> AppearsOnTable<QS> for SelectBy<T>
+where
+    T: Selectable,
+    T::Expression: AppearsOnTable<QS>,
+    Self: Expression,
+{
+}

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -382,7 +382,7 @@ pub mod prelude {
     pub use crate::deserialize::{Queryable, QueryableByName};
     #[doc(inline)]
     pub use crate::expression::{
-        AppearsOnTable, BoxableExpression, Expression, IntoSql, SelectableExpression,
+        AppearsOnTable, BoxableExpression, Expression, IntoSql, Selectable, SelectableExpression,
     };
 
     #[doc(inline)]
@@ -406,6 +406,8 @@ pub mod prelude {
     pub use crate::query_source::{Column, JoinTo, QuerySource, Table};
     #[doc(inline)]
     pub use crate::result::{ConnectionError, ConnectionResult, OptionalExtension, QueryResult};
+
+    pub use crate::expression::SelectableHelper;
 
     #[cfg(feature = "mysql")]
     #[doc(inline)]

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -12,6 +12,7 @@ use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::query_builder::*;
+use crate::query_dsl::load_dsl::CompatibleType;
 use crate::result::*;
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
@@ -59,11 +60,12 @@ impl Connection for MysqlConnection {
     }
 
     #[doc(hidden)]
-    fn load<T, U>(&self, source: T) -> QueryResult<Vec<U>>
+    fn load<T, U, ST>(&self, source: T) -> QueryResult<Vec<U>>
     where
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
-        U: FromSqlRow<T::SqlType, Self::Backend>,
+        T::SqlType: CompatibleType<U, Self::Backend, SqlType = ST>,
+        U: FromSqlRow<ST, Self::Backend>,
         Self::Backend: QueryMetadata<T::SqlType>,
     {
         use crate::result::Error::DeserializationError;

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -72,7 +72,8 @@ fn lookup_type<T: Connection<Backend = Pg>>(
         }
         Some(schema) => vec![schema],
         None => {
-            search_path = crate::dsl::sql("SHOW search_path").get_result::<String>(conn)?;
+            search_path = crate::dsl::sql::<crate::sql_types::Text>("SHOW search_path")
+                .get_result::<String>(conn)?;
 
             search_path
                 .split(',')

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -42,11 +42,11 @@ where
     type SqlType = Untyped;
 }
 
-impl<U, DB, E, ST> CompatibleType<U, DB> for SelectBy<U>
+impl<U, DB, E, ST> CompatibleType<U, DB> for SelectBy<U, DB>
 where
     DB: Backend,
     ST: SqlType + TypedExpressionType,
-    U: Selectable<Expression = E>,
+    U: Selectable<DB, SelectExpression = E>,
     E: Expression<SqlType = ST>,
     U: FromSqlRow<ST, DB>,
 {

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -48,6 +48,8 @@ pub use self::belonging_to_dsl::BelongingToDsl;
 pub use self::combine_dsl::CombineDsl;
 pub use self::join_dsl::{InternalJoinDsl, JoinOnDsl, JoinWithImplicitOnClause};
 #[doc(hidden)]
+pub use self::load_dsl::CompatibleType;
+#[doc(hidden)]
 pub use self::load_dsl::LoadQuery;
 pub use self::save_changes_dsl::{SaveChangesDsl, UpdateAndFetchResults};
 

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -21,6 +21,7 @@ use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
 use crate::prelude::*;
 use crate::query_builder::{AsQuery, QueryFragment, QueryId};
+use crate::query_dsl::load_dsl::CompatibleType;
 
 /// An r2d2 connection manager for use with Diesel.
 ///
@@ -147,11 +148,12 @@ where
         (&**self).execute(query)
     }
 
-    fn load<T, U>(&self, source: T) -> QueryResult<Vec<U>>
+    fn load<T, U, ST>(&self, source: T) -> QueryResult<Vec<U>>
     where
         T: AsQuery,
         T::Query: QueryFragment<Self::Backend> + QueryId,
-        U: FromSqlRow<T::SqlType, Self::Backend>,
+        T::SqlType: CompatibleType<U, Self::Backend, SqlType = ST>,
+        U: FromSqlRow<ST, Self::Backend>,
         Self::Backend: QueryMetadata<T::SqlType>,
     {
         (&**self).load(source)

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -61,13 +61,15 @@ macro_rules! tuple_impls {
                 type Nullable = Nullable<($($T,)*)>;
             }
 
-            impl<$($T),+> Selectable for ($($T,)+) where
-                $($T: Selectable),+,
+            impl<$($T,)+ __DB> Selectable<__DB> for ($($T,)+)
+            where
+                __DB: Backend,
+                $($T: Selectable<__DB>),+,
             {
-                type Expression = ($($T::Expression,)+);
+                type SelectExpression = ($($T::SelectExpression,)+);
 
-                fn new_expression() -> Self::Expression {
-                    ($($T::new_expression(),)+)
+                fn construct_selection() -> Self::SelectExpression {
+                    ($($T::construct_selection(),)+)
                 }
             }
 

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -110,7 +110,7 @@ error[E0277]: the trait bound `{integer}: SelectableExpression<()>` is not satis
               <(A, B) as SelectableExpression<QS>>
               <(A, B, C) as SelectableExpression<QS>>
               <(A, B, C, D) as SelectableExpression<QS>>
-            and 127 others
+            and 128 others
     = note: required because of the requirements on the impl of `SelectableExpression<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
     = note: 1 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -132,7 +132,7 @@ error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
               <(A, B) as ValidGrouping<__GroupByClause>>
               <(A, B, C) as ValidGrouping<__GroupByClause>>
               <(A, B, C, D) as ValidGrouping<__GroupByClause>>
-            and 122 others
+            and 123 others
     = note: required because of the requirements on the impl of `ValidGrouping<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
     = note: 1 redundant requirements hidden
     = note: required because of the requirements on the impl of `ValidGrouping<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -149,7 +149,7 @@ error[E0277]: the trait bound `{integer}: SelectableExpression<()>` is not satis
              <(A, B) as SelectableExpression<QS>>
              <(A, B, C) as SelectableExpression<QS>>
              <(A, B, C, D) as SelectableExpression<QS>>
-           and 127 others
+           and 128 others
    = note: required because of the requirements on the impl of `SelectableExpression<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -168,7 +168,7 @@ error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
              <(A, B) as ValidGrouping<__GroupByClause>>
              <(A, B, C) as ValidGrouping<__GroupByClause>>
              <(A, B, C, D) as ValidGrouping<__GroupByClause>>
-           and 122 others
+           and 123 others
    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -186,7 +186,7 @@ error[E0277]: the trait bound `{integer}: QueryId` is not satisfied
              <() as QueryId>
              <(A, B) as QueryId>
              <(A, B, C) as QueryId>
-           and 188 others
+           and 189 others
    = note: required because of the requirements on the impl of `QueryId` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: 3 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryId` for `SelectStatement<(), diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>`
@@ -203,7 +203,7 @@ error[E0277]: the trait bound `{integer}: QueryFragment<_>` is not satisfied
              <() as QueryFragment<DB>>
              <(A, B) as QueryFragment<__DB>>
              <(A, B, C) as QueryFragment<__DB>>
-           and 218 others
+           and 219 others
    = note: required because of the requirements on the impl of `QueryFragment<_>` for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)`
    = note: 2 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryFragment<_>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -228,7 +228,7 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              <(A, B) as diesel::Expression>
              <(A, B, C) as diesel::Expression>
              <(A, B, C, D) as diesel::Expression>
-           and 103 others
+           and 104 others
    = note: required because of the requirements on the impl of `AsExpression<diesel::sql_types::Double>` for `{integer}`
    = note: required because of the requirements on the impl of `AsExpressionList<diesel::sql_types::Double>` for `({integer}, f64)`
 

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              <(A, B) as diesel::Expression>
              <(A, B, C) as diesel::Expression>
              <(A, B, C, D) as diesel::Expression>
-           and 107 others
+           and 108 others
    = note: required because of the requirements on the impl of `diesel::Expression` for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>`
    = note: required because of the requirements on the impl of `FilterDsl<Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>` for `SelectStatement<string_primary_key::table>`
 
@@ -46,6 +46,6 @@ error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
              <(A, B) as ValidGrouping<__GroupByClause>>
              <(A, B, C) as ValidGrouping<__GroupByClause>>
              <(A, B, C, D) as ValidGrouping<__GroupByClause>>
-           and 128 others
+           and 129 others
    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>`
    = note: required because of the requirements on the impl of `FilterDsl<Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>` for `SelectStatement<string_primary_key::table>`

--- a/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
+++ b/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
@@ -9,5 +9,5 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              <(A, B) as diesel::Expression>
              <(A, B, C) as diesel::Expression>
              <(A, B, C, D) as diesel::Expression>
-           and 107 others
+           and 108 others
    = note: required because of the requirements on the impl of `AsExpression<diesel::sql_types::Text>` for `{integer}`

--- a/diesel_compile_tests/tests/fail/queryable_type_missmatch.stderr
+++ b/diesel_compile_tests/tests/fail/queryable_type_missmatch.stderr
@@ -1,45 +1,39 @@
-error[E0277]: the trait bound `UserWithToFewFields: diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): CompatibleType<UserWithToFewFields, _>` is not satisfied
   --> $DIR/queryable_type_missmatch.rs:59:26
    |
 59 |     let _ = users::table.load::<UserWithToFewFields>(conn);
-   |                          ^^^^ the trait `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `UserWithToFewFields`
+   |                          ^^^^ the trait `CompatibleType<UserWithToFewFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    |
    = help: the following implementations were found:
-             <UserWithToFewFields as diesel::Queryable<(__ST0, __ST1), __DB>>
-   = note: required because of the requirements on the impl of `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWithToFewFields`
+             <(SA, SB, SC) as CompatibleType<__T, __DB>>
    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithToFewFields>` for `users::table`
 
-error[E0277]: the trait bound `UserWithToManyFields: diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): CompatibleType<UserWithToManyFields, _>` is not satisfied
   --> $DIR/queryable_type_missmatch.rs:61:26
    |
 61 |     let _ = users::table.load::<UserWithToManyFields>(conn);
-   |                          ^^^^ the trait `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `UserWithToManyFields`
+   |                          ^^^^ the trait `CompatibleType<UserWithToManyFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    |
    = help: the following implementations were found:
-             <UserWithToManyFields as diesel::Queryable<(__ST0, __ST1, __ST2, __ST3), __DB>>
-   = note: required because of the requirements on the impl of `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWithToManyFields`
+             <(SA, SB, SC) as CompatibleType<__T, __DB>>
    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithToManyFields>` for `users::table`
 
-error[E0277]: the trait bound `(std::string::String, i32, Option<std::string::String>): FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): CompatibleType<UserWrongOrder, _>` is not satisfied
   --> $DIR/queryable_type_missmatch.rs:63:26
    |
 63 |     let _ = users::table.load::<UserWrongOrder>(conn);
-   |                          ^^^^ the trait `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `(std::string::String, i32, Option<std::string::String>)`
+   |                          ^^^^ the trait `CompatibleType<UserWrongOrder, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    |
    = help: the following implementations were found:
-             <(B, C, A) as FromStaticSqlRow<(SB, SC, SA), __DB>>
-   = note: required because of the requirements on the impl of `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWrongOrder`
-   = note: required because of the requirements on the impl of `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserWrongOrder`
+             <(SA, SB, SC) as CompatibleType<__T, __DB>>
    = note: required because of the requirements on the impl of `LoadQuery<_, UserWrongOrder>` for `users::table`
 
-error[E0277]: the trait bound `(i32, i32, Option<std::string::String>): FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not satisfied
+error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): CompatibleType<UserTypeMissmatch, _>` is not satisfied
   --> $DIR/queryable_type_missmatch.rs:65:26
    |
 65 |     let _ = users::table.load::<UserTypeMissmatch>(conn);
-   |                          ^^^^ the trait `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` is not implemented for `(i32, i32, Option<std::string::String>)`
+   |                          ^^^^ the trait `CompatibleType<UserTypeMissmatch, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    |
    = help: the following implementations were found:
-             <(B, C, A) as FromStaticSqlRow<(SB, SC, SA), __DB>>
-   = note: required because of the requirements on the impl of `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserTypeMissmatch`
-   = note: required because of the requirements on the impl of `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>), _>` for `UserTypeMissmatch`
+             <(SA, SB, SC) as CompatibleType<__T, __DB>>
    = note: required because of the requirements on the impl of `LoadQuery<_, UserTypeMissmatch>` for `users::table`

--- a/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
+++ b/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
@@ -10,6 +10,7 @@ error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, _>` is not 
              <i32 as FromSql<diesel::sql_types::Integer, Sqlite>>
    = note: required because of the requirements on the impl of `Queryable<diesel::sql_types::Text, _>` for `i32`
    = note: required because of the requirements on the impl of `FromSqlRow<diesel::sql_types::Text, _>` for `i32`
+   = note: required because of the requirements on the impl of `CompatibleType<i32, _>` for `diesel::sql_types::Text`
    = note: required because of the requirements on the impl of `LoadQuery<_, i32>` for `SelectStatement<users::table, diesel::query_builder::select_clause::SelectClause<columns::name>>`
 
 error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, _>` is not satisfied
@@ -27,4 +28,5 @@ error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, _
    = note: required because of the requirements on the impl of `FromSql<diesel::sql_types::Integer, _>` for `std::string::String`
    = note: required because of the requirements on the impl of `Queryable<diesel::sql_types::Integer, _>` for `std::string::String`
    = note: required because of the requirements on the impl of `FromSqlRow<diesel::sql_types::Integer, _>` for `std::string::String`
+   = note: required because of the requirements on the impl of `CompatibleType<std::string::String, _>` for `diesel::sql_types::Integer`
    = note: required because of the requirements on the impl of `LoadQuery<_, std::string::String>` for `SelectStatement<users::table, diesel::query_builder::select_clause::SelectClause<columns::id>>`

--- a/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
+++ b/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
@@ -13,4 +13,5 @@ error[E0277]: the trait bound `*const str: FromSql<BigInt, _>` is not satisfied
    = note: required because of the requirements on the impl of `FromSql<BigInt, _>` for `std::string::String`
    = note: required because of the requirements on the impl of `Queryable<BigInt, _>` for `std::string::String`
    = note: required because of the requirements on the impl of `FromSqlRow<BigInt, _>` for `std::string::String`
+   = note: required because of the requirements on the impl of `CompatibleType<std::string::String, _>` for `BigInt`
    = note: required because of the requirements on the impl of `LoadQuery<_, std::string::String>` for `SelectStatement<users::table, diesel::query_builder::select_clause::SelectClause<SqlLiteral<BigInt>>>`

--- a/diesel_compile_tests/tests/fail/selectable.rs
+++ b/diesel_compile_tests/tests/fail/selectable.rs
@@ -68,10 +68,10 @@ struct UserWithPostCount {
     post_count: i64,
 }
 
-impl Selectable for UserWithPostCount {
-    type Expression = (users::id, users::name, diesel::dsl::count<posts::id>);
+impl Selectable<diesel::pg::Pg> for UserWithPostCount {
+    type SelectExpression = (users::id, users::name, diesel::dsl::count<posts::id>);
 
-    fn new_expression() -> Self::Expression {
+    fn construct_selection() -> Self::SelectExpression {
         (users::id, users::name, diesel::dsl::count(posts::id))
     }
 }

--- a/diesel_compile_tests/tests/fail/selectable.rs
+++ b/diesel_compile_tests/tests/fail/selectable.rs
@@ -192,9 +192,9 @@ fn main() {
     let _ = users::table.select(UserWithoutSelectable::as_select()).load(&conn).unwrap();
 
     // type locking
-    let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
-    let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
-    let _ = posts::table.select((Post::as_select(), posts::title)).load::<((i32, String, i32), String)>(&conn).unwrap();
+    let _ = posts::table.select(Post::as_select()).load::<(i32, String)>(&conn).unwrap();
+    let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String)>(&conn).unwrap();
+    let _ = posts::table.select((Post::as_select(), posts::title)).load::<((i32, String), String)>(&conn).unwrap();
     let _ = diesel::insert_into(posts::table)
         .values(posts::title.eq(""))
         .returning(Post::as_select())

--- a/diesel_compile_tests/tests/fail/selectable.rs
+++ b/diesel_compile_tests/tests/fail/selectable.rs
@@ -1,0 +1,212 @@
+extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> Text,
+        user_id -> Integer,
+    }
+}
+
+joinable!(posts -> users(user_id));
+allow_tables_to_appear_in_same_query!(users, posts);
+
+#[derive(Selectable, Queryable)]
+#[table_name = "users"]
+struct UserWithEmbeddedPost {
+    id: i32,
+    name: String,
+    #[diesel(embed)]
+    post: Post,
+}
+
+#[derive(Selectable, Queryable)]
+#[table_name = "users"]
+struct UserWithOptionalPost {
+    id: i32,
+    name: String,
+    #[diesel(embed)]
+    post: Option<Post>,
+}
+
+#[derive(Selectable, Queryable)]
+#[table_name = "posts"]
+struct Post {
+    id: i32,
+    title: String,
+}
+
+#[derive(Selectable)]
+#[table_name = "posts"]
+struct PostWithWrongField {
+    id: i32,
+    // There is a typo here:
+    titel: String
+}
+
+#[derive(Selectable)]
+// wrong table name here
+#[table_name = "post"]
+struct PostWithWrongTableName {
+    id: i32,
+    title: String,
+}
+
+#[derive(Queryable)]
+struct UserWithPostCount {
+    id: i32,
+    name: String,
+    post_count: i64,
+}
+
+impl Selectable for UserWithPostCount {
+    type Expression = (users::id, users::name, diesel::dsl::count<posts::id>);
+
+    fn new_expression() -> Self::Expression {
+        (users::id, users::name, diesel::dsl::count(posts::id))
+    }
+}
+
+#[derive(Queryable)]
+struct UserWithoutSelectable {
+    id: i32,
+    name: String
+}
+
+
+fn main() {
+    let conn = PgConnection::establish("").unwrap();
+
+    // supported queries
+    //
+    // plain queries
+    let _  = posts::table.select(Post::as_select()).load(&conn).unwrap();
+
+    // boxed queries
+    let _  = posts::table.into_boxed().select(Post::as_select()).load(&conn).unwrap();
+    let _  = posts::table.select(Post::as_select()).into_boxed().load(&conn).unwrap();
+
+    // mixed clauses
+    let _ = posts::table.select((Post::as_select(), posts::title)).load::<(_, String)>(&conn).unwrap();
+
+    // This works for inner joins
+    let _ = users::table
+        .inner_join(posts::table)
+        .select(UserWithEmbeddedPost::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // also for left joins
+    let _ = users::table
+        .left_join(posts::table)
+        .select(UserWithOptionalPost::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // allow manual impls with complex expressions
+    // (and group by)
+    let _ = users::table
+        .inner_join(posts::table)
+        .group_by(users::id)
+        .select(UserWithPostCount::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // inserts
+    let _ = diesel::insert_into(posts::table)
+        .values(posts::title.eq(""))
+        .returning(Post::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // update
+    let _ = diesel::update(posts::table)
+        .set(posts::title.eq(""))
+        .returning(Post::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // delete
+    let _ = diesel::delete(posts::table)
+        .returning(Post::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // forbidden queries
+    //
+    // left joins force nullable
+    let _ = users::table
+        .left_join(posts::table)
+        .select(UserWithEmbeddedPost::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // group by clauses are considered
+    let _ = users::table
+        .inner_join(posts::table)
+        .group_by(posts::id)
+        .select(UserWithEmbeddedPost::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // missing group by clause
+    let _ = users::table
+        .inner_join(posts::table)
+        .select(UserWithPostCount::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // cannot load results from more than one table via
+    // returning clauses
+    let _ = diesel::insert_into(users::table)
+        .values(users::name.eq(""))
+        .returning(UserWithEmbeddedPost::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // cannot load results from more than one table via
+    // returning clauses
+    let _ = diesel::update(users::table)
+        .set(users::name.eq(""))
+        .returning(UserWithEmbeddedPost::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // cannot load results from more than one table via
+    // returning clauses
+    let _ = diesel::delete(users::table)
+        .returning(UserWithEmbeddedPost::as_select())
+        .load(&conn)
+        .unwrap();
+
+    // cannot use this method without deriving selectable
+    let _ = users::table.select(UserWithoutSelectable::as_select()).load(&conn).unwrap();
+
+    // type locking
+    let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
+    let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
+    let _ = posts::table.select((Post::as_select(), posts::title)).load::<((i32, String, i32), String)>(&conn).unwrap();
+    let _ = diesel::insert_into(posts::table)
+        .values(posts::title.eq(""))
+        .returning(Post::as_select())
+        .load::<(i32, String, i32)>(&conn)
+        .unwrap();
+
+    // cannot use backend specific selectable with other backend
+    let conn = SqliteConnection::establish("").unwrap();
+    let _ = users::table
+        .inner_join(posts::table)
+        .group_by(users::id)
+        .select(UserWithPostCount::as_select())
+        .load(&conn)
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -1,0 +1,595 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `post`
+  --> $DIR/selectable.rs:58:16
+   |
+58 | #[table_name = "post"]
+   |                ^^^^^^ use of undeclared crate or module `post`
+
+error[E0412]: cannot find type `titel` in module `posts`
+  --> $DIR/selectable.rs:53:5
+   |
+53 |     titel: String
+   |     ^^^^^ not found in `posts`
+
+error[E0425]: cannot find value `titel` in module `posts`
+  --> $DIR/selectable.rs:53:5
+   |
+53 |     titel: String
+   |     ^^^^^ not found in `posts`
+
+error[E0271]: type mismatch resolving `<posts::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Never`
+   --> $DIR/selectable.rs:149:10
+    |
+149 |         .select(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^ expected struct `diesel::query_source::Once`, found struct `diesel::query_source::Never`
+    |
+    = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
+    = note: 4 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:149:10
+    |
+149 |         .select(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
+    = note: 4 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:149:10
+    |
+149 |         .select(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
+    = note: 4 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+
+error[E0271]: type mismatch resolving `<posts::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Never`
+   --> $DIR/selectable.rs:150:10
+    |
+150 |         .load(&conn)
+    |          ^^^^ expected struct `diesel::query_source::Once`, found struct `diesel::query_source::Never`
+    |
+    = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
+    = note: 4 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:150:10
+    |
+150 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
+    = note: 4 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:150:10
+    |
+150 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
+    = note: 4 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::id>` is not satisfied
+   --> $DIR/selectable.rs:157:10
+    |
+157 |         .select(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::id>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::title>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::id`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+
+error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::name>` is not satisfied
+   --> $DIR/selectable.rs:157:10
+    |
+157 |         .select(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::name>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::id>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::title>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::name`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+
+error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::id>` is not satisfied
+   --> $DIR/selectable.rs:158:10
+    |
+158 |         .load(&conn)
+    |          ^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::id>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::title>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::id`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+
+error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::name>` is not satisfied
+   --> $DIR/selectable.rs:158:10
+    |
+158 |         .load(&conn)
+    |          ^^^^ the trait `IsContainedInGroupBy<users::columns::name>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::id>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::title>>
+              <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::name`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+
+error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+   --> $DIR/selectable.rs:164:10
+    |
+164 |         .select(UserWithPostCount::as_select())
+    |          ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    |
+    = help: the following implementations were found:
+              <diesel::expression::is_aggregate::No as MixedAggregates<diesel::expression::is_aggregate::Never>>
+              <diesel::expression::is_aggregate::No as MixedAggregates<diesel::expression::is_aggregate::No>>
+    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `(users::columns::id, users::columns::name, count::count::count<diesel::sql_types::Integer, posts::columns::id>)`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `SelectBy<UserWithPostCount>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithPostCount>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+
+error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+   --> $DIR/selectable.rs:165:10
+    |
+165 |         .load(&conn)
+    |          ^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    |
+    = help: the following implementations were found:
+              <diesel::expression::is_aggregate::No as MixedAggregates<diesel::expression::is_aggregate::Never>>
+              <diesel::expression::is_aggregate::No as MixedAggregates<diesel::expression::is_aggregate::No>>
+    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `(users::columns::id, users::columns::name, count::count::count<diesel::sql_types::Integer, posts::columns::id>)`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `SelectBy<UserWithPostCount>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithPostCount>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount>>>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:172:10
+    |
+172 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:172:10
+    |
+172 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
+   --> $DIR/selectable.rs:172:10
+    |
+172 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ expected struct `diesel::query_source::Never`, found struct `diesel::query_source::Once`
+    |
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `posts::columns::id`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:173:10
+    |
+173 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:173:10
+    |
+173 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
+   --> $DIR/selectable.rs:173:10
+    |
+173 |         .load(&conn)
+    |          ^^^^ expected struct `diesel::query_source::Never`, found struct `diesel::query_source::Once`
+    |
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `posts::columns::id`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:180:10
+    |
+180 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:180:10
+    |
+180 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
+   --> $DIR/selectable.rs:180:10
+    |
+180 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ expected struct `diesel::query_source::Never`, found struct `diesel::query_source::Once`
+    |
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `posts::columns::id`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:181:10
+    |
+181 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:181:10
+    |
+181 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
+   --> $DIR/selectable.rs:181:10
+    |
+181 |         .load(&conn)
+    |          ^^^^ expected struct `diesel::query_source::Never`, found struct `diesel::query_source::Once`
+    |
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `posts::columns::id`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:187:10
+    |
+187 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:187:10
+    |
+187 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+
+error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
+   --> $DIR/selectable.rs:187:10
+    |
+187 |         .returning(UserWithEmbeddedPost::as_select())
+    |          ^^^^^^^^^ expected struct `diesel::query_source::Never`, found struct `diesel::query_source::Once`
+    |
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `posts::columns::id`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+
+error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:188:10
+    |
+188 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |
+    = help: the following implementations were found:
+              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::id as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::id as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
+   --> $DIR/selectable.rs:188:10
+    |
+188 |         .load(&conn)
+    |          ^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+    |
+    = help: the following implementations were found:
+              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<SelectStatement<From>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, Inner>>>
+              <posts::columns::title as SelectableExpression<diesel::query_source::joins::Join<Left, Right, LeftOuter>>>
+              <posts::columns::title as SelectableExpression<posts::table>>
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
+   --> $DIR/selectable.rs:188:10
+    |
+188 |         .load(&conn)
+    |          ^^^^ expected struct `diesel::query_source::Never`, found struct `diesel::query_source::Once`
+    |
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `posts::columns::id`
+    = note: 1 redundant requirements hidden
+    = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
+    = note: 2 redundant requirements hidden
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+
+error[E0599]: the function or associated item `as_select` exists for struct `UserWithoutSelectable`, but its trait bounds were not satisfied
+   --> $DIR/selectable.rs:192:56
+    |
+80  | struct UserWithoutSelectable {
+    | ----------------------------
+    | |
+    | function or associated item `as_select` not found for this
+    | doesn't satisfy `UserWithoutSelectable: diesel::SelectableHelper`
+    | doesn't satisfy `UserWithoutSelectable: diesel::Selectable`
+...
+192 |     let _ = users::table.select(UserWithoutSelectable::as_select()).load(&conn).unwrap();
+    |                                                        ^^^^^^^^^ function or associated item cannot be called on `UserWithoutSelectable` due to unsatisfied trait bounds
+    |
+    = note: the following trait bounds were not satisfied:
+            `UserWithoutSelectable: diesel::Selectable`
+            which is required by `UserWithoutSelectable: diesel::SelectableHelper`
+            `&UserWithoutSelectable: diesel::Selectable`
+            which is required by `&UserWithoutSelectable: diesel::SelectableHelper`
+            `&mut UserWithoutSelectable: diesel::Selectable`
+            which is required by `&mut UserWithoutSelectable: diesel::SelectableHelper`
+
+error[E0277]: the trait bound `SelectBy<Post>: SingleValue` is not satisfied
+   --> $DIR/selectable.rs:195:52
+    |
+195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
+    |                                                    ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post>`
+    |
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post>>>`
+
+error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post>, _>` is not satisfied
+   --> $DIR/selectable.rs:195:52
+    |
+195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
+    |                                                    ^^^^ the trait `diesel::Queryable<SelectBy<Post>, _>` is not implemented for `(i32, std::string::String, i32)`
+    |
+    = help: the following implementations were found:
+              <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
+              <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post>, _>` for `(i32, std::string::String, i32)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post>>>`
+
+error[E0277]: the trait bound `SelectBy<Post>: SingleValue` is not satisfied
+   --> $DIR/selectable.rs:196:65
+    |
+196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
+    |                                                                 ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post>`
+    |
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post>, posts::table, _>`
+
+error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post>, _>` is not satisfied
+   --> $DIR/selectable.rs:196:65
+    |
+196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
+    |                                                                 ^^^^ the trait `diesel::Queryable<SelectBy<Post>, _>` is not implemented for `(i32, std::string::String, i32)`
+    |
+    = help: the following implementations were found:
+              <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
+              <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post>, _>` for `(i32, std::string::String, i32)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post>, posts::table, _>`
+
+error[E0277]: the trait bound `(SelectBy<Post>, diesel::sql_types::Text): CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not satisfied
+   --> $DIR/selectable.rs:197:68
+    |
+197 |     let _ = posts::table.select((Post::as_select(), posts::title)).load::<((i32, String, i32), String)>(&conn).unwrap();
+    |                                                                    ^^^^ the trait `CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not implemented for `(SelectBy<Post>, diesel::sql_types::Text)`
+    |
+    = help: the following implementations were found:
+              <(SA, SB) as CompatibleType<__T, __DB>>
+    = note: required because of the requirements on the impl of `LoadQuery<_, ((i32, std::string::String, i32), std::string::String)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<(SelectBy<Post>, posts::columns::title)>>`
+
+error[E0277]: the trait bound `SelectBy<Post>: SingleValue` is not satisfied
+   --> $DIR/selectable.rs:201:10
+    |
+201 |         .load::<(i32, String, i32)>(&conn)
+    |          ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post>`
+    |
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `InsertStatement<posts::table, ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<Post>>>`
+
+error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post>, _>` is not satisfied
+   --> $DIR/selectable.rs:201:10
+    |
+201 |         .load::<(i32, String, i32)>(&conn)
+    |          ^^^^ the trait `diesel::Queryable<SelectBy<Post>, _>` is not implemented for `(i32, std::string::String, i32)`
+    |
+    = help: the following implementations were found:
+              <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
+              <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post>, _>` for `(i32, std::string::String, i32)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `InsertStatement<posts::table, ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<Post>>>`

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -521,56 +521,58 @@ error[E0599]: the function or associated item `as_select` exists for struct `Use
 error[E0277]: the trait bound `SelectBy<Post, _>: SingleValue` is not satisfied
    --> $DIR/selectable.rs:195:52
     |
-195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
+195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String)>(&conn).unwrap();
     |                                                    ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post, _>`
     |
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post, _>>>`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post, _>>>`
 
-error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post, _>, _>` is not satisfied
+error[E0277]: the trait bound `(i32, std::string::String): diesel::Queryable<SelectBy<Post, _>, _>` is not satisfied
    --> $DIR/selectable.rs:195:52
     |
-195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
-    |                                                    ^^^^ the trait `diesel::Queryable<SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String, i32)`
+195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String)>(&conn).unwrap();
+    |                                                    ^^^^ the trait `diesel::Queryable<SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String)`
     |
     = help: the following implementations were found:
-              <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
-              <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
-    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post, _>, _>` for `(i32, std::string::String, i32)`
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post, _>>>`
+              <(A, B) as diesel::Queryable<(SA, SB), __DB>>
+              <(A, B) as diesel::Queryable<Record<(SA, SB)>, Pg>>
+              <(std::collections::Bound<T>, std::collections::Bound<T>) as diesel::Queryable<diesel::sql_types::Range<ST>, Pg>>
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post, _>, _>` for `(i32, std::string::String)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post, _>>>`
 
 error[E0277]: the trait bound `SelectBy<Post, _>: SingleValue` is not satisfied
    --> $DIR/selectable.rs:196:65
     |
-196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
+196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String)>(&conn).unwrap();
     |                                                                 ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post, _>`
     |
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post, _>, posts::table, _>`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String)>` for `BoxedSelectStatement<'_, SelectBy<Post, _>, posts::table, _>`
 
-error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post, _>, _>` is not satisfied
+error[E0277]: the trait bound `(i32, std::string::String): diesel::Queryable<SelectBy<Post, _>, _>` is not satisfied
    --> $DIR/selectable.rs:196:65
     |
-196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
-    |                                                                 ^^^^ the trait `diesel::Queryable<SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String, i32)`
+196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String)>(&conn).unwrap();
+    |                                                                 ^^^^ the trait `diesel::Queryable<SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String)`
     |
     = help: the following implementations were found:
-              <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
-              <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
-    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post, _>, _>` for `(i32, std::string::String, i32)`
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post, _>, posts::table, _>`
+              <(A, B) as diesel::Queryable<(SA, SB), __DB>>
+              <(A, B) as diesel::Queryable<Record<(SA, SB)>, Pg>>
+              <(std::collections::Bound<T>, std::collections::Bound<T>) as diesel::Queryable<diesel::sql_types::Range<ST>, Pg>>
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post, _>, _>` for `(i32, std::string::String)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String)>` for `BoxedSelectStatement<'_, SelectBy<Post, _>, posts::table, _>`
 
-error[E0277]: the trait bound `(SelectBy<Post, _>, diesel::sql_types::Text): CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not satisfied
+error[E0277]: the trait bound `(SelectBy<Post, _>, diesel::sql_types::Text): CompatibleType<((i32, std::string::String), std::string::String), _>` is not satisfied
    --> $DIR/selectable.rs:197:68
     |
-197 |     let _ = posts::table.select((Post::as_select(), posts::title)).load::<((i32, String, i32), String)>(&conn).unwrap();
-    |                                                                    ^^^^ the trait `CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not implemented for `(SelectBy<Post, _>, diesel::sql_types::Text)`
+197 |     let _ = posts::table.select((Post::as_select(), posts::title)).load::<((i32, String), String)>(&conn).unwrap();
+    |                                                                    ^^^^ the trait `CompatibleType<((i32, std::string::String), std::string::String), _>` is not implemented for `(SelectBy<Post, _>, diesel::sql_types::Text)`
     |
     = help: the following implementations were found:
               <(SA, SB) as CompatibleType<__T, __DB>>
-    = note: required because of the requirements on the impl of `LoadQuery<_, ((i32, std::string::String, i32), std::string::String)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<(SelectBy<Post, _>, posts::columns::title)>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, ((i32, std::string::String), std::string::String)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<(SelectBy<Post, _>, posts::columns::title)>>`
 
 error[E0277]: the trait bound `SelectBy<Post, _>: SingleValue` is not satisfied
    --> $DIR/selectable.rs:201:10

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -24,8 +24,8 @@ error[E0271]: type mismatch resolving `<posts::table as AppearsInFromClause<post
     |
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
     = note: 4 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost, _>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:149:10
@@ -41,8 +41,8 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
     = note: 4 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost, _>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:149:10
@@ -58,8 +58,8 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
     = note: 4 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost, _>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
 
 error[E0271]: type mismatch resolving `<posts::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Never`
    --> $DIR/selectable.rs:150:10
@@ -69,10 +69,10 @@ error[E0271]: type mismatch resolving `<posts::table as AppearsInFromClause<post
     |
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
     = note: 4 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>`
-    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:150:10
@@ -88,10 +88,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
     = note: 4 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>`
-    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:150:10
@@ -107,10 +107,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
     = note: 4 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>`
-    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectClauseExpression<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>` for `diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, LeftOuter>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::id>` is not satisfied
    --> $DIR/selectable.rs:157:10
@@ -124,8 +124,8 @@ error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::c
               <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
     = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::id`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost, _>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
 
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::name>` is not satisfied
    --> $DIR/selectable.rs:157:10
@@ -139,8 +139,8 @@ error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::c
               <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
     = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::name`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithEmbeddedPost, _>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::DefaultSelectClause, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
 
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::id>` is not satisfied
    --> $DIR/selectable.rs:158:10
@@ -154,9 +154,9 @@ error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::c
               <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
     = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::id`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
 
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::name>` is not satisfied
    --> $DIR/selectable.rs:158:10
@@ -170,9 +170,9 @@ error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::c
               <posts::columns::id as IsContainedInGroupBy<posts::columns::user_id>>
     = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `users::columns::name`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `ValidGrouping<posts::columns::id>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithEmbeddedPost, _>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>`
 
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
    --> $DIR/selectable.rs:164:10
@@ -185,8 +185,8 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggreg
               <diesel::expression::is_aggregate::No as MixedAggregates<diesel::expression::is_aggregate::No>>
     = note: required because of the requirements on the impl of `ValidGrouping<()>` for `(users::columns::id, users::columns::name, count::count::count<diesel::sql_types::Integer, posts::columns::id>)`
     = note: 1 redundant requirements hidden
-    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `SelectBy<UserWithPostCount>`
-    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithPostCount>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
+    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `SelectBy<UserWithPostCount, Pg>`
+    = note: required because of the requirements on the impl of `SelectDsl<SelectBy<UserWithPostCount, Pg>>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>>`
 
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
    --> $DIR/selectable.rs:165:10
@@ -199,9 +199,9 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggreg
               <diesel::expression::is_aggregate::No as MixedAggregates<diesel::expression::is_aggregate::No>>
     = note: required because of the requirements on the impl of `ValidGrouping<()>` for `(users::columns::id, users::columns::name, count::count::count<diesel::sql_types::Integer, posts::columns::id>)`
     = note: 1 redundant requirements hidden
-    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `SelectBy<UserWithPostCount>`
-    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithPostCount>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount>>>`
+    = note: required because of the requirements on the impl of `ValidGrouping<()>` for `SelectBy<UserWithPostCount, Pg>`
+    = note: required because of the requirements on the impl of `Query` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount, Pg>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithPostCount>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount, Pg>>>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:172:10
@@ -217,8 +217,8 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:172:10
@@ -234,8 +234,8 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
    --> $DIR/selectable.rs:172:10
@@ -248,8 +248,8 @@ error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<post
     = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:173:10
@@ -265,9 +265,9 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:173:10
@@ -283,9 +283,9 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
    --> $DIR/selectable.rs:173:10
@@ -298,9 +298,9 @@ error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<post
     = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `InsertStatement<users::table, ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:180:10
@@ -316,8 +316,8 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:180:10
@@ -333,8 +333,8 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
    --> $DIR/selectable.rs:180:10
@@ -347,8 +347,8 @@ error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<post
     = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:181:10
@@ -364,9 +364,9 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:181:10
@@ -382,9 +382,9 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
    --> $DIR/selectable.rs:181:10
@@ -397,9 +397,9 @@ error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<post
     = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:187:10
@@ -415,7 +415,7 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:187:10
@@ -431,7 +431,7 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
 
 error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
    --> $DIR/selectable.rs:187:10
@@ -444,7 +444,7 @@ error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<post
     = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
 
 error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:188:10
@@ -460,9 +460,9 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
               <posts::columns::id as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users::table>` is not satisfied
    --> $DIR/selectable.rs:188:10
@@ -478,9 +478,9 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
               <posts::columns::title as SelectableExpression<posts::table>>
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<posts::table>>::Count == diesel::query_source::Once`
    --> $DIR/selectable.rs:188:10
@@ -493,9 +493,9 @@ error[E0271]: type mismatch resolving `<users::table as AppearsInFromClause<post
     = note: required because of the requirements on the impl of `AppearsOnTable<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
-    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost>`
-    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost>>>`
+    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `SelectBy<UserWithEmbeddedPost, _>`
+    = note: required because of the requirements on the impl of `Query` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, UserWithEmbeddedPost>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::returning_clause::ReturningClause<SelectBy<UserWithEmbeddedPost, _>>>`
 
 error[E0599]: the function or associated item `as_select` exists for struct `UserWithoutSelectable`, but its trait bounds were not satisfied
    --> $DIR/selectable.rs:192:56
@@ -504,92 +504,124 @@ error[E0599]: the function or associated item `as_select` exists for struct `Use
     | ----------------------------
     | |
     | function or associated item `as_select` not found for this
-    | doesn't satisfy `UserWithoutSelectable: diesel::SelectableHelper`
-    | doesn't satisfy `UserWithoutSelectable: diesel::Selectable`
+    | doesn't satisfy `UserWithoutSelectable: diesel::Selectable<_>`
+    | doesn't satisfy `UserWithoutSelectable: diesel::SelectableHelper<_>`
 ...
 192 |     let _ = users::table.select(UserWithoutSelectable::as_select()).load(&conn).unwrap();
     |                                                        ^^^^^^^^^ function or associated item cannot be called on `UserWithoutSelectable` due to unsatisfied trait bounds
     |
     = note: the following trait bounds were not satisfied:
-            `UserWithoutSelectable: diesel::Selectable`
-            which is required by `UserWithoutSelectable: diesel::SelectableHelper`
-            `&UserWithoutSelectable: diesel::Selectable`
-            which is required by `&UserWithoutSelectable: diesel::SelectableHelper`
-            `&mut UserWithoutSelectable: diesel::Selectable`
-            which is required by `&mut UserWithoutSelectable: diesel::SelectableHelper`
+            `UserWithoutSelectable: diesel::Selectable<_>`
+            which is required by `UserWithoutSelectable: diesel::SelectableHelper<_>`
+            `&UserWithoutSelectable: diesel::Selectable<_>`
+            which is required by `&UserWithoutSelectable: diesel::SelectableHelper<_>`
+            `&mut UserWithoutSelectable: diesel::Selectable<_>`
+            which is required by `&mut UserWithoutSelectable: diesel::SelectableHelper<_>`
 
-error[E0277]: the trait bound `SelectBy<Post>: SingleValue` is not satisfied
+error[E0277]: the trait bound `SelectBy<Post, _>: SingleValue` is not satisfied
    --> $DIR/selectable.rs:195:52
     |
 195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
-    |                                                    ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post>`
+    |                                                    ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post, _>`
     |
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post>>>`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post, _>>>`
 
-error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post>, _>` is not satisfied
+error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post, _>, _>` is not satisfied
    --> $DIR/selectable.rs:195:52
     |
 195 |     let _ = posts::table.select(Post::as_select()).load::<(i32, String, i32)>(&conn).unwrap();
-    |                                                    ^^^^ the trait `diesel::Queryable<SelectBy<Post>, _>` is not implemented for `(i32, std::string::String, i32)`
+    |                                                    ^^^^ the trait `diesel::Queryable<SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String, i32)`
     |
     = help: the following implementations were found:
               <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
               <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
-    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post>, _>` for `(i32, std::string::String, i32)`
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post>>>`
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post, _>, _>` for `(i32, std::string::String, i32)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<SelectBy<Post, _>>>`
 
-error[E0277]: the trait bound `SelectBy<Post>: SingleValue` is not satisfied
+error[E0277]: the trait bound `SelectBy<Post, _>: SingleValue` is not satisfied
    --> $DIR/selectable.rs:196:65
     |
 196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
-    |                                                                 ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post>`
+    |                                                                 ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post, _>`
     |
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post>, posts::table, _>`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post, _>, posts::table, _>`
 
-error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post>, _>` is not satisfied
+error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post, _>, _>` is not satisfied
    --> $DIR/selectable.rs:196:65
     |
 196 |     let _ = posts::table.select(Post::as_select()).into_boxed().load::<(i32, String, i32)>(&conn).unwrap();
-    |                                                                 ^^^^ the trait `diesel::Queryable<SelectBy<Post>, _>` is not implemented for `(i32, std::string::String, i32)`
+    |                                                                 ^^^^ the trait `diesel::Queryable<SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String, i32)`
     |
     = help: the following implementations were found:
               <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
               <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
-    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post>, _>` for `(i32, std::string::String, i32)`
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post>, posts::table, _>`
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post, _>, _>` for `(i32, std::string::String, i32)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `BoxedSelectStatement<'_, SelectBy<Post, _>, posts::table, _>`
 
-error[E0277]: the trait bound `(SelectBy<Post>, diesel::sql_types::Text): CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not satisfied
+error[E0277]: the trait bound `(SelectBy<Post, _>, diesel::sql_types::Text): CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not satisfied
    --> $DIR/selectable.rs:197:68
     |
 197 |     let _ = posts::table.select((Post::as_select(), posts::title)).load::<((i32, String, i32), String)>(&conn).unwrap();
-    |                                                                    ^^^^ the trait `CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not implemented for `(SelectBy<Post>, diesel::sql_types::Text)`
+    |                                                                    ^^^^ the trait `CompatibleType<((i32, std::string::String, i32), std::string::String), _>` is not implemented for `(SelectBy<Post, _>, diesel::sql_types::Text)`
     |
     = help: the following implementations were found:
               <(SA, SB) as CompatibleType<__T, __DB>>
-    = note: required because of the requirements on the impl of `LoadQuery<_, ((i32, std::string::String, i32), std::string::String)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<(SelectBy<Post>, posts::columns::title)>>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, ((i32, std::string::String, i32), std::string::String)>` for `SelectStatement<posts::table, diesel::query_builder::select_clause::SelectClause<(SelectBy<Post, _>, posts::columns::title)>>`
 
-error[E0277]: the trait bound `SelectBy<Post>: SingleValue` is not satisfied
+error[E0277]: the trait bound `SelectBy<Post, _>: SingleValue` is not satisfied
    --> $DIR/selectable.rs:201:10
     |
 201 |         .load::<(i32, String, i32)>(&conn)
-    |          ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post>`
+    |          ^^^^ the trait `SingleValue` is not implemented for `SelectBy<Post, _>`
     |
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `InsertStatement<posts::table, ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<Post>>>`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `InsertStatement<posts::table, ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<Post, _>>>`
 
-error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post>, _>` is not satisfied
+error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<SelectBy<Post, _>, _>` is not satisfied
    --> $DIR/selectable.rs:201:10
     |
 201 |         .load::<(i32, String, i32)>(&conn)
-    |          ^^^^ the trait `diesel::Queryable<SelectBy<Post>, _>` is not implemented for `(i32, std::string::String, i32)`
+    |          ^^^^ the trait `diesel::Queryable<SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String, i32)`
     |
     = help: the following implementations were found:
               <(A, B, C) as diesel::Queryable<(SA, SB, SC), __DB>>
               <(A, B, C) as diesel::Queryable<Record<(SA, SB, SC)>, Pg>>
-    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post>, _>` for `(i32, std::string::String, i32)`
-    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post>`
-    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `InsertStatement<posts::table, ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<Post>>>`
+    = note: required because of the requirements on the impl of `FromSqlRow<SelectBy<Post, _>, _>` for `(i32, std::string::String, i32)`
+    = note: required because of the requirements on the impl of `CompatibleType<(i32, std::string::String, i32), _>` for `SelectBy<Post, _>`
+    = note: required because of the requirements on the impl of `LoadQuery<_, (i32, std::string::String, i32)>` for `InsertStatement<posts::table, ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::Insert, diesel::query_builder::returning_clause::ReturningClause<SelectBy<Post, _>>>`
+
+error[E0271]: type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == Pg`
+   --> $DIR/selectable.rs:210:10
+    |
+210 |         .load(&conn)
+    |          ^^^^ expected struct `Sqlite`, found struct `Pg`
+    |
+    = note: required because of the requirements on the impl of `LoadQuery<diesel::SqliteConnection, UserWithPostCount>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount, Pg>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::id>>`
+
+error[E0277]: the trait bound `Sqlite: HasSqlType<SelectBy<UserWithPostCount, Pg>>` is not satisfied
+   --> $DIR/selectable.rs:210:10
+    |
+210 |         .load(&conn)
+    |          ^^^^ the trait `HasSqlType<SelectBy<UserWithPostCount, Pg>>` is not implemented for `Sqlite`
+    |
+    = help: the following implementations were found:
+              <Sqlite as HasSqlType<BigInt>>
+              <Sqlite as HasSqlType<Bool>>
+              <Sqlite as HasSqlType<diesel::sql_types::Binary>>
+              <Sqlite as HasSqlType<diesel::sql_types::Date>>
+            and 8 others
+    = note: required because of the requirements on the impl of `QueryMetadata<SelectBy<UserWithPostCount, Pg>>` for `Sqlite`
+    = note: required because of the requirements on the impl of `LoadQuery<diesel::SqliteConnection, UserWithPostCount>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount, Pg>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::id>>`
+
+error[E0277]: the trait bound `SelectBy<UserWithPostCount, Pg>: SingleValue` is not satisfied
+   --> $DIR/selectable.rs:210:10
+    |
+210 |         .load(&conn)
+    |          ^^^^ the trait `SingleValue` is not implemented for `SelectBy<UserWithPostCount, Pg>`
+    |
+    = note: required because of the requirements on the impl of `QueryMetadata<SelectBy<UserWithPostCount, Pg>>` for `Sqlite`
+    = note: required because of the requirements on the impl of `LoadQuery<diesel::SqliteConnection, UserWithPostCount>` for `SelectStatement<JoinOn<diesel::query_source::joins::Join<users::table, posts::table, Inner>, Grouped<diesel::expression::operators::Eq<diesel::expression::nullable::Nullable<posts::columns::user_id>, diesel::expression::nullable::Nullable<users::columns::id>>>>, diesel::query_builder::select_clause::SelectClause<SelectBy<UserWithPostCount, Pg>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::id>>`

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -736,9 +736,6 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 /// To implement `Selectable` this derive needs to know the corresponding table
 /// type. By default it uses the `snake_case` type name with an added `s`.
 /// It is possible to change this default by using `#[table_name = "something"]`.
-/// In both cases the module for that table must be in scope.
-/// For example, to derive this for a struct called `User`, you will
-/// likely need a line such as `use schema::users;`
 ///
 /// If the name of a field on your struct is different than the column in your
 /// `table!` declaration, or if you are deriving this trait on a tuple struct,
@@ -751,24 +748,23 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 /// Fields from a inner struct can come from a different table, as long as the
 /// select clause is valid in current query.
 ///
-/// The derive enables SelectByDsl for the statement, in order to
-/// use LoadDsl, you might also check the `Queryable` trait and derive.
+/// The derive enables using the `SelectableHelper::as_select` method to construct
+/// select clauses, in order to use LoadDsl, you might also check the
+/// `Queryable` trait and derive.
 ///
 /// # Attributes
 ///
 /// ## Type attributes
 ///
-/// * `#[table_name = "some_table"]`, to specify that this type contains
-///   columns for the specified table. If no field attributes are specified
-///   the derive will use the sql type of the corresponding column.
+/// * `#[table_name = "path::to::table"]`, specifies a path to the table for which the
+/// current type is selectable. The path is relative to the current module.
+/// If this attribute is not used, the type name converted to
+/// `snake_case` with an added `s` is used as table name.
 ///
 /// ## Field attributes
-/// * `#[table_name = "some_table"]`, overrides the table name for
-///    a given field. This attribute is optional.
 /// * `#[column_name = "some_column"]`, overrides the column name for
 ///    a given field. If not set, the name of the field is used as column
-///    name. This attribute is required on tuple structs, if
-///    `#[table_name = "some_table"]` is used, otherwise it's optional.
+///    name.
 /// * `#[diesel(embed)]`, specifies that the current field maps not only
 ///    single database column, but is a type that implements
 ///    `Selectable` on it's own

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -45,6 +45,7 @@ mod insertable;
 mod query_id;
 mod queryable;
 mod queryable_by_name;
+mod selectable;
 mod sql_function;
 mod sql_type;
 mod valid_grouping;
@@ -728,6 +729,52 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(QueryableByName, attributes(table_name, column_name, sql_type, diesel))]
 pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
     expand_proc_macro(input, queryable_by_name::derive)
+}
+
+/// Implements `Selectable`
+///
+/// To implement `Selectable` this derive needs to know the corresponding table
+/// type. By default it uses the `snake_case` type name with an added `s`.
+/// It is possible to change this default by using `#[table_name = "something"]`.
+/// In both cases the module for that table must be in scope.
+/// For example, to derive this for a struct called `User`, you will
+/// likely need a line such as `use schema::users;`
+///
+/// If the name of a field on your struct is different than the column in your
+/// `table!` declaration, or if you are deriving this trait on a tuple struct,
+/// you can annotate the field with `#[column_name = "some_column"]`. For tuple
+/// structs, all fields must have this annotation.
+///
+/// If a field is another struct which implements `Selectable`,
+/// instead of a column, you can annotate that struct with `#[diesel(embed)]`.
+/// Then all fields contained by that inner struct are selected as separate tuple.
+/// Fields from a inner struct can come from a different table, as long as the
+/// select clause is valid in current query.
+///
+/// The derive enables SelectByDsl for the statement, in order to
+/// use LoadDsl, you might also check the `Queryable` trait and derive.
+///
+/// # Attributes
+///
+/// ## Type attributes
+///
+/// * `#[table_name = "some_table"]`, to specify that this type contains
+///   columns for the specified table. If no field attributes are specified
+///   the derive will use the sql type of the corresponding column.
+///
+/// ## Field attributes
+/// * `#[table_name = "some_table"]`, overrides the table name for
+///    a given field. This attribute is optional.
+/// * `#[column_name = "some_column"]`, overrides the column name for
+///    a given field. If not set, the name of the field is used as column
+///    name. This attribute is required on tuple structs, if
+///    `#[table_name = "some_table"]` is used, otherwise it's optional.
+/// * `#[diesel(embed)]`, specifies that the current field maps not only
+///    single database column, but is a type that implements
+///    `Selectable` on it's own
+#[proc_macro_derive(Selectable, attributes(table_name, column_name, sql_type, diesel))]
+pub fn derive_selectable(input: TokenStream) -> TokenStream {
+    expand_proc_macro(input, selectable::derive)
 }
 
 /// Implement necessary traits for adding a new sql type

--- a/diesel_derives/src/selectable.rs
+++ b/diesel_derives/src/selectable.rs
@@ -1,0 +1,60 @@
+use proc_macro2;
+use syn;
+
+use field::*;
+use model::*;
+use util::*;
+
+pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagnostic> {
+    let model = Model::from_item(&item)?;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+    let struct_name = &item.ident;
+
+    let field_columns_ty = model
+        .fields()
+        .iter()
+        .map(|f| field_column_ty(f, &model))
+        .collect::<Result<Vec<_>, _>>()?;
+    let field_columns_inst = model
+        .fields()
+        .iter()
+        .map(|f| field_column_inst(f, &model))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(wrap_in_dummy_mod(quote! {
+        use diesel::expression::Selectable;
+
+        impl #impl_generics Selectable
+            for #struct_name #ty_generics
+        #where_clause
+        {
+            type Expression = (#(#field_columns_ty,)*);
+            fn new_expression() -> Self::Expression {
+                (#(#field_columns_inst,)*)
+            }
+        }
+    }))
+}
+
+fn field_column_ty(field: &Field, model: &Model) -> Result<syn::Type, Diagnostic> {
+    if field.has_flag("embed") {
+        let embed_ty = &field.ty;
+        Ok(parse_quote!(<#embed_ty as Selectable>::Expression))
+    } else {
+        let table_name = model.table_name();
+        let column_name = field.column_name();
+        Ok(parse_quote!(#table_name::#column_name))
+    }
+}
+
+fn field_column_inst(field: &Field, model: &Model) -> Result<syn::Expr, Diagnostic> {
+    if field.has_flag("embed") {
+        let embed_ty = &field.ty;
+        Ok(parse_quote!(<#embed_ty as Selectable>::new_expression()))
+    } else {
+        let table_name = model.table_name();
+        let column_name = field.column_name();
+        Ok(parse_quote!(#table_name::#column_name))
+    }
+}

--- a/diesel_derives/tests/selectable.rs
+++ b/diesel_derives/tests/selectable.rs
@@ -1,0 +1,88 @@
+use diesel::*;
+
+use helpers::connection;
+
+table! {
+    my_structs (foo) {
+        foo -> Integer,
+        bar -> Integer,
+    }
+}
+
+#[test]
+fn named_struct_definition() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[table_name = "my_structs"]
+    struct MyStruct {
+        foo: i32,
+        bar: i32,
+    }
+
+    let conn = connection();
+    let data = my_structs::table
+        .select_by::<MyStruct>()
+        .get_result::<MyStruct>(&conn);
+    assert!(data.is_err());
+}
+
+#[test]
+fn tuple_struct() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[table_name = "my_structs"]
+    struct MyStruct(
+        #[column_name = "foo"] i32,
+        #[table_name = "my_structs"]
+        #[column_name = "bar"]
+        i32,
+    );
+
+    let conn = connection();
+    let data = my_structs::table
+        .select_by::<MyStruct>()
+        .get_result::<MyStruct>(&conn);
+    assert!(data.is_err());
+}
+
+// FIXME: Test usage with renamed columns
+
+#[test]
+fn embedded_struct() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[table_name = "my_structs"]
+    struct A {
+        foo: i32,
+        #[diesel(embed)]
+        b: B,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    struct B {
+        #[table_name = "my_structs"]
+        bar: i32,
+    }
+
+    let conn = connection();
+    let data = my_structs::table.select_by::<A>().get_result::<A>(&conn);
+    assert!(data.is_err());
+}
+
+#[test]
+fn embedded_option() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[table_name = "my_structs"]
+    struct A {
+        foo: i32,
+        #[diesel(embed)]
+        b: Option<B>,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[table_name = "my_structs"]
+    struct B {
+        bar: i32,
+    }
+
+    let conn = connection();
+    let data = my_structs::table.select_by::<A>().get_result::<A>(&conn);
+    assert!(data.is_err());
+}

--- a/diesel_derives/tests/selectable.rs
+++ b/diesel_derives/tests/selectable.rs
@@ -20,8 +20,8 @@ fn named_struct_definition() {
 
     let conn = connection();
     let data = my_structs::table
-        .select_by::<MyStruct>()
-        .get_result::<MyStruct>(&conn);
+        .select(MyStruct::as_select())
+        .get_result(&conn);
     assert!(data.is_err());
 }
 
@@ -29,17 +29,12 @@ fn named_struct_definition() {
 fn tuple_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
     #[table_name = "my_structs"]
-    struct MyStruct(
-        #[column_name = "foo"] i32,
-        #[table_name = "my_structs"]
-        #[column_name = "bar"]
-        i32,
-    );
+    struct MyStruct(#[column_name = "foo"] i32, #[column_name = "bar"] i32);
 
     let conn = connection();
     let data = my_structs::table
-        .select_by::<MyStruct>()
-        .get_result::<MyStruct>(&conn);
+        .select(MyStruct::as_select())
+        .get_result(&conn);
     assert!(data.is_err());
 }
 
@@ -56,13 +51,13 @@ fn embedded_struct() {
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[table_name = "my_structs"]
     struct B {
-        #[table_name = "my_structs"]
         bar: i32,
     }
 
     let conn = connection();
-    let data = my_structs::table.select_by::<A>().get_result::<A>(&conn);
+    let data = my_structs::table.select(A::as_select()).get_result(&conn);
     assert!(data.is_err());
 }
 
@@ -83,6 +78,6 @@ fn embedded_option() {
     }
 
     let conn = connection();
-    let data = my_structs::table.select_by::<A>().get_result::<A>(&conn);
+    let data = my_structs::table.select(A::as_select()).get_result(&conn);
     assert!(data.is_err());
 }

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -14,3 +14,4 @@ mod identifiable;
 mod insertable;
 mod queryable;
 mod queryable_by_name;
+mod selectable;

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -27,7 +27,7 @@ bigdecimal = ">= 0.0.13, < 0.3.0"
 rand = "0.7"
 
 [features]
-default = []
+default = ["sqlite"]
 unstable = ["diesel/unstable"]
 postgres = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -27,7 +27,7 @@ bigdecimal = ">= 0.0.13, < 0.3.0"
 rand = "0.7"
 
 [features]
-default = ["sqlite"]
+default = []
 unstable = ["diesel/unstable"]
 postgres = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]

--- a/diesel_tests/tests/deserialization.rs
+++ b/diesel_tests/tests/deserialization.rs
@@ -2,7 +2,8 @@ use crate::schema::*;
 use diesel::*;
 use std::borrow::Cow;
 
-#[derive(Queryable, PartialEq, Debug)]
+#[derive(Queryable, PartialEq, Debug, Selectable)]
+#[table_name = "users"]
 struct CowUser<'a> {
     id: i32,
     name: Cow<'a, str>,
@@ -20,5 +21,9 @@ fn generated_queryable_allows_lifetimes() {
     assert_eq!(
         Ok(expected_user),
         users.select((id, name)).first(&connection)
+    );
+    assert_eq!(
+        users.select((id, name)).first::<CowUser>(&connection),
+        users.select(CowUser::as_select()).first(&connection)
     );
 }

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -41,3 +41,25 @@ fn distinct_on() {
 
     assert_eq!(expected_data, data);
 }
+
+#[cfg(feature = "postgres")]
+#[test]
+fn distinct_on_select_by() {
+    use crate::schema::users::dsl::*;
+
+    let connection = connection();
+    connection
+        .execute(
+            "INSERT INTO users (name, hair_color) VALUES ('Sean', 'black'), ('Sean', NULL), ('Tess', NULL), ('Tess', NULL)",
+        )
+        .unwrap();
+
+    let source = users.select_by::<NewUser>().order(name).distinct_on(name);
+    let expected_data = vec![
+        NewUser::new("Sean", Some("black")),
+        NewUser::new("Tess", None),
+    ];
+    let data: Vec<_> = source.load(&connection).unwrap();
+
+    assert_eq!(expected_data, data);
+}

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -54,7 +54,10 @@ fn distinct_on_select_by() {
         )
         .unwrap();
 
-    let source = users.select_by::<NewUser>().order(name).distinct_on(name);
+    let source = users
+        .select(NewUser::as_select())
+        .order(name)
+        .distinct_on(name);
     let expected_data = vec![
         NewUser::new("Sean", Some("black")),
         NewUser::new("Tess", None),

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -211,6 +211,56 @@ fn filter_then_select() {
 }
 
 #[test]
+fn select_by_then_filter() {
+    use crate::schema::users::dsl::*;
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    let source = users.select(UserName::as_select());
+    assert_eq!(
+        Ok(UserName::new("Sean")),
+        source.filter(name.eq("Sean")).first(&connection)
+    );
+    assert_eq!(
+        Ok(UserName::new("Tess")),
+        source.filter(name.eq("Tess")).first(&connection)
+    );
+    assert_eq!(
+        Err(NotFound),
+        source.filter(name.eq("Jim")).first::<UserName>(&connection)
+    );
+}
+
+#[test]
+fn filter_then_select_by() {
+    use crate::schema::users::dsl::*;
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    assert_eq!(
+        Ok(UserName::new("Sean")),
+        users
+            .filter(name.eq("Sean"))
+            .select(UserName::as_select())
+            .first(&connection)
+    );
+    assert_eq!(
+        Ok(UserName::new("Tess")),
+        users
+            .filter(name.eq("Tess"))
+            .select(UserName::as_select())
+            .first(&connection)
+    );
+    assert_eq!(
+        Err(NotFound),
+        users
+            .filter(name.eq("Jim"))
+            .select(UserName::as_select())
+            .first::<UserName>(&connection)
+    );
+}
+
+#[test]
 fn filter_on_multiple_columns() {
     use crate::schema::users::dsl::*;
 

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -104,3 +104,21 @@ fn select_then_find() {
     assert_eq!(Ok(String::from("Sean")), sean);
     assert_eq!(Ok(String::from("Tess")), tess);
 }
+
+#[test]
+fn select_by_then_find() {
+    use crate::schema::users::dsl::*;
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let sean = users
+        .select(UserName::as_select())
+        .find(1)
+        .first(&connection);
+    let tess = users
+        .select(UserName::as_select())
+        .find(2)
+        .first(&connection);
+
+    assert_eq!(Ok(UserName::new("Sean")), sean);
+    assert_eq!(Ok(UserName::new("Tess")), tess);
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -42,6 +42,7 @@ mod schema;
 mod schema_dsl;
 mod schema_inference;
 mod select;
+mod select_by;
 mod serialize_as;
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 mod transactions;

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -11,7 +11,16 @@ include!("sqlite_schema.rs");
 include!("mysql_schema.rs");
 
 #[derive(
-    PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, QueryableByName,
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Queryable,
+    Identifiable,
+    Insertable,
+    AsChangeset,
+    QueryableByName,
+    Selectable,
 )]
 #[table_name = "users"]
 pub struct User {
@@ -39,6 +48,16 @@ impl User {
 
     pub fn new_post(&self, title: &str, body: Option<&str>) -> NewPost {
         NewPost::new(self.id, title, body)
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Selectable)]
+#[table_name = "users"]
+pub struct UserName(#[column_name = "name"] pub String);
+
+impl UserName {
+    pub fn new(name: &str) -> Self {
+        UserName(name.to_string())
     }
 }
 
@@ -78,7 +97,7 @@ mod backend_specifics;
 
 pub use self::backend_specifics::*;
 
-#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset)]
+#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset, Selectable)]
 #[table_name = "users"]
 pub struct NewUser {
     pub name: String,

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -168,9 +168,13 @@ fn selecting_multiple_aggregate_expressions_without_group_by() {
         count: i64,
         max_name: Option<String>,
     }
-    impl Selectable for CountAndMax {
-        type Expression = (CountStar, max<name>);
-        fn new_expression() -> Self::Expression {
+    impl<DB> Selectable<DB> for CountAndMax
+    where
+        DB: diesel::backend::Backend,
+    {
+        type SelectExpression = (CountStar, max<name>);
+
+        fn construct_selection() -> Self::SelectExpression {
             (count_star(), max(name))
         }
     }

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -1,0 +1,217 @@
+use super::schema::*;
+use diesel::*;
+#[test]
+fn selecting_basic_data() {
+    use crate::schema::users::dsl::*;
+
+    let connection = connection();
+    connection
+        .execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .unwrap();
+
+    let expected_data = vec![
+        User {
+            id: 1,
+            name: "Sean".to_string(),
+            hair_color: None,
+        },
+        User {
+            id: 2,
+            name: "Tess".to_string(),
+            hair_color: None,
+        },
+    ];
+    let actual_data: Vec<_> = users.select(User::as_select()).load(&connection).unwrap();
+    assert_eq!(expected_data, actual_data);
+}
+
+#[test]
+fn with_safe_select() {
+    use crate::schema::users::dsl::*;
+
+    let connection = connection();
+    connection
+        .execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .unwrap();
+
+    let select_name = users.select(UserName::as_select());
+    let names: Vec<UserName> = select_name.load(&connection).unwrap();
+
+    assert_eq!(vec![UserName::new("Sean"), UserName::new("Tess")], names);
+}
+
+table! {
+    select {
+        id -> Integer,
+        join -> Integer,
+    }
+}
+
+#[test]
+#[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
+fn selecting_columns_and_tables_with_reserved_names() {
+    use crate::schema_dsl::*;
+    let connection = connection();
+    create_table(
+        "select",
+        (
+            integer("id").primary_key().auto_increment(),
+            integer("join").not_null(),
+        ),
+    )
+    .execute(&connection)
+    .unwrap();
+    connection
+        .execute("INSERT INTO \"select\" (\"join\") VALUES (1), (2), (3)")
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Queryable, Selectable)]
+    #[table_name = "select"]
+    struct Select {
+        join: i32,
+    }
+
+    let expected_data = vec![1, 2, 3]
+        .into_iter()
+        .map(|join| Select { join })
+        .collect::<Vec<_>>();
+    let actual_data: Vec<Select> = select::table
+        .select(Select::as_select())
+        .load(&connection)
+        .unwrap();
+    assert_eq!(expected_data, actual_data);
+}
+
+#[test]
+#[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
+fn selecting_columns_with_different_definition_order() {
+    use crate::schema_dsl::*;
+    let connection = connection();
+    drop_table_cascade(&connection, "users");
+    create_table(
+        "users",
+        (
+            integer("id").primary_key().auto_increment(),
+            string("hair_color"),
+            string("name").not_null(),
+        ),
+    )
+    .execute(&connection)
+    .unwrap();
+    let expected_user = User::with_hair_color(1, "Sean", "black");
+    insert_into(users::table)
+        .values(&NewUser::new("Sean", Some("black")))
+        .execute(&connection)
+        .unwrap();
+    let user_from_select = users::table.select(User::as_select()).first(&connection);
+
+    assert_eq!(Ok(&expected_user), user_from_select.as_ref());
+}
+
+#[test]
+fn selection_using_subselect() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let ids: Vec<i32> = users::table.select(users::id).load(&connection).unwrap();
+    let query = format!(
+        "INSERT INTO posts (user_id, title) VALUES ({}, 'Hello'), ({}, 'World')",
+        ids[0], ids[1]
+    );
+    connection.execute(&query).unwrap();
+
+    #[derive(Debug, PartialEq, Queryable, Selectable)]
+    struct Post(#[column_name = "title"] String);
+
+    let users = users::table
+        .filter(users::name.eq("Sean"))
+        .select(users::id);
+    let data = posts::table
+        .select(Post::as_select())
+        .filter(posts::user_id.eq_any(users))
+        .load(&connection)
+        .unwrap();
+
+    assert_eq!(vec![Post("Hello".to_string())], data);
+}
+
+#[test]
+fn select_can_be_called_on_query_that_is_valid_subselect_but_invalid_query() {
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let sean = find_user_by_name("Sean", &connection);
+    let tess = find_user_by_name("Tess", &connection);
+    insert_into(posts::table)
+        .values(&vec![
+            tess.new_post("Tess", None),
+            sean.new_post("Hi", None),
+        ])
+        .execute(&connection)
+        .unwrap();
+
+    let invalid_query_but_valid_subselect = posts::table
+        .select(posts::user_id)
+        .filter(posts::title.eq(users::name));
+    let users_with_post_using_name_as_title = users::table
+        .select(User::as_select())
+        .filter(users::id.eq_any(invalid_query_but_valid_subselect))
+        .load(&connection);
+
+    assert_eq!(Ok(vec![tess]), users_with_post_using_name_as_title);
+}
+
+#[test]
+fn selecting_multiple_aggregate_expressions_without_group_by() {
+    use self::users::dsl::*;
+    use diesel::dsl::{count_star, max, CountStar};
+    use diesel::helper_types::max;
+
+    #[derive(Queryable)]
+    struct CountAndMax {
+        count: i64,
+        max_name: Option<String>,
+    }
+    impl Selectable for CountAndMax {
+        type Expression = (CountStar, max<name>);
+        fn new_expression() -> Self::Expression {
+            (count_star(), max(name))
+        }
+    }
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+    let CountAndMax { count, max_name } = users
+        .select(CountAndMax::as_select())
+        .get_result(&connection)
+        .unwrap();
+
+    assert_eq!(2, count);
+    assert_eq!(Some(String::from("Tess")), max_name);
+}
+
+#[test]
+fn mixed_selectable_and_plain_select() {
+    use crate::schema::users::dsl::*;
+
+    let connection = connection_with_sean_and_tess_in_users_table();
+
+    let expected_data = vec![
+        (
+            User {
+                id: 1,
+                name: "Sean".to_string(),
+                hair_color: None,
+            },
+            "Sean".to_string(),
+        ),
+        (
+            User {
+                id: 2,
+                name: "Tess".to_string(),
+                hair_color: None,
+            },
+            "Tess".to_string(),
+        ),
+    ];
+    let actual_data: Vec<_> = users
+        .select((User::as_select(), name))
+        .load(&connection)
+        .unwrap();
+    assert_eq!(expected_data, actual_data);
+}

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -1,13 +1,11 @@
 use super::schema::*;
 use diesel::*;
+
 #[test]
 fn selecting_basic_data() {
     use crate::schema::users::dsl::*;
 
-    let connection = connection();
-    connection
-        .execute("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
-        .unwrap();
+    let connection = connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![
         User {


### PR DESCRIPTION
This is a rather large PR. It builds on both #2709 and #2367.

This provides a `Selectable` trait that allows to attach a select clause construction to types. Additionally a corresponding derive is provided, so that this can be used to construct select clauses matching types that implement `Queryable`, so that we side step the "famous" type errors you get if you mix up the field order in such a struct. 
This version requires explicit calls to `.select()` to set that select clause. In contrast to #2367 we don't add an additional method for that, but instead use a type constructor provided by the `Selectable` trait to construct the select clause explicitly. I feel that this way this feature composes better with other parts of `QueryDsl`. So is it for example possible to mix select clause parts coming from `Selectable` and other explicit parts. As soon as you use `as_select()` for some part of your select clause that type is locked in and only that type will be accepted at the corresponding position using `.load()` or similar methods. This is to prevent errors coming from accidentally mixing structs or something like that.
In contrast to `#2709` this does not provide explicit `select_and_load()` methods as those had really bad error messages. It remains possible for third party crates to provide such methods.


Closes #2709
Closes #2367
fixes #2037
fixes #1435 