### PR TITLE
Explictly sort migrations on migration redo to ensure that we revert

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -438,7 +438,7 @@ fn redo_migrations<Conn, DB>(
             .map(|m| (m.name().version().as_owned(), m))
             .collect::<HashMap<_, _>>();
 
-        let migrations = reverted_versions
+        let mut migrations = reverted_versions
             .into_iter()
             .map(|v| {
                 migrations
@@ -446,6 +446,8 @@ fn redo_migrations<Conn, DB>(
                     .ok_or_else(|| MigrationError::UnknownMigrationVersion(v.as_owned()))
             })
             .collect::<Result<Vec<_>, _>>()?;
+        // Sort the migrations by version to apply them in order.
+        migrations.sort_by_key(|m| m.name().version().as_owned());
 
         harness.run_migrations(&migrations)?;
 

--- a/diesel_cli/tests/migration_redo.rs
+++ b/diesel_cli/tests/migration_redo.rs
@@ -69,8 +69,8 @@ fn migration_redo_runs_the_last_two_migrations_down_and_up() {
         result.stdout()
             == "Rolling back migration 2017-09-12-210424_create_bills\n\
                 Rolling back migration 2017-09-03-210424_create_contracts\n\
-                Running migration 2017-09-12-210424_create_bills\n\
-                Running migration 2017-09-03-210424_create_contracts\n",
+                Running migration 2017-09-03-210424_create_contracts\n\
+                Running migration 2017-09-12-210424_create_bills\n",
         "Unexpected stdout : {}",
         result.stdout()
     );
@@ -247,9 +247,9 @@ fn migration_redo_all_runs_all_migrations_down_and_up() {
             == "Rolling back migration 2017-09-12-210424_create_bills\n\
                 Rolling back migration 2017-09-03-210424_create_contracts\n\
                 Rolling back migration 2017-08-31-210424_create_customers\n\
-                Running migration 2017-09-12-210424_create_bills\n\
+                Running migration 2017-08-31-210424_create_customers\n\
                 Running migration 2017-09-03-210424_create_contracts\n\
-                Running migration 2017-08-31-210424_create_customers\n",
+                Running migration 2017-09-12-210424_create_bills\n",
         "Unexpected stdout : {}",
         result.stdout()
     );
@@ -305,9 +305,9 @@ fn migration_redo_with_more_than_max_should_redo_all() {
             == "Rolling back migration 2017-09-12-210424_create_bills\n\
                 Rolling back migration 2017-09-03-210424_create_contracts\n\
                 Rolling back migration 2017-08-31-210424_create_customers\n\
-                Running migration 2017-09-12-210424_create_bills\n\
+                Running migration 2017-08-31-210424_create_customers\n\
                 Running migration 2017-09-03-210424_create_contracts\n\
-                Running migration 2017-08-31-210424_create_customers\n",
+                Running migration 2017-09-12-210424_create_bills\n",
         "Unexpected stdout : {}",
         result.stdout()
     );


### PR DESCRIPTION
them from newest to oldest, but apply them in the revers order