### PR TITLE
Supporting Const-Generics on derives for FromSqlRow and AsExpression

### DIFF
--- a/diesel_compile_tests/tests/fail/as_expression_bad_sql_type.stderr
+++ b/diesel_compile_tests/tests/fail/as_expression_bad_sql_type.stderr
@@ -10,13 +10,13 @@ error: `sql_type` must be in the form `sql_type = "value"`
 6 | #[sql_type]
   |   ^^^^^^^^
 
-error: Invalid Rust type
+error: Invalid Rust type: `@%&&*`
  --> $DIR/as_expression_bad_sql_type.rs:7:14
   |
 7 | #[sql_type = "@%&&*"]
   |              ^^^^^^^
 
-error: Invalid Rust type
+error: Invalid Rust type: `1omg`
  --> $DIR/as_expression_bad_sql_type.rs:8:14
   |
 8 | #[sql_type = "1omg"]

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -9,8 +9,13 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
         MetaItem::with_name(&item.attrs, "diesel").unwrap_or_else(|| MetaItem::empty("diesel"));
     let struct_ty = ty_for_foreign_derive(&item, &flags)?;
 
-    item.generics.params.push(parse_quote!(__ST));
-    item.generics.params.push(parse_quote!(__DB));
+    // To prevent double issue with mutable borrow below while creating where clause
+    let initial_item = item.clone();
+
+    let lifetimes = initial_item.generics.lifetimes().collect::<Vec<_>>();
+    let ty_params = initial_item.generics.type_params().collect::<Vec<_>>();
+    let const_params = initial_item.generics.const_params().collect::<Vec<_>>();
+
     {
         let where_clause = item
             .generics
@@ -26,12 +31,13 @@ pub fn derive(mut item: syn::DeriveInput) -> Result<TokenStream, Diagnostic> {
             .predicates
             .push(parse_quote!(Self: FromSql<__ST, __DB>));
     }
-    let (impl_generics, _, where_clause) = item.generics.split_for_impl();
+    let (_, _, where_clause) = item.generics.split_for_impl();
 
     Ok(wrap_in_dummy_mod(quote! {
         use diesel::deserialize::{self, FromSql, Queryable};
 
-        impl #impl_generics Queryable<__ST, __DB> for #struct_ty
+        // Need to put __ST and __DB after lifetimes but before const params
+        impl<#(#lifetimes,)* __ST, __DB, #(#ty_params,)* #(#const_params,)*> Queryable<__ST, __DB> for #struct_ty
         #where_clause
         {
             type Row = Self;

--- a/diesel_derives/src/meta.rs
+++ b/diesel_derives/src/meta.rs
@@ -181,8 +181,10 @@ impl MetaItem {
 
     pub fn ty_value(&self) -> Result<syn::Type, Diagnostic> {
         let str = self.lit_str_value()?;
-        str.parse()
-            .map_err(|_| str.span().error("Invalid Rust type"))
+        str.parse().map_err(|_| {
+            str.span()
+                .error(format!("Invalid Rust type: `{}`", str.value()))
+        })
     }
 
     pub fn expect_str_value(&self) -> String {

--- a/diesel_derives/tests/as_expression.rs
+++ b/diesel_derives/tests/as_expression.rs
@@ -1,0 +1,89 @@
+use diesel::backend::Backend;
+use diesel::deserialize::FromSql;
+use diesel::expression::AsExpression;
+use diesel::serialize::{Output, ToSql};
+use diesel::*;
+use std::convert::TryInto;
+use std::io::Write;
+
+use helpers::connection;
+
+table! {
+    my_structs (foo) {
+        foo -> Integer,
+        bar -> Text,
+    }
+}
+use diesel::sql_types::Text;
+#[derive(Debug, AsExpression, FromSqlRow, Clone, Copy, PartialEq)]
+#[sql_type = "Text"]
+struct StringArray<const N: usize>(pub [u8; N]);
+
+impl<DB, const N: usize> FromSql<Text, DB> for StringArray<N>
+where
+    DB: Backend,
+    String: FromSql<Text, DB>,
+{
+    fn from_sql(bytes: backend::RawValue<DB>) -> deserialize::Result<Self> {
+        let string = <String as FromSql<Text, DB>>::from_sql(bytes)?;
+        let bytes_array: [u8; N] = string.into_bytes().try_into().unwrap();
+        Ok(StringArray(bytes_array))
+    }
+}
+
+impl<DB, const N: usize> ToSql<Text, DB> for StringArray<N>
+where
+    DB: Backend,
+    String: ToSql<Text, DB>,
+{
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+        let string = std::str::from_utf8(&self.0).unwrap().to_owned();
+
+        string.to_sql(out)
+    }
+}
+
+#[test]
+fn struct_with_sql_type() {
+    #[derive(Debug, Clone, PartialEq, Queryable, Selectable)]
+    #[table_name = "my_structs"]
+    struct MyStruct {
+        foo: i32,
+        bar: StringArray<4>,
+    }
+
+    let conn = &mut connection();
+    let data = my_structs::table
+        .select(MyStruct::as_select())
+        .get_result(conn);
+    assert!(data.is_err());
+}
+
+// #[test]
+// #[cfg(all(feature = "postgres", not(feature = "sqlite"), not(feature = "mysql")))]
+// fn test_generic_array_type() {
+//     #[derive(Debug, Clone, PartialEq, Queryable)]
+//     struct MySqlItem {
+//         foo: StringArray<2>,
+//         bar: i32,
+//     }
+
+//     let new_generic_array_expression = GenericArray([4.4, 4.4]);
+
+//     let conn = &mut connection();
+//     let data = select(sql::<(Array<Float8>, Integer)>("[1, 2], 2")).get_result(conn);
+//     assert_eq!(
+//         Ok(MySqlItem {
+//             foo: StringArray([29, 1]),
+//             bar: 2
+//         }),
+//         data
+//     );
+// }
+
+// ::<dyn Expression<SqlType = Array<Float8>>>
+
+// use diesel::sql_types::{Array, Float8};
+// #[derive(Debug, AsExpression, Clone, Copy, PartialEq)]
+// #[sql_type = "Array<Float8>"]
+// struct GenericArray<T, const N: usize>(pub [T; N]);

--- a/diesel_derives/tests/as_expression.rs
+++ b/diesel_derives/tests/as_expression.rs
@@ -59,31 +59,3 @@ fn struct_with_sql_type() {
     assert!(data.is_err());
 }
 
-// #[test]
-// #[cfg(all(feature = "postgres", not(feature = "sqlite"), not(feature = "mysql")))]
-// fn test_generic_array_type() {
-//     #[derive(Debug, Clone, PartialEq, Queryable)]
-//     struct MySqlItem {
-//         foo: StringArray<2>,
-//         bar: i32,
-//     }
-
-//     let new_generic_array_expression = GenericArray([4.4, 4.4]);
-
-//     let conn = &mut connection();
-//     let data = select(sql::<(Array<Float8>, Integer)>("[1, 2], 2")).get_result(conn);
-//     assert_eq!(
-//         Ok(MySqlItem {
-//             foo: StringArray([29, 1]),
-//             bar: 2
-//         }),
-//         data
-//     );
-// }
-
-// ::<dyn Expression<SqlType = Array<Float8>>>
-
-// use diesel::sql_types::{Array, Float8};
-// #[derive(Debug, AsExpression, Clone, Copy, PartialEq)]
-// #[sql_type = "Array<Float8>"]
-// struct GenericArray<T, const N: usize>(pub [T; N]);

--- a/diesel_derives/tests/as_expression.rs
+++ b/diesel_derives/tests/as_expression.rs
@@ -2,6 +2,7 @@ use diesel::backend::Backend;
 use diesel::deserialize::FromSql;
 use diesel::expression::AsExpression;
 use diesel::serialize::{Output, ToSql};
+use diesel::sql_types::Text;
 use diesel::*;
 use std::convert::TryInto;
 use std::io::Write;
@@ -14,7 +15,7 @@ table! {
         bar -> Text,
     }
 }
-use diesel::sql_types::Text;
+
 #[derive(Debug, AsExpression, FromSqlRow, Clone, Copy, PartialEq)]
 #[sql_type = "Text"]
 struct StringArray<const N: usize>(pub [u8; N]);
@@ -58,4 +59,3 @@ fn struct_with_sql_type() {
         .get_result(conn);
     assert!(data.is_err());
 }
-

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -15,3 +15,5 @@ mod insertable;
 mod queryable;
 mod queryable_by_name;
 mod selectable;
+
+mod as_expression;

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -9,10 +9,10 @@ mod helpers;
 mod schema;
 
 mod as_changeset;
+mod as_expression;
 mod associations;
 mod identifiable;
 mod insertable;
 mod queryable;
 mod queryable_by_name;
 mod selectable;
-mod as_expression;

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -15,5 +15,4 @@ mod insertable;
 mod queryable;
 mod queryable_by_name;
 mod selectable;
-
 mod as_expression;


### PR DESCRIPTION
This pull request updates the diesel_derives macros for deriving the FromSqlRow and the AsExpression traits to allow for const-generics. In the FromSqlRow, there were issues with the order of standard generics and const generics. In the AsExpression derivation, there was a const-generic missing totally. 

This pull request does not build with the standard rust-toolchain of 1.48 but it does build with 1.51 and the test succeeds.

This won't be able to merge until diesel upgrades to rust 1.51, so it is currently blocked. I spoke with @weiznich about this in issue #2834. This  pr should also totally resolve #2834.
