### PR TITLE
Report r2d2 connections as broken if the thread is currently panicking.

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -117,7 +117,7 @@ where
     }
 
     fn has_broken(&self, _conn: &mut T) -> bool {
-        false
+        std::thread::panicking()
     }
 }
 


### PR DESCRIPTION
See https://github.com/diesel-rs/diesel/issues/2124#issuecomment-513321714

Unfortunately, this has never been successfully upstreamed into r2d2, and so it's still an issue to this day.

I think this PR is the best way to move forward on this issue.