### PR TITLE
Make Connection impl for PooledConnection more generic

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -97,17 +97,19 @@ where
     }
 }
 
-impl<T> SimpleConnection for PooledConnection<ConnectionManager<T>>
+impl<M> SimpleConnection for PooledConnection<M>
 where
-    T: Connection + Send + 'static,
+    M: ManageConnection,
+    M::Connection: Connection + Send + 'static,
 {
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
         (&**self).batch_execute(query)
     }
 }
 
-impl<C> Connection for PooledConnection<ConnectionManager<C>>
+impl<C, M> Connection for PooledConnection<M>
 where
+    M: ManageConnection<Connection = C>,
     C: Connection<TransactionManager = AnsiTransactionManager> + Send + 'static,
     C::Backend: UsesAnsiSavepointSyntax,
 {


### PR DESCRIPTION
Instead of hardcoding the ConnectionManager type, allow it to be anything which implements ManageConnection. This allows other crates to accept a generic ManageConnection as well.

For example, I want to create a `TestConnectionManager`, use it with `r2d2::Pool`, and pass the resulting `PooledConnection` to a function which accepts `impl Connection<Backend=Pg>`. With this change that's possible.

```rust
use std::env;
use diesel::{
    Connection, PgConnection, pg::Pg,
    r2d2::{self, ManageConnection, ConnectionManager}
};

fn main() {
    let database_uri = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
    let pool = r2d2::Pool::builder()
            .max_size(10)
            .build(TestConnectionManager::new(database_uri)).unwrap();

    task(pool.get().unwrap());
}

fn task(conn: impl Connection<Backend=Pg>) { }


#[derive(Debug, Clone)]
pub struct TestConnectionManager<T>(ConnectionManager<T>);

impl TestConnectionManager<PgConnection> {
    fn new(database_uri: String) -> Self {
        Self(ConnectionManager::new(database_uri))
    }
}

impl<T> ManageConnection for TestConnectionManager<T>
where T: Connection + Send + 'static {
    type Connection = T;
    type Error = r2d2::Error;

    fn connect(&self) -> Result<T, r2d2::Error> {
        let conn = self.0.connect()?;
        conn.begin_test_transaction().map_err(r2d2::Error::QueryError)?;
        Ok(conn)
    }

    fn is_valid(&self, conn: &mut T) -> Result<(), r2d2::Error> {
        self.0.is_valid(conn)
    }

    fn has_broken(&self, conn: &mut T) -> bool {
        self.0.has_broken(conn)
    }
}
```