### PR TITLE
Using GitHub actions concurrency mode to reduce CI queue time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 
 name: CI Tests
 
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   check_and_test:
     name: Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 name: CI Tests
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+# This will ensure that only one commit will be running tests at a time on each PR.
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
In my past contributions, I've found that GitHub actions are heavily queued because they are under-resourced. This PR will use concurrency mode to ensure that only one commit on each PR will run tests. This way when we do multiple commits, the tests from the previous commit will automatically break and only the tests from the last commit will run. This will greatly save our testing resources. Especially if the contributor is unable to stop the GitHub actions.