### PR TITLE
Allow declaring aliases in separate crates from the schema

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -824,6 +824,17 @@ macro_rules! __diesel_table_impl {
                 type Count = $crate::query_source::Never;
             }
 
+            // impl<S1: AliasSource<Table=table>, S2: AliasSource<Table=table>> AppearsInFromClause<Alias<S1>> for Alias<S2>
+            // Those are specified by the `alias!` macro, but this impl will allow it to implement this trait even in downstream
+            // crates from the schema
+            impl<S1, S2> $crate::query_source::aliasing::AliasAliasAppearsInFromClause<table, S2, S1> for table
+            where S1: $crate::query_source::aliasing::AliasSource<Target=table>,
+                  S2: $crate::query_source::aliasing::AliasSource<Target=table>,
+                  S1: $crate::query_source::aliasing::AliasAliasAppearsInFromClauseSameTable<S2, table>,
+            {
+                type Count = <S1 as $crate::query_source::aliasing::AliasAliasAppearsInFromClauseSameTable<S2, table>>::Count;
+            }
+
             impl<S> $crate::query_source::AppearsInFromClause<$crate::query_source::Alias<S>> for table
             where S: $crate::query_source::aliasing::AliasSource,
             {

--- a/diesel/src/query_source/aliasing/alias.rs
+++ b/diesel/src/query_source/aliasing/alias.rs
@@ -107,6 +107,19 @@ where
     }
 }
 
+#[doc(hidden)]
+/// This trait is used to allow external crates to implement
+/// `AppearsInFromClause<QS> for Alias<S>`
+///
+/// at the table level without running in conflicting impl issues
+///
+/// Implementing this at the table level (in the crate that defines the tables)
+/// does not result in conflicting impl issues because the table is the struct
+/// we're implementing on.
+pub trait AliasAppearsInFromClause<S, QS> {
+    /// Will be passed on to the `impl AppearsInFromClause<QS>`
+    type Count;
+}
 impl<S, QS> AppearsInFromClause<QS> for Alias<S>
 where
     S: AliasSource,
@@ -114,20 +127,16 @@ where
 {
     type Count = <S::Target as AliasAppearsInFromClause<S, QS>>::Count;
 }
-#[doc(hidden)]
-/// This trait is used to allow external crates to implement
-/// `AppearsInFromClause<QS> for Alias<S>`
-///
-/// without running in conflicting impl issues
-pub trait AliasAppearsInFromClause<S, QS> {
-    /// Will be passed on to the `impl AppearsInFromClause<QS>`
-    type Count;
-}
+
 #[doc(hidden)]
 /// This trait is used to allow external crates to implement
 /// `AppearsInFromClause<Alias<S2>> for Alias<S1>`
 ///
-/// without running in conflicting impl issues
+/// at the table level without running in conflicting impl issues
+///
+/// Implementing this at the table level (in the crate that defines the tables)
+/// does not result in conflicting impl issues because the tables are specified as both first
+/// argument of the trait and struct we're implementing on.
 pub trait AliasAliasAppearsInFromClause<T2, S1, S2> {
     /// Will be passed on to the `impl AppearsInFromClause<QS>`
     type Count;
@@ -138,6 +147,24 @@ where
     T1: AliasAliasAppearsInFromClause<S2::Target, S1, S2>,
 {
     type Count = <T1 as AliasAliasAppearsInFromClause<S2::Target, S1, S2>>::Count;
+}
+
+#[doc(hidden)]
+/// This trait is used to allow external crates to implement
+/// `AppearsInFromClause<Alias<S2>> for Alias<S1>`
+///
+/// at the alias level without running in conflicting impl issues
+///
+/// Implementing this at the alias level (in the crate that defines the aliases)
+/// does not result in conflicting impl issues because the aliases are specified as both first
+/// argument of the trait and struct we're implementing on.
+///
+/// The corresponding implementation of `AliasAliasAppearsInFromClause` for implementors of this
+/// trait is done at the table level, to avoid conflict with the implementation for distinct tables
+/// below.
+pub trait AliasAliasAppearsInFromClauseSameTable<S2, T> {
+    /// Will be passed on to the `impl AppearsInFromClause<QS>`
+    type Count;
 }
 
 // impl<S: AliasSource<Table=T1>> AppearsInFromClause<T2> for Alias<S>

--- a/diesel/src/query_source/aliasing/macros.rs
+++ b/diesel/src/query_source/aliasing/macros.rs
@@ -112,7 +112,7 @@ macro_rules! alias {
             }
 
             // impl AppearsInFromClause<Alias<$alias>> for Alias<$alias>
-            impl $crate::query_source::aliasing::AliasAliasAppearsInFromClause<$($table)::+::table, $alias_ty, $alias_ty> for $($table)::+::table {
+            impl $crate::query_source::aliasing::AliasAliasAppearsInFromClauseSameTable<$alias_ty, $($table)::+::table> for $alias_ty {
                 type Count = $crate::query_source::Once;
             }
         )*
@@ -135,13 +135,13 @@ macro_rules! __internal_alias_helper {
         $(
             $crate::static_cond!{if ($left_table_tt) == ($right_table_tt) {
                 $crate::static_cond!{if ($left_sql_name) != ($right_sql_name) {
-                    impl $crate::query_source::aliasing::AliasAliasAppearsInFromClause<$left_table_ty, $right_alias, $left_alias>
-                        for $right_table_ty
+                    impl $crate::query_source::aliasing::AliasAliasAppearsInFromClauseSameTable<$left_alias, $left_table_ty>
+                        for $right_alias
                     {
                         type Count = $crate::query_source::Never;
                     }
-                    impl $crate::query_source::aliasing::AliasAliasAppearsInFromClause<$right_table_ty, $left_alias, $right_alias>
-                        for $left_table_ty
+                    impl $crate::query_source::aliasing::AliasAliasAppearsInFromClauseSameTable<$right_alias, $left_table_ty>
+                        for $left_alias
                     {
                         type Count = $crate::query_source::Never;
                     }

--- a/diesel/src/query_source/aliasing/mod.rs
+++ b/diesel/src/query_source/aliasing/mod.rs
@@ -9,7 +9,10 @@ mod field_alias_mapper;
 mod joins;
 mod macros;
 
-pub use alias::{Alias, AliasAliasAppearsInFromClause, AliasAppearsInFromClause};
+pub use alias::{
+    Alias, AliasAliasAppearsInFromClause, AliasAliasAppearsInFromClauseSameTable,
+    AliasAppearsInFromClause,
+};
 pub use aliased_field::AliasedField;
 pub use field_alias_mapper::{FieldAliasMapper, FieldAliasMapperAssociatedTypesDisjointnessTrick};
 


### PR DESCRIPTION
The current implementation wouldn't allow declaring aliases downstream from a schema crate: it would result in conflicting impls.

This solves this issue in the same way we solved the conflicting impl issues for tables/Aliases: by using an additional trait dedicated to the impls in the `alias` macro, which downstream crates are allowed to implement (because it's on the alias), and make it so that any implementors of this trait also get the corresponding implementation done (this is done in the `table` macro).