### PR TITLE
Put the `backend::sql_dialect` module behind the

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -290,6 +290,13 @@ pub trait SqlDialect: self::private::TrustedBackend {
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
 pub(crate) mod sql_dialect {
+    #![cfg_attr(
+        not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"),
+        // Otherwise there are false positives
+        // because the lint seems to believe that these pub statements
+        // are not required, but they are required through the various backend impls
+        allow(unreachable_pub)
+    )]
     #[cfg(doc)]
     use super::SqlDialect;
 
@@ -304,18 +311,11 @@ pub(crate) mod sql_dialect {
         /// If you use a custom type to specify specialized support for `ON CONFLICT` clauses
         /// implementing this trait opts into reusing diesels existing `ON CONFLICT`
         /// `QueryFragment` implementations
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-
-        pub(crate) trait SupportsOnConflictClause {}
+        pub trait SupportsOnConflictClause {}
 
         /// This marker type indicates that `ON CONFLICT` clauses are not supported for this backend
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct DoesNotSupportOnConflictClause;
+        pub struct DoesNotSupportOnConflictClause;
     }
 
     /// This module contains all reusable options to configure
@@ -328,25 +328,16 @@ pub(crate) mod sql_dialect {
         ///
         /// If you use custom type to specify specialized support for `RETURNING` clauses
         /// implementing this trait opts in supporting `RETURNING` clause syntax
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) trait SupportsReturningClause {}
+        pub trait SupportsReturningClause {}
 
         /// Indicates that a backend provides support for `RETURNING` clauses
         /// using the postgresql `RETURNING` syntax
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct PgLikeReturningClause;
+        pub struct PgLikeReturningClause;
 
         /// Indicates that a backend does not support `RETURNING` clauses
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct DoesNotSupportReturningClause;
+        pub struct DoesNotSupportReturningClause;
 
         impl SupportsReturningClause for PgLikeReturningClause {}
     }
@@ -365,26 +356,17 @@ pub(crate) mod sql_dialect {
         /// expressions implementing this trait opts in support for `DEFAULT`
         /// value expressions for inserts. Otherwise diesel will emulate this
         /// behaviour.
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) trait SupportsDefaultKeyword {}
+        pub trait SupportsDefaultKeyword {}
 
         /// Indicates that a backend support `DEFAULT` value expressions
         /// for `INSERT INTO` statements based on the ISO SQL standard
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct IsoSqlDefaultKeyword;
+        pub struct IsoSqlDefaultKeyword;
 
         /// Indicates that a backend does not support `DEFAULT` value
         /// expressions0for `INSERT INTO` statements
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct DoesNotSupportDefaultKeyword;
+        pub struct DoesNotSupportDefaultKeyword;
 
         impl SupportsDefaultKeyword for IsoSqlDefaultKeyword {}
     }
@@ -397,30 +379,20 @@ pub(crate) mod sql_dialect {
     pub(crate) mod batch_insert_support {
         /// A marker trait indicating if batch insert statements
         /// are supported for this backend or not
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) trait SupportsBatchInsert {}
+        pub trait SupportsBatchInsert {}
 
         /// Indicates that this backend does not support batch
         /// insert statements.
         /// In this case diesel will emulate batch insert support
         /// by inserting each row on it's own
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct DoesNotSupportBatchInsert;
+        pub struct DoesNotSupportBatchInsert;
 
         /// Indicates that this backend supports postgres style
         /// batch insert statements to insert multiple rows using one
         /// insert statement
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-
-        pub(crate) struct PostgresLikeBatchInsertSupport;
+        pub struct PostgresLikeBatchInsertSupport;
 
         impl SupportsBatchInsert for PostgresLikeBatchInsertSupport {}
     }
@@ -437,10 +409,7 @@ pub(crate) mod sql_dialect {
         /// that a row consisting only of default
         /// values should be inserted
         #[derive(Debug, Clone, Copy)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct AnsiDefaultValueClause;
+        pub struct AnsiDefaultValueClause;
     }
 
     /// This module contains all reusable options to configure
