### PR TITLE
Fix #3156

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -144,11 +144,15 @@ impl crate::r2d2::R2D2Connection for MysqlConnection {
     }
 
     fn is_broken(&mut self) -> bool {
-        self.transaction_state
-            .status
-            .transaction_depth()
-            .map(|d| d.is_some())
-            .unwrap_or(true)
+        match self.transaction_state.status.transaction_depth() {
+            // all transactions are closed
+            // so we don't consider this connection broken
+            Ok(None) => false,
+            // The transaction manager is in an error state
+            // or contains an open transaction
+            // Therefore we consider this connection broken
+            Err(_) | Ok(Some(_)) => true,
+        }
     }
 }
 

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -147,7 +147,7 @@ impl crate::r2d2::R2D2Connection for MysqlConnection {
         self.transaction_state
             .status
             .transaction_depth()
-            .map(|d| d.is_none())
+            .map(|d| d.is_some())
             .unwrap_or(true)
     }
 }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -177,11 +177,15 @@ impl crate::r2d2::R2D2Connection for PgConnection {
     }
 
     fn is_broken(&mut self) -> bool {
-        self.transaction_state
-            .status
-            .transaction_depth()
-            .map(|d| d.is_some())
-            .unwrap_or(true)
+        match self.transaction_state.status.transaction_depth() {
+            // all transactions are closed
+            // so we don't consider this connection broken
+            Ok(None) => false,
+            // The transaction manager is in an error state
+            // or contains an open transaction
+            // Therefore we consider this connection broken
+            Err(_) | Ok(Some(_)) => true,
+        }
     }
 }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -180,7 +180,7 @@ impl crate::r2d2::R2D2Connection for PgConnection {
         self.transaction_state
             .status
             .transaction_depth()
-            .map(|d| d.is_none())
+            .map(|d| d.is_some())
             .unwrap_or(true)
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -141,11 +141,15 @@ impl crate::r2d2::R2D2Connection for crate::sqlite::SqliteConnection {
     }
 
     fn is_broken(&mut self) -> bool {
-        self.transaction_state
-            .status
-            .transaction_depth()
-            .map(|d| d.is_some())
-            .unwrap_or(true)
+        match self.transaction_state.status.transaction_depth() {
+            // all transactions are closed
+            // so we don't consider this connection broken
+            Ok(None) => false,
+            // The transaction manager is in an error state
+            // or contains an open transaction
+            // Therefore we consider this connection broken
+            Err(_) | Ok(Some(_)) => true,
+        }
     }
 }
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -144,7 +144,7 @@ impl crate::r2d2::R2D2Connection for crate::sqlite::SqliteConnection {
         self.transaction_state
             .status
             .transaction_depth()
-            .map(|d| d.is_none())
+            .map(|d| d.is_some())
             .unwrap_or(true)
     }
 }


### PR DESCRIPTION
Our `R2D2Connection::is_broken` implementations where broken in such a
way that they marked any valid connection as broken as soon as it was
checked into the pool again. This resulted in the pool opening new
connections everytime a connection was checked out of the pool, which
obviously removes the possibility of reusing the same connection again
and again. This commit fixes that issue and adds some tests to ensure
that we do not break this again in the future.