### PR TITLE
Address #3173

### DIFF
--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -48,19 +48,6 @@ impl<T: QueryId> QueryId for Nullable<T> {
     const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
 }
 
-impl<T, DB> Selectable<DB> for Option<T>
-where
-    DB: Backend,
-    T: Selectable<DB>,
-    Nullable<T::SelectExpression>: Expression,
-{
-    type SelectExpression = Nullable<T::SelectExpression>;
-
-    fn construct_selection() -> Self::SelectExpression {
-        Nullable::new(T::construct_selection())
-    }
-}
-
 impl<T, QS> SelectableExpression<QS> for Nullable<T>
 where
     Self: AppearsOnTable<QS>,

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -99,7 +99,6 @@ impl Connection for MysqlConnection {
         StatementIterator::from_stmt(stmt, &metadata)
     }
 
-    #[doc(hidden)]
     fn execute_returning_count<T>(&mut self, source: &T) -> QueryResult<usize>
     where
         T: QueryFragment<Self::Backend> + QueryId,
@@ -131,7 +130,6 @@ impl Connection for MysqlConnection {
         }
     }
 
-    #[doc(hidden)]
     fn transaction_state(&mut self) -> &mut AnsiTransactionManager {
         &mut self.transaction_state
     }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -146,7 +146,6 @@ impl Connection for PgConnection {
         })
     }
 
-    #[doc(hidden)]
     fn execute_returning_count<T>(&mut self, source: &T) -> QueryResult<usize>
     where
         T: QueryFragment<Pg> + QueryId,

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -195,8 +195,8 @@ mod private {
     }
 
     #[cfg_attr(
