### PR TITLE
[1.4.x] Backport "Send" bounds for BoxedSelectStatements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Updated `libsqlite3-sys` to allow version 0.22
 * Updated `ipnetwork` to allow version 0.18
+* Boxed queries (constructed from `.into_boxed()`) are now `Send`.
 
 ## [1.4.6] - 2021-03-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ members = [
     "examples/mysql/getting_started_step_1",
     "examples/mysql/getting_started_step_2",
     "examples/mysql/getting_started_step_3",
-    # Dependency on out-dated bcrypt
-    #"examples/postgres/advanced-blog-cli",
     "examples/postgres/all_about_inserts",
     "examples/postgres/all_about_updates",
     "examples/postgres/getting_started_step_1",
@@ -24,6 +22,10 @@ members = [
     "examples/sqlite/getting_started_step_1",
     "examples/sqlite/getting_started_step_2",
     "examples/sqlite/getting_started_step_3",
+]
+exclude = [
+    # Dependency on out-dated bcrypt; doesn't build on 1.4.x
+    "examples/postgres/advanced-blog-cli",
 ]
 
 [replace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ members = [
     "examples/mysql/getting_started_step_1",
     "examples/mysql/getting_started_step_2",
     "examples/mysql/getting_started_step_3",
-    "examples/postgres/advanced-blog-cli",
+    # Dependency on out-dated bcrypt
+    #"examples/postgres/advanced-blog-cli",
     "examples/postgres/all_about_inserts",
     "examples/postgres/all_about_updates",
     "examples/postgres/getting_started_step_1",

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["orm", "database", "blockchain", "sql"]
 categories = ["database"]
 
 [dependencies]
-byteorder = "1.0"
+byteorder = { version = ">=1.0, <1.4" }
 diesel_derives = "~1.4.0"
 chrono = { version = "0.4", optional = true }
 libc = { version = "0.2.0", optional = true }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -270,7 +270,7 @@ macro_rules! table {
             sql_name = unknown,
             name = unknown,
             schema = public,
-            primary_key = (id),
+            primary_key = id,
         }
     }
 }

--- a/diesel/src/query_builder/order_clause.rs
+++ b/diesel/src/query_builder/order_clause.rs
@@ -1,20 +1,20 @@
 simple_clause!(NoOrderClause, OrderClause, " ORDER BY ");
 
-impl<'a, DB, Expr> Into<Option<Box<dyn QueryFragment<DB> + 'a>>> for OrderClause<Expr>
+impl<'a, DB, Expr> Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>> for OrderClause<Expr>
 where
     DB: Backend,
-    Expr: QueryFragment<DB> + 'a,
+    Expr: QueryFragment<DB> + Send + 'a,
 {
-    fn into(self) -> Option<Box<dyn QueryFragment<DB> + 'a>> {
+    fn into(self) -> Option<Box<dyn QueryFragment<DB> + Send + 'a>> {
         Some(Box::new(self.0))
     }
 }
 
-impl<'a, DB> Into<Option<Box<dyn QueryFragment<DB> + 'a>>> for NoOrderClause
+impl<'a, DB> Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>> for NoOrderClause
 where
     DB: Backend,
 {
-    fn into(self) -> Option<Box<dyn QueryFragment<DB> + 'a>> {
+    fn into(self) -> Option<Box<dyn QueryFragment<DB> + Send + 'a>> {
         None
     }
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -40,10 +40,17 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
         from: QS,
         distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
         where_clause: BoxedWhereClause<'a, DB>,
+<<<<<<< HEAD
         order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
         limit: Box<dyn QueryFragment<DB> + Send + 'a>,
         offset: Box<dyn QueryFragment<DB> + Send + 'a>,
         group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
