### PR TITLE
Allow `DISTINCT ON` to be used with queries containing an explicit sort order

### DIFF
--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -23,6 +23,33 @@ where
     T::SqlType: SingleValue,
 {
 }
+impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<crate::helper_types::Desc<T>>
+where
+    T: Expression,
+    T::SqlType: SingleValue,
+{
+}
+impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<crate::helper_types::Asc<T>>
+where
+    T: Expression,
+    T::SqlType: SingleValue,
+{
+}
+
+impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+    for OrderClause<(crate::helper_types::Desc<T>,)>
+where
+    T: Expression,
+    T::SqlType: SingleValue,
+{
+}
+impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+    for OrderClause<(crate::helper_types::Asc<T>,)>
+where
+    T: Expression,
+    T::SqlType: SingleValue,
+{
+}
 
 impl<T> QueryFragment<Pg> for DistinctOnClause<T>
 where

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.0.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "bigdecimal",
  "bitflags",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -27,7 +27,7 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
              <diesel::query_builder::order_clause::OrderClause<(__D, T0)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
-           and 14 others
+           and 18 others
    = note: required because of the requirements on the impl of `OrderDsl<columns::id>` for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>`
 
 error[E0308]: mismatched types
@@ -59,5 +59,5 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
              <diesel::query_builder::order_clause::OrderClause<(__D, T0)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
              <diesel::query_builder::order_clause::OrderClause<(__D, T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<__D>>>
-           and 14 others
+           and 18 others
    = note: required because of the requirements on the impl of `OrderDsl<columns::id>` for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>`

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -32,12 +32,29 @@ fn distinct_on() {
         .select((name, hair_color))
         .order(name)
         .distinct_on(name);
-    let expected_data = vec![
+    let mut expected_data = vec![
         ("Sean".to_string(), Some("black".to_string())),
         ("Tess".to_string(), None),
     ];
     let data: Vec<_> = source.load(connection).unwrap();
 
+    assert_eq!(expected_data, data);
+
+    let source = users
+        .select((name, hair_color))
+        .order(name.asc())
+        .distinct_on(name);
+    let data: Vec<_> = source.load(connection).unwrap();
+
+    assert_eq!(expected_data, data);
+
+    let source = users
+        .select((name, hair_color))
+        .order(name.desc())
+        .distinct_on(name);
+    let data: Vec<_> = source.load(connection).unwrap();
+
+    expected_data.reverse();
     assert_eq!(expected_data, data);
 }
 


### PR DESCRIPTION
This fixes the issue reported here: https://github.com/diesel-rs/diesel/discussions/3144#discussioncomment-2658922