### PR TITLE
Fix/3182

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install libsqlite3-dev libpq-dev libmysqlclient-dev
+      - name: Set environment variables
+        shell: bash
+        run: |
+          echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
+          echo "RUSTDOCFLAGS=-D warnings" >> $GITHUB_ENV
 
       - name: Remove potential newer clippy.toml from dependencies
         run: |
@@ -386,9 +391,9 @@ jobs:
           cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "postgres diesel/postgres"
           cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "postgres" --no-default-features
           cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "postgres"
-          cargo clippy --tests --manifest-path examples/postgres/getting_started_step1/Cargo.toml
-          cargo clippy --tests --manifest-path examples/postgres/getting_started_step2/Cargo.toml
-          cargo clippy --tests --manifest-path examples/postgres/getting_started_step3/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/getting_started_step_1/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/getting_started_step_2/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/getting_started_step_3/Cargo.toml
           cargo clippy --tests --manifest-path examples/postgres/advanced-blog-cli/Cargo.toml
           cargo clippy --tests --manifest-path examples/postgres/all_about_inserts/Cargo.toml
           cargo clippy --tests --manifest-path examples/postgres/all_about_updates/Cargo.toml
@@ -401,9 +406,9 @@ jobs:
           cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "sqlite diesel/sqlite"
           cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "sqlite" --no-default-features
           cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "sqlite"
-          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step1/Cargo.toml
-          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step2/Cargo.toml
-          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step3/Cargo.toml
+          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step_1/Cargo.toml
+          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step_2/Cargo.toml
+          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step_3/Cargo.toml
           cargo clippy --tests --manifest-path examples/sqlite/all_about_inserts/Cargo.toml
 
           cargo clippy --tests --manifest-path diesel_derives/Cargo.toml --features "mysql diesel/mysql"
@@ -413,9 +418,9 @@ jobs:
           cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "mysql diesel/mysql"
           cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "mysql" --no-default-features
           cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "mysql"
-          cargo clippy --tests --manifest-path examples/mysql/getting_started_step1/Cargo.toml
-          cargo clippy --tests --manifest-path examples/mysql/getting_started_step2/Cargo.toml
-          cargo clippy --tests --manifest-path examples/mysql/getting_started_step3/Cargo.toml
+          cargo clippy --tests --manifest-path examples/mysql/getting_started_step_1/Cargo.toml
+          cargo clippy --tests --manifest-path examples/mysql/getting_started_step_2/Cargo.toml
+          cargo clippy --tests --manifest-path examples/mysql/getting_started_step_3/Cargo.toml
           cargo clippy --tests --manifest-path examples/mysql/all_about_inserts/Cargo.toml
 
       - name: Check formating

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,10 +377,46 @@ jobs:
           find ~/.cargo/registry -iname "*clippy.toml" -delete
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all
+        run:
+          cargo clippy --tests --manifest-path diesel_derives/Cargo.toml --features "postgres diesel/postgres"
+          cargo clippy --tests --manifest-path diesel/Cargo.toml --features "postgres"
+          cargo clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "postgres diesel/postgres"
+          cargo clippy --tests --manifest-path diesel_migrations/migrations_internals/Cargo.toml
+          cargo clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "postgres diesel/postgres"
+          cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "postgres diesel/postgres"
+          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "postgres"
+          cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "postgres"
+          cargo clippy --tests --manifest-path examples/postgres/getting_started_step1/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/getting_started_step2/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/getting_started_step3/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/advanced-blog-cli/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/all_about_inserts/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/all_about_updates/Cargo.toml
+          cargo clippy --tests --manifest-path examples/postgres/custom_types/Cargo.toml
+
+          cargo clippy --tests --manifest-path diesel_derives/Cargo.toml --features "sqlite diesel/sqlite"
+          cargo clippy --tests --manifest-path diesel/Cargo.toml --features "sqlite"
+          cargo clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "sqlite diesel/sqlite"
+          cargo clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "sqlite diesel/sqlite"
+          cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "sqlite diesel/sqlite"
+          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "sqlite"
+          cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "sqlite"
+          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step1/Cargo.toml
+          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step2/Cargo.toml
+          cargo clippy --tests --manifest-path examples/sqlite/getting_started_step3/Cargo.toml
+          cargo clippy --tests --manifest-path examples/sqlite/all_about_inserts/Cargo.toml
+
+          cargo clippy --tests --manifest-path diesel_derives/Cargo.toml --features "mysql diesel/mysql"
+          cargo clippy --tests --manifest-path diesel/Cargo.toml --features "mysql"
+          cargo clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "mysql diesel/mysql"
+          cargo clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "mysql diesel/mysql"
+          cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "mysql diesel/mysql"
+          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "mysql"
+          cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "mysql"
+          cargo clippy --tests --manifest-path examples/mysql/getting_started_step1/Cargo.toml
+          cargo clippy --tests --manifest-path examples/mysql/getting_started_step2/Cargo.toml
+          cargo clippy --tests --manifest-path examples/mysql/getting_started_step3/Cargo.toml
+          cargo clippy --tests --manifest-path examples/mysql/all_about_inserts/Cargo.toml
 
       - name: Check formating
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,14 +377,14 @@ jobs:
           find ~/.cargo/registry -iname "*clippy.toml" -delete
 
       - name: Run clippy
-        run:
+        run: |
           cargo clippy --tests --manifest-path diesel_derives/Cargo.toml --features "postgres diesel/postgres"
           cargo clippy --tests --manifest-path diesel/Cargo.toml --features "postgres"
           cargo clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "postgres diesel/postgres"
           cargo clippy --tests --manifest-path diesel_migrations/migrations_internals/Cargo.toml
           cargo clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "postgres diesel/postgres"
           cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "postgres diesel/postgres"
-          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "postgres"
+          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "postgres" --no-default-features
           cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "postgres"
           cargo clippy --tests --manifest-path examples/postgres/getting_started_step1/Cargo.toml
           cargo clippy --tests --manifest-path examples/postgres/getting_started_step2/Cargo.toml
@@ -399,7 +399,7 @@ jobs:
           cargo clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "sqlite diesel/sqlite"
           cargo clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "sqlite diesel/sqlite"
           cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "sqlite diesel/sqlite"
-          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "sqlite"
+          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "sqlite" --no-default-features
           cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "sqlite"
           cargo clippy --tests --manifest-path examples/sqlite/getting_started_step1/Cargo.toml
           cargo clippy --tests --manifest-path examples/sqlite/getting_started_step2/Cargo.toml
@@ -411,7 +411,7 @@ jobs:
           cargo clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "mysql diesel/mysql"
           cargo clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "mysql diesel/mysql"
           cargo clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "mysql diesel/mysql"
-          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "mysql"
+          cargo clippy --tests --manifest-path diesel_cli/Cargo.toml --features "mysql" --no-default-features
           cargo clippy --tests --manifest-path diesel_tests/Cargo.toml --features "mysql"
           cargo clippy --tests --manifest-path examples/mysql/getting_started_step1/Cargo.toml
           cargo clippy --tests --manifest-path examples/mysql/getting_started_step2/Cargo.toml

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -672,6 +672,9 @@ mod test {
 
     #[test]
     #[cfg(feature = "mysql")]
+    // This function uses a collect with side effects (spawning threads)
+    // so clippy is wrong here
+    #[allow(clippy::needless_collect)]
     fn mysql_transaction_depth_commits_tracked_properly_on_serialization_failure() {
         use crate::result::DatabaseErrorKind::SerializationFailure;
         use crate::result::Error::DatabaseError;
@@ -775,6 +778,9 @@ mod test {
 
     #[test]
     #[cfg(feature = "mysql")]
+    // This function uses a collect with side effects (spawning threads)
+    // so clippy is wrong here
+    #[allow(clippy::needless_collect)]
     fn mysql_nested_transaction_depth_commits_tracked_properly_on_serialization_failure() {
         use crate::result::DatabaseErrorKind::SerializationFailure;
         use crate::result::Error::DatabaseError;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -178,7 +178,6 @@
     clippy::redundant_field_names,
     clippy::type_complexity
 )]
-#![cfg_attr(test, allow(clippy::option_map_unwrap_or, clippy::result_unwrap_used))]
 #![warn(
     clippy::unwrap_used,
     clippy::print_stdout,
@@ -191,6 +190,7 @@
     clippy::items_after_statements,
     clippy::used_underscore_binding
 )]
