### PR TITLE
ONLY <table> postgres keyword (second attempt)

### DIFF
--- a/diesel/src/pg/expression/extensions/mod.rs
+++ b/diesel/src/pg/expression/extensions/mod.rs
@@ -2,5 +2,7 @@
 //! building expressions. These traits are not exported by default. The are also
 //! re-exported in `diesel::dsl`
 mod interval_dsl;
+mod only_dsl;
 
 pub use self::interval_dsl::IntervalDsl;
+pub use self::only_dsl::OnlyDsl;

--- a/diesel/src/pg/expression/extensions/only_dsl.rs
+++ b/diesel/src/pg/expression/extensions/only_dsl.rs
@@ -1,0 +1,54 @@
+use crate::query_builder::Only;
+use crate::Table;
+
+/// The `only` method
+///
+/// This is only implemented for the Postgres backend.
+/// The `ONLY` clause is used to select only from one table and not any inherited ones.
+///
+/// Calling this function on a table (`mytable.only()`) will result in the SQL `ONLY mytable`.
+/// `mytable.only()` can be used just like any table in diesel since it implements
+/// [Table](crate::Table).
+///
+/// Example:
+///
+/// ```rust
+/// # include!("../../../doctest_setup.rs");
+/// # use schema::{posts, users};
+/// # use diesel::dsl::*;
+/// # fn main() {
+/// # let connection = &mut establish_connection();
+/// let n_sers_in_main_table = users::table
+///     .only()
+///     .select(count(users::id))
+///     .first::<i64>(connection);
+/// # }
+/// ```
+/// Selects the number of entries in the `users` table excluding any rows found in inherited
+/// tables.
+///
+/// It can also be used in inner joins:
+///
+/// ```rust
+/// # include!("../../../doctest_setup.rs");
+/// # use schema::{posts, users};
+/// # use diesel::dsl::*;
+/// # fn main() {
+/// # let connection = &mut establish_connection();
+/// # let _ =
+/// users::table
+///     .inner_join(posts::table.only())
+///     .select((users::name, posts::title))
+///     .load::<(String, String)>(connection);
+/// # }
+/// ```
+/// That query excludes any posts that reside in any inherited table.
+///
+pub trait OnlyDsl: Table {
+    /// See the trait-level docs.
+    fn only(self) -> Only<Self> {
+        Only { source: self }
+    }
+}
+
+impl<T: Table> OnlyDsl for T {}

--- a/diesel/src/pg/query_builder/mod.rs
+++ b/diesel/src/pg/query_builder/mod.rs
@@ -5,6 +5,7 @@ use crate::result::QueryResult;
 mod distinct_on;
 mod limit_offset;
 pub(crate) mod on_constraint;
+pub(crate) mod only;
 mod query_fragment_impls;
 pub use self::distinct_on::DistinctOnClause;
 

