### PR TITLE
Coerce pg types to lowercase untils wrapped in quotes

### DIFF
--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -138,11 +138,10 @@ fn get_type_name(attr: &MetaItem) -> Result<Option<PgType>, Diagnostic> {
     let schema = attr.nested_item("type_schema")?;
     Ok(attr.nested_item("type_name")?.map(|ty| {
         attr.warn_if_other_options(&["type_name", "type_schema"]);
-        let mut type_string = ty.expect_str_value();
-        if !(type_string.starts_with('"') && type_string.ends_with('"')) {
-            type_string = type_string.to_lowercase()
-        }
-        PgType::Lookup(type_string, schema.map(|schema| schema.expect_str_value()))
+        PgType::Lookup(
+            ty.expect_str_value(),
+            schema.map(|schema| schema.expect_str_value()),
+        )
     }))
 }
 

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -138,10 +138,11 @@ fn get_type_name(attr: &MetaItem) -> Result<Option<PgType>, Diagnostic> {
     let schema = attr.nested_item("type_schema")?;
     Ok(attr.nested_item("type_name")?.map(|ty| {
         attr.warn_if_other_options(&["type_name", "type_schema"]);
-        PgType::Lookup(
-            ty.expect_str_value(),
-            schema.map(|schema| schema.expect_str_value()),
-        )
+        let mut type_string = ty.expect_str_value();
+        if !(type_string.starts_with('"') && type_string.ends_with('"')) {
+            type_string = type_string.to_lowercase()
+        }
+        PgType::Lookup(type_string, schema.map(|schema| schema.expect_str_value()))
     }))
 }
 


### PR DESCRIPTION
## Background

I lost a _lot_ of time to this today. This might not be the best way to go about solving it, but _some_ mechanism to inform users what's going on would be good. Essentially I was implementing a custom enum. This is roughly the code I have:

```rust
#[derive(SqlType, Debug)]
#[postgres(type_name = "MyEnum")]
pub struct MyEnumType;

#[derive(Clone, Debug, AsExpression, FromSqlRow)]
#[sql_type = "MyEnumType"]
enum MyEnum { ... }
```

Notice that `type_name` is PascalCase. Something I didn't recognize (that I should've) is that pg coerces all identifiers to lowercase unless they're explicitly wrapped in quotes. When I created the enum in the database it was via a statement like 

```sql
CREATE TYPE MyEnum AS ENUM (
    'state1',
    'state2'
);
```

Notice again that `MyEnum` is pascal case. Then, when I was trying to make a call to serialize something in the DB I got this error:

```
Unknown diesel error: SerializationError(FailedToLookupTypeError(PgMetadataCacheKey { schema: None, type_name: \"MyEnum\" }))
```

Everything looked right! I could not for the life of me figure out what was up. This `FailedToLookupTypeError` is happening because the key that the `PgMetadata` struct actually has is all lowercase. 

## Solution

I've went for the simplest possible solution here. Assuming the type isn't wrapped in quotes (which would cause postgres to preserve the casing) then we `to_lowercase()` the type name such that it matches the `PgMetadataCacheKey`. There may be more sophisticated solutions here, but it's a bit beyond the time I have to invest in it. Also, I've obviously only made this change for pg given I'm somewhat familiar with its behavior. 

If you're good w/ this level of change I can push it forward further. Perhaps, if we know the casing behavior for MySql and sqlite, we can put fixes in place for those as well. 