@@ -454,10 +423,7 @@ pub(crate) mod sql_dialect {
         /// the `FROM` clause in `SELECT` statements
         /// if no table/view is queried
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct AnsiSqlFromClauseSyntax;
+        pub struct AnsiSqlFromClauseSyntax;
     }
 
     /// This module contains all reusable options to configure
@@ -471,10 +437,7 @@ pub(crate) mod sql_dialect {
         /// treats `EXIST()` as function
         /// like expression
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct AnsiSqlExistsSyntax;
+        pub struct AnsiSqlExistsSyntax;
     }
 
     /// This module contains all reusable options to configure
@@ -487,10 +450,7 @@ pub(crate) mod sql_dialect {
         /// Indicates that this backend requires a single bind
         /// per array element in `IN()` and `NOT IN()` expression
         #[derive(Debug, Copy, Clone)]
-        #[diesel_derives::__diesel_public_if(
-            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
-        )]
-        pub(crate) struct AnsiSqlArrayComparison;
+        pub struct AnsiSqlArrayComparison;
     }
 }
 

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -142,7 +142,10 @@ pub type BindCollector<'a, DB> = <DB as HasBindCollector<'a>>::BindCollector;
 /// a custom `QueryFragment<YourBackend, YourSpecialSyntaxType>` implementation
 /// to specialize on generic `QueryFragment<DB, DB::AssociatedType>` implementations.
 ///
-/// See the [`sql_dialect`] module for options provided by diesel out of the box.
+#[cfg_attr(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+    doc = "See the [`sql_dialect`] module for options provided by diesel out of the box."
+)]
 pub trait SqlDialect: self::private::TrustedBackend {
     /// Configures how this backends supports `RETURNING` clauses
     ///
@@ -157,13 +160,19 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "implementation for `ReturningClause`"
     )]
     ///
-    /// See [`sql_dialect::returning_clause`] for provided default implementations
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::returning_clause`] for provided default implementations"
+    )]
     type ReturningClause;
     /// Configures how this backend supports `ON CONFLICT` clauses
     ///
     /// This allows backends to opt in `ON CONFLICT` clause support
     ///
-    /// See [`sql_dialect::on_conflict_clause`] for provided default implementations
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::on_conflict_clause`] for provided default implementations"
+    )]
     type OnConflictClause;
     /// Configures how this backend handles the bare `DEFAULT` keyword for
     /// inserting the default value in a `INSERT INTO` `VALUES` clause
@@ -171,7 +180,10 @@ pub trait SqlDialect: self::private::TrustedBackend {
     /// This allows backends to opt in support for `DEFAULT` value expressions
     /// for insert statements
     ///
-    /// See [`sql_dialect::default_keyword_for_insert`] for provided default implementations
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::default_keyword_for_insert`] for provided default implementations"
+    )]
     type InsertWithDefaultKeyword;
     /// Configures how this backend handles Batch insert statements
     ///
@@ -185,7 +197,10 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "implementation for `BatchInsert`"
     )]
     ///
-    /// See [`sql_dialect::batch_insert_support`] for provided default implementations
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::batch_insert_support`] for provided default implementations"
+    )]
     type BatchInsertSupport;
     /// Configures how this backend handles the `DEFAULT VALUES` clause for
     /// insert statements.
@@ -200,7 +215,10 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "implementation for `DefaultValues`"
     )]
     ///
-    /// See [`sql_dialect::default_value_clause`] for provided default implementations
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::default_value_clause`] for provided default implementations"
+    )]
     type DefaultValueClauseForInsert;
     /// Configures how this backend handles empty `FROM` clauses for select statements.
     ///
@@ -214,7 +232,10 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "implementation for `NoFromClause`"
     )]
     ///
-    /// See [`sql_dialect::from_clause_syntax`] for provided default implementations
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::from_clause_syntax`] for provided default implementations"
+    )]
     type EmptyFromClauseSyntax;
     /// Configures how this backend handles `EXISTS()` expressions.
     ///
@@ -228,7 +249,10 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "implementation for `Exists`"
     )]
     ///
