### PR TITLE
Allow the `pagination.rs` to accept the optional page parameters.

### DIFF
--- a/examples/postgres/advanced-blog-cli/src/pagination.rs
+++ b/examples/postgres/advanced-blog-cli/src/pagination.rs
@@ -3,18 +3,21 @@ use diesel::prelude::*;
 use diesel::query_builder::*;
 use diesel::query_dsl::methods::LoadQuery;
 use diesel::sql_types::BigInt;
+use std::fmt::Debug;
 
 pub trait Paginate: Sized {
-    fn paginate(self, page: i64) -> Paginated<Self>;
+    fn paginate(self, page: Option<i64>) -> Paginated<Self>;
 }
 
 impl<T> Paginate for T {
-    fn paginate(self, page: i64) -> Paginated<Self> {
+    fn paginate(self, page: Option<i64>) -> Paginated<Self> {
+        let offset = if page.is_some() { (page.clone().unwrap() - 1) * DEFAULT_PER_PAGE } else { -1 };
         Paginated {
             query: self,
+            some_per_page: Some(DEFAULT_PER_PAGE),
             per_page: DEFAULT_PER_PAGE,
             page,
-            offset: (page - 1) * DEFAULT_PER_PAGE,
+            offset,
         }
     }
 }
@@ -24,30 +27,50 @@ const DEFAULT_PER_PAGE: i64 = 10;
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct Paginated<T> {
     query: T,
-    page: i64,
+    page: Option<i64>,
+    some_per_page: Option<i64>,
     per_page: i64,
     offset: i64,
 }
 
 impl<T> Paginated<T> {
-    pub fn per_page(self, per_page: i64) -> Self {
+    pub fn per_page(self, some_per_page: Option<i64>) -> Self {
+        let per_page = if some_per_page.is_some() { some_per_page.clone().unwrap() } else { -1 };
+        let offset = if some_per_page.is_some() && self.page.is_some() { (self.page.clone().unwrap() - 1) * some_per_page.clone().unwrap() } else { -1 };
+
         Paginated {
+            some_per_page,
             per_page,
-            offset: (self.page - 1) * per_page,
+            offset,
             ..self
         }
     }
 
-    pub fn load_and_count_pages<'a, U>(self, conn: &mut PgConnection) -> QueryResult<(Vec<U>, i64)>
-    where
-        Self: LoadQuery<'a, PgConnection, (U, i64)>,
+    pub fn load_and_count_pages<'a, U>(
+        self,
+        conn: &mut PgConnection,
+    ) -> QueryResult<(Vec<U>, i64, i64)>
+        where
+            Self: LoadQuery<'a, PgConnection, (U, i64)>,
     {
-        let per_page = self.per_page;
-        let results = self.load::<(U, i64)>(conn)?;
-        let total = results.get(0).map(|x| x.1).unwrap_or(0);
-        let records = results.into_iter().map(|x| x.0).collect();
-        let total_pages = (total as f64 / per_page as f64).ceil() as i64;
-        Ok((records, total_pages))
+        let some_page = self.page.clone();
+        let some_per_page = self.some_per_page.clone();
+
+        let results = self.load::<(U, i64)>(conn);
+
+        let unwrapped_results = results?;
+
+        if some_page.is_some() && some_per_page.is_some() {
+            let per_page = some_per_page.unwrap();
+            let total = unwrapped_results.get(0).map(|x| x.1).unwrap_or(0);
+            let records = unwrapped_results.into_iter().map(|x| x.0).collect();
+            let total_pages = (total as f64 / per_page as f64).ceil() as i64;
+            Ok((records, total_pages, total))
+        } else {
+            let total = unwrapped_results.get(0).map(|x| x.1).unwrap_or(0);
+            let records = unwrapped_results.into_iter().map(|x| x.0).collect();
+            Ok((records, 1, total))
+        }
     }
 }
 
@@ -58,16 +81,22 @@ impl<T: Query> Query for Paginated<T> {
 impl<T> RunQueryDsl<PgConnection> for Paginated<T> {}
 
 impl<T> QueryFragment<Pg> for Paginated<T>
-where
-    T: QueryFragment<Pg>,
+    where
+        T: QueryFragment<Pg>,
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
-        out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
-        self.query.walk_ast(out.reborrow())?;
-        out.push_sql(") t LIMIT ");
-        out.push_bind_param::<BigInt, _>(&self.per_page)?;
-        out.push_sql(" OFFSET ");
-        out.push_bind_param::<BigInt, _>(&self.offset)?;
+        if self.page.is_some() && self.some_per_page.is_some() {
+            out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
+            self.query.walk_ast(out.reborrow())?;
+            out.push_sql(") t LIMIT ");
+            out.push_bind_param::<BigInt, _>(&self.per_page)?;
+            out.push_sql(" OFFSET ");
+            out.push_bind_param::<BigInt, _>(&self.offset)?;
+        } else {
+            out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
+            self.query.walk_ast(out.reborrow())?;
+            out.push_sql(") t");
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
In the `advanced-blog-cli` example, it would be more practical for the `pagination.rs` has the ability to accept optional page parameters. When the page parameters are none, then it will return all the entities from the database. In addition, returning the total number of entities regardless of the page parameters are often used in real projects.