### PR TITLE
Upgraded num-bigint and bigdecimal dependencies

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -25,7 +25,7 @@ url = { version = "2.1.0", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 uuid = { version = ">=0.7.0, <0.9.0", optional = true }
 ipnetwork = { version = ">=0.12.2, <0.19.0", optional = true }
-num-bigint = { version = ">=0.2.0, <0.4.0", optional = true }
+num-bigint = { version = ">=0.2.0, <0.5.0", optional = true }
 num-traits = { version = "0.2.0", optional = true }
 num-integer = { version = "0.1.39", optional = true }
 bigdecimal = { version = ">=0.0.13, < 0.4.0", optional = true }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,14 +14,9 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.0"
-chrono = { version = "0.4.19", optional = true, default-features = false, features = [
-    "clock",
-    "std",
-] }
+chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = [
-    "min_sqlite_version_3_7_16",
-] }
+libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = "0.2.0", optional = true }
 pq-sys = { version = "0.4.0", optional = true }
 quickcheck = { version = "0.9.0", optional = true }
@@ -30,7 +25,7 @@ url = { version = "2.1.0", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 uuid = { version = ">=0.7.0, <0.9.0", optional = true }
 ipnetwork = { version = ">=0.12.2, <0.19.0", optional = true }
-num-bigint = { version = ">=0.2.0, <0.5.0", optional = true }
+num-bigint = { version = ">=0.2.0, <0.4.0", optional = true }
 num-traits = { version = "0.2.0", optional = true }
 num-integer = { version = "0.1.39", optional = true }
 bigdecimal = { version = ">=0.0.13, < 0.4.0", optional = true }
@@ -59,13 +54,7 @@ huge-tables = ["64-column-tables"]
 128-column-tables = ["64-column-tables"]
 postgres = ["pq-sys", "bitflags", "diesel_derives/postgres"]
 sqlite = ["libsqlite3-sys", "diesel_derives/sqlite"]
-mysql = [
-    "mysqlclient-sys",
-    "url",
-    "percent-encoding",
-    "diesel_derives/mysql",
-    "bitflags",
-]
+mysql = ["mysqlclient-sys", "url", "percent-encoding", "diesel_derives/mysql", "bitflags"]
 without-deprecated = []
 with-deprecated = []
 network-address = ["ipnetwork", "libc"]

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,21 +14,26 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.0"
-chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.19", optional = true, default-features = false, features = [
+    "clock",
+    "std",
+] }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = [
+    "min_sqlite_version_3_7_16",
+] }
 mysqlclient-sys = { version = "0.2.0", optional = true }
 pq-sys = { version = "0.4.0", optional = true }
 quickcheck = { version = "0.9.0", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }
 url = { version = "2.1.0", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
-uuid = { version = ">=0.7.0, <0.9.0", optional = true}
+uuid = { version = ">=0.7.0, <0.9.0", optional = true }
 ipnetwork = { version = ">=0.12.2, <0.19.0", optional = true }
-num-bigint = { version = ">=0.2.0, <0.4.0", optional = true }
+num-bigint = { version = ">=0.2.0, <0.5.0", optional = true }
 num-traits = { version = "0.2.0", optional = true }
 num-integer = { version = "0.1.39", optional = true }
-bigdecimal = { version = ">=0.0.13, < 0.3.0", optional = true }
+bigdecimal = { version = ">=0.0.13, < 0.4.0", optional = true }
 bitflags = { version = "1.2.0", optional = true }
 r2d2 = { version = ">= 0.8.2, < 0.9.0", optional = true }
 itoa = "0.4.0"
@@ -54,7 +59,13 @@ huge-tables = ["64-column-tables"]
 128-column-tables = ["64-column-tables"]
 postgres = ["pq-sys", "bitflags", "diesel_derives/postgres"]
 sqlite = ["libsqlite3-sys", "diesel_derives/sqlite"]
-mysql = ["mysqlclient-sys", "url", "percent-encoding", "diesel_derives/mysql", "bitflags"]
+mysql = [
+    "mysqlclient-sys",
+    "url",
+    "percent-encoding",
+    "diesel_derives/mysql",
+    "bitflags",
+]
 without-deprecated = []
 with-deprecated = []
 network-address = ["ipnetwork", "libc"]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -23,7 +23,7 @@ quickcheck = "0.9"
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.19.0"
-bigdecimal = ">= 0.0.13, < 0.3.0"
+bigdecimal = ">= 0.0.13, < 0.4.0"
 rand = "0.7"
 
 [features]


### PR DESCRIPTION
This updates `num-bigint` to allow also for version 0.4, which has small changes and doesn't impact the build, and `bigdecimal`, which only updates its dependency on `num-bigint`.