### PR TITLE
Add some additional checks to `#[derive(Selectable)]` to ensure field

### DIFF
--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -420,6 +420,13 @@ pub use diesel_derives::QueryableByName;
 ///     }
 /// }
 /// ```
+#[cfg_attr(
+    feature = "nightly-error-messages",
+    rustc_on_unimplemented(
+        message = "Cannot deserialize a value of the type `{A}` as `{Self}`",
+        note = "Double check your type mappings via the documentation of `{A}`"
+    )
+)]
 pub trait FromSql<A, DB: Backend>: Sized {
     /// See the trait documentation.
     fn from_sql(bytes: DB::RawValue<'_>) -> Result<Self>;

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -24,6 +24,17 @@ pub type Result<T> = result::Result<T, Box<dyn Error + Send + Sync>>;
 ///
 /// This trait can be [derived](derive@Queryable)
 ///
+/// ## How to resolve compiler errors while loading data from the database
+///
+/// In case you getting uncomprehensable compiler errors while loading data
+/// from the database you might want to consider using
+/// [`#[derive(Selectable)]`](derive@crate::prelude::Selectable) +
+/// `#[diesel(check_for_backend(YourBackendType))]` to check for mismatching fields at compile
+/// time. This drastically improves the quality of the generated error messages by pointing
+/// to concrete mismatches at field level. You need to specify the concrete database backend
+/// this specific struct is indented to be used with, as otherwise rustc cannot correctly
+/// identify the required deserialization implementation.
+///
 /// ## Interaction with `NULL`/`Option`
 /// [`Nullable`][crate::sql_types::Nullable] types can be queried into `Option`.
 /// This is valid for single fields, tuples, and structures with `Queryable`.

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -1450,6 +1450,19 @@ pub trait RunQueryDsl<Conn>: Sized {
     /// [`execute`]: crate::query_dsl::RunQueryDsl::execute()
     /// [`sql_query`]: crate::sql_query()
     ///
+    /// ## How to resolve compiler errors while loading data from the database
+    ///
+    /// In case you getting uncomprehensable compiler errors while loading data
+    /// from the database into a type using [`#[derive(Queryable)]`](derive@crate::prelude::Queryable)
+    /// you might want to consider
+    /// using  [`#[derive(Selectable)]`](derive@crate::prelude::Selectable) +
+    /// `#[diesel(check_for_backend(YourBackendType))]`
+    /// to check for mismatching fields at compile time. This drastically improves
+    /// the quality of the generated error messages by pointing to concrete type mismatches at
+    /// field level.You need to specify the concrete database backend
+    /// this specific struct is indented to be used with, as otherwise rustc cannot correctly
+    /// identify the required deserialization implementation.
+    ///
     /// # Examples
     ///
     /// ## Returning a single field

--- a/diesel_compile_tests/tests/fail/derive/bad_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_primary_key.stderr
@@ -15,6 +15,8 @@ error: unexpected end of input, expected parentheses
    |
 26 | #[diesel(primary_key)]
    |                     ^
+   |
+   = help: The correct format looks like `#[diesel(key1, key2)]`
 
 error: expected parentheses
   --> tests/fail/derive/bad_primary_key.rs:33:22

--- a/diesel_compile_tests/tests/fail/derive/unknown_attribute.stderr
+++ b/diesel_compile_tests/tests/fail/derive/unknown_attribute.stderr
@@ -1,11 +1,11 @@
-error: unknown attribute, expected one of `aggregate`, `not_sized`, `foreign_derive`, `table_name`, `sql_type`, `treat_none_as_default_value`, `treat_none_as_null`, `belongs_to`, `mysql_type`, `sqlite_type`, `postgres_type`, `primary_key`
- --> $DIR/unknown_attribute.rs:5:10
+error: unknown attribute, expected one of `aggregate`, `not_sized`, `foreign_derive`, `table_name`, `sql_type`, `treat_none_as_default_value`, `treat_none_as_null`, `belongs_to`, `mysql_type`, `sqlite_type`, `postgres_type`, `primary_key`, `check_for_backend`
+ --> tests/fail/derive/unknown_attribute.rs:5:10
   |
 5 | #[diesel(what = true)]
   |          ^^^^
 
 error: unknown attribute, expected one of `embed`, `column_name`, `sql_type`, `serialize_as`, `deserialize_as`, `select_expression`, `select_expression_type`
-  --> $DIR/unknown_attribute.rs:12:14
+  --> tests/fail/derive/unknown_attribute.rs:12:14
    |
 12 |     #[diesel(what = true)]
    |              ^^^^

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sql_type.stderr
@@ -73,12 +73,13 @@ error[E0412]: cannot find type `foo` in this scope
 27 |     #[sql_type = "foo"]
    |                  ^^^^^ not found in this scope
 
-error[E0277]: the trait bound `i32: FromSql<_, __DB>` is not satisfied
+error[E0277]: Cannot deserialize a value of the type `_` as `i32`
   --> tests/fail/derive_deprecated/deprecated_sql_type.rs:25:10
    |
 25 | #[derive(QueryableByName)]
    |          ^^^^^^^^^^^^^^^ the trait `FromSql<_, __DB>` is not implemented for `i32`
    |
+   = note: Double check your type mappings via the documentation of `_`
    = help: the following other types implement trait `FromSql<A, DB>`:
              <i32 as FromSql<diesel::sql_types::Integer, Mysql>>
              <i32 as FromSql<diesel::sql_types::Integer, Pg>>

--- a/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
+++ b/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, _>` is not satisfied
+error[E0277]: Cannot deserialize a value of the type `diesel::sql_types::Text` as `i32`
   --> tests/fail/select_carries_correct_result_type_info.rs:19:39
    |
 19 |     let ids = select_name.load::<i32>(&mut connection);
@@ -6,6 +6,7 @@ error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, _>` is not 
    |                           |
    |                           required by a bound introduced by this call
    |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Text`
    = help: the following other types implement trait `FromSql<A, DB>`:
              <i32 as FromSql<diesel::sql_types::Integer, Mysql>>
              <i32 as FromSql<diesel::sql_types::Integer, Pg>>
@@ -20,7 +21,7 @@ note: required by a bound in `diesel::RunQueryDsl::load`
    |         Self: LoadQuery<'query, Conn, U>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
-error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, _>` is not satisfied
+error[E0277]: Cannot deserialize a value of the type `diesel::sql_types::Integer` as `*const str`
   --> tests/fail/select_carries_correct_result_type_info.rs:20:42
    |
 20 |     let names = select_id.load::<String>(&mut connection);
@@ -28,6 +29,7 @@ error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, _
    |                           |
    |                           required by a bound introduced by this call
    |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Integer`
    = help: the following other types implement trait `FromSql<A, DB>`:
              <*const str as FromSql<diesel::sql_types::Text, Mysql>>
              <*const str as FromSql<diesel::sql_types::Text, Pg>>

--- a/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
+++ b/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `*const str: FromSql<BigInt, _>` is not satisfied
+error[E0277]: Cannot deserialize a value of the type `BigInt` as `*const str`
   --> tests/fail/select_sql_still_ensures_result_type.rs:16:51
    |
 16 |     let count = select_count.get_result::<String>(&mut connection).unwrap();
@@ -6,6 +6,7 @@ error[E0277]: the trait bound `*const str: FromSql<BigInt, _>` is not satisfied
    |                              |
    |                              required by a bound introduced by this call
    |
+   = note: Double check your type mappings via the documentation of `BigInt`
    = help: the following other types implement trait `FromSql<A, DB>`:
              <*const str as FromSql<diesel::sql_types::Text, Mysql>>
              <*const str as FromSql<diesel::sql_types::Text, Pg>>

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
@@ -11,16 +11,29 @@ table! {
 
 #[derive(Selectable, Queryable)]
 #[diesel(table_name = users)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 struct User {
     id: String,
     name: i32,
 }
 
+#[derive(Selectable, Queryable)]
+#[diesel(table_name = users)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+struct UserCorrect {
+    id: i32,
+    name: String,
+}
 
 fn main() {
     let mut conn = PgConnection::establish("...").unwrap();
 
-    users::table.select(User::as_select()).load(&mut conn).unwrap();
-
-
+    users::table
+        .select(User::as_select())
+        .load(&mut conn)
+        .unwrap();
+    users::table
+        .select(UserCorrect::as_select())
+        .load(&mut conn)
+        .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
@@ -1,0 +1,26 @@
+extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+#[derive(Selectable, Queryable)]
+#[diesel(table_name = users)]
+struct User {
+    id: String,
+    name: i32,
+}
+
+
+fn main() {
+    let mut conn = PgConnection::establish("...").unwrap();
+
+    users::table.select(User::as_select()).load(&mut conn).unwrap();
+
+
+}

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -1,0 +1,119 @@
+error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Mysql>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:16:11
+   |
+16 |     name: i32,
+   |           ^^^ the trait `FromSql<diesel::sql_types::Text, Mysql>` is not implemented for `i32`
+   |
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <f32 as FromSql<diesel::sql_types::Float, Mysql>>
+             <f32 as FromSql<diesel::sql_types::Float, Pg>>
+             <f32 as FromSql<diesel::sql_types::Float, Sqlite>>
+             <f64 as FromSql<diesel::sql_types::Double, Mysql>>
+             <f64 as FromSql<diesel::sql_types::Double, Pg>>
+             <f64 as FromSql<diesel::sql_types::Double, Sqlite>>
+             <i16 as FromSql<diesel::sql_types::SmallInt, Mysql>>
+             <i16 as FromSql<diesel::sql_types::SmallInt, Pg>>
+           and 13 others
+   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Text, Mysql>` for `i32`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Sqlite>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:16:11
+   |
+16 |     name: i32,
+   |           ^^^ the trait `FromSql<diesel::sql_types::Text, Sqlite>` is not implemented for `i32`
+   |
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <f32 as FromSql<diesel::sql_types::Float, Mysql>>
+             <f32 as FromSql<diesel::sql_types::Float, Pg>>
+             <f32 as FromSql<diesel::sql_types::Float, Sqlite>>
+             <f64 as FromSql<diesel::sql_types::Double, Mysql>>
+             <f64 as FromSql<diesel::sql_types::Double, Pg>>
+             <f64 as FromSql<diesel::sql_types::Double, Sqlite>>
+             <i16 as FromSql<diesel::sql_types::SmallInt, Mysql>>
+             <i16 as FromSql<diesel::sql_types::SmallInt, Pg>>
+           and 13 others
+   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Text, Sqlite>` for `i32`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Pg>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:16:11
+   |
+16 |     name: i32,
+   |           ^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
+   |
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <f32 as FromSql<diesel::sql_types::Float, Mysql>>
+             <f32 as FromSql<diesel::sql_types::Float, Pg>>
+             <f32 as FromSql<diesel::sql_types::Float, Sqlite>>
+             <f64 as FromSql<diesel::sql_types::Double, Mysql>>
+             <f64 as FromSql<diesel::sql_types::Double, Pg>>
+             <f64 as FromSql<diesel::sql_types::Double, Sqlite>>
+             <i16 as FromSql<diesel::sql_types::SmallInt, Mysql>>
+             <i16 as FromSql<diesel::sql_types::SmallInt, Pg>>
+           and 13 others
+   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Text, Pg>` for `i32`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, Mysql>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:15:9
+   |
+15 |     id: String,
+   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Mysql>` is not implemented for `*const str`
+   |
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <*const str as FromSql<diesel::sql_types::Text, Mysql>>
+             <*const str as FromSql<diesel::sql_types::Text, Pg>>
+             <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
+             <std::string::String as FromSql<ST, DB>>
+             <std::string::String as FromSql<TimestamptzSqlite, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Date, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Time, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Timestamp, Sqlite>>
+   = note: required because of the requirements on the impl of `FromSql<diesel::sql_types::Integer, Mysql>` for `std::string::String`
+   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Integer, Mysql>` for `std::string::String`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, Sqlite>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:15:9
+   |
+15 |     id: String,
+   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Sqlite>` is not implemented for `*const str`
+   |
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <*const str as FromSql<diesel::sql_types::Text, Mysql>>
+             <*const str as FromSql<diesel::sql_types::Text, Pg>>
+             <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
+             <std::string::String as FromSql<ST, DB>>
+             <std::string::String as FromSql<TimestamptzSqlite, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Date, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Time, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Timestamp, Sqlite>>
+   = note: required because of the requirements on the impl of `FromSql<diesel::sql_types::Integer, Sqlite>` for `std::string::String`
+   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Integer, Sqlite>` for `std::string::String`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, Pg>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:15:9
+   |
+15 |     id: String,
+   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
+   |
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <*const str as FromSql<diesel::sql_types::Text, Mysql>>
+             <*const str as FromSql<diesel::sql_types::Text, Pg>>
+             <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
+             <std::string::String as FromSql<ST, DB>>
+             <std::string::String as FromSql<TimestamptzSqlite, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Date, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Time, Sqlite>>
+             <std::string::String as FromSql<diesel::sql_types::Timestamp, Sqlite>>
+   = note: required because of the requirements on the impl of `FromSql<diesel::sql_types::Integer, Pg>` for `std::string::String`
+   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Integer, Pg>` for `std::string::String`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Pg>` is not satisfied
+error[E0277]: Cannot deserialize a value of the type `diesel::sql_types::Text` as `i32`
   --> tests/fail/selectable_with_typemisamatch.rs:17:11
    |
 17 |     name: i32,
    |           ^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Text`
    = help: the following other types implement trait `FromSql<A, DB>`:
              <i32 as FromSql<diesel::sql_types::Integer, Mysql>>
              <i32 as FromSql<diesel::sql_types::Integer, Pg>>
@@ -13,12 +14,13 @@ error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Pg>` is not
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, Pg>` is not satisfied
+error[E0277]: Cannot deserialize a value of the type `diesel::sql_types::Integer` as `*const str`
   --> tests/fail/selectable_with_typemisamatch.rs:16:9
    |
 16 |     id: String,
    |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
    |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Integer`
    = help: the following other types implement trait `FromSql<A, DB>`:
              <*const str as FromSql<diesel::sql_types::Text, Mysql>>
              <*const str as FromSql<diesel::sql_types::Text, Pg>>

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -1,119 +1,30 @@
-error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Mysql>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:16:11
-   |
-16 |     name: i32,
-   |           ^^^ the trait `FromSql<diesel::sql_types::Text, Mysql>` is not implemented for `i32`
-   |
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             <f32 as FromSql<diesel::sql_types::Float, Mysql>>
-             <f32 as FromSql<diesel::sql_types::Float, Pg>>
-             <f32 as FromSql<diesel::sql_types::Float, Sqlite>>
-             <f64 as FromSql<diesel::sql_types::Double, Mysql>>
-             <f64 as FromSql<diesel::sql_types::Double, Pg>>
-             <f64 as FromSql<diesel::sql_types::Double, Sqlite>>
-             <i16 as FromSql<diesel::sql_types::SmallInt, Mysql>>
-             <i16 as FromSql<diesel::sql_types::SmallInt, Pg>>
-           and 13 others
-   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Text, Mysql>` for `i32`
-   = help: see issue #48214
-   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-
-error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Sqlite>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:16:11
-   |
-16 |     name: i32,
-   |           ^^^ the trait `FromSql<diesel::sql_types::Text, Sqlite>` is not implemented for `i32`
-   |
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             <f32 as FromSql<diesel::sql_types::Float, Mysql>>
-             <f32 as FromSql<diesel::sql_types::Float, Pg>>
-             <f32 as FromSql<diesel::sql_types::Float, Sqlite>>
-             <f64 as FromSql<diesel::sql_types::Double, Mysql>>
-             <f64 as FromSql<diesel::sql_types::Double, Pg>>
-             <f64 as FromSql<diesel::sql_types::Double, Sqlite>>
-             <i16 as FromSql<diesel::sql_types::SmallInt, Mysql>>
-             <i16 as FromSql<diesel::sql_types::SmallInt, Pg>>
-           and 13 others
-   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Text, Sqlite>` for `i32`
-   = help: see issue #48214
-   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-
 error[E0277]: the trait bound `i32: FromSql<diesel::sql_types::Text, Pg>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:16:11
+  --> tests/fail/selectable_with_typemisamatch.rs:17:11
    |
-16 |     name: i32,
+17 |     name: i32,
    |           ^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
    = help: the following other types implement trait `FromSql<A, DB>`:
-             <f32 as FromSql<diesel::sql_types::Float, Mysql>>
-             <f32 as FromSql<diesel::sql_types::Float, Pg>>
-             <f32 as FromSql<diesel::sql_types::Float, Sqlite>>
-             <f64 as FromSql<diesel::sql_types::Double, Mysql>>
-             <f64 as FromSql<diesel::sql_types::Double, Pg>>
-             <f64 as FromSql<diesel::sql_types::Double, Sqlite>>
-             <i16 as FromSql<diesel::sql_types::SmallInt, Mysql>>
-             <i16 as FromSql<diesel::sql_types::SmallInt, Pg>>
-           and 13 others
-   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Text, Pg>` for `i32`
-   = help: see issue #48214
-   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-
-error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, Mysql>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:15:9
-   |
-15 |     id: String,
-   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Mysql>` is not implemented for `*const str`
-   |
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             <*const str as FromSql<diesel::sql_types::Text, Mysql>>
-             <*const str as FromSql<diesel::sql_types::Text, Pg>>
-             <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
-             <std::string::String as FromSql<ST, DB>>
-             <std::string::String as FromSql<TimestamptzSqlite, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Date, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Time, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Timestamp, Sqlite>>
-   = note: required because of the requirements on the impl of `FromSql<diesel::sql_types::Integer, Mysql>` for `std::string::String`
-   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Integer, Mysql>` for `std::string::String`
-   = help: see issue #48214
-   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-
-error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, Sqlite>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:15:9
-   |
-15 |     id: String,
-   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Sqlite>` is not implemented for `*const str`
-   |
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             <*const str as FromSql<diesel::sql_types::Text, Mysql>>
-             <*const str as FromSql<diesel::sql_types::Text, Pg>>
-             <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
-             <std::string::String as FromSql<ST, DB>>
-             <std::string::String as FromSql<TimestamptzSqlite, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Date, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Time, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Timestamp, Sqlite>>
-   = note: required because of the requirements on the impl of `FromSql<diesel::sql_types::Integer, Sqlite>` for `std::string::String`
-   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Integer, Sqlite>` for `std::string::String`
+             <i32 as FromSql<diesel::sql_types::Integer, Mysql>>
+             <i32 as FromSql<diesel::sql_types::Integer, Pg>>
+             <i32 as FromSql<diesel::sql_types::Integer, Sqlite>>
+   = note: required for `i32` to implement `diesel::Queryable<diesel::sql_types::Text, Pg>`
+   = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `*const str: FromSql<diesel::sql_types::Integer, Pg>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:15:9
+  --> tests/fail/selectable_with_typemisamatch.rs:16:9
    |
-15 |     id: String,
+16 |     id: String,
    |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
    |
    = help: the following other types implement trait `FromSql<A, DB>`:
              <*const str as FromSql<diesel::sql_types::Text, Mysql>>
              <*const str as FromSql<diesel::sql_types::Text, Pg>>
              <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
-             <std::string::String as FromSql<ST, DB>>
-             <std::string::String as FromSql<TimestamptzSqlite, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Date, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Time, Sqlite>>
-             <std::string::String as FromSql<diesel::sql_types::Timestamp, Sqlite>>
-   = note: required because of the requirements on the impl of `FromSql<diesel::sql_types::Integer, Pg>` for `std::string::String`
-   = note: required because of the requirements on the impl of `diesel::Queryable<diesel::sql_types::Integer, Pg>` for `std::string::String`
+   = note: required for `std::string::String` to implement `FromSql<diesel::sql_types::Integer, Pg>`
+   = note: required for `std::string::String` to implement `diesel::Queryable<diesel::sql_types::Integer, Pg>`
+   = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "1024"]
 // Clippy lints
 #![allow(
     clippy::needless_doctest_main,
@@ -455,7 +454,10 @@ pub fn derive_query_id(input: TokenStream) -> TokenStream {
 /// **Note**: When this trait is derived, it will assume that __all fields on
 /// your struct__ matches __all fields in the query__, including the order and
 /// count. This means that field order is significant if you are using
-/// `#[derive(Queryable)]`. __Field name has no effect__.
+/// `#[derive(Queryable)]`. __Field name has no effect__. If you see errors while
+/// loading data into a struct that derives `Queryable`: Consider using [`#[derive(Selectable)]`]
+/// + `#[diesel(check_for_backend(YourBackendType))]` to check for mismatching fields at compile
+/// time.
 ///
 /// To provide custom deserialization behavior for a field, you can use
 /// `#[diesel(deserialize_as = SomeType)]`. If this attribute is present, Diesel
@@ -843,6 +845,16 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 ///    current type is selectable. The path is relative to the current module.
 ///    If this attribute is not used, the type name converted to
 ///    `snake_case` with an added `s` is used as table name.
+///
+/// ## Optional Type attributes
+///
+/// * `#[diesel(check_for_backend(diesel::pg::Pg, diesel::mysql::Mysql))]`, instructs
+///    the derive to generate additional code to identify potential type mismatches.
+///    It accepts a list of backend types to check the types against. Using this option
+///    will result in much better error messages in cases where some types in your `Queryable`
+///    struct do not match. You need to specify the concrete database backend
+///    this specific struct is indented to be used with, as otherwise rustc cannot correctly
+///    identify the required deserialization implementation.
 ///
 /// ## Field attributes
 ///

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -25,6 +25,7 @@ pub struct Model {
     pub mysql_type: Option<MysqlType>,
     pub sqlite_type: Option<SqliteType>,
     pub postgres_type: Option<PostgresType>,
+    pub check_for_backend: Option<syn::punctuated::Punctuated<syn::TypePath, syn::Token![,]>>,
     fields: Vec<Field>,
 }
 
@@ -61,6 +62,7 @@ impl Model {
         let mut mysql_type = None;
         let mut sqlite_type = None;
         let mut postgres_type = None;
+        let mut check_for_backend = None;
 
         for attr in parse_attributes(attrs) {
             match attr.item {
@@ -80,6 +82,9 @@ impl Model {
                 StructAttr::MysqlType(_, val) => mysql_type = Some(val),
                 StructAttr::SqliteType(_, val) => sqlite_type = Some(val),
                 StructAttr::PostgresType(_, val) => postgres_type = Some(val),
+                StructAttr::CheckForBackend(_, b) => {
+                    check_for_backend = Some(b);
+                }
             }
         }
 
@@ -100,6 +105,7 @@ impl Model {
             sqlite_type,
             postgres_type,
             fields: fields_from_item_data(fields),
+            check_for_backend,
         }
     }
 


### PR DESCRIPTION
compatibility

We generate an additional function with trait bounds for each fields to check whether a certain rust field type is compatible with the underlying database type. This greatly improves error messages for potential type mismatches, as the user now gets an error message that points to the field causing the problem + which has a pretty clear meaning (stating that `FromSql<…>` is not implemented).

Unfortunaly that's not a perfect solution as we need to check against **concrete** backend implementation. This PR solves this by hard-coding all three out of the box supported backends (behind the corresponding feature flags). That works for cases where users want to have compatibility with all enabled backends, but there are certainly use-cases where this is not the case. We might need some opt-in/opt-out system here to prevent this from being a breaking change or making it impossible to support valid use-cases. On the one hand we might want to have this as default as the improved error messages is something which is really helpful for new users, on the other hand I cannot see how that would be possible without breaking changes.

Another down-side of this approach is that it generates basically duplicated error messages when more than one backend is enabled.

This is currently marked as Draft as I see that more as request for comments due to the various problems outlined above. I really would like to see something like that in stable diesel as this would improve the usability quite significantly in my opinion. (We would just need to tell everyone to use `Selectable` and after that at least many cryptic errors will go away)