### PR TITLE
Make the `ValidGrouping` impl for `AliasedField` more generic

### DIFF
--- a/diesel/src/query_source/aliasing/aliased_field.rs
+++ b/diesel/src/query_source/aliasing/aliased_field.rs
@@ -77,10 +77,13 @@ where
 {
     type IsAggregate = is_aggregate::No;
 }
-impl<S, C> ValidGrouping<AliasedField<S, C>> for AliasedField<S, C>
+
+impl<S, C1, C2> ValidGrouping<AliasedField<S, C1>> for AliasedField<S, C2>
 where
     S: AliasSource,
-    C: Column<Table = S::Target>,
+    C1: Column<Table = S::Target>,
+    C2: Column<Table = S::Target>,
+    C2: ValidGrouping<C1, IsAggregate = is_aggregate::Yes>,
 {
     type IsAggregate = is_aggregate::Yes;
 }

--- a/diesel_compile_tests/tests/fail/alias_and_group_by.rs
+++ b/diesel_compile_tests/tests/fail/alias_and_group_by.rs
@@ -1,0 +1,37 @@
+extern crate diesel;
+
+use diesel::alias;
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+fn main() {
+    let conn = &mut PgConnection::establish("…").unwrap();
+    let user_alias = alias!(users as user1);
+
+    // allowed as this groups by the the same field
+    user_alias
+        .group_by(user_alias.field(users::name))
+        .select(user_alias.field(users::name))
+        .execute(conn)
+        .unwrap();
+
+    // allowed as this groups by the primary key
+    user_alias
+        .group_by(user_alias.field(users::id))
+        .select(user_alias.field(users::name))
+        .execute(conn)
+        .unwrap();
+
+    // fails as this groups by an incompatible field
+    user_alias
+        .group_by(user_alias.field(users::name))
+        .select(user_alias.field(users::id))
+        .execute(conn)
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/fail/alias_and_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/alias_and_group_by.stderr
@@ -1,0 +1,20 @@
+error[E0271]: type mismatch resolving `<columns::name as IsContainedInGroupBy<columns::id>>::Output == diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/alias_and_group_by.rs:34:10
+   |
+34 |         .select(user_alias.field(users::id))
+   |          ^^^^^^ expected struct `diesel::expression::is_contained_in_group_by::No`, found struct `diesel::expression::is_contained_in_group_by::Yes`
+   |
+note: required because of the requirements on the impl of `ValidGrouping<columns::name>` for `columns::id`
+  --> tests/fail/alias_and_group_by.rs:6:1
+   |
+6  | / table! {
+7  | |     users {
+8  | |         id -> Integer,
+9  | |         name -> VarChar,
+10 | |     }
+11 | | }
+   | |_^
+   = note: 1 redundant requirement hidden
+   = note: required because of the requirements on the impl of `ValidGrouping<AliasedField<user1, columns::name>>` for `AliasedField<user1, columns::id>`
+   = note: required because of the requirements on the impl of `SelectDsl<AliasedField<user1, columns::id>>` for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<Alias<user1>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, diesel::query_builder::limit_offset_clause::LimitOffsetClause<diesel::query_builder::limit_clause::NoLimitClause, diesel::query_builder::offset_clause::NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<AliasedField<user1, columns::name>>>`
+   = note: this error originates in the macro `$crate::__diesel_column` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_tests/tests/alias.rs
+++ b/diesel_tests/tests/alias.rs
@@ -184,9 +184,10 @@ fn aliasing_with_group_by_and_primary_key() {
     let res = user_alias
         .group_by(user_alias.field(users::id))
         .select(user_alias.field(users::name))
+        .order_by(user_alias.field(users::id))
         .load::<String>(connection)
         .unwrap();
     assert!(res.len() == 2);
-    assert_eq!(res[1], "Sean");
-    assert_eq!(res[0], "Tess");
+    assert_eq!(res[0], "Sean");
+    assert_eq!(res[1], "Tess");
 }

--- a/diesel_tests/tests/alias.rs
+++ b/diesel_tests/tests/alias.rs
@@ -173,3 +173,20 @@ fn visibility() {
         const USERS_ALIAS_2: Alias<UsersAlias2> = users as users_alias_2;
     }
 }
+
+// regression test for
+// https://github.com/diesel-rs/diesel/issues/3319
+#[test]
+fn aliasing_with_group_by_and_primary_key() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let user_alias = alias!(users as user1);
+
+    let res = user_alias
+        .group_by(user_alias.field(users::id))
+        .select(user_alias.field(users::name))
+        .load::<String>(connection)
+        .unwrap();
+    assert!(res.len() == 2);
+    assert_eq!(res[1], "Sean");
+    assert_eq!(res[0], "Tess");
+}


### PR DESCRIPTION
This commits makes the `ValidGrouping` impl for `AliasedField` more generic so that diesel now also accepts queries which group by a primary key and select any other field of the alias. This change is backward compatible even with the changed trait impl as any type that satisfied the old impl also satisfies the new impl for `C1` == `C2`.

This fixes #3319