### PR TITLE
Introduce a public API to set values for `Output` directly

### DIFF
--- a/diesel/src/sqlite/connection/bind_collector.rs
+++ b/diesel/src/sqlite/connection/bind_collector.rs
@@ -18,7 +18,7 @@ impl SqliteBindCollector<'_> {
 /// This type represents a value bound to
 /// an sqlite prepared statement
 ///
-/// It can be constructed via the various `From<T>` implemenations
+/// It can be constructed via the various `From<T>` implementations
 #[derive(Debug)]
 pub struct SqliteBindValue<'a> {
     pub(in crate::sqlite) inner: InternalSqliteBindValue<'a>,

--- a/diesel/src/sqlite/connection/bind_collector.rs
+++ b/diesel/src/sqlite/connection/bind_collector.rs
@@ -6,7 +6,7 @@ use crate::QueryResult;
 
 #[derive(Debug)]
 pub struct SqliteBindCollector<'a> {
-    pub(in crate::sqlite) binds: Vec<(SqliteBindValue<'a>, SqliteType)>,
+    pub(in crate::sqlite) binds: Vec<(InternalSqliteBindValue<'a>, SqliteType)>,
 }
 
 impl SqliteBindCollector<'_> {
@@ -15,8 +15,87 @@ impl SqliteBindCollector<'_> {
     }
 }
 
+/// This type represents a value bound to
+/// an sqlite prepared statement
+///
+/// It can be constructed via the various `From<T>` implemenations
 #[derive(Debug)]
