### PR TITLE
Update doc.yml: catchup & fix warning

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --manifest-path diesel/Cargo.toml --features "postgres sqlite mysql extras" --workspace --exclude=diesel_compile_tests
+        args: --manifest-path diesel/Cargo.toml --features "postgres sqlite mysql extras" --workspace
 
     - name: Publish documentation
       if: success()


### PR DESCRIPTION
Since #2629 merged: no need for "Publish Docs" action exclude `diesel_compile_tests`, avoid job warning.

Ref: https://github.com/diesel-rs/diesel/actions/runs/1586901813

> warning: excluded package(s) `diesel_compile_tests` not found in workspace `/home/runner/work/diesel/diesel`