### PR TITLE
CLI: Allow running without a `down.sql` migration

### DIFF
--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -4,10 +4,6 @@ use clap::{
 };
 use clap_complete::Shell;
 
-fn str_as_char(str: &str) -> char {
-    str.chars().next().unwrap()
-}
-
 pub fn build_cli() -> Command<'static> {
     let database_arg = Arg::new("DATABASE_URL")
         .long("database-url")
@@ -31,7 +27,7 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("REVERT_ALL")
                         .long("all")
-                        .short(str_as_char("a"))
+                        .short('a')
                         .help("Reverts previously run migration files.")
                         .takes_value(false)
                         .conflicts_with("REVERT_NUMBER"),
@@ -39,7 +35,7 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("REVERT_NUMBER")
                         .long("number")
-                        .short(str_as_char("n"))
+                        .short('n')
                         .help("Reverts the last `n` migration files.")
                         .long_help(
                             "When this option is specified the last `n` migration files \
@@ -60,7 +56,7 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("REDO_ALL")
                         .long("all")
-                        .short(str_as_char("a"))
+                        .short('a')
                         .help("Reverts and re-runs all migrations.")
                         .long_help(
                             "When this option is specified all migrations \
@@ -73,7 +69,7 @@ pub fn build_cli() -> Command<'static> {
                 .arg(
                     Arg::new("REDO_NUMBER")
                         .long("number")
-                        .short(str_as_char("n"))
+                        .short('n')
                         .help("Redo the last `n` migration files.")
                         .long_help(
                             "When this option is specified the last `n` migration files \
@@ -112,6 +108,16 @@ pub fn build_cli() -> Command<'static> {
                              for most use cases.",
                         )
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::new("MIGRATION_NO_DOWN_FILE")
+                        .short('u') // only Up
+                        .long("no-down")
+                        .help(
+                            "Don't generate a down.sql file. \
+                            You won't be able to run migration `revert` or `redo`.",
+                        )
+                        .takes_value(false),
                 )
                 .arg(
                     Arg::new("MIGRATION_FORMAT")
@@ -165,7 +171,7 @@ pub fn build_cli() -> Command<'static> {
         .arg(
             Arg::new("schema")
                 .long("schema")
-                .short(str_as_char("s"))
+                .short('s')
                 .takes_value(true)
                 .help("The name of the schema."),
         )
@@ -179,14 +185,14 @@ pub fn build_cli() -> Command<'static> {
         )
         .arg(
             Arg::new("only-tables")
-                .short(str_as_char("o"))
+                .short('o')
                 .long("only-tables")
                 .help("Only include tables from table-name that matches regexp.")
                 .conflicts_with("except-tables"),
         )
         .arg(
             Arg::new("except-tables")
-                .short(str_as_char("e"))
+                .short('e')
                 .long("except-tables")
                 .help("Exclude tables from table-name that matches regex.")
                 .conflicts_with("only-tables"),

--- a/diesel_cli/tests/database_reset.rs
+++ b/diesel_cli/tests/database_reset.rs
@@ -31,7 +31,7 @@ fn reset_runs_database_setup() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     assert!(db.table_exists("posts"));
@@ -101,7 +101,7 @@ fn reset_works_with_migration_dir_by_arg() {
         "foo",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     assert!(db.table_exists("posts"));
@@ -132,7 +132,7 @@ fn reset_works_with_migration_dir_by_env() {
         "bar",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     assert!(db.table_exists("posts"));
@@ -214,7 +214,7 @@ fn reset_respects_migrations_dir_from_diesel_toml() {
         "custom_migrations",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     assert!(db.table_exists("users"));

--- a/diesel_cli/tests/database_setup.rs
+++ b/diesel_cli/tests/database_setup.rs
@@ -49,7 +49,7 @@ fn database_setup_runs_migrations_if_no_schema_table() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // sanity check
@@ -96,7 +96,7 @@ fn database_setup_respects_migration_dir_by_arg_to_database() {
         "foo",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // sanity check
@@ -128,7 +128,7 @@ fn database_setup_respects_migration_dir_by_arg() {
         "foo",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // sanity check
@@ -160,7 +160,7 @@ fn database_setup_respects_migration_dir_by_env() {
         "bar",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // sanity check
@@ -199,7 +199,7 @@ fn database_setup_respects_migrations_dir_from_diesel_toml() {
         "custom_migrations",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // sanity check

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -70,6 +70,24 @@ fn migration_generate_creates_a_migration_with_initial_contents() {
 }
 
 #[test]
+fn migration_generate_with_no_down_file_has_no_down_file() {
+    let p = project("migration_name").folder("migrations").build();
+    let result = p
+        .command("migration")
+        .arg("generate")
+        .arg("--no-down")
+        .arg("hello")
+        .run();
+    assert!(result.is_success(), "Command failed: {:?}", result);
+
+    let migrations = p.migrations();
+    let migration = &migrations[0];
+
+    assert!(migration.path().join("up.sql").exists());
+    assert!(!migration.path().join("down.sql").exists());
+}
+
+#[test]
 fn migration_generate_doesnt_require_database_url_to_be_set() {
     let p = project("migration_name").folder("migrations").build();
     let result = p

--- a/diesel_cli/tests/migration_list.rs
+++ b/diesel_cli/tests/migration_list.rs
@@ -18,7 +18,7 @@ fn migration_list_lists_pending_applied_migrations() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY)",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     assert!(!db.table_exists("users"));
@@ -67,7 +67,7 @@ fn migration_list_lists_migrations_ordered_by_timestamp() {
     p.command("setup").run();
 
     let tag1 = format!("{}_initial", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag1, "", "");
+    p.create_migration(&tag1, "", Some(""));
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -76,7 +76,7 @@ fn migration_list_lists_migrations_ordered_by_timestamp() {
     sleep(Duration::from_millis(1100));
 
     let tag2 = format!("{}_alter", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag2, "", "");
+    p.create_migration(&tag2, "", Some(""));
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -93,23 +93,23 @@ fn migration_list_orders_unknown_timestamps_last() {
     p.command("setup").run();
 
     let tag1 = format!("{}_migration1", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag1, "", "");
+    p.create_migration(&tag1, "", Some(""));
 
     let tag4 = "abc_migration4";
-    p.create_migration(tag4, "", "");
+    p.create_migration(tag4, "", Some(""));
 
     let tag5 = "zzz_migration5";
-    p.create_migration(tag5, "", "");
+    p.create_migration(tag5, "", Some(""));
 
     sleep(Duration::from_millis(1100));
 
     let tag2 = format!("{}_migration2", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag2, "", "");
+    p.create_migration(&tag2, "", Some(""));
 
     sleep(Duration::from_millis(1100));
 
     let tag3 = format!("{}_migration3", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag3, "", "");
+    p.create_migration(&tag3, "", Some(""));
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -126,22 +126,22 @@ fn migration_list_orders_nontimestamp_versions_alphabetically() {
     p.command("setup").run();
 
     let tag4 = "a_migration";
-    p.create_migration(tag4, "", "");
+    p.create_migration(tag4, "", Some(""));
 
     let tag6 = "bc_migration";
-    p.create_migration(tag6, "", "");
+    p.create_migration(tag6, "", Some(""));
 
     let tag5 = "aa_migration";
-    p.create_migration(tag5, "", "");
+    p.create_migration(tag5, "", Some(""));
 
     let tag1 = "!wow_migration";
-    p.create_migration(tag1, "", "");
+    p.create_migration(tag1, "", Some(""));
 
     let tag3 = "7letters";
-    p.create_migration(tag3, "", "");
+    p.create_migration(tag3, "", Some(""));
 
     let tag2 = format!("{}_stamped_migration", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag2, "", "");
+    p.create_migration(&tag2, "", Some(""));
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -158,10 +158,10 @@ fn migration_list_orders_old_and_new_timestamp_forms_mixed_correctly() {
     p.command("setup").run();
 
     let tag1 = "20170505070309_migration";
-    p.create_migration(tag1, "", "");
+    p.create_migration(tag1, "", Some(""));
 
     let tag2 = "2017-11-23-064836_migration";
-    p.create_migration(tag2, "", "");
+    p.create_migration(tag2, "", Some(""));
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -189,7 +189,7 @@ fn migration_list_respects_migrations_dir_from_diesel_toml() {
         "custom_migrations",
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY)",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     assert!(!db.table_exists("users"));

--- a/diesel_cli/tests/migration_redo.rs
+++ b/diesel_cli/tests/migration_redo.rs
@@ -6,7 +6,7 @@ fn migration_redo_runs_the_last_migration_down_and_up() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY);",
-        "DROP TABLE users;",
+        Some("DROP TABLE users;"),
     );
 
     // Make sure the project is setup
@@ -37,19 +37,19 @@ fn migration_redo_runs_the_last_two_migrations_down_and_up() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE contracts",
+        Some("DROP TABLE contracts"),
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE bills",
+        Some("DROP TABLE bills"),
     );
 
     // Make sure the project is setup
@@ -88,7 +88,7 @@ fn migration_redo_respects_migration_dir_var() {
         "foo",
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY);",
-        "DROP TABLE users;",
+        Some("DROP TABLE users;"),
     );
 
     // Make sure the project is setup
@@ -121,7 +121,7 @@ fn migration_redo_respects_migration_dir_env() {
         "bar",
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY);",
-        "DROP TABLE users;",
+        Some("DROP TABLE users;"),
     );
 
     // Make sure the project is setup
@@ -154,7 +154,7 @@ fn error_migrations_fails() {
     p.create_migration(
         "redo_error_migrations_fails",
         "CREATE TABLE users (id INTEGER PRIMARY KEY);",
-        "DROP TABLE users};",
+        Some("DROP TABLE users};"),
     );
 
     // Make sure the project is setup
@@ -185,7 +185,7 @@ fn migration_redo_respects_migrations_dir_from_diesel_toml() {
         "custom_migrations",
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY);",
-        "DROP TABLE users;",
+        Some("DROP TABLE users;"),
     );
 
     // Make sure the project is setup
@@ -216,19 +216,19 @@ fn migration_redo_all_runs_all_migrations_down_and_up() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE contracts",
+        Some("DROP TABLE contracts"),
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE bills",
+        Some("DROP TABLE bills"),
     );
 
     // Make sure the project is setup
@@ -269,19 +269,19 @@ fn migration_redo_with_more_than_max_should_redo_all() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE contracts",
+        Some("DROP TABLE contracts"),
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE bills",
+        Some("DROP TABLE bills"),
     );
 
     // Make sure the project is setup
@@ -356,7 +356,7 @@ fn migration_redo_with_zero_should_not_revert_any_migration() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     // Make sure the project is setup

--- a/diesel_cli/tests/migration_revert.rs
+++ b/diesel_cli/tests/migration_revert.rs
@@ -10,7 +10,7 @@ fn migration_revert_runs_the_last_migration_down() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // Make sure the project is setup
@@ -38,7 +38,7 @@ fn migration_revert_respects_migration_dir_var() {
         "foo",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // Make sure the project is setup.
@@ -70,7 +70,7 @@ fn migration_revert_respects_migration_dir_env() {
         "bar",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // Make sure the project is setup.
@@ -112,7 +112,7 @@ fn migration_revert_respects_migration_dir_from_diesel_toml() {
         "custom_migrations",
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // Make sure the project is setup.
@@ -141,19 +141,19 @@ fn migration_revert_runs_the_last_two_migration_down() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE contracts",
+        Some("DROP TABLE contracts"),
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE bills",
+        Some("DROP TABLE bills"),
     );
 
     // Make sure the project is setup
@@ -194,19 +194,19 @@ fn migration_revert_all_runs_the_migrations_down() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE contracts",
+        Some("DROP TABLE contracts"),
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE bills",
+        Some("DROP TABLE bills"),
     );
 
     // Make sure the project is setup
@@ -244,7 +244,7 @@ fn migration_revert_with_zero_should_not_revert_any_migration() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     // Make sure the project is setup
@@ -306,19 +306,19 @@ fn migration_revert_with_more_than_max_should_revert_all() {
     p.create_migration(
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE customers",
+        Some("DROP TABLE customers"),
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE contracts",
+        Some("DROP TABLE contracts"),
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
-        "DROP TABLE bills",
+        Some("DROP TABLE bills"),
     );
 
     // Make sure the project is setup
@@ -349,4 +349,44 @@ fn migration_revert_with_more_than_max_should_revert_all() {
     assert!(!db.table_exists("customers"));
     assert!(!db.table_exists("contracts"));
     assert!(!db.table_exists("bills"));
+}
+
+#[test]
+fn migration_revert_gives_reasonable_error_message_on_missing_down() {
+    let p = project("migration_revert_error_message_on_missing_down")
+        .folder("migrations")
+        .build();
+    let db = database(&p.database_url());
+
+    p.create_migration(
+        "12345_create_users_table",
+        "CREATE TABLE users ( id INTEGER )",
+        None,
+    );
+
+    // Make sure the project is setup
+    p.command("setup").run();
+
+    assert!(db.table_exists("users"));
+
+    let result = p.command("migration").arg("revert").run();
+
+    assert!(
+        !result.is_success(),
+        "Result was successful when it shouldn't be {:?}",
+        result
+    );
+    assert!(
+        result.stdout().contains("Rolling back migration 12345"),
+        "Unexpected stdout {}",
+        result.stdout()
+    );
+    assert!(
+        result
+            .stderr()
+            .contains("Missing `down.sql` file to revert migration"),
+        "Unexpected stderr {}",
+        result.stderr()
+    );
+    assert!(db.table_exists("users"));
 }

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -283,7 +283,7 @@ fn test_print_schema_config(test_name: &str, test_path: &Path, schema: String, e
     let p = p.build();
 
     p.command("setup").run();
-    p.create_migration("12345_create_schema", &schema, "");
+    p.create_migration("12345_create_schema", &schema, None);
 
     let result = p.command("migration").arg("run").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);

--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -88,7 +88,7 @@ fn setup_runs_migrations_if_no_schema_table() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     // sanity check
@@ -116,7 +116,7 @@ fn setup_doesnt_run_migrations_if_schema_table_exists() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
-        "DROP TABLE users",
+        Some("DROP TABLE users"),
     );
 
     let result = p.command("setup").run();

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -156,19 +156,27 @@ impl Project {
         migration_path.display().to_string()
     }
 
-    pub fn create_migration(&self, name: &str, up: &str, down: &str) {
+    pub fn create_migration(&self, name: &str, up: &str, down: Option<&str>) {
         self.create_migration_in_directory("migrations", name, up, down);
     }
 
-    pub fn create_migration_in_directory(&self, directory: &str, name: &str, up: &str, down: &str) {
+    pub fn create_migration_in_directory(
+        &self,
+        directory: &str,
+        name: &str,
+        up: &str,
+        down: Option<&str>,
+    ) {
         let migration_path = self.directory.path().join(directory).join(name);
         fs::create_dir(&migration_path)
             .expect("Migrations folder must exist to create a migration");
         let mut up_file = fs::File::create(&migration_path.join("up.sql")).unwrap();
         up_file.write_all(up.as_bytes()).unwrap();
 
-        let mut down_file = fs::File::create(&migration_path.join("down.sql")).unwrap();
-        down_file.write_all(down.as_bytes()).unwrap();
+        if let Some(down) = down {
+            let mut down_file = fs::File::create(&migration_path.join("down.sql")).unwrap();
+            down_file.write_all(down.as_bytes()).unwrap();
+        }
     }
 }
 

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -47,7 +47,7 @@ fn migration_literal_from_path(path: &Path) -> proc_macro2::TokenStream {
     if version_from_string(&name).is_none() {
         panic!(
             "Invalid migration directory, the directory's name should be \
-             <timestamp>_<name_of_migration>, and it should only contain \
+             <timestamp>_<name_of_migration>, and it should contain \
              up.sql and down.sql."
         );
     }

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -46,21 +46,28 @@ fn migration_literal_from_path(path: &Path) -> proc_macro2::TokenStream {
         .to_string_lossy();
     if version_from_string(&name).is_none() {
         panic!(
-            "Invalid migration directory, the directory's name should be \
+            "Invalid migration directory: the directory's name should be \
              <timestamp>_<name_of_migration>, and it should contain \
-             up.sql and down.sql."
+             up.sql and optionally down.sql."
         );
     }
-    let up_sql = path.join("up.sql");
-    let up_sql_path = up_sql.to_str();
-    let down_sql = path.join("down.sql");
-    let down_sql_path = down_sql.to_str();
+    let up_sql_path = path.join("up.sql");
+    let up_sql_path = up_sql_path.to_str();
+    let down_sql_path = path.join("down.sql");
     let metadata = TomlMetadata::read_from_file(&path.join("metadata.toml")).unwrap_or_default();
     let run_in_transaction = metadata.run_in_transaction;
 
+    let down_sql = match down_sql_path.metadata() {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => quote! { None },
+        _ => {
+            let down_sql_path = down_sql_path.to_str();
+            quote! { Some(include_str!(#down_sql_path)) }
+        }
+    };
+
     quote!(diesel_migrations::EmbeddedMigration::new(
         include_str!(#up_sql_path),
-        include_str!(#down_sql_path),
+        #down_sql,
         diesel_migrations::EmbeddedName::new(#name),
         diesel_migrations::TomlMetadataWrapper::new(#run_in_transaction)
     ))

--- a/diesel_migrations/src/errors.rs
+++ b/diesel_migrations/src/errors.rs
@@ -25,6 +25,9 @@ pub enum MigrationError {
     UnknownMigrationVersion(MigrationVersion<'static>),
     /// No migrations had to be/ could be run
     NoMigrationRun,
+    /// `down.sql` file is missing, and you're asking for a `revert`
+    /// or `redo`
+    NoMigrationRevertFile,
 }
 
 impl Error for MigrationError {}
@@ -40,7 +43,7 @@ impl fmt::Display for MigrationError {
             MigrationError::UnknownMigrationFormat(_) => write!(
                 f,
                 "Invalid migration directory, the directory's name should be \
-                 <timestamp>_<name_of_migration>, and it should only contain up.sql and down.sql."
+                 <timestamp>_<name_of_migration>, and it should contain up.sql and down.sql."
             ),
             MigrationError::IoError(ref error) => write!(f, "{}", error),
             MigrationError::UnknownMigrationVersion(ref version) => write!(
@@ -52,6 +55,9 @@ impl fmt::Display for MigrationError {
                 f,
                 "No migrations have been run. Did you forget `diesel migration run`?"
             ),
+            MigrationError::NoMigrationRevertFile => {
+                write!(f, "Missing `down.sql` file to revert migration")
+            }
         }
     }
 }

--- a/diesel_migrations/src/errors.rs
+++ b/diesel_migrations/src/errors.rs
@@ -42,8 +42,9 @@ impl fmt::Display for MigrationError {
             ),
             MigrationError::UnknownMigrationFormat(_) => write!(
                 f,
-                "Invalid migration directory, the directory's name should be \
-                 <timestamp>_<name_of_migration>, and it should contain up.sql and down.sql."
+                "Invalid migration directory: the directory's name should be \
+                 <timestamp>_<name_of_migration>, and it should contain up.sql and \
+                 optionally down.sql."
             ),
             MigrationError::IoError(ref error) => write!(f, "{}", error),
             MigrationError::UnknownMigrationVersion(ref version) => write!(

--- a/diesel_migrations/src/file_based_migrations.rs
+++ b/diesel_migrations/src/file_based_migrations.rs
@@ -186,10 +186,10 @@ impl<DB: Backend> Migration<DB> for SqlFileMigration {
 
     fn revert(&self, conn: &mut dyn BoxableConnection<DB>) -> migration::Result<()> {
         let down_path = self.base_path.join("down.sql");
-        if !matches!(down_path.metadata(), Err(e) if e.kind() == std::io::ErrorKind::NotFound) {
-            Ok(run_sql_from_file(conn, &down_path, &self.name)?)
-        } else {
+        if matches!(down_path.metadata(), Err(e) if e.kind() == std::io::ErrorKind::NotFound) {
             Err(MigrationError::NoMigrationRevertFile.into())
+        } else {
+            Ok(run_sql_from_file(conn, &down_path, &self.name)?)
         }
     }
 


### PR DESCRIPTION
Some people don't like to write down migrations, as depending on your workflow, they take a lot of time to write, may be *never* used (esp. when you have CD pipelines and just reset the database from scratch when developing), and consequently are typically largely untested.

I wish to support this for those (like us) who would rather write a new `up` migration to revert unwanted changes through CI/CD if necessary.

(NB: The original issue is that since we typically wouldn't fill `down.sql`, we would have to go edit that file to add a newline for formatting everytime we create a migration, and then leave it there even though it doesn't mean anything, and we would be unsure which ones were properly filled and which ones weren't.)