### PR TITLE
Deprecating old feature names

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -93,6 +93,7 @@
 
 #![cfg_attr(feature = "unstable", feature(trait_alias))]
 // Built-in Lints
+#![allow(deprecated)]
 #![deny(warnings)]
 #![warn(
     missing_debug_implementations,

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -93,7 +93,6 @@
 
 #![cfg_attr(feature = "unstable", feature(trait_alias))]
 // Built-in Lints
-#![allow(deprecated)]
 #![deny(warnings)]
 #![warn(
     missing_debug_implementations,

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -2,6 +2,10 @@
 #![cfg_attr(rustfmt, rustfmt_skip)] // https://github.com/rust-lang-nursery/rustfmt/issues/2755
 
 pub(crate) mod prelude {
+    #[cfg_attr(
+        any(feature = "huge-tables", feature = "large-tables"),
+        allow(deprecated)
+    )]
     #[doc(inline)]
     pub use crate::{
         allow_columns_to_appear_in_same_group_by_clause,

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -319,6 +319,10 @@ macro_rules! __diesel_column {
 /// ```ignore
 /// pub type BoxedQuery<'a, DB, ST = SqlType> = BoxedSelectStatement<'a, ST, table, DB>;
 /// ```
+
+#[allow(deprecated)]
+#[cfg_attr(feature="huge-tables", deprecated="`huge-tables` is deprecated in favor of `64-column-tables`")]
+#[cfg_attr(feature="large-tables", deprecated="`large-tables` is deprecated in favor of `32-column-tables`")]
 #[macro_export]
 macro_rules! table {
     ($($tokens:tt)*) => {

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -1,4 +1,11 @@
-#![allow(unused_parens)] // FIXME: Remove this attribute once false positive is resolved.
+// FIXME: Remove this attribute once false positive is resolved.
+#![allow(unused_parens)]
+// conditionally allow deprecated items to allow using the
+// "deprecated" table! macro
+#![cfg_attr(
+    any(feature = "huge-tables", feature = "large-tables"),
+    allow(deprecated)
+)]
 
 use super::backend::{FailedToLookupTypeError, InnerPgTypeMetadata};
 use super::{Pg, PgTypeMetadata};


### PR DESCRIPTION
PR addressing https://github.com/diesel-rs/diesel/issues/1636

* Had to add `#![allow(deprecated)]` or builds will fail
* Adding listed features with deprecated message but allow build
* Life cycle of this, messages should be updated when the release is known for removing the deprecated feature all together.