--- a/diesel/src/pg/query_builder/only.rs
+++ b/diesel/src/pg/query_builder/only.rs
@@ -1,0 +1,95 @@
+use crate::expression::{Expression, ValidGrouping};
+use crate::pg::Pg;
+use crate::query_builder::{AsQuery, AstPass, FromClause, QueryFragment, QueryId, SelectStatement};
+use crate::query_source::QuerySource;
+use crate::result::QueryResult;
+use crate::{JoinTo, SelectableExpression, Table};
+
+/// Represents a query with an `ONLY` clause.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Only<S> {
+    pub(crate) source: S,
+}
+
+impl<S> QueryId for Only<S>
+where
+    Self: 'static,
+    S: QueryId,
+{
+    type QueryId = Self;
+    const HAS_STATIC_QUERY_ID: bool = <S as QueryId>::HAS_STATIC_QUERY_ID;
+}
+
+impl<S> QuerySource for Only<S>
+where
+    S: Table + Clone,
+    <S as QuerySource>::DefaultSelection: ValidGrouping<()> + SelectableExpression<Only<S>>,
+{
+    type FromClause = Self;
+    type DefaultSelection = <S as QuerySource>::DefaultSelection;
+
+    fn from_clause(&self) -> Self::FromClause {
+        self.clone()
+    }
+
+    fn default_selection(&self) -> Self::DefaultSelection {
+        self.source.default_selection()
+    }
+}
+
+impl<S> QueryFragment<Pg> for Only<S>
+where
+    S: QueryFragment<Pg>,
+{
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        pass.push_sql(" ONLY ");
+        self.source.walk_ast(pass.reborrow())?;
+        Ok(())
+    }
+}
+
+impl<S> AsQuery for Only<S>
+where
+    S: Table + Clone,
+    <S as QuerySource>::DefaultSelection: ValidGrouping<()> + SelectableExpression<Only<S>>,
+{
+    type SqlType = <<Self as QuerySource>::DefaultSelection as Expression>::SqlType;
+    type Query = SelectStatement<FromClause<Self>>;
+
+    fn as_query(self) -> Self::Query {
+        SelectStatement::simple(self)
+    }
+}
+
+impl<S, T> JoinTo<T> for Only<S>
+where
+    S: JoinTo<T>,
+    T: Table,
+    S: Table,
+{
+    type FromClause = <S as JoinTo<T>>::FromClause;
+    type OnClause = <S as JoinTo<T>>::OnClause;
+
+    fn join_target(rhs: T) -> (Self::FromClause, Self::OnClause) {
+        <S as JoinTo<T>>::join_target(rhs)
+    }
+}
+impl<S> Table for Only<S>
+where
+    S: Table + Clone + AsQuery,
+
+    <S as Table>::PrimaryKey: SelectableExpression<Only<S>>,
+    <S as Table>::AllColumns: SelectableExpression<Only<S>>,
+    <S as QuerySource>::DefaultSelection: ValidGrouping<()> + SelectableExpression<Only<S>>,
+{
+    type PrimaryKey = <S as Table>::PrimaryKey;
+    type AllColumns = <S as Table>::AllColumns;
+
+    fn primary_key(&self) -> Self::PrimaryKey {
+        self.source.primary_key()
+    }
+
+    fn all_columns() -> Self::AllColumns {
+        S::all_columns()
+    }
+}

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -102,6 +102,9 @@ pub(crate) use self::insert_statement::ColumnList;
 pub(crate) use self::select_statement::BoxedSelectStatement;
 pub(crate) use self::select_statement::SelectStatement;
 
+#[cfg(feature = "postgres_backend")]
+pub use crate::pg::query_builder::only::Only;
+
 use crate::backend::{Backend, HasBindCollector};
 use crate::result::QueryResult;
 use std::error::Error;

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
@@ -6,10 +6,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::functions::aggregate_folding::sum::sum<diesel::sql_types::Integer, posts::columns::id>`
    = note: required because of the requirements on the impl of `SelectDsl<diesel::expression::functions::aggregate_folding::sum::sum<diesel::sql_types::Integer, posts::columns::id>>` for `SelectStatement<FromClause<users::table>>`
 
@@ -46,10 +46,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::functions::aggregate_folding::avg::avg<diesel::sql_types::Integer, posts::columns::id>`
    = note: required because of the requirements on the impl of `SelectDsl<diesel::expression::functions::aggregate_folding::avg::avg<diesel::sql_types::Integer, posts::columns::id>>` for `SelectStatement<FromClause<users::table>>`
 
@@ -86,10 +86,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::functions::aggregate_ordering::max::max<diesel::sql_types::Integer, posts::columns::id>`
    = note: required because of the requirements on the impl of `SelectDsl<diesel::expression::functions::aggregate_ordering::max::max<diesel::sql_types::Integer, posts::columns::id>>` for `SelectStatement<FromClause<users::table>>`
 
@@ -126,10 +126,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::functions::aggregate_ordering::min::min<diesel::sql_types::Integer, posts::columns::id>`
    = note: required because of the requirements on the impl of `SelectDsl<diesel::expression::functions::aggregate_ordering::min::min<diesel::sql_types::Integer, posts::columns::id>>` for `SelectStatement<FromClause<users::table>>`
 

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -110,7 +110,7 @@ error[E0277]: the trait bound `{integer}: SelectableExpression<NoFromClause>` is
               <(T0, T1) as SelectableExpression<QS>>
               <(T0, T1, T2) as SelectableExpression<QS>>
               <(T0, T1, T2, T3) as SelectableExpression<QS>>
-            and 149 others
+            and 155 others
     = note: required because of the requirements on the impl of `SelectableExpression<NoFromClause>` for `({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>)`
     = note: 1 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<NoFromClause>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -152,7 +152,7 @@ error[E0277]: the trait bound `{integer}: SelectableExpression<NoFromClause>` is
              <(T0, T1) as SelectableExpression<QS>>
              <(T0, T1, T2) as SelectableExpression<QS>>
              <(T0, T1, T2, T3) as SelectableExpression<QS>>
-           and 149 others
+           and 155 others
    = note: required because of the requirements on the impl of `SelectableExpression<NoFromClause>` for `({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>)`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<NoFromClause>` for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>`
