### PR TITLE
Replace useless call to `ok` with `unwrap`

### DIFF
--- a/examples/postgres/getting_started_step_1/src/lib.rs
+++ b/examples/postgres/getting_started_step_1/src/lib.rs
@@ -7,7 +7,7 @@ use dotenvy::dotenv;
 use std::env;
 
 pub fn establish_connection() -> PgConnection {
-    dotenv().ok();
+    dotenv().unwrap();
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     PgConnection::establish(&database_url)


### PR DESCRIPTION
Replace useless call to `ok` with `unwrap`. This is also what dotenvy recommends: https://docs.rs/dotenvy/latest/dotenvy/fn.dotenv.html.