### PR TITLE
1.4.x: Update 'libsqlite3-sys' to 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## [1.4.7] - 2021-06-03
+
+### Fixed
+
+* Updated 'libsqlite3-sys' to 0.22
+
 ## [1.4.6] - 2021-03-05
 
 ### Fixed

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.0"
 diesel_derives = "~1.4.0"
 chrono = { version = "0.4", optional = true }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.21.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 pq-sys = { version = ">=0.3.0, <0.5.0", optional = true }
 quickcheck = { version = "0.4", optional = true }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -27,7 +27,7 @@ tempfile = "3.0.0"
 toml = "0.4.6"
 url = { version = "1.4.0", optional = true }
 barrel = { version = ">= 0.5.0", optional = true, features = ["diesel"] }
-libsqlite3-sys = { version = ">=0.8.0, <0.21.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 
 [dev-dependencies]
 difference = "1.0"


### PR DESCRIPTION
Update `libsqlite3-sys`. Without this update, Rocket's `rocket_contrib`, which depends on `diesel`, cannot update other dependencies, resulting in quite a few out of date dependencies.

Unless the CI does something special, this will almost certainly fail the CI. The 1.4.x branch seems to be in a rather broken state. `rust-toolchain` points to an MSRV that is incorrect, and the source doesn't build due to a `deny`. In any case, here's the PR.