### PR TITLE
Add explicit static lifetime to BoxableConnection DB

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -439,7 +439,7 @@ where
     }
 }
 
-impl<DB: Backend> dyn BoxableConnection<DB> {
+impl<DB: Backend + 'static> dyn BoxableConnection<DB> {
     /// Downcast the current connection to a specific connection
     /// type.
     ///


### PR DESCRIPTION
It seems it is now required.
See issue https://github.com/rust-lang/rust/issues/95028