### PR TITLE
Explain None/null convention in `column.eq` docstring

### DIFF
--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -10,7 +10,23 @@ pub trait ExpressionMethods: Expression + Sized {
     /// Creates a SQL `=` expression.
     ///
     /// Note that this function follows SQL semantics around `None`/`null` values,
-    /// so `column.eq(None)` will never match. Use [`column.is_null()`](ExpressionMethods::is_null()) instead.
+    /// so `eq(None)` will never match. Use [`is_null`](ExpressionMethods::is_null()) instead.
+    ///
+    ///
+    #[cfg_attr(
+        any(feature = "sqlite", feature = "postgres"),
+        doc = "To get behavior that is more like the Rust `=` operator you can also use the"
+    )]
+    #[cfg_attr(
+        feature = "sqlite",
+        doc = "sqlite-specific [`is`](crate::SqliteExpressionMethods::is())"
+    )]
+    #[cfg_attr(all(feature = "sqlite", feature = "postgres"), doc = "or the")]
+    #[cfg_attr(
+        feature = "postgres",
+        doc = "postgres-specific [`is_not_distinct_from`](crate::PgExpressionMethods::is_not_distinct_from())"
+    )]
+    #[cfg_attr(any(feature = "sqlite", feature = "postgres"), doc = ".")]
     ///
     /// # Example
     ///

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -9,6 +9,9 @@ use crate::sql_types::{SingleValue, SqlType};
 pub trait ExpressionMethods: Expression + Sized {
     /// Creates a SQL `=` expression.
     ///
+    /// Note that this function follows SQL semantics around `None`/`null` values,
+    /// so `column.eq(None)` will never match. Use [`column.is_null()`](ExpressionMethods::is_null()) instead.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -21,6 +24,32 @@ pub trait ExpressionMethods: Expression + Sized {
     /// assert_eq!(Ok(1), data.first(connection));
     /// # }
     /// ```
+    ///
+    /// Matching against `None` follows SQL semantics:
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// let data = animals
+    ///     .select(species)
+    ///     .filter(name.eq::<Option<String>>(None))
+    ///     .first::<String>(connection);
+    /// assert_eq!(Err(diesel::NotFound), data);
+    ///
+    /// let data = animals
+    ///     .select(species)
+    ///     .filter(name.is_null())
+    ///     .first::<String>(connection)?;
+    /// assert_eq!("spider", data);
+    /// #     Ok(())
+    /// # }
     #[doc(alias = "=")]
     fn eq<T>(self, other: T) -> dsl::Eq<Self, T>
     where

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.0.0-rc.1"
+version = "2.0.0"
 dependencies = [
  "bigdecimal",
  "bitflags",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.0-rc.1"
+version = "2.0.0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/diesel_compile_tests/tests/fail/subselect_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/subselect_requires_correct_type.stderr
@@ -1,14 +1,14 @@
 error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: diesel::expression::array_comparison::AsInExpression<diesel::sql_types::Integer>` is not satisfied
-  --> tests/fail/subselect_requires_correct_type.rs:22:59
-   |
-22 |     let query = posts::table.filter(posts::user_id.eq_any(subquery));
-   |                                                    ------ ^^^^^^^^ the trait `diesel::expression::array_comparison::AsInExpression<diesel::sql_types::Integer>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
-   |                                                    |
-   |                                                    required by a bound introduced by this call
-   |
-   = help: the trait `diesel::expression::array_comparison::AsInExpression<ST>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H, LC>`
+   --> tests/fail/subselect_requires_correct_type.rs:22:59
+    |
+22  |     let query = posts::table.filter(posts::user_id.eq_any(subquery));
+    |                                                    ------ ^^^^^^^^ the trait `diesel::expression::array_comparison::AsInExpression<diesel::sql_types::Integer>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
+    |                                                    |
+    |                                                    required by a bound introduced by this call
+    |
+    = help: the trait `diesel::expression::array_comparison::AsInExpression<ST>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H, LC>`
 note: required by a bound in `eq_any`
-  --> $DIESEL/src/expression_methods/global_expression_methods.rs
-   |
-   |         T: AsInExpression<Self::SqlType>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `eq_any`
+   --> $DIESEL/src/expression_methods/global_expression_methods.rs
+    |
+    |         T: AsInExpression<Self::SqlType>,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `eq_any`


### PR DESCRIPTION
After running into the same issue as described in #1306 I thought I'd add to the docstring explaining that the `.eq` method follows SQL semantics, not Rust semantics when it comes to `None`.