### PR TITLE
Provide a helper type for `.on`

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -353,6 +353,9 @@ pub mod helper_types {
     pub type LeftJoinOn<Source, Rhs, On> =
         <Source as InternalJoinDsl<Rhs, joins::LeftOuter, On>>::Output;
 
+    /// Represents the return type of `rhs.on(on)`
+    pub type On<Source, On> = joins::OnClauseWrapper<Source, On>;
+
     use super::associations::HasTable;
     use super::query_builder::{AsChangeset, IntoUpdateTarget, UpdateStatement};
 

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -1,3 +1,4 @@
+use crate::helper_types;
 use crate::query_builder::AsQuery;
 use crate::query_source::joins::OnClauseWrapper;
 use crate::query_source::{JoinTo, QuerySource, Table};
@@ -72,7 +73,7 @@ where
 /// # }
 pub trait JoinOnDsl: Sized {
     /// See the trait documentation.
-    fn on<On>(self, on: On) -> OnClauseWrapper<Self, On> {
+    fn on<On>(self, on: On) -> helper_types::On<Self, On> {
         OnClauseWrapper::new(self, on)
     }
 }


### PR DESCRIPTION
This is useful when you have a table that you typically want to join on using a very complex clause, and you want to implement a function `on_xxx_and(some_additional_conditions)` on it to make that easy .

I used to use it despite it being doc hidden but now it's fully private.
I think it's reasonable to have that helper type given that `on` is public API.