### PR TITLE
Fixed believed error in documentation

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -142,7 +142,7 @@
 //! provided by `uuid`
 //! - `network-address`: This feature flag enables support for (de)serializing IP and Macadresse values from the
 //! database using types provided by `ipnetwork`
-//! - `numeric`: This feature flag enables support for (de)support numeric values from the database using types
+//! - `numeric`: This feature flag enables support for (de)serializing numeric values from the database using types
 //! provided by `bigdecimal`
 //! - `r2d2`: This feature flag enables support for the `r2d2` connection pool implementation.
 //! - `extras`: This feature enables the feature flaged support for any third party crate. This implies the


### PR DESCRIPTION
Judging by the other uses of this above, I believe this should be `(de)serializing` istead of `(de)support`