+#![cfg_attr(test, allow(clippy::map_unwrap_or, clippy::unwrap_used))]
 
 extern crate diesel_derives;
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -1289,14 +1289,14 @@ mod tests {
 
     #[test]
     fn check_json_bind() {
-        let conn = &mut crate::test_helpers::connection();
-
         table! {
             json_test {
                 id -> Integer,
                 json_field -> Text,
             }
         }
+
+        let conn = &mut crate::test_helpers::connection();
 
         crate::sql_query("DROP TABLE IF EXISTS json_test CASCADE")
             .execute(conn)

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -301,24 +301,20 @@ fn fun_with_row_iters() {
         Row::get(&first_row, 0).unwrap(),
         Row::get(&first_row, 1).unwrap(),
     );
-    let first_values = (first_fields.0.value(), first_fields.1.value());
+    let _first_values = (first_fields.0.value(), first_fields.1.value());
 
     assert!(row_iter.next().unwrap().is_err());
-    std::mem::drop(first_values);
     assert!(row_iter.next().unwrap().is_err());
-    std::mem::drop(first_fields);
 
     let second_row = row_iter.next().unwrap().unwrap();
     let second_fields = (
         Row::get(&second_row, 0).unwrap(),
         Row::get(&second_row, 1).unwrap(),
     );
-    let second_values = (second_fields.0.value(), second_fields.1.value());
+    let _second_values = (second_fields.0.value(), second_fields.1.value());
 
     assert!(row_iter.next().unwrap().is_err());
-    std::mem::drop(second_values);
     assert!(row_iter.next().unwrap().is_err());
-    std::mem::drop(second_fields);
 
     assert!(row_iter.next().is_none());
 

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -301,20 +301,24 @@ fn fun_with_row_iters() {
         Row::get(&first_row, 0).unwrap(),
         Row::get(&first_row, 1).unwrap(),
     );
-    let _first_values = (first_fields.0.value(), first_fields.1.value());
+    let first_values = (first_fields.0.value(), first_fields.1.value());
 
     assert!(row_iter.next().unwrap().is_err());
+    std::mem::drop(first_values);
     assert!(row_iter.next().unwrap().is_err());
+    std::mem::drop(first_fields);
 
     let second_row = row_iter.next().unwrap().unwrap();
     let second_fields = (
         Row::get(&second_row, 0).unwrap(),
         Row::get(&second_row, 1).unwrap(),
     );
-    let _second_values = (second_fields.0.value(), second_fields.1.value());
+    let second_values = (second_fields.0.value(), second_fields.1.value());
 
     assert!(row_iter.next().unwrap().is_err());
+    std::mem::drop(first_values);
     assert!(row_iter.next().unwrap().is_err());
+    std::mem::drop(second_fields);
 
     assert!(row_iter.next().is_none());
 

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -316,7 +316,7 @@ fn fun_with_row_iters() {
     let second_values = (second_fields.0.value(), second_fields.1.value());
 
     assert!(row_iter.next().unwrap().is_err());
-    std::mem::drop(first_values);
+    std::mem::drop(second_values);
     assert!(row_iter.next().unwrap().is_err());
     std::mem::drop(second_fields);
 

--- a/diesel/src/mysql/query_builder/mod.rs
+++ b/diesel/src/mysql/query_builder/mod.rs
@@ -26,7 +26,7 @@ impl QueryBuilder<Mysql> for MysqlQueryBuilder {
 
     fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
         self.push_sql("`");
-        self.push_sql(&identifier.replace("`", "``"));
+        self.push_sql(&identifier.replace('`', "``"));
         self.push_sql("`");
         Ok(())
     }

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -4,7 +4,7 @@ use crate::deserialize;
 use std::error::Error;
 
 /// Raw mysql value as received from the database
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct MysqlValue<'a> {
     raw: &'a [u8],
     tpe: MysqlType,

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -273,12 +273,8 @@ mod tests {
         let query =
             crate::sql_query("SELECT not_existent FROM also_not_there;").execute(connection);
 
-        if let Err(err) = query {
-            if let DatabaseError(_, string) = err {
-                assert_eq!(Some(26), string.statement_position());
-            } else {
-                unreachable!();
-            }
+        if let Err(DatabaseError(_, string)) = query {
+            assert_eq!(Some(26), string.statement_position());
         } else {
             unreachable!();
         }
@@ -367,14 +363,14 @@ mod tests {
         let insert = query
             .insert_into(users::table)
             .into_columns((users::id, users::name));
-        assert_eq!(true, insert.execute(connection).is_ok());
+        assert!(insert.execute(connection).is_ok());
         assert_eq!(1, connection.statement_cache.len());
 
         let query = users::table.filter(users::id.eq(42)).into_boxed();
         let insert = query
             .insert_into(users::table)
             .into_columns((users::id, users::name));
-        assert_eq!(true, insert.execute(connection).is_ok());
+        assert!(insert.execute(connection).is_ok());
         assert_eq!(2, connection.statement_cache.len());
     }
 
@@ -392,7 +388,7 @@ mod tests {
         let insert =
             crate::insert_into(users::table).values((users::id.eq(42), users::name.eq("Foo")));
 
-        assert_eq!(true, insert.execute(connection).is_ok());
+        assert!(insert.execute(connection).is_ok());
         assert_eq!(1, connection.statement_cache.len());
     }
 
@@ -410,7 +406,7 @@ mod tests {
         let insert = crate::insert_into(users::table)
             .values(vec![(users::id.eq(42), users::name.eq("Foo"))]);
 
-        assert_eq!(true, insert.execute(connection).is_ok());
+        assert!(insert.execute(connection).is_ok());
         assert_eq!(0, connection.statement_cache.len());
     }
 
@@ -428,7 +424,7 @@ mod tests {
         let insert =
             crate::insert_into(users::table).values([(users::id.eq(42), users::name.eq("Foo"))]);
 
-        assert_eq!(true, insert.execute(connection).is_ok());
+        assert!(insert.execute(connection).is_ok());
         assert_eq!(1, connection.statement_cache.len());
     }
 
@@ -585,6 +581,9 @@ mod tests {
     }
 
     #[test]
+    // This function uses collect with an side effect (spawning threads)
+    // so this is a false positive from clippy
+    #[allow(clippy::needless_collect)]
     fn postgres_transaction_depth_is_tracked_properly_on_serialization_failure() {
         use crate::pg::connection::raw::PgTransactionStatus;
         use crate::result::DatabaseErrorKind::SerializationFailure;
@@ -692,6 +691,9 @@ mod tests {
     }
 
     #[test]
+    // This function uses collect with an side effect (spawning threads)
+    // so this is a false positive from clippy
+    #[allow(clippy::needless_collect)]
     fn postgres_transaction_depth_is_tracked_properly_on_nested_serialization_failure() {
         use crate::pg::connection::raw::PgTransactionStatus;
         use crate::result::DatabaseErrorKind::SerializationFailure;

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -242,6 +242,9 @@ impl IntervalDsl for f64 {
 }
 
 #[cfg(test)]
+// those macros define nested function
+// that's fine for this test code
+#[allow(clippy::items_after_statements)]
 mod tests {
     extern crate dotenvy;
     extern crate quickcheck;

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -64,6 +64,9 @@ use crate::expression::AsExpression;
 macro_rules! array_as_expression {
     ($ty:ty, $sql_type:ty) => {
         #[cfg(feature = "postgres_backend")]
+        // this simplifies the macro implemntation
+        // as some macro calls use this lifetime
+        #[allow(clippy::extra_unused_lifetimes)]
         impl<'a, 'b, ST: 'static, T> AsExpression<$sql_type> for $ty {
             type Expression = Bound<$sql_type, Self>;
 

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -31,7 +31,7 @@ impl FromSql<sql_types::Timestamp, Pg> for SystemTime {
     fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let usecs_passed = <i64 as FromSql<sql_types::BigInt, Pg>>::from_sql(bytes)?;
         let before_epoch = usecs_passed < 0;
-        let time_passed = usecs_to_duration(usecs_passed.abs() as u64);
+        let time_passed = usecs_to_duration(usecs_passed.unsigned_abs());
 
         if before_epoch {
             Ok(pg_epoch() - time_passed)

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -604,7 +604,7 @@ where
     }
 }
 
-impl<'a, F, S, D, W, O, LOf, G, H> SelectNullableDsl
+impl<F, S, D, W, O, LOf, G, H> SelectNullableDsl
     for SelectStatement<F, SelectClause<S>, D, W, O, LOf, G, H>
 {
     type Output = SelectStatement<F, SelectClause<Nullable<S>>, D, W, O, LOf, G, H>;
@@ -624,7 +624,7 @@ impl<'a, F, S, D, W, O, LOf, G, H> SelectNullableDsl
     }
 }
 
-impl<'a, F, D, W, O, LOf, G, H> SelectNullableDsl
+impl<F, D, W, O, LOf, G, H> SelectNullableDsl
     for SelectStatement<F, DefaultSelectClause<F>, D, W, O, LOf, G, H>
 where
     F: AsQuerySource,

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -32,6 +32,9 @@ pub trait QuerySource {
 
     /// The actual `FROM` clause of this type. This is typically only called in
     /// `QueryFragment` implementations.
+    // from here is something different than from in rust
+    // as this literally refercs to SQL from.
+    #[allow(clippy::wrong_self_convention)]
     fn from_clause(&self) -> Self::FromClause;
     /// The default select clause of this type, which should be used if no
     /// select clause was explicitly specified. This should always be a tuple of

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -96,6 +96,9 @@ where
     Args::build_from_row(&row).map_err(Error::DeserializationError)
 }
 
+// clippy is wrong here, the let binding is required
+// for lifetime reasons
+#[allow(clippy::let_unit_value)]
 pub(super) fn process_sql_function_result<RetSqlType, Ret>(
     result: &'_ Ret,
 ) -> QueryResult<InternalSqliteBindValue<'_>>

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     fn register_noarg_function() {
         let connection = &mut SqliteConnection::establish(":memory:").unwrap();
-        answer::register_impl(&connection, || 42).unwrap();
+        answer::register_impl(connection, || 42).unwrap();
 
         let answer = crate::select(answer()).get_result::<i32>(connection);
         assert_eq!(Ok(42), answer);
@@ -465,7 +465,7 @@ mod tests {
     #[test]
     fn register_nondeterministic_noarg_function() {
         let connection = &mut SqliteConnection::establish(":memory:").unwrap();
-        answer::register_nondeterministic_impl(&connection, || 42).unwrap();
+        answer::register_nondeterministic_impl(connection, || 42).unwrap();
 
         let answer = crate::select(answer()).get_result::<i32>(connection);
         assert_eq!(Ok(42), answer);

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -475,7 +475,6 @@ extern "C" fn run_aggregator_final_function<ArgsSqlType, RetSqlType, Args, Ret, 
     });
     if let Err(e) = result {
         e.emit(ctx);
-        return;
     }
 }
 

--- a/diesel/src/sqlite/query_builder/mod.rs
+++ b/diesel/src/sqlite/query_builder/mod.rs
@@ -27,7 +27,7 @@ impl QueryBuilder<Sqlite> for SqliteQueryBuilder {
 
     fn push_identifier(&mut self, identifier: &str) -> QueryResult<()> {
         self.push_sql("`");
-        self.push_sql(&identifier.replace("`", "``"));
+        self.push_sql(&identifier.replace('`', "``"));
         self.push_sql("`");
         Ok(())
     }

--- a/diesel_cli/src/infer_schema_internals/inference.rs
+++ b/diesel_cli/src/infer_schema_internals/inference.rs
@@ -97,7 +97,7 @@ fn get_column_information(
         }
     };
     if let Err(NotFound) = column_info {
-        Err(format!("no table exists named {}", table.to_string()).into())
+        Err(format!("no table exists named {}", table).into())
     } else {
         column_info.map_err(Into::into)
     }
@@ -137,7 +137,7 @@ pub(crate) fn get_primary_keys(
         Err(format!(
             "Diesel only supports tables with primary keys. \
              Table {} has no primary key",
-            table.to_string()
+            table,
         )
         .into())
     } else {

--- a/diesel_cli/src/infer_schema_internals/information_schema.rs
+++ b/diesel_cli/src/infer_schema_internals/information_schema.rs
@@ -559,7 +559,7 @@ mod tests {
         let id = ColumnInformation::new("id", "int4", pg_catalog.clone(), false);
         let text_col = ColumnInformation::new("text_col", "varchar", pg_catalog.clone(), true);
         let not_null = ColumnInformation::new("not_null", "text", pg_catalog.clone(), false);
-        let array_col = ColumnInformation::new("array_col", "_varchar", pg_catalog.clone(), false);
+        let array_col = ColumnInformation::new("array_col", "_varchar", pg_catalog, false);
         assert_eq!(
             Ok(vec![id, text_col, not_null]),
             get_table_data(&mut connection, &table_1, &ColumnSorting::OrdinalPosition)
@@ -594,14 +594,14 @@ mod tests {
         let table_3 = TableName::new("table_3", "test_schema");
         let fk_one = ForeignKeyConstraint {
             child_table: table_2.clone(),
-            parent_table: table_1.clone(),
+            parent_table: table_1,
             foreign_key: "fk_one".into(),
             foreign_key_rust_name: "fk_one".into(),
             primary_key: "id".into(),
         };
         let fk_two = ForeignKeyConstraint {
-            child_table: table_3.clone(),
-            parent_table: table_2.clone(),
+            child_table: table_3,
+            parent_table: table_2,
             foreign_key: "fk_two".into(),
             foreign_key_rust_name: "fk_two".into(),
             primary_key: "id".into(),

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -368,14 +368,14 @@ fn load_foreign_key_constraints_loads_foreign_keys() {
     let table_3 = TableName::from_name("table_3");
     let fk_one = ForeignKeyConstraint {
         child_table: table_2.clone(),
-        parent_table: table_1.clone(),
+        parent_table: table_1,
         foreign_key: "fk_one".into(),
         foreign_key_rust_name: "fk_one".into(),
         primary_key: "id".into(),
     };
     let fk_two = ForeignKeyConstraint {
-        child_table: table_3.clone(),
-        parent_table: table_2.clone(),
+        child_table: table_3,
+        parent_table: table_2,
         foreign_key: "fk_two".into(),
         foreign_key_rust_name: "fk_two".into(),
         primary_key: "id".into(),

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -11,7 +11,7 @@
     clippy::used_underscore_binding,
     missing_copy_implementations
 )]
-#![cfg_attr(test, allow(clippy::result_unwrap_used))]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod config;
 

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -289,6 +289,7 @@ impl Display for CustomTypeList {
                 Ok(())
             }
             #[cfg(feature = "sqlite")]
+            #[allow(clippy::print_in_format_impl)]
             Backend::Sqlite => {
                 let _ = (&f, self.with_docs);
                 for t in &self.types_sorted {
@@ -302,6 +303,7 @@ impl Display for CustomTypeList {
                 )
             }
             #[cfg(feature = "mysql")]
+            #[allow(clippy::print_in_format_impl)]
             Backend::Mysql => {
                 let _ = (&f, self.with_docs);
                 for t in &self.types_sorted {

--- a/diesel_cli/tests/migration_list.rs
+++ b/diesel_cli/tests/migration_list.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_fun_call)]
 use chrono::Utc;
 use std::thread::sleep;
 use std::time::Duration;
@@ -95,10 +96,10 @@ fn migration_list_orders_unknown_timestamps_last() {
     p.create_migration(&tag1, "", "");
 
     let tag4 = "abc_migration4";
-    p.create_migration(&tag4, "", "");
+    p.create_migration(tag4, "", "");
 
     let tag5 = "zzz_migration5";
-    p.create_migration(&tag5, "", "");
+    p.create_migration(tag5, "", "");
 
     sleep(Duration::from_millis(1100));
 
@@ -113,7 +114,7 @@ fn migration_list_orders_unknown_timestamps_last() {
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
     let output = result.stdout();
-    assert_tags_in_order(output, &[&tag1, &tag2, &tag3, &tag4, &tag5]);
+    assert_tags_in_order(output, &[&tag1, &tag2, &tag3, tag4, tag5]);
 }
 
 #[test]
@@ -125,19 +126,19 @@ fn migration_list_orders_nontimestamp_versions_alphabetically() {
     p.command("setup").run();
 
     let tag4 = "a_migration";
-    p.create_migration(&tag4, "", "");
+    p.create_migration(tag4, "", "");
 
     let tag6 = "bc_migration";
-    p.create_migration(&tag6, "", "");
+    p.create_migration(tag6, "", "");
 
     let tag5 = "aa_migration";
-    p.create_migration(&tag5, "", "");
+    p.create_migration(tag5, "", "");
 
     let tag1 = "!wow_migration";
-    p.create_migration(&tag1, "", "");
+    p.create_migration(tag1, "", "");
 
     let tag3 = "7letters";
-    p.create_migration(&tag3, "", "");
+    p.create_migration(tag3, "", "");
 
     let tag2 = format!("{}_stamped_migration", Utc::now().format(TIMESTAMP_FORMAT));
     p.create_migration(&tag2, "", "");
@@ -145,7 +146,7 @@ fn migration_list_orders_nontimestamp_versions_alphabetically() {
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
     let output = result.stdout();
-    assert_tags_in_order(output, &[&tag1, &tag2, &tag3, &tag4, &tag5, &tag6]);
+    assert_tags_in_order(output, &[tag1, &tag2, tag3, tag4, tag5, tag6]);
 }
 
 #[test]
@@ -157,15 +158,15 @@ fn migration_list_orders_old_and_new_timestamp_forms_mixed_correctly() {
     p.command("setup").run();
 
     let tag1 = "20170505070309_migration";
-    p.create_migration(&tag1, "", "");
+    p.create_migration(tag1, "", "");
 
     let tag2 = "2017-11-23-064836_migration";
-    p.create_migration(&tag2, "", "");
+    p.create_migration(tag2, "", "");
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
     let output = result.stdout();
-    assert_tags_in_order(output, &[&tag1, &tag2]);
+    assert_tags_in_order(output, &[tag1, tag2]);
 }
 
 #[test]

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_fun_call)]
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};

--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -46,7 +46,7 @@ impl TestCommand {
             .build_command()
             .output()
             .expect("failed to execute process");
-        CommandResult { output: output }
+        CommandResult { output }
     }
 
     fn build_command(&self) -> Command {

--- a/diesel_cli/tests/support/mod.rs
+++ b/diesel_cli/tests/support/mod.rs
@@ -4,9 +4,8 @@ macro_rules! try_drop {
         match $e {
             Ok(x) => x,
             Err(e) => {
-                use std::io::{stderr, Write};
                 if ::std::thread::panicking() {
-                    write!(stderr(), "{}: {:?}", $msg, e).unwrap();
+                    eprintln!("{}: {:?}", $msg, e);
                     return;
                 } else {
                     panic!("{}: {:?}", $msg, e);

--- a/diesel_cli/tests/support/mysql_database.rs
+++ b/diesel_cli/tests/support/mysql_database.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_fun_call)]
 use diesel::connection::SimpleConnection;
 use diesel::dsl::sql;
 use diesel::sql_types::Bool;
@@ -50,7 +51,7 @@ impl Database {
     }
 
     fn split_url(&self) -> (String, String) {
-        let mut split: Vec<&str> = self.url.split("/").collect();
+        let mut split: Vec<&str> = self.url.split('/').collect();
         let database = split.pop().unwrap();
         let mysql_url = format!("{}/{}", split.join("/"), "information_schema");
         (database.into(), mysql_url)

--- a/diesel_cli/tests/support/postgres_database.rs
+++ b/diesel_cli/tests/support/postgres_database.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_fun_call)]
 use diesel::connection::SimpleConnection;
 use diesel::dsl::sql;
 use diesel::sql_types::Bool;
@@ -49,7 +50,7 @@ impl Database {
     }
 
     fn split_url(&self) -> (String, String) {
-        let mut split: Vec<&str> = self.url.split("/").collect();
+        let mut split: Vec<&str> = self.url.split('/').collect();
         let database = split.pop().unwrap();
         let postgres_url = format!("{}/{}", split.join("/"), "postgres");
         (database.into(), postgres_url)

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -84,7 +84,7 @@ impl Project {
             .read_dir()
             .expect("Error reading directory")
             .map(|e| Migration {
-                path: e.expect("error reading entry").path().into(),
+                path: e.expect("error reading entry").path(),
             })
             .collect()
     }

--- a/diesel_cli/tests/support/sqlite_database.rs
+++ b/diesel_cli/tests/support/sqlite_database.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_fun_call)]
 use diesel::connection::SimpleConnection;
 use diesel::dsl::sql;
 use diesel::sql_types::Bool;

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -33,10 +33,7 @@ pub fn derive(item: DeriveInput) -> TokenStream {
 
     let treat_none_as_null = model.treat_none_as_null();
 
-    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
-    let mut impl_generics = item.generics.clone();
-    impl_generics.params.push(parse_quote!('update));
-    let (impl_generics, _, _) = impl_generics.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
     let mut generate_borrowed_changeset = true;
 
@@ -106,6 +103,10 @@ pub fn derive(item: DeriveInput) -> TokenStream {
     };
 
     let changeset_borrowed = if generate_borrowed_changeset {
+        let mut impl_generics = item.generics.clone();
+        impl_generics.params.push(parse_quote!('update));
+        let (impl_generics, _, _) = impl_generics.split_for_impl();
+
         quote! {
             impl #impl_generics AsChangeset for &'update #struct_name #ty_generics
             #where_clause

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -13,10 +13,7 @@ pub fn derive(item: DeriveInput) -> TokenStream {
     let table_name = &model.table_name();
     let struct_name = &item.ident;
 
-    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
-    let mut impl_generics = item.generics.clone();
-    impl_generics.params.push(parse_quote!('insert));
-    let (impl_generics, ..) = impl_generics.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
     let mut generate_borrowed_insert = true;
 
@@ -97,6 +94,10 @@ pub fn derive(item: DeriveInput) -> TokenStream {
     };
 
     let insert_borrowed = if generate_borrowed_insert {
+        let mut impl_generics = item.generics.clone();
+        impl_generics.params.push(parse_quote!('insert));
+        let (impl_generics, ..) = impl_generics.split_for_impl();
+
         quote! {
             impl #impl_generics Insertable<#table_name::table>
                 for &'insert #struct_name #ty_generics

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -226,9 +226,9 @@ fn with_serialize_as() {
     #[diesel(sql_type = sql_types::Text)]
     struct UppercaseString(pub String);
 
-    impl Into<UppercaseString> for String {
-        fn into(self) -> UppercaseString {
-            UppercaseString(self.to_uppercase())
+    impl From<String> for UppercaseString {
+        fn from(val: String) -> Self {
+            UppercaseString(val.to_uppercase())
         }
     }
 

--- a/diesel_derives/tests/queryable_by_name.rs
+++ b/diesel_derives/tests/queryable_by_name.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::blacklisted_name)]
 use diesel::sql_types::Integer;
 use diesel::*;
 

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -59,8 +59,7 @@ pub fn search_for_migrations_directory(path: &Path) -> Option<PathBuf> {
     if migration_path.is_dir() {
         Some(migration_path)
     } else {
-        path.parent()
-            .and_then(|p| search_for_migrations_directory(p))
+        path.parent().and_then(search_for_migrations_directory)
     }
 }
 

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -9,7 +9,7 @@ pub fn expand(path: String) -> proc_macro2::TokenStream {
     let migrations_path_opt = if path.is_empty() {
         None
     } else {
-        Some(path.replace("\"", ""))
+        Some(path.replace('"', ""))
     };
     let migrations_expr = migration_directory_from_given_path(migrations_path_opt.as_deref())
         .unwrap_or_else(|_| {

--- a/diesel_migrations/migrations_macros/src/lib.rs
+++ b/diesel_migrations/migrations_macros/src/lib.rs
@@ -20,7 +20,7 @@
     missing_debug_implementations,
     missing_copy_implementations
 )]
-#![cfg_attr(test, allow(clippy::option_unwrap_used, clippy::result_unwrap_used))]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 extern crate proc_macro;
 
 mod embed_migrations;

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -14,7 +14,7 @@ diesel = { path = "../diesel", default-features = false, features = ["quickcheck
 diesel_migrations = { path = "../diesel_migrations" }
 dotenvy = "0.15"
 quickcheck = "1.0.3"
-uuid = { version = ">=0.7.0, <2.0.0" }
+uuid = { version = "1.0.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnetwork = ">=0.12.2, <0.19.0"
 bigdecimal = ">= 0.0.13, < 0.4.0"

--- a/diesel_tests/tests/annotations.rs
+++ b/diesel_tests/tests/annotations.rs
@@ -50,9 +50,10 @@ fn association_where_parent_and_child_have_underscores() {
     }
 
     impl SpecialPost {
+        #[allow(clippy::new_ret_no_self)]
         fn new(user_id: i32, title: &str) -> NewSpecialPost {
             NewSpecialPost {
-                user_id: user_id,
+                user_id,
                 title: title.to_owned(),
             }
         }
@@ -66,10 +67,9 @@ fn association_where_parent_and_child_have_underscores() {
     }
 
     impl SpecialComment {
+        #[allow(clippy::new_ret_no_self)]
         fn new(special_post_id: i32) -> NewSpecialComment {
-            NewSpecialComment {
-                special_post_id: special_post_id,
-            }
+            NewSpecialComment { special_post_id }
         }
     }
 

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -134,7 +134,7 @@ fn grouping_associations_maintains_ordering() {
     assert_eq!(expected_data, users_and_posts);
 
     // Test when sorted manually
-    let users = vec![sean.clone(), tess.clone()];
+    let users = vec![sean, tess];
     let mut posts = Post::belonging_to(&users)
         .load::<Post>(&mut connection)
         .unwrap();

--- a/diesel_tests/tests/boxed_queries.rs
+++ b/diesel_tests/tests/boxed_queries.rs
@@ -54,11 +54,11 @@ fn boxed_queries_can_differ_conditionally() {
     assert_eq!(Ok(expected_data), all);
 
     let ordered = source(Query::Ordered).load(connection);
-    let expected_data = vec![tess.clone(), sean.clone(), jim.clone()];
+    let expected_data = vec![tess, sean.clone(), jim];
     assert_eq!(Ok(expected_data), ordered);
 
     let one = source(Query::One).load(connection);
-    let expected_data = vec![sean.clone()];
+    let expected_data = vec![sean];
     assert_eq!(Ok(expected_data), one);
 }
 

--- a/diesel_tests/tests/errors.rs
+++ b/diesel_tests/tests/errors.rs
@@ -106,6 +106,8 @@ fn foreign_key_violation_correct_constraint_name() {
 
 #[test]
 #[cfg(feature = "postgres")]
+// This is a false positive as there is a side effect of this collect (spawning threads)
+#[allow(clippy::needless_collect)]
 fn isolation_errors_are_detected() {
     use diesel::result::DatabaseErrorKind::SerializationFailure;
     use diesel::result::Error::{CommitTransactionFailed, DatabaseError};

--- a/diesel_tests/tests/expressions/ops.rs
+++ b/diesel_tests/tests/expressions/ops.rs
@@ -116,6 +116,8 @@ fn test_adding_nullables() {
 }
 
 #[test]
+#[allow(clippy::eq_op)]
+// As this creates a sql expression clippy is wrong here
 fn test_subtracting_nullables() {
     use crate::schema::nullable_table::dsl::*;
     let connection = &mut connection_with_nullable_table_data();
@@ -156,6 +158,8 @@ fn test_multiplying_nullables() {
 }
 
 #[test]
+#[allow(clippy::eq_op)]
+// As this creates a sql expression clippy is wrong here
 fn test_dividing_nullables() {
     use crate::schema::nullable_table::dsl::*;
     let connection = &mut connection_with_nullable_table_data();
@@ -220,6 +224,8 @@ fn test_adding_unsigned() {
 
 #[test]
 #[cfg(feature = "mysql")]
+#[allow(clippy::eq_op)]
+// As this creates a sql expression clippy is wrong here
 fn test_subtracting_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();
@@ -238,6 +244,8 @@ fn test_subtracting_unsigned() {
 
 #[test]
 #[cfg(feature = "mysql")]
+#[allow(clippy::identity_op)]
+// As this creates a sql expression clippy is wrong here
 fn test_multiplying_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();
@@ -256,6 +264,8 @@ fn test_multiplying_unsigned() {
 
 #[test]
 #[cfg(feature = "mysql")]
+#[allow(clippy::identity_op, clippy::eq_op)]
+// As this creates a sql expression clippy is wrong here
 fn test_dividing_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();

--- a/diesel_tests/tests/expressions/ops.rs
+++ b/diesel_tests/tests/expressions/ops.rs
@@ -205,8 +205,8 @@ fn precedence_with_parens_is_maintained() {
 fn test_adding_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();
-    connection
-        .execute("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+    diesel::sql_query("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+        .execute(connection)
         .unwrap();
 
     let expected_data = vec![2, 3];
@@ -223,8 +223,8 @@ fn test_adding_unsigned() {
 fn test_subtracting_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();
-    connection
-        .execute("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+    diesel::sql_query("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+        .execute(connection)
         .unwrap();
 
     let expected_data = vec![0, 1];
@@ -241,8 +241,8 @@ fn test_subtracting_unsigned() {
 fn test_multiplying_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();
-    connection
-        .execute("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+    diesel::sql_query("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+        .execute(connection)
         .unwrap();
 
     let expected_data = vec![1, 2];
@@ -259,8 +259,8 @@ fn test_multiplying_unsigned() {
 fn test_dividing_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();
-    connection
-        .execute("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+    diesel::sql_query("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+        .execute(connection)
         .unwrap();
 
     let expected_data = vec![1, 2];
@@ -277,8 +277,8 @@ fn test_dividing_unsigned() {
 fn test_multiple_unsigned() {
     use crate::schema::unsigned_table::dsl::*;
     let connection = &mut connection();
-    connection
-        .execute("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+    diesel::sql_query("INSERT INTO unsigned_table VALUES (1,1), (2,2)")
+        .execute(connection)
         .unwrap();
 
     let expected_data = vec![1, 1];

--- a/diesel_tests/tests/internal_details.rs
+++ b/diesel_tests/tests/internal_details.rs
@@ -62,6 +62,6 @@ fn ensure_sqlite_does_not_access_dropped_buffers() {
 
     let mut iter = Connection::load(connection, query).unwrap();
 
-    assert_eq!(iter.next().is_some(), true);
-    assert_eq!(iter.next().is_none(), true);
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
 }

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -301,6 +301,7 @@ fn select_right_side_with_nullable_column_first() {
 }
 
 #[test]
+#[allow(clippy::type_complexity)]
 fn select_left_join_right_side_with_non_null_inside() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
@@ -467,7 +468,7 @@ fn selecting_parent_child_grandchild() {
         (sean.clone(), (posts[0].clone(), comments[2].clone())),
         (sean.clone(), (posts[2].clone(), comments[1].clone())),
     ];
-    assert_eq!(Ok(expected.clone()), data);
+    assert_eq!(Ok(expected), data);
 
     let data = users::table
         .inner_join(
@@ -523,8 +524,8 @@ fn selecting_parent_child_grandchild() {
     let expected = vec![
         (sean.clone(), Some((posts[0].clone(), comments[0].clone()))),
         (sean.clone(), Some((posts[0].clone(), comments[2].clone()))),
-        (sean.clone(), Some((posts[2].clone(), comments[1].clone()))),
-        (tess.clone(), None),
+        (sean, Some((posts[2].clone(), comments[1].clone()))),
+        (tess, None),
     ];
     assert_eq!(Ok(expected), data);
 }
@@ -546,7 +547,7 @@ fn selecting_grandchild_child_parent() {
     let expected = vec![
         (comments[0].clone(), (posts[0].clone(), sean.clone())),
         (comments[2].clone(), (posts[0].clone(), sean.clone())),
-        (comments[1].clone(), (posts[2].clone(), sean.clone())),
+        (comments[1].clone(), (posts[2].clone(), sean)),
     ];
     assert_eq!(Ok(expected), data);
 }
@@ -568,7 +569,7 @@ fn selecting_four_tables_deep() {
         .load(&mut connection);
     let expected = vec![(
         sean.clone(),
-        (posts[0].clone(), (comments[0].clone(), likes[0].clone())),
+        (posts[0].clone(), (comments[0].clone(), likes[0])),
     )];
     assert_eq!(Ok(expected), data);
 
@@ -579,19 +580,13 @@ fn selecting_four_tables_deep() {
     let expected = vec![
         (
             sean.clone(),
-            (
-                posts[0].clone(),
-                (comments[0].clone(), Some(likes[0].clone())),
-            ),
+            (posts[0].clone(), (comments[0].clone(), Some(likes[0]))),
         ),
         (
             sean.clone(),
             (posts[0].clone(), (comments[2].clone(), None)),
         ),
-        (
-            sean.clone(),
-            (posts[2].clone(), (comments[1].clone(), None)),
-        ),
+        (sean, (posts[2].clone(), (comments[1].clone(), None))),
     ];
     assert_eq!(Ok(expected), data);
 }
@@ -611,7 +606,7 @@ fn selecting_parent_child_sibling() {
         .inner_join(posts::table)
         .inner_join(likes::table)
         .load(&mut connection);
-    let expected = vec![(tess.clone(), posts[1].clone(), likes[0].clone())];
+    let expected = vec![(tess.clone(), posts[1].clone(), likes[0])];
     assert_eq!(Ok(expected), data);
 
     let data = users::table
@@ -621,8 +616,8 @@ fn selecting_parent_child_sibling() {
         .load(&mut connection);
     let expected = vec![
         (sean.clone(), posts[0].clone(), None),
-        (sean.clone(), posts[2].clone(), None),
-        (tess.clone(), posts[1].clone(), Some(likes[0].clone())),
+        (sean, posts[2].clone(), None),
+        (tess, posts[1].clone(), Some(likes[0])),
     ];
     assert_eq!(Ok(expected), data);
 }
@@ -653,7 +648,7 @@ fn selecting_crazy_nested_joins() {
             sean.clone(),
             (
                 posts[0].clone(),
-                Some((comments[0].clone(), Some(likes[0].clone()))),
+                Some((comments[0].clone(), Some(likes[0]))),
                 None,
             ),
         ),
@@ -665,10 +660,7 @@ fn selecting_crazy_nested_joins() {
             sean.clone(),
             (posts[2].clone(), Some((comments[1].clone(), None)), None),
         ),
-        (
-            tess.clone(),
-            (posts[1].clone(), None, Some(followings[0].clone())),
-        ),
+        (tess.clone(), (posts[1].clone(), None, Some(followings[0]))),
     ];
     assert_eq!(Ok(expected), data);
 
@@ -682,7 +674,7 @@ fn selecting_crazy_nested_joins() {
             sean.clone(),
             (
                 posts[0].clone(),
-                Some((comments[0].clone(), Some(likes[0].clone()))),
+                Some((comments[0].clone(), Some(likes[0]))),
             ),
             Some(followings[0]),
         ),
@@ -692,11 +684,11 @@ fn selecting_crazy_nested_joins() {
             Some(followings[0]),
         ),
         (
-            sean.clone(),
+            sean,
             (posts[2].clone(), Some((comments[1].clone(), None))),
             Some(followings[0]),
         ),
-        (tess.clone(), (posts[1].clone(), None), None),
+        (tess, (posts[1].clone(), None), None),
     ];
     assert_eq!(Ok(expected), data);
 }

--- a/diesel_tests/tests/schema/backend_specifics.rs
+++ b/diesel_tests/tests/schema/backend_specifics.rs
@@ -15,8 +15,8 @@ pub struct Post {
 impl Post {
     pub fn new(id: i32, user_id: i32, title: &str, body: Option<&str>) -> Self {
         Post {
-            id: id,
-            user_id: user_id,
+            id,
+            user_id,
             title: title.to_string(),
             body: body.map(|s| s.to_string()),
         }

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -32,7 +32,7 @@ pub struct User {
 impl User {
     pub fn new(id: i32, name: &str) -> Self {
         User {
-            id: id,
+            id,
             name: name.to_string(),
             hair_color: None,
         }
@@ -40,7 +40,7 @@ impl User {
 
     pub fn with_hair_color(id: i32, name: &str, hair_color: &str) -> Self {
         User {
-            id: id,
+            id,
             name: name.to_string(),
             hair_color: Some(hair_color.to_string()),
         }
@@ -72,8 +72,8 @@ pub struct Comment {
 impl Comment {
     pub fn new(id: i32, post_id: i32, text: &str) -> Self {
         Comment {
-            id: id,
-            post_id: post_id,
+            id,
+            post_id,
             text: text.into(),
         }
     }
@@ -142,7 +142,7 @@ pub struct NewPost {
 impl NewPost {
     pub fn new(user_id: i32, title: &str, body: Option<&str>) -> Self {
         NewPost {
-            user_id: user_id,
+            user_id,
             title: title.into(),
             body: body.map(|b| b.into()),
         }
@@ -165,10 +165,7 @@ pub struct FkTest {
 
 impl FkTest {
     pub fn new(id: i32, fk_id: i32) -> Self {
-        FkTest {
-            id: id,
-            fk_id: fk_id,
-        }
+        FkTest { id, fk_id }
     }
 }
 

--- a/diesel_tests/tests/schema/postgres_specific_schema.rs
+++ b/diesel_tests/tests/schema/postgres_specific_schema.rs
@@ -16,8 +16,8 @@ pub struct Post {
 impl Post {
     pub fn new(id: i32, user_id: i32, title: &str, body: Option<&str>) -> Self {
         Post {
-            id: id,
-            user_id: user_id,
+            id,
+            user_id,
             title: title.to_string(),
             body: body.map(|s| s.to_string()),
             tags: Vec::new(),

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -8,10 +8,7 @@ pub struct CreateTable<'a, Cols> {
 
 impl<'a, Cols> CreateTable<'a, Cols> {
     pub fn new(name: &'a str, columns: Cols) -> Self {
-        CreateTable {
-            name: name,
-            columns: columns,
-        }
+        CreateTable { name, columns }
     }
 }
 
@@ -26,8 +23,8 @@ pub struct Column<'a, T> {
 impl<'a, T> Column<'a, T> {
     pub fn new(name: &'a str, type_name: &'a str) -> Self {
         Column {
-            name: name,
-            type_name: type_name,
+            name,
+            type_name,
             _marker: PhantomData,
         }
     }

--- a/diesel_tests/tests/schema_inference.rs
+++ b/diesel_tests/tests/schema_inference.rs
@@ -171,7 +171,7 @@ mod sqlite {
 
         let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11);
         let inferred_datetime_types = InferredDatetimeTypes {
-            dt: dt,
+            dt,
             date: dt.date(),
             time: dt.time(),
             timestamp: dt,

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -64,7 +64,7 @@ fn with_select_sql() {
         .execute(connection)
         .unwrap();
 
-    assert_eq!(Ok(3), select_count.clone().first(connection));
+    assert_eq!(Ok(3), select_count.first(connection));
 }
 
 #[test]

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -245,7 +245,7 @@ fn selecting_parent_child_grandchild() {
         (sean.clone(), (posts[0].clone(), comments[2].clone())),
         (sean.clone(), (posts[2].clone(), comments[1].clone())),
     ];
-    assert_eq!(Ok(expected.clone()), data);
+    assert_eq!(Ok(expected), data);
 
     let data = users::table
         .inner_join(
@@ -305,8 +305,8 @@ fn selecting_parent_child_grandchild() {
     let expected = vec![
         (sean.clone(), Some((posts[0].clone(), comments[0].clone()))),
         (sean.clone(), Some((posts[0].clone(), comments[2].clone()))),
-        (sean.clone(), Some((posts[2].clone(), comments[1].clone()))),
-        (tess.clone(), None),
+        (sean, Some((posts[2].clone(), comments[1].clone()))),
+        (tess, None),
     ];
     assert_eq!(Ok(expected), data);
 }
@@ -389,7 +389,7 @@ fn selecting_parent_child_grandchild_nested() {
             },
         },
     ];
-    assert_eq!(Ok(expected.clone()), data);
+    assert_eq!(Ok(expected), data);
 
     #[derive(Queryable, Selectable, Clone, Debug, PartialEq)]
     #[diesel(table_name = users)]
@@ -601,7 +601,7 @@ fn selecting_parent_child_grandchild_nested() {
         User4 {
             id: sean.id,
             name: sean.name.clone(),
-            hair_color: sean.hair_color.clone(),
+            hair_color: sean.hair_color,
             post: Some(Post4 {
                 id: posts[2].id,
                 user_id: posts[2].user_id,
@@ -613,7 +613,7 @@ fn selecting_parent_child_grandchild_nested() {
         User4 {
             id: tess.id,
             name: tess.name.clone(),
-            hair_color: tess.hair_color.clone(),
+            hair_color: tess.hair_color,
             post: None,
         },
     ];
@@ -640,7 +640,7 @@ fn selecting_grandchild_child_parent() {
     let expected = vec![
         (comments[0].clone(), (posts[0].clone(), sean.clone())),
         (comments[2].clone(), (posts[0].clone(), sean.clone())),
-        (comments[1].clone(), (posts[2].clone(), sean.clone())),
+        (comments[1].clone(), (posts[2].clone(), sean)),
     ];
     assert_eq!(Ok(expected), data);
 }
@@ -677,7 +677,7 @@ fn selecting_crazy_nested_joins() {
             sean.clone(),
             (
                 posts[0].clone(),
-                Some((comments[0].clone(), Some(likes[0].clone()))),
+                Some((comments[0].clone(), Some(likes[0]))),
                 None,
             ),
         ),
@@ -689,10 +689,7 @@ fn selecting_crazy_nested_joins() {
             sean.clone(),
             (posts[2].clone(), Some((comments[1].clone(), None)), None),
         ),
-        (
-            tess.clone(),
-            (posts[1].clone(), None, Some(followings[0].clone())),
-        ),
+        (tess.clone(), (posts[1].clone(), None, Some(followings[0]))),
     ];
     assert_eq!(Ok(expected), data);
 
@@ -711,7 +708,7 @@ fn selecting_crazy_nested_joins() {
             sean.clone(),
             (
                 posts[0].clone(),
-                Some((comments[0].clone(), Some(likes[0].clone()))),
+                Some((comments[0].clone(), Some(likes[0]))),
             ),
             Some(followings[0]),
         ),
@@ -721,11 +718,11 @@ fn selecting_crazy_nested_joins() {
             Some(followings[0]),
         ),
         (
-            sean.clone(),
+            sean,
             (posts[2].clone(), Some((comments[1].clone(), None))),
             Some(followings[0]),
         ),
-        (tess.clone(), (posts[1].clone(), None), None),
+        (tess, (posts[1].clone(), None), None),
     ];
     assert_eq!(Ok(expected), data);
 }

--- a/diesel_tests/tests/transactions.rs
+++ b/diesel_tests/tests/transactions.rs
@@ -5,7 +5,7 @@ use diesel::*;
 #[test]
 #[cfg(not(feature = "sqlite"))] // FIXME: This test is only valid when operating on a file and not :memory:
 fn transaction_executes_fn_in_a_sql_transaction() {
-    const TEST_NAME: &'static str = "transaction_executes_fn_in_a_sql_transaction";
+    const TEST_NAME: &str = "transaction_executes_fn_in_a_sql_transaction";
     let conn1 = &mut connection_without_transaction();
     let conn2 = &mut connection_without_transaction();
     setup_test_table(conn1, TEST_NAME);
@@ -98,7 +98,7 @@ fn transaction_rollback_returns_error() {
 #[test]
 fn transactions_can_be_nested() {
     let connection = &mut connection_without_transaction();
-    const TEST_NAME: &'static str = "transactions_can_be_nested";
+    const TEST_NAME: &str = "transactions_can_be_nested";
     setup_test_table(connection, TEST_NAME);
     fn get_count(connection: &mut TestConnection) -> i64 {
         count_test_table(connection, TEST_NAME)

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -381,6 +381,7 @@ use std::{f32, f64};
 
 #[test]
 #[cfg(feature = "postgres")]
+#[allow(clippy::float_cmp)]
 fn f32_from_sql() {
     assert_eq!(0.0, query_single_value::<Float, f32>("0.0::real"));
     assert_eq!(0.5, query_single_value::<Float, f32>("0.5::real"));
@@ -398,6 +399,7 @@ fn f32_from_sql() {
 
 #[test]
 #[cfg(any(feature = "mysql", feature = "sqlite"))]
+#[allow(clippy::float_cmp)]
 fn f32_from_sql() {
     assert_eq!(0.0, query_single_value::<Float, f32>("0.0"));
     assert_eq!(0.5, query_single_value::<Float, f32>("0.5"));
@@ -412,6 +414,7 @@ fn f32_from_sql() {
 
 #[test]
 #[cfg(feature = "postgres")]
+#[allow(clippy::float_cmp)]
 fn f32_to_sql() {
     assert!(query_to_sql_equality::<Float, f32>("0.0::real", 0.0));
     assert!(query_to_sql_equality::<Float, f32>("0.5::real", 0.5));
@@ -458,6 +461,7 @@ fn f32_to_sql() {
 
 #[test]
 #[cfg(feature = "postgres")]
+#[allow(clippy::float_cmp)]
 fn f64_from_sql() {
     assert_eq!(
         0.0,
@@ -481,6 +485,7 @@ fn f64_from_sql() {
 
 #[test]
 #[cfg(any(feature = "mysql", feature = "sqlite"))]
+#[allow(clippy::float_cmp)]
 fn f64_from_sql() {
     assert_eq!(0.0, query_single_value::<Double, f64>("0.0"));
     assert_eq!(0.5, query_single_value::<Double, f64>("0.5"));

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -69,6 +69,7 @@ macro_rules! test_round_trip {
     };
     ($test_name:ident, $sql_type:ty, $tpe:ty, $map_fn:ident, $cmp: expr) => {
         #[test]
+        #[allow(clippy::type_complexity)]
         fn $test_name() {
             use diesel::sql_types::*;
 
@@ -228,6 +229,7 @@ mod pg_types {
     test_round_trip!(json_roundtrips, Json, SerdeWrapper, mk_serde_json);
     test_round_trip!(jsonb_roundtrips, Jsonb, SerdeWrapper, mk_serde_json);
 
+    #[allow(clippy::type_complexity)]
     fn mk_uuid(data: (u32, u16, u16, (u8, u8, u8, u8, u8, u8, u8, u8))) -> self::uuid::Uuid {
         let a = data.3;
         let b = [a.0, a.1, a.2, a.3, a.4, a.5, a.6, a.7];
@@ -300,12 +302,7 @@ mod pg_types {
             if r < earliest_pg_date {
                 let diff = earliest_pg_date - r;
                 r = earliest_pg_date + diff;
-            }
-            /*else if r > latest_pg_date {
-                let diff = r - latest_pg_date;
-                r = earliest_pg_date + diff;
-            }*/
-            else {
+            } else {
                 break;
             }
         }
@@ -457,7 +454,7 @@ mod mysql_types {
     pub fn mk_naive_timestamp((mut seconds, nanos): (i64, u32)) -> NaiveDateTime {
         // https://dev.mysql.com/doc/refman/8.0/en/datetime.html
         let earliest_mysql_date = NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 1);
-        let latest_mysql_date = NaiveDate::from_ymd(2038, 1, 19).and_hms(03, 14, 7);
+        let latest_mysql_date = NaiveDate::from_ymd(2038, 1, 19).and_hms(3, 14, 7);
 
         if seconds != 0 {
             seconds = earliest_mysql_date.timestamp()
@@ -600,7 +597,7 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
 
 #[cfg(feature = "mysql")]
 pub fn mk_naive_date(days: u32) -> NaiveDate {
-    let earliest_mysql_date = NaiveDate::from_ymd(1000, 01, 01);
+    let earliest_mysql_date = NaiveDate::from_ymd(1000, 1, 1);
     let latest_mysql_date = NaiveDate::from_ymd(9999, 12, 31);
     let num_days_representable = latest_mysql_date
         .signed_duration_since(earliest_mysql_date)

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -92,6 +92,7 @@ macro_rules! test_round_trip {
     };
 }
 
+#[allow(clippy::float_cmp)]
 pub fn f32_ne(a: &f32, b: &f32) -> bool {
     if a.is_nan() && b.is_nan() {
         false
@@ -100,6 +101,7 @@ pub fn f32_ne(a: &f32, b: &f32) -> bool {
     }
 }
 
+#[allow(clippy::float_cmp)]
 pub fn f64_ne(a: &f64, b: &f64) -> bool {
     if a.is_nan() && b.is_nan() {
         false
@@ -233,7 +235,7 @@ mod pg_types {
     fn mk_uuid(data: (u32, u16, u16, (u8, u8, u8, u8, u8, u8, u8, u8))) -> self::uuid::Uuid {
         let a = data.3;
         let b = [a.0, a.1, a.2, a.3, a.4, a.5, a.6, a.7];
-        uuid::Uuid::from_fields(data.0, data.1, data.2, &b).unwrap()
+        uuid::Uuid::from_fields(data.0, data.1, data.2, &b)
     }
 
     fn mk_macaddr(data: (u8, u8, u8, u8, u8, u8)) -> [u8; 6] {

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -206,7 +206,7 @@ fn sql_syntax_is_correct_when_option_field_comes_mixed_with_non_option() {
         .first::<Post>(connection)
         .unwrap();
 
-    let expected_post = Post::new(post.id, sean.id, "Hello".into(), Some("earth".into()));
+    let expected_post = Post::new(post.id, sean.id, "Hello", Some("earth"));
     assert_eq!(expected_post, post);
 }
 

--- a/examples/mysql/all_about_inserts/src/lib.rs
+++ b/examples/mysql/all_about_inserts/src/lib.rs
@@ -258,24 +258,24 @@ fn insert_get_results_batch() {
     use diesel::result::Error;
 
     let conn = &mut establish_connection();
-    conn.test_transaction::<_, Error, _>(|| {
+    conn.test_transaction::<_, Error, _>(|conn| {
         use diesel::select;
         use schema::users::dsl::*;
 
-        let now = select(diesel::dsl::now).get_result::<NaiveDateTime>(&conn)?;
+        let now = select(diesel::dsl::now).get_result::<NaiveDateTime>(conn)?;
 
-        let inserted_users = conn.transaction::<_, Error, _>(|| {
+        let inserted_users = conn.transaction::<_, Error, _>(|conn| {
             let inserted_count = insert_into(users)
                 .values(&vec![
                     (id.eq(1), name.eq("Sean")),
                     (id.eq(2), name.eq("Tess")),
                 ])
-                .execute(&conn)?;
+                .execute(conn)?;
 
             Ok(users
                 .order(id.desc())
                 .limit(inserted_count as i64)
-                .load(&conn)?
+                .load(conn)?
                 .into_iter()
                 .rev()
                 .collect::<Vec<_>>())
@@ -330,18 +330,18 @@ fn insert_get_result() {
     use diesel::result::Error;
 
     let conn = &mut establish_connection();
-    conn.test_transaction::<_, Error, _>(|| {
+    conn.test_transaction::<_, Error, _>(|conn| {
         use diesel::select;
         use schema::users::dsl::*;
 
-        let now = select(diesel::dsl::now).get_result::<NaiveDateTime>(&conn)?;
+        let now = select(diesel::dsl::now).get_result::<NaiveDateTime>(conn)?;
 
-        let inserted_user = conn.transaction::<_, Error, _>(|| {
+        let inserted_user = conn.transaction::<_, Error, _>(|conn| {
             insert_into(users)
                 .values((id.eq(3), name.eq("Ruby")))
-                .execute(&conn)?;
+                .execute(conn)?;
 
-            users.order(id.desc()).first(&conn)
+            users.order(id.desc()).first(conn)
         })?;
 
         let expected_user = User {

--- a/examples/sqlite/all_about_inserts/src/lib.rs
+++ b/examples/sqlite/all_about_inserts/src/lib.rs
@@ -273,24 +273,24 @@ fn insert_get_results_batch() {
     use diesel::result::Error;
 
     let conn = &mut establish_connection();
-    conn.test_transaction::<_, Error, _>(|| {
+    conn.test_transaction::<_, Error, _>(|conn| {
         use diesel::select;
         use schema::users::dsl::*;
 
-        let now = select(diesel::dsl::now).get_result::<NaiveDateTime>(&conn)?;
+        let now = select(diesel::dsl::now).get_result::<NaiveDateTime>(conn)?;
 
-        let inserted_users = conn.transaction::<_, Error, _>(|| {
+        let inserted_users = conn.transaction::<_, Error, _>(|conn| {
             let inserted_count = insert_into(users)
                 .values(&vec![
                     (id.eq(1), name.eq("Sean")),
                     (id.eq(2), name.eq("Tess")),
                 ])
-                .execute(&conn)?;
+                .execute(conn)?;
 
             Ok(users
                 .order(id.desc())
                 .limit(inserted_count as i64)
-                .load(&conn)?
+                .load(conn)?
                 .into_iter()
                 .rev()
                 .collect::<Vec<_>>())
@@ -346,13 +346,13 @@ fn examine_sql_from_insert_get_results_batch() {
 //     use diesel::result::Error;
 
 //     let conn = &mut establish_connection();
-//     conn.test_transaction::<_, Error, _>(|| {
+//     conn.test_transaction::<_, Error, _>(|conn| {
 //         use diesel::select;
 //         use schema::users::dsl::*;
 
 //         let now = select(diesel::dsl::now).get_result::<NaiveDateTime>(&conn)?;
 
-//         let inserted_user = conn.transaction::<_, Error, _>(|| {
+//         let inserted_user = conn.transaction::<_, Error, _>(|conn| {
 //             insert_into(users)
 //                 .values((id.eq(3), name.eq("Ruby")))
 //                 .execute(&conn)?;


### PR DESCRIPTION
This PR ensures that we run clippy also for our test code to prevent things like #3182 from happen.
Additionally it fixes a large number of clippy warnings occuring while running `cargo +nightly clippy` against our crates.