### PR TITLE
docs: Fix typo in nullability operators section

### DIFF
--- a/guide_drafts/migration_guide.md
+++ b/guide_drafts/migration_guide.md
@@ -114,7 +114,7 @@ of `BoxableExpression` as it may change the resulting sql type there. As a possi
 there we recommend to use one of the following functions:
 
 * `NullableExpressionMethods::nullable()`
-* `NullableExpressionMethods::assume_not_nullable()`
+* `NullableExpressionMethods::assume_not_null()`
 
 ## Changed nullability of array elements<a name="#2-0-0-nullability-of-array-elements"></a>
 


### PR DESCRIPTION
This PR fixes the typo noted in https://github.com/diesel-rs/diesel/discussions/3144#discussioncomment-2658922 . Related docs [here](https://docs.diesel.rs/master/diesel/expression_methods/trait.NullableExpressionMethods.html).