-        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-        cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")
+        doc_cfg,
+        doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub trait CompatibleType<U, DB> {
         type SqlType;

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -113,7 +113,6 @@ impl Connection for SqliteConnection {
         Ok(StatementIterator::new(statement_use))
     }
 
-    #[doc(hidden)]
     fn execute_returning_count<T>(&mut self, source: &T) -> QueryResult<usize>
     where
         T: QueryFragment<Self::Backend> + QueryId,

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -124,13 +124,6 @@ impl InferConnection {
 macro_rules! call_with_conn {
     (
         $database_url:expr,
-        $($func:ident)::+
-    ) => {
-        call_with_conn!($database_url, $($func)::+ ())
-    };
-
-    (
-        $database_url:expr,
         $($func:ident)::+ ($($args:expr),*)
     ) => {
         match crate::database::InferConnection::establish(&$database_url)

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -1,3 +1,5 @@
+use diesel::deserialize::FromSqlRow;
+use diesel::expression::AsExpression;
 use diesel::*;
 use helpers::*;
 use schema::*;

--- a/diesel_derives/tests/selectable.rs
+++ b/diesel_derives/tests/selectable.rs
@@ -86,3 +86,31 @@ fn embedded_option() {
     let data = my_structs::table.select(A::as_select()).get_result(conn);
     assert!(data.is_err());
 }
+
+#[test]
+fn embedded_option_with_nullable_field() {
+    table! {
+        my_structs (foo) {
+            foo -> Integer,
+            bar -> Nullable<Integer>,
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[diesel(table_name = my_structs)]
+    struct A {
+        foo: i32,
+        #[diesel(embed)]
+        b: Option<B>,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[diesel(table_name = my_structs)]
+    struct B {
+        bar: Option<i32>,
+    }
+
+    let conn = &mut connection();
+    let data = my_structs::table.select(A::as_select()).get_result(conn);
+    assert!(data.is_err());
+}

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 #[macro_use]
 extern crate cfg_if;
 #[macro_use]

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -701,7 +701,7 @@ fn selecting_crazy_nested_joins() {
     assert_eq!(Ok(expected), data);
 }
 
-fn connection_with_fixture_data_for_multitable_joins() -> (TestConnection, TestData) {
+pub(crate) fn connection_with_fixture_data_for_multitable_joins() -> (TestConnection, TestData) {
     let mut connection = connection_with_sean_and_tess_in_users_table();
 
     let sean = find_user_by_name("Sean", &mut connection);
@@ -775,11 +775,11 @@ fn connection_with_fixture_data_for_multitable_joins() -> (TestConnection, TestD
     (connection, test_data)
 }
 
-struct TestData {
-    sean: User,
-    tess: User,
-    posts: Vec<Post>,
-    comments: Vec<Comment>,
-    likes: Vec<Like>,
-    followings: Vec<Following>,
+pub struct TestData {
+    pub sean: User,
+    pub tess: User,
+    pub posts: Vec<Post>,
+    pub comments: Vec<Comment>,
+    pub likes: Vec<Like>,
+    pub followings: Vec<Following>,
 }

--- a/diesel_tests/tests/schema/backend_specifics.rs
+++ b/diesel_tests/tests/schema/backend_specifics.rs
@@ -1,6 +1,8 @@
 use super::*;
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations, QueryableByName)]
+#[derive(
+    PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations, QueryableByName, Selectable,
+)]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = posts)]
 pub struct Post {

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -61,8 +61,8 @@ impl UserName {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations)]
-#[diesel(belongs_to(Post))]
+#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations, Selectable)]
+#[diesel(belongs_to(Post), table_name = comments)]
 pub struct Comment {
     id: i32,
     post_id: i32,
@@ -79,7 +79,9 @@ impl Comment {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Associations, Identifiable)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Associations, Identifiable, Selectable,
+)]
 #[diesel(belongs_to(User))]
 #[diesel(belongs_to(Post))]
 #[diesel(table_name = followings)]
@@ -177,14 +179,16 @@ pub struct NullableColumn {
     value: Option<i32>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Identifiable, Associations)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Queryable, Insertable, Identifiable, Associations, Selectable,
+)]
 #[diesel(table_name = likes)]
-#[diesel(primary_key(user_id, comment_id))]
+#[diesel(primary_key(comment_id, user_id))]
 #[diesel(belongs_to(User))]
 #[diesel(belongs_to(Comment))]
 pub struct Like {
-    pub user_id: i32,
     pub comment_id: i32,
+    pub user_id: i32,
 }
 
 #[cfg(feature = "postgres")]

--- a/diesel_tests/tests/schema/postgres_specific_schema.rs
+++ b/diesel_tests/tests/schema/postgres_specific_schema.rs
@@ -1,6 +1,8 @@
 use super::{posts, User};
 
-#[derive(PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations, QueryableByName)]
+#[derive(
+    PartialEq, Eq, Debug, Clone, Queryable, Identifiable, Associations, QueryableByName, Selectable,
+)]
 #[diesel(table_name = posts)]
 #[diesel(belongs_to(User))]
 pub struct Post {

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -217,3 +217,515 @@ fn mixed_selectable_and_plain_select() {
         .unwrap();
     assert_eq!(expected_data, actual_data);
 }
+
+// The following tests are duplicates from tests in joins.rs
+// They are used to verify that selectable behaves equivalent to the corresponding
+// raw select
+#[test]
+fn selecting_parent_child_grandchild() {
+    use crate::joins::TestData;
+
+    let (mut connection, test_data) =
+        crate::joins::connection_with_fixture_data_for_multitable_joins();
+    let TestData {
+        sean,
+        tess,
+        posts,
+        comments,
+        ..
+    } = test_data;
+
+    let data = users::table
+        .inner_join(posts::table.inner_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(<(User, (Post, Comment)) as SelectableHelper<_>>::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        (sean.clone(), (posts[0].clone(), comments[0].clone())),
+        (sean.clone(), (posts[0].clone(), comments[2].clone())),
+        (sean.clone(), (posts[2].clone(), comments[1].clone())),
+    ];
+    assert_eq!(Ok(expected.clone()), data);
+
+    let data = users::table
+        .inner_join(
+            posts::table
+                .on(users::id.eq(posts::user_id).and(posts::id.eq(posts[0].id)))
+                .inner_join(comments::table),
+        )
+        .order((users::id, posts::id, comments::id))
+        .select(<(User, (Post, Comment)) as SelectableHelper<_>>::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        (sean.clone(), (posts[0].clone(), comments[0].clone())),
+        (sean.clone(), (posts[0].clone(), comments[2].clone())),
+    ];
+    assert_eq!(Ok(expected), data);
+
+    let data = users::table
+        .inner_join(posts::table.left_outer_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(<(User, (Post, Option<Comment>)) as SelectableHelper<_>>::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        (sean.clone(), (posts[0].clone(), Some(comments[0].clone()))),
+        (sean.clone(), (posts[0].clone(), Some(comments[2].clone()))),
+        (sean.clone(), (posts[2].clone(), Some(comments[1].clone()))),
+        (tess.clone(), (posts[1].clone(), None)),
+    ];
+    assert_eq!(Ok(expected), data);
+
+    let data = users::table
+        .left_outer_join(posts::table.left_outer_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(<(User, Option<(Post, Option<Comment>)>) as SelectableHelper<_>>::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        (
+            sean.clone(),
+            Some((posts[0].clone(), Some(comments[0].clone()))),
+        ),
+        (
+            sean.clone(),
+            Some((posts[0].clone(), Some(comments[2].clone()))),
+        ),
+        (
+            sean.clone(),
+            Some((posts[2].clone(), Some(comments[1].clone()))),
+        ),
+        (tess.clone(), Some((posts[1].clone(), None))),
+    ];
+    assert_eq!(Ok(expected), data);
+
+    let data = users::table
+        .left_outer_join(posts::table.inner_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(<(User, Option<(Post, Comment)>) as SelectableHelper<_>>::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        (sean.clone(), Some((posts[0].clone(), comments[0].clone()))),
+        (sean.clone(), Some((posts[0].clone(), comments[2].clone()))),
+        (sean.clone(), Some((posts[2].clone(), comments[1].clone()))),
+        (tess.clone(), None),
+    ];
+    assert_eq!(Ok(expected), data);
+}
+
+#[test]
+fn selecting_parent_child_grandchild_nested() {
+    use crate::joins::TestData;
+
+    let (mut connection, test_data) =
+        crate::joins::connection_with_fixture_data_for_multitable_joins();
+    let TestData {
+        sean,
+        tess,
+        posts,
+        comments,
+        ..
+    } = test_data;
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = users)]
+    struct User1 {
+        id: i32,
+        name: String,
+        hair_color: Option<String>,
+        #[diesel(embed)]
+        post: Post1,
+    }
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = posts)]
+    struct Post1 {
+        id: i32,
+        user_id: i32,
+        title: String,
+        body: Option<String>,
+        #[diesel(embed)]
+        comment: Comment,
+    }
+
+    let data = users::table
+        .inner_join(posts::table.inner_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(User1::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        User1 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Post1 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: comments[0].clone(),
+            },
+        },
+        User1 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Post1 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: comments[2].clone(),
+            },
+        },
+        User1 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Post1 {
+                id: posts[2].id,
+                user_id: posts[2].user_id,
+                title: posts[2].title.clone(),
+                body: posts[2].body.clone(),
+                comment: comments[1].clone(),
+            },
+        },
+    ];
+    assert_eq!(Ok(expected.clone()), data);
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = users)]
+    struct User2 {
+        id: i32,
+        name: String,
+        hair_color: Option<String>,
+        #[diesel(embed)]
+        post: Post2,
+    }
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = posts)]
+    struct Post2 {
+        id: i32,
+        user_id: i32,
+        title: String,
+        body: Option<String>,
+        #[diesel(embed)]
+        comment: Option<Comment>,
+    }
+
+    let data = users::table
+        .inner_join(posts::table.left_outer_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(User2::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        User2 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Post2 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: Some(comments[0].clone()),
+            },
+        },
+        User2 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Post2 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: Some(comments[2].clone()),
+            },
+        },
+        User2 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Post2 {
+                id: posts[2].id,
+                user_id: posts[2].user_id,
+                title: posts[2].title.clone(),
+                body: posts[2].body.clone(),
+                comment: Some(comments[1].clone()),
+            },
+        },
+        User2 {
+            id: tess.id,
+            name: tess.name.clone(),
+            hair_color: tess.hair_color.clone(),
+            post: Post2 {
+                id: posts[1].id,
+                user_id: posts[1].user_id,
+                title: posts[1].title.clone(),
+                body: posts[1].body.clone(),
+                comment: None,
+            },
+        },
+    ];
+    assert_eq!(Ok(expected), data);
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = users)]
+    struct User3 {
+        id: i32,
+        name: String,
+        hair_color: Option<String>,
+        #[diesel(embed)]
+        post: Option<Post3>,
+    }
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = posts)]
+    struct Post3 {
+        id: i32,
+        user_id: i32,
+        title: String,
+        body: Option<String>,
+        #[diesel(embed)]
+        comment: Option<Comment>,
+    }
+
+    let data = users::table
+        .left_outer_join(posts::table.left_outer_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(User3::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        User3 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Some(Post3 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: Some(comments[0].clone()),
+            }),
+        },
+        User3 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Some(Post3 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: Some(comments[2].clone()),
+            }),
+        },
+        User3 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Some(Post3 {
+                id: posts[2].id,
+                user_id: posts[2].user_id,
+                title: posts[2].title.clone(),
+                body: posts[2].body.clone(),
+                comment: Some(comments[1].clone()),
+            }),
+        },
+        User3 {
+            id: tess.id,
+            name: tess.name.clone(),
+            hair_color: tess.hair_color.clone(),
+            post: Some(Post3 {
+                id: posts[1].id,
+                user_id: posts[1].user_id,
+                title: posts[1].title.clone(),
+                body: posts[1].body.clone(),
+                comment: None,
+            }),
+        },
+    ];
+    assert_eq!(Ok(expected), data);
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = users)]
+    struct User4 {
+        id: i32,
+        name: String,
+        hair_color: Option<String>,
+        #[diesel(embed)]
+        post: Option<Post4>,
+    }
+
+    #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
+    #[diesel(table_name = posts)]
+    struct Post4 {
+        id: i32,
+        user_id: i32,
+        title: String,
+        body: Option<String>,
+        #[diesel(embed)]
+        comment: Comment,
+    }
+
+    let data = users::table
+        .left_outer_join(posts::table.inner_join(comments::table))
+        .order((users::id, posts::id, comments::id))
+        .select(User4::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        User4 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Some(Post4 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: comments[0].clone(),
+            }),
+        },
+        User4 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Some(Post4 {
+                id: posts[0].id,
+                user_id: posts[0].user_id,
+                title: posts[0].title.clone(),
+                body: posts[0].body.clone(),
+                comment: comments[2].clone(),
+            }),
+        },
+        User4 {
+            id: sean.id,
+            name: sean.name.clone(),
+            hair_color: sean.hair_color.clone(),
+            post: Some(Post4 {
+                id: posts[2].id,
+                user_id: posts[2].user_id,
+                title: posts[2].title.clone(),
+                body: posts[2].body.clone(),
+                comment: comments[1].clone(),
+            }),
+        },
+        User4 {
+            id: tess.id,
+            name: tess.name.clone(),
+            hair_color: tess.hair_color.clone(),
+            post: None,
+        },
+    ];
+    assert_eq!(Ok(expected), data);
+}
+
+#[test]
+fn selecting_grandchild_child_parent() {
+    use crate::joins::TestData;
+    let (mut connection, test_data) =
+        crate::joins::connection_with_fixture_data_for_multitable_joins();
+    let TestData {
+        sean,
+        posts,
+        comments,
+        ..
+    } = test_data;
+
+    let data = comments::table
+        .inner_join(posts::table.inner_join(users::table))
+        .order((users::id, posts::id, comments::id))
+        .select(<(Comment, (Post, User)) as SelectableHelper<_>>::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        (comments[0].clone(), (posts[0].clone(), sean.clone())),
+        (comments[2].clone(), (posts[0].clone(), sean.clone())),
+        (comments[1].clone(), (posts[2].clone(), sean.clone())),
+    ];
+    assert_eq!(Ok(expected), data);
+}
+
+#[test]
+fn selecting_crazy_nested_joins() {
+    use crate::joins::TestData;
+    let (mut connection, test_data) =
+        crate::joins::connection_with_fixture_data_for_multitable_joins();
+    let TestData {
+        sean,
+        tess,
+        posts,
+        likes,
+        comments,
+        followings,
+        ..
+    } = test_data;
+
+    let data = users::table
+        .inner_join(
+            posts::table
+                .left_join(comments::table.left_join(likes::table))
+                .left_join(followings::table),
+        )
+        .select(<(
+            User,
+            (Post, Option<(Comment, Option<Like>)>, Option<Following>),
+        ) as SelectableHelper<_>>::as_select())
+        .order((users::id, posts::id, comments::id))
+        .load(&mut connection);
+    let expected = vec![
+        (
+            sean.clone(),
+            (
+                posts[0].clone(),
+                Some((comments[0].clone(), Some(likes[0].clone()))),
+                None,
+            ),
+        ),
+        (
+            sean.clone(),
+            (posts[0].clone(), Some((comments[2].clone(), None)), None),
+        ),
+        (
+            sean.clone(),
+            (posts[2].clone(), Some((comments[1].clone(), None)), None),
+        ),
+        (
+            tess.clone(),
+            (posts[1].clone(), None, Some(followings[0].clone())),
+        ),
+    ];
+    assert_eq!(Ok(expected), data);
+
+    let data = users::table
+        .inner_join(posts::table.left_join(comments::table.left_join(likes::table)))
+        .left_join(followings::table)
+        .order((users::id, posts::id, comments::id))
+        .select(<(
+            User,
+            (Post, Option<(Comment, Option<Like>)>),
+            Option<Following>,
+        ) as SelectableHelper<_>>::as_select())
+        .load(&mut connection);
+    let expected = vec![
+        (
+            sean.clone(),
+            (
+                posts[0].clone(),
+                Some((comments[0].clone(), Some(likes[0].clone()))),
+            ),
+            Some(followings[0]),
+        ),
+        (
+            sean.clone(),
+            (posts[0].clone(), Some((comments[2].clone(), None))),
+            Some(followings[0]),
+        ),
+        (
+            sean.clone(),
+            (posts[2].clone(), Some((comments[1].clone(), None))),
+            Some(followings[0]),
+        ),
+        (tess.clone(), (posts[1].clone(), None), None),
+    ];
+    assert_eq!(Ok(expected), data);
+}


