### PR TITLE
Fix #3446

### DIFF
--- a/diesel_cli/src/infer_schema_internals/data_structures.rs
+++ b/diesel_cli/src/infer_schema_internals/data_structures.rs
@@ -119,9 +119,9 @@ where
 pub struct ForeignKeyConstraint {
     pub child_table: TableName,
     pub parent_table: TableName,
-    pub foreign_key: String,
-    pub foreign_key_rust_name: String,
-    pub primary_key: String,
+    pub foreign_key_columns: Vec<String>,
+    pub foreign_key_columns_rust: Vec<String>,
+    pub primary_key_columns: Vec<String>,
 }
 
 impl ForeignKeyConstraint {

--- a/diesel_cli/src/infer_schema_internals/foreign_keys.rs
+++ b/diesel_cli/src/infer_schema_internals/foreign_keys.rs
@@ -30,12 +30,13 @@ pub fn remove_unsafe_foreign_keys_for_codegen(
         .filter(|fk| fk.parent_table != fk.child_table)
         .filter(|fk| safe_tables.contains(&fk.parent_table))
         .filter(|fk| safe_tables.contains(&fk.child_table))
+        .filter(|fk| fk.foreign_key_columns.len() == 1)
         .filter(|fk| {
             let pk_columns = get_primary_keys(&mut conn, &fk.parent_table).expect(&format!(
                 "Error loading primary keys for `{}`",
                 fk.parent_table
             ));
-            pk_columns.len() == 1 && pk_columns[0] == fk.primary_key
+            pk_columns.len() == 1 && Some(&pk_columns[0]) == fk.primary_key_columns.get(0)
         })
         .filter(|fk| !duplicates.contains(&fk.ordered_tables()))
         .cloned()

--- a/diesel_cli/src/infer_schema_internals/inference.rs
+++ b/diesel_cli/src/infer_schema_internals/inference.rs
@@ -222,8 +222,7 @@ pub fn load_foreign_key_constraints(
         }
         #[cfg(feature = "postgres")]
         InferConnection::Pg(ref mut c) => {
-            super::information_schema::load_foreign_key_constraints(c, schema_name)
-                .map_err(Into::into)
+            super::pg::load_foreign_key_constraints(c, schema_name).map_err(Into::into)
         }
         #[cfg(feature = "mysql")]
         InferConnection::Mysql(ref mut c) => {
@@ -234,9 +233,10 @@ pub fn load_foreign_key_constraints(
     constraints.map(|mut ct| {
         ct.sort();
         ct.iter_mut().for_each(|foreign_key_constraint| {
-            if is_reserved_name(&foreign_key_constraint.foreign_key_rust_name) {
-                foreign_key_constraint.foreign_key_rust_name =
-                    format!("{}_", foreign_key_constraint.foreign_key_rust_name);
+            for name in &mut foreign_key_constraint.foreign_key_columns_rust {
+                if is_reserved_name(name) {
+                    *name = format!("{name}_");
+                }
             }
         });
         ct

--- a/diesel_cli/src/infer_schema_internals/pg.rs
+++ b/diesel_cli/src/infer_schema_internals/pg.rs
@@ -115,6 +115,85 @@ mod information_schema {
     }
 }
 
+sql_function! {
+    #[aggregate]
+    fn array_agg(input: diesel::sql_types::Text) -> diesel::sql_types::Array<diesel::sql_types::Text>;
+}
+
+#[allow(clippy::similar_names)]
+pub fn load_foreign_key_constraints(
+    connection: &mut PgConnection,
+    schema_name: Option<&str>,
+) -> QueryResult<Vec<ForeignKeyConstraint>> {
+    use super::information_schema::information_schema::key_column_usage as kcu;
+    use super::information_schema::information_schema::referential_constraints as rc;
+    use super::information_schema::information_schema::table_constraints as tc;
+
+    let default_schema = Pg::default_schema(connection)?;
+    let schema_name = schema_name.unwrap_or(&default_schema);
+
+    let constraint_names = tc::table
+        .filter(tc::constraint_type.eq("FOREIGN KEY"))
+        .filter(tc::table_schema.eq(schema_name))
+        .inner_join(
+            rc::table.on(tc::constraint_schema
+                .eq(rc::constraint_schema)
+                .and(tc::constraint_name.eq(rc::constraint_name))),
+        )
+        .select((
+            rc::constraint_schema,
+            rc::constraint_name,
+            rc::unique_constraint_schema,
+            rc::unique_constraint_name,
+        ))
+        .load::<(String, String, Option<String>, Option<String>)>(connection)?;
+
+    constraint_names
+        .into_iter()
+        .map(
+            |(foreign_key_schema, foreign_key_name, primary_key_schema, primary_key_name)| {
+                let foreign_key = kcu::table
+                    .filter(kcu::constraint_schema.eq(&foreign_key_schema))
+                    .filter(kcu::constraint_name.eq(&foreign_key_name))
+                    .group_by((kcu::table_name, kcu::table_schema))
+                    .select((
+                        kcu::table_name,
+                        kcu::table_schema,
+                        array_agg(kcu::column_name),
+                    ))
+                    .first::<(String, String, Vec<String>)>(connection)?;
+                let primary_key = kcu::table
+                    .filter(kcu::constraint_schema.nullable().eq(primary_key_schema))
+                    .filter(kcu::constraint_name.nullable().eq(primary_key_name))
+                    .group_by((kcu::table_name, kcu::table_schema))
+                    .select((
+                        kcu::table_name,
+                        kcu::table_schema,
+                        array_agg(kcu::column_name),
+                    ))
+                    .first::<(String, String, Vec<String>)>(connection)?;
+
+                let mut primary_key_table = TableName::new(primary_key.0, primary_key.1);
+                primary_key_table.strip_schema_if_matches(&default_schema);
+                let mut foreign_key_table = TableName::new(foreign_key.0, foreign_key.1);
+                foreign_key_table.strip_schema_if_matches(&default_schema);
+
+                let primary_key_columns = primary_key.2;
+                let foreign_key_columns = foreign_key.2;
+
+                Ok(ForeignKeyConstraint {
+                    child_table: foreign_key_table,
+                    parent_table: primary_key_table,
+                    foreign_key_columns_rust: foreign_key_columns.clone(),
+                    foreign_key_columns,
+                    primary_key_columns,
+                })
+            },
+        )
+        .filter(|e| !matches!(e, Err(diesel::result::Error::NotFound)))
+        .collect()
+}
+
 #[cfg(test)]
 mod test {
     extern crate dotenvy;
@@ -201,5 +280,47 @@ mod test {
             get_table_comment(&mut connection, &table_1)
         );
         assert_eq!(Ok(None), get_table_comment(&mut connection, &table_2));
+    }
+
+    #[test]
+    fn get_foreign_keys_loads_foreign_keys() {
+        let mut connection = connection();
+
+        diesel::sql_query("CREATE SCHEMA test_schema")
+            .execute(&mut connection)
+            .unwrap();
+        diesel::sql_query("CREATE TABLE test_schema.table_1 (id SERIAL PRIMARY KEY)")
+            .execute(&mut connection)
+            .unwrap();
+        diesel::sql_query(
+                "CREATE TABLE test_schema.table_2 (id SERIAL PRIMARY KEY, fk_one INTEGER NOT NULL REFERENCES test_schema.table_1)",
+            ).execute(&mut connection)
+            .unwrap();
+        diesel::sql_query(
+                "CREATE TABLE test_schema.table_3 (id SERIAL PRIMARY KEY, fk_two INTEGER NOT NULL REFERENCES test_schema.table_2)",
+            ).execute(&mut connection)
+            .unwrap();
+
+        let table_1 = TableName::new("table_1", "test_schema");
+        let table_2 = TableName::new("table_2", "test_schema");
+        let table_3 = TableName::new("table_3", "test_schema");
+        let fk_one = ForeignKeyConstraint {
+            child_table: table_2.clone(),
+            parent_table: table_1,
+            foreign_key_columns: vec!["fk_one".into()],
+            foreign_key_columns_rust: vec!["fk_one".into()],
+            primary_key_columns: vec!["id".into()],
+        };
+        let fk_two = ForeignKeyConstraint {
+            child_table: table_3,
+            parent_table: table_2,
+            foreign_key_columns: vec!["fk_two".into()],
+            foreign_key_columns_rust: vec!["fk_two".into()],
+            primary_key_columns: vec!["id".into()],
+        };
+        assert_eq!(
+            Ok(vec![fk_one, fk_two]),
+            load_foreign_key_constraints(&mut connection, Some("test_schema"))
+        );
     }
 }

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -519,7 +519,7 @@ impl<'a> Display for Joinable<'a> {
         write!(
             f,
             "diesel::joinable!({} -> {} ({}));",
-            child_table_name, parent_table_name, self.0.foreign_key_rust_name,
+            child_table_name, parent_table_name, self.0.foreign_key_columns_rust[0],
         )
     }
 }

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -270,6 +270,17 @@ fn print_schema_reserved_names() {
     test_print_schema("print_schema_reserved_name_mitigation_issue_3404", vec![])
 }
 
+#[test]
+#[cfg(feature = "postgres")]
+fn print_schema_regression_3446_ignore_compound_foreign_keys() {
+    test_print_schema("print_schema_regression_3446_compound_keys", vec![])
+}
+
+#[test]
+fn print_schema_several_keys_with_compound_key() {
+    test_print_schema("print_schema_several_keys_with_compound_key", vec![])
+}
+
 #[cfg(feature = "sqlite")]
 const BACKEND: &str = "sqlite";
 #[cfg(feature = "postgres")]
@@ -332,7 +343,6 @@ fn test_print_schema_config(test_name: &str, test_path: &Path, schema: String) {
 
     p.command("setup").run();
     p.create_migration("12345_create_schema", &schema, None);
-
     let result = p.command("migration").arg("run").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
 

--- a/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
@@ -1,0 +1,38 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_regression_3446_ignore_compound_foreign_keys"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    payment_card (id) {
+        id -> Int4,
+        code -> Text,
+        holder_id -> Int4,
+    }
+}
+
+diesel::table! {
+    person (id) {
+        id -> Int4,
+        name -> Text,
+    }
+}
+
+diesel::table! {
+    transaction (id) {
+        id -> Int4,
+        executed_at -> Timestamptz,
+        payment_card_id -> Int4,
+        card_code -> Text,
+    }
+}
+
+diesel::joinable!(payment_card -> person (holder_id));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    payment_card,
+    person,
+    transaction,
+);
+

--- a/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/schema.sql
@@ -1,0 +1,19 @@
+CREATE TABLE person (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE payment_card (
+    id SERIAL PRIMARY KEY,
+    code TEXT NOT NULL,
+    holder_id INT NOT NULL REFERENCES person(id),
+    UNIQUE (id, code)
+);
+
+CREATE TABLE transaction (
+    id SERIAL PRIMARY KEY,
+    executed_at TIMESTAMPTZ NOT NULL,
+    payment_card_id INT NOT NULL,
+    card_code TEXT NOT NULL,
+    FOREIGN KEY (payment_card_id, card_code) REFERENCES payment_card (id, code)
+);

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
@@ -1,0 +1,36 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_several_keys_with_compound_key"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    payment_card (id) {
+        id -> Integer,
+        code -> Varchar,
+    }
+}
+
+diesel::table! {
+    transaction_one (id) {
+        id -> Integer,
+        card_code -> Varchar,
+        payment_card_id -> Integer,
+        by_card_id -> Integer,
+    }
+}
+
+diesel::table! {
+    transaction_two (id) {
+        id -> Integer,
+        payment_card_id -> Integer,
+        card_code -> Varchar,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    payment_card,
+    transaction_one,
+    transaction_two,
+);
+

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/schema.sql
@@ -1,0 +1,24 @@
+CREATE TABLE payment_card (
+    id INT PRIMARY KEY,
+    code VARCHAR(50) NOT NULL,
+    UNIQUE(id, code)
+);
+
+CREATE TABLE transaction_one (
+    id INT PRIMARY KEY,
+    card_code VARCHAR(50) NOT NULL,
+    payment_card_id INT NOT NULL,
+    by_card_id INT NOT NULL REFERENCES payment_card(id),
+    FOREIGN KEY (payment_card_id, card_code)
+    REFERENCES payment_card (id, code)
+);
+
+-- The only difference between transaction_one and transaction_two is the order of the 2nd and 3rd columns.
+-- Note that because of that, the joinable will be different!
+CREATE TABLE transaction_two (
+    id INT PRIMARY KEY,
+    payment_card_id INT NOT NULL,
+    card_code VARCHAR(50) NOT NULL,
+    FOREIGN KEY (payment_card_id, card_code)
+    REFERENCES payment_card (id, code)
+);

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/postgres/expected.snap
@@ -1,0 +1,36 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_several_keys_with_compound_key"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    payment_card (id) {
+        id -> Int4,
+        code -> Text,
+    }
+}
+
+diesel::table! {
+    transaction_one (id) {
+        id -> Int4,
+        card_code -> Text,
+        payment_card_id -> Int4,
+        by_card_id -> Int4,
+    }
+}
+
+diesel::table! {
+    transaction_two (id) {
+        id -> Int4,
+        payment_card_id -> Int4,
+        card_code -> Text,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    payment_card,
+    transaction_one,
+    transaction_two,
+);
+

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/postgres/schema.sql
@@ -1,0 +1,24 @@
+CREATE TABLE payment_card (
+    id INT PRIMARY KEY,
+    code TEXT NOT NULL,
+    UNIQUE(id, code)
+);
+
+CREATE TABLE transaction_one (
+    id INT PRIMARY KEY,
+    card_code TEXT NOT NULL,
+    payment_card_id INT NOT NULL,
+    by_card_id INT NOT NULL REFERENCES payment_card(id),
+    FOREIGN KEY (payment_card_id, card_code)
+    REFERENCES payment_card (id, code)
+);
+
+-- The only difference between transaction_one and transaction_two is the order of the 2nd and 3rd columns.
+-- Note that because of that, the joinable will be different!
+CREATE TABLE transaction_two (
+    id INT PRIMARY KEY,
+    payment_card_id INT NOT NULL,
+    card_code TEXT NOT NULL,
+    FOREIGN KEY (payment_card_id, card_code)
+    REFERENCES payment_card (id, code)
+);

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/sqlite/expected.snap
@@ -1,0 +1,36 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_several_keys_with_compound_key"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    payment_card (id) {
+        id -> Integer,
+        code -> Text,
+    }
+}
+
+diesel::table! {
+    transaction_one (id) {
+        id -> Integer,
+        card_code -> Text,
+        payment_card_id -> Integer,
+        by_card_id -> Integer,
+    }
+}
+
+diesel::table! {
+    transaction_two (id) {
+        id -> Integer,
+        payment_card_id -> Integer,
+        card_code -> Text,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    payment_card,
+    transaction_one,
+    transaction_two,
+);
+

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/sqlite/schema.sql
@@ -1,0 +1,24 @@
+CREATE TABLE payment_card (
+    id INT NOT NULL PRIMARY KEY,
+    code TEXT NOT NULL,
+    UNIQUE(id, code)
+);
+
+CREATE TABLE transaction_one (
+    id INT NOT NULL PRIMARY KEY,
+    card_code TEXT NOT NULL,
+    payment_card_id INT NOT NULL,
+    by_card_id INT NOT NULL REFERENCES payment_card(id),
+    FOREIGN KEY (payment_card_id, card_code)
+    REFERENCES payment_card (id, code)
+);
+
+-- The only difference between transaction_one and transaction_two is the order of the 2nd and 3rd columns.
+-- Note that because of that, the joinable will be different!
+CREATE TABLE transaction_two (
+    id INT NOT NULL PRIMARY KEY,
+    payment_card_id INT NOT NULL,
+    card_code TEXT NOT NULL,
+    FOREIGN KEY (payment_card_id, card_code)
+    REFERENCES payment_card (id, code)
+);

--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -46,6 +46,8 @@ impl TestCommand {
             .build_command()
             .output()
             .expect("failed to execute process");
+        println!("STDOUT: {}", String::from_utf8_lossy(&output.stdout));
+        println!("STDERR: {}", String::from_utf8_lossy(&output.stderr));
         CommandResult { output }
     }
 


### PR DESCRIPTION
This commit fixes an issue where diesel print-schema incorrectly emitted a `joinable!` call for compound foreign keys by filtering out such foreign key constraints more explicitly.