### PR TITLE
Add support for delete or_filter

### DIFF
--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -4,7 +4,7 @@ use crate::expression::{AppearsOnTable, SelectableExpression};
 use crate::query_builder::returning_clause::*;
 use crate::query_builder::where_clause::*;
 use crate::query_builder::*;
-use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
+use crate::query_dsl::methods::{BoxedDsl, FilterDsl, OrFilterDsl};
 use crate::query_dsl::RunQueryDsl;
 use crate::query_source::Table;
 use crate::result::QueryResult;
@@ -136,6 +136,22 @@ where
         DeleteStatement {
             table: self.table,
             where_clause: self.where_clause.and(predicate),
+            returning: self.returning,
+        }
+    }
+}
+
+impl<T, U, Ret, Predicate> OrFilterDsl<Predicate> for DeleteStatement<T, U, Ret>
+where
+    U: WhereOr<Predicate>,
+    Predicate: AppearsOnTable<T>,
+{
+    type Output = DeleteStatement<T, U::Output, Ret>;
+
+    fn or_filter(self, predicate: Predicate) -> Self::Output {
+        DeleteStatement {
+            table: self.table,
+            where_clause: self.where_clause.or(predicate),
             returning: self.returning,
         }
     }

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -1,5 +1,5 @@
 use crate::backend::Backend;
-use crate::dsl::{Filter, IntoBoxed};
+use crate::dsl::{Filter, IntoBoxed, OrFilter};
 use crate::expression::{AppearsOnTable, SelectableExpression};
 use crate::query_builder::returning_clause::*;
 use crate::query_builder::where_clause::*;
@@ -71,6 +71,39 @@ impl<T, U> DeleteStatement<T, U, NoReturningClause> {
         Self: FilterDsl<Predicate>,
     {
         FilterDsl::filter(self, predicate)
+    }
+
+    /// Adds to the `WHERE` clause of a query using `OR`
+    ///
+    /// If there is already a `WHERE` clause, the result will be `(old OR new)`.
+    /// Calling `foo.filter(bar).or_filter(baz)`
+    /// is identical to `foo.filter(bar.or(baz))`.
+    /// However, the second form is much harder to do dynamically.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let deleted_rows = diesel::delete(users)
+    ///     .filter(name.eq("Sean"))
+    ///     .or_filter(name.eq("Tess"))
+    ///     .execute(connection);
+    /// assert_eq!(Ok(2), deleted_rows);
+    ///
+    /// let num_users = users.count().first(connection);
+    ///
+    /// assert_eq!(Ok(0), num_users);
+    /// # }
+    /// ```
+    pub fn or_filter<Predicate>(self, predicate: Predicate) -> OrFilter<Self, Predicate>
+    where
+        Self: OrFilterDsl<Predicate>,
+    {
+        OrFilterDsl::or_filter(self, predicate)
     }
 
     /// Boxes the `WHERE` clause of this delete statement.

--- a/diesel_tests/tests/delete.rs
+++ b/diesel_tests/tests/delete.rs
@@ -42,3 +42,18 @@ fn return_deleted_records() {
     let num_users = users.count().first(connection);
     assert_eq!(Ok(1), num_users);
 }
+
+#[test]
+fn delete_or_filter() {
+    use crate::schema::users::dsl::*;
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    let deleted_rows =
+        delete(users.filter(name.eq("Sean")).or_filter(name.eq("Tess"))).execute(connection);
+
+    assert_eq!(Ok(2), deleted_rows);
+
+    let num_users = users.count().first(connection);
+
+    assert_eq!(Ok(0), num_users);
+}


### PR DESCRIPTION
As noted on [Gitter](https://gitter.im/diesel-rs/diesel?at=61b66845c2cc0e5343fbcf37), delete queries do not currently support `or_filter`. This adds support for that.