### PR DESCRIPTION
This is a tricky one. It seems like the behaviour described in that
issue should work out of the box, but it doesn't. I've spend some time
to investigate various solutions to make this work, but I came to the
conclusion that the current behaviour is the correct one.

The underlying issue here is that such an query promotes the inner
`Nullable<_>` of the field onto the outer `Queryable` wrapper. Without
`Selectable` that would require a select clause like
`.select((table::column.assume_not_null(),).nullable())`. This is
technically a safe pattern, but requires the usage of the "advanced"
`assume_not_null()` method to forcibly convert types to their not null representation.

Possible solutions tried to make the enable constructs shown in that
issue:

* I've tried to make the `impl Selectable for Option<T>` return the
following `SelectExpression`:
`dsl::Nullable<dsl::AssumeNotNull<T::SelectExpression>>`
where `AssumeNotNull` converts each tuple element to the corresponding
not nullable expression, while `Nullable` wraps the tuple itself into a
nullable type wrapper.
* I've tried to apply a similar approach like that one above, but only
for derived impls by manipulating the generated code for a optional
field with `#[diesel(embed)]`

Both solutions require changes to our sql type system, as for example
allowing to load a non nullable value into a `Option<T>` to enable their
usage in a more general scope as the presented example case.
(See the added test cases for this). That by itself would be fine in my
opinion, as this is always a safe operation. Unfortunately the
`AssumeNotNull` transformation would be applied recursively for all
sub-tuples, which in turn would cause trouble with nested joins (again
see the examples). We would be able to workaround this issue by allowing
the `FromSql<ST, DB> for Option<T>` impl for non-nullable types to catch
null values, which in turn really feels like a bad hack. (You would like
to get an error there instead, but nested nullable information are
gone.)
All in all this lead me to the conclusion that the current behaviour is
correct.

This PR adds a few additional tests (an adjusted version of the test
from the bug report + more tests around nested joins) and does move
around some code bits that I noticed while working on this.

I think the official answer for the bug report would be: Either wrap the
inner type also in an `Option` or provide a manual `Selectable` impl
that does the "right" thing there.