### PR TITLE
Add documentation to diesel's r2d2 module on what happens when connections fail inside a pool

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -1,6 +1,20 @@
 //! Connection pooling via r2d2.
 //!
 //! Note: This module requires enabling the `r2d2` feature
+//!
+//! When used inside a pool, if an individual connection becomes
+//! broken (as determined by the [R2D2Connection::is_broken] method)
+//! then `r2d2` will put close and return the connection to the DB.
+//!
+//! `diesel` determines broken connections by whether or not the current
+//! thread is panicking or if individual `Connection` structs are
+//! broken (determined by the `is_broken()` method). Generically, these
+//! are left to individual backends to implement themselves.
+//!
+//! For SQLite, PG, and MySQL backends, specifically, `is_broken()`
+//! is determined by whether or not the `TransactionManagerStatus` (as a part
+//! of the `AnsiTransactionManager` struct) is in an `InError` state.
+//!
 
 pub use r2d2::*;
 


### PR DESCRIPTION
Addresses questions from https://github.com/diesel-rs/diesel/issues/2963

I wasn't sure if this was the best place to put this documentation as this is a module level docstring, though only concerns itself with errors, so... 🤷‍♂️  perhaps [here](https://github.com/diesel-rs/diesel/blob/a12f95f70d8f32eaefb42ec9d4e4b93904a51c96/diesel/src/r2d2.rs#L78) is a better place to put it? In any case, wanted to push up this documentation first for a check on accuracy 