### PR TITLE
Switch from dotenv to dotenvy

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -39,7 +39,7 @@ path = "../diesel_derives"
 
 [dev-dependencies]
 cfg-if = "1"
-dotenv = "0.15"
+dotenvy = "0.15"
 ipnetwork = ">=0.12.2, <0.19.0"
 quickcheck = "1.0.3"
 

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "postgres")] {

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -164,13 +164,13 @@ impl MysqlConnection {
 
 #[cfg(test)]
 mod tests {
-    extern crate dotenv;
+    extern crate dotenvy;
 
     use super::*;
     use std::env;
 
     fn connection() -> MysqlConnection {
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
         let database_url = env::var("MYSQL_UNIT_TEST_DATABASE_URL")
             .or_else(|_| env::var("MYSQL_DATABASE_URL"))
             .or_else(|_| env::var("DATABASE_URL"))

--- a/diesel/src/mysql/types/date_and_time.rs
+++ b/diesel/src/mysql/types/date_and_time.rs
@@ -259,7 +259,7 @@ impl FromSql<Date, Mysql> for NaiveDate {
 #[cfg(all(test, feature = "chrono"))]
 mod tests {
     extern crate chrono;
-    extern crate dotenv;
+    extern crate dotenvy;
 
     use self::chrono::{Duration, NaiveDate, NaiveTime, Utc};
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -255,7 +255,7 @@ extern "C" fn noop_notice_processor(_: *mut libc::c_void, _message: *const libc:
 
 #[cfg(test)]
 mod tests {
-    extern crate dotenv;
+    extern crate dotenvy;
 
     use super::*;
     use crate::dsl::sql;

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -243,7 +243,7 @@ impl IntervalDsl for f64 {
 
 #[cfg(test)]
 mod tests {
-    extern crate dotenv;
+    extern crate dotenvy;
     extern crate quickcheck;
 
     use self::quickcheck::quickcheck;

--- a/diesel/src/pg/transaction.rs
+++ b/diesel/src/pg/transaction.rs
@@ -377,7 +377,7 @@ impl QueryFragment<Pg> for Deferrable {
 
 #[test]
 fn test_transaction_builder_generates_correct_sql() {
-    extern crate dotenv;
+    extern crate dotenvy;
 
     macro_rules! assert_sql {
         ($query:expr, $sql:expr) => {
@@ -388,8 +388,8 @@ fn test_transaction_builder_generates_correct_sql() {
         };
     }
 
-    let database_url = dotenv::var("PG_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    let database_url = dotenvy::var("PG_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let mut conn = PgConnection::establish(&database_url).unwrap();
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -125,7 +125,7 @@ impl FromSql<Date, Pg> for NaiveDate {
 #[cfg(test)]
 mod tests {
     extern crate chrono;
-    extern crate dotenv;
+    extern crate dotenvy;
 
     use self::chrono::naive::MAX_DATE;
     use self::chrono::{Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -58,7 +58,7 @@ fn duration_to_usecs(duration: Duration) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    extern crate dotenv;
+    extern crate dotenvy;
 
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -101,7 +101,7 @@ impl ToSql<Timestamp, Sqlite> for NaiveDateTime {
 #[cfg(test)]
 mod tests {
     extern crate chrono;
-    extern crate dotenv;
+    extern crate dotenvy;
 
     use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 

--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -1,4 +1,4 @@
-extern crate dotenv;
+extern crate dotenvy;
 
 use crate::prelude::*;
 
@@ -37,8 +37,8 @@ cfg_if! {
         }
 
         pub fn database_url() -> String {
-            dotenv::var("MYSQL_UNIT_TEST_DATABASE_URL")
-                .or_else(|_| dotenv::var("DATABASE_URL"))
+            dotenvy::var("MYSQL_UNIT_TEST_DATABASE_URL")
+                .or_else(|_| dotenvy::var("DATABASE_URL"))
                 .expect("DATABASE_URL must be set in order to run tests")
         }
     } else {
@@ -65,7 +65,7 @@ pub fn pg_connection_no_transaction() -> PgConnection {
 
 #[cfg(feature = "postgres")]
 pub fn pg_database_url() -> String {
-    dotenv::var("PG_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::var("PG_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests")
 }

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -10,7 +10,7 @@ autobenches = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dotenv = "0.15"
+dotenvy = "0.15"
 criterion = "0.3.2"
 sqlx = {version = "0.5.0", features = ["runtime-tokio-rustls"], optional = true}
 tokio = {version = "1", optional = true}
@@ -34,7 +34,7 @@ features = []
 [build-dependencies]
 diesel = { path = "../diesel", default-features = false }
 diesel_migrations = { path = "../diesel_migrations" }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 
 [[bench]]

--- a/diesel_bench/benches/diesel_async_benches.rs
+++ b/diesel_bench/benches/diesel_async_benches.rs
@@ -116,9 +116,9 @@ pub struct NewComment<'a>(
 
 #[cfg(feature = "mysql")]
 async fn connection() -> TestConnection {
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("MYSQL_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let mut conn = diesel_async::AsyncMysqlConnection::establish(&connection_url)
         .await
@@ -143,9 +143,9 @@ async fn connection() -> TestConnection {
 
 #[cfg(feature = "postgres")]
 async fn connection() -> TestConnection {
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("PG_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("PG_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let mut conn = diesel_async::AsyncPgConnection::establish(&connection_url)
         .await

--- a/diesel_bench/benches/diesel_benches.rs
+++ b/diesel_bench/benches/diesel_benches.rs
@@ -111,9 +111,9 @@ pub struct NewComment<'a>(
 
 #[cfg(feature = "mysql")]
 fn connection() -> TestConnection {
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("MYSQL_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let mut conn = MysqlConnection::establish(&connection_url).unwrap();
     diesel::sql_query("SET FOREIGN_KEY_CHECKS = 0")
@@ -136,9 +136,9 @@ fn connection() -> TestConnection {
 
 #[cfg(feature = "postgres")]
 fn connection() -> TestConnection {
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("PG_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("PG_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let mut conn = PgConnection::establish(&connection_url).unwrap();
     diesel::sql_query("TRUNCATE TABLE comments CASCADE")
@@ -155,7 +155,7 @@ fn connection() -> TestConnection {
 
 #[cfg(feature = "sqlite")]
 fn connection() -> TestConnection {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let mut conn = diesel::SqliteConnection::establish(":memory:").unwrap();
     for migration in super::SQLITE_MIGRATION_SQL {
         diesel::sql_query(*migration).execute(&mut conn).unwrap();

--- a/diesel_bench/benches/mysql_benches.rs
+++ b/diesel_bench/benches/mysql_benches.rs
@@ -24,9 +24,9 @@ pub struct Comment {
 }
 
 fn connection() -> Conn {
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("MYSQL_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let opts = Opts::from_url(&connection_url).unwrap();
     let mut conn = Conn::new(opts).unwrap();

--- a/diesel_bench/benches/postgres_benches.rs
+++ b/diesel_bench/benches/postgres_benches.rs
@@ -26,9 +26,9 @@ pub struct Comment {
 }
 
 fn connection() -> Client {
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("POSTGRES_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("POSTGRES_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let mut client = Client::connect(&connection_url, NoTls).unwrap();
 

--- a/diesel_bench/benches/quaint_benches.rs
+++ b/diesel_bench/benches/quaint_benches.rs
@@ -39,18 +39,18 @@ pub struct UserWithPost {
 }
 
 fn connect(rt: &mut Runtime) -> Quaint {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let db_url = if cfg!(feature = "sqlite") {
-        dotenv::var("SQLITE_DATABASE_URL")
-            .or_else(|_| dotenv::var("DATABASE_URL"))
+        dotenvy::var("SQLITE_DATABASE_URL")
+            .or_else(|_| dotenvy::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests")
     } else if cfg!(feature = "postgres") {
-        dotenv::var("POSTGRES_DATABASE_URL")
-            .or_else(|_| dotenv::var("DATABASE_URL"))
+        dotenvy::var("POSTGRES_DATABASE_URL")
+            .or_else(|_| dotenvy::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests")
     } else if cfg!(feature = "mysql") {
-        dotenv::var("MYSQL_DATABASE_URL")
-            .or_else(|_| dotenv::var("DATABASE_URL"))
+        dotenvy::var("MYSQL_DATABASE_URL")
+            .or_else(|_| dotenvy::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests")
     } else {
         unimplemented!()

--- a/diesel_bench/benches/rust_orm_benches.rs
+++ b/diesel_bench/benches/rust_orm_benches.rs
@@ -79,21 +79,21 @@ mod for_load {
 
 fn connect() -> EntityManager {
     let mut pool = Pool::new();
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     let db_url = if cfg!(feature = "sqlite") {
-        let url = dotenv::var("SQLITE_DATABASE_URL")
-            .or_else(|_| dotenv::var("DATABASE_URL"))
+        let url = dotenvy::var("SQLITE_DATABASE_URL")
+            .or_else(|_| dotenvy::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests");
 
         url.replace("sqlite:", "sqlite://")
     } else if cfg!(feature = "postgres") {
-        dotenv::var("POSTGRES_DATABASE_URL")
-            .or_else(|_| dotenv::var("DATABASE_URL"))
+        dotenvy::var("POSTGRES_DATABASE_URL")
+            .or_else(|_| dotenvy::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests")
     } else if cfg!(feature = "mysql") {
-        dotenv::var("MYSQL_DATABASE_URL")
-            .or_else(|_| dotenv::var("DATABASE_URL"))
+        dotenvy::var("MYSQL_DATABASE_URL")
+            .or_else(|_| dotenvy::var("DATABASE_URL"))
             .expect("DATABASE_URL must be set in order to run tests")
     } else {
         unimplemented!()

--- a/diesel_bench/benches/sea_orm_benches/mod.rs
+++ b/diesel_bench/benches/sea_orm_benches/mod.rs
@@ -18,9 +18,9 @@ fn connection() -> (sqlx::PgPool, DatabaseConnection, Runtime) {
 
     let rt = Runtime::new().expect("Failed to start runtime");
 
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("PG_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("PG_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let (pool, db) = rt.block_on(async {
         use sqlx::Executor;
@@ -45,9 +45,9 @@ fn connection() -> (sqlx::MySqlPool, DatabaseConnection, Runtime) {
 
     let rt = Runtime::new().expect("Failed to start runtime");
 
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("MYSQL_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let (pool, db) = rt.block_on(async {
         use sqlx::Executor;
@@ -74,7 +74,7 @@ fn connection() -> (sqlx::SqlitePool, DatabaseConnection, Runtime) {
     use sea_orm::SqlxSqliteConnector;
 
     let rt = Runtime::new().expect("Failed to start runtime");
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     let (pool, db) = rt.block_on(async {
         use sqlx::Executor;

--- a/diesel_bench/benches/sqlx_benches.rs
+++ b/diesel_bench/benches/sqlx_benches.rs
@@ -72,9 +72,9 @@ fn connection() -> (Runtime, Connection) {
 
     let runtime = Runtime::new().expect("Failed to create runtime");
 
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("POSTGRES_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("POSTGRES_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
 
     let conn = runtime.block_on(async {
@@ -103,9 +103,9 @@ fn connection() -> (Runtime, Connection) {
 
     let runtime = Runtime::new().expect("Failed to create runtime");
 
-    dotenv::dotenv().ok();
-    let connection_url = dotenv::var("MYSQL_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    dotenvy::dotenv().ok();
+    let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
 
     let conn = runtime.block_on(async {

--- a/diesel_bench/build.rs
+++ b/diesel_bench/build.rs
@@ -1,8 +1,8 @@
 extern crate diesel;
 extern crate diesel_migrations as migrations;
-extern crate dotenv;
+extern crate dotenvy;
 use self::diesel::*;
-use self::dotenv::dotenv;
+use self::dotenvy::dotenv;
 use std::env;
 
 #[cfg(not(any(feature = "mysql", feature = "sqlite", feature = "postgres")))]

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -22,7 +22,7 @@ doc = false
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 clap = "3.1"
 clap_complete = "3.1"
-dotenv = "0.15"
+dotenvy = "0.15"
 heck = "0.3.1"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.5"

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -383,9 +383,9 @@ pub fn load_foreign_key_constraints(
 
 #[cfg(all(test, feature = "postgres"))]
 mod tests {
-    extern crate dotenv;
+    extern crate dotenvy;
 
-    use self::dotenv::dotenv;
+    use self::dotenvy::dotenv;
     use super::*;
     use std::env;
 

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -46,7 +46,7 @@ use self::database_error::{DatabaseError, DatabaseResult};
 pub static TIMESTAMP_FORMAT: &str = "%Y-%m-%d-%H%M%S";
 
 fn main() {
-    use dotenv::dotenv;
+    use dotenvy::dotenv;
     dotenv().ok();
 
     let matches = cli::build_cli().get_matches();

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "sqlite"))]
-extern crate dotenv;
+extern crate dotenvy;
 #[cfg(not(feature = "sqlite"))]
 extern crate url;
 
@@ -96,7 +96,7 @@ impl Project {
 
     #[cfg(any(feature = "postgres", feature = "mysql"))]
     fn database_url_from_env(&self, var: &str) -> url::Url {
-        use self::dotenv::dotenv;
+        use self::dotenvy::dotenv;
         use std::env;
         dotenv().ok();
 

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro-error = "1.0.4"
 
 [dev-dependencies]
 cfg-if = "1"
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [dev-dependencies.diesel]
 version = "~2.0.0"

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -323,7 +323,7 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # extern crate diesel;
-/// # extern crate dotenv;
+/// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 /// # use diesel::{prelude::*, serialize::{ToSql, Output, self}, deserialize::{FromSqlRow}, expression::AsExpression, sql_types, backend::Backend};
 /// # use schema::users;
@@ -472,7 +472,7 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # extern crate diesel;
-/// # extern crate dotenv;
+/// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 /// #
 /// #[derive(Queryable, PartialEq, Debug)]
@@ -500,7 +500,7 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # extern crate diesel;
-/// # extern crate dotenv;
+/// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 /// #
 /// # use schema::users;
@@ -554,7 +554,7 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # extern crate diesel;
-/// # extern crate dotenv;
+/// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 /// #
 /// use schema::users;
@@ -666,7 +666,7 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # extern crate diesel;
-/// # extern crate dotenv;
+/// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 /// # use schema::users;
 /// # use diesel::sql_query;
@@ -697,7 +697,7 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # extern crate diesel;
-/// # extern crate dotenv;
+/// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 /// # use diesel::sql_query;
 /// # use schema::users;
@@ -749,7 +749,7 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # extern crate diesel;
-/// # extern crate dotenv;
+/// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 /// # use schema::users;
 /// # use diesel::sql_query;

--- a/diesel_derives/tests/helpers.rs
+++ b/diesel_derives/tests/helpers.rs
@@ -16,13 +16,13 @@ cfg_if! {
             conn
         }
     } else if #[cfg(feature = "postgres")] {
-        extern crate dotenv;
+        extern crate dotenvy;
 
         pub type TestConnection = PgConnection;
 
         pub fn connection() -> TestConnection {
-            let database_url = dotenv::var("PG_DATABASE_URL")
-                .or_else(|_| dotenv::var("DATABASE_URL"))
+            let database_url = dotenvy::var("PG_DATABASE_URL")
+                .or_else(|_| dotenvy::var("DATABASE_URL"))
                 .expect("DATABASE_URL must be set in order to run tests");
             let mut conn = PgConnection::establish(&database_url).unwrap();
             conn.begin_test_transaction().unwrap();
@@ -36,13 +36,13 @@ cfg_if! {
             conn
         }
     } else if #[cfg(feature = "mysql")] {
-        extern crate dotenv;
+        extern crate dotenvy;
 
         pub type TestConnection = MysqlConnection;
 
         pub fn connection() -> TestConnection {
-            let database_url = dotenv::var("MYSQL_UNIT_TEST_DATABASE_URL")
-                .or_else(|_| dotenv::var("DATABASE_URL"))
+            let database_url = dotenvy::var("MYSQL_UNIT_TEST_DATABASE_URL")
+                .or_else(|_| dotenvy::var("DATABASE_URL"))
                 .expect("DATABASE_URL must be set in order to run tests");
             let mut conn = MysqlConnection::establish(&database_url).unwrap();
             sql_query("DROP TABLE IF EXISTS users CASCADE").execute(&mut conn).unwrap();

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -13,7 +13,7 @@ path = "../diesel/"
 default-features = false
 
 [dev-dependencies]
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[example]]
 name = "querying_basic_schemas"

--- a/diesel_dynamic_schema/tests/connection_setup.rs
+++ b/diesel_dynamic_schema/tests/connection_setup.rs
@@ -40,8 +40,8 @@ pub fn establish_connection() -> diesel::PgConnection {
     use diesel::*;
 
     let mut conn = PgConnection::establish(
-        &dotenv::var("DATABASE_URL")
-            .or_else(|_| dotenv::var("PG_DATABASE_URL"))
+        &dotenvy::var("DATABASE_URL")
+            .or_else(|_| dotenvy::var("PG_DATABASE_URL"))
             .expect("Set either `DATABASE_URL` or `PG_DATABASE_URL`"),
     )
     .unwrap();
@@ -55,8 +55,8 @@ pub fn establish_connection() -> diesel::MysqlConnection {
     use diesel::*;
 
     let mut conn = MysqlConnection::establish(
-        &dotenv::var("DATABASE_URL")
-            .or_else(|_| dotenv::var("MYSQL_DATABASE_URL"))
+        &dotenvy::var("DATABASE_URL")
+            .or_else(|_| dotenvy::var("MYSQL_DATABASE_URL"))
             .expect("Set either `DATABASE_URL` or `MYSQL_DATABASE_URL`"),
     )
     .unwrap();

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -17,7 +17,7 @@ version = "~2.0.0"
 path = "migrations_macros"
 
 [dev-dependencies]
-dotenv = "0.15"
+dotenvy = "0.15"
 cfg-if = "1.0.0"
 tempfile = "3.2"
 

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -17,7 +17,7 @@ path = "../migrations_internals"
 
 [dev-dependencies]
 tempfile = "3.1.0"
-dotenv = "0.15"
+dotenvy = "0.15"
 cfg-if = "1.0.0"
 
 [dev-dependencies.diesel]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -12,7 +12,7 @@ assert_matches = "1.0.1"
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "network-address", "numeric", "with-deprecated"] }
 diesel_migrations = { path = "../diesel_migrations" }
-dotenv = "0.15"
+dotenvy = "0.15"
 quickcheck = "1.0.3"
 uuid = { version = ">=0.7.0, <0.9.0" }
 serde_json = { version=">=0.9, <2.0" }

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -8,7 +8,7 @@ extern crate chrono;
 extern crate diesel;
 #[cfg(feature = "sqlite")]
 extern crate diesel_migrations;
-extern crate dotenv;
+extern crate dotenvy;
 extern crate quickcheck;
 
 mod alias;

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -251,8 +251,8 @@ pub fn connection_without_transaction() -> TestConnection {
 
 #[cfg(feature = "postgres")]
 pub fn backend_specific_connection() -> TestConnection {
-    let connection_url = dotenv::var("PG_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    let connection_url = dotenvy::var("PG_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     let mut conn = PgConnection::establish(&connection_url).unwrap();
 
@@ -276,8 +276,8 @@ pub fn backend_specific_connection() -> TestConnection {
 
 #[cfg(feature = "mysql")]
 pub fn backend_specific_connection() -> TestConnection {
-    let connection_url = dotenv::var("MYSQL_DATABASE_URL")
-        .or_else(|_| dotenv::var("DATABASE_URL"))
+    let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
         .expect("DATABASE_URL must be set in order to run tests");
     MysqlConnection::establish(&connection_url).unwrap()
 }

--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/mysql/getting_started_step_1/src/lib.rs
+++ b/examples/mysql/getting_started_step_1/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 pub fn establish_connection() -> MysqlConnection {

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/mysql/getting_started_step_2/src/lib.rs
+++ b/examples/mysql/getting_started_step_2/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 use self::models::{NewPost, Post};

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/mysql/getting_started_step_3/src/lib.rs
+++ b/examples/mysql/getting_started_step_3/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 use self::models::{NewPost, Post};

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 bcrypt = "0.10.1"
 chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres", "chrono"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 structopt = "0.3"
 tempfile = "3.1.0"
 

--- a/examples/postgres/advanced-blog-cli/src/auth.rs
+++ b/examples/postgres/advanced-blog-cli/src/auth.rs
@@ -9,7 +9,7 @@ pub enum AuthenticationError {
     IncorrectPassword,
     NoUsernameSet,
     NoPasswordSet,
-    EnvironmentError(dotenv::Error),
+    EnvironmentError(dotenvy::Error),
     BcryptError(BcryptError),
     DatabaseError(diesel::result::Error),
 }
@@ -86,21 +86,21 @@ fn register_user(
 }
 
 fn get_username() -> Result<String, AuthenticationError> {
-    if_not_present(dotenv::var("BLOG_USERNAME"), NoUsernameSet)
+    if_not_present(dotenvy::var("BLOG_USERNAME"), NoUsernameSet)
 }
 
 fn get_password() -> Result<String, AuthenticationError> {
-    if_not_present(dotenv::var("BLOG_PASSWORD"), NoPasswordSet)
+    if_not_present(dotenvy::var("BLOG_PASSWORD"), NoPasswordSet)
 }
 
 fn if_not_present<T>(
-    res: Result<T, dotenv::Error>,
+    res: Result<T, dotenvy::Error>,
     on_not_present: AuthenticationError,
 ) -> Result<T, AuthenticationError> {
     use std::env::VarError::NotPresent;
 
     res.map_err(|e| match e {
-        dotenv::Error::EnvVar(NotPresent) => on_not_present,
+        dotenvy::Error::EnvVar(NotPresent) => on_not_present,
         e => AuthenticationError::EnvironmentError(e),
     })
 }

--- a/examples/postgres/advanced-blog-cli/src/main.rs
+++ b/examples/postgres/advanced-blog-cli/src/main.rs
@@ -24,7 +24,7 @@ use self::schema::*;
 fn main() {
     let matches = Cli::from_args();
 
-    let database_url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
     handle_error(run_cli(&database_url, matches));
 }

--- a/examples/postgres/advanced-blog-cli/src/test_helpers.rs
+++ b/examples/postgres/advanced-blog-cli/src/test_helpers.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use std::sync::{Mutex, MutexGuard};
 
 pub fn connection() -> PgConnection {
-    let url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let mut conn = PgConnection::establish(&url).unwrap();
     let migrations = FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
@@ -13,7 +13,7 @@ pub fn connection() -> PgConnection {
 }
 
 pub fn this_test_modifies_env() -> MutexGuard<'static, ()> {
-    let _ = dotenv::var("FORCING_DOTENV_LOAD");
+    let _ = dotenvy::var("FORCING_DOTENV_LOAD");
     lazy_static! {
         static ref ENV_LOCK: Mutex<()> = Mutex::new(());
     }

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/postgres/getting_started_step_1/src/lib.rs
+++ b/examples/postgres/getting_started_step_1/src/lib.rs
@@ -3,7 +3,7 @@ pub mod schema;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 pub fn establish_connection() -> PgConnection {

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/postgres/getting_started_step_2/src/lib.rs
+++ b/examples/postgres/getting_started_step_2/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 use self::models::{NewPost, Post};

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/postgres/getting_started_step_3/src/lib.rs
+++ b/examples/postgres/getting_started_step_3/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 use self::models::{NewPost, Post};

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/sqlite/getting_started_step_1/src/lib.rs
+++ b/examples/sqlite/getting_started_step_1/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 pub fn establish_connection() -> SqliteConnection {

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/sqlite/getting_started_step_2/src/lib.rs
+++ b/examples/sqlite/getting_started_step_2/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 use self::models::NewPost;

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [[bin]]
 name = "show_posts"

--- a/examples/sqlite/getting_started_step_3/src/lib.rs
+++ b/examples/sqlite/getting_started_step_3/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 use models::NewPost;


### PR DESCRIPTION
Unfortunately dotenv isn't maintained anymore (last commit 2 years ago). That's why [dotenvy](https://github.com/allan2/dotenvy) was created. It's a well maintained fork or the original dotenv.