### PR TITLE
Allow for "bool" type from django

### DIFF
--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -256,7 +256,7 @@ fn is_binary(type_name: &str) -> bool {
 }
 
 fn is_bool(type_name: &str) -> bool {
-    type_name == "boolean" || type_name.contains("tiny") && type_name.contains("int")
+    type_name.contains("bool") || type_name.contains("tiny") && type_name.contains("int")
 }
 
 fn is_smallint(type_name: &str) -> bool {


### PR DESCRIPTION
Hey all.

Encountered this issue while attempting to modernize a Django app by running `diesel print-schema` on an already created SQLite3 db, which returned `Unsupported type: bool`.

Django appears to have [used `"bool"` for their types](https://github.com/django/django/blob/24effbceb871e71d3bc320b91252f743714722df/django/db/backends/sqlite3/base.py#L32) instead of `"boolean"`.