@@ -189,7 +189,7 @@ error[E0277]: the trait bound `{integer}: QueryFragment<Pg>` is not satisfied
              <() as QueryFragment<DB>>
              <(T0, T1) as QueryFragment<__DB>>
              <(T0, T1, T2) as QueryFragment<__DB>>
-           and 266 others
+           and 267 others
    = note: required because of the requirements on the impl of `QueryFragment<Pg>` for `({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>)`
    = note: 3 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryFragment<Pg>` for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>`
@@ -206,7 +206,7 @@ error[E0277]: the trait bound `{integer}: QueryId` is not satisfied
              <() as QueryId>
              <(T0, T1) as QueryId>
              <(T0, T1, T2) as QueryId>
-           and 230 others
+           and 231 others
    = note: required because of the requirements on the impl of `QueryId` for `({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>)`
    = note: 3 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryId` for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>`

--- a/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
@@ -8,8 +8,8 @@ error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisf
              <users::table as JoinTo<Alias<S>>>
              <users::table as JoinTo<BoxedSelectStatement<'a, FromClause<QS>, ST, DB>>>
              <users::table as JoinTo<JoinOn<Join, On>>>
-             <users::table as JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>>
-             <users::table as JoinTo<diesel::internal::table_macro::Join<Left, Right, Kind>>>
+             <users::table as JoinTo<Only<S>>>
+           and 2 others
    = note: required because of the requirements on the impl of `JoinWithImplicitOnClause<posts::table, Inner>` for `users::table`
 
 error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
@@ -22,8 +22,8 @@ error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisf
              <users::table as JoinTo<Alias<S>>>
              <users::table as JoinTo<BoxedSelectStatement<'a, FromClause<QS>, ST, DB>>>
              <users::table as JoinTo<JoinOn<Join, On>>>
-             <users::table as JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>>
-             <users::table as JoinTo<diesel::internal::table_macro::Join<Left, Right, Kind>>>
+             <users::table as JoinTo<Only<S>>>
+           and 2 others
    = note: required because of the requirements on the impl of `JoinWithImplicitOnClause<posts::table, LeftOuter>` for `users::table`
 
 error[E0277]: the trait bound `posts::table: JoinTo<users::table>` is not satisfied
@@ -36,7 +36,7 @@ error[E0277]: the trait bound `posts::table: JoinTo<users::table>` is not satisf
              <posts::table as JoinTo<Alias<S>>>
              <posts::table as JoinTo<BoxedSelectStatement<'a, FromClause<QS>, ST, DB>>>
              <posts::table as JoinTo<JoinOn<Join, On>>>
-             <posts::table as JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>>
-           and 2 others
+             <posts::table as JoinTo<Only<S>>>
+           and 3 others
    = note: required because of the requirements on the impl of `JoinTo<users::table>` for `diesel::internal::table_macro::Join<posts::table, comments::table, Inner>`
    = note: required because of the requirements on the impl of `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<diesel::internal::table_macro::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>` for `users::table`

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
@@ -6,10 +6,10 @@ error[E0277]: the trait bound `bad::columns::age: SelectableExpression<users::ta
    |
    = help: the following implementations were found:
              <bad::columns::age as SelectableExpression<JoinOn<Join, On>>>
+             <bad::columns::age as SelectableExpression<Only<bad::table>>>
              <bad::columns::age as SelectableExpression<SelectStatement<FromClause<From>>>>
              <bad::columns::age as SelectableExpression<bad::table>>
-             <bad::columns::age as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <bad::columns::age as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
+           and 2 others
    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<bad::columns::age>>`
 
 error[E0277]: the trait bound `bad::columns::age: SelectableExpression<users::table>` is not satisfied
