### PR TITLE
Add support for slices of refs with BelongingToDsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 * Added support for table aliasing via the `alias!` macro
 
+* Added support for the usage of slices of references with `belonging_to` from `BelongingToDsl`
+
 ### Removed
 
 * All previously deprecated items have been removed.

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -80,6 +80,22 @@ fn derive_belongs_to(item: &DeriveInput, model: &Model, assoc: &BelongsTo) -> To
                 #table_name::#foreign_key
             }
         }
+
+        impl #impl_generics diesel::associations::BelongsTo<&'_ #parent_struct>
+            for #struct_name #ty_generics
+        #where_clause
+        {
+            type ForeignKey = #foreign_key_ty;
+            type ForeignKeyColumn = #table_name::#foreign_key;
+
+            fn foreign_key(&self) -> std::option::Option<&Self::ForeignKey> {
+                #foreign_key_expr
+            }
+
+            fn foreign_key_column() -> Self::ForeignKeyColumn {
+                #table_name::#foreign_key
+            }
+        }
     }
 }
 

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -44,5 +44,15 @@ pub fn derive(item: DeriveInput) -> TokenStream {
                 (#(&self.#field_name),*)
             }
         }
+
+        impl #ref_generics Identifiable for &'ident &'ident #struct_name #ty_generics
+            #where_clause
+        {
+            type Id = (#(&'ident #field_ty),*);
+
+            fn id(self) -> Self::Id {
+                (#(&self.#field_name),*)
+            }
+        }
     })
 }

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -45,7 +45,7 @@ pub fn derive(item: DeriveInput) -> TokenStream {
             }
         }
 
-        impl #ref_generics Identifiable for &'ident &'ident #struct_name #ty_generics
+        impl #ref_generics Identifiable for &'_ &'ident #struct_name #ty_generics
             #where_clause
         {
             type Id = (#(&'ident #field_ty),*);

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -163,6 +163,10 @@ pub fn derive_as_expression(input: TokenStream) -> TokenStream {
 /// This derive implement support for diesel's associations api. Check the
 /// module level documentation of the `diesel::associations` module for details.
 ///
+/// This derive generates the following impls:
+/// * `impl BelongsTo<Parent> for YourType`
+/// * `impl BelongsTo<&'a Parent> for YourType`
+///
 /// # Attributes
 ///
 /// # Required container attributes
@@ -233,6 +237,10 @@ pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
 /// you can specify a path to the table with `#[diesel(table_name = path::to::table)]`.
 /// Our rules for inferring table names is considered public API.
 /// It will never change without a major version bump.
+///
+/// This derive generates the following impls:
+/// * `impl Identifiable for &'a YourType`
+/// * `impl Identifiable for &'a &'a YourType`
 ///
 /// # Attributes
 ///

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -38,6 +38,23 @@ fn eager_loading_associations_for_multiple_records() {
     assert_eq!(expected_data, users_and_posts);
 }
 
+#[test]
+fn eager_loading_associations_for_multiple_ref_records() {
+    let (mut connection, sean, tess, _) = conn_with_test_data();
+
+    let users = vec![&sean, &tess];
+    let posts = Post::belonging_to(&users)
+        .load::<Post>(&mut connection)
+        .unwrap()
+        .grouped_by(&users);
+    let users_and_posts = users.into_iter().zip(posts).collect::<Vec<_>>();
+
+    let seans_posts = Post::belonging_to(&sean).load(&mut connection).unwrap();
+    let tess_posts = Post::belonging_to(&tess).load(&mut connection).unwrap();
+    let expected_data = vec![(&sean, seans_posts), (&tess, tess_posts)];
+    assert_eq!(expected_data, users_and_posts);
+}
+
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 mod eager_loading_with_string_keys {
     use crate::schema::{connection, drop_table_cascade};


### PR DESCRIPTION
See #3138 for discussions.

We cannot add a blanked impl like
```rust
impl<'a, T> Identifiable for &'a &'a T
where
    &'a T: Identifiable
{
    // …
}
```

here as this results in type inference issues with `.belonging_to` and
`.grouped_by`. Rustc tries to infinitely recurse on `&&&&&…&&& T as
Identifiable` then. As of this I've opted into just generating concrete
impls via `#[derive(Identifiable)]` as this works around this type
inference issues.

Also we cannot use a wild card impl for the added `BelongsTo<&Parent>`
case as this causes a conflicting impl error with our
`BelongsTo` impls for tuples. So again we use concrete impls here.


cc #3140 

@valkum Sorry to open this parallel PR, but I had done some experimentation with the blanked `Identifiable` impl and noticed that the code is basically finished at that state of experimentation. So I've just pushed this version.