### PR TITLE
Generate Postgres Arrays with Nullable elements by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,7 +248,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Implementations of custom SQLite SQL functions now check for panics
 
-* `infer_schema!` now generates `Array<Nullable<ST>>` rather than `Array<ST>` for Postgres Array types. Existence of 
+* `diesel print-schema` now generates `Array<Nullable<ST>>` rather than `Array<ST>` for Postgres Array types. Existence of 
   `NULL` values in database arrays would previously result in deserialization errors. Non-nullable arrays are now opt
   in (by schema patching).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,10 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 * Implementations of custom SQLite SQL functions now check for panics
 
+* `infer_schema!` now generates `Array<Nullable<ST>>` rather than `Array<ST>` for Postgres Array types. Existence of 
+  `NULL` values in database arrays would previously result in deserialization errors. Non-nullable arrays are now opt
+  in (by schema patching).
+
 ### Deprecated
 
 * `diesel_(prefix|postfix|infix)_operator!` have been deprecated. These macros

--- a/diesel_cli/src/infer_schema_internals/data_structures.rs
+++ b/diesel_cli/src/infer_schema_internals/data_structures.rs
@@ -34,7 +34,7 @@ impl fmt::Display for ColumnType {
             write!(out, "Nullable<")?;
         }
         if self.is_array {
-            write!(out, "Array<")?;
+            write!(out, "Array<Nullable<")?;
         }
         if self.is_unsigned {
             write!(out, "Unsigned<")?;
@@ -44,7 +44,7 @@ impl fmt::Display for ColumnType {
             write!(out, ">")?;
         }
         if self.is_array {
-            write!(out, ">")?;
+            write!(out, ">>")?;
         }
         if self.is_nullable {
             write!(out, ">")?;

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -210,6 +210,12 @@ fn print_schema_generated_columns_with_generated_always() {
     test_print_schema("print_schema_generated_columns_generated_always", vec![])
 }
 
+#[test]
+#[cfg(feature = "postgres")]
+fn print_schema_array_type() {
+    test_print_schema("print_schema_array_type", vec![])
+}
+
 #[cfg(feature = "sqlite")]
 const BACKEND: &str = "sqlite";
 #[cfg(feature = "postgres")]

--- a/diesel_cli/tests/print_schema/print_schema_array_type/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_array_type/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/print_schema/print_schema_array_type/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_array_type/postgres/expected.rs
@@ -1,0 +1,8 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    users (id) {
+        id -> Int4,
+        tags -> Array<Nullable<Text>>,
+    }
+}

--- a/diesel_cli/tests/print_schema/print_schema_array_type/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_array_type/postgres/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+    id   SERIAL PRIMARY KEY,
+    tags TEXT[] NOT NULL
+);


### PR DESCRIPTION
It's not possible to enforce non-nullability of Postgres array elements.

The previous behaviour of mapping to `Array<ST>` works fine in practice because Diesel would never _itself_ insert arrays with `NULL` elements. This was at the risk of deserialization errors though, should `NULL` values ever be made present (e.g. by some other process/manually).