@@ -20,10 +20,10 @@ error[E0277]: the trait bound `bad::columns::age: SelectableExpression<users::ta
    |
    = help: the following implementations were found:
              <bad::columns::age as SelectableExpression<JoinOn<Join, On>>>
+             <bad::columns::age as SelectableExpression<Only<bad::table>>>
              <bad::columns::age as SelectableExpression<SelectStatement<FromClause<From>>>>
              <bad::columns::age as SelectableExpression<bad::table>>
-             <bad::columns::age as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <bad::columns::age as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(users::columns::name, bad::columns::age)`
    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, diesel::query_builder::returning_clause::ReturningClause<(users::columns::name, bad::columns::age)>>`
 

--- a/diesel_compile_tests/tests/fail/derive/aliases.stderr
+++ b/diesel_compile_tests/tests/fail/derive/aliases.stderr
@@ -87,10 +87,10 @@ error[E0277]: the trait bound `users::columns::id: SelectableExpression<Alias<us
    |
    = help: the following implementations were found:
              <users::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <users::columns::id as SelectableExpression<Only<users::table>>>
              <users::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <users::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <users::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <users::columns::id as SelectableExpression<users::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectDsl<users::columns::id>` for `SelectStatement<FromClause<Alias<users2>>>`
 
 error[E0277]: the trait bound `users::columns::id: SelectableExpression<Alias<users2>>` is not satisfied
@@ -101,10 +101,10 @@ error[E0277]: the trait bound `users::columns::id: SelectableExpression<Alias<us
    |
    = help: the following implementations were found:
              <users::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <users::columns::id as SelectableExpression<Only<users::table>>>
              <users::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <users::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <users::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <users::columns::id as SelectableExpression<users::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<Alias<users2>>>` for `diesel::query_builder::select_clause::SelectClause<users::columns::id>`
    = note: required because of the requirements on the impl of `Query` for `SelectStatement<FromClause<Alias<users2>>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>`
    = note: required because of the requirements on the impl of `LoadQuery<'_, _, i32>` for `SelectStatement<FromClause<Alias<users2>>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>`
@@ -135,8 +135,8 @@ error[E0277]: the trait bound `users::table: JoinTo<pets::table>` is not satisfi
              <users::table as JoinTo<Alias<S>>>
              <users::table as JoinTo<BoxedSelectStatement<'a, FromClause<QS>, ST, DB>>>
              <users::table as JoinTo<JoinOn<Join, On>>>
-             <users::table as JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>>
-           and 2 others
+             <users::table as JoinTo<Only<S>>>
+           and 3 others
    = note: required because of the requirements on the impl of `JoinTo<pets::table>` for `Alias<users2>`
    = note: required because of the requirements on the impl of `JoinWithImplicitOnClause<Alias<users2>, Inner>` for `pets::table`
 

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
@@ -6,10 +6,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `DistinctOnDsl<posts::columns::id>` for `users::table`
 
 error[E0277]: the trait bound `(diesel::sql_types::Text, diesel::sql_types::Text): SingleValue` is not satisfied
@@ -28,10 +28,10 @@ error[E0277]: the trait bound `users::columns::name: SelectableExpression<posts:
    |
    = help: the following implementations were found:
              <users::columns::name as SelectableExpression<JoinOn<Join, On>>>
+             <users::columns::name as SelectableExpression<Only<users::table>>>
              <users::columns::name as SelectableExpression<SelectStatement<FromClause<From>>>>
              <users::columns::name as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <users::columns::name as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <users::columns::name as SelectableExpression<users::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<posts::table>` for `(posts::columns::name, users::columns::name)`
    = note: required because of the requirements on the impl of `DistinctOnDsl<(posts::columns::name, users::columns::name)>` for `posts::table`
 

--- a/diesel_compile_tests/tests/fail/only_only_on_table.rs
+++ b/diesel_compile_tests/tests/fail/only_only_on_table.rs
@@ -1,0 +1,24 @@
+extern crate diesel;
+
+use diesel::dsl::*;
+use diesel::*;
+
+table! {
+    foo (id) {
+        id -> Int8,
+    }
+}
+
+fn main() {
+    foo::table.select(foo::id).only();
+    foo::table.select(foo::id).filter(foo::id.eq(1)).only();
+    foo::table.select(foo::id.only());
+
+    // .only() is not supported for SQLite
+    let mut conn = SqliteConnection::establish("").unwrap();
+    foo::table.only().load(&mut conn).unwrap();
+
+    // .only() is not supported for MySql
+    let mut conn = MysqlConnection::establish("").unwrap();
+    foo::table.only().load(&mut conn).unwrap();
+}

