### PR TITLE
Add support for slices of refs with BelongingToDsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 * Added support for table aliasing via the `alias!` macro
 
+* Added support for the usage of slices of references with `belonging_to` from `BelongingToDsl`
+
 ### Removed
 
 * All previously deprecated items have been removed.

--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -408,5 +408,16 @@ pub trait Identifiable: HasTable {
     fn id(self) -> Self::Id;
 }
 
+impl<T> Identifiable for &T
+where
+    T: Identifiable + Copy,
+{
+    type Id = T::Id;
+
+    fn id(self) -> Self::Id {
+        T::id(*self)
+    }
+}
+
 #[doc(inline)]
 pub use diesel_derives::Identifiable;

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -80,6 +80,22 @@ fn derive_belongs_to(item: &DeriveInput, model: &Model, assoc: &BelongsTo) -> To
                 #table_name::#foreign_key
             }
         }
+
+        impl #impl_generics diesel::associations::BelongsTo<&#parent_struct>
+            for #struct_name #ty_generics
+        #where_clause
+        {
+            type ForeignKey = #foreign_key_ty;
+            type ForeignKeyColumn = #table_name::#foreign_key;
+
+            fn foreign_key(&self) -> std::option::Option<&Self::ForeignKey> {
+                #foreign_key_expr
+            }
+
+            fn foreign_key_column() -> Self::ForeignKeyColumn {
+                #table_name::#foreign_key
+            }
+        }
     }
 }
 

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -38,6 +38,22 @@ fn eager_loading_associations_for_multiple_records() {
     assert_eq!(expected_data, users_and_posts);
 }
 
+#[test]
+fn reference_based_eager_loading() {
+    let (mut connection, sean, tess, _) = conn_with_test_data();
+    // Notice the not needed clone here, in contrast to eager_loading_associations_for_multiple_records
+    let users = vec![&sean, &tess];
+    let posts = Post::belonging_to(&users)
+        .load::<Post>(&mut connection)
+        .unwrap()
+        .grouped_by(&users);
+    let users_and_posts = users.into_iter().zip(posts).collect::<Vec<_>>();
+    let seans_posts: Vec<Post> = Post::belonging_to(&sean).load(&mut connection).unwrap();
+    let tess_posts = Post::belonging_to(&tess).load(&mut connection).unwrap();
+    let expected_data = vec![(&sean, seans_posts), (&tess, tess_posts)];
+    assert_eq!(expected_data, users_and_posts);
+}
+
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 mod eager_loading_with_string_keys {
     use crate::schema::{connection, drop_table_cascade};


### PR DESCRIPTION
See https://github.com/diesel-rs/diesel/discussions/3138 for discussions.

Add support for slices of refs with `BelongingToDsl`

To support this usage we need to implement Identifiable for references of references as well, thus we add a blanket impl here.

Furthermore, `BelongsTo` needs to be implemented for `&Parent`.
As blanked implementation for this is only possible with workarounds to avoid
overlapping implementations, we instead add an additional implementation to
the derive macro.

I am currently looking into the recent feedback from the discussion and will update this PR once I am satisfied.