### PR TITLE
This commit fixes a potential race condition in our r2d2 tests

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -500,7 +500,11 @@ mod tests {
                 .unwrap();
         }
 
-        assert_eq!(acquire_count.load(Ordering::Relaxed), 1);
+        // we are not interested in the acquire count here
+        // as the pool opens a new connection in the background
+        // that could lead to this test failing if that happens to fast
+        // (which is sometimes the case for sqlite)
+        //assert_eq!(acquire_count.load(Ordering::Relaxed), 1);
         assert_eq!(release_count.load(Ordering::Relaxed), 1);
         assert_eq!(checkin_count.load(Ordering::Relaxed), 2);
         assert_eq!(checkout_count.load(Ordering::Relaxed), 2);
@@ -519,7 +523,11 @@ mod tests {
         }))
         .unwrap_err();
 
-        assert_eq!(acquire_count.load(Ordering::Relaxed), 2);
+        // we are not interested in the acquire count here
+        // as the pool opens a new connection in the background
+        // that could lead to this test failing if that happens to fast
+        // (which is sometimes the case for sqlite)
+        //assert_eq!(acquire_count.load(Ordering::Relaxed), 2);
         assert_eq!(release_count.load(Ordering::Relaxed), 2);
         assert_eq!(checkin_count.load(Ordering::Relaxed), 3);
         assert_eq!(checkout_count.load(Ordering::Relaxed), 3);


### PR DESCRIPTION
This was triggered by the fact that the pool tries to open a new
connection after the old one was closed. As this happens in a background
thread this happens concurrently to our test code. That means if
establishing a new connection is fast that will increase the
acquire_count before we checked it. We observed this happening for
sqlite. I've opted into just not checking the acquire count there as
this is not really relevant anyway at that point.