### PR TITLE
Optimize sqlite `StatementIterator`

### DIFF
--- a/diesel/src/sqlite/connection/row.rs
+++ b/diesel/src/sqlite/connection/row.rs
@@ -19,7 +19,6 @@ pub(super) enum PrivateSqliteRow<'stmt, 'query> {
         values: Vec<Option<OwnedSqliteValue>>,
         column_names: Rc<[Option<String>]>,
     },
-    TemporaryEmpty,
 }
 
 impl<'stmt, 'query> PrivateSqliteRow<'stmt, 'query> {
@@ -57,7 +56,6 @@ impl<'stmt, 'query> PrivateSqliteRow<'stmt, 'query> {
                     .collect(),
                 column_names: column_names.clone(),
             },
-            PrivateSqliteRow::TemporaryEmpty => PrivateSqliteRow::TemporaryEmpty,
         }
     }
 }
@@ -110,16 +108,6 @@ impl<'stmt, 'idx, 'query> RowIndex<&'idx str> for SqliteRow<'stmt, 'query> {
             PrivateSqliteRow::Duplicated { column_names, .. } => column_names
                 .iter()
                 .position(|n| n.as_ref().map(|s| s as &str) == Some(field_name)),
-            PrivateSqliteRow::TemporaryEmpty => {
-                // This cannot happen as this is only a temproray state
-                // used inside of `StatementIterator::next()`
-                unreachable!(
-                    "You've reached an impossible internal state. \
-                     If you ever see this error message please open \
-                     an issue at https://github.com/diesel-rs/diesel \
-                     providing example code how to trigger this error."
-                )
-            }
         }
     }
 }
@@ -137,16 +125,6 @@ impl<'stmt, 'query> Field<'stmt, Sqlite> for SqliteField<'stmt, 'query> {
             PrivateSqliteRow::Duplicated { column_names, .. } => column_names
                 .get(self.col_idx as usize)
                 .and_then(|t| t.as_ref().map(|n| n as &str)),
-            PrivateSqliteRow::TemporaryEmpty => {
-                // This cannot happen as this is only a temproray state
-                // used inside of `StatementIterator::next()`
-                unreachable!(
-                    "You've reached an impossible internal state. \
-                     If you ever see this error message please open \
-                     an issue at https://github.com/diesel-rs/diesel \
-                     providing example code how to trigger this error."
-                )
-            }
         }
     }
 

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -49,16 +49,6 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
             PrivateSqliteRow::Duplicated { values, .. } => {
                 values.get(col_idx as usize).and_then(|v| v.as_ref())?.value
             }
