### PR TITLE
support `serialize_as` for `AsChangeset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 * Added support for PostgreSQL's `SIMILAR TO` and `NOT SIMILAR TO`.
 
 * Added `#[diesel(serialize_as)]` analogous to `#[diesel(deserialize_as)]`. This allows
-  customization of the serialization behaviour of `Insertable` structs.
+  customization of the serialization behaviour of `Insertable` and `AsChangeset` structs.
 
 * Added support for `GROUP BY` clauses
 

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
-use syn::{DeriveInput, Path};
+use syn::{DeriveInput, Expr, Path, Type};
 
+use attrs::AttributeSpanWrapper;
 use field::Field;
 use model::Model;
 use util::{inner_of_option_ty, is_option_ty, wrap_in_dummy_mod};
@@ -37,58 +38,105 @@ pub fn derive(item: DeriveInput) -> TokenStream {
     impl_generics.params.push(parse_quote!('update));
     let (impl_generics, _, _) = impl_generics.split_for_impl();
 
-    let ref_changeset_ty = fields_for_update.iter().map(|field| {
-        field_changeset_ty(
-            field,
-            &table_name,
-            treat_none_as_null,
-            Some(quote!(&'update)),
-        )
-    });
-    let ref_changeset_expr = fields_for_update
-        .iter()
-        .map(|field| field_changeset_expr(field, &table_name, treat_none_as_null, Some(quote!(&))));
+    let mut generate_borrowed_changeset = true;
 
-    let direct_changeset_ty = fields_for_update
-        .iter()
-        .map(|field| field_changeset_ty(field, &table_name, treat_none_as_null, None));
-    let direct_changeset_expr = fields_for_update
-        .iter()
-        .map(|field| field_changeset_expr(field, &table_name, treat_none_as_null, None));
+    let mut direct_field_ty = Vec::with_capacity(fields_for_update.len());
+    let mut direct_field_assign = Vec::with_capacity(fields_for_update.len());
+    let mut ref_field_ty = Vec::with_capacity(fields_for_update.len());
+    let mut ref_field_assign = Vec::with_capacity(fields_for_update.len());
+
+    for field in fields_for_update {
+        match field.serialize_as.as_ref() {
+            Some(AttributeSpanWrapper { item: ty, .. }) => {
+                direct_field_ty.push(field_changeset_ty_serialize_as(
+                    field,
+                    table_name,
+                    ty,
+                    treat_none_as_null,
+                ));
+                direct_field_assign.push(field_changeset_expr_serialize_as(
+                    field,
+                    table_name,
+                    ty,
+                    treat_none_as_null,
+                ));
+
+                generate_borrowed_changeset = false; // as soon as we hit one field with #[diesel(serialize_as)] there is no point in generating the impl of AsChangeset for borrowed structs
+            }
+            None => {
+                direct_field_ty.push(field_changeset_ty(
+                    field,
+                    table_name,
+                    None,
+                    treat_none_as_null,
+                ));
+                direct_field_assign.push(field_changeset_expr(
+                    field,
+                    table_name,
+                    None,
+                    treat_none_as_null,
+                ));
+                ref_field_ty.push(field_changeset_ty(
+                    field,
+                    table_name,
+                    Some(quote!(&'update)),
+                    treat_none_as_null,
+                ));
+                ref_field_assign.push(field_changeset_expr(
+                    field,
+                    table_name,
+                    Some(quote!(&)),
+                    treat_none_as_null,
+                ));
+            }
+        }
+    }
+
+    let changeset_owned = quote! {
+        impl #impl_generics AsChangeset for #struct_name #ty_generics
+        #where_clause
+        {
+            type Target = #table_name::table;
+            type Changeset = <(#(#direct_field_ty,)*) as AsChangeset>::Changeset;
+
+            fn as_changeset(self) -> Self::Changeset {
+                (#(#direct_field_assign,)*).as_changeset()
+            }
+        }
+    };
+
+    let changeset_borrowed = if generate_borrowed_changeset {
+        quote! {
+            impl #impl_generics AsChangeset for &'update #struct_name #ty_generics
+            #where_clause
+            {
+                type Target = #table_name::table;
+                type Changeset = <(#(#ref_field_ty,)*) as AsChangeset>::Changeset;
+
+                fn as_changeset(self) -> Self::Changeset {
+                    (#(#ref_field_assign,)*).as_changeset()
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
 
     wrap_in_dummy_mod(quote!(
         use diesel::query_builder::AsChangeset;
         use diesel::prelude::*;
 
-        impl #impl_generics AsChangeset for &'update #struct_name #ty_generics
-        #where_clause
-        {
-            type Target = #table_name::table;
-            type Changeset = <(#(#ref_changeset_ty,)*) as AsChangeset>::Changeset;
+        #changeset_owned
 
-            fn as_changeset(self) -> Self::Changeset {
-                (#(#ref_changeset_expr,)*).as_changeset()
-            }
-        }
-
-        impl #impl_generics AsChangeset for #struct_name #ty_generics
-        #where_clause
-        {
-            type Target = #table_name::table;
-            type Changeset = <(#(#direct_changeset_ty,)*) as AsChangeset>::Changeset;
-
-            fn as_changeset(self) -> Self::Changeset {
-                (#(#direct_changeset_expr,)*).as_changeset()
-            }
-        }
+        #changeset_borrowed
     ))
 }
 
 fn field_changeset_ty(
     field: &Field,
     table_name: &Path,
-    treat_none_as_null: bool,
     lifetime: Option<TokenStream>,
+    treat_none_as_null: bool,
 ) -> TokenStream {
     let column_name = field.column_name();
     if !treat_none_as_null && is_option_ty(&field.ty) {
@@ -103,8 +151,8 @@ fn field_changeset_ty(
 fn field_changeset_expr(
     field: &Field,
     table_name: &Path,
-    treat_none_as_null: bool,
     lifetime: Option<TokenStream>,
+    treat_none_as_null: bool,
 ) -> TokenStream {
     let field_name = &field.name;
     let column_name = field.column_name();
@@ -116,5 +164,36 @@ fn field_changeset_expr(
         }
     } else {
         quote!(#table_name::#column_name.eq(#lifetime self.#field_name))
+    }
+}
+
+fn field_changeset_ty_serialize_as(
+    field: &Field,
+    table_name: &Path,
+    ty: &Type,
+    treat_none_as_null: bool,
+) -> TokenStream {
+    let column_name = field.column_name();
+    if !treat_none_as_null && is_option_ty(&field.ty) {
+        let inner_ty = inner_of_option_ty(ty);
+        quote!(std::option::Option<diesel::dsl::Eq<#table_name::#column_name, #inner_ty>>)
+    } else {
+        quote!(diesel::dsl::Eq<#table_name::#column_name, #ty>)
+    }
+}
+
+fn field_changeset_expr_serialize_as(
+    field: &Field,
+    table_name: &Path,
+    ty: &Type,
+    treat_none_as_null: bool,
+) -> TokenStream {
+    let field_name = &field.name;
+    let column_name = field.column_name();
+    let column: Expr = parse_quote!(#table_name::#column_name);
+    if !treat_none_as_null && is_option_ty(&field.ty) {
+        quote!(self.#field_name.map(|x| #column.eq(::std::convert::Into::<#ty>::into(x))))
+    } else {
+        quote!(#column.eq(::std::convert::Into::<#ty>::into(self.#field_name)))
     }
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -61,6 +61,17 @@ mod valid_grouping;
 /// from the name of the corresponding column, you can annotate the field with
 /// `#[diesel(column_name = some_column_name)]`.
 ///
+/// To provide custom serialization behavior for a field, you can use
+/// `#[diesel(serialize_as = "SomeType")]`. If this attribute is present, Diesel
+/// will call `.into` on the corresponding field and serialize the instance of `SomeType`,
+/// rather than the actual field on your struct. This can be used to add custom behavior for a
+/// single field, or use types that are otherwise unsupported by Diesel.
+/// Normally, Diesel produces two implementations of the `AsChangeset` trait for your
+/// struct using this derive: one for an owned version and one for a borrowed version.
+/// Using `#[diesel(serialize_as)]` implies a conversion using `.into` which consumes the underlying value.
+/// Hence, once you use `#[diesel(serialize_as)]`, Diesel can no longer insert borrowed
+/// versions of your struct.
+///
 /// By default, any `Option` fields on the struct are skipped if their value is
 /// `None`. If you would like to assign `NULL` to the field instead, you can
 /// annotate your struct with `#[diesel(treat_none_as_null = true)]`.
@@ -86,6 +97,10 @@ mod valid_grouping;
 /// * `#[diesel(column_name = some_column_name)]`, overrides the column name
 ///    of the current field to `some_column_name`. By default the field
 ///    name is used as column name.
+/// * `#[diesel(serialize_as = "SomeType")]`, instead of serializing the actual
+///    field type, Diesel will convert the field into `SomeType` using `.into` and
+///    serialize that instead. By default this derive will serialize directly using
+///    the actual field type.
 #[proc_macro_error]
 #[proc_macro_derive(
     AsChangeset,

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -62,7 +62,7 @@ mod valid_grouping;
 /// `#[diesel(column_name = some_column_name)]`.
 ///
 /// To provide custom serialization behavior for a field, you can use
-/// `#[diesel(serialize_as = "SomeType")]`. If this attribute is present, Diesel
+/// `#[diesel(serialize_as = SomeType)]`. If this attribute is present, Diesel
 /// will call `.into` on the corresponding field and serialize the instance of `SomeType`,
 /// rather than the actual field on your struct. This can be used to add custom behavior for a
 /// single field, or use types that are otherwise unsupported by Diesel.
@@ -97,7 +97,7 @@ mod valid_grouping;
 /// * `#[diesel(column_name = some_column_name)]`, overrides the column name
 ///    of the current field to `some_column_name`. By default the field
 ///    name is used as column name.
-/// * `#[diesel(serialize_as = "SomeType")]`, instead of serializing the actual
+/// * `#[diesel(serialize_as = SomeType)]`, instead of serializing the actual
 ///    field type, Diesel will convert the field into `SomeType` using `.into` and
 ///    serialize that instead. By default this derive will serialize directly using
 ///    the actual field type.

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -221,7 +221,7 @@ fn with_explicit_column_names() {
 #[test]
 fn with_serialize_as() {
     #[derive(Debug, FromSqlRow, AsExpression)]
-    #[sql_type = "sql_types::Text"]
+    #[diesel(sql_type = sql_types::Text)]
     struct UppercaseString(pub String);
 
     impl Into<UppercaseString> for String {


### PR DESCRIPTION
model after `Insertable`'s `serialize_as` in #2553 , cc @thomaseizinger .