### PR TITLE
build: bump serde_regex to v1.1

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -29,7 +29,7 @@ url = { version = "2.1.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.21.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 diffy = "0.2.0"
 regex = "1.0.6"
-serde_regex = "0.3.1"
+serde_regex = "1.1"
 
 [dependencies.diesel]
 version = "~2.0.0"


### PR DESCRIPTION
serde_regex has been released in v1.1. So I upgraded it to v1.1.  I checked the serde_regex changelog and it's all about adding new features, so I think it's safe to upgrade its version.