### PR TITLE
[postgres] Match more postgres errors explicitly

### DIFF
--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -343,6 +343,17 @@ mod tests {
     }
 
     #[test]
+    fn wait_a_looooong_time() {
+        let connection = &mut connection();
+
+        crate::sql_query(
+            "SELECT pg_sleep(100.0);",
+        )
+        .execute(connection)
+        .unwrap();
+    }
+
+    #[test]
     fn static_batch_inserts_are_cached() {
         let connection = &mut connection();
         connection.begin_test_transaction().unwrap();

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -343,17 +343,6 @@ mod tests {
     }
 
     #[test]
-    fn wait_a_looooong_time() {
-        let connection = &mut connection();
-
-        crate::sql_query(
-            "SELECT pg_sleep(100.0);",
-        )
-        .execute(connection)
-        .unwrap();
-    }
-
-    #[test]
     fn static_batch_inserts_are_cached() {
         let connection = &mut connection();
         connection.begin_test_transaction().unwrap();

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -64,10 +64,7 @@ impl PgResult {
                         | Some(error_codes::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION) => {
                             DatabaseErrorKind::ClosedConnection
                         }
-                        e => {
-                            eprintln!("Unknown error code: {:?}", e);
-                            DatabaseErrorKind::Unknown
-                        }
+                        _ => DatabaseErrorKind::Unknown,
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
                 // NOTE: Ideally, we'd remove this check, in favor of matching

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -58,9 +58,20 @@ impl PgResult {
                             DatabaseErrorKind::NotNullViolation
                         }
                         Some(error_codes::CHECK_VIOLATION) => DatabaseErrorKind::CheckViolation,
-                        _ => DatabaseErrorKind::Unknown,
+                        Some(error_codes::CONNECTION_EXCEPTION)
+                            | Some(error_codes::CONNECTION_FAILURE)
+                            | Some(error_codes::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
+                            | Some(error_codes::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION) => {
+                            DatabaseErrorKind::ClosedConnection
+                        }
+                        e => {
+                            eprintln!("Unknown error code: {:?}", e);
+                            DatabaseErrorKind::Unknown
+                        }
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
+                // TODO: I'd like to remove this check, but it appears to be
+                // happening in cases where the return code is "None".
                 if error_information.message() == CLOSED_CONNECTION_MSG {
                     error_kind = DatabaseErrorKind::ClosedConnection;
                 }
@@ -207,13 +218,17 @@ fn get_result_field<'a>(res: *mut PGresult, field: ResultField) -> Option<&'a st
 
 mod error_codes {
     //! These error codes are documented at
-    //! <https://www.postgresql.org/docs/9.5/static/errcodes-appendix.html>
+    //! <https://www.postgresql.org/docs/current/errcodes-appendix.html>
     //!
     //! They are not exposed programmatically through libpq.
-    pub const UNIQUE_VIOLATION: &str = "23505";
+    pub const CONNECTION_EXCEPTION: &str  = "08000";
+    pub const CONNECTION_FAILURE: &str    = "08006";
+    pub const SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION: &str    = "08001";
+    pub const SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION: &str    = "08004";
+    pub const NOT_NULL_VIOLATION: &str    = "23502";
     pub const FOREIGN_KEY_VIOLATION: &str = "23503";
-    pub const SERIALIZATION_FAILURE: &str = "40001";
+    pub const UNIQUE_VIOLATION: &str      = "23505";
+    pub const CHECK_VIOLATION: &str       = "23514";
     pub const READ_ONLY_TRANSACTION: &str = "25006";
-    pub const NOT_NULL_VIOLATION: &str = "23502";
-    pub const CHECK_VIOLATION: &str = "23514";
+    pub const SERIALIZATION_FAILURE: &str = "40001";
 }

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -59,9 +59,9 @@ impl PgResult {
                         }
                         Some(error_codes::CHECK_VIOLATION) => DatabaseErrorKind::CheckViolation,
                         Some(error_codes::CONNECTION_EXCEPTION)
-                            | Some(error_codes::CONNECTION_FAILURE)
-                            | Some(error_codes::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
-                            | Some(error_codes::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION) => {
+                        | Some(error_codes::CONNECTION_FAILURE)
+                        | Some(error_codes::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
+                        | Some(error_codes::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION) => {
                             DatabaseErrorKind::ClosedConnection
                         }
                         e => {
@@ -70,8 +70,13 @@ impl PgResult {
                         }
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
-                // TODO: I'd like to remove this check, but it appears to be
-                // happening in cases where the return code is "None".
+                // NOTE: Ideally, we'd remove this check, in favor of matching
+                // on an error code (instead of the more brittle description
+                // string).
+                //
+                // Unfortunately, this particular error is often propagated in
+                // cases - such as network disconnect - without any accompanying
+                // "SqlState", and therefore without an error code..
                 if error_information.message() == CLOSED_CONNECTION_MSG {
                     error_kind = DatabaseErrorKind::ClosedConnection;
                 }
@@ -221,14 +226,14 @@ mod error_codes {
     //! <https://www.postgresql.org/docs/current/errcodes-appendix.html>
     //!
     //! They are not exposed programmatically through libpq.
-    pub const CONNECTION_EXCEPTION: &str  = "08000";
-    pub const CONNECTION_FAILURE: &str    = "08006";
-    pub const SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION: &str    = "08001";
-    pub const SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION: &str    = "08004";
-    pub const NOT_NULL_VIOLATION: &str    = "23502";
+    pub const CONNECTION_EXCEPTION: &str = "08000";
+    pub const CONNECTION_FAILURE: &str = "08006";
+    pub const SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION: &str = "08001";
+    pub const SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION: &str = "08004";
+    pub const NOT_NULL_VIOLATION: &str = "23502";
     pub const FOREIGN_KEY_VIOLATION: &str = "23503";
-    pub const UNIQUE_VIOLATION: &str      = "23505";
-    pub const CHECK_VIOLATION: &str       = "23514";
+    pub const UNIQUE_VIOLATION: &str = "23505";
+    pub const CHECK_VIOLATION: &str = "23514";
     pub const READ_ONLY_TRANSACTION: &str = "25006";
     pub const SERIALIZATION_FAILURE: &str = "40001";
 }


### PR DESCRIPTION
This PR originally attempted to avoid "string matching" for connection-based errors. This didn't work, and I documented my findings below.

Instead, this PR now simply attempts to handle more connection-based errors explicitly,
and provides some documentation about "why we're still doing string matching" as a catch-all for network-based errors.

-------

(These instructions are specific to the commit at https://github.com/diesel-rs/diesel/pull/2911/commits/1af6c15d520d06e333192937cdb0f14db114ea9c )

To repro, after checking out diesel and applying this PR:

- Run `$ docker-compose up`
- Run `$ cargo test --features "postgres"`. This starts the tests, including a test that just hangs out sleeping (I don't want to submit this test, but it's easy for repro-ing).
- Run `$ docker network disconnect diesel_default diesel.postgres`. This causes the sleeping test to fail, and shows what the result of a network disconnect through Diesel.

After doing this, I see the following output:

```
test pg::connection::tests::wait_a_looooong_time ... FAILED

failures:

---- pg::connection::tests::wait_a_looooong_time stdout ----
Unknown error code: None
thread 'pg::connection::tests::wait_a_looooong_time' panicked at 'called `Result::unwrap()` on an `Err` value: DatabaseError(ClosedConnection, "server closed the connection unexpectedly\n\tThis probably means the server terminated abnormally\n\tbefore or while processing the request.\n")', diesel/src/pg/connection/mod.rs:353:10
```

Indicating:
- The actual error code is none
- We only see a `ClosedConnection` error because of the equality check on the "server closed the connection..." message.