### PR TITLE
Remove unused lifetime from derived impls

### DIFF
--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -21,8 +21,9 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     let table_name = model.table_name();
 
     let (_, ty_generics, where_clause) = item.generics.split_for_impl();
-    let mut impl_generics = item.generics.clone();
-    impl_generics.params.push(parse_quote!('update));
+    let impl_generics = item.generics.clone();
+    let mut impl_generics_ref = item.generics.clone();
+    impl_generics_ref.params.push(parse_quote!('update));
     let (impl_generics, _, _) = impl_generics.split_for_impl();
 
     let fields_for_update = model
@@ -64,7 +65,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
             use diesel::query_builder::AsChangeset;
             use diesel::prelude::*;
 
-            impl #impl_generics AsChangeset for &'update #struct_name #ty_generics
+            impl #impl_generics_ref AsChangeset for &'update #struct_name #ty_generics
             #where_clause
             {
                 type Target = #table_name::table;

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -22,8 +22,9 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
     let struct_name = &item.ident;
 
     let (_, ty_generics, where_clause) = item.generics.split_for_impl();
-    let mut impl_generics = item.generics.clone();
-    impl_generics.params.push(parse_quote!('insert));
+    let impl_generics = item.generics.clone();
+    let mut impl_generics_ref = item.generics.clone();
+    impl_generics_ref.params.push(parse_quote!('insert));
     let (impl_generics, ..) = impl_generics.split_for_impl();
 
     let (direct_field_ty, direct_field_assign): (Vec<_>, Vec<_>) = model
@@ -65,7 +66,7 @@ pub fn derive(item: syn::DeriveInput) -> Result<proc_macro2::TokenStream, Diagno
                 }
             }
 
-            impl #impl_generics Insertable<#table_name::table>
+            impl #impl_generics_ref Insertable<#table_name::table>
                 for &'insert #struct_name #ty_generics
             #where_clause
             {


### PR DESCRIPTION
This change removes a generated lifetime from the derived implementations of Insertable and AsChangeset for owned structs. These lifetimes should only be added to the implementation over references.

On newer versions of Clippy (with the release of Rust 1.62.0, as of this commit), this results in a lint error: extra_unused_lifetimes.

See
https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
for more information.
