### PR TITLE
Allow custom select expressions in `Selectable`

### DIFF
--- a/diesel_derives/src/attrs.rs
+++ b/diesel_derives/src/attrs.rs
@@ -8,14 +8,15 @@ use syn::parse::discouraged::Speculative;
 use syn::parse::{Parse, ParseStream, Parser, Result};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
-use syn::{parenthesized, Attribute, Ident, LitBool, LitStr, Path, TypePath};
+use syn::{parenthesized, Attribute, Expr, Ident, LitBool, LitStr, Path, TypePath};
 
 use deprecated::ParseDeprecated;
 use parsers::{BelongsTo, MysqlType, PostgresType, SqliteType};
 use util::{
     parse_eq, parse_paren, unknown_attribute, BELONGS_TO_NOTE, COLUMN_NAME_NOTE,
-    DESERIALIZE_AS_NOTE, MYSQL_TYPE_NOTE, POSTGRES_TYPE_NOTE, SERIALIZE_AS_NOTE, SQLITE_TYPE_NOTE,
-    SQL_TYPE_NOTE, TABLE_NAME_NOTE, TREAT_NONE_AS_DEFAULT_VALUE_NOTE, TREAT_NONE_AS_NULL_NOTE,
+    DESERIALIZE_AS_NOTE, MYSQL_TYPE_NOTE, POSTGRES_TYPE_NOTE, SELECT_EXPRESSION_NOTE,
+    SELECT_EXPRESSION_TYPE_NOTE, SERIALIZE_AS_NOTE, SQLITE_TYPE_NOTE, SQL_TYPE_NOTE,
+    TABLE_NAME_NOTE, TREAT_NONE_AS_DEFAULT_VALUE_NOTE, TREAT_NONE_AS_NULL_NOTE,
 };
 
 pub struct AttributeSpanWrapper<T> {
@@ -31,6 +32,8 @@ pub enum FieldAttr {
     SqlType(Ident, TypePath),
     SerializeAs(Ident, TypePath),
     DeserializeAs(Ident, TypePath),
+    SelectExpression(Ident, Expr),
+    SelectExpressionType(Ident, TypePath),
 }
 
 #[derive(Clone)]
@@ -110,6 +113,14 @@ impl Parse for FieldAttr {
                 name,
                 parse_eq(input, DESERIALIZE_AS_NOTE)?,
             )),
+            "select_expression" => Ok(FieldAttr::SelectExpression(
+                name,
+                parse_eq(input, SELECT_EXPRESSION_NOTE)?,
+            )),
+            "select_expression_type" => Ok(FieldAttr::SelectExpressionType(
+                name,
+                parse_eq(input, SELECT_EXPRESSION_TYPE_NOTE)?,
+            )),
 
             _ => unknown_attribute(
                 &name,
@@ -132,7 +143,9 @@ impl Spanned for FieldAttr {
             | FieldAttr::ColumnName(ident, _)
             | FieldAttr::SqlType(ident, _)
             | FieldAttr::SerializeAs(ident, _)
-            | FieldAttr::DeserializeAs(ident, _) => ident.span(),
+            | FieldAttr::DeserializeAs(ident, _)
+            | FieldAttr::SelectExpression(ident, _)
+            | FieldAttr::SelectExpressionType(ident, _) => ident.span(),
         }
     }
 }

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::spanned::Spanned;
-use syn::{Field as SynField, Ident, Index, Type};
+use syn::{Expr, Field as SynField, Ident, Index, Type};
 
 use attrs::{parse_attributes, AttributeSpanWrapper, FieldAttr, SqlIdentifier};
 
@@ -13,6 +13,8 @@ pub struct Field {
     pub sql_type: Option<AttributeSpanWrapper<Type>>,
     pub serialize_as: Option<AttributeSpanWrapper<Type>>,
     pub deserialize_as: Option<AttributeSpanWrapper<Type>>,
+    pub select_expression: Option<AttributeSpanWrapper<Expr>>,
+    pub select_expression_type: Option<AttributeSpanWrapper<Type>>,
     pub embed: Option<AttributeSpanWrapper<bool>>,
 }
 
@@ -27,6 +29,8 @@ impl Field {
         let mut serialize_as = None;
         let mut deserialize_as = None;
         let mut embed = None;
+        let mut select_expression = None;
+        let mut select_expression_type = None;
 
         for attr in parse_attributes(attrs) {
             let attribute_span = attr.attribute_span;
@@ -60,6 +64,20 @@ impl Field {
                         ident_span,
                     })
                 }
