### PR TITLE
Tighten minimum required version for libsqlite3-sys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,8 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
   with the database. Beside of the changed signature, existing impls of this trait should remain unchanged in almost 
   all cases.
 
+* The minimal supported version of libsqlite3-sys is now 0.17.2.
+
 ### Fixed
 
 * Many types were incorrectly considered non-aggregate when they should not

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.24.0", optional = true, features = ["bundled_bindings"] }
+libsqlite3-sys = { version = ">=0.17.2, <0.24.0", optional = true, features = ["bundled_bindings"] }
 mysqlclient-sys = { version = "0.2.0", optional = true }
 pq-sys = { version = "0.4.0", optional = true }
 quickcheck = { version = "1.0.3", optional = true }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -26,7 +26,7 @@ heck = "0.3.1"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.5"
 url = { version = "2.1.0", optional = true }
-libsqlite3-sys = { version = ">=0.8.0, <0.24.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
+libsqlite3-sys = { version = ">=0.17.2, <0.24.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 diffy = "0.2.0"
 regex = "1.0.6"
 serde_regex = "1.1"


### PR DESCRIPTION
`libsqlite3-sys` is built with the `bundled_bindings`
feature enabled which was introduced in commit [1]
which in turn is part of `libsqlite3-sys` 0.17.2.

Versions below 0.17.2 will hence fail to compile.
Therefore, tighten the minimum required version.

[1] https://github.com/rusqlite/rusqlite/commit/c70d14854282ccddcf9c42d2078eebad54eb7c86<br>