### PR TITLE
Updated version number for the CLI

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_cli"
-version = "1.4.0"
+version = "2.0.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 description = "Provides the CLI for the Diesel crate"


### PR DESCRIPTION
This PR updates the version of the `diesel_cli` crate to 2.0.0. It was the only crate in the repo missing that version bump.