--- a/diesel_compile_tests/tests/fail/only_only_on_table.stderr
+++ b/diesel_compile_tests/tests/fail/only_only_on_table.stderr
@@ -1,0 +1,96 @@
+error[E0599]: the method `only` exists for struct `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>`, but its trait bounds were not satisfied
+  --> tests/fail/only_only_on_table.rs:13:32
+   |
+13 |       foo::table.select(foo::id).only();
+   |                                  ^^^^ method cannot be called on `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>` due to unsatisfied trait bounds
+   |
+  ::: $DIESEL/src/query_builder/select_statement/mod.rs
+   |
+   | / pub struct SelectStatement<
+   | |     From,
+   | |     Select = DefaultSelectClause<From>,
+   | |     Distinct = NoDistinctClause,
+...  |
+   | |     pub(crate) locking: Locking,
+   | | }
+   | | -
+   | | |
+   | |_doesn't satisfy `_: Table`
+   |   doesn't satisfy `_: diesel::dsl::OnlyDsl`
+   |
+   = note: the following trait bounds were not satisfied:
+           `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: Table`
+           which is required by `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: diesel::dsl::OnlyDsl`
+           `&SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: Table`
+           which is required by `&SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: diesel::dsl::OnlyDsl`
+           `&mut SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: Table`
+           which is required by `&mut SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: diesel::dsl::OnlyDsl`
+
+error[E0599]: the method `only` exists for struct `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>`, but its trait bounds were not satisfied
+  --> tests/fail/only_only_on_table.rs:14:54
+   |
+14 |       foo::table.select(foo::id).filter(foo::id.eq(1)).only();
+   |                                                        ^^^^ method cannot be called on `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>` due to unsatisfied trait bounds
+   |
+  ::: $DIESEL/src/query_builder/select_statement/mod.rs
+   |
+   | / pub struct SelectStatement<
+   | |     From,
+   | |     Select = DefaultSelectClause<From>,
+   | |     Distinct = NoDistinctClause,
+...  |
+   | |     pub(crate) locking: Locking,
+   | | }
+   | | -
+   | | |
+   | |_doesn't satisfy `_: Table`
+   |   doesn't satisfy `_: diesel::dsl::OnlyDsl`
+   |
+   = note: the following trait bounds were not satisfied:
+           `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>: Table`
+           which is required by `SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>: diesel::dsl::OnlyDsl`
+           `&SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>: Table`
+           which is required by `&SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>: diesel::dsl::OnlyDsl`
+           `&mut SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>: Table`
+           which is required by `&mut SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<BigInt, i64>>>>>: diesel::dsl::OnlyDsl`
+
+error[E0599]: the method `only` exists for struct `columns::id`, but its trait bounds were not satisfied
+  --> tests/fail/only_only_on_table.rs:15:31
+   |
+6  | / table! {
+7  | |     foo (id) {
+8  | |         id -> Int8,
+9  | |     }
+10 | | }
+   | | -
+   | | |
+   | | method `only` not found for this
+   | |_doesn't satisfy `columns::id: Table`
+   |   doesn't satisfy `columns::id: diesel::dsl::OnlyDsl`
+...
+15 |       foo::table.select(foo::id.only());
+   |                                 ^^^^ method cannot be called on `columns::id` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `columns::id: Table`
+           which is required by `columns::id: diesel::dsl::OnlyDsl`
+           `&columns::id: Table`
+           which is required by `&columns::id: diesel::dsl::OnlyDsl`
+           `&mut columns::id: Table`
+           which is required by `&mut columns::id: diesel::dsl::OnlyDsl`
+
+error[E0271]: type mismatch resolving `<diesel::SqliteConnection as diesel::Connection>::Backend == Pg`
+  --> tests/fail/only_only_on_table.rs:19:23
+   |
+19 |     foo::table.only().load(&mut conn).unwrap();
+   |                       ^^^^ expected struct `Sqlite`, found struct `Pg`
+   |
+   = note: required because of the requirements on the impl of `LoadQuery<'_, diesel::SqliteConnection, _>` for `Only<foo::table>`
+
+error[E0271]: type mismatch resolving `<diesel::MysqlConnection as diesel::Connection>::Backend == Pg`
+  --> tests/fail/only_only_on_table.rs:23:23
+   |
+23 |     foo::table.only().load(&mut conn).unwrap();
+   |                       ^^^^ expected struct `Mysql`, found struct `Pg`
+   |
+   = note: required because of the requirements on the impl of `LoadQuery<'_, diesel::MysqlConnection, _>` for `Only<foo::table>`

--- a/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
@@ -6,10 +6,10 @@ error[E0277]: the trait bound `non_users::columns::noname: SelectableExpression<
    |
    = help: the following implementations were found:
              <non_users::columns::noname as SelectableExpression<JoinOn<Join, On>>>
+             <non_users::columns::noname as SelectableExpression<Only<non_users::table>>>
              <non_users::columns::noname as SelectableExpression<SelectStatement<FromClause<From>>>>
              <non_users::columns::noname as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <non_users::columns::noname as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <non_users::columns::noname as SelectableExpression<non_users::table>>
+           and 2 others
 
 error[E0277]: the trait bound `non_users::columns::noname: SelectableExpression<users::table>` is not satisfied
   --> tests/fail/returning_clause_requires_selectable_expression.rs:31:20
@@ -19,10 +19,10 @@ error[E0277]: the trait bound `non_users::columns::noname: SelectableExpression<
    |
    = help: the following implementations were found:
              <non_users::columns::noname as SelectableExpression<JoinOn<Join, On>>>
