### PR TITLE
CLI - Don't silent fail when failing to read migration directory

### DIFF
--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -29,7 +29,7 @@ pub fn expand(path: String) -> proc_macro2::TokenStream {
 fn migration_literals_from_path(
     path: &Path,
 ) -> Result<Vec<proc_macro2::TokenStream>, Box<dyn Error>> {
-    let mut migrations = migrations_directories(path).collect::<Result<Vec<_>, _>>()?;
+    let mut migrations = migrations_directories(path)?.collect::<Result<Vec<_>, _>>()?;
 
     migrations.sort_by_key(DirEntry::path);
 


### PR DESCRIPTION
The `migrations_directories` from `migration_internals` silently dropped failing to read the migrations directory by calling `into_iter()` on the result of `read_dir()`.

The error is now propagated as an extra `Result` level on these functions, because keeping the same signature would require putting these errors inside the iterator, which would have required adding a dependency on `either` for the implementation to not be unreasonable.