### PR TITLE
Remove time dependency from chrono

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database"]
 [dependencies]
 byteorder = "1.0"
 diesel_derives = "~1.4.0"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.8.0, <0.23.0", optional = true, features = ["min_sqlite_version_3_7_16"] }
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }


### PR DESCRIPTION
I know this is changed in the master branch, but it would be nice to have on 1.4.x as well, considering that 2.0.0 isn't out yet.