+             <non_users::columns::noname as SelectableExpression<Only<non_users::table>>>
              <non_users::columns::noname as SelectableExpression<SelectStatement<FromClause<From>>>>
              <non_users::columns::noname as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <non_users::columns::noname as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <non_users::columns::noname as SelectableExpression<non_users::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `Query` for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, diesel::query_builder::returning_clause::ReturningClause<non_users::columns::noname>>`
 
 error[E0277]: the trait bound `non_users::columns::noname: SelectableExpression<users::table>` is not satisfied
@@ -33,8 +33,8 @@ error[E0277]: the trait bound `non_users::columns::noname: SelectableExpression<
    |
    = help: the following implementations were found:
              <non_users::columns::noname as SelectableExpression<JoinOn<Join, On>>>
+             <non_users::columns::noname as SelectableExpression<Only<non_users::table>>>
              <non_users::columns::noname as SelectableExpression<SelectStatement<FromClause<From>>>>
              <non_users::columns::noname as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <non_users::columns::noname as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <non_users::columns::noname as SelectableExpression<non_users::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `Query` for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<users::columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<non_users::columns::noname>>`

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
@@ -17,10 +17,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `posts::columns::title`
@@ -45,10 +45,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
    = note: 2 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `lower::lower<posts::columns::title>`
@@ -86,10 +86,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
    = note: 3 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `posts::columns::title`
@@ -114,10 +114,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
    = note: 4 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `lower::lower<posts::columns::title>`
@@ -155,10 +155,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
    = note: 3 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `posts::columns::title`
@@ -183,10 +183,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
    = note: 4 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `lower::lower<posts::columns::title>`
@@ -224,10 +224,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<pets:
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<pets::table, SelectStatement<FromClause<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>` for `posts::columns::title`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<pets::table, SelectStatement<FromClause<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `posts::columns::title`
@@ -252,10 +252,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<pets:
    |
    = help: the following implementations were found:
              <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::title as SelectableExpression<Only<posts::table>>>
              <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::title as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<pets::table, SelectStatement<FromClause<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>` for `posts::columns::title`
    = note: 2 redundant requirements hidden
    = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<pets::table, SelectStatement<FromClause<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `lower::lower<posts::columns::title>`
@@ -293,10 +293,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
     = note: 4 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<pets::table, SelectStatement<FromClause<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `posts::columns::title`
@@ -321,10 +321,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
     = note: 5 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<pets::table, SelectStatement<FromClause<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `lower::lower<posts::columns::title>`

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
@@ -88,10 +88,10 @@ error[E0277]: the trait bound `columns::id: SelectableExpression<SelectStatement
    |
    = help: the following implementations were found:
              <columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <columns::id as SelectableExpression<Only<users::table>>>
              <columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <columns::id as SelectableExpression<users::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `DistinctOnDsl<columns::id>` for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, diesel::query_builder::limit_offset_clause::LimitOffsetClause<diesel::query_builder::limit_clause::NoLimitClause, diesel::query_builder::offset_clause::NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
 
 error[E0271]: type mismatch resolving `<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>>>`

--- a/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
@@ -6,8 +6,8 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectDsl<posts::columns::id>` for `SelectStatement<FromClause<users::table>>`

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -35,10 +35,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
     = note: 4 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -52,10 +52,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
     = note: 4 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -82,10 +82,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::id`
     = note: 4 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -101,10 +101,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>>` for `posts::columns::title`
     = note: 4 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<JoinOn<diesel::internal::table_macro::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -211,10 +211,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -228,10 +228,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -259,10 +259,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -277,10 +277,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -310,10 +310,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -327,10 +327,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -358,10 +358,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -376,10 +376,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -409,10 +409,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -425,10 +425,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -454,10 +454,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
     |
     = help: the following implementations were found:
               <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::id as SelectableExpression<Only<posts::table>>>
               <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::id as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`
