### PR TITLE
Fix #3470

### DIFF
--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -1017,9 +1017,9 @@ mod test {
             .execute(conn)?;
             conn.transaction(|conn| {
                 sql_query("SET TRANSACTION READ ONLY").execute(conn)?;
-                dbg!(crate::update(rollback_test::table)
+                crate::update(rollback_test::table)
                     .set(rollback_test::value.eq(0))
-                    .execute(conn))
+                    .execute(conn)
             })
             .map(|_| {
                 panic!("Should use the `or_else` branch");
@@ -1060,6 +1060,7 @@ mod test {
         .execute(conn)
         .unwrap();
 
+        let start_barrier = Arc::new(Barrier::new(2));
         let commit_barrier = Arc::new(Barrier::new(2));
 
         let other_start_barrier = start_barrier.clone();
@@ -1080,7 +1081,7 @@ mod test {
                         conn
                     ).transaction_depth().expect("Transaction depth")
                 );
-                let _ = rollback_test2::table.load::<(i32, i32)>(conn)?;
+                rollback_test2::table.load::<(i32, i32)>(conn)?;
                 crate::insert_into(rollback_test2::table)
                     .values((rollback_test2::id.eq(1), rollback_test2::value.eq(42)))
                     .execute(conn)?;
@@ -1091,6 +1092,7 @@ mod test {
                             conn
                         ).transaction_depth().expect("Transaction depth")
                     );
+                    start_barrier.wait();
                     commit_barrier.wait();
                     let r = rollback_test2::table.load::<(i32, i32)>(conn);
                     assert!(r.is_err());
@@ -1102,9 +1104,14 @@ mod test {
                         conn
                     ).transaction_depth().expect("Transaction depth")
                 );
-                assert!(r.is_ok());
+                assert!(
+                    matches!(r, Err(crate::result::Error::RollbackTransaction)),
+                    "rollback failed (such errors should be ignored by transaction manager): {}",
+                    r.unwrap_err()
+                );
                 let r = rollback_test2::table.load::<(i32, i32)>(conn);
                 assert!(r.is_err());
+                // This should fail because of ser failure
                 Ok(())
             });
             assert!(r.is_err());