-            PrivateSqliteRow::TemporaryEmpty => {
-                // This cannot happen as this is only a temproray state
-                // used inside of `StatementIterator::next()`
-                unreachable!(
-                    "You've reached an impossible internal state. \
-                     If you ever see this error message please open \
-                     an issue at https://github.com/diesel-rs/diesel \
-                     providing example code how to trigger this error."
-                )
-            }
         };
 
         let ret = Self { _row: row, value };

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -59,10 +59,6 @@ impl<'stmt, 'query> StatementIterator<'stmt, 'query> {
                 }
             }
         } else {
-            match last_row {
-                PrivateSqliteRow::Direct(_) => dbg!("direct"),
-                PrivateSqliteRow::Duplicated { .. } => dbg!("duplicated"),
-            };
             // any other state than `PrivateSqliteRow::Direct` is invalid here
             // and should not happen. If this ever happens this is a logic error
             // in the code above

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -12,16 +12,74 @@ pub struct StatementIterator<'stmt, 'query> {
     field_count: usize,
 }
 
+impl<'stmt, 'query> StatementIterator<'stmt, 'query> {
+    #[cold]
+    fn handle_duplicated_row_case(
+        outer_last_row: &mut Rc<RefCell<PrivateSqliteRow<'stmt, 'query>>>,
+        column_names: &mut Option<Rc<[Option<String>]>>,
+        field_count: usize,
+    ) -> Option<QueryResult<SqliteRow<'stmt, 'query>>> {
+        // We don't own the statement. There is another existing reference, likly because
+        // a user stored the row in some long time container before calling next another time
+        // In this case we copy out the current values into a temporary store and advance
+        // the statement iterator internally afterwards
+        let mut last_row = {
+            let mut last_row = match outer_last_row.try_borrow_mut() {
+                Ok(o) => o,
+                Err(_e) => {
+                    return Some(Err(crate::result::Error::DeserializationError(
+                                    "Failed to reborrow row. Try to release any `SqliteField` or `SqliteValue` \
+                                     that exists at this point"
+                                        .into(),
+                                )));
+                }
+            };
+            let last_row = &mut *last_row;
+            let duplicated = last_row.duplicate(column_names);
+            std::mem::replace(last_row, duplicated)
+        };
+        if let PrivateSqliteRow::Direct(ref mut stmt) = last_row {
+            let res = unsafe {
+                // This is actually safe here as we've already
+                // performed one step. For the first step we would have
+                // used `PrivateStatementIterator::NotStarted` where we don't
+                // have access to `PrivateSqliteRow` at all
+                stmt.step(false)
+            };
+            match res {
+                Err(e) => Some(Err(e)),
+                Ok(false) => None,
+                Ok(true) => {
+                    let field_count = field_count;
+                    Some(Ok(SqliteRow {
+                        inner: Rc::clone(&outer_last_row),
+                        field_count,
+                    }))
+                }
+            }
+        } else {
+            // any other state than `PrivateSqliteRow::Direct` is invalid here
+            // and should not happen. If this ever happens this is a logic error
+            // in the code above
+            unreachable!(
+                "You've reached an impossible internal state. \
+                             If you ever see this error message please open \
+                             an issue at https://github.com/diesel-rs/diesel \
+                             providing example code how to trigger this error."
+            )
+        }
+    }
+}
+
 enum PrivateStatementIterator<'stmt, 'query> {
-    NotStarted(StatementUse<'stmt, 'query>),
+    NotStarted(Option<StatementUse<'stmt, 'query>>),
     Started(Rc<RefCell<PrivateSqliteRow<'stmt, 'query>>>),
-    TemporaryEmpty,
 }
 
 impl<'stmt, 'query> StatementIterator<'stmt, 'query> {
     pub fn new(stmt: StatementUse<'stmt, 'query>) -> StatementIterator<'stmt, 'query> {
         Self {
-            inner: PrivateStatementIterator::NotStarted(stmt),
+            inner: PrivateStatementIterator::NotStarted(Some(stmt)),
             column_names: None,
             field_count: 0,
         }
@@ -32,42 +90,54 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
     type Item = QueryResult<SqliteRow<'stmt, 'query>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        use PrivateStatementIterator::{NotStarted, Started, TemporaryEmpty};
-
-        match std::mem::replace(&mut self.inner, TemporaryEmpty) {
-            NotStarted(stmt) => match stmt.step() {
-                Err(e) => Some(Err(e)),
-                Ok(None) => None,
-                Ok(Some(stmt)) => {
-                    let field_count = stmt.column_count() as usize;
-                    self.field_count = field_count;
-                    let inner = Rc::new(RefCell::new(PrivateSqliteRow::Direct(stmt)));
-                    self.inner = Started(inner.clone());
-                    Some(Ok(SqliteRow { inner, field_count }))
+        use PrivateStatementIterator::{NotStarted, Started};
+        match &mut self.inner {
+            NotStarted(ref mut stmt) if stmt.is_some() => {
+                let mut stmt = stmt
+                    .take()
+                    .expect("It must be there because we checked that above");
+                let step = unsafe {
+                    // This is safe as we pass `first_step = true` to reset the cached column names
+                    stmt.step(true)
+                };
+                match step {
+                    Err(e) => Some(Err(e)),
+                    Ok(false) => None,
+                    Ok(true) => {
+                        let field_count = stmt.column_count() as usize;
+                        self.field_count = field_count;
+                        let inner = Rc::new(RefCell::new(PrivateSqliteRow::Direct(stmt)));
+                        self.inner = Started(inner.clone());
+                        Some(Ok(SqliteRow { inner, field_count }))
+                    }
                 }
-            },
-            Started(mut last_row) => {
+            }
+            Started(ref mut last_row) => {
                 // There was already at least one iteration step
                 // We check here if the caller already released the row value or not
                 // by checking if our Rc owns the data or not
-                if let Some(last_row_ref) = Rc::get_mut(&mut last_row) {
+                if let Some(last_row_ref) = Rc::get_mut(last_row) {
                     // We own the statement, there is no other reference here.
                     // This means we don't need to copy out values from the sqlite provided
                     // datastructures for now
                     // We don't need to use the runtime borrowing system of the RefCell here
                     // as we have a mutable reference, so all of this below is checked at compile time
-                    if let PrivateSqliteRow::Direct(stmt) =
-                        std::mem::replace(last_row_ref.get_mut(), PrivateSqliteRow::TemporaryEmpty)
-                    {
-                        match stmt.step() {
+                    if let PrivateSqliteRow::Direct(ref mut stmt) = last_row_ref.get_mut() {
+                        let step = unsafe {
+                            // This is actually safe here as we've already
+                            // performed one step. For the first step we would have
+                            // used `PrivateStatementIterator::NotStarted` where we don't
+                            // have access to `PrivateSqliteRow` at all
+
+                            stmt.step(false)
+                        };
+                        match step {
                             Err(e) => Some(Err(e)),
-                            Ok(None) => None,
-                            Ok(Some(stmt)) => {
+                            Ok(false) => None,
+                            Ok(true) => {
                                 let field_count = self.field_count;
-                                (*last_row_ref.get_mut()) = PrivateSqliteRow::Direct(stmt);
-                                self.inner = Started(last_row.clone());
                                 Some(Ok(SqliteRow {
-                                    inner: last_row,
+                                    inner: Rc::clone(last_row),
                                     field_count,
                                 }))
                             }
@@ -84,55 +154,19 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
                         )
                     }
                 } else {
-                    // We don't own the statement. There is another existing reference, likly because
-                    // a user stored the row in some long time container before calling next another time
-                    // In this case we copy out the current values into a temporary store and advance
-                    // the statement iterator internally afterwards
-                    let last_row = {
-                        let mut last_row = match last_row.try_borrow_mut() {
-                            Ok(o) => o,
-                            Err(_e) => {
-                                self.inner = Started(last_row.clone());
-                                return Some(Err(crate::result::Error::DeserializationError(
-                                    "Failed to reborrow row. Try to release any `SqliteField` or `SqliteValue` \
-                                     that exists at this point"
-                                        .into(),
-                                )));
-                            }
-                        };
-                        let last_row = &mut *last_row;
-                        let duplicated = last_row.duplicate(&mut self.column_names);
-                        std::mem::replace(last_row, duplicated)
-                    };
-                    if let PrivateSqliteRow::Direct(stmt) = last_row {
-                        match stmt.step() {
-                            Err(e) => Some(Err(e)),
-                            Ok(None) => None,
-                            Ok(Some(stmt)) => {
-                                let field_count = self.field_count;
-                                let last_row =
-                                    Rc::new(RefCell::new(PrivateSqliteRow::Direct(stmt)));
-                                self.inner = Started(last_row.clone());
-                                Some(Ok(SqliteRow {
-                                    inner: last_row,
-                                    field_count,
-                                }))
-                            }
-                        }
-                    } else {
-                        // any other state than `PrivateSqliteRow::Direct` is invalid here
-                        // and should not happen. If this ever happens this is a logic error
-                        // in the code above
-                        unreachable!(
-                            "You've reached an impossible internal state. \
+                    Self::handle_duplicated_row_case(
+                        last_row,
+                        &mut self.column_names,
+                        self.field_count,
+                    )
+                }
+            }
+            NotStarted(_) => unreachable!(
+                "You've reached an impossible internal state. \
                              If you ever see this error message please open \
                              an issue at https://github.com/diesel-rs/diesel \
                              providing example code how to trigger this error."
-                        )
-                    }
-                }
-            }
-            TemporaryEmpty => None,
+            ),
         }
     }
 }


### PR DESCRIPTION
This change remove a temporary state from the sqlite StatementIterator
which showed up in some profiles for our benchmarks. The benchmarks show
a 1-6% improvement in construction count for the query benchmarks and
no changes for the insert benchmarks.


<details>
<summary> Relevant benchmark results </summary>

```
bench_trivial_query/diesel/1
                        time:   [6541.7627 cycles 6542.1171 cycles 6542.5357 cycles]
                        change: [-3.0210% -2.8542% -2.7324%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe
bench_trivial_query/diesel_boxed/1
                        time:   [13976.9443 cycles 13981.9545 cycles 13986.5513 cycles]
                        change: [-1.4962% -1.4095% -1.3296%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
bench_trivial_query/diesel_queryable_by_name/1
                        time:   [40414.1384 cycles 40456.7169 cycles 40500.9642 cycles]
                        change: [-0.7671% -0.6327% -0.5016%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_trivial_query/diesel/10000
                        time:   [23882021.3000 cycles 23882214.7229 cycles 23882406.7944 cycles]
                        change: [-6.0633% -6.0461% -6.0331%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
bench_trivial_query/diesel_boxed/10000
                        time:   [23890404.5122 cycles 23890792.3608 cycles 23891254.8076 cycles]
                        change: [-6.0062% -6.0030% -5.9998%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
bench_trivial_query/diesel_queryable_by_name/10000
                        time:   [27181116.5123 cycles 27189714.1840 cycles 27198788.2537 cycles]
                        change: [-5.4711% -5.4298% -5.3904%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_medium_complex_query/diesel/1
                        time:   [22495.0324 cycles 22496.0806 cycles 22497.3718 cycles]
                        change: [-1.5580% -1.4632% -1.3608%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
bench_medium_complex_query/diesel_boxed/1
                        time:   [41632.5260 cycles 41681.6865 cycles 41730.2439 cycles]
                        change: [-1.0619% -0.9198% -0.7813%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
bench_medium_complex_query/diesel_queryable_by_name/1
                        time:   [126045.5130 cycles 126164.1230 cycles 126292.1045 cycles]
                        change: [-0.4169% -0.2920% -0.1611%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
bench_medium_complex_query/diesel/10000
                        time:   [23650424.9443 cycles 23653430.5380 cycles 23656376.8618 cycles]
                        change: [-3.0016% -2.9868% -2.9741%] (p = 0.00 < 0.05)
                        Performance has improved.
bench_medium_complex_query/diesel_boxed/10000
                        time:   [23666598.7259 cycles 23673235.8710 cycles 23683469.4276 cycles]
                        change: [-2.9908% -2.9637% -2.9209%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
bench_medium_complex_query/diesel_queryable_by_name/10000
                        time:   [50436656.7219 cycles 50448976.0640 cycles 50461415.4847 cycles]
                        change: [-3.1256% -3.0928% -3.0606%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.2s, enable flat sampling, or reduce sample count to 60.
Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Collecting 100 samples in estimated 5.1724 s (5050 iter                                                                                                                                                            bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially
                        time:   [4011704.3305 cycles 4012211.9494 cycles 4012708.0785 cycles]
                        change: [-3.6397% -3.0779% -1.9779%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low severe
  4 (4.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

<details>