### PR TITLE
Reduced the required dependencies for diesel_dynamic_schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path diesel_dynamic_schema/Cargo.toml --no-default-features --features "${{ matrix.backend }}"
+          args: --manifest-path diesel_dynamic_schema/Cargo.toml --no-default-features --features "${{ matrix.backend }} diesel/${{ matrix.backend }}"
 
       - name: Run diesel_benches
         uses: actions-rs/cargo@v1
@@ -422,7 +422,6 @@ jobs:
           RUSTFLAGS: -Zsanitizer=address
           ASAN_OPTIONS: detect_stack_use_after_return=1
         run: cargo -Z build-std test --manifest-path diesel/Cargo.toml --no-default-features --features "sqlite extras libsqlite3-sys libsqlite3-sys/bundled libsqlite3-sys/with-asan" --target x86_64-unknown-linux-gnu
-
 
   minimal_rust_version:
     name: Check Minimal supported rust version (1.54.0)

--- a/bin/test
+++ b/bin/test
@@ -26,7 +26,7 @@ else
   (cd diesel_migrations && cargo test --features "sqlite diesel/sqlite" $*)
   (cd diesel_derives && cargo test --features "diesel/sqlite" $*)
   (cd diesel_tests && cargo test --features "sqlite" --no-default-features $*)
-  (cd diesel_dynamic_schema && cargo test --features "sqlite" $*)
+  (cd diesel_dynamic_schema && cargo test --features "sqlite diesel/sqlite" $*)
   (cd diesel_bench && cargo test --features "sqlite" --benches $*)
 
   (cd diesel_migrations && cargo test --features "postgres diesel/postgres" $*)
@@ -34,7 +34,7 @@ else
   (cd diesel_derives && cargo test --features "diesel/postgres" $*)
   (cd diesel_cli && cargo test --features "postgres" --no-default-features $*)
   (cd diesel_tests && cargo test --features "postgres" --no-default-features $*)
-  (cd diesel_dynamic_schema && cargo test --features "postgres" $*)
+  (cd diesel_dynamic_schema && cargo test --features "postgres diesel/postgres" $*)
   (cd diesel_bench && cargo test --features "postgres" --benches $*)
 
   (cd diesel_migrations && cargo test --features "mysql diesel/mysql" $* -- --test-threads 1)
@@ -42,7 +42,7 @@ else
   (cd diesel_derives && cargo test --features "diesel/mysql" $* -- --test-threads 1)
   (cd diesel_cli && cargo test --features "mysql" --no-default-features $* -- --test-threads 1)
   (cd diesel_tests && cargo test --features "mysql" --no-default-features $* -- --test-threads 1)
-  (cd diesel_dynamic_schema && cargo test --features "mysql" $* -- --test-threads 1)
+  (cd diesel_dynamic_schema && cargo test --features "mysql diesel/mysql" $* -- --test-threads 1)
   (cd diesel_bench && cargo test --features "mysql" --benches $* -- --test-threads 1)
 
   (cd diesel_compile_tests && cargo test $*)

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -12,6 +12,12 @@ version = "2.0.0"
 path = "../diesel/"
 default-features = false
 
+[dev-dependencies.diesel]
+version = "2.0.0"
+path = "../diesel/"
+default-features = false
+features = ["postgres", "mysql"]
+
 [dev-dependencies]
 dotenvy = "0.15"
 

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -12,12 +12,6 @@ version = "2.0.0"
 path = "../diesel/"
 default-features = false
 
-[dev-dependencies.diesel]
-version = "2.0.0"
-path = "../diesel/"
-default-features = false
-features = ["postgres", "mysql"]
-
 [dev-dependencies]
 dotenvy = "0.15"
 

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -37,6 +37,6 @@ harness = true
 
 [features]
 default = []
-postgres = ["diesel/postgres"]
+postgres = ["diesel/postgres_backend"]
 sqlite = ["diesel/sqlite"]
-mysql = ["diesel/mysql"]
+mysql = ["diesel/mysql_backend"]


### PR DESCRIPTION
Now that we have the `postgres_backend` and `mysql_backend` features (would it make sense to also have the `sqlite_backend` feature?), I think it should be possible to use these dependencies so that we don't need to compile the system features. This can reduce compilation time of crates that provide their own PostgreSQL and MySQL connections (such as the new async connections).