### PR TITLE
Ignore RUSTSEC-2020-0159

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+ignore = [
+    # we cannot do much here without an update from chrono + we do not call any affected function
+    "RUSTSEC-2020-0159"
+] 


### PR DESCRIPTION
* we cannot do much there, without fundamental changes to rust-std
* we do not call either setenv, nor any affected chrono function in
  diesel itself (only in tests)
* I don't want to get that much e-mails about failed actions