### PR TITLE
Upgrade 'libsqlite3-sys' to 0.23

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 byteorder = "1.0"
 chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = ["bundled_bindings"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.24.0", optional = true, features = ["bundled_bindings"] }
 mysqlclient-sys = { version = "0.2.0", optional = true }
 pq-sys = { version = "0.4.0", optional = true }
 quickcheck = { version = "0.9.0", optional = true }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -26,7 +26,7 @@ heck = "0.3.1"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.5"
 url = { version = "2.1.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.21.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.8.0, <0.24.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 diffy = "0.2.0"
 regex = "1.0.6"
 serde_regex = "1.1"


### PR DESCRIPTION
Just updates `libsqlite3-sys` to 0.23 which introduced more feature flags like `bundled-sqlcipher`.