@@ -472,10 +472,10 @@ error[E0277]: the trait bound `posts::columns::title: SelectableExpression<users
     |
     = help: the following implementations were found:
               <posts::columns::title as SelectableExpression<JoinOn<Join, On>>>
+              <posts::columns::title as SelectableExpression<Only<posts::table>>>
               <posts::columns::title as SelectableExpression<SelectStatement<FromClause<From>>>>
               <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-              <posts::columns::title as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-              <posts::columns::title as SelectableExpression<posts::table>>
+            and 2 others
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::title)`
     = note: 2 redundant requirements hidden
     = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>`

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
@@ -6,10 +6,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::user_id)`
    = note: required because of the requirements on the impl of `SelectDsl<(posts::columns::id, posts::columns::user_id)>` for `SelectStatement<FromClause<users::table>>`
 
@@ -21,10 +21,10 @@ error[E0277]: the trait bound `posts::columns::user_id: SelectableExpression<use
    |
    = help: the following implementations were found:
              <posts::columns::user_id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::user_id as SelectableExpression<Only<posts::table>>>
              <posts::columns::user_id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::user_id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::user_id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::user_id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, posts::columns::user_id)`
    = note: required because of the requirements on the impl of `SelectDsl<(posts::columns::id, posts::columns::user_id)>` for `SelectStatement<FromClause<users::table>>`
 
