### PR TITLE
Fix three rustdoc::broken_intra_doc_links

### DIFF
--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -1129,9 +1129,10 @@ macro_rules! __diesel_table_generate_static_query_fragment_for_table {
 ///
 /// The generated `ON` clause will always join to the primary key of the parent
 /// table. This macro removes the need to call [`.on`] explicitly, you will
-/// still need to invoke [`allow_tables_to_appear_in_same_query!`] for these two tables to
-/// be able to use the resulting query, unless you are using `diesel print-schema`
-/// which will generate it for you.
+/// still need to invoke
+/// [`allow_tables_to_appear_in_same_query!`](crate::allow_tables_to_appear_in_same_query)
+/// for these two tables to be able to use the resulting query, unless you are
+/// using `diesel print-schema` which will generate it for you.
 ///
 /// If you are using `diesel print-schema`, an invocation of this macro
 /// will be generated for every foreign key in your database unless

--- a/diesel/src/query_source/aliasing/alias.rs
+++ b/diesel/src/query_source/aliasing/alias.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 #[derive(Debug, Clone, Copy, Default)]
 /// Represents an alias within diesel's query builder
 ///
-/// See [alias!] for more details.
+/// See [`alias!`](crate::alias) for more details.
 pub struct Alias<S> {
     pub(crate) source: S,
 }

--- a/diesel/src/query_source/aliasing/aliased_field.rs
+++ b/diesel/src/query_source/aliasing/aliased_field.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 #[derive(Debug, Clone, Copy)]
 /// Represents an aliased field (column) within diesel's query builder
 ///
-/// See [alias!] for more details.
+/// See [`alias!`](crate::alias) for more details.
 pub struct AliasedField<S, F> {
     pub(super) _alias_source: PhantomData<S>,
     pub(super) _field: F,


### PR DESCRIPTION
I am working on a bit on https://github.com/rust-lang/rust/issues/93588 and found these warnings distracting, so I decided to help fix them.

### Step-by-step:
1. `cargo +nightly doc --manifest-path diesel/Cargo.toml`

### Expected result:
No warnings

### Actual result:
```
warning: unresolved link to `alias`
  --> diesel/src/query_source/aliasing/alias.rs:16:10
   |
16 | /// See [alias!] for more details.
   |          ^^^^^^ no item named `alias` in scope
   |
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
   = note: `macro_rules` named `alias` exists in this crate, but it is not in scope at this link's location

warning: unresolved link to `alias`
  --> diesel/src/query_source/aliasing/aliased_field.rs:19:10
   |
19 | /// See [alias!] for more details.
   |          ^^^^^^ no item named `alias` in scope
   |
   = note: `macro_rules` named `alias` exists in this crate, but it is not in scope at this link's location

warning: unresolved link to `allow_tables_to_appear_in_same_query`
    --> diesel/src/macros/mod.rs:1132:28
     |
1132 | /// still need to invoke [`allow_tables_to_appear_in_same_query!`] for these two tables to
     |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `allow_tables_to_appear_in_same_query` in scope
     |
     = note: `macro_rules` named `allow_tables_to_appear_in_same_query` exists in this crate, but it is not in scope at this link's location
```
