### PR TITLE
Add documentation in `r2d2` module of example application using connection pooling

### DIFF
--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -5,6 +5,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "postgres")] {
         #[allow(dead_code)]
         type DB = diesel::pg::Pg;
+        type DbConnection = PgConnection;
 
         fn database_url_for_env() -> String {
             database_url_from_env("PG_DATABASE_URL")
@@ -15,30 +16,36 @@ cfg_if::cfg_if! {
             PgConnection::establish(&connection_url).unwrap()
         }
 
+        fn setup_database(connection: &mut PgConnection) {
+            connection.begin_test_transaction().unwrap();
+            clean_tables(connection);
+            create_tables_with_data(connection);
+        }
+
+        fn clean_tables(connection: &mut PgConnection) {
+            diesel::sql_query("DROP TABLE IF EXISTS users CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS animals CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS posts CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS comments CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS brands CASCADE").execute(connection).unwrap();
+        }
+
         fn connection_no_data() -> PgConnection {
             let mut connection = connection_no_transaction();
             connection.begin_test_transaction().unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS users CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS animals CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS posts CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS comments CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS brands CASCADE").execute(&mut connection).unwrap();
-
+            clean_tables(&mut connection);
             connection
         }
 
-        #[allow(dead_code)]
-        fn establish_connection() -> PgConnection {
-            let mut connection = connection_no_data();
-
+        fn create_tables_with_data(connection: &mut PgConnection) {
             diesel::sql_query("CREATE TABLE users (
                 id SERIAL PRIMARY KEY,
                 name VARCHAR NOT NULL
             )")
-                .execute(&mut connection)
+                .execute(connection)
                 .unwrap();
             diesel::sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
-                .execute(&mut connection)
+                .execute(connection)
                 .unwrap();
 
             diesel::sql_query("CREATE TABLE animals (
@@ -47,44 +54,50 @@ cfg_if::cfg_if! {
                 legs INTEGER NOT NULL,
                 name VARCHAR
             )")
-                .execute(&mut connection)
+                .execute(connection)
                 .unwrap();
             diesel::sql_query("INSERT INTO animals (species, legs, name) VALUES
                                ('dog', 4, 'Jack'),
                                ('spider', 8, null)"
-            ).execute(&mut connection).unwrap();
+            ).execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE posts (
                 id SERIAL PRIMARY KEY,
                 user_id INTEGER NOT NULL,
                 title VARCHAR NOT NULL
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO posts (user_id, title) VALUES
                 (1, 'My first post'),
                 (1, 'About Rust'),
-                (2, 'My first post too')").execute(&mut connection).unwrap();
+                (2, 'My first post too')").execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE comments (
                 id SERIAL PRIMARY KEY,
                 post_id INTEGER NOT NULL,
                 body VARCHAR NOT NULL
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO comments (post_id, body) VALUES
                 (1, 'Great post'),
                 (2, 'Yay! I am learning Rust'),
-                (3, 'I enjoyed your post')").execute(&mut connection).unwrap();
+                (3, 'I enjoyed your post')").execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE brands (
                 id SERIAL PRIMARY KEY,
                 color VARCHAR NOT NULL DEFAULT 'Green',
                 accent VARCHAR DEFAULT 'Blue'
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
+        }
 
+        #[allow(dead_code)]
+        fn establish_connection() -> PgConnection {
+            let mut connection = connection_no_data();
+            create_tables_with_data(&mut connection);
             connection
         }
     } else if #[cfg(feature = "sqlite")] {
         #[allow(dead_code)]
         type DB = diesel::sqlite::Sqlite;
+        type DbConnection = SqliteConnection;
 
         fn database_url_for_env() -> String {
             String::from(":memory:")
@@ -94,119 +107,136 @@ cfg_if::cfg_if! {
             SqliteConnection::establish(":memory:").unwrap()
         }
 
-        #[allow(dead_code)]
-        fn establish_connection() -> SqliteConnection {
-            let mut connection = connection_no_data();
+        fn setup_database(connection: &mut SqliteConnection) {
+            create_tables_with_data(connection);
+        }
 
+        fn create_tables_with_data(connection: &mut SqliteConnection) {
             diesel::sql_query("CREATE TABLE users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name VARCHAR NOT NULL
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
-                .execute(&mut connection).unwrap();
+                .execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE animals (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 species VARCHAR NOT NULL,
                 legs INTEGER NOT NULL,
                 name VARCHAR
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO animals (species, legs, name) VALUES
                                ('dog', 4, 'Jack'),
                                ('spider', 8, null)"
-            ).execute(&mut connection).unwrap();
+            ).execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE posts (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 user_id INTEGER NOT NULL,
                 title VARCHAR NOT NULL
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO posts (user_id, title) VALUES
                 (1, 'My first post'),
                 (1, 'About Rust'),
-                (2, 'My first post too')").execute(&mut connection).unwrap();
+                (2, 'My first post too')").execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE comments (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 post_id INTEGER NOT NULL,
                 body VARCHAR NOT NULL
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO comments (post_id, body) VALUES
                 (1, 'Great post'),
                 (2, 'Yay! I am learning Rust'),
-                (3, 'I enjoyed your post')").execute(&mut connection).unwrap();
+                (3, 'I enjoyed your post')").execute(connection).unwrap();
+        }
 
+        #[allow(dead_code)]
+        fn establish_connection() -> SqliteConnection {
+            let mut connection = connection_no_data();
+            create_tables_with_data(&mut connection);
             connection
         }
     } else if #[cfg(feature = "mysql")] {
         #[allow(dead_code)]
         type DB = diesel::mysql::Mysql;
+        type DbConnection = MysqlConnection;
 
         fn database_url_for_env() -> String {
             database_url_from_env("MYSQL_UNIT_TEST_DATABASE_URL")
         }
 
+        fn setup_database(connection: &mut MysqlConnection) {
+            clean_tables(connection);
+            create_tables_with_data(connection);
+        }
+
+        fn clean_tables(connection: &mut MysqlConnection) {
+            diesel::sql_query("SET FOREIGN_KEY_CHECKS=0").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS users CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS animals CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS posts CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS comments CASCADE").execute(connection).unwrap();
+            diesel::sql_query("DROP TABLE IF EXISTS brands CASCADE").execute(connection).unwrap();
+            diesel::sql_query("SET FOREIGN_KEY_CHECKS=1").execute(connection).unwrap();
+        }
+
         fn connection_no_data() -> MysqlConnection {
             let connection_url = database_url_for_env();
             let mut connection = MysqlConnection::establish(&connection_url).unwrap();
-            diesel::sql_query("SET FOREIGN_KEY_CHECKS=0").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS users CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS animals CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS posts CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS comments CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("DROP TABLE IF EXISTS brands CASCADE").execute(&mut connection).unwrap();
-            diesel::sql_query("SET FOREIGN_KEY_CHECKS=1").execute(&mut connection).unwrap();
-
+            clean_tables(&mut connection);
             connection
         }
 
-        #[allow(dead_code)]
-        fn establish_connection() -> MysqlConnection {
-            let mut connection = connection_no_data();
-
+        fn create_tables_with_data(connection: &mut MysqlConnection) {
             diesel::sql_query("CREATE TABLE users (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 name TEXT NOT NULL
-            ) CHARACTER SET utf8mb4").execute(&mut connection).unwrap();
+            ) CHARACTER SET utf8mb4").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
-                      .execute(&mut connection).unwrap();
+                      .execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE animals (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 species TEXT NOT NULL,
                 legs INTEGER NOT NULL,
                 name TEXT
-            ) CHARACTER SET utf8mb4").execute(&mut connection).unwrap();
+            ) CHARACTER SET utf8mb4").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO animals (species, legs, name) VALUES
                                ('dog', 4, 'Jack'),
-                               ('spider', 8, null)").execute(&mut connection).unwrap();
+                               ('spider', 8, null)").execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE posts (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 user_id INTEGER NOT NULL,
                 title TEXT NOT NULL
-            ) CHARACTER SET utf8mb4").execute(&mut connection).unwrap();
+            ) CHARACTER SET utf8mb4").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO posts (user_id, title) VALUES
                 (1, 'My first post'),
                 (1, 'About Rust'),
-                (2, 'My first post too')").execute(&mut connection).unwrap();
+                (2, 'My first post too')").execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE comments (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 post_id INTEGER NOT NULL,
                 body TEXT NOT NULL
-            ) CHARACTER SET utf8mb4").execute(&mut connection).unwrap();
+            ) CHARACTER SET utf8mb4").execute(connection).unwrap();
             diesel::sql_query("INSERT INTO comments (post_id, body) VALUES
                 (1, 'Great post'),
                 (2, 'Yay! I am learning Rust'),
-                (3, 'I enjoyed your post')").execute(&mut connection).unwrap();
+                (3, 'I enjoyed your post')").execute(connection).unwrap();
 
             diesel::sql_query("CREATE TABLE brands (
                 id INTEGER PRIMARY KEY AUTO_INCREMENT,
                 color VARCHAR(255) NOT NULL DEFAULT 'Green',
                 accent VARCHAR(255) DEFAULT 'Blue'
-            )").execute(&mut connection).unwrap();
+            )").execute(connection).unwrap();
+        }
 
