### PR TITLE
Bump chrono to 0.4.20 and remove deprecated code usage

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 byteorder = { version = "1.0", optional = true }
-chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.20", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.26.0", optional = true, features = ["bundled_bindings"] }
 mysqlclient-sys = { version = "0.2.5", optional = true }

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -2,8 +2,6 @@
 //! and `Timestamp` fields. It is enabled with the `chrono` feature.
 
 extern crate chrono;
-
-use self::chrono::naive::MAX_DATE;
 use self::chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
 use super::{PgDate, PgTime, PgTimestamp};
@@ -126,7 +124,10 @@ impl FromSql<Date, Pg> for NaiveDate {
         match pg_epoch_date().checked_add_signed(Duration::days(i64::from(offset))) {
             Some(date) => Ok(date),
             None => {
-                let error_message = format!("Chrono can only represent dates up to {:?}", MAX_DATE);
+                let error_message = format!(
+                    "Chrono can only represent dates up to {:?}",
+                    chrono::Date::<Utc>::MAX_UTC
+                );
                 Err(error_message.into())
             }
         }
@@ -138,7 +139,6 @@ mod tests {
     extern crate chrono;
     extern crate dotenvy;
 
-    use self::chrono::naive::MAX_DATE;
     use self::chrono::{Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};
 
     use crate::dsl::{now, sql};
@@ -261,7 +261,7 @@ mod tests {
         let query = select(sql::<Date>("'J0'::date").eq(julian_epoch));
         assert!(query.get_result::<bool>(connection).unwrap());
 
-        let max_date = MAX_DATE;
+        let max_date = NaiveDate::MAX;
         let query = select(sql::<Date>("'262143-12-31'::date").eq(max_date));
         assert!(query.get_result::<bool>(connection).unwrap());
 
@@ -292,7 +292,7 @@ mod tests {
         let query = select(sql::<Date>("'J0'::date"));
         assert_eq!(Ok(julian_epoch), query.get_result::<NaiveDate>(connection));
 
-        let max_date = MAX_DATE;
+        let max_date = NaiveDate::MAX;
         let query = select(sql::<Date>("'262143-12-31'::date"));
         assert_eq!(Ok(max_date), query.get_result::<NaiveDate>(connection));
 

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -625,10 +625,8 @@ fn mk_bigdecimal(data: (i64, u64)) -> bigdecimal::BigDecimal {
 
 #[cfg(feature = "postgres")]
 pub fn mk_naive_date(days: u32) -> NaiveDate {
-    use chrono::naive::MAX_DATE;
-
     let earliest_pg_date = NaiveDate::from_ymd(-4713, 11, 24);
-    let latest_chrono_date = MAX_DATE;
+    let latest_chrono_date = NaiveDate::MAX;
     let num_days_representable = latest_chrono_date
         .signed_duration_since(earliest_pg_date)
         .num_days();
@@ -647,10 +645,8 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
 
 #[cfg(feature = "sqlite")]
 pub fn mk_naive_date(days: u32) -> NaiveDate {
-    use chrono::naive::{MAX_DATE, MIN_DATE};
-
-    let earliest_sqlite_date = MIN_DATE;
-    let latest_sqlite_date = MAX_DATE;
+    let earliest_sqlite_date = NaiveDate::MIN;
+    let latest_sqlite_date = NaiveDate::MAX;
     let num_days_representable = latest_sqlite_date
         .signed_duration_since(earliest_sqlite_date)
         .num_days();


### PR DESCRIPTION
I've opted for removing support for 0.4.19 instead of just allowing the deprecated constant as we haven't released 2.0 yet and so it's easier to support future versions.