@@ -1117,6 +1124,7 @@ mod test {
         });
 
         let t2 = std::thread::spawn(move || {
+            other_start_barrier.wait();
             let conn = &mut crate::test_helpers::pg_connection_no_transaction();
             assert_eq!(
                 None,

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -385,6 +385,14 @@ where
                             return Ok(());
                         }
                     }
+                    TransactionManagerStatus::Valid(ValidTransactionManagerStatus {
+                        in_transaction: None,
+                    }) => {
+                        // we would have returned `NotInTransaction` if that was already the state
+                        // before we made our call
+                        // => Transaction manager status has been fixed by the underlying connection
+                        // so we don't need to set_in_error
+                    }
                     _ => tm_status.set_in_error(),
                 }
                 Err(rollback_error)

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -321,7 +321,7 @@ where
 
         let (
             (rollback_sql, rolling_back_top_level),
-            requires_rollback_maybe_up_to_top_level_before_run,
+            requires_rollback_maybe_up_to_top_level_before_execute,
         ) = match transaction_state.in_transaction {
             Some(ref in_transaction) => (
                 match in_transaction.transaction_depth.get() {
@@ -346,8 +346,8 @@ where
                 {
                     Ok(()) => {}
                     Err(Error::NotInTransaction) if rolling_back_top_level => {
-                        // Transaction exit may have already been detected by connection.
-                        // It's fine
+                        // Transaction exit may have already been detected by connection
+                        // implementation. It's fine.
                     }
                     Err(e) => return Err(e),
                 }
@@ -374,7 +374,7 @@ where
                         *transaction_depth = NonZeroU32::new(transaction_depth.get() - 1)
                             .expect("Depth was checked to be > 1");
                         *requires_rollback_maybe_up_to_top_level = true;
-                        if requires_rollback_maybe_up_to_top_level_before_run {
+                        if requires_rollback_maybe_up_to_top_level_before_execute {
                             // In that case, we tolerate that savepoint releases fail
                             // -> we should ignore errors
                             return Ok(());

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -1111,8 +1111,10 @@ mod test {
                 );
                 let r = rollback_test2::table.load::<(i32, i32)>(conn);
                 assert!(r.is_err());
-                // This should fail because of ser failure
-                Ok(())
+                // fun fact: if hitting "commit" after receiving a serialization failure, PG
+                // returns that the commit has succeeded, but in fact it was actually rolled back.
+                // soo.. one should avoid doing that
+                r
             });
             assert!(r.is_err());
             assert_eq!(

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -143,7 +143,7 @@ impl TransactionManagerStatus {
         feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
     )]
     /// Whether we may be interested in calling
-    /// `set_top_level_transaction_requires_rollback_if_not_broken`
+    /// `set_requires_rollback_maybe_up_to_top_level_if_not_broken`
     ///
     /// You should typically not need this outside of a custom backend implementation
     pub(crate) fn is_not_broken_and_in_transaction(&self) -> bool {
@@ -162,19 +162,21 @@ impl TransactionManagerStatus {
     #[diesel_derives::__diesel_public_if(
         feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
     )]
-    /// If in transaction and transaction manager is not broken, registers that the
-    /// connection can not be used anymore until top-level transaction is rolled back
-    /// or an intermediate rollbach to savepoint succceeds
-    pub(crate) fn set_top_level_transaction_may_require_rollback(&mut self) {
+    /// If in transaction and transaction manager is not broken, registers that it's possible that
+    /// the connection can not be used anymore until top-level transaction is rolled back.
+    ///
+    /// If that is registered, savepoints rollbacks will still be attempted, but failure to do so
+    /// will not result in an error. (Some may succeed, some may not.)
+    pub(crate) fn set_requires_rollback_maybe_up_to_top_level(&mut self) {
         if let TransactionManagerStatus::Valid(ValidTransactionManagerStatus {
             in_transaction:
                 Some(InTransactionStatus {
-                    top_level_transaction_may_require_rollback,
+                    requires_rollback_maybe_up_to_top_level,
                     ..
                 }),
         }) = self
         {
-            *top_level_transaction_may_require_rollback = true;
+            *requires_rollback_maybe_up_to_top_level = true;
         }
     }
 
@@ -214,7 +216,9 @@ pub struct ValidTransactionManagerStatus {
 #[derive(Debug)]
 struct InTransactionStatus {
     transaction_depth: NonZeroU32,
-    top_level_transaction_may_require_rollback: bool,
+    /// If that is registered, savepoints rollbacks will still be attempted, but failure to do so
+    /// will not result in an error. (Some may succeed, some may not.)
+    requires_rollback_maybe_up_to_top_level: bool,
     test_transaction: bool,
 }
 
@@ -253,7 +257,7 @@ impl ValidTransactionManagerStatus {
             (None, TransactionDepthChange::IncreaseDepth) => {
                 self.in_transaction = Some(InTransactionStatus {
                     transaction_depth: NonZeroU32::new(1).expect("1 is non-zero"),
-                    top_level_transaction_may_require_rollback: false,
+                    requires_rollback_maybe_up_to_top_level: false,
                     test_transaction: false,
                 });
                 Ok(())
@@ -333,39 +337,25 @@ where
     fn rollback_transaction(conn: &mut Conn) -> QueryResult<()> {
         let transaction_state = Self::get_transaction_state(conn)?;
 
-        let rollback_sql = match transaction_state.in_transaction {
-            Some(ref mut in_transaction) => match in_transaction.transaction_depth.get() {
-                1 => Cow::Borrowed("ROLLBACK"),
-                depth_gt1 => Cow::Owned(format!(
-                    "ROLLBACK TO SAVEPOINT diesel_savepoint_{}",
-                    depth_gt1 - 1
-                )),
-            },
-            None => return Err(Error::NotInTransaction),
-        };
+        let (rollback_sql, requires_rollback_maybe_up_to_top_level_before_run) =
+            match transaction_state.in_transaction {
+                Some(ref in_transaction) => (
+                    match in_transaction.transaction_depth.get() {
+                        1 => Cow::Borrowed("ROLLBACK"),
+                        depth_gt1 => Cow::Owned(format!(
+                            "ROLLBACK TO SAVEPOINT diesel_savepoint_{}",
+                            depth_gt1 - 1
+                        )),
+                    },
+                    in_transaction.requires_rollback_maybe_up_to_top_level,
+                ),
+                None => return Err(Error::NotInTransaction),
+            };
 
         match conn.batch_execute(&rollback_sql) {
             Ok(()) => {
-                let tm_status = &mut Self::get_transaction_state(conn)?;
-                if let ValidTransactionManagerStatus {
-                    in_transaction:
-                        Some(InTransactionStatus {
-                            top_level_transaction_may_require_rollback:
-                                ref mut top_level_transaction_requires_rollback,
-                            ..
-                        }),
-                } = tm_status
-                {
-                    // rolling back the save point did work, even if the connection
-                    // was marked to require a top level rollback. This likely means that
-                    // we recovered the transaction state and we are able to perform
-                    // normal operations from now on. Therefore we remove the
-                    // `top_level_transaction_requires_rollback` flag.
-                    if *top_level_transaction_requires_rollback {
-                        *top_level_transaction_requires_rollback = false;
-                    }
-                }
-                tm_status.change_transaction_depth(TransactionDepthChange::DecreaseDepth)?;
+                Self::get_transaction_state(conn)?
+                    .change_transaction_depth(TransactionDepthChange::DecreaseDepth)?;
                 Ok(())
             }
             Err(rollback_error) => {
@@ -375,28 +365,24 @@ where
                         in_transaction:
                             Some(InTransactionStatus {
                                 transaction_depth,
-                                top_level_transaction_may_require_rollback:
-                                    top_level_transaction_requires_rollback,
+                                requires_rollback_maybe_up_to_top_level,
                                 ..
                             }),
                     }) if transaction_depth.get() > 1 => {
                         // A savepoint failed to rollback - we may still attempt to repair
-                        // the connection by rolling back top-level transaction.
+                        // the connection by rolling back higher levels.
+
+                        // To make it easier on the user (that they don't have to really
+                        // look at actual transaction depth and can just rely on the number
+                        // of times they have called begin/commit/rollback) we still
+                        // decrement here:
                         *transaction_depth = NonZeroU32::new(transaction_depth.get() - 1)
                             .expect("Depth was checked to be > 1");
-                        if *top_level_transaction_requires_rollback {
-                            // Rolling back the save point did not work. This likely means
-                            // we won't be able to do anything until top-level
-                            // is rolled back.
-
-                            // To make it easier on the user (that they don't have to really look
-                            // at actual transaction depth and can just rely on the number of
-                            // times they have called begin/commit/rollback) we don't mark the
-                            // transaction manager as out of the savepoints as soon as we
-                            // realize there is that issue, but instead we still decrement here:
+                        *requires_rollback_maybe_up_to_top_level = true;
+                        if requires_rollback_maybe_up_to_top_level_before_run {
+                            // In that case, some rollbacks may succeed, some may not
+                            // -> we should ignore errors
                             return Ok(());
-                        } else {
-                            *top_level_transaction_requires_rollback = true;
                         }
                     }
                     _ => tm_status.set_in_error(),
@@ -432,35 +418,19 @@ where
                 if let TransactionManagerStatus::Valid(ValidTransactionManagerStatus {
                     in_transaction:
                         Some(InTransactionStatus {
-                            ref mut transaction_depth,
-                            top_level_transaction_may_require_rollback: true,
+                            requires_rollback_maybe_up_to_top_level: true,
                             ..
                         }),
                 }) = conn.transaction_state().status
                 {
-                    match transaction_depth.get() {
-                        1 => match Self::rollback_transaction(conn) {
-                            Ok(()) => {}
-                            Err(rollback_error) => {
-                                conn.transaction_state().status.set_in_error();
-                                return Err(Error::RollbackErrorOnCommit {
-                                    rollback_error: Box::new(rollback_error),
-                                    commit_error: Box::new(commit_error),
-                                });
-                            }
-                        },
-                        depth_gt1 => {
-                            // There's no point in *actually* rolling back this one
-                            // because we won't be able to do anything until top-level
-                            // is rolled back.
-
-                            // To make it easier on the user (that they don't have to really look
-                            // at actual transaction depth and can just rely on the number of
-                            // times they have called begin/commit/rollback) we don't mark the
-                            // transaction manager as out of the savepoints as soon as we
-                            // realize there is that issue, but instead we still decrement here:
-                            *transaction_depth = NonZeroU32::new(depth_gt1 - 1)
-                                .expect("Depth was checked to be > 1");
+                    match Self::rollback_transaction(conn) {
+                        Ok(()) => {}
+                        Err(rollback_error) => {
+                            conn.transaction_state().status.set_in_error();
+                            return Err(Error::RollbackErrorOnCommit {
+                                rollback_error: Box::new(rollback_error),
+                                commit_error: Box::new(commit_error),
+                            });
                         }
                     }
                 }
@@ -502,7 +472,7 @@ mod test {
                 if self.top_level_requires_rollback_after_next_batch_execute {
                     self.transaction_state
                         .status
-                        .set_top_level_transaction_may_require_rollback();
+                        .set_requires_rollback_maybe_up_to_top_level();
                 }
                 res
             }

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -171,7 +171,7 @@ fn update_transaction_manager_status<T>(
     if let Err(Error::DatabaseError(DatabaseErrorKind::SerializationFailure, _)) = query_result {
         transaction_manager
             .status
-            .set_top_level_transaction_requires_rollback()
+            .set_top_level_transaction_may_require_rollback()
     }
     query_result
 }

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -171,7 +171,7 @@ fn update_transaction_manager_status<T>(
     if let Err(Error::DatabaseError(DatabaseErrorKind::SerializationFailure, _)) = query_result {
         transaction_manager
             .status
-            .set_top_level_transaction_may_require_rollback()
+            .set_requires_rollback_maybe_up_to_top_level()
     }
     query_result
 }

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -171,7 +171,7 @@ fn update_transaction_manager_status<T>(
     if let Err(Error::DatabaseError(DatabaseErrorKind::SerializationFailure, _)) = query_result {
         transaction_manager
             .status
-            .set_requires_rollback_maybe_up_to_top_level()
+            .set_requires_rollback_maybe_up_to_top_level(true)
     }
     query_result
 }

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -123,6 +123,7 @@ unsafe impl Send for PgConnection {}
 
 impl SimpleConnection for PgConnection {
     fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
+        dbg!(query);
         let query = CString::new(query)?;
         let inner_result = unsafe {
             self.connection_and_transaction_manager
@@ -241,7 +242,7 @@ fn update_transaction_manager_status<T>(
                 // status
                 match raw_conn.transaction_status() {
                     PgTransactionStatus::InError => {
-                        tm.status.set_top_level_transaction_requires_rollback()
+                        tm.status.set_top_level_transaction_may_require_rollback()
                     }
                     PgTransactionStatus::Unknown => tm.status.set_in_error(),
                     PgTransactionStatus::Idle => {
@@ -328,6 +329,7 @@ impl PgConnection {
             &'conn mut ConnectionAndTransactionManager,
         ) -> QueryResult<R>,
     ) -> QueryResult<R> {
+        dbg!(crate::debug_query(source));
         let mut bind_collector = RawBytesBindCollector::<Pg>::new();
         source.collect_binds(&mut bind_collector, self, &Pg)?;
         let binds = bind_collector.binds;

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -230,36 +230,54 @@ fn update_transaction_manager_status<T>(
     query_result: QueryResult<T>,
     conn: &mut ConnectionAndTransactionManager,
 ) -> QueryResult<T> {
-    if let Err(Error::DatabaseError { .. }) = query_result {
-        /// avoid monomorphizing for every result type - this part will not be inlined
-        fn non_generic_inner(conn: &mut ConnectionAndTransactionManager) {
-            let raw_conn: &mut RawConnection = &mut conn.raw_connection;
-            let tm: &mut AnsiTransactionManager = &mut conn.transaction_state;
-            if tm.status.is_not_broken_and_in_transaction() {
-                // libpq keeps track of the transaction status internally, and that is accessible
-                // via `transaction_status`. We can use that to update the AnsiTransactionManager
-                // status
-                match raw_conn.transaction_status() {
-                    PgTransactionStatus::InError => {
-                        tm.status.set_requires_rollback_maybe_up_to_top_level()
+    /// avoid monomorphizing for every result type - this part will not be inlined
+    fn non_generic_inner(conn: &mut ConnectionAndTransactionManager, is_err: bool) {
+        let raw_conn: &mut RawConnection = &mut conn.raw_connection;
+        let tm: &mut AnsiTransactionManager = &mut conn.transaction_state;
+        // libpq keeps track of the transaction status internally, and that is accessible
+        // via `transaction_status`. We can use that to update the AnsiTransactionManager
+        // status
+        match raw_conn.transaction_status() {
+            PgTransactionStatus::InError => {
+                tm.status.set_requires_rollback_maybe_up_to_top_level(true)
+            }
+            PgTransactionStatus::Unknown => tm.status.set_in_error(),
+            PgTransactionStatus::Idle => {
+                // This is useful in particular for commit attempts (even
+                // if `COMMIT` errors it still exits transaction)
+
+                // This may repair the transaction manager
+                tm.status = TransactionManagerStatus::Valid(Default::default())
+            }
+            PgTransactionStatus::InTransaction => {
+                let transaction_status = &mut tm.status;
+                // If we weren't an error, it is possible that we were a transaction start
+                // -> we should tolerate any state
+                if is_err {
+                    // An error may not have us enter a transaction, so if we weren't in one
+                    // we may not be in one now
+                    if !matches!(transaction_status, TransactionManagerStatus::Valid(valid_tm) if valid_tm.transaction_depth().is_some())
+                    {
+                        // -> transaction manager is broken
+                        transaction_status.set_in_error()
                     }
-                    PgTransactionStatus::Unknown => tm.status.set_in_error(),
-                    PgTransactionStatus::Idle => {
-                        tm.status = TransactionManagerStatus::Valid(Default::default())
-                    }
-                    PgTransactionStatus::InTransaction => {
-                        let transaction_status = &mut tm.status;
-                        if !matches!(transaction_status, TransactionManagerStatus::Valid(valid_tm) if valid_tm.transaction_depth().is_some())
-                        {
-                            transaction_status.set_in_error()
-                        }
-                    }
-                    PgTransactionStatus::Active => {}
+                } else {
+                    // If transaction was InError before, but now it's not (because we attempted
+                    // a rollback), we may pretend it's fixed because
+                    // if it isn't Postgres *will* tell us again.
+
+                    // Fun fact: if we have not received an `InTransaction` status however,
+                    // postgres will *not* warn us that transaction is broken when attempting to
+                    // commit, so we may think that commit has succeeded but in fact it hasn't.
+                    tm.status.set_requires_rollback_maybe_up_to_top_level(false)
                 }
             }
+            PgTransactionStatus::Active => {
+                // This is a transient state for libpq - nothing we can deduce here.
+            }
         }
-        non_generic_inner(conn)
     }
+    non_generic_inner(conn, query_result.is_err());
     query_result
 }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -245,7 +245,6 @@ fn update_transaction_manager_status<T>(
                     }
                     PgTransactionStatus::Unknown => tm.status.set_in_error(),
                     PgTransactionStatus::Idle => {
-                        // This may repair the transaction manager
                         tm.status = TransactionManagerStatus::Valid(Default::default())
                     }
                     PgTransactionStatus::InTransaction => {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -123,7 +123,6 @@ unsafe impl Send for PgConnection {}
 
 impl SimpleConnection for PgConnection {
     fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
-        dbg!(query);
         let query = CString::new(query)?;
         let inner_result = unsafe {
             self.connection_and_transaction_manager
@@ -242,7 +241,7 @@ fn update_transaction_manager_status<T>(
                 // status
                 match raw_conn.transaction_status() {
                     PgTransactionStatus::InError => {
-                        tm.status.set_top_level_transaction_may_require_rollback()
+                        tm.status.set_requires_rollback_maybe_up_to_top_level()
                     }
                     PgTransactionStatus::Unknown => tm.status.set_in_error(),
                     PgTransactionStatus::Idle => {
@@ -329,7 +328,6 @@ impl PgConnection {
             &'conn mut ConnectionAndTransactionManager,
         ) -> QueryResult<R>,
     ) -> QueryResult<R> {
-        dbg!(crate::debug_query(source));
         let mut bind_collector = RawBytesBindCollector::<Pg>::new();
         source.collect_binds(&mut bind_collector, self, &Pg)?;
         let binds = bind_collector.binds;

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -108,6 +108,8 @@ impl RawConnection {
         RawResult::new(ptr, self)
     }
 
+    /// This is reasonably inexpensive as it just accesses variables internal to the connection
+    /// that are kept up to date by the `ReadyForQuery` messages from the PG server
     pub(super) fn transaction_status(&self) -> PgTransactionStatus {
         unsafe { PQtransactionStatus(self.internal_connection.as_ptr()) }.into()
     }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -73,8 +73,7 @@ pub enum Error {
     RollbackErrorOnCommit {
         /// The error that was encountered when attempting the rollback
         rollback_error: Box<Error>,
-        /// If the rollback attempt resulted from a failed attempt to commit the transaction,
-        /// you will find the related error here.
+        /// The error that was encountered during the failed commit attempt
         commit_error: Box<Error>,
     },
 


### PR DESCRIPTION
This commit tries to address an issue where we do not issue rollback to savepoint commands due to libpq reporting a transaction as broken. It turns out that transactions are sometimes recoverable by just rolling back to a previous savepoint instead of rolling back the outer transaction.

We address this issue by always executing the `ROLLBACK TO SAVEPOINT` command even if a connection is required as needing a top level rollback. This was previously skipped. We do ignore any errors from that attempt if the requires top level rollback flag is set. If the `ROLLBACK TO SAVEPOINT` command succeeds, we consider the transaction as recovered and disable the requires top level rollback flag.

cc @jtgeibel