+                FieldAttr::SelectExpression(_, value) => {
+                    select_expression = Some(AttributeSpanWrapper {
+                        item: value,
+                        attribute_span,
+                        ident_span,
+                    })
+                }
+                FieldAttr::SelectExpressionType(_, value) => {
+                    select_expression_type = Some(AttributeSpanWrapper {
+                        item: Type::Path(value),
+                        attribute_span,
+                        ident_span,
+                    })
+                }
                 FieldAttr::Embed(_) => {
                     embed = Some(AttributeSpanWrapper {
                         item: true,
@@ -88,6 +106,8 @@ impl Field {
             sql_type,
             serialize_as,
             deserialize_as,
+            select_expression,
+            select_expression_type,
             embed,
         }
     }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -855,7 +855,7 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 ///   It should be used in conjunction with `select_expression_type` (described below)
 /// * `#[diesel(select_expression_type = the_custom_select_expression_type]`, to be used
 ///   in conjunction with `select_expression` (described above).
-///   For example: `#[diesel(select_expression = dsl::IsNotNull<my_table::some_field>)]`
+///   For example: `#[diesel(select_expression_type = dsl::IsNotNull<my_table::some_field>)]`
 #[proc_macro_error]
 #[proc_macro_derive(Selectable, attributes(diesel))]
 pub fn derive_selectable(input: TokenStream) -> TokenStream {

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -848,6 +848,14 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 /// * `#[diesel(embed)]`, specifies that the current field maps not only
 ///    single database column, but is a type that implements
 ///    `Selectable` on it's own
+/// * `#[diesel(select_expression = some_custom_select_expression)]`, overrides
+///   the entire select expression for the given field. It may be used to select with
+///   custom tuples, or specify `select_expression = my_table::some_field.is_not_null()`,
+///   or separate tables...
+///   It should be used in conjunction with `select_expression_type` (described below)
+/// * `#[diesel(select_expression_type = the_custom_select_expression_type]`, to be used
+///   in conjunction with `select_expression` (described above).
+///   For example: `#[diesel(select_expression = dsl::IsNotNull<my_table::some_field>)]`
 #[proc_macro_error]
 #[proc_macro_derive(Selectable, attributes(diesel))]
 pub fn derive_selectable(input: TokenStream) -> TokenStream {

--- a/diesel_derives/src/selectable.rs
+++ b/diesel_derives/src/selectable.rs
@@ -48,7 +48,10 @@ pub fn derive(item: DeriveInput) -> TokenStream {
 }
 
 fn field_column_ty(field: &Field, model: &Model) -> TokenStream {
-    if field.embed() {
+    if let Some(ref select_expression_type) = field.select_expression_type {
+        let ty = &select_expression_type.item;
+        quote!(#ty)
+    } else if field.embed() {
         let embed_ty = &field.ty;
         quote!(<#embed_ty as Selectable<__DB>>::SelectExpression)
     } else {
@@ -59,7 +62,10 @@ fn field_column_ty(field: &Field, model: &Model) -> TokenStream {
 }
 
 fn field_column_inst(field: &Field, model: &Model) -> TokenStream {
-    if field.embed() {
+    if let Some(ref select_expression) = field.select_expression {
+        let expr = &select_expression.item;
+        quote!(#expr)
+    } else if field.embed() {
         let embed_ty = &field.ty;
         quote!(<#embed_ty as Selectable<__DB>>::construct_selection())
     } else {

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -17,6 +17,10 @@ pub const MYSQL_TYPE_NOTE: &str = "mysql_type(name = \"foo\")";
 pub const SQLITE_TYPE_NOTE: &str = "sqlite_type(name = \"foo\")";
 pub const POSTGRES_TYPE_NOTE: &str = "postgres_type(name = \"foo\", schema = \"public\")";
 pub const POSTGRES_TYPE_NOTE_ID: &str = "postgres_type(oid = 37, array_oid = 54)";
+pub const SELECT_EXPRESSION_NOTE: &str =
+    "select_expression = schema::table_name::column_name.is_not_null()";
+pub const SELECT_EXPRESSION_TYPE_NOTE: &str =
+    "select_expression_type = dsl::IsNotNull<schema::table_name::column_name>";
 
 pub fn unknown_attribute(name: &Ident, valid: &[&str]) -> ! {
     let prefix = if valid.len() == 1 { "" } else { " one of" };

--- a/diesel_derives/tests/selectable.rs
+++ b/diesel_derives/tests/selectable.rs
@@ -114,3 +114,28 @@ fn embedded_option_with_nullable_field() {
     let data = my_structs::table.select(A::as_select()).get_result(conn);
     assert!(data.is_err());
 }
+
+#[test]
+fn manually_specified_expression() {
+    table! {
+        my_structs (foo) {
+            foo -> Integer,
+            bar -> Nullable<Text>,
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Queryable, Selectable)]
+    #[diesel(table_name = my_structs)]
+    struct A {
+        foo: i32,
+        #[diesel(
+            select_expression = my_structs::bar.is_not_null(),
+            select_expression_type = dsl::IsNotNull<my_structs::bar>
+        )]
+        bar_is_set: bool,
+    }
+
+    let conn = &mut connection();
+    let data = my_structs::table.select(A::as_select()).get_result(conn);
+    assert!(data.is_err());
+}


### PR DESCRIPTION
It's is a recurring use-case that 90% of the fields of a `Selectable` struct could be selected directly, but just one of them needs a bit more complex expression.

For this use case, this commit adds support for specifying fully custom select expression at the field level when deriving `Selectable`, by specifying the `select_expression` and `select_expression_type` attributes.

e.g: 
https://github.com/diesel-rs/diesel/blob/0d6395dd74dbf5ed1c0621082a40d5544a4fd224/diesel_derives/tests/selectable.rs#L131-L135

This could probably be later improved by getting able to infer `select_expression_type` for simple cases.