### PR TITLE
More flexible Selectable derive

### DIFF
--- a/diesel_derives/src/selectable.rs
+++ b/diesel_derives/src/selectable.rs
@@ -9,10 +9,19 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     let model = Model::from_item(&item)?;
 
     let (_, ty_generics, _) = item.generics.split_for_impl();
+
     let mut generics = item.generics.clone();
     generics
         .params
         .push(parse_quote!(__DB: diesel::backend::Backend));
+    for embed_field in model.fields().iter().filter(|f| f.has_flag("embed")) {
+        let embed_ty = &embed_field.ty;
+        generics
+            .where_clause
+            .get_or_insert_with(|| parse_quote!(where))
+            .predicates
+            .push(parse_quote!(#embed_ty: Selectable<__DB>));
+    }
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     let struct_name = &item.ident;

--- a/diesel_derives/tests/selectable.rs
+++ b/diesel_derives/tests/selectable.rs
@@ -44,7 +44,7 @@ fn tuple_struct() {
 fn embedded_struct() {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
     #[table_name = "my_structs"]
-    struct A {
+    struct A<B> {
         foo: i32,
         #[diesel(embed)]
         b: B,
@@ -52,12 +52,14 @@ fn embedded_struct() {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
     #[table_name = "my_structs"]
-    struct B {
+    struct C {
         bar: i32,
     }
 
     let conn = &mut connection();
-    let data = my_structs::table.select(A::as_select()).get_result(conn);
+    let data = my_structs::table
+        .select(A::<C>::as_select())
+        .get_result(conn);
     assert!(data.is_err());
 }
 


### PR DESCRIPTION
Resolves #2950

Previously, if fields had `embed`, the `Selectable` derive supposed that they implemented `Selectable<DB>` for every `DB: Backend`.

If that wasn't the case (generic subfield or backend-specific impl) the derive would fail.

This commit fixes this issue by introducing the appropriate additional `where` bounds.