### PR TITLE
fix #3018

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -264,9 +264,10 @@ where
 impl<ST, F, S, D, W, O, LOf, G, H, LC, Expr> OrderDsl<Expr>
     for SelectStatement<F, S, D, W, O, LOf, G, H, LC>
 where
-    Expr: AppearsOnTable<F> + ValidOrderingForDistinct<D>,
+    Expr: AppearsOnTable<F>,
     Self: SelectQuery<SqlType = ST>,
     SelectStatement<F, S, D, W, OrderClause<Expr>, LOf, G, H, LC>: SelectQuery<SqlType = ST>,
+    OrderClause<Expr>: ValidOrderingForDistinct<D>,
 {
     type Output = SelectStatement<F, S, D, W, OrderClause<Expr>, LOf, G, H, LC>;
 

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
@@ -21,6 +21,12 @@ fn main() {
     // verify that we could use distinct on with an order clause that contains also a different column
     let _ = users::table.order_by((users::name, users::id)).distinct_on(users::name);
 
+    // verify that we could use distinct on with a select expression and an order clause that contains a different column
+    let _ = users::table
+        .distinct_on(users::id)
+        .select(users::id)
+        .order_by((users::id, users::name));
+
     // verify that this works also with `then_order_by`
     let _ = users::table
         .order_by(users::name)
@@ -44,7 +50,7 @@ fn main() {
         .into_boxed();
 
     // compile fail section
-    // 
+    //
     // we do not allow queries with order clauses that does not contain the distinct value
     let _ = users::table.order_by(users::id).distinct_on(users::name);
 

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -1,33 +1,25 @@
 error[E0308]: mismatched types
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:49:58
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:55:58
    |
-49 |     let _ = users::table.order_by(users::id).distinct_on(users::name);
+55 |     let _ = users::table.order_by(users::id).distinct_on(users::name);
    |                                                          ^^^^^^^^^^^ expected struct `columns::id`, found struct `columns::name`
 
 error[E0308]: mismatched types
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:53:73
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:59:73
    |
-53 |     let _ = users::table.order_by((users::id, users::name)).distinct_on(users::name);
+59 |     let _ = users::table.order_by((users::id, users::name)).distinct_on(users::name);
    |                                                                         ^^^^^^^^^^^ expected struct `columns::id`, found struct `columns::name`
 
 error[E0308]: mismatched types
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:59:22
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:65:22
    |
-59 |         .distinct_on(users::name);
+65 |         .distinct_on(users::name);
    |                      ^^^^^^^^^^^ expected struct `columns::id`, found struct `columns::name`
 
-error[E0277]: the trait bound `columns::id: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:63:60
-   |
-63 |     let _ = users::table.distinct_on(users::name).order_by(users::id);
-   |                                                            ^^^^^^^^^ the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `columns::id`
-   |
-   = note: required because of the requirements on the impl of `OrderDsl<columns::id>` for `SelectStatement<FromClause<users::table>, DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>`
-
 error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<columns::id>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:63:51
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:69:51
    |
-63 |     let _ = users::table.distinct_on(users::name).order_by(users::id);
+69 |     let _ = users::table.distinct_on(users::name).order_by(users::id);
    |                                                   ^^^^^^^^ the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
    |
    = help: the following implementations were found:
@@ -36,39 +28,30 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
            and 14 others
-   = note: required because of the requirements on the impl of `SelectQuery` for `SelectStatement<FromClause<users::table>, DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>`
    = note: required because of the requirements on the impl of `OrderDsl<columns::id>` for `SelectStatement<FromClause<users::table>, DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>`
 
 error[E0308]: mismatched types
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:66:58
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:72:58
    |
-66 |     let _ = users::table.order_by(users::id).distinct_on(users::name).into_boxed();
+72 |     let _ = users::table.order_by(users::id).distinct_on(users::name).into_boxed();
    |                                                          ^^^^^^^^^^^ expected struct `columns::id`, found struct `columns::name`
 
 error[E0308]: mismatched types
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:70:22
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:76:22
    |
-70 |         .distinct_on(users::name)
+76 |         .distinct_on(users::name)
    |                      ^^^^^^^^^^^ expected struct `columns::id`, found struct `columns::name`
 
 error[E0308]: mismatched types
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:77:22
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:83:22
    |
-77 |         .distinct_on(users::name)
+83 |         .distinct_on(users::name)
    |                      ^^^^^^^^^^^ expected struct `columns::id`, found struct `columns::name`
 
-error[E0277]: the trait bound `columns::id: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:84:19
-   |
-84 |         .order_by(users::id)
-   |                   ^^^^^^^^^ the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `columns::id`
-   |
-   = note: required because of the requirements on the impl of `OrderDsl<columns::id>` for `SelectStatement<FromClause<users::table>, DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>`
-
 error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<columns::id>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-  --> tests/fail/distinct_on_requires_matching_order_clause.rs:84:10
+  --> tests/fail/distinct_on_requires_matching_order_clause.rs:90:10
    |
-84 |         .order_by(users::id)
+90 |         .order_by(users::id)
    |          ^^^^^^^^ the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
    |
    = help: the following implementations were found:
@@ -77,5 +60,4 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
            and 14 others
-   = note: required because of the requirements on the impl of `SelectQuery` for `SelectStatement<FromClause<users::table>, DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>`
    = note: required because of the requirements on the impl of `OrderDsl<columns::id>` for `SelectStatement<FromClause<users::table>, DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>`

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -66,3 +66,28 @@ fn distinct_on_select_by() {
 
     assert_eq!(expected_data, data);
 }
+
+#[cfg(feature = "postgres")]
+#[test]
+fn distinct_on_select_order_by_two_columns() {
+    use crate::schema::users::dsl::*;
+
+    let connection = &mut connection();
+    connection
+        .execute(
+            "INSERT INTO users (name, hair_color) VALUES ('Sean', 'black'), ('Sean', 'aqua'), ('Tess', 'bronze'), ('Tess', 'champagne')",
+        )
+        .unwrap();
+
+    let source = users
+        .select((name, hair_color))
+        .order((name, hair_color.desc()))
+        .distinct_on(name);
+    let expected_data = vec![
+        NewUser::new("Sean", Some("black")),
+        NewUser::new("Tess", Some("champagne")),
+    ];
+    let data: Vec<_> = source.load(connection).unwrap();
+
+    assert_eq!(expected_data, data);
+}


### PR DESCRIPTION
Fix #3018. 

Still a WIP, adding desc on the first order_by column doesn't work yet. Is `diesel_compile_tests/` it a good place to add these tests ? 

This code gives me the following error : 

```rust
let _ = users::table
    .distinct_on(users::id)
    .select(users::id)
    .order_by((users::id.desc(), users::name));
```
```
35 |         .order_by((users::id.desc(), users::name));
|          ^^^^^^^^ the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::id>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(diesel::expression::operators::Desc<columns::id>, columns::name)>`
|
= help: the following implementations were found:
<diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
<diesel::query_builder::order_clause::OrderClause<(__D, T0)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
<diesel::query_builder::order_clause::OrderClause<(__D, T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
<diesel::query_builder::order_clause::OrderClause<(__D, T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
and 14 others
= note: required because of the requirements on the impl of `OrderDsl<(diesel::expression::operators::Desc<columns::id>, columns::name)>` for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, DistinctOnClause<columns::id>>`
```