### PR TITLE
Determining closed connections using `PQstatus` rather than matching on message strings

### DIFF
--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -41,7 +41,7 @@ impl SimpleConnection for PgConnection {
     fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
         let query = CString::new(query)?;
         let inner_result = unsafe { self.raw_connection.exec(query.as_ptr()) };
-        PgResult::new(inner_result?)?;
+        PgResult::new(inner_result?, &self.raw_connection)?;
         Ok(())
     }
 }

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -15,6 +15,12 @@ pub(super) struct RawConnection {
     internal_connection: NonNull<PGconn>,
 }
 
+impl From<&RawConnection> for *const PGconn {
+    fn from(raw_conn: &RawConnection) -> *const PGconn {
+        raw_conn.internal_connection.as_ptr()
+    }
+}
+
 impl RawConnection {
     pub(super) fn establish(database_url: &str) -> ConnectionResult<Self> {
         let connection_string = CString::new(database_url)?;

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -104,7 +104,7 @@ impl RawConnection {
     }
 
     pub(super) fn get_status(&self) -> ConnStatusType {
-        unsafe { PQstatus(self.internal_connection.as_ptr() as *const PGconn) }
+        unsafe { PQstatus(self.internal_connection.as_ptr()) }
     }
 }
 

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -15,12 +15,6 @@ pub(super) struct RawConnection {
     internal_connection: NonNull<PGconn>,
 }
 
-impl From<&RawConnection> for *const PGconn {
-    fn from(raw_conn: &RawConnection) -> *const PGconn {
-        raw_conn.internal_connection.as_ptr()
-    }
-}
-
 impl RawConnection {
     pub(super) fn establish(database_url: &str) -> ConnectionResult<Self> {
         let connection_string = CString::new(database_url)?;
@@ -107,6 +101,10 @@ impl RawConnection {
 
     pub(super) fn transaction_status(&self) -> PgTransactionStatus {
         unsafe { PQtransactionStatus(self.internal_connection.as_ptr()) }.into()
+    }
+
+    pub(super) fn get_status(&self) -> ConnStatusType {
+        unsafe { PQstatus(self.internal_connection.as_ptr() as *const PGconn) }
     }
 }
 

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -70,8 +70,8 @@ impl PgResult {
                         _ => DatabaseErrorKind::Unknown,
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
-                let pc: *const PGconn = conn.into();
-                if unsafe { PQstatus(pc) } == ConnStatusType::CONNECTION_BAD {
+                let pg_connection: *const PGconn = conn.into();
+                if unsafe { PQstatus(pg_connection) } == ConnStatusType::CONNECTION_BAD {
                     error_kind = DatabaseErrorKind::ClosedConnection;
                 }
                 Err(Error::DatabaseError(error_kind, error_information))

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -7,14 +7,10 @@ use std::os::raw as libc;
 use std::rc::Rc;
 use std::{slice, str};
 
-use super::raw::RawResult;
+use super::raw::{RawConnection, RawResult};
 use super::row::PgRow;
 use crate::result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
 use crate::util::OnceCell;
-
-// Message after a database connection has been unexpectedly closed.
-const CLOSED_CONNECTION_MSG: &str = "server closed the connection unexpectedly\n\t\
-This probably means the server terminated abnormally\n\tbefore or while processing the request.\n";
 
 pub(crate) struct PgResult {
     internal_result: RawResult,
@@ -28,7 +24,7 @@ pub(crate) struct PgResult {
 
 impl PgResult {
     #[allow(clippy::new_ret_no_self)]
-    pub(super) fn new(internal_result: RawResult) -> QueryResult<Self> {
+    pub(super) fn new(internal_result: RawResult, conn: &RawConnection) -> QueryResult<Self> {
         let result_status = unsafe { PQresultStatus(internal_result.as_ptr()) };
         match result_status {
             ExecStatusType::PGRES_COMMAND_OK | ExecStatusType::PGRES_TUPLES_OK => {
@@ -74,14 +70,8 @@ impl PgResult {
                         _ => DatabaseErrorKind::Unknown,
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
-                // NOTE: Ideally, we'd remove this check, in favor of matching
-                // on an error code (instead of the more brittle description
-                // string).
-                //
-                // Unfortunately, this particular error is often propagated in
-                // cases - such as network disconnect - without any accompanying
-                // "SqlState", and therefore without an error code..
-                if error_information.message() == CLOSED_CONNECTION_MSG {
+                let pc: *const PGconn = conn.into();
+                if unsafe { PQstatus(pc) } == ConnStatusType::CONNECTION_BAD {
                     error_kind = DatabaseErrorKind::ClosedConnection;
                 }
                 Err(Error::DatabaseError(error_kind, error_information))

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -70,8 +70,8 @@ impl PgResult {
                         _ => DatabaseErrorKind::Unknown,
                     };
                 let error_information = Box::new(PgErrorInformation(internal_result));
-                let pg_connection: *const PGconn = conn.into();
-                if unsafe { PQstatus(pg_connection) } == ConnStatusType::CONNECTION_BAD {
+                let conn_status = conn.get_status();
+                if conn_status == ConnStatusType::CONNECTION_BAD {
                     error_kind = DatabaseErrorKind::ClosedConnection;
                 }
                 Err(Error::DatabaseError(error_kind, error_information))

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -44,7 +44,7 @@ impl Statement {
             )
         };
 
-        PgResult::new(internal_res?)
+        PgResult::new(internal_res?, raw_connection)
     }
 
     pub(super) fn prepare(
@@ -69,7 +69,7 @@ impl Statement {
                 param_types_to_ptr(Some(&param_types_vec)),
             )
         };
-        PgResult::new(internal_result?)?;
+        PgResult::new(internal_result?, raw_connection)?;
 
         Ok(Statement {
             name,

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -17,9 +17,7 @@
 //! # use diesel::r2d2::CustomizeConnection;
 //! # use diesel::r2d2::Error as R2D2Error;
 //! use diesel::r2d2::Pool;
-//! use diesel::r2d2::PooledConnection;
 //! use diesel::result::Error;
-//! use std::env;
 //! use std::thread;
 //!
 //! # #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
Addresses https://github.com/diesel-rs/diesel/issues/2957

## Description

This PR makes it so that errors reported for the `PgResult` need to match on message strings directly from libpq. Instead we call `PQstatus` directly and attempt to match against the `ConnStatusType::CONNECTION_BAD` variant.

## Testing

`cargo test --no-default-features --features "extras postgres"` passes