### PR TITLE
Add ability to serialize additional fields to the MigrationMetadata

### DIFF
--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -130,6 +130,14 @@ pub trait MigrationMetadata {
     fn run_in_transaction(&self) -> bool {
         true
     }
+
+    /// Any additional fields found in the migration metadata, that are not
+    /// explicitly used by diesel.
+    ///
+    /// The values are JSON-serialized strings
+    fn additional_fields(&self) -> std::collections::HashMap<String, String> {
+        std::collections::HashMap::new()
+    }
 }
 
 /// A migration source is an entity that can be used

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -9,4 +9,5 @@ rust-version = "1.56.0"
 [dependencies]
 serde = {version = "1", features = ["derive"]}
 toml = "0.5"
+serde_json = "1"
 

--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -20,38 +20,61 @@
     missing_copy_implementations
 )]
 
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs::{DirEntry, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
 #[doc(hidden)]
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[allow(missing_copy_implementations)]
 pub struct TomlMetadata {
     #[serde(default)]
     pub run_in_transaction: bool,
+
+    #[serde(flatten)]
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl Default for TomlMetadata {
     fn default() -> Self {
         Self {
             run_in_transaction: true,
+            additional_fields: HashMap::default(),
         }
     }
 }
 
 impl TomlMetadata {
-    pub const fn new(run_in_transaction: bool) -> Self {
-        Self { run_in_transaction }
+    pub fn new(run_in_transaction: bool) -> Self {
+        Self {
+            run_in_transaction,
+            additional_fields: HashMap::new(),
+        }
     }
 
     pub fn read_from_file(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
         let mut toml = String::new();
         let mut file = File::open(path)?;
         file.read_to_string(&mut toml)?;
+        Self::from_toml_str(&toml)
+    }
 
-        Ok(toml::from_str(&toml)?)
+    pub fn from_toml_str(toml: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(toml::from_str(toml)?)
+    }
+
+    pub fn to_toml_string(&self) -> Result<String, Box<dyn std::error::Error>> {
+        Ok(toml::to_string(&self)?)
+    }
+
+    pub fn serialized_additional_fields(&self) -> HashMap<String, String> {
+        let mut map = HashMap::with_capacity(self.additional_fields.len());
+        for (k, v) in self.additional_fields.iter() {
+            map.insert(k.clone(), serde_json::to_string(v).unwrap_or_default());
+        }
+        map
     }
 }
 
@@ -100,4 +123,49 @@ pub fn migrations_directories(
             })
             .transpose()
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static RAW_TOML: &str = r#"
+run_in_transaction = false
+boolean_field = false
+string_field = "Something"
+
+[foo]
+name = "Bar"
+"#;
+
+    #[test]
+    fn extracts_additional_fields() {
+        let md = TomlMetadata::from_toml_str(RAW_TOML).unwrap();
+        dbg!(&md);
+        assert!(!md.run_in_transaction);
+        assert!(md.additional_fields.contains_key("boolean_field"));
+        assert!(md.additional_fields.contains_key("string_field"));
+        assert!(md.additional_fields.contains_key("foo"));
+        assert!(!md.additional_fields.contains_key("name"));
+    }
+
+    #[test]
+    fn round_trip() {
+        let md = TomlMetadata::from_toml_str(RAW_TOML).unwrap();
+        let toml = md.to_toml_string().unwrap();
+        let new = TomlMetadata::from_toml_str(&toml).unwrap();
+        assert_eq!(md.run_in_transaction, new.run_in_transaction);
+        for (k, v) in md.additional_fields.iter() {
+            assert_eq!(v, new.additional_fields.get(k).unwrap());
+        }
+    }
+
+    #[test]
+    fn additional_fields_serialization() {
+        let md = TomlMetadata::from_toml_str(RAW_TOML).unwrap();
+        let fields = md.serialized_additional_fields();
+        assert_eq!("\"Something\"", fields.get("string_field").unwrap());
+        assert_eq!("false", fields.get("boolean_field").unwrap());
+        assert_eq!(r#"{"name":"Bar"}"#, fields.get("foo").unwrap());
+    }
 }

--- a/diesel_migrations/src/file_based_migrations.rs
+++ b/diesel_migrations/src/file_based_migrations.rs
@@ -254,14 +254,23 @@ pub struct TomlMetadataWrapper(TomlMetadata);
 
 impl TomlMetadataWrapper {
     #[doc(hidden)]
-    pub const fn new(run_in_transaction: bool) -> Self {
+    pub fn new(run_in_transaction: bool) -> Self {
         Self(TomlMetadata::new(run_in_transaction))
+    }
+
+    #[doc(hidden)]
+    pub fn from_toml_str_or_default(toml: &'static str) -> Self {
+        Self(TomlMetadata::from_toml_str(toml).unwrap_or_default())
     }
 }
 
 impl MigrationMetadata for TomlMetadataWrapper {
     fn run_in_transaction(&self) -> bool {
         self.0.run_in_transaction
+    }
+
+    fn additional_fields(&self) -> std::collections::HashMap<String, String> {
+        self.0.serialized_additional_fields()
     }
 }
 


### PR DESCRIPTION
We would like to attach additional fields to the `MigrationMetadata`, to give us the ability to manage the migrations in a better fashion.

### How we'll use it
Our tenants are separated in different schemas, but also there's a shared schema. 

Normally we would set the scope for each tenant via `search_path` before running migrations, and try to make the "shared" migrations idempotent, but that's annoyingly complicated and not flexible.

By allowing additional fields in the metadata, we would be able to extract a flag like `is_shared`, and only run that in the "global" scope, not once for each tenant.

An alternative that we considered for that, would be splitting the two sets of migrations into different folders, and merging the two sets afterwards, but extending the metadata seemed cleaner.