### PR TITLE
Fix #3016

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -190,4 +190,12 @@ pub trait Connection: SimpleConnection + Sized + Send {
 
     #[doc(hidden)]
     fn transaction_manager(&self) -> &Self::TransactionManager;
+
+    #[doc(hidden)]
+    fn set_timeout(&mut self, _duration: Option<std::time::Duration>) {}
+
+    #[doc(hidden)]
+    fn get_timeout(&self) -> Option<std::time::Duration> {
+        None
+    }
 }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -105,6 +105,14 @@ impl Connection for PgConnection {
     fn transaction_manager(&self) -> &Self::TransactionManager {
         &self.transaction_manager
     }
+
+    fn set_timeout(&mut self, duration: Option<std::time::Duration>) {
+        self.raw_connection.timeout = duration;
+    }
+
+    fn get_timeout(&self) -> Option<std::time::Duration> {
+        self.raw_connection.timeout
+    }
 }
 
 impl PgConnection {


### PR DESCRIPTION
This demonstrate a potential fix for #3016 by using the async libpq
interface + busy polling. This allows us to abort polling as soon as we
reach the timeout.
I see multiple issues with this approach:
* Add's new methods to `Connection` (`get_timeout`/`set_timeout`). This
  could likely be avoided by exposing them directly on `PgConnection`.
On the other hand that would, at least for 1.4.x imply that we cannot
use those timeout only for the `is_valid` function. It would be all or
nothing then.
* This uses busy polling, which could be quite inefficient. I'm not sure
  what better posibilities there are without pulling in
tokio/mio/async_std.