### PR TITLE
Add Sqlite support for the RETURNING clause

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,8 +263,15 @@ jobs:
           command: test
           args: --manifest-path diesel_tests/Cargo.toml --no-default-features --features "${{ matrix.backend }} unstable"
 
+      - name: Run diesel_tests (beta)
+        if: matrix.run == 'beta'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path diesel_tests/Cargo.toml --no-default-features --features "${{ matrix.backend }},returning_clauses_for_sqlite_3_35"
+
       - name: Run diesel_tests
-        if: matrix.run != 'nightly'
+        if: matrix.run == 'stable'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Added support for all the derive attributes being inside `#[diesel(...)]`
 
+* Added support for `RETURNING` expressions for Sqlite via the `returning_clauses_for_sqlite_3_35` feature
+
 ### Removed
 
 * All previously deprecated items have been removed.

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -61,6 +61,7 @@ network-address = ["ipnetwork", "libc"]
 numeric = ["num-bigint", "bigdecimal", "num-traits", "num-integer"]
 postgres_backend = ["diesel_derives/postgres", "bitflags", "byteorder"]
 mysql_backend = ["diesel_derives/mysql", "byteorder"]
+returning_clauses_for_sqlite_3_35 = []
 
 [package.metadata.docs.rs]
 features = ["postgres", "mysql", "sqlite", "extras"]

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -54,7 +54,10 @@ impl TypeMetadata for Sqlite {
 }
 
 impl SqlDialect for Sqlite {
+    #[cfg(not(feature = "returning_clauses_for_sqlite_3_35"))]
     type ReturningClause = sql_dialect::returning_clause::DoesNotSupportReturningClause;
+    #[cfg(feature = "returning_clauses_for_sqlite_3_35")]
+    type ReturningClause = sql_dialect::returning_clause::PgLikeReturningClause;
 
     type OnConflictClause = SqliteOnConflictClaues;
 

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -27,6 +27,7 @@ unstable = ["diesel/unstable"]
 postgres = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]
 mysql = ["diesel/mysql"]
+returning_clauses_for_sqlite_3_35 = ["diesel/returning_clauses_for_sqlite_3_35"]
 
 [[test]]
 name = "integration_tests"

--- a/diesel_tests/tests/delete.rs
+++ b/diesel_tests/tests/delete.rs
@@ -29,7 +29,10 @@ fn delete_single_record() {
 }
 
 #[test]
-#[cfg(not(any(feature = "sqlite", feature = "mysql")))]
+#[cfg(not(any(
+    all(feature = "sqlite", not(feature = "returning_clauses_for_sqlite_3_35")),
+    feature = "mysql"
+)))]
 fn return_deleted_records() {
     use crate::schema::users::dsl::*;
     let connection = &mut connection_with_sean_and_tess_in_users_table();

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -82,7 +82,10 @@ fn test_updating_multiple_columns() {
 }
 
 #[test]
-#[cfg(not(any(feature = "sqlite", feature = "mysql")))]
+#[cfg(not(any(
+    all(feature = "sqlite", not(feature = "returning_clauses_for_sqlite_3_35")),
+    feature = "mysql"
+)))]
 fn update_returning_struct() {
     use crate::schema::users::dsl::*;
 
@@ -97,7 +100,10 @@ fn update_returning_struct() {
 }
 
 #[test]
-#[cfg(not(any(feature = "sqlite", feature = "mysql")))]
+#[cfg(not(any(
+    all(feature = "sqlite", not(feature = "returning_clauses_for_sqlite_3_35")),
+    feature = "mysql"
+)))]
 fn update_with_custom_returning_clause() {
     use crate::schema::users::dsl::*;
 


### PR DESCRIPTION
Add Sqlite support for the `RETURNING` clause by leveraging
the implementation for Postgres. So this change is essentially
just adjusting the build system to enable the support if a
Sqlite version which supports the `RETURNING` clause [1] is
complied against.

The "insert record with returning" unit tests for Postgres
couldn't be re-used because Sqlite doesn't support batch insert.
Because those tests provide value for Postgres, new versions
for Sqlite have been created which don't use batch insert.

[1] https://sqlite.org/releaselog/3_35_0.html