### PR TITLE
Updated ipnetwork to 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Increasing the minimal supported Rust version will always be coupled at least wi
   may be enabled concurrently with the previously existing `network-address`
   feature.
 
+### Fixed
+
+* Updated `ipnetwork` to allow version 0.20.
+
 ## [2.0.0 Rc0] 2022-04-22
 
 ### Added

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { version = ">=0.8.0, <2.0", optional = true }
 url = { version = "2.1.0", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 uuid = { version = ">=0.7.0, <2.0.0", optional = true }
-ipnetwork = { version = ">=0.12.2, <0.20.0", optional = true }
+ipnetwork = { version = ">=0.12.2, <0.21.0", optional = true }
 ipnet = { version = "2.5.0", optional = true }
 num-bigint = { version = ">=0.2.0, <0.5.0", optional = true }
 num-traits = { version = "0.2.0", optional = true }
@@ -41,7 +41,7 @@ path = "../diesel_derives"
 [dev-dependencies]
 cfg-if = "1"
 dotenvy = "0.15"
-ipnetwork = ">=0.12.2, <0.20.0"
+ipnetwork = ">=0.12.2, <0.21.0"
 quickcheck = "1.0.3"
 
 [features]

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -17,7 +17,7 @@ quickcheck = "1.0.3"
 uuid = { version = "1.0.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnet = { version = "2.5.0" }
-ipnetwork = ">=0.12.2, <0.20.0"
+ipnetwork = ">=0.12.2, <0.21.0"
 bigdecimal = ">= 0.0.13, < 0.4.0"
 rand = "0.8.4"
 libsqlite3-sys = { version = "0.24", optional = true }


### PR DESCRIPTION
This PR updates the ipnetwork dependency to also allow ipnetwork 0.20.