### PR TITLE
diesel_cli: handle file: URLs in sqlite db setup

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -26,7 +26,7 @@ dotenvy = "0.15"
 heck = "0.4.0"
 serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.5"
-url = { version = "2.2.2", optional = true }
+url = { version = "2.2.2" }
 libsqlite3-sys = { version = ">=0.17.2, <0.26.0", optional = true }
 diffy = "0.2.0"
 regex = "1.0.6"
@@ -49,9 +49,9 @@ url = { version = "2.2.2" }
 
 [features]
 default = ["postgres", "sqlite", "mysql"]
-postgres = ["diesel/postgres", "url", "uses_information_schema"]
+postgres = ["diesel/postgres", "uses_information_schema"]
 sqlite = ["diesel/sqlite"]
-mysql = ["diesel/mysql", "url", "uses_information_schema"]
+mysql = ["diesel/mysql", "uses_information_schema"]
 sqlite-bundled = ["sqlite", "libsqlite3-sys/bundled"]
 uses_information_schema = []
 

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -363,6 +363,8 @@ fn change_database_of_url(database_url: &str, default_database: &str) -> (String
 }
 
 #[cfg(feature = "sqlite")]
+/// sqlite accepts either file: URLs, or bare paths (the latter of which may be relative).
+/// Check for which case we're in and return the path if we can retrieve it.
 fn path_from_sqlite_url(database_url: &str) -> DatabaseResult<::std::path::PathBuf> {
     if database_url.starts_with("file:/") {
         // looks like a file URL


### PR DESCRIPTION
Fixes #3301.

```
The previous code in create_database_if_needed assumed the string
argument 'database_url' was a path in the sqlite case. This needs to be
supported since it's the only way to use a relative path with
diesel_cli, but it led to surprising behavior when passing a file:///
URL -- when checking for the existence of the DB, diesel_cli would look
for a relative path file:/foo/bar where it should've looked for an
absolute path /foo/bar.
```

Testing done:
```
#!/bin/sh

migrations="$(realpath path/to/some/migrations/)"
manifest_path="$(realpath Cargo.toml)"

setup() {
    cargo run --no-default-features \
        --manifest-path=$manifest_path \
        --features=sqlite -- \
        --database-url="$1" database \
        --migration-dir="$migrations" setup;
}

tmp="$(mktemp -d)"

echo "file URLs now work"
setup file://$tmp/db
echo "and match up with equivalent absolute paths (no-op)"
setup $tmp/db
rm $tmp/db

echo "paths still work for creation"
setup $tmp/db
rm $tmp/db

echo "file URLs must be absolute (3 slashes); this fails"
( cd $tmp; setup file://db; )

echo "relative paths still work"
( cd $tmp; setup db; )
```

NOTE: the error I used for bad URLs (e.g. the second-to-last test case above) seems semantically correct, but has a pretty unfriendly `Display` implementation (which is what `diesel_cli` uses for error messaging); it just dumps the URL with no context. The following change helped with that, but I felt it was reaching too deep for this change:

```
diff --git a/diesel/src/result.rs b/diesel/src/result.rs
index ce8b1ad00..c13e9f467 100644
--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -356,7 +356,7 @@ impl Display for ConnectionError {
         match *self {
             ConnectionError::InvalidCString(ref nul_err) => nul_err.fmt(f),
             ConnectionError::BadConnection(ref s) => write!(f, "{}", s),
-            ConnectionError::InvalidConnectionUrl(ref s) => write!(f, "{}", s),
+            ConnectionError::InvalidConnectionUrl(ref s) => write!(f, "invalid connection URL: {}", s),
             ConnectionError::CouldntSetupConfiguration(ref e) => e.fmt(f),
         }
     }

```

NOTE: I have not done further testing of the CLI to see if there are similar issues elsewhere with `file:///` URLs.