### PR TITLE
Add "delete" ability to `diesel_dynamic_schema::Table`

### DIFF
--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -1,3 +1,4 @@
+use diesel::associations::HasTable;
 use diesel::backend::Backend;
 use diesel::expression::expression_types;
 use diesel::internal::table_macro::{FromClause, SelectStatement};
@@ -111,4 +112,19 @@ where
 impl<T, U> QueryId for Table<T, U> {
     type QueryId = ();
     const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<T, U> HasTable for Table<T, U>
+where
+    T: Default,
+    Self: QuerySource + AsQuery,
+{
+    type Table = Self;
+
+    fn table() -> Self {
+        Self {
+            name: T::default(),
+            schema: None,
+        }
+    }
 }

--- a/diesel_dynamic_schema/tests/delete.rs
+++ b/diesel_dynamic_schema/tests/delete.rs
@@ -1,0 +1,40 @@
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::*;
+
+#[test]
+fn delete_one_record() {
+    let connection = &mut crate::establish_connection();
+    crate::create_user_table(connection);
+    sql_query("INSERT INTO users (id, name, hair_color) VALUES (42, 'Sean', 'black'), (43, 'Tess', 'black')")
+        .execute(connection)
+        .unwrap();
+
+    let users = diesel_dynamic_schema::table("users");
+    let id = users.column::<Integer, _>("id");
+
+    diesel::delete(users.filter(id.eq(42)))
+        .execute(connection)
+        .unwrap();
+
+    let name = users.column::<Text, _>("name");
+    let names = users.select(name).load::<String>(connection);
+    assert_eq!(Ok(vec!["Tess".into()]), names);
+}
+
+// #[test]
+// fn truncate_table() {
+//     let connection = &mut crate::establish_connection();
+//     crate::create_user_table(connection);
+//     sql_query("INSERT INTO users (id, name, hair_color) VALUES (42, 'Sean', 'black'), (43, 'Tess', 'black')")
+//         .execute(connection)
+//         .unwrap();
+
+//     let users = diesel_dynamic_schema::table("users");
+
+//     diesel::delete(users).execute(connection).unwrap();
+
+//     let name = users.column::<Text, _>("name");
+//     let names = users.select(name).load::<String>(connection);
+//     assert_eq!(Ok(Vec::new()), names);
+// }

--- a/diesel_dynamic_schema/tests/lib.rs
+++ b/diesel_dynamic_schema/tests/lib.rs
@@ -9,6 +9,8 @@ mod dynamic_values;
 
 mod connection_setup;
 
+mod delete;
+
 use connection_setup::{create_user_table, establish_connection};
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
This draft PR is meant to add "delete" capabilities to `diesel_dynamic_schema::Table`. Once it's working fine, this code should work:

```rust
    let users = diesel_dynamic_schema::table("users");
    let id = users.column::<Integer, _>("id");

    diesel::delete(users.filter(id.eq(42)))
        .execute(connection)
        .unwrap();
```

Also, I would like to implement the truncate table statements, but it's currently not working (I need to implement `diesel::query_builder::IntoUpdateTarget` for `diesel_dynamic_schema::Table`).

I would like to see if the CI complains with the new changes.