### PR TITLE
Numeric implements SqlOrd (for 1.4.x)

### DIFF
--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -19,6 +19,8 @@ impl<T: SqlOrd + NotNull> SqlOrd for sql_types::Nullable<T> {}
 impl SqlOrd for sql_types::Timestamptz {}
 #[cfg(feature = "postgres")]
 impl<T: SqlOrd> SqlOrd for sql_types::Array<T> {}
+#[cfg(feature = "postgres")]
+impl SqlOrd for sql_types::Numeric {}
 
 #[cfg(feature = "mysql")]
 impl SqlOrd for sql_types::Unsigned<sql_types::SmallInt> {}


### PR DESCRIPTION
This is just like https://github.com/diesel-rs/diesel/pull/3206 but targets the 1.4.x branch, in case this change is appropriate for a release branch.

(Wasn't sure which branch should be targeted.)