### PR TITLE
Derive debug for `AnsiTransactionManager`

### DIFF
--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -70,8 +70,7 @@ pub trait TransactionManager<Conn: Connection> {
 
 /// An implementation of `TransactionManager` which can be used for backends
 /// which use ANSI standard syntax for savepoints such as SQLite and PostgreSQL.
-#[allow(missing_debug_implementations, missing_copy_implementations)]
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AnsiTransactionManager {
     pub(crate) status: TransactionManagerStatus,
 }


### PR DESCRIPTION
This might be useful for third party connection implementations as they could inspect that type for debugging reasons.

As discussed here: https://github.com/blackbeam/rust-mysql-simple/discussions/320#discussioncomment-3370769

cc @somehowchris
