### PR TITLE
Inline `FromSqlRow::build_from_row` as this function seems to be real…

### DIFF
--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -501,6 +501,11 @@ where
     DB: Backend,
     T::Row: FromStaticSqlRow<ST, DB>,
 {
+    // This inline(always) attribute is here as benchmarks have shown
+    // a up to 5% reduction in instruction count of having it here
+    //
+    // A plain inline attribute does not show similar improvements
+    #[inline(always)]
     fn build_from_row<'a>(row: &impl Row<'a, DB>) -> Result<Self> {
         let row = <T::Row as FromStaticSqlRow<ST, DB>>::build_from_row(row)?;
         T::build(row)


### PR DESCRIPTION
…ly hot

This seems to give up to 5% reduction in instruction count for the
`diesel/trivial_query/1000` benchmarks. Similar improvements are
observed for the boxed query variants.
This change seems to be neutral for the `queryable_by_name` variant.
For the insert/1 benchmark a slight regression in instruction count can
be observed.

<details>
<summary> Instruction count results for sqlite </summary>

```
Benchmarking bench_trivial_query/diesel/1
Benchmarking bench_trivial_query/diesel/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel/1: Collecting 100 samples in estimated 5.0001 s (5.3M iterations)
Benchmarking bench_trivial_query/diesel/1: Analyzing
bench_trivial_query/diesel/1
                        time:   [6631.5643 cycles 6631.6183 cycles 6631.6818 cycles]
                        change: [-1.7072% -1.5398% -1.4189%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
Benchmarking bench_trivial_query/diesel_boxed/1
Benchmarking bench_trivial_query/diesel_boxed/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_boxed/1: Collecting 100 samples in estimated 5.0082 s (2.8M iterations)
Benchmarking bench_trivial_query/diesel_boxed/1: Analyzing
bench_trivial_query/diesel_boxed/1
                        time:   [14066.6441 cycles 14074.4052 cycles 14083.1550 cycles]
                        change: [-0.7852% -0.6954% -0.6081%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking bench_trivial_query/diesel_queryable_by_name/1
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Collecting 100 samples in estimated 5.0076 s (717k iterations)
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Analyzing
bench_trivial_query/diesel_queryable_by_name/1
                        time:   [40693.0672 cycles 40741.3429 cycles 40787.8319 cycles]
                        change: [-0.1766% -0.0358% +0.1173%] (p = 0.63 > 0.05)
                        No change in performance detected.
Benchmarking bench_trivial_query/diesel/10000
Benchmarking bench_trivial_query/diesel/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel/10000: Collecting 100 samples in estimated 5.1886 s (1500 iterations)
Benchmarking bench_trivial_query/diesel/10000: Analyzing
bench_trivial_query/diesel/10000
                        time:   [24512122.3959 cycles 24512577.2900 cycles 24513115.1949 cycles]
                        change: [-3.5840% -3.5663% -3.5528%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking bench_trivial_query/diesel_boxed/10000
Benchmarking bench_trivial_query/diesel_boxed/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_boxed/10000: Collecting 100 samples in estimated 5.0874 s (1300 iterations)
Benchmarking bench_trivial_query/diesel_boxed/10000: Analyzing
bench_trivial_query/diesel_boxed/10000
                        time:   [24518803.3590 cycles 24519045.0485 cycles 24519307.7216 cycles]
                        change: [-3.5343% -3.5311% -3.5282%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Collecting 100 samples in estimated 5.3154 s (1500 iterations)
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Analyzing
bench_trivial_query/diesel_queryable_by_name/10000
                        time:   [28743309.8501 cycles 28754252.2793 cycles 28765608.6953 cycles]
                        change: [-0.0365% +0.0119% +0.0637%] (p = 0.63 > 0.05)
                        No change in performance detected.

Benchmarking bench_medium_complex_query/diesel/1
Benchmarking bench_medium_complex_query/diesel/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel/1: Collecting 100 samples in estimated 5.0034 s (1.3M iterations)
Benchmarking bench_medium_complex_query/diesel/1: Analyzing
bench_medium_complex_query/diesel/1
                        time:   [22548.9274 cycles 22550.3950 cycles 22551.9069 cycles]
                        change: [-1.3553% -1.2767% -1.2094%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe
Benchmarking bench_medium_complex_query/diesel_boxed/1
Benchmarking bench_medium_complex_query/diesel_boxed/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_boxed/1: Collecting 100 samples in estimated 5.0151 s (783k iterations)
Benchmarking bench_medium_complex_query/diesel_boxed/1: Analyzing
bench_medium_complex_query/diesel_boxed/1
                        time:   [41760.8067 cycles 41812.9123 cycles 41863.7104 cycles]
                        change: [-0.7143% -0.5621% -0.4125%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Collecting 100 samples in estimated 5.0704 s (242k iterations)
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Analyzing
bench_medium_complex_query/diesel_queryable_by_name/1
                        time:   [126161.9076 cycles 126314.0646 cycles 126468.3027 cycles]
                        change: [-0.3028% -0.1768% -0.0426%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking bench_medium_complex_query/diesel/10000
Benchmarking bench_medium_complex_query/diesel/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel/10000: Collecting 100 samples in estimated 5.2915 s (1600 iterations)
Benchmarking bench_medium_complex_query/diesel/10000: Analyzing
bench_medium_complex_query/diesel/10000
                        time:   [23719614.1555 cycles 23720756.0894 cycles 23721964.3690 cycles]
                        change: [-2.7188% -2.7107% -2.7030%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking bench_medium_complex_query/diesel_boxed/10000
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Collecting 100 samples in estimated 5.0078 s (1600 iterations)
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Analyzing
bench_medium_complex_query/diesel_boxed/10000
                        time:   [23740217.2206 cycles 23742031.2981 cycles 23743919.5385 cycles]
                        change: [-2.6910% -2.6817% -2.6718%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Collecting 100 samples in estimated 5.4863 s (800 iterations)
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Analyzing
bench_medium_complex_query/diesel_queryable_by_name/10000
                        time:   [52014662.6896 cycles 52025980.7713 cycles 52037541.8849 cycles]
                        change: [-0.0940% -0.0636% -0.0319%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially
Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Warming up for 3.0000 s
Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Collecting 100 samples in estimated 7.9573 s (10k iterations)
Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Analyzing
bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially
                        time:   [4083632.9812 cycles 4084033.4615 cycles 4084438.2963 cycles]
                        change: [-1.9411% -1.9167% -1.8927%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low severe
  5 (5.00%) low mild

Benchmarking bench_insert/diesel/1
Benchmarking bench_insert/diesel/1: Warming up for 3.0000 s
Benchmarking bench_insert/diesel/1: Collecting 100 samples in estimated 5.0110 s (1.4M iterations)
Benchmarking bench_insert/diesel/1: Analyzing
bench_insert/diesel/1   time:   [21686.4179 cycles 21710.7645 cycles 21744.7704 cycles]
                        change: [+1.2245% +1.2673% +1.3238%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe
Benchmarking bench_insert/diesel/100
Benchmarking bench_insert/diesel/100: Warming up for 3.0000 s
Benchmarking bench_insert/diesel/100: Collecting 100 samples in estimated 5.1293 s (81k iterations)
Benchmarking bench_insert/diesel/100: Analyzing
bench_insert/diesel/100 time:   [445801.7393 cycles 445915.7752 cycles 446020.6958 cycles]
                        change: [-0.3686% -0.0552% +0.2431%] (p = 0.74 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  5 (5.00%) high severe
```

</details>

<details>
<summary> Instruction count results for postgres </summary>

```
Benchmarking bench_trivial_query/diesel/1
Benchmarking bench_trivial_query/diesel/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel/1: Collecting 100 samples in estimated 5.1317 s (101k iterations)
Benchmarking bench_trivial_query/diesel/1: Analyzing
bench_trivial_query/diesel/1
                        time:   [38048.2013 cycles 38106.5733 cycles 38178.5096 cycles]
                        change: [-0.7354% -0.4243% -0.1089%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe
Benchmarking bench_trivial_query/diesel_boxed/1
Benchmarking bench_trivial_query/diesel_boxed/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_boxed/1: Collecting 100 samples in estimated 5.3435 s (76k iterations)
Benchmarking bench_trivial_query/diesel_boxed/1: Analyzing
bench_trivial_query/diesel_boxed/1
                        time:   [44999.7193 cycles 45082.2404 cycles 45171.4159 cycles]
                        change: [+0.0300% +0.2963% +0.5514%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
Benchmarking bench_trivial_query/diesel_queryable_by_name/1
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Collecting 100 samples in estimated 5.4633 s (40k iterations)
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Analyzing
bench_trivial_query/diesel_queryable_by_name/1
                        time:   [72880.3084 cycles 72976.2007 cycles 73084.0511 cycles]
                        change: [+0.2939% +0.5314% +0.7586%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking bench_trivial_query/diesel/10000
Benchmarking bench_trivial_query/diesel/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel/10000: Collecting 100 samples in estimated 5.0160 s (900 iterations)
Benchmarking bench_trivial_query/diesel/10000: Analyzing
bench_trivial_query/diesel/10000
                        time:   [17560636.7414 cycles 17564762.2911 cycles 17568868.5345 cycles]
                        change: [-4.6275% -4.6034% -4.5784%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high severe
Benchmarking bench_trivial_query/diesel_boxed/10000
Benchmarking bench_trivial_query/diesel_boxed/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_boxed/10000: Collecting 100 samples in estimated 5.2869 s (1100 iterations)
Benchmarking bench_trivial_query/diesel_boxed/10000: Analyzing
bench_trivial_query/diesel_boxed/10000
                        time:   [17564383.7809 cycles 17567436.4191 cycles 17570365.2915 cycles]
                        change: [-4.6143% -4.5971% -4.5781%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) low mild
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Collecting 100 samples in estimated 5.1647 s (800 iterations)
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Analyzing
bench_trivial_query/diesel_queryable_by_name/10000
                        time:   [20740996.8299 cycles 20746089.5888 cycles 20751237.7310 cycles]
                        change: [-0.5229% -0.4380% -0.3507%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking bench_medium_complex_query/diesel/1
Benchmarking bench_medium_complex_query/diesel/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel/1: Collecting 100 samples in estimated 5.4490 s (56k iterations)
Benchmarking bench_medium_complex_query/diesel/1: Analyzing
bench_medium_complex_query/diesel/1
                        time:   [42910.4147 cycles 42989.3808 cycles 43077.3165 cycles]
                        change: [-0.9526% -0.4223% +0.0316%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
Benchmarking bench_medium_complex_query/diesel_boxed/1
Benchmarking bench_medium_complex_query/diesel_boxed/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_boxed/1: Collecting 100 samples in estimated 5.3308 s (56k iterations)
Benchmarking bench_medium_complex_query/diesel_boxed/1: Analyzing
bench_medium_complex_query/diesel_boxed/1
                        time:   [57380.2105 cycles 57474.6191 cycles 57579.0053 cycles]
                        change: [-0.7327% -0.4473% -0.1593%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Collecting 100 samples in estimated 5.6712 s (30k iterations)
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Analyzing
bench_medium_complex_query/diesel_queryable_by_name/1
                        time:   [76826.7633 cycles 77022.1824 cycles 77241.4062 cycles]
                        change: [+0.2801% +0.5407% +0.8106%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking bench_medium_complex_query/diesel/10000
Benchmarking bench_medium_complex_query/diesel/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel/10000: Collecting 100 samples in estimated 5.5453 s (500 iterations)
Benchmarking bench_medium_complex_query/diesel/10000: Analyzing
bench_medium_complex_query/diesel/10000
                        time:   [14010287.9891 cycles 14014142.6680 cycles 14017825.9652 cycles]
                        change: [-4.3124% -4.2877% -4.2596%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
Benchmarking bench_medium_complex_query/diesel_boxed/10000
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Collecting 100 samples in estimated 5.0389 s (700 iterations)
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Analyzing
bench_medium_complex_query/diesel_boxed/10000
                        time:   [14024275.4065 cycles 14026706.6829 cycles 14028843.7395 cycles]
                        change: [-4.2928% -4.2725% -4.2568%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) low severe
  4 (4.00%) low mild
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Collecting 100 samples in estimated 5.0343 s (500 iterations)
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Analyzing
bench_medium_complex_query/diesel_queryable_by_name/10000
                        time:   [37508547.4168 cycles 37515032.9100 cycles 37521855.5548 cycles]
                        change: [-0.5407% -0.5175% -0.4930%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  10 (10.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially
Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Warming up for 3.0000 s
Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Collecting 100 samples in estimated 7.4806 s (200 iterations)
Benchmarking bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially: Analyzing
bench_loading_associations_sequentially/diesel/bench_loading_associations_sequentially
                        time:   [27178524.1355 cycles 27189448.9800 cycles 27200407.0314 cycles]
                        change: [-2.3369% -2.2529% -2.1767%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking bench_insert/diesel/1
Benchmarking bench_insert/diesel/1: Warming up for 3.0000 s
Benchmarking bench_insert/diesel/1: Collecting 100 samples in estimated 5.1435 s (1100 iterations)
Benchmarking bench_insert/diesel/1: Analyzing
bench_insert/diesel/1   time:   [44645.9955 cycles 45105.0409 cycles 45640.7648 cycles]
                        change: [+0.8815% +2.3523% +3.8685%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking bench_insert/diesel/100
Benchmarking bench_insert/diesel/100: Warming up for 3.0000 s
Benchmarking bench_insert/diesel/100: Collecting 100 samples in estimated 5.2093 s (800 iterations)
Benchmarking bench_insert/diesel/100: Analyzing
bench_insert/diesel/100 time:   [362191.7953 cycles 362769.1450 cycles 363418.6903 cycles]
                        change: [+0.5532% +0.7504% +0.9407%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

```

</details>

<details>
<summary> Instruction count results for mysql </summary>

```
Benchmarking bench_trivial_query/diesel/1
Benchmarking bench_trivial_query/diesel/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel/1: Collecting 100 samples in estimated 5.2965 s (76k iterations)
Benchmarking bench_trivial_query/diesel/1: Analyzing
bench_trivial_query/diesel/1
                        time:   [35868.7409 cycles 35940.1754 cycles 36019.9634 cycles]
                        change: [-1.1072% -0.5051% +0.1019%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
Benchmarking bench_trivial_query/diesel_boxed/1
Benchmarking bench_trivial_query/diesel_boxed/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_boxed/1: Collecting 100 samples in estimated 5.0325 s (66k iterations)
Benchmarking bench_trivial_query/diesel_boxed/1: Analyzing
bench_trivial_query/diesel_boxed/1
                        time:   [43362.3760 cycles 43407.8336 cycles 43461.5261 cycles]
                        change: [-0.3809% +0.0656% +0.5369%] (p = 0.78 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Benchmarking bench_trivial_query/diesel_queryable_by_name/1
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Collecting 100 samples in estimated 5.3392 s (40k iterations)
Benchmarking bench_trivial_query/diesel_queryable_by_name/1: Analyzing
bench_trivial_query/diesel_queryable_by_name/1
                        time:   [67468.2011 cycles 67641.6416 cycles 67828.6375 cycles]
                        change: [+0.4014% +0.8787% +1.3478%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
Benchmarking bench_trivial_query/diesel/10000
Benchmarking bench_trivial_query/diesel/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel/10000: Collecting 100 samples in estimated 5.2871 s (500 iterations)
Benchmarking bench_trivial_query/diesel/10000: Analyzing
bench_trivial_query/diesel/10000
                        time:   [21275792.3421 cycles 21277503.0420 cycles 21279298.3636 cycles]
                        change: [-3.9274% -3.9118% -3.8984%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking bench_trivial_query/diesel_boxed/10000
Benchmarking bench_trivial_query/diesel_boxed/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_boxed/10000: Collecting 100 samples in estimated 5.7921 s (500 iterations)
Benchmarking bench_trivial_query/diesel_boxed/10000: Analyzing
bench_trivial_query/diesel_boxed/10000
                        time:   [21285756.0006 cycles 21287272.7720 cycles 21288873.2752 cycles]
                        change: [-3.8907% -3.8749% -3.8618%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Warming up for 3.0000 s
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Collecting 100 samples in estimated 5.8932 s (400 iterations)
Benchmarking bench_trivial_query/diesel_queryable_by_name/10000: Analyzing
bench_trivial_query/diesel_queryable_by_name/10000
                        time:   [25542233.3935 cycles 25544852.1050 cycles 25547849.2449 cycles]
                        change: [-0.3445% -0.3300% -0.3148%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

Benchmarking bench_medium_complex_query/diesel/1
Benchmarking bench_medium_complex_query/diesel/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel/1: Collecting 100 samples in estimated 5.4194 s (35k iterations)
Benchmarking bench_medium_complex_query/diesel/1: Analyzing
bench_medium_complex_query/diesel/1
                        time:   [55544.9429 cycles 55677.1427 cycles 55809.1062 cycles]
                        change: [+0.6647% +1.2275% +1.8029%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
Benchmarking bench_medium_complex_query/diesel_boxed/1
Benchmarking bench_medium_complex_query/diesel_boxed/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_boxed/1: Collecting 100 samples in estimated 5.5265 s (35k iterations)
Benchmarking bench_medium_complex_query/diesel_boxed/1: Analyzing
bench_medium_complex_query/diesel_boxed/1
                        time:   [72772.4990 cycles 72830.1846 cycles 72891.7301 cycles]
                        change: [+0.6801% +0.9763% +1.2600%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Collecting 100 samples in estimated 5.1068 s (30k iterations)
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/1: Analyzing
bench_medium_complex_query/diesel_queryable_by_name/1
                        time:   [93887.4702 cycles 94092.5741 cycles 94304.5120 cycles]
                        change: [-0.0076% +0.3737% +0.7438%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
Benchmarking bench_medium_complex_query/diesel/10000
Benchmarking bench_medium_complex_query/diesel/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel/10000: Collecting 100 samples in estimated 5.9517 s (500 iterations)
Benchmarking bench_medium_complex_query/diesel/10000: Analyzing
bench_medium_complex_query/diesel/10000
                        time:   [14989858.1113 cycles 14991432.9320 cycles 14993078.3903 cycles]
                        change: [-3.7782% -3.7650% -3.7498%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking bench_medium_complex_query/diesel_boxed/10000
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Collecting 100 samples in estimated 5.7030 s (700 iterations)
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Analyzing
bench_medium_complex_query/diesel_boxed/10000
                        time:   [14997018.4479 cycles 14998168.5214 cycles 14999365.1041 cycles]
                        change: [-3.9114% -3.8545% -3.8201%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Warming up for 3.0000 s
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Collecting 100 samples in estimated 6.0270 s (400 iterations)
Benchmarking bench_medium_complex_query/diesel_queryable_by_name/10000: Analyzing
bench_medium_complex_query/diesel_queryable_by_name/10000
                        time:   [43881555.4323 cycles 43883839.8650 cycles 43886196.7899 cycles]
                        change: [-0.1859% -0.1755% -0.1656%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

<details>
