### PR TITLE
Upgraded dependencies

### DIFF
--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -18,7 +18,7 @@ path = "migrations_macros"
 
 [dev-dependencies]
 dotenv = "0.15"
-cfg-if = "0.1.10"
+cfg-if = "1.0.0"
 tempfile = "3.2"
 
 [dependencies.diesel]

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -18,7 +18,7 @@ path = "../migrations_internals"
 [dev-dependencies]
 tempfile = "3.1.0"
 dotenv = "0.15"
-cfg-if = "0.1.10"
+cfg-if = "1.0.0"
 
 [dev-dependencies.diesel]
 version = "~2.0.0"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -24,7 +24,7 @@ uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.19.0"
 bigdecimal = ">= 0.0.13, < 0.4.0"
-rand = "0.7"
+rand = "0.8.4"
 
 [features]
 default = []

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -24,7 +24,7 @@ uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.19.0"
 bigdecimal = ">= 0.0.13, < 0.4.0"
-rand = "0.8.4"
+rand = "0.7"
 
 [features]
 default = []

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 edition = "2018"
 
 [dependencies]
-bcrypt = "0.8.1"
+bcrypt = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres", "chrono"] }
 dotenv = "0.15"


### PR DESCRIPTION
This PR upgrades all dependencies to their latest available versions. It removes all duplicate dependencies except for those coming from the "quickcheck" upgrade, tracked in #2930, and those coming from Clap 2.x, since 3.0 has not been released yet (https://github.com/clap-rs/clap/issues/2869).