### PR TITLE
Improve code generated by the insertable derive

### DIFF
--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.rs
@@ -1,0 +1,16 @@
+use diesel::prelude::*;
+
+table! {
+    users(id) {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+#[derive(Insertable)]
+struct User {
+    id: String,
+    name: i32,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
@@ -1,0 +1,33 @@
+error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
+  --> tests/fail/derive/bad_insertable.rs:12:5
+   |
+12 |     id: String,
+   |     ^^ the trait `diesel::Expression` is not implemented for `std::string::String`
+   |
+   = note: required because of the requirements on the impl of `AsExpression<diesel::sql_types::Integer>` for `std::string::String`
+
+error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
+  --> tests/fail/derive/bad_insertable.rs:13:5
+   |
+13 |     name: i32,
+   |     ^^^^ the trait `diesel::Expression` is not implemented for `i32`
+   |
+   = note: required because of the requirements on the impl of `AsExpression<diesel::sql_types::Text>` for `i32`
+
+error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
+  --> tests/fail/derive/bad_insertable.rs:12:5
+   |
+12 |     id: String,
+   |     ^^ the trait `diesel::Expression` is not implemented for `std::string::String`
+   |
+   = note: required because of the requirements on the impl of `diesel::Expression` for `&'insert std::string::String`
+   = note: required because of the requirements on the impl of `AsExpression<diesel::sql_types::Integer>` for `&'insert std::string::String`
+
+error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
+  --> tests/fail/derive/bad_insertable.rs:13:5
+   |
+13 |     name: i32,
+   |     ^^^^ the trait `diesel::Expression` is not implemented for `i32`
+   |
+   = note: required because of the requirements on the impl of `diesel::Expression` for `&'insert i32`
+   = note: required because of the requirements on the impl of `AsExpression<diesel::sql_types::Text>` for `&'insert i32`

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -106,7 +106,7 @@ pub fn derive(item: DeriveInput) -> TokenStream {
                 type Values = <(#(#ref_field_ty,)*) as Insertable<#table_name::table>>::Values;
 
                 fn values(self) -> <(#(#ref_field_ty,)*) as Insertable<#table_name::table>>::Values {
-                   (#(#ref_field_assign,)*).values()
+                    (#(#ref_field_assign,)*).values()
                 }
             }
         }


### PR DESCRIPTION
This commit changes the code generated by the insertable derive in such
a way that error messages about field mismatches now point to the fields
itself, instead to the derive.

See here for the old error message: https://github.com/weiznich/rust-foundation-community-grant/blob/77f131de301a4a113c45db15c66e6247a3e4bee9/test_cases/tests/diesel/bad_insertable_field.stderr