### PR TITLE
Migration guide draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
-For any named minimal supported rust version we guarantee that it is possible to build diesel with the 
+For any named minimal supported Rust version we guarantee that it is possible to build Diesel with the 
 default features enabled using some set of dependencies. Those set of dependencies is not necessarily 
 an up to date version of the specific dependency. We check this by using the unstable `-Z minimal-version` cargo flag. 
-Increasing the minimal supported rust version will always be coupled at least with a minor release.
+Increasing the minimal supported Rust version will always be coupled at least with a minor release.
 
 ## Unreleased
 

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -89,7 +89,7 @@ pub type Asc<Expr> = super::operators::Asc<Expr>;
 pub type Nullable<Expr> = super::nullable::Nullable<Expr>;
 
 /// The return type of
-/// [`expr.assume_not_null()`](crate::expression_methods::ExpressionMethods::assume_not_null())
+/// [`expr.assume_not_null()`](crate::expression_methods::NullableExpressionMethods::assume_not_null())
 pub type AssumeNotNull<Expr> = super::assume_not_null::AssumeNotNull<Expr>;
 
 /// The return type of

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -442,6 +442,54 @@ pub trait ExpressionMethods: Expression + Sized {
     fn asc(self) -> dsl::Asc<Self> {
         Asc::new(self)
     }
+}
+
+impl<T> ExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: SingleValue,
+{
+}
+
+/// Methods present on all expressions
+pub trait NullableExpressionMethods: Expression + Sized {
+    /// Converts this potentially non-null expression into one which is treated
+    /// as nullable. This method has no impact on the generated SQL, and is only
+    /// used to allow certain comparisons that would otherwise fail to compile.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # #![allow(dead_code)]
+    /// # include!("../doctest_setup.rs");
+    /// # use diesel::sql_types::*;
+    /// # use schema::users;
+    /// #
+    /// table! {
+    ///     posts {
+    ///         id -> Integer,
+    ///         user_id -> Integer,
+    ///         author_name -> Nullable<VarChar>,
+    ///     }
+    /// }
+    /// #
+    /// # joinable!(posts -> users (user_id));
+    /// # allow_tables_to_appear_in_same_query!(posts, users);
+    ///
+    /// fn main() {
+    ///     use self::users::dsl::*;
+    ///     use self::posts::dsl::{posts, author_name};
+    ///     let connection = &mut establish_connection();
+    ///
+    ///     let data = users.inner_join(posts)
+    ///         .filter(name.nullable().eq(author_name))
+    ///         .select(name)
+    ///         .load::<String>(connection);
+    ///     println!("{:?}", data);
+    /// }
+    /// ```
+    fn nullable(self) -> dsl::Nullable<Self> {
+        nullable::Nullable::new(self)
+    }
 
     /// Converts this potentially nullable expression into one which will be **assumed**
     /// to be not-null. This method has no impact on the generated SQL, however it will
@@ -559,54 +607,6 @@ pub trait ExpressionMethods: Expression + Sized {
     /// ```
     fn assume_not_null(self) -> dsl::AssumeNotNull<Self> {
         assume_not_null::AssumeNotNull::new(self)
-    }
-}
-
-impl<T> ExpressionMethods for T
-where
-    T: Expression,
-    T::SqlType: SingleValue,
-{
-}
-
-/// Methods present on all expressions
-pub trait NullableExpressionMethods: Expression + Sized {
-    /// Converts this potentially non-null expression into one which is treated
-    /// as nullable. This method has no impact on the generated SQL, and is only
-    /// used to allow certain comparisons that would otherwise fail to compile.
-    ///
-    /// # Example
-    /// ```no_run
-    /// # #![allow(dead_code)]
-    /// # include!("../doctest_setup.rs");
-    /// # use diesel::sql_types::*;
-    /// # use schema::users;
-    /// #
-    /// table! {
-    ///     posts {
-    ///         id -> Integer,
-    ///         user_id -> Integer,
-    ///         author_name -> Nullable<VarChar>,
-    ///     }
-    /// }
-    /// #
-    /// # joinable!(posts -> users (user_id));
-    /// # allow_tables_to_appear_in_same_query!(posts, users);
-    ///
-    /// fn main() {
-    ///     use self::users::dsl::*;
-    ///     use self::posts::dsl::{posts, author_name};
-    ///     let connection = &mut establish_connection();
-    ///
-    ///     let data = users.inner_join(posts)
-    ///         .filter(name.nullable().eq(author_name))
-    ///         .select(name)
-    ///         .load::<String>(connection);
-    ///     println!("{:?}", data);
-    /// }
-    /// ```
-    fn nullable(self) -> dsl::Nullable<Self> {
-        nullable::Nullable::new(self)
     }
 }
 

--- a/guide_drafts/migration_guide.md
+++ b/guide_drafts/migration_guide.md
@@ -6,7 +6,6 @@ This document outlines notable changes and presents potential update strategies.
 We recommend to start the upgrade by removing the usage of all items that 
 are marked as deprecated in Diesel 1.4.x.
 
-We expect that not all users are effected equally by different required changes. 
 Any code base using migrating to Diesel 2.0 is expected to be affected at least by 
 the following changes:
 
@@ -45,7 +44,7 @@ We do not provide explicit migration steps but we encourage users to reach out w
 <a name="2-0-0-mutable-connection"></a>
 
 Diesel now requires mutable access to the `Connection` to perform any database interaction. The following changes
-are required for all usages of a `Connection` type:
+are required for all usages of any `Connection` type:
 
 ```diff
 - let connection = PgConnection::establish_connection("…")?;

--- a/guide_drafts/migration_guide.md
+++ b/guide_drafts/migration_guide.md
@@ -9,7 +9,7 @@ are marked as deprecated in Diesel 1.4.x.
 Any code base using migrating to Diesel 2.0 is expected to be affected at least by 
 the following changes:
 
-* [Diesel requires now a mutable connetion type](2-0-0-mutable-connection)
+* [Diesel now requires a mutable reference to the connection](2-0-0-mutable-connection)
 * [Changed derive attributes](2-0-0-derive-attributes)
 
 Users of `diesel_migration` are additionally affected by the following change:

--- a/guide_drafts/migration_guide.md
+++ b/guide_drafts/migration_guide.md
@@ -1,0 +1,277 @@
+# Diesel 2.0 Migration guide
+
+Diesel 2.0 changes large parts of the internal implementation of diesel. 
+In some cases this impacts code written using Diesel 1.4.x. 
+This document outlines notable changes and presents potential update strategies. 
+We recommend to start the upgrade by removing the usage of all items that 
+are deprecated on Diesel 1.4.x.
+
+We expect that not all users are effected equally by different required changes. 
+Any code base using migrating to Diesel 2.0 is expected to be affected at least by 
+the following changes:
+
+* [Diesel requires now a mutable connetion type](2-0-0-mutable-connection)
+* [Changed derive attributes](2-0-0-derive-attributes)
+
+Any users of `diesel_migration` are additionally affected by the following change:
+
+* [`diesel_migration` rewrite](2-0-0-upgrade-migrations)
+
+Any user of `BoxableExpression` might be affected by the following change:
+
+* [Changed nullability of operators](2-0-0-nullability-ops)
+
+Any users that implement support for their SQL types or type mappings are affected 
+by the following changes:
+
+* [Changed required traits for custom SQL types](2-0-0-custom-type-implementation)
+* [Changed `ToSql` implementations](2-0-0-to-sql)
+* [Changed `FromSql` implementations](2-0-0-from-sql)
+
+Any user that used the `no_arg_sql_function!` macro might want to replace their usage:
+
+* [Deprecated usage of `no_arg_sql_function!` macro](2-0-0-no_arg_sql_function)
+
+Users that update generic diesel code will also be affected by the following changes:
+
+* [Removing `NonAggregate` in favor of `ValidGrouping`](2-0-0-upgrade-non-aggregate)
+* [Changed generic bounds](2-0-0-generic-changes)
+
+Additionally this release contains many changes for users that implemented a custom backend/connection.
+We do not provide explicit migration steps there, but we encourage users to reach out for questions there. 
+
+## Mutable Connections required
+<a name="2-0-0-mutable-connection"></a>
+
+Diesel now requires mutable access to the `Connection` to perform any database interaction. The following changes
+are required for all usages of a `Connection` type:
+
+```diff
+- let connection = PgConnection::establish_connection("…")?;
+- let result = some_query.load(&connection)?;
++ let mut connection = PgConnection::establish_connection("…")?;
++ let result = some_query.load(&mut connection)?;
+```
+
+We expect that this is a straightforward change as there connection already can execute only one query at the time.
+
+
+## Derive attributes
+<a name="2-0-0-derive-attributes"></a>
+
+We have updated all of our diesel derive attributes to follow the patterns that are used
+widely in the rust ecosystem. This means that all of them need to be wrapped by `#[diesel()]` now. And you can specify multiple attributes on the same line now separated by `,`.
+
+This is backward compatible and thus all of your old attributes will still work, but with
+warnings. The attributes can be upgraded by either looking at the warnings or by reading
+diesel derive documentation reference.
+
+## `diesel_migration` rewrite
+<a name = "2-0-0-upgrade-migrations"></a>
+
+We have completely rewritten the `diesel_migration` crate. As part of this rewrite all 
+free standing functions are removed from `diesel_migration`. Equivalent functionality 
+is now provided by the `MigrationHarness` trait, which is implemented for any `Connection` 
+type and for `HarnessWithOutput`. Checkout their documentation for details.
+
+Additionally this rewrite changed the way we provide migrations. Instead of having a own implementation
+for file based and embedded migration we now provide a unified `MigrationSource` trait to abstract 
+over the differences. `diesel_migration` provides two implementations:
+
+* `FileBasedMigrations`, which mirrors the existing behaviour to load raw sql migrations at run time
+form a specific directory
+* `EmbeddedMigrations`, which mirrors the existing `embed_migrations!` macro. 
+
+Finally the `embed_migrations!()` macro itself changed. Instead of generating a magical embedded module 
+it now generates an instance of `EmbeddedMigrations`, that could be stored in a constant for example.
+
+That means code using `embed_migrations!()` needs to be changed from
+```rust
+embed_migrations!()
+
+fn run_migration(conn: &PgConnection) {
+    embedded_migrations::run(conn).unwrap()
+}
+```
+to 
+```rust
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+
+fn run_migration(conn: &PgConnection) {
+    conn.run_pending_migrations(MIGRATIONS).unwrap();
+}
+```
+
+## Changed nullability of operators
+<a name="2-0-0-nullability-ops"></a>
+
+We changed the way how we handle the propagation of null values through binary operators. Diesel 1.x always assumed 
+that the result of a binary operation `value_a > value_b` is not nullable, which does not match the behaviour of the 
+underlying databases. `value_a > null` may return a `NULL` value there. With Diesel 2.0 we changed this to match more
+closely the behaviour of the underlying databases. We expect that this change has the biggest impact on existing usages
+of `BoxableExpression` as it may change the resulting sql type there. As possibly workaround for divering sql types 
+there we recommend to use one of the following functions:
+
+* `NullableExpressionMethods::nullable()`
+* `NullableExpressionMethods::assume_not_nullable()`
+
+## Custom SQL type implementations
+<a name="2-0-0-custom-type-implementation"></a>
+
+We changed how we mark sql types as nullable at type level. For this we replaced the `NonNull` trait with a 
+more generic `SqlType` trait, which allows to mark a sql type as (non-) nullable. This may affect custom
+sql type implementations.
+
+Users that already use the existing `#[derive(SqlType)]` do not need to change any code. The derive internally
+generates the correct code after the update. Users that use a manual implementation of `NonNull` need to replace
+it with a corresponding `SqlType` implementation:
+
+```diff
+- impl NonNull for MyCustomSqlType {}
++ impl SqlType for MyCustomSqlType {
++     type IsNull = diesel::sql_types::is_nullable::NotNull;
++ }
+```
+
+Additionally the diesel CLI tool was changed so that it automatically generates the rust side definition of custom SQL types 
+as long as they appear on any table. This feature currently only supports the PostgreSQL backend, as all other supported backends
+do not support real custom types at SQL level at all.
+
+## Changed `ToSql` implementations
+
+We restructured the way diesel serializes rust values to their backend specific representation.
+This enables us to skip copying the value at all if the specific backend supports writing to a 
+shared buffer. Unfortunately, this feature requires changes to the `ToSql` trait. This change introduces
+a lifetime that ensures that a value implementing `ToSql` outlives the underlying serialisation buffer.
+Additionally we separated the output buffer type for Sqlite from the type used for PostgreSQL and Mysql.
+
+This has the implication that for generic implementations using a inner existing `ToSql` implementation you cannot
+create temporary values anymore and forward them to the inner implementation.
+
+For backend concrete implementations there are the following functions avaible to workaround this limitation:
+
+* `Output::reborrow()` for the `Pg` and `Mysql` backend
+* `Output::set_value()` for the `Sqlite` backend (Checkout the documentation of `SqliteBindValue` for accepted values)
+
+
+
+## Changed `FromSql` implementations
+<a name="2-0-0-from-sql"></a>
+
+We changed the raw value representation for both, the postgres and mysql
+backend, from a `& [u8]` to an opaque type. This allows us to include additional information like the database side
+type there. This change enables users to write `FromSql` implementations that decide dynamically which kind of value
+was received. The new value types for both backends expose a `as_bytes()` method to access the underlying byte buffer.
+
+Any affected backend needs to perform the following changes:
+
+```diff
+impl<DB: Backend> FromSql<YourSqlType, DB> for YourType {
+-    fn from_sql(bytes: &[u8]) -> deserialize::Result<Self> {
++    fn from_sql(value: backend::RawValue<DB>) -> deserialize::Result<Self> {
++        let bytes = value.as_bytes();
+         // …
+     }
+}
+```
+
+
+
+## `no_arg_sql_function`
+<a name="2-0-0-no_arg_sql_function"></a>
+
+The `no_arg_sql_function` was deprecated without direct replacement. At the same time the
+`sql_function!` macro gained support for sql functions without argument. This support generates slightly 
+different code. Instead of representing the sql function as zero sized struct, `sql_function!` will generate an ordinary function call without arguments. This requires changing any usage of the generated dsl. This change 
+affects any usage of `no_arg_sql_function!` in third party crates.
+
+```diff
+- no_arg_sql_function!(now, sql_types::Timestamp, "Represents the SQL NOW() function");
+- 
+- diesel::select(now)
+ 
++ sql_function!{
++     /// Represents the SQL NOW() function
++     fn now() -> sql_types::Timestamp;
++ }
++
++ diesel::select(now())
+```
+
+### Replacement of `NonAggregate` with `ValidGrouping`
+<a name="2-0-0-upgrade-non-aggregate"></a>
+
+Diesel does now fully enforce aggregation rules, which required us to change the way we represent aggregation 
+at the type system level. This is used to provide `group_by` support. Diesels aggregation rules 
+match the semantics of PostgreSQL or Mysql with the `ONLY_FULL_GROUP_BY` option enabled.
+
+As part of this change we removed the `NonAggregate` trait in favor of a new more expressive `ValidGrouping`
+trait. Existing implementations of `NonAggregate` must be replaced with an equivalent `ValidGrouping` implementation.
+
+The following change shows how to replace an existing implementation with a strictly equivalent implementation.
+```diff
+- impl NonAggregate for MyQueryNode {}
++ impl ValidGrouping<()> for MyQueryNode {
++    type IsAggregate = is_aggregate::No;
++ }
+```
+Additional changes may be required to adapt custom query ast implementations to fully support `group_by` clauses. 
+Checkout the documentation of `ValidGrouping` for details there.
+
+In addition any occurrence of `NonAggregate` in trait bounds needs to be replaced. Again the following
+change shows the strictly equivalent version:
+
+```diff
+ where
+-     T: NonAggregate,
++     T: ValidGrouping<()>,
++     T::IsAggregate: MixedGrouping<is_aggregate::No, Output = is_aggregate::No>,
++     is_aggregate::No: MixedGrouping<T::IsAggregate, Output = is_aggregate::No>,
+```
+
+
+## Other changes to generics
+<a name="2-0-0-generic-changes">
+
+In addition to the changes listed above, we changed numerous internal details of diesel. This will have impacts on
+most people that wrote non trivial generic code abstracting over diesel. This section tries to list as much of those
+changes as possible
+
+### Removed most of the non-public reachable API
+
+With Diesel 2.0 we removed most of the API which was marked with `#[doc(hidden)]`. Technically these parts of the API 
+have always been private to diesel. This change enforces this distinction a in a stricter way. In addition some
+parts of these formerly hidden API are now documented and exposed behind the
+`i-implement-a-third-party-backend-and-opt-into-breaking-changes` crate feature. As the name already implies 
+we reserve the right to change these API's between different diesel 2.x minor releases, so you should always specify
+a concrete minor release version if you use these API's.
+If you depended on such an API and you cannot find a suitable replacement we invite you to work with us on exposing the corresponding 
+feature as part of the stable API.
+
+### Changed structure of the deserialization traits
+
+We changed the internal structure of the `FromSqlRow`, `Queryable` and `QueryableByName` trait family used for deserialization. This change allows us to unify our deserialization code.
+We hopefully put sufficient wild card implementations in place so that old trait bounds imply 
+the right trait anyway. For cases where this does not hold true, the following changes may be required:
+
+`Queryable<ST, DB>` is now equivalent to `FromSqlRow<ST, DB>`. The later is used as actual trait bound 
+on the corresponding `RunQueryDsl` methods.
+`QueryableByName<DB>` is now equivalent to `FromSqlRow<Untyped, DB>`. The later is used as actual trait 
+on the corresponding `RunQueryDsl` methods.
+
+### Changed the scope of `QueryFragment` implementations
+
+With diesel 2.0 we introduced a way to specialise `QueryFragment` implementations for specific backend, while 
+providing a generic implementation for other backends. To be able to use this feature in the future we marked
+existing wild card `QueryFragment` implementations with an additional `DieselReserveSpecialization`. 
+Rustc suggests just adding an additional trait bound on this trait. It's not possible to add a bound on 
+this trait without opting into breaking changes and it's almost never required to actually do that. Any
+occurrence of an error mentioning this trait can simply be fixed by adding a trait bound like follows:
+```rust
+where
+    QueryAstNodeMentionedInTheErrorMessage: QueryFragment<BackendType>
+```
+
+This rule has one notable exception: Third party backend implementations. We expect those backends to opt into the 
+`i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature anyway, as it's otherwise not possible to 
+implement a third party backend.


### PR DESCRIPTION
This PR adds a first draft of the migration guide for the diesel 2.0 release. I would like to have something in place for a rc release.

[Rendered draft](https://github.com/weiznich/diesel/blob/migration_guide/guide_drafts/migration_guide.md)

Additionally I've put two small other related changes in here:
* Updating the changelog a bit
* Moving `assume_not_nullable` to `NullableExpressionMethods` as that is a better place for it, right next to `nullable()`.

Comments and improvements to the guide are welcome.

(To the other changes as well)