### PR TITLE
COUNT(DISTINCT ...) support

### DIFF
--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,11 +1,13 @@
 use std::marker::PhantomData;
 
-use super::{functions::sql_function, is_aggregate, AsExpression};
+use super::functions::sql_function;
+use super::{is_aggregate, AsExpression};
 use super::{Expression, ValidGrouping};
 use crate::query_builder::*;
 use crate::result::QueryResult;
 use crate::sql_types::{BigInt, DieselNumericOps, SingleValue, SqlType};
-use crate::{backend::Backend, AppearsOnTable, SelectableExpression};
+use crate::backend::Backend;
+use crate::{AppearsOnTable, SelectableExpression};
 
 sql_function! {
     /// Creates a SQL `COUNT` expression

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -92,7 +92,8 @@ impl_selectable_expression!(CountStar);
 /// # fn main() {
 /// #     use schema::posts::dsl::*;
 /// #     let connection = establish_connection();
-/// assert_eq!(Ok(2), posts.select(count_distinct(user_id)).first(&connection));
+/// let unique_user_count = posts.select(count_distinct(user_id)).first(&connection);
+/// assert_eq!(Ok(2), unique_user_count);
 /// # }
 /// ```
 pub fn count_distinct<T, E>(expr: E) -> CountDistinct<T, E::Expression>

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -3,10 +3,10 @@ use std::marker::PhantomData;
 use super::functions::sql_function;
 use super::{is_aggregate, AsExpression};
 use super::{Expression, ValidGrouping};
+use crate::backend::Backend;
 use crate::query_builder::*;
 use crate::result::QueryResult;
 use crate::sql_types::{BigInt, DieselNumericOps, SingleValue, SqlType};
-use crate::backend::Backend;
 use crate::{AppearsOnTable, SelectableExpression};
 
 sql_function! {

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,9 +1,11 @@
-use super::functions::sql_function;
+use std::marker::PhantomData;
+
+use super::{functions::sql_function, is_aggregate, AsExpression};
 use super::{Expression, ValidGrouping};
-use crate::backend::Backend;
 use crate::query_builder::*;
 use crate::result::QueryResult;
 use crate::sql_types::{BigInt, DieselNumericOps, SingleValue, SqlType};
+use crate::{backend::Backend, AppearsOnTable, SelectableExpression};
 
 sql_function! {
     /// Creates a SQL `COUNT` expression
@@ -71,3 +73,83 @@ impl<DB: Backend> QueryFragment<DB> for CountStar {
 }
 
 impl_selectable_expression!(CountStar);
+
+/// Creates a SQL `COUNT(DISTINCT ...)` expression
+///
+/// As with most bare functions, this is not exported by default. You can import
+/// it specifically as `diesel::dsl::count_distinct`, or glob import
+/// `diesel::dsl::*`
+///
+/// # Examples
+///
+/// ```rust
+/// # #[macro_use] extern crate diesel;
+/// # include!("../doctest_setup.rs");
+/// # use diesel::dsl::*;
+/// #
+/// # fn main() {
+/// #     use schema::posts::dsl::*;
+/// #     let connection = establish_connection();
+/// assert_eq!(Ok(2), posts.select(count_distinct(user_id)).first(&connection));
+/// # }
+/// ```
+pub fn count_distinct<T, E>(expr: E) -> CountDistinct<T, E::Expression>
+where
+    T: SqlType + SingleValue,
+    E: AsExpression<T>,
+{
+    CountDistinct {
+        expr: expr.as_expression(),
+        _marker: PhantomData,
+    }
+}
+
+#[derive(Debug, Clone, Copy, QueryId, DieselNumericOps)]
+#[doc(hidden)]
+pub struct CountDistinct<T, E> {
+    expr: E,
+    _marker: PhantomData<T>,
+}
+
+impl<T, E> Expression for CountDistinct<T, E>
+where
+    T: SqlType + SingleValue,
+    E: Expression,
+{
+    type SqlType = BigInt;
+}
+
+impl<T, E, GB> ValidGrouping<GB> for CountDistinct<T, E>
+where
+    T: SqlType + SingleValue,
+{
+    type IsAggregate = is_aggregate::Yes;
+}
+
+impl<T, E, QS> SelectableExpression<QS> for CountDistinct<T, E>
+where
+    Self: AppearsOnTable<QS>,
+    E: SelectableExpression<QS>,
+{
+}
+
+impl<T, E, QS> AppearsOnTable<QS> for CountDistinct<T, E>
+where
+    Self: Expression,
+    E: AppearsOnTable<QS>,
+{
+}
+
+impl<T, E, DB> QueryFragment<DB> for CountDistinct<T, E>
+where
+    T: SqlType + SingleValue,
+    DB: Backend,
+    for<'a> &'a E: QueryFragment<DB>,
+{
+    fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+        out.push_sql("COUNT(DISTINCT ");
+        (&self.expr).walk_ast(out.reborrow())?;
+        out.push_sql(")");
+        Ok(())
+    }
+}

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -75,6 +75,9 @@ pub mod dsl {
     /// The return type of [`count_star()`](crate::dsl::count_star())
     pub type count_star = super::count::CountStar;
 
+    /// The return type of [`count_distinct()`](crate::dsl::count_distinct())
+    pub type count_distinct<Expr> = super::count::CountDistinct<SqlTypeOf<Expr>, Expr>;
+
     /// The return type of [`date(expr)`](crate::dsl::date())
     pub type date<Expr> = super::functions::date_and_time::date::HelperType<Expr>;
 }


### PR DESCRIPTION
As mentioned in #2713, there is not currently support for select `COUNT(DISTINCT column)`. This PR adds the function `count_distinct`, with usage:

```rust
assert_eq!(Ok(2), posts.select(count_distinct(user_id)).first(&connection))
```

I've based in the implementation on the `exists` and `sql_function` implementations, so if there is a better way to implement this I'm happy to take guidance.

There are some failing CI tests, but the errors seem rather unrelated to my changes - so if anyone as any advice to as to how to fix those or if thy can be ignored that'd be great.

---

As an aside, I see the existing count queries use `type SqlType = BigInt`. Would it not make more sense to use `Unsigned<BigInt>`, as a presumably you can't have negative counts?