### PR TITLE
Make `RawBindCollector` fields public

### DIFF
--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -21,7 +21,7 @@ pub use self::global_expression_methods::{ExpressionMethods, NullableExpressionM
 #[doc(inline)]
 pub use self::text_expression_methods::TextExpressionMethods;
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "postgres_backend")]
 #[doc(inline)]
 pub use crate::pg::expression::expression_methods::*;
 

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -45,11 +45,17 @@ pub struct RawBytesBindCollector<DB: Backend + TypeMetadata> {
     /// The metadata associated with each bind parameter.
     ///
     /// This vec is guaranteed to be the same length as `binds`.
+    #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
     pub metadata: Vec<DB::TypeMetadata>,
+    #[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
+    pub(crate) metadata: Vec<DB::TypeMetadata>,
     /// The serialized bytes for each bind parameter.
     ///
     /// This vec is guaranteed to be the same length as `metadata`.
+    #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
     pub binds: Vec<Option<Vec<u8>>>,
+    #[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
+    pub(crate) binds: Vec<Option<Vec<u8>>>,
 }
 
 #[allow(clippy::new_without_default)]

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -40,15 +40,16 @@ pub trait BindCollector<'a, DB: TypeMetadata>: Sized {
 ///
 /// For most backends, this is the concrete implementation of `BindCollector`
 /// that should be used.
+#[non_exhaustive]
 pub struct RawBytesBindCollector<DB: Backend + TypeMetadata> {
     /// The metadata associated with each bind parameter.
     ///
     /// This vec is guaranteed to be the same length as `binds`.
-    pub(crate) metadata: Vec<DB::TypeMetadata>,
+    pub metadata: Vec<DB::TypeMetadata>,
     /// The serialized bytes for each bind parameter.
     ///
     /// This vec is guaranteed to be the same length as `metadata`.
-    pub(crate) binds: Vec<Option<Vec<u8>>>,
+    pub binds: Vec<Option<Vec<u8>>>,
 }
 
 #[allow(clippy::new_without_default)]


### PR DESCRIPTION
Otherwise it's not possible to use this bind collector type from a third
party crate (like `diesel_async` or any pure rust mysql/postgres implementation)