### PR TITLE
Implement Display for PgMoney

### DIFF
--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -38,7 +38,7 @@ impl ToSql<Money, Pg> for PgMoney {
 }
 
 impl fmt::Display for PgMoney {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "{}", self.0)
     }
 }

--- a/diesel/src/pg/types/money.rs
+++ b/diesel/src/pg/types/money.rs
@@ -1,5 +1,6 @@
 //! Support for Money values under PostgreSQL.
 use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::fmt;
 
 use crate::deserialize::{self, FromSql, FromSqlRow};
 use crate::expression::AsExpression;
@@ -35,6 +36,13 @@ impl ToSql<Money, Pg> for PgMoney {
         ToSql::<BigInt, Pg>::to_sql(&self.0, out)
     }
 }
+
+impl fmt::Display for PgMoney {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", self.0)
+    }
+}
+
 
 impl Add for PgMoney {
     type Output = Self;


### PR DESCRIPTION
Serialization via serde is difficult due to the inability to implement traits for diesel types in projects that use diesel.
Alternatively, providing the Display trait in the package would allow serialization of the type PgMoney/Cents by using serde_with DisplayFromStr.