### PR TITLE
Fix typo in code sample in 2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,7 +289,7 @@ fn run_migration(conn: &PgConnection) {
 ```
 to 
 ```rust
-pub const MIGRATIONS: EmbededMigrations = embed_migrations!();
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 fn run_migration(conn: &PgConnection) {
     conn.run_pending_migrations(MIGRATIONS).unwrap();


### PR DESCRIPTION
The real name of the type is `EmbeddedMigrations`.