+        #[allow(dead_code)]
+        fn establish_connection() -> MysqlConnection {
+            let mut connection = connection_no_data();
+            create_tables_with_data(&mut connection);
             connection.begin_test_transaction().unwrap();
             connection
         }

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -6,8 +6,12 @@ cfg_if::cfg_if! {
         #[allow(dead_code)]
         type DB = diesel::pg::Pg;
 
+        fn database_url_for_env() -> String {
+            database_url_from_env("PG_DATABASE_URL")
+        }
+
         fn connection_no_transaction() -> PgConnection {
-            let connection_url = database_url_from_env("PG_DATABASE_URL");
+            let connection_url = database_url_for_env();
             PgConnection::establish(&connection_url).unwrap()
         }
 
@@ -82,6 +86,10 @@ cfg_if::cfg_if! {
         #[allow(dead_code)]
         type DB = diesel::sqlite::Sqlite;
 
+        fn database_url_for_env() -> String {
+            String::from(":memory:")
+        }
+
         fn connection_no_data() -> SqliteConnection {
             SqliteConnection::establish(":memory:").unwrap()
         }
@@ -134,8 +142,12 @@ cfg_if::cfg_if! {
         #[allow(dead_code)]
         type DB = diesel::mysql::Mysql;
 
+        fn database_url_for_env() -> String {
+            database_url_from_env("MYSQL_UNIT_TEST_DATABASE_URL")
+        }
+
         fn connection_no_data() -> MysqlConnection {
-            let connection_url = database_url_from_env("MYSQL_UNIT_TEST_DATABASE_URL");
+            let connection_url = database_url_for_env();
             let mut connection = MysqlConnection::establish(&connection_url).unwrap();
             diesel::sql_query("SET FOREIGN_KEY_CHECKS=0").execute(&mut connection).unwrap();
             diesel::sql_query("DROP TABLE IF EXISTS users CASCADE").execute(&mut connection).unwrap();

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -18,8 +18,6 @@
 //! use diesel::r2d2::ConnectionManager;
 //! use diesel::r2d2::Pool;
 //! use std::env;
-//! use std::sync::Arc;
-//! use std::sync::Mutex;
 //! use std::thread;
 //!
 //! pub type PostgresPool = Pool<ConnectionManager<PgConnection>>;
@@ -60,18 +58,17 @@
 //!
 //! fn main() {
 //!     let pool_size = 1;
-//!     let connection_pool = Arc::new(Mutex::new(get_connection_pool(pool_size)));
-//!     setup_user_table(&mut connection_pool.lock().unwrap().get().unwrap());
+//!     let pool = get_connection_pool(pool_size);
+//!     setup_user_table(&mut pool.get().unwrap());
 //!
 //!     let mut threads = vec![];
 //!     let max_users_to_create = 1;
 //!
 //!     for i in 0..max_users_to_create {
-//!         let connection_pool = Arc::clone(&connection_pool);
+//!         let pool = pool.clone();
 //!         threads.push(thread::spawn({
 //!             move || {
-//!                 let connection_pool = connection_pool.lock().unwrap();
-//!                 let conn = &mut connection_pool.get().unwrap();
+//!                 let conn = &mut pool.get().unwrap();
 //!                 let name = format!("Person {}", i);
 //!                 create_user(conn, &name).unwrap();
 //!             }
@@ -82,7 +79,7 @@
 //!         handle.join().unwrap();
 //!     }
 //!
-//!     delete_user_table(&mut connection_pool.lock().unwrap().get().unwrap());
+//!     delete_user_table(&mut pool.get().unwrap());
 //! }
 //! ```
 //!


### PR DESCRIPTION
# Description

Addresses https://github.com/diesel-rs/diesel/issues/1951 by adding a small application as a doctest to the `r2d2` module

In addition to that, I've notably had to do a few things to the `doctest_setup.rs` module:
- Moved all the `DROP TABLE` statements into a `clean_tables()` function
- And all the `CREATE` and `INSERT` ones into a `create_tables_with_data()` one
- Both of which explicitly take `&mut DbConnection` as their single argument

# Testing

`bin/test` passes all the way up until [this test](https://github.com/diesel-rs/diesel/blob/cb9ac5e5329391b780127beea7a1be07590122f0/bin/test#L44) at which point I get the following errors which seem unrelated?
```
+ cd diesel_tests
+ cargo test --features mysql --no-default-features -- --test-threads 1
   Compiling diesel_derives v2.0.0 (/Users/stevenchu/personal_projects/rust/diesel/diesel_derives)
   Compiling diesel v2.0.0 (/Users/stevenchu/personal_projects/rust/diesel/diesel)
   Compiling diesel_migrations v2.0.0 (/Users/stevenchu/personal_projects/rust/diesel/diesel_migrations)
   Compiling diesel_tests v0.1.0 (/Users/stevenchu/personal_projects/rust/diesel/diesel_tests)
error[E0599]: the method `execute` exists for mutable reference `&mut diesel::MysqlConnection`, but its trait bounds were not satisfied
   --> diesel_tests/tests/expressions/ops.rs:209:10
    |
209 |         .execute("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
    |          ^^^^^^^ method cannot be called on `&mut diesel::MysqlConnection` due to unsatisfied trait bounds
    |
   ::: /Users/stevenchu/personal_projects/rust/diesel/diesel/src/mysql/connection/mod.rs:26:1
    |
26  | pub struct MysqlConnection {
    | --------------------------
    | |
    | doesn't satisfy `diesel::MysqlConnection: diesel::RunQueryDsl<_>`
    | doesn't satisfy `diesel::MysqlConnection: diesel::Table`
    |
    = note: the following trait bounds were not satisfied:
            `&mut diesel::MysqlConnection: diesel::Table`
            which is required by `&mut diesel::MysqlConnection: diesel::RunQueryDsl<_>`
            `&&mut diesel::MysqlConnection: diesel::Table`
            which is required by `&&mut diesel::MysqlConnection: diesel::RunQueryDsl<_>`
            `&mut &mut diesel::MysqlConnection: diesel::Table`
            which is required by `&mut &mut diesel::MysqlConnection: diesel::RunQueryDsl<_>`
            `diesel::MysqlConnection: diesel::Table`
            which is required by `diesel::MysqlConnection: diesel::RunQueryDsl<_>`
            `&diesel::MysqlConnection: diesel::Table`
            which is required by `&diesel::MysqlConnection: diesel::RunQueryDsl<_>`
...
```