### PR TITLE
Fix `FileBasedMigrations` documentation

### DIFF
--- a/diesel_migrations/src/file_based_migrations.rs
+++ b/diesel_migrations/src/file_based_migrations.rs
@@ -33,6 +33,7 @@ use crate::errors::{MigrationError, RunMigrationsError};
 /// - 20160107082941_create_posts
 ///     - up.sql
 ///     - down.sql
+///     - metadata.toml
 /// ```
 ///
 /// ```sql

--- a/diesel_migrations/src/file_based_migrations.rs
+++ b/diesel_migrations/src/file_based_migrations.rs
@@ -65,15 +65,15 @@ use crate::errors::{MigrationError, RunMigrationsError};
 /// ```
 ///
 /// ```toml
-/// # 20160107082941_create_posts/metadata.toml
+/// ## 20160107082941_create_posts/metadata.toml
 ///
-/// # specifices if a migration is executed inside a
-/// # transaction or not. This configuration is optional
-/// # by default all migrations are run in transactions.
-/// #
-/// # For certain types of migrations, like creating an
-/// # index onto a existing column, it is required
-/// # to set this to false
+/// ## specifices if a migration is executed inside a
+/// ## transaction or not. This configuration is optional
+/// ## by default all migrations are run in transactions.
+/// ##
+/// ## For certain types of migrations, like creating an
+/// ## index onto a existing column, it is required
+/// ## to set this to false
 /// run_in_transaction = true
 /// ```
 #[derive(Clone)]


### PR DESCRIPTION
The `run_in_transaction` example for `FileBasedMigrations` has most of its documentation hidden by rustdoc because a single `#` is used to [hide portions of the example](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#hiding-portions-of-the-example), while the intent seems to have been toml comments

This PR escapes them by using `##` instead so it renders correctly