### PR TITLE
Added generated column support for sqlite when the type is specified

### DIFF
--- a/diesel_cli/src/infer_schema_internals/data_structures.rs
+++ b/diesel_cli/src/infer_schema_internals/data_structures.rs
@@ -97,9 +97,9 @@ where
 #[cfg(feature = "sqlite")]
 impl<ST> Queryable<ST, Sqlite> for ColumnInformation
 where
-    (i32, String, String, bool, Option<String>, bool): FromStaticSqlRow<ST, Sqlite>,
+    (i32, String, String, bool, Option<String>, bool, i32): FromStaticSqlRow<ST, Sqlite>,
 {
-    type Row = (i32, String, String, bool, Option<String>, bool);
+    type Row = (i32, String, String, bool, Option<String>, bool, i32);
 
     fn build(row: Self::Row) -> deserialize::Result<Self> {
         Ok(ColumnInformation::new(row.1, row.2, None, !row.3))

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -125,6 +125,11 @@ pub fn get_table_data(
 ) -> QueryResult<Vec<ColumnInformation>> {
     let sqlite_version = get_sqlite_version(conn);
     let query = if sqlite_version >= SqliteVersion::new(3, 26, 0) {
+        /*
+         * To get generated columns we need to use TABLE_XINFO
+         * This would return hidden columns as well, but those would need to be created at runtime
+         * therefore they aren't an issue.
+         */
         format!("PRAGMA TABLE_XINFO('{}')", &table.sql_name)
     } else {
         format!("PRAGMA TABLE_INFO('{}')", &table.sql_name)

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -107,21 +107,15 @@ impl SqliteVersion {
     }
 }
 
-fn get_sqlite_version(
-    conn: &mut SqliteConnection
-) -> SqliteVersion {
+fn get_sqlite_version(conn: &mut SqliteConnection) -> SqliteVersion {
     let query = "SELECT sqlite_version()";
     let result = sql::<sql_types::Text>(&query).load::<String>(conn).unwrap();
     let parts = result[0]
         .split('.')
-        .map(|part| { part.parse().unwrap() })
+        .map(|part| part.parse().unwrap())
         .collect::<Vec<u32>>();
     assert_eq!(parts.len(), 3);
-    SqliteVersion::new(
-        parts[0],
-        parts[1],
-        parts[2],
-    )
+    SqliteVersion::new(parts[0], parts[1], parts[2])
 }
 
 pub fn get_table_data(

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -146,7 +146,11 @@ pub fn get_primary_keys(
 pub fn determine_column_type(
     attr: &ColumnInformation,
 ) -> Result<ColumnType, Box<dyn Error + Send + Sync + 'static>> {
-    let type_name = attr.type_name.to_lowercase();
+    let mut type_name = attr.type_name.to_lowercase();
+    if type_name == "generated always" {
+        type_name.clear();
+    }
+
     let path = if is_bool(&type_name) {
         String::from("Bool")
     } else if is_smallint(&type_name) {

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -21,6 +21,7 @@ table! {
         notnull -> Bool,
         dflt_value -> Nullable<VarChar>,
         pk -> Bool,
+        hidden -> Integer,
     }
 }
 
@@ -94,7 +95,7 @@ pub fn get_table_data(
     table: &TableName,
     column_sorting: &ColumnSorting,
 ) -> QueryResult<Vec<ColumnInformation>> {
-    let query = format!("PRAGMA TABLE_INFO('{}')", &table.sql_name);
+    let query = format!("PRAGMA TABLE_XINFO('{}')", &table.sql_name);
     let mut result = sql::<pragma_table_info::SqlType>(&query).load(conn)?;
     match column_sorting {
         ColumnSorting::OrdinalPosition => {}
@@ -115,6 +116,7 @@ struct FullTableInfo {
     _not_null: bool,
     _dflt_value: Option<String>,
     primary_key: bool,
+    _hidden: i32,
 }
 
 #[derive(Queryable)]
@@ -133,7 +135,7 @@ pub fn get_primary_keys(
     conn: &mut SqliteConnection,
     table: &TableName,
 ) -> QueryResult<Vec<String>> {
-    let query = format!("PRAGMA TABLE_INFO('{}')", &table.sql_name);
+    let query = format!("PRAGMA TABLE_XINFO('{}')", &table.sql_name);
     let results = sql::<pragma_table_info::SqlType>(&query).load::<FullTableInfo>(conn)?;
     Ok(results
         .into_iter()

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -198,6 +198,18 @@ fn print_schema_specifying_schema_name_with_custom_type() {
     )
 }
 
+#[test]
+#[cfg(feature = "sqlite")]
+fn print_schema_generated_columns() {
+    test_print_schema("print_schema_generated_columns", vec![])
+}
+
+#[test]
+#[cfg(feature = "sqlite")]
+fn print_schema_generated_columns_with_generated_always() {
+    test_print_schema("print_schema_generated_columns_generated_always", vec![])
+}
+
 #[cfg(feature = "sqlite")]
 const BACKEND: &str = "sqlite";
 #[cfg(feature = "postgres")]

--- a/diesel_cli/tests/print_schema/print_schema_generated_columns/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_generated_columns/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = false

--- a/diesel_cli/tests/print_schema/print_schema_generated_columns/sqlite/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_generated_columns/sqlite/expected.rs
@@ -1,0 +1,8 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    generated (id) {
+        id -> Nullable<Integer>,
+        generated -> Nullable<Integer>,
+    }
+}

--- a/diesel_cli/tests/print_schema/print_schema_generated_columns/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_generated_columns/sqlite/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE generated (
+    id integer primary key,
+    generated integer as (id * 3)
+);

--- a/diesel_cli/tests/print_schema/print_schema_generated_columns_generated_always/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_generated_columns_generated_always/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = false

--- a/diesel_cli/tests/print_schema/print_schema_generated_columns_generated_always/sqlite/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_generated_columns_generated_always/sqlite/expected.rs
@@ -1,0 +1,8 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    generated (id) {
+        id -> Nullable<Integer>,
+        generated -> Nullable<Integer>,
+    }
+}

--- a/diesel_cli/tests/print_schema/print_schema_generated_columns_generated_always/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_generated_columns_generated_always/sqlite/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE generated (
+    id integer primary key,
+    generated integer generated always as (id * 3)
+);


### PR DESCRIPTION
This is a WIP pr for issue #2912.
Adds in support for generated columns in sqlite, if they are written like this:
```sql
generated integer as (id * 3)
```