### PR TITLE
Explicitly call `mysql_stmt_free_result` for each executed statement

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -105,10 +105,8 @@ impl Connection for MysqlConnection {
         T: QueryFragment<Self::Backend> + QueryId,
     {
         let stmt = self.prepared_query(source)?;
-        unsafe {
-            stmt.execute()?;
-        }
-        Ok(stmt.affected_rows())
+        let stmt_use = unsafe { stmt.execute()? };
+        Ok(stmt_use.affected_rows())
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
This change adds explicit calls to `mysql_stmt_free_result` for each statement where we have called `mysql_stmt_fetch_result`. This seems to be required according to [the documentation](https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-fetch.html) to free internal buffers.