### PR TITLE
Make TransactionDepthChange public

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -22,7 +22,7 @@ use crate::result::*;
 use std::fmt::Debug;
 
 pub use self::transaction_manager::{
-    AnsiTransactionManager, TransactionManager, TransactionManagerStatus,
+    AnsiTransactionManager, TransactionDepthChange, TransactionManager, TransactionManagerStatus,
     ValidTransactionManagerStatus,
 };
 


### PR DESCRIPTION
This is kind of required as otherwise custom connection implementations
cannot provide their own transaction manager implementation.