### PR TITLE
Fixed URL deprecated method

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -365,7 +365,7 @@ fn change_database_of_url(database_url: &str, default_database: &str) -> (String
     let database = base.path_segments().unwrap().last().unwrap().to_owned();
     let mut new_url = base.join(default_database).unwrap();
     new_url.set_query(base.query());
-    (database, new_url.into_string())
+    (database, new_url.into())
 }
 
 #[allow(clippy::needless_pass_by_value)]


### PR DESCRIPTION
This commit fixes a deprecation in the `url` crate, that is making builds of `diesel_cli` fail (because the deprecated warnings are denied).