-pub enum SqliteBindValue<'a> {
+pub struct SqliteBindValue<'a> {
+    pub(in crate::sqlite) inner: InternalSqliteBindValue<'a>,
+}
+
+impl<'a> From<i32> for SqliteBindValue<'a> {
+    fn from(i: i32) -> Self {
+        Self {
+            inner: InternalSqliteBindValue::I32(i),
+        }
+    }
+}
+
+impl<'a> From<i64> for SqliteBindValue<'a> {
+    fn from(i: i64) -> Self {
+        Self {
+            inner: InternalSqliteBindValue::I64(i),
+        }
+    }
+}
+
+impl<'a> From<f64> for SqliteBindValue<'a> {
+    fn from(f: f64) -> Self {
+        Self {
+            inner: InternalSqliteBindValue::F64(f),
+        }
+    }
+}
+
+impl<'a, T> From<Option<T>> for SqliteBindValue<'a>
+where
+    T: Into<SqliteBindValue<'a>>,
+{
+    fn from(o: Option<T>) -> Self {
+        match o {
+            Some(v) => v.into(),
+            None => Self {
+                inner: InternalSqliteBindValue::Null,
+            },
+        }
+    }
+}
+
+impl<'a> From<&'a str> for SqliteBindValue<'a> {
+    fn from(s: &'a str) -> Self {
+        Self {
+            inner: InternalSqliteBindValue::BorrowedString(s),
+        }
+    }
+}
+
+impl<'a> From<String> for SqliteBindValue<'a> {
+    fn from(s: String) -> Self {
+        Self {
+            inner: InternalSqliteBindValue::String(s.into_boxed_str()),
+        }
+    }
+}
+
+impl<'a> From<Vec<u8>> for SqliteBindValue<'a> {
+    fn from(b: Vec<u8>) -> Self {
+        Self {
+            inner: InternalSqliteBindValue::Binary(b.into_boxed_slice()),
+        }
+    }
+}
+
+impl<'a> From<&'a [u8]> for SqliteBindValue<'a> {
+    fn from(b: &'a [u8]) -> Self {
+        Self {
+            inner: InternalSqliteBindValue::BorrowedBinary(b),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InternalSqliteBindValue<'a> {
     BorrowedString(&'a str),
     String(Box<str>),
     BorrowedBinary(&'a [u8]),
@@ -27,20 +106,24 @@ pub enum SqliteBindValue<'a> {
     Null,
 }
 
-impl std::fmt::Display for SqliteBindValue<'_> {
+impl std::fmt::Display for InternalSqliteBindValue<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let n = match self {
-            SqliteBindValue::BorrowedString(_) | SqliteBindValue::String(_) => "Text",
-            SqliteBindValue::BorrowedBinary(_) | SqliteBindValue::Binary(_) => "Binary",
-            SqliteBindValue::I32(_) | SqliteBindValue::I64(_) => "Integer",
-            SqliteBindValue::F64(_) => "Float",
-            SqliteBindValue::Null => "Null",
+            InternalSqliteBindValue::BorrowedString(_) | InternalSqliteBindValue::String(_) => {
+                "Text"
+            }
+            InternalSqliteBindValue::BorrowedBinary(_) | InternalSqliteBindValue::Binary(_) => {
+                "Binary"
+            }
+            InternalSqliteBindValue::I32(_) | InternalSqliteBindValue::I64(_) => "Integer",
+            InternalSqliteBindValue::F64(_) => "Float",
+            InternalSqliteBindValue::Null => "Null",
         };
         f.write_str(n)
     }
 }
 
-impl SqliteBindValue<'_> {
+impl InternalSqliteBindValue<'_> {
     pub(in crate::sqlite) fn result_of(self, ctx: &mut libsqlite3_sys::sqlite3_context) {
         use libsqlite3_sys as ffi;
         use std::os::raw as libc;
@@ -49,34 +132,36 @@ impl SqliteBindValue<'_> {
         // - `ctx` points to valid memory
         unsafe {
             match self {
-                SqliteBindValue::BorrowedString(s) => ffi::sqlite3_result_text(
+                InternalSqliteBindValue::BorrowedString(s) => ffi::sqlite3_result_text(
                     ctx,
                     s.as_ptr() as *const libc::c_char,
                     s.len() as libc::c_int,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                SqliteBindValue::String(s) => ffi::sqlite3_result_text(
+                InternalSqliteBindValue::String(s) => ffi::sqlite3_result_text(
                     ctx,
                     s.as_ptr() as *const libc::c_char,
                     s.len() as libc::c_int,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                SqliteBindValue::Binary(b) => ffi::sqlite3_result_blob(
+                InternalSqliteBindValue::Binary(b) => ffi::sqlite3_result_blob(
                     ctx,
                     b.as_ptr() as *const libc::c_void,
                     b.len() as libc::c_int,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                SqliteBindValue::BorrowedBinary(b) => ffi::sqlite3_result_blob(
+                InternalSqliteBindValue::BorrowedBinary(b) => ffi::sqlite3_result_blob(
                     ctx,
                     b.as_ptr() as *const libc::c_void,
                     b.len() as libc::c_int,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                SqliteBindValue::I32(i) => ffi::sqlite3_result_int(ctx, i as libc::c_int),
-                SqliteBindValue::I64(l) => ffi::sqlite3_result_int64(ctx, l),
-                SqliteBindValue::F64(d) => ffi::sqlite3_result_double(ctx, d as libc::c_double),
-                SqliteBindValue::Null => ffi::sqlite3_result_null(ctx),
+                InternalSqliteBindValue::I32(i) => ffi::sqlite3_result_int(ctx, i as libc::c_int),
+                InternalSqliteBindValue::I64(l) => ffi::sqlite3_result_int64(ctx, l),
+                InternalSqliteBindValue::F64(d) => {
+                    ffi::sqlite3_result_double(ctx, d as libc::c_double)
+                }
+                InternalSqliteBindValue::Null => ffi::sqlite3_result_null(ctx),
             }
         }
     }
@@ -90,7 +175,10 @@ impl<'a> BindCollector<'a, Sqlite> for SqliteBindCollector<'a> {
         Sqlite: crate::sql_types::HasSqlType<T>,
         U: crate::serialize::ToSql<T, Sqlite>,
     {
-        let mut to_sql_output = Output::new(SqliteBindValue::Null, metadata_lookup);
+        let value = SqliteBindValue {
+            inner: InternalSqliteBindValue::Null,
+        };
+        let mut to_sql_output = Output::new(value, metadata_lookup);
         let is_null = bind
             .to_sql(&mut to_sql_output)
             .map_err(crate::result::Error::SerializationError)?;
@@ -98,8 +186,8 @@ impl<'a> BindCollector<'a, Sqlite> for SqliteBindCollector<'a> {
         let metadata = Sqlite::metadata(metadata_lookup);
         self.binds.push((
             match is_null {
-                IsNull::No => bind,
-                IsNull::Yes => SqliteBindValue::Null,
+                IsNull::No => bind.inner,
+                IsNull::Yes => InternalSqliteBindValue::Null,
             },
             metadata,
         ));

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -10,7 +10,7 @@ mod statement_iterator;
 mod stmt;
 
 pub(in crate::sqlite) use self::bind_collector::SqliteBindCollector;
-pub(crate) use self::bind_collector::SqliteBindValue;
+pub use self::bind_collector::SqliteBindValue;
 pub use self::sqlite_value::SqliteValue;
 
 use std::os::raw as libc;

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -12,7 +12,7 @@ mod types;
 pub mod query_builder;
 
 pub use self::backend::{Sqlite, SqliteType};
-pub(crate) use self::connection::SqliteBindValue;
+pub use self::connection::SqliteBindValue;
 pub use self::connection::SqliteConnection;
 pub use self::connection::SqliteValue;
 pub use self::query_builder::SqliteQueryBuilder;

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -17,8 +17,7 @@ impl FromSql<Date, Sqlite> for NaiveDate {
 
 impl ToSql<Date, Sqlite> for NaiveDate {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        let s = self.format(SQLITE_DATE_FORMAT).to_string();
-        out.set_owned_string(s);
+        out.set_value(self.format(SQLITE_DATE_FORMAT).to_string());
         Ok(IsNull::No)
     }
 }
@@ -45,8 +44,7 @@ impl FromSql<Time, Sqlite> for NaiveTime {
 
 impl ToSql<Time, Sqlite> for NaiveTime {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        let s = self.format("%T%.f").to_string();
-        out.set_owned_string(s);
+        out.set_value(self.format("%T%.f").to_string());
         Ok(IsNull::No)
     }
 }
@@ -95,8 +93,7 @@ impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
 
 impl ToSql<Timestamp, Sqlite> for NaiveDateTime {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        let s = self.format("%F %T%.f").to_string();
-        out.set_owned_string(s);
+        out.set_value(self.format("%F %T%.f").to_string());
         Ok(IsNull::No)
     }
 }

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -76,49 +76,49 @@ impl ToSql<sql_types::Bool, Sqlite> for bool {
 
 impl ToSql<sql_types::Text, Sqlite> for str {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_borrowed_string(self);
+        out.set_value(self);
         Ok(IsNull::No)
     }
 }
 
 impl ToSql<sql_types::Binary, Sqlite> for [u8] {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_borrowed_binary(self);
+        out.set_value(self);
         Ok(IsNull::No)
     }
 }
 
 impl ToSql<sql_types::SmallInt, Sqlite> for i16 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_small_int(*self);
+        out.set_value(*self as i32);
         Ok(IsNull::No)
     }
 }
 
 impl ToSql<sql_types::Integer, Sqlite> for i32 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_int(*self);
+        out.set_value(*self);
         Ok(IsNull::No)
     }
 }
 
 impl ToSql<sql_types::BigInt, Sqlite> for i64 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_big_int(*self);
+        out.set_value(*self);
         Ok(IsNull::No)
     }
 }
 
 impl ToSql<sql_types::Float, Sqlite> for f32 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_float(*self);
+        out.set_value(*self as f64);
         Ok(IsNull::No)
     }
 }
 
 impl ToSql<sql_types::Double, Sqlite> for f64 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_double(*self);
+        out.set_value(*self);
         Ok(IsNull::No)
     }
 }


### PR DESCRIPTION
This satifies two use cases:

* Using temporary values as part of the `ToSql<T, Sqlite>` implemenation
* Allowing third parties to provide their own custom `BindCollector`
impl that does not implement `Write`.