### PR TITLE
No unnecessary boxing in load_iter

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -376,6 +376,11 @@ pub mod helper_types {
     #[cfg(feature = "postgres_backend")]
     pub type SelectFromOnly<T> =
         crate::query_builder::SelectStatement<crate::pg::query_builder::only_clause::Only<T>>;
+
+    /// [`Iterator`](std::iter::Iterator) of [`QueryResult<U>`](crate::result::QueryResult)
+    ///
+    /// See [`RunQueryDsl::load_iter`] for more information
+    pub type LoadIter<'a, Q, Conn, U> = <Q as load_dsl::LoadQueryGatWorkaround<'a, Conn, U>>::Ret;
 }
 
 pub mod prelude {

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -51,7 +51,7 @@ pub use self::join_dsl::{InternalJoinDsl, JoinOnDsl, JoinWithImplicitOnClause};
 #[doc(hidden)]
 pub use self::load_dsl::CompatibleType;
 #[doc(hidden)]
-pub use self::load_dsl::{LoadQuery, LoadQueryGatWorkaround};
+pub use self::load_dsl::LoadQuery;
 pub use self::save_changes_dsl::{SaveChangesDsl, UpdateAndFetchResults};
 
 /// The traits used by `QueryDsl`.
@@ -1405,9 +1405,11 @@ pub trait RunQueryDsl<Conn>: Sized {
         self.internal_load(conn)?.collect()
     }
 
-    /// Executes the given query, returning a [`Iterator`] with the returned rows.
+    /// Executes the given query, returning an [`Iterator`] with the returned rows.
     ///
-    /// **You should normally prefer to use [`RunQueryDsl::load`] instead**. This method
+    /// The iterator's item is [`QueryResult<U>`](crate::result::QueryResult).
+    ///
+    /// You should normally prefer to use [`RunQueryDsl::load`] instead. This method
     /// is provided for situations where the result needs to be collected into a different
     /// container than a [`Vec`]
     ///
@@ -1503,10 +1505,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn load_iter<'a, U>(
-        self,
-        conn: &'a mut Conn,
-    ) -> QueryResult<<Self as LoadQueryGatWorkaround<'a, Conn, U>>::Ret>
+    fn load_iter<'a, U>(self, conn: &'a mut Conn) -> QueryResult<LoadIter<'a, Self, Conn, U>>
     where
         U: 'a,
         Self: LoadQuery<Conn, U> + 'a,

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -51,7 +51,7 @@ pub use self::join_dsl::{InternalJoinDsl, JoinOnDsl, JoinWithImplicitOnClause};
 #[doc(hidden)]
 pub use self::load_dsl::CompatibleType;
 #[doc(hidden)]
-pub use self::load_dsl::LoadQuery;
+pub use self::load_dsl::{LoadQuery, LoadQueryGatWorkaround};
 pub use self::save_changes_dsl::{SaveChangesDsl, UpdateAndFetchResults};
 
 /// The traits used by `QueryDsl`.
@@ -1506,12 +1506,12 @@ pub trait RunQueryDsl<Conn>: Sized {
     fn load_iter<'a, U>(
         self,
         conn: &'a mut Conn,
-    ) -> QueryResult<Box<dyn Iterator<Item = QueryResult<U>> + 'a>>
+    ) -> QueryResult<<Self as LoadQueryGatWorkaround<'a, Conn, U>>::Ret>
     where
         U: 'a,
         Self: LoadQuery<Conn, U> + 'a,
     {
-        self.internal_load(conn).map(|i| Box::new(i) as Box<_>)
+        self.internal_load(conn)
     }
 
     /// Runs the command, and returns the affected row.


### PR DESCRIPTION
This recently slipped through my review of #2799, but was pointed out by rust-analyzer.
I'm not sure why we'd want to force boxing here. I'd rather avoid the dynamic dispatch by default and let the user do it if necessary (which seems very unlikely).