### PR TITLE
Fix copy/paste issue in group_by documentation.

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -955,7 +955,7 @@ pub trait QueryDsl: Sized {
     /// Use [`QueryDsl::select()`] to specify one.
     ///
     /// If there was already a group by clause, it will be overridden.
-    /// Ordering by multiple columns can be achieved by passing a tuple of those
+    /// Grouping by multiple columns can be achieved by passing a tuple of those
     /// columns.
     ///
     /// Diesel follows postgresql's group by semantic, this means any column


### PR DESCRIPTION
It looks like the `group_by()` documentation was probably copied from `order()`, but this particular phrase was missed when tweaking it to apply to 'group_by' instead of `order()`.