### PR TITLE
Fix potential name collisions in code generated by the `table!` macro

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -63,9 +63,9 @@ macro_rules! __diesel_internal_backend_specific_table_impls {
             type FromClause = $crate::query_builder::Only<S>;
             type OnClause = <$crate::query_builder::Only<S> as $crate::JoinTo<$table>>::OnClause;
 
-            fn join_target(rhs: $crate::query_builder::Only<S>) -> (Self::FromClause, Self::OnClause) {
-                let (_, on_clause) = $crate::query_builder::Only::<S>::join_target($table);
-                (rhs, on_clause)
+            fn join_target(__diesel_internal_rhs: $crate::query_builder::Only<S>) -> (Self::FromClause, Self::OnClause) {
+                let (_, __diesel_internal_on_clause) = $crate::query_builder::Only::<S>::join_target($table);
+                (__diesel_internal_rhs, __diesel_internal_on_clause)
             }
         }
 
@@ -113,13 +113,13 @@ macro_rules! __diesel_column {
             $crate::internal::table_macro::StaticQueryFragmentInstance<table>: $crate::query_builder::QueryFragment<DB>,
         {
             #[allow(non_snake_case)]
-            fn walk_ast<'b>(&'b self, mut __out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
+            fn walk_ast<'b>(&'b self, mut __diesel_internal_out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
             {
                 const FROM_CLAUSE: $crate::internal::table_macro::StaticQueryFragmentInstance<table> = $crate::internal::table_macro::StaticQueryFragmentInstance::new();
 
-                FROM_CLAUSE.walk_ast(__out.reborrow())?;
-                __out.push_sql(".");
-                __out.push_identifier($sql_name)
+                FROM_CLAUSE.walk_ast(__diesel_internal_out.reborrow())?;
+                __diesel_internal_out.push_sql(".");
+                __diesel_internal_out.push_identifier($sql_name)
             }
         }
 
@@ -195,9 +195,9 @@ macro_rules! __diesel_column {
         {
             type Output = $crate::dsl::Eq<Self, T::Expression>;
 
-            fn eq_all(self, rhs: T) -> Self::Output {
+            fn eq_all(self, __diesel_internal_rhs: T) -> Self::Output {
                 use $crate::expression_methods::ExpressionMethods;
-                self.eq(rhs)
+                self.eq(__diesel_internal_rhs)
             }
         }
 
@@ -805,8 +805,8 @@ macro_rules! __diesel_table_impl {
                 DB: $crate::backend::Backend,
                 <table as $crate::internal::table_macro::StaticQueryFragment>::Component: $crate::query_builder::QueryFragment<DB>
             {
-                fn walk_ast<'b>(&'b self, pass: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()> {
-                    <table as $crate::internal::table_macro::StaticQueryFragment>::STATIC_COMPONENT.walk_ast(pass)
+                fn walk_ast<'b>(&'b self, __diesel_internal_pass: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()> {
+                    <table as $crate::internal::table_macro::StaticQueryFragment>::STATIC_COMPONENT.walk_ast(__diesel_internal_pass)
                 }
             }
 
@@ -887,8 +887,8 @@ macro_rules! __diesel_table_impl {
             {
                 type Out = $crate::query_source::AliasedField<S, C>;
 
-                fn map(column: C, alias: &$crate::query_source::Alias<S>) -> Self::Out {
-                    alias.field(column)
+                fn map(__diesel_internal_column: C, __diesel_internal_alias: &$crate::query_source::Alias<S>) -> Self::Out {
+                    __diesel_internal_alias.field(__diesel_internal_column)
                 }
             }
 
@@ -904,9 +904,9 @@ macro_rules! __diesel_table_impl {
                 type FromClause = $crate::internal::table_macro::Join<Left, Right, Kind>;
                 type OnClause = <$crate::internal::table_macro::Join<Left, Right, Kind> as $crate::JoinTo<table>>::OnClause;
 
-                fn join_target(rhs: $crate::internal::table_macro::Join<Left, Right, Kind>) -> (Self::FromClause, Self::OnClause) {
-                    let (_, on_clause) = $crate::internal::table_macro::Join::join_target(table);
-                    (rhs, on_clause)
+                fn join_target(__diesel_internal_rhs: $crate::internal::table_macro::Join<Left, Right, Kind>) -> (Self::FromClause, Self::OnClause) {
+                    let (_, __diesel_internal_on_clause) = $crate::internal::table_macro::Join::join_target(table);
+                    (__diesel_internal_rhs, __diesel_internal_on_clause)
                 }
             }
 
@@ -916,9 +916,9 @@ macro_rules! __diesel_table_impl {
                 type FromClause = $crate::internal::table_macro::JoinOn<Join, On>;
                 type OnClause = <$crate::internal::table_macro::JoinOn<Join, On> as $crate::JoinTo<table>>::OnClause;
 
-                fn join_target(rhs: $crate::internal::table_macro::JoinOn<Join, On>) -> (Self::FromClause, Self::OnClause) {
-                    let (_, on_clause) = $crate::internal::table_macro::JoinOn::join_target(table);
-                    (rhs, on_clause)
+                fn join_target(__diesel_internal_rhs: $crate::internal::table_macro::JoinOn<Join, On>) -> (Self::FromClause, Self::OnClause) {
+                    let (_, __diesel_internal_on_clause) = $crate::internal::table_macro::JoinOn::join_target(table);
+                    (__diesel_internal_rhs, __diesel_internal_on_clause)
                 }
             }
 
@@ -929,9 +929,9 @@ macro_rules! __diesel_table_impl {
                 type FromClause = $crate::internal::table_macro::SelectStatement<$crate::internal::table_macro::FromClause<F>, S, D, W, O, L, Of, G>;
                 type OnClause = <$crate::internal::table_macro::SelectStatement<$crate::internal::table_macro::FromClause<F>, S, D, W, O, L, Of, G> as $crate::JoinTo<table>>::OnClause;
 
-                fn join_target(rhs: $crate::internal::table_macro::SelectStatement<$crate::internal::table_macro::FromClause<F>, S, D, W, O, L, Of, G>) -> (Self::FromClause, Self::OnClause) {
-                    let (_, on_clause) = $crate::internal::table_macro::SelectStatement::join_target(table);
-                    (rhs, on_clause)
+                fn join_target(__diesel_internal_rhs: $crate::internal::table_macro::SelectStatement<$crate::internal::table_macro::FromClause<F>, S, D, W, O, L, Of, G>) -> (Self::FromClause, Self::OnClause) {
+                    let (_, __diesel_internal_on_clause) = $crate::internal::table_macro::SelectStatement::join_target(table);
+                    (__diesel_internal_rhs, __diesel_internal_on_clause)
                 }
             }
 
@@ -941,9 +941,9 @@ macro_rules! __diesel_table_impl {
             {
                 type FromClause = $crate::internal::table_macro::BoxedSelectStatement<'a, $crate::internal::table_macro::FromClause<QS>, ST, DB>;
                 type OnClause = <$crate::internal::table_macro::BoxedSelectStatement<'a, $crate::internal::table_macro::FromClause<QS>, ST, DB> as $crate::JoinTo<table>>::OnClause;
-                fn join_target(rhs: $crate::internal::table_macro::BoxedSelectStatement<'a, $crate::internal::table_macro::FromClause<QS>, ST, DB>) -> (Self::FromClause, Self::OnClause) {
-                    let (_, on_clause) = $crate::internal::table_macro::BoxedSelectStatement::join_target(table);
-                    (rhs, on_clause)
+                fn join_target(__diesel_internal_rhs: $crate::internal::table_macro::BoxedSelectStatement<'a, $crate::internal::table_macro::FromClause<QS>, ST, DB>) -> (Self::FromClause, Self::OnClause) {
+                    let (_, __diesel_internal_on_clause) = $crate::internal::table_macro::BoxedSelectStatement::join_target(table);
+                    (__diesel_internal_rhs, __diesel_internal_on_clause)
                 }
             }
 
@@ -954,9 +954,9 @@ macro_rules! __diesel_table_impl {
                 type FromClause = $crate::query_source::Alias<S>;
                 type OnClause = <$crate::query_source::Alias<S> as $crate::JoinTo<table>>::OnClause;
 
-                fn join_target(rhs: $crate::query_source::Alias<S>) -> (Self::FromClause, Self::OnClause) {
-                    let (_, on_clause) = $crate::query_source::Alias::<S>::join_target(table);
-                    (rhs, on_clause)
+                fn join_target(__diesel_internal_rhs: $crate::query_source::Alias<S>) -> (Self::FromClause, Self::OnClause) {
+                    let (_, __diesel_internal_on_clause) = $crate::query_source::Alias::<S>::join_target(table);
+                    (__diesel_internal_rhs, __diesel_internal_on_clause)
                 }
             }
 
@@ -1015,13 +1015,13 @@ macro_rules! __diesel_table_impl {
                     <table as $crate::QuerySource>::FromClause: $crate::query_builder::QueryFragment<DB>,
                 {
                     #[allow(non_snake_case)]
-                    fn walk_ast<'b>(&'b self, mut __out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
+                    fn walk_ast<'b>(&'b self, mut __diesel_internal_out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
                     {
                         use $crate::QuerySource;
                         const FROM_CLAUSE: $crate::internal::table_macro::StaticQueryFragmentInstance<table> = $crate::internal::table_macro::StaticQueryFragmentInstance::new();
 
-                        FROM_CLAUSE.walk_ast(__out.reborrow())?;
-                        __out.push_sql(".*");
+                        FROM_CLAUSE.walk_ast(__diesel_internal_out.reborrow())?;
+                        __diesel_internal_out.push_sql(".*");
                         Ok(())
                     }
                 }

--- a/diesel/src/macros/ops.rs
+++ b/diesel/src/macros/ops.rs
@@ -14,8 +14,8 @@ macro_rules! operator_allowed {
         {
             type Output = $crate::internal::table_macro::ops::$op<Self, Rhs::Expression>;
 
-            fn $fn_name(self, rhs: Rhs) -> Self::Output {
-                $crate::internal::table_macro::ops::$op::new(self, rhs.as_expression())
+            fn $fn_name(self, __diesel_internal_rhs: Rhs) -> Self::Output {
+                $crate::internal::table_macro::ops::$op::new(self, __diesel_internal_rhs.as_expression())
             }
         }
     };


### PR DESCRIPTION
This commit fixes potential name collisions in code generated by the
`table!` macro by prefixing function argument names with
`__diesel_internal`. The underlying problem here is that rust accepts
patterns as part of the function signature. This combined with the fact
that each zero sized struct (so all column/table structs) are type +
value at the same time results in problems as soon as the users tries to
create a column/table with the same name as one of the used arguments.
So for example if the users has a table that contains an `alias` column,
that would have caused a name collision inside of the following function
signature:

```rust
fn map(column: C, alias: &$crate::query_source::Alias<S>) -> Self::Out
```

Rustc would have interpreted `alias` here as zero sized struct literal,
which of course has a different type than the corresponding RHS. That
results in a compiler error about mismatched types.

This commit fixes this problem by prefixing the corresponding variables
with `__diesel_internal`, which is hopefully reasonably uncommon, so
that no one uses that as column name prefix.