+=======
+        order: Option<Box<QueryFragment<DB> + Send + 'a>>,
+        limit: Box<QueryFragment<DB> + Send + 'a>,
+        offset: Box<QueryFragment<DB> + Send + 'a>,
+        group_by: Box<QueryFragment<DB> + Send + 'a>,
+>>>>>>> Run rustfmt
     ) -> Self {
         BoxedSelectStatement {
             select: select,

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -40,17 +40,10 @@ impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
         from: QS,
         distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
         where_clause: BoxedWhereClause<'a, DB>,
-<<<<<<< HEAD
         order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
         limit: Box<dyn QueryFragment<DB> + Send + 'a>,
         offset: Box<dyn QueryFragment<DB> + Send + 'a>,
         group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
-=======
-        order: Option<Box<QueryFragment<DB> + Send + 'a>>,
-        limit: Box<QueryFragment<DB> + Send + 'a>,
-        offset: Box<QueryFragment<DB> + Send + 'a>,
-        group_by: Box<QueryFragment<DB> + Send + 'a>,
->>>>>>> Run rustfmt
     ) -> Self {
         BoxedSelectStatement {
             select: select,
@@ -350,8 +343,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::*;
     use crate::backend::Backend;
+    use crate::prelude::*;
 
     table! {
         users {
@@ -359,7 +352,11 @@ mod tests {
         }
     }
 
-    fn assert_send<T>(_: T) where T: Send {}
+    fn assert_send<T>(_: T)
+    where
+        T: Send,
+    {
+    }
 
     fn assert_boxed_query_send<B: Backend>() {
         assert_send(users::table.into_boxed::<B>());

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -347,3 +347,34 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use crate::backend::Backend;
+
+    table! {
+        users {
+            id -> Integer,
+        }
+    }
+
+    fn assert_send<T>(_: T) where T: Send {}
+
+    fn assert_boxed_query_send<B: Backend>() {
+        assert_send(users::table.into_boxed::<B>());
+        assert_send(users::table.filter(users::id.eq(10)).into_boxed::<B>());
+    }
+
+    #[test]
+    fn boxed_is_send() {
+        #[cfg(feature = "postgres")]
+        assert_boxed_query_send::<crate::pg::Pg>();
+
+        #[cfg(feature = "sqlite")]
+        assert_boxed_query_send::<crate::sqlite::Sqlite>();
+
+        #[cfg(feature = "mysql")]
+        assert_boxed_query_send::<crate::mysql::Mysql>();
+    }
+}

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -22,28 +22,28 @@ use sql_types::{BigInt, Bool, NotNull, Nullable};
 
 #[allow(missing_debug_implementations)]
 pub struct BoxedSelectStatement<'a, ST, QS, DB> {
-    select: Box<dyn QueryFragment<DB> + 'a>,
+    select: Box<dyn QueryFragment<DB> + Send + 'a>,
     from: QS,
-    distinct: Box<dyn QueryFragment<DB> + 'a>,
+    distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
     where_clause: BoxedWhereClause<'a, DB>,
-    order: Option<Box<dyn QueryFragment<DB> + 'a>>,
-    limit: Box<dyn QueryFragment<DB> + 'a>,
-    offset: Box<dyn QueryFragment<DB> + 'a>,
-    group_by: Box<dyn QueryFragment<DB> + 'a>,
+    order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
+    limit: Box<dyn QueryFragment<DB> + Send + 'a>,
+    offset: Box<dyn QueryFragment<DB> + Send + 'a>,
+    group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
     _marker: PhantomData<ST>,
 }
 
 impl<'a, ST, QS, DB> BoxedSelectStatement<'a, ST, QS, DB> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        select: Box<dyn QueryFragment<DB> + 'a>,
+        select: Box<dyn QueryFragment<DB> + Send + 'a>,
         from: QS,
-        distinct: Box<dyn QueryFragment<DB> + 'a>,
+        distinct: Box<dyn QueryFragment<DB> + Send + 'a>,
         where_clause: BoxedWhereClause<'a, DB>,
-        order: Option<Box<dyn QueryFragment<DB> + 'a>>,
-        limit: Box<dyn QueryFragment<DB> + 'a>,
-        offset: Box<dyn QueryFragment<DB> + 'a>,
-        group_by: Box<dyn QueryFragment<DB> + 'a>,
+        order: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
+        limit: Box<dyn QueryFragment<DB> + Send + 'a>,
+        offset: Box<dyn QueryFragment<DB> + Send + 'a>,
+        group_by: Box<dyn QueryFragment<DB> + Send + 'a>,
     ) -> Self {
         BoxedSelectStatement {
             select: select,
@@ -164,7 +164,7 @@ where
 impl<'a, ST, QS, DB, Selection> SelectDsl<Selection> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    Selection: SelectableExpression<QS> + QueryFragment<DB> + 'a,
+    Selection: SelectableExpression<QS> + QueryFragment<DB> + Send + 'a,
 {
     type Output = BoxedSelectStatement<'a, Selection::SqlType, QS, DB>;
 
@@ -237,7 +237,7 @@ where
 impl<'a, ST, QS, DB, Order> OrderDsl<Order> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    Order: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
+    Order: QueryFragment<DB> + AppearsOnTable<QS> + Send + 'a,
 {
     type Output = Self;
 
@@ -250,7 +250,7 @@ where
 impl<'a, ST, QS, DB, Order> ThenOrderDsl<Order> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend + 'a,
-    Order: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
+    Order: QueryFragment<DB> + AppearsOnTable<QS> + Send + 'a,
 {
     type Output = Self;
 
@@ -266,7 +266,7 @@ where
 impl<'a, ST, QS, DB, Expr> GroupByDsl<Expr> for BoxedSelectStatement<'a, ST, QS, DB>
 where
     DB: Backend,
-    Expr: QueryFragment<DB> + AppearsOnTable<QS> + 'a,
+    Expr: QueryFragment<DB> + AppearsOnTable<QS> + Send + 'a,
     Self: Query,
 {
     type Output = Self;

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -344,13 +344,13 @@ impl<'a, F, S, D, W, O, L, Of, G, DB> BoxedDsl<'a, DB>
 where
     Self: AsQuery,
     DB: Backend,
-    S: QueryFragment<DB> + SelectableExpression<F> + 'a,
-    D: QueryFragment<DB> + 'a,
+    S: QueryFragment<DB> + SelectableExpression<F> + Send + 'a,
+    D: QueryFragment<DB> + Send + 'a,
     W: Into<BoxedWhereClause<'a, DB>>,
-    O: Into<Option<Box<dyn QueryFragment<DB> + 'a>>>,
-    L: QueryFragment<DB> + 'a,
-    Of: QueryFragment<DB> + 'a,
-    G: QueryFragment<DB> + 'a,
+    O: Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>>,
+    L: QueryFragment<DB> + Send + 'a,
+    Of: QueryFragment<DB> + Send + 'a,
+    G: QueryFragment<DB> + Send + 'a,
 {
     type Output = BoxedSelectStatement<'a, S::SqlType, F, DB>;
 
@@ -374,13 +374,13 @@ where
     Self: AsQuery,
     DB: Backend,
     F: QuerySource,
-    F::DefaultSelection: QueryFragment<DB> + 'a,
-    D: QueryFragment<DB> + 'a,
+    F::DefaultSelection: QueryFragment<DB> + Send + 'a,
+    D: QueryFragment<DB> + Send + 'a,
     W: Into<BoxedWhereClause<'a, DB>>,
-    O: Into<Option<Box<dyn QueryFragment<DB> + 'a>>>,
-    L: QueryFragment<DB> + 'a,
-    Of: QueryFragment<DB> + 'a,
-    G: QueryFragment<DB> + 'a,
+    O: Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>>,
+    L: QueryFragment<DB> + Send + 'a,
+    Of: QueryFragment<DB> + Send + 'a,
+    G: QueryFragment<DB> + Send + 'a,
 {
     type Output = BoxedSelectStatement<'a, <F::DefaultSelection as Expression>::SqlType, F, DB>;
     fn internal_into_boxed(self) -> Self::Output {

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -108,7 +108,7 @@ where
 impl<'a, DB, Predicate> Into<BoxedWhereClause<'a, DB>> for WhereClause<Predicate>
 where
     DB: Backend,
-    Predicate: QueryFragment<DB> + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
 {
     fn into(self) -> BoxedWhereClause<'a, DB> {
         BoxedWhereClause::Where(Box::new(self.0))
@@ -125,7 +125,7 @@ impl<QS, Expr> ValidWhereClause<QS> for WhereClause<Expr> where Expr: AppearsOnT
 
 #[allow(missing_debug_implementations)] // We can't...
 pub enum BoxedWhereClause<'a, DB> {
-    Where(Box<dyn QueryFragment<DB> + 'a>),
+    Where(Box<dyn QueryFragment<DB> + Send + 'a>),
     None,
 }
 
@@ -153,7 +153,7 @@ impl<'a, DB> QueryId for BoxedWhereClause<'a, DB> {
 impl<'a, DB, Predicate> WhereAnd<Predicate> for BoxedWhereClause<'a, DB>
 where
     DB: Backend + 'a,
-    Predicate: QueryFragment<DB> + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
 {
     type Output = Self;
 
@@ -170,7 +170,7 @@ where
 impl<'a, DB, Predicate> WhereOr<Predicate> for BoxedWhereClause<'a, DB>
 where
     DB: Backend + 'a,
-    Predicate: QueryFragment<DB> + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
 {
     type Output = Self;
 


### PR DESCRIPTION
Cherry picks https://github.com/diesel-rs/diesel/pull/1990 onto the 1.4.x branch.

I believe this is non-breaking - and already merged in main - but it helps Diesel users writing async adapters on the latest stable release.