### PR TITLE
Implement Hash, PartialEq and Eq for dynamic columns and tables

### DIFF
--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -8,7 +8,7 @@ use diesel::query_builder::*;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 /// A database table column.
 /// This type is created by the [`column`](crate::Table::column()) function.
 pub struct Column<T, U, ST> {

--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -8,7 +8,7 @@ use diesel::query_builder::*;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 /// A database table column.
 /// This type is created by the [`column`](crate::Table::column()) function.
 pub struct Column<T, U, ST> {

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -8,7 +8,7 @@ use std::borrow::Borrow;
 use crate::column::Column;
 use crate::dummy_expression::*;
 
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 /// A database table.
 /// This type is created by the [`table`](crate::table()) function.
 pub struct Table<T, U = T> {

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -8,7 +8,7 @@ use std::borrow::Borrow;
 use crate::column::Column;
 use crate::dummy_expression::*;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 /// A database table.
 /// This type is created by the [`table`](crate::table()) function.
 pub struct Table<T, U = T> {


### PR DESCRIPTION
This implements `Hash`, `PartialEq` and `Eq` for dynamic columns and tables when their internal types implement them too. It's just a simple derive, which allows using a `Column` or a `Table` as the key of a map, for example, or comparing two tables/columns for equality. This can be useful to create caches, or if an API receives columns or tables dynamically.