### PR TITLE
Call rollback_transaction instead of begin_transaction when rolling back

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -196,7 +196,7 @@ where
     }
 
     fn rollback_transaction(conn: &mut PooledConnection<M>) -> QueryResult<()> {
-        T::begin_transaction(&mut **conn)
+        T::rollback_transaction(&mut **conn)
     }
 
     fn commit_transaction(conn: &mut PooledConnection<M>) -> QueryResult<()> {


### PR DESCRIPTION
In https://github.com/diesel-rs/diesel/commit/cfb95067153ba55dff556c0b580cbc0e47f3fd28 in the file `diesel/src/r2d2.rs` the `rollback_transaction` function implementing `TransactionManager` was changed to call `T::begin_transaction` instead of `T::rollback_transaction`. This appears to be a copy-paste error, and it's causing problems because errors returned by the function (closure) passed to `transaction` are being ignored and, instead of the transaction being rolled back, a new savepoint is being created.

To reproduce, start a new project with just the following dependency:
```
diesel = { git = "https://github.com/diesel-rs/diesel", rev = "0aa0da7941289fc0a4f6acd866e0a6913c87979d", features = ["chrono", "postgres", "r2d2", "serde_json"] }
```

And the following `main.rs` file:
```
#[macro_use]
extern crate diesel;

use diesel::{Connection, PgConnection, r2d2, RunQueryDsl};

mod schema;

const DB_URL: &str = "<REDACTED>";

#[derive(Debug)]
enum TxnError {
    Internal(diesel::result::Error),
    IDExists,
}

impl From<diesel::result::Error> for TxnError {
    fn from(err: diesel::result::Error) -> Self {
        TxnError::Internal(err)
    }
}

fn main() {
    let db_pool = r2d2::Pool::builder()
        .max_size(5)
        .build(r2d2::ConnectionManager::<PgConnection>::new(DB_URL))
        .unwrap();

    let mut conn = db_pool.get().unwrap();

    conn.transaction::<(), TxnError, _>(|conn| {
        use diesel::{insert_into, prelude::*};
        use schema::a::dsl::{a, id};

        insert_into(a)
            .values(&id.eq(123))
            .execute(conn)?;

        Ok(())
    })
        .unwrap();

    let _ignored = conn.transaction::<(), TxnError, _>(|conn| {
        Err(TxnError::IDExists)
    });
}
```

And this migration:
```
create table a (
  id int primary key
);
```

With the following for `diesel.toml`:
```
[print_schema]
file = "src/schema.rs"
```

You get a `src/schema.rs` file generated when you run the migration.

Start a Postgres server configured to _log all queries/statements_.

Do `cargo run`.  Check the Postgres query logs, and notice that we have the following queries:
- `BEGIN`
- `INSERT INTO "a" ("id") VALUES ($1)`
- `COMMIT`
- `BEGIN`
- `SAVEPOINT diesel_savepoint_1`

But there is no `ROLLBACK` for the second transaction.