### PR TITLE
Make `InsertStatement` fields public behind feature flag so that third party backends can use these information more easily

### DIFF
--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -174,7 +174,7 @@ impl<T: QuerySource, U, Op, Ret> InsertStatement<T, U, Op, Ret> {
     #[diesel_derives::__diesel_public_if(
         feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
     )]
-    pub fn new(target: T, records: U, operator: Op, returning: Ret) -> Self {
+    pub(crate) fn new(target: T, records: U, operator: Op, returning: Ret) -> Self {
         InsertStatement {
             into_clause: target.from_clause(),
             operator,

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -122,8 +122,6 @@ where
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-#[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
 /// A fully constructed insert statement.
 ///
 /// The parameters of this struct represent:
@@ -140,6 +138,8 @@ where
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
     public_fields(operator, target, records, returning)
 )]
+#[derive(Debug, Copy, Clone)]
+#[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
 pub struct InsertStatement<T: QuerySource, U, Op = Insert, Ret = NoReturningClause> {
     /// The operator used by this InsertStatement
     ///

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -136,10 +136,20 @@ where
 /// - `Ret`: The `RETURNING` clause of the query. The specific types used to
 ///   represent this are private. You can safely rely on the default type
 ///   representing a query without a `RETURNING` clause.
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+    public_fields(operator, target, records, returning)
+)]
 pub struct InsertStatement<T: QuerySource, U, Op = Insert, Ret = NoReturningClause> {
+    /// The operator used by this InsertStatement
+    ///
+    /// Corresponds to either `Insert` or `Replace`
     operator: Op,
+    /// The table we are inserting into
     target: T,
+    /// The data which should be inserted
     records: U,
+    /// An optional returning clause
     returning: Ret,
     into_clause: T::FromClause,
 }
@@ -160,7 +170,11 @@ where
 }
 
 impl<T: QuerySource, U, Op, Ret> InsertStatement<T, U, Op, Ret> {
-    fn new(target: T, records: U, operator: Op, returning: Ret) -> Self {
+    /// Create a new InsertStatement instance
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub fn new(target: T, records: U, operator: Op, returning: Ret) -> Self {
         InsertStatement {
             into_clause: target.from_clause(),
             operator,


### PR DESCRIPTION
This is required for third party backends to implement similar batch inserts in a similar way than sqlite 

See https://github.com/GiGainfosystems/diesel-oci/pull/45/commits/f2d117c92ca8e2a517611b80761876a35f55ede2 for details.