### PR TITLE
Numeric implements SqlOrd

### DIFF
--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -19,6 +19,8 @@ impl<T> SqlOrd for sql_types::Nullable<T> where T: SqlOrd + SqlType<IsNull = is_
 impl SqlOrd for sql_types::Timestamptz {}
 #[cfg(feature = "postgres")]
 impl<T: SqlOrd> SqlOrd for sql_types::Array<T> {}
+#[cfg(feature = "postgres")]
+impl SqlOrd for sql_types::Numeric {}
 
 #[cfg(feature = "mysql")]
 impl SqlOrd for sql_types::Datetime {}


### PR DESCRIPTION
For postgres at least (untested on other databases), `Numeric` should implement `SqlOrd` to allow use of aggregation functions like `max()`.