@@ -61,10 +61,10 @@ error[E0277]: the trait bound `posts::columns::id: SelectableExpression<users::t
    |
    = help: the following implementations were found:
              <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
              <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
              <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<diesel::internal::table_macro::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<posts::table>>
+           and 2 others
    = note: required because of the requirements on the impl of `SelectableExpression<users::table>` for `(posts::columns::id, users::columns::name)`
    = note: required because of the requirements on the impl of `SelectDsl<(posts::columns::id, users::columns::name)>` for `SelectStatement<FromClause<users::table>>`
 

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -37,6 +37,8 @@ mod internal_details;
 mod joins;
 mod limit_offset;
 mod macros;
+#[cfg(feature = "postgres")]
+mod only;
 mod order;
 mod perf_details;
 mod raw_sql;

--- a/diesel_tests/tests/only.rs
+++ b/diesel_tests/tests/only.rs
@@ -1,0 +1,239 @@
+use crate::schema::connection;
+use diesel::dsl::*;
+use diesel::pg::expression::dsl::OnlyDsl;
+use diesel::prelude::*;
+
+// The reason we declare tables specifically for these tests, is that we test inheritance and thus
+// need two tables for each table to that end, along with an extra column `archived` (although
+// maybe not strictly necessary to test the `ONLY` feature, it serves the use case of using
+// inheritance for archival)
+
+table! {
+    users (id) {
+        id -> Int4,
+        name -> Varchar,
+        archived -> Bool,
+    }
+}
+table! {
+    users_archived (id) {
+        id -> Int4,
+        name -> Varchar,
+        archived -> Bool,
+    }
+}
+table! {
+    posts (id) {
+        id -> Int4,
+        user_id -> Int4,
+        title -> Varchar,
+        body -> Nullable<Text>,
+        tags -> Array<Text>,
+        archived -> Bool,
+    }
+}
+table! {
+    posts_archived (id) {
+        id -> Int4,
+        user_id -> Int4,
+        title -> Varchar,
+        body -> Nullable<Text>,
+        tags -> Array<Text>,
+        archived -> Bool,
+    }
+}
+joinable!(posts -> users (user_id));
+allow_tables_to_appear_in_same_query!(users, users_archived, posts, posts_archived);
+
+fn setup_tables(connection: &mut PgConnection) {
+    // NOTE: In these tests, we don't use foreign key constraints for maximum flexibility.
+    // The reason is that a real FK cannot reference an entry in an inherited table (e.g.
+    // posts_archived), while we want to do so in these tests.
+    for table in &["users", "users_archived", "posts", "posts_archived"] {
+        diesel::sql_query(&format!("DROP TABLE IF EXISTS {} CASCADE", table))
+            .execute(connection)
+            .unwrap();
+    }
+    sql_query(
+        "CREATE TABLE users (
+            id serial primary key,
+            name varchar not null,
+            archived bool not null default false
+        )",
+    )
+    .execute(connection)
+    .unwrap();
+
+    sql_query("CREATE TABLE users_archived (check (archived = true)) inherits (users);")
+        .execute(connection)
+        .unwrap();
+
+    sql_query(
+        "CREATE TABLE posts (
+            id serial primary key,
+            user_id integer not null,
+            title varchar not null,
+            body text,
+            tags text[],
+            archived bool not null default false
+        )",
+    )
+    .execute(connection)
+    .unwrap();
+
+    sql_query("CREATE TABLE posts_archived (check (archived = true)) inherits (posts);")
+        .execute(connection)
+        .unwrap();
+}
+
+fn test_scenario(connection: &mut PgConnection) {
+    // Two users - one is archived.
+    // Each user has two posts - one archived each.
+    let uid: i32 = diesel::insert_into(users::table)
+        .values(users::name.eq("Sean"))
+        .returning(users::id)
+        .get_result(connection)
+        .unwrap();
+    assert_eq!(uid, 1);
+
+    let uid: i32 = diesel::insert_into(users_archived::table)
+        .values((
+            users_archived::name.eq("Tess"),
+            users_archived::archived.eq(true),
+        ))
+        .returning(users_archived::id)
+        .get_result(connection)
+        .unwrap();
+    assert_eq!(uid, 2);
+
+    for user_id in [1, 2] {
+        diesel::insert_into(posts::table)
+            .values((posts::user_id.eq(user_id), posts::title.eq("Post")))
+            .execute(connection)
+            .unwrap();
+        diesel::insert_into(posts_archived::table)
+            .values((
+                posts_archived::user_id.eq(user_id),
+                posts_archived::title.eq("Archived post"),
+                posts_archived::archived.eq(true),
+            ))
+            .execute(connection)
+            .unwrap();
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset, Selectable)]
+#[diesel(table_name = users)]
+pub struct NewUser {
+    pub name: String,
+}
+
+#[test]
+fn select_from_only_with_inherited_table() {
+    let connection = &mut connection();
+    setup_tables(connection);
+    test_scenario(connection);
+
+    // There is now only one entry in the users_archived table, none in the users table.
+
+    let n_users = users::table
+        .select(count(users::id))
+        .first::<i64>(connection)
+        .unwrap();
+    assert_eq!(n_users, 2);
+
+    let n_users_in_main_table = users::table
+        .only()
+        .select(count(users::id))
+        .first::<i64>(connection)
+        .unwrap();
+    assert_eq!(n_users_in_main_table, 1);
+}
+
+#[test]
+fn select_from_only_filtering_and_find() {
+    // Test that it's possible to call `.only().filter(..)`
+    let connection = &mut connection();
+    setup_tables(connection);
+    test_scenario(connection);
+
+    assert_eq!(
+        users::table
+            .only()
+            .filter(users::name.eq("Sean"))
+            .select(users::name)
+            .load::<String>(connection)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        users::table
+            .only()
+            .filter(users::name.eq("Tess"))
+            .select(users::name)
+            .load::<String>(connection)
+            .unwrap()
+            .len(),
+        0
+    );
+    assert_eq!(
+        users::table
+            .only()
+            .find(1)
+            .count()
+            .get_result::<i64>(connection)
+            .unwrap(),
+        1
+    );
+}
+
+#[test]
+fn inner_join_only() {
+    // Test that it's possible to call:
+    // - `.only().inner_join(X::table)`
+    // - `.inner_join(X::table.only())`
+    // - `.only().inner_join(X::table.only())`
+
+    let connection = &mut connection();
+    setup_tables(connection);
+    test_scenario(connection);
+
+    // Exclude archived users
+    let results: Vec<(String, String)> = users::table
+        .only()
+        .inner_join(posts::table)
+        .select((users::name, posts::title))
+        .load(connection)
+        .unwrap();
+    assert_eq!(
+        results,
+        vec![
+            ("Sean".to_string(), "Post".to_string()),
+            ("Sean".to_string(), "Archived post".to_string())
+        ]
+    );
+
+    // Exclude archived posts
+    let results: Vec<(String, String)> = users::table
+        .inner_join(posts::table.only())
+        .select((users::name, posts::title))
+        .load(connection)
+        .unwrap();
+    assert_eq!(
+        results,
+        vec![
+            ("Sean".to_string(), "Post".to_string()),
+            ("Tess".to_string(), "Post".to_string())
+        ]
+    );
+
+    // Exclude archived users and posts
+    let results: Vec<(String, String)> = users::table
+        .only()
+        .inner_join(posts::table.only())
+        .select((users::name, posts::title))
+        .load(connection)
+        .unwrap();
+    assert_eq!(results, vec![("Sean".to_string(), "Post".to_string())]);
+}


### PR DESCRIPTION
`Only<S>` (the result of `mytable.only()`) implements `Table`, and only works on `Pg` backend.

I had to add some new macros with long names `__diesel_internal_backend_specific_*`. For example for a postgres-only part of the `allow_tables_to_appear_in_same_query` macro.