### PR TITLE
Update benchmark implementations

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -69,21 +69,21 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: bench
-          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} async-std rust_postgres futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_std"
+          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} rust_postgres futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio quaint quaint/postgresql quaint/serde-support serde"
 
       - name: Run Benchmarks (Sqlite)
         if: matrix.backend == 'sqlite'
         uses: actions-rs/cargo@v1
         with:
           command: bench
-          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} async-std rusqlite futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_std"
+          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} tokio rusqlite futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio quaint quaint/sqlite quaint/serde-support serde"
 
       - name: Run Benchmarks (Mysql)
         if: matrix.backend == 'mysql'
         uses: actions-rs/cargo@v1
         with:
           command: bench
-          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} async-std rustorm rustorm/with-${{matrix.backend}} rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_std"
+          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} tokio rustorm rustorm/with-${{matrix.backend}} rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio quaint quaint/mysql quaint/serde-support serde"
 
       - name: Push metrics
         env:

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -12,17 +12,16 @@ autobenches = false
 [dependencies]
 dotenv = "0.15"
 criterion = "0.3.2"
-sqlx = {version = "0.5.0", optional = true}
-async-std = { version = "1.5", optional = true}
+sqlx = {version = "0.5.0", features = ["runtime-tokio-rustls"], optional = true}
+tokio = {version = "1", optional = true}
 rusqlite = {version = "0.25", optional = true}
 rust_postgres = {version = "0.19", optional = true, package = "postgres"}
 rust_mysql = {version = "21.0.1", optional = true, package = "mysql"}
 rustorm = {version = "0.20", optional = true}
 rustorm_dao = {version = "0.20", optional = true}
 quaint = {version = "0.2.0-alpha.13", optional = true}
-tokio = {version = "0.2", optional = true}
 serde = {version = "1", optional = true, features = ["derive"]}
-sea-orm = {version = "0.3", optional = true, features = ["runtime-async-std-rustls"]}
+sea-orm = {version = "0.3", optional = true, features = ["runtime-tokio-rustls"]}
 futures = {version = "0.3", optional = true}
 
 [dependencies.diesel]
@@ -47,7 +46,7 @@ default = []
 postgres = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]
 mysql = ["diesel/mysql"]
-sqlx-bench = ["sqlx", "async-std", "sqlx/runtime-async-std-rustls"]
+sqlx-bench = ["sqlx", "tokio", "sqlx/runtime-tokio-rustls"]
 
 [patch.crates-io]
-quaint = {git = "https://github.com/prisma/quaint", rev = "ec9384f"}
+quaint = {git = "https://github.com/prisma/quaint", rev = "e077df3"}

--- a/diesel_bench/Readme.md
+++ b/diesel_bench/Readme.md
@@ -33,9 +33,9 @@ To enable other crates add the following features:
 
 * `SQLx: ` `sqlx-bench sqlx/$backend $backend`
 * `Rustorm`: `rustorm rustorm/with-$backend rustorm_dao $backend`
-* `SeaORM`: `sea-orm sea-orm/sqlx-$backend sqlx async-std criterion/async_std futures $backend`
+* `SeaORM`: `sea-orm sea-orm/sqlx-$backend sqlx tokio criterion/tokio futures $backend`
 * `Quaint`: `quaint quaint/$backend tokio quaint/serde-support serde $backend`
-* `Postgres`: `rust-postgres $backend`
+* `Postgres`: `rust_postgres $backend`
 * `Rusqlite`: `rusqlite $backend`
 * `Mysql`: `rust-mysql $backend`
 

--- a/diesel_bench/benches/lib.rs
+++ b/diesel_bench/benches/lib.rs
@@ -148,7 +148,7 @@ fn bench_medium_complex_query(c: &mut Criterion) {
             crate::quaint_benches::bench_medium_complex_query(b, *i);
         });
 
-        #[cfg(feature = "sqlx-bench")]
+        #[cfg(all(feature = "sqlx-bench", not(feature = "sqlite")))]
         group.bench_with_input(
             BenchmarkId::new("sqlx_query_as_macro", size),
             size,

--- a/diesel_bench/benches/quaint_benches.rs
+++ b/diesel_bench/benches/quaint_benches.rs
@@ -58,9 +58,20 @@ fn connect(rt: &mut Runtime) -> Quaint {
 
     let conn = rt.block_on({
         async {
-            let conn = Quaint::new(&db_url).await.unwrap();
+            let conn;
+
+            #[cfg(feature = "sqlite")]
+            {
+                conn = Quaint::new_in_memory().unwrap();
+            }
+
+            #[cfg(not(feature = "sqlite"))]
+            {
+                conn = Quaint::new(&db_url).await.unwrap();
+            }
 
             if cfg!(feature = "sqlite") {
+                #[cfg(feature = "sqlite")]
                 for migration in super::SQLITE_MIGRATION_SQL {
                     conn.execute_raw(migration, &[]).await.unwrap();
                 }


### PR DESCRIPTION
* Use the tokio runtime for sqlx/sea-orm as requested here: https://github.com/launchbadge/sqlx/issues/1481#issuecomment-947025316
* Update quaint to a version that uses tokio 1.0 and reenable it in the
  metrics job

cc @billy1624 and @abonander 