-    /// See [`sql_dialect::exists_syntax`] for provided default implementations
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::exists_syntax`] for provided default implementations"
+    )]
     type ExistsSyntax;
 
     /// Configures how this backend handles `IN()` and `NOT IN()` expressions.
@@ -245,54 +269,94 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "implementations for `In`, `NotIn` and `Many`"
     )]
     ///
-    /// See `[sql_dialect::array_comparison`] for provided default implementations
-    type ArrayComparision;
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::array_comparison`] for provided default implementations"
+    )]
+    type ArrayComparison;
 }
 
 /// This module contains all options provided by diesel to configure the [`SqlDialect`] trait.
-pub mod sql_dialect {
+// This module is only public behind the unstable feature flag, as we may want to change SqlDialect
+// implementations of existing backends because of:
+// * The backend gained support for previously unsupported SQL operations
+// * The backend fixed/introduced a bug that requires special handling
+// * We got some edge case wrong with sharing the implementation between backends
+//
+// By not exposing these types publically we are able to change the exact definitions later on
+// as users cannot write trait bounds that ensure that a specific type is used in place of
+// an existing associated type.
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+pub(crate) mod sql_dialect {
     #[cfg(doc)]
     use super::SqlDialect;
 
     /// This module contains all diesel provided reusable options to
     /// configure [`SqlDialect::OnConflictClause`]
-    pub mod on_conflict_clause {
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod on_conflict_clause {
         /// A marker trait indicating if a `ON CONFLICT` clause is supported or not
         ///
         /// If you use a custom type to specify specialized support for `ON CONFLICT` clauses
         /// implementing this trait opts into reusing diesels existing `ON CONFLICT`
         /// `QueryFragment` implementations
-        pub trait SupportsOnConflictClause {}
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+
+        pub(crate) trait SupportsOnConflictClause {}
 
         /// This marker type indicates that `ON CONFLICT` clauses are not supported for this backend
         #[derive(Debug, Copy, Clone)]
-        pub struct DoesNotSupportOnConflictClause;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct DoesNotSupportOnConflictClause;
     }
 
     /// This module contains all reusable options to configure
     /// [`SqlDialect::ReturningClause`]
-    pub mod returning_clause {
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod returning_clause {
         /// A marker trait indicating if a `RETURNING` clause is supported or not
         ///
         /// If you use custom type to specify specialized support for `RETURNING` clauses
         /// implementing this trait opts in supporting `RETURNING` clause syntax
-        pub trait SupportsReturningClause {}
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) trait SupportsReturningClause {}
 
         /// Indicates that a backend provides support for `RETURNING` clauses
         /// using the postgresql `RETURNING` syntax
         #[derive(Debug, Copy, Clone)]
-        pub struct PgLikeReturningClause;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct PgLikeReturningClause;
 
         /// Indicates that a backend does not support `RETURNING` clauses
         #[derive(Debug, Copy, Clone)]
-        pub struct DoesNotSupportReturningClause;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct DoesNotSupportReturningClause;
 
         impl SupportsReturningClause for PgLikeReturningClause {}
     }
 
     /// This module contains all reusable options to configure
     /// [`SqlDialect::InsertWithDefaultKeyword`]
-    pub mod default_keyword_for_insert {
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod default_keyword_for_insert {
         /// A marker trait indicating if a `DEFAULT` like expression
         /// is supported as part of `INSERT INTO` clauses to indicate
         /// that a default value should be inserted at a specific position
@@ -301,86 +365,132 @@ pub mod sql_dialect {
         /// expressions implementing this trait opts in support for `DEFAULT`
         /// value expressions for inserts. Otherwise diesel will emulate this
         /// behaviour.
-        pub trait SupportsDefaultKeyword {}
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) trait SupportsDefaultKeyword {}
 
         /// Indicates that a backend support `DEFAULT` value expressions
         /// for `INSERT INTO` statements based on the ISO SQL standard
         #[derive(Debug, Copy, Clone)]
-        pub struct IsoSqlDefaultKeyword;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct IsoSqlDefaultKeyword;
 
         /// Indicates that a backend does not support `DEFAULT` value
         /// expressions0for `INSERT INTO` statements
         #[derive(Debug, Copy, Clone)]
-        pub struct DoesNotSupportDefaultKeyword;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct DoesNotSupportDefaultKeyword;
 
         impl SupportsDefaultKeyword for IsoSqlDefaultKeyword {}
     }
 
     /// This module contains all reusable options to configure
     /// [`SqlDialect::BatchInsertSupport`]
-    pub mod batch_insert_support {
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod batch_insert_support {
         /// A marker trait indicating if batch insert statements
         /// are supported for this backend or not
-        pub trait SupportsBatchInsert {}
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) trait SupportsBatchInsert {}
 
         /// Indicates that this backend does not support batch
         /// insert statements.
         /// In this case diesel will emulate batch insert support
         /// by inserting each row on it's own
         #[derive(Debug, Copy, Clone)]
-        pub struct DoesNotSupportBatchInsert;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct DoesNotSupportBatchInsert;
 
         /// Indicates that this backend supports postgres style
         /// batch insert statements to insert multiple rows using one
         /// insert statement
         #[derive(Debug, Copy, Clone)]
-        pub struct PostgresLikeBatchInsertSupport;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+
+        pub(crate) struct PostgresLikeBatchInsertSupport;
 
         impl SupportsBatchInsert for PostgresLikeBatchInsertSupport {}
     }
 
     /// This module contains all reusable options to configure
     /// [`SqlDialect::DefaultValueClauseForInsert`]
-    pub mod default_value_clause {
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod default_value_clause {
 
         /// Indicates that this backend uses the
         /// `DEFAULT VALUES` syntax to specify
         /// that a row consisting only of default
         /// values should be inserted
         #[derive(Debug, Clone, Copy)]
-        pub struct AnsiDefaultValueClause;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct AnsiDefaultValueClause;
     }
 
     /// This module contains all reusable options to configure
     /// [`SqlDialect::EmptyFromClauseSyntax`]
-    pub mod from_clause_syntax {
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod from_clause_syntax {
 
         /// Indicates that this backend skips
         /// the `FROM` clause in `SELECT` statements
         /// if no table/view is queried
         #[derive(Debug, Copy, Clone)]
-        pub struct AnsiSqlFromClauseSyntax;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct AnsiSqlFromClauseSyntax;
     }
 
     /// This module contains all reusable options to configure
     /// [`SqlDialect::ExistsSyntax`]
-    pub mod exists_syntax {
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod exists_syntax {
 
         /// Indicates that this backend
         /// treats `EXIST()` as function
         /// like expression
         #[derive(Debug, Copy, Clone)]
-        pub struct AnsiSqlExistsSyntax;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct AnsiSqlExistsSyntax;
     }
 
     /// This module contains all reusable options to configure
-    /// [`SqlDialect::ArrayComparision`]
-    pub mod array_comparision {
+    /// [`SqlDialect::ArrayComparison`]
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) mod array_comparison {
 
         /// Indicates that this backend requires a single bind
         /// per array element in `IN()` and `NOT IN()` expression
         #[derive(Debug, Copy, Clone)]
-        pub struct AnsiSqlArrayComparison;
+        #[diesel_derives::__diesel_public_if(
+            feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+        )]
+        pub(crate) struct AnsiSqlArrayComparison;
     }
 }
 

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -23,7 +23,7 @@ use std::marker::PhantomData;
 ///
 /// Third party backend can customize the [`QueryFragment`]
 /// implementation of this query dsl node via
-/// [`SqlDialect::ArrayComparision`]. A customized implementation
+/// [`SqlDialect::ArrayComparison`]. A customized implementation
 /// is expected to provide the same sematics as a ANSI SQL
 /// `IN` expression.
 ///
@@ -43,7 +43,7 @@ pub struct In<T, U> {
 ///
 /// Third party backend can customize the [`QueryFragment`]
 /// implementation of this query dsl node via
-/// [`SqlDialect::ArrayComparision`]. A customized implementation
+/// [`SqlDialect::ArrayComparison`]. A customized implementation
 /// is expected to provide the same sematics as a ANSI SQL
 /// `NOT IN` expression.0
 ///
@@ -89,18 +89,17 @@ where
 impl<T, U, DB> QueryFragment<DB> for In<T, U>
 where
     DB: Backend,
-    Self: QueryFragment<DB, DB::ArrayComparision>,
+    Self: QueryFragment<DB, DB::ArrayComparison>,
 {
     fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
-        <Self as QueryFragment<DB, DB::ArrayComparision>>::walk_ast(self, pass)
+        <Self as QueryFragment<DB, DB::ArrayComparison>>::walk_ast(self, pass)
     }
 }
 
-impl<T, U, DB> QueryFragment<DB, sql_dialect::array_comparision::AnsiSqlArrayComparison>
-    for In<T, U>
+impl<T, U, DB> QueryFragment<DB, sql_dialect::array_comparison::AnsiSqlArrayComparison> for In<T, U>
 where
     DB: Backend
-        + SqlDialect<ArrayComparision = sql_dialect::array_comparision::AnsiSqlArrayComparison>,
+        + SqlDialect<ArrayComparison = sql_dialect::array_comparison::AnsiSqlArrayComparison>,
     T: QueryFragment<DB>,
     U: QueryFragment<DB> + MaybeEmpty,
 {
@@ -120,18 +119,18 @@ where
 impl<T, U, DB> QueryFragment<DB> for NotIn<T, U>
 where
     DB: Backend,
-    Self: QueryFragment<DB, DB::ArrayComparision>,
+    Self: QueryFragment<DB, DB::ArrayComparison>,
 {
     fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
-        <Self as QueryFragment<DB, DB::ArrayComparision>>::walk_ast(self, pass)
+        <Self as QueryFragment<DB, DB::ArrayComparison>>::walk_ast(self, pass)
     }
 }
 
-impl<T, U, DB> QueryFragment<DB, sql_dialect::array_comparision::AnsiSqlArrayComparison>
+impl<T, U, DB> QueryFragment<DB, sql_dialect::array_comparison::AnsiSqlArrayComparison>
     for NotIn<T, U>
 where
     DB: Backend
-        + SqlDialect<ArrayComparision = sql_dialect::array_comparision::AnsiSqlArrayComparison>,
+        + SqlDialect<ArrayComparison = sql_dialect::array_comparison::AnsiSqlArrayComparison>,
     T: QueryFragment<DB>,
     U: QueryFragment<DB> + MaybeEmpty,
 {
@@ -234,7 +233,7 @@ where
 ///
 /// Third party backend can customize the [`QueryFragment`]
 /// implementation of this query dsl node via
-/// [`SqlDialect::ArrayComparision`]. The default
+/// [`SqlDialect::ArrayComparison`]. The default
 /// implementation does generate one bind per value
 /// in the `values` field.
 ///
@@ -290,20 +289,20 @@ where
 
 impl<ST, I, DB> QueryFragment<DB> for Many<ST, I>
 where
-    Self: QueryFragment<DB, DB::ArrayComparision>,
+    Self: QueryFragment<DB, DB::ArrayComparison>,
     DB: Backend,
 {
     fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
-        <Self as QueryFragment<DB, DB::ArrayComparision>>::walk_ast(self, pass)
+        <Self as QueryFragment<DB, DB::ArrayComparison>>::walk_ast(self, pass)
     }
 }
 
-impl<ST, I, DB> QueryFragment<DB, sql_dialect::array_comparision::AnsiSqlArrayComparison>
+impl<ST, I, DB> QueryFragment<DB, sql_dialect::array_comparison::AnsiSqlArrayComparison>
     for Many<ST, I>
 where
     DB: Backend
         + HasSqlType<ST>
-        + SqlDialect<ArrayComparision = sql_dialect::array_comparision::AnsiSqlArrayComparison>,
+        + SqlDialect<ArrayComparison = sql_dialect::array_comparison::AnsiSqlArrayComparison>,
     ST: SingleValue,
     I: ToSql<ST, DB>,
 {

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -89,7 +89,7 @@ impl SqlDialect for Mysql {
     type EmptyFromClauseSyntax = sql_dialect::from_clause_syntax::AnsiSqlFromClauseSyntax;
     type ExistsSyntax = sql_dialect::exists_syntax::AnsiSqlExistsSyntax;
 
-    type ArrayComparision = sql_dialect::array_comparision::AnsiSqlArrayComparison;
+    type ArrayComparison = sql_dialect::array_comparison::AnsiSqlArrayComparison;
 }
 
 impl DieselReserveSpecialization for Mysql {}

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -140,7 +140,7 @@ impl SqlDialect for Pg {
 
     type EmptyFromClauseSyntax = sql_dialect::from_clause_syntax::AnsiSqlFromClauseSyntax;
     type ExistsSyntax = sql_dialect::exists_syntax::AnsiSqlExistsSyntax;
-    type ArrayComparision = PgStyleArrayComparision;
+    type ArrayComparison = PgStyleArrayComparision;
 }
 
 impl DieselReserveSpecialization for Pg {}

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -59,7 +59,7 @@ impl SqlDialect for Sqlite {
     #[cfg(feature = "returning_clauses_for_sqlite_3_35")]
     type ReturningClause = sql_dialect::returning_clause::PgLikeReturningClause;
 
-    type OnConflictClause = SqliteOnConflictClaues;
+    type OnConflictClause = SqliteOnConflictClause;
 
     type InsertWithDefaultKeyword =
         sql_dialect::default_keyword_for_insert::DoesNotSupportDefaultKeyword;
@@ -68,16 +68,16 @@ impl SqlDialect for Sqlite {
 
     type EmptyFromClauseSyntax = sql_dialect::from_clause_syntax::AnsiSqlFromClauseSyntax;
     type ExistsSyntax = sql_dialect::exists_syntax::AnsiSqlExistsSyntax;
-    type ArrayComparision = sql_dialect::array_comparision::AnsiSqlArrayComparison;
+    type ArrayComparison = sql_dialect::array_comparison::AnsiSqlArrayComparison;
 }
 
 impl DieselReserveSpecialization for Sqlite {}
 impl TrustedBackend for Sqlite {}
 
 #[derive(Debug, Copy, Clone)]
-pub struct SqliteOnConflictClaues;
+pub struct SqliteOnConflictClause;
 
-impl sql_dialect::on_conflict_clause::SupportsOnConflictClause for SqliteOnConflictClaues {}
+impl sql_dialect::on_conflict_clause::SupportsOnConflictClause for SqliteOnConflictClause {}
 
 #[derive(Debug, Copy, Clone)]
 pub struct SqliteBatchInsert;

--- a/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -1,25 +1,25 @@
-error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>: QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not satisfied
+error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>: QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not satisfied
   --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:17:10
    |
 17 |         .get_result(&mut connection);
-   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
+   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
    |
    = help: the following implementations were found:
-             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, PgLikeReturningClause>>
+             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, backend::sql_dialect::returning_clause::PgLikeReturningClause>>
              <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB>>
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &str>>>>, diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>>`
    = note: required because of the requirements on the impl of `LoadQuery<'_, diesel::SqliteConnection, _>` for `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &str>>>>>`
 
-error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<columns::name>: QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not satisfied
+error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<columns::name>: QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not satisfied
   --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:21:10
    |
 21 |         .get_result(&mut connection);
-   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
+   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
    |
    = help: the following implementations were found:
-             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, PgLikeReturningClause>>
+             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, backend::sql_dialect::returning_clause::PgLikeReturningClause>>
              <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB>>
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
    = note: 1 redundant requirements hidden

--- a/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -1,25 +1,25 @@
-error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>: QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not satisfied
+error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>: QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not satisfied
   --> tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs:29:10
    |
 29 |         .get_result::<User>(&mut connection);
-   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
+   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
    |
    = help: the following implementations were found:
-             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, PgLikeReturningClause>>
+             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, backend::sql_dialect::returning_clause::PgLikeReturningClause>>
              <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB>>
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>>`
    = note: required because of the requirements on the impl of `LoadQuery<'_, SqliteConnection, User>` for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>>`
 
-error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<columns::name>: QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not satisfied
+error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<columns::name>: QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not satisfied
   --> tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs:34:10
    |
 34 |         .get_result::<String>(&mut connection);
-   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
+   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
    |
    = help: the following implementations were found:
-             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, PgLikeReturningClause>>
+             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, backend::sql_dialect::returning_clause::PgLikeReturningClause>>
              <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB>>
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
    = note: 1 redundant requirements hidden

--- a/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -1,25 +1,25 @@
-error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>: QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not satisfied
+error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>: QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not satisfied
   --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:18:10
    |
 18 |         .get_result(&mut connection);
-   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
+   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
    |
    = help: the following implementations were found:
-             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, PgLikeReturningClause>>
+             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, backend::sql_dialect::returning_clause::PgLikeReturningClause>>
              <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB>>
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>`
    = note: 1 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &str>>, diesel::query_builder::returning_clause::ReturningClause<(columns::id, columns::name)>>`
    = note: required because of the requirements on the impl of `LoadQuery<'_, diesel::SqliteConnection, _>` for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Text, &str>>>`
 
-error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<columns::name>: QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not satisfied
+error[E0277]: the trait bound `diesel::query_builder::returning_clause::ReturningClause<columns::name>: QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not satisfied
   --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:23:10
    |
 23 |         .get_result(&mut connection);
-   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
+   |          ^^^^^^^^^^ the trait `QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not implemented for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
    |
    = help: the following implementations were found:
-             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, PgLikeReturningClause>>
+             <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB, backend::sql_dialect::returning_clause::PgLikeReturningClause>>
              <diesel::query_builder::returning_clause::ReturningClause<Expr> as QueryFragment<DB>>
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `diesel::query_builder::returning_clause::ReturningClause<columns::name>`
    = note: 1 redundant requirements hidden

--- a/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
@@ -6,17 +6,17 @@ error[E0277]: the trait bound `diesel::query_builder::insert_statement::batch_in
    |
    = help: the following implementations were found:
              <diesel::query_builder::insert_statement::batch_insert::BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID> as QueryFragment<DB>>
-             <diesel::query_builder::insert_statement::batch_insert::BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<V, Tab>>, Tab, QId, HAS_STATIC_QUERY_ID> as QueryFragment<DB, PostgresLikeBatchInsertSupport>>
+             <diesel::query_builder::insert_statement::batch_insert::BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<V, Tab>>, Tab, QId, HAS_STATIC_QUERY_ID> as QueryFragment<DB, backend::sql_dialect::batch_insert_support::PostgresLikeBatchInsertSupport>>
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `diesel::query_builder::insert_statement::batch_insert::BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>`
    = note: 2 redundant requirements hidden
    = note: required because of the requirements on the impl of `QueryFragment<Sqlite>` for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::batch_insert::BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing>>`
    = note: required because of the requirements on the impl of `ExecuteDsl<diesel::SqliteConnection, Sqlite>` for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::batch_insert::BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing>>`
 
-error[E0271]: type mismatch resolving `<Sqlite as SqlDialect>::InsertWithDefaultKeyword == IsoSqlDefaultKeyword`
+error[E0271]: type mismatch resolving `<Sqlite as SqlDialect>::InsertWithDefaultKeyword == backend::sql_dialect::default_keyword_for_insert::IsoSqlDefaultKeyword`
   --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:17:10
    |
 17 |         .execute(&mut connection);
-   |          ^^^^^^^ expected struct `DoesNotSupportDefaultKeyword`, found struct `IsoSqlDefaultKeyword`
+   |          ^^^^^^^ expected struct `backend::sql_dialect::default_keyword_for_insert::DoesNotSupportDefaultKeyword`, found struct `backend::sql_dialect::default_keyword_for_insert::IsoSqlDefaultKeyword`
    |
    = note: required because of the requirements on the impl of `CanInsertInSingleQuery<Sqlite>` for `diesel::query_builder::insert_statement::batch_insert::BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::internal::derives::as_expression::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>`
    = note: 1 redundant requirements hidden


### PR DESCRIPTION
`i-implement-a-third-party-backend-and-opt-into-breaking-changes`

This will allow us to change some of the associated types on existing
`SqlDialect` impls in later diesel versions. We might want to do this
for the following reasons:

* The backend gained support for previously unsupported SQL operations
* The backend fixed/introduced a bug that requires special handling
* We got some edge case wrong with sharing the implementation between
backends

Additionally this commit fixes a few types in type and module names in
the `sql_dialect` module.