### PR TITLE
FIX metadata lookup with no schema failing on non-lowercase types

### DIFF
--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -90,9 +90,9 @@ fn lookup_type<T: Connection<Backend = Pg>>(
         // and let postgres figure out the name resolution on it's own.
         metadata_query
             .filter(
-                pg_type::oid.eq(crate::dsl::sql("")
+                pg_type::oid.eq(crate::dsl::sql("quote_ident(")
                     .bind::<crate::sql_types::Text, _>(&cache_key.type_name)
-                    .sql("::regtype::oid")),
+                    .sql(")::regtype::oid")),
             )
             .first(conn)?
     };

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -16,7 +16,7 @@ table! {
 }
 
 #[derive(SqlType)]
-#[diesel(postgres_type(name = "my_type"))]
+#[diesel(postgres_type(name = "My_Type"))]
 pub struct MyType;
 
 #[derive(Debug, PartialEq, FromSqlRow, AsExpression)]
@@ -69,10 +69,10 @@ fn custom_types_round_trip() {
     connection
         .batch_execute(
             r#"
-        CREATE TYPE my_type AS ENUM ('foo', 'bar');
+        CREATE TYPE "My_Type" AS ENUM ('foo', 'bar');
         CREATE TABLE custom_types (
             id SERIAL PRIMARY KEY,
-            custom_enum my_type NOT NULL
+            custom_enum "My_Type" NOT NULL
         );
     "#,
         )
@@ -95,7 +95,7 @@ table! {
 }
 
 #[derive(SqlType)]
-#[diesel(postgres_type(name = "my_type", schema = "custom_schema"))]
+#[diesel(postgres_type(name = "My_Type", schema = "custom_schema"))]
 pub struct MyTypeInCustomSchema;
 
 #[derive(Debug, PartialEq, FromSqlRow, AsExpression)]
@@ -149,10 +149,10 @@ fn custom_types_in_custom_schema_round_trip() {
         .batch_execute(
             r#"
         CREATE SCHEMA IF NOT EXISTS custom_schema;
-        CREATE TYPE custom_schema.my_type AS ENUM ('foo', 'bar');
+        CREATE TYPE custom_schema."My_Type" AS ENUM ('foo', 'bar');
         CREATE TABLE custom_schema.custom_types_with_custom_schema (
             id SERIAL PRIMARY KEY,
-            custom_enum custom_schema.my_type NOT NULL
+            custom_enum custom_schema."My_Type" NOT NULL
         );
     "#,
         )


### PR DESCRIPTION
Fix #2992