### PR TITLE
Update benchmark dependencies

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: bench
-          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} tokio rusqlite futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio quaint quaint/sqlite quaint/serde-support serde"
+          args: --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} tokio rusqlite futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio"
 
       - name: Run Benchmarks (Mysql)
         if: matrix.backend == 'mysql'

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -14,14 +14,14 @@ dotenv = "0.15"
 criterion = "0.3.2"
 sqlx = {version = "0.5.0", features = ["runtime-tokio-rustls"], optional = true}
 tokio = {version = "1", optional = true}
-rusqlite = {version = "0.25", optional = true}
+rusqlite = {version = "0.26", optional = true}
 rust_postgres = {version = "0.19", optional = true, package = "postgres"}
 rust_mysql = {version = "21.0.1", optional = true, package = "mysql"}
 rustorm = {version = "0.20", optional = true}
 rustorm_dao = {version = "0.20", optional = true}
 quaint = {version = "0.2.0-alpha.13", optional = true}
 serde = {version = "1", optional = true, features = ["derive"]}
-sea-orm = {version = "0.3", optional = true, features = ["runtime-tokio-rustls"]}
+sea-orm = {version = "0.5", optional = true, features = ["runtime-tokio-rustls"]}
 futures = {version = "0.3", optional = true}
 
 [dependencies.diesel]


### PR DESCRIPTION
* Allow to use sqlx 0.5.10 which hopefully should fix the sqlite
benchmarks
* Update sea-orm to 0.5
* Remove quaint/sqlite as they use a old libsqlite3 version