### PR TITLE
Fix #2793

### DIFF
--- a/diesel_compile_tests/tests/fail/derive/bad_column_name.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_column_name.rs
@@ -5,6 +5,8 @@ table! {
     users {
         id -> Integer,
         name -> Text,
+        #[sql_name = "type"]
+        tpe -> Text,
     }
 }
 
@@ -27,6 +29,22 @@ struct User2 {
 struct User3 {
     #[diesel(column_name = true)]
     name: String,
+}
+
+
+#[derive(Insertable)]
+#[diesel(table_name = users)]
+struct User4 {
+    #[diesel(column_name = "type")]
+    ty: String,
+}
+
+
+#[derive(AsChangeset)]
+#[diesel(table_name = users)]
+struct User5 {
+    #[diesel(column_name = "type")]
+    ty: String,
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_column_name.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_column_name.stderr
@@ -1,19 +1,31 @@
 error: unexpected end of input, expected `=`
-  --> tests/fail/derive/bad_column_name.rs:14:25
+  --> tests/fail/derive/bad_column_name.rs:16:25
    |
-14 |     #[diesel(column_name)]
+16 |     #[diesel(column_name)]
    |                         ^
    |
    = help: The correct format looks like `#[diesel(column_name = foo)]`
 
 error: expected `=`
-  --> tests/fail/derive/bad_column_name.rs:21:25
+  --> tests/fail/derive/bad_column_name.rs:23:25
    |
-21 |     #[diesel(column_name(another))]
+23 |     #[diesel(column_name(another))]
    |                         ^
 
 error: expected string literal
-  --> tests/fail/derive/bad_column_name.rs:28:28
+  --> tests/fail/derive/bad_column_name.rs:30:28
    |
-28 |     #[diesel(column_name = true)]
+30 |     #[diesel(column_name = true)]
    |                            ^^^^
+
+error: Expected valid identifier, found `type`. Diesel automatically renames invalid identifiers, perhaps you meant to write `type_`?
+  --> tests/fail/derive/bad_column_name.rs:38:28
+   |
+38 |     #[diesel(column_name = "type")]
+   |                            ^^^^^^
+
+error: Expected valid identifier, found `type`. Diesel automatically renames invalid identifiers, perhaps you meant to write `type_`?
+  --> tests/fail/derive/bad_column_name.rs:46:28
+   |
+46 |     #[diesel(column_name = "type")]
+   |                            ^^^^^^

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -140,6 +140,7 @@ fn field_changeset_ty(
     treat_none_as_null: bool,
 ) -> TokenStream {
     let column_name = field.column_name();
+    column_name.valid_ident();
     if !treat_none_as_null && is_option_ty(&field.ty) {
         let field_ty = inner_of_option_ty(&field.ty);
         quote!(std::option::Option<diesel::dsl::Eq<#table_name::#column_name, #lifetime #field_ty>>)
@@ -157,6 +158,7 @@ fn field_changeset_expr(
 ) -> TokenStream {
     let field_name = &field.name;
     let column_name = field.column_name();
+    column_name.valid_ident();
     if !treat_none_as_null && is_option_ty(&field.ty) {
         if lifetime.is_some() {
             quote!(self.#field_name.as_ref().map(|x| #table_name::#column_name.eq(x)))
@@ -175,6 +177,7 @@ fn field_changeset_ty_serialize_as(
     treat_none_as_null: bool,
 ) -> TokenStream {
     let column_name = field.column_name();
+    column_name.valid_ident();
     if !treat_none_as_null && is_option_ty(&field.ty) {
         let inner_ty = inner_of_option_ty(ty);
         quote!(std::option::Option<diesel::dsl::Eq<#table_name::#column_name, #inner_ty>>)
@@ -191,6 +194,7 @@ fn field_changeset_expr_serialize_as(
 ) -> TokenStream {
     let field_name = &field.name;
     let column_name = field.column_name();
+    column_name.valid_ident();
     let column: Expr = parse_quote!(#table_name::#column_name);
     if !treat_none_as_null && is_option_ty(&field.ty) {
         quote!(self.#field_name.map(|x| #column.eq(::std::convert::Into::<#ty>::into(x))))

--- a/diesel_derives/src/attrs.rs
+++ b/diesel_derives/src/attrs.rs
@@ -48,6 +48,18 @@ impl SqlIdentifier {
     pub fn span(&self) -> Span {
         self.span
     }
+
+    pub fn valid_ident(&self) {
+        if syn::parse_str::<Ident>(&self.field_name).is_err() {
+            abort!(
+                self.span(),
+                "Expected valid identifier, found `{0}`. \
+                 Diesel automatically renames invalid identifiers, \
+                 perhaps you meant to write `{0}_`?",
+                self.field_name
+            )
+        }
+    }
 }
 
 impl ToTokens for SqlIdentifier {

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -151,6 +151,7 @@ fn field_ty_serialize_as(
     treat_none_as_default_value: bool,
 ) -> TokenStream {
     let column_name = field.column_name();
+    column_name.valid_ident();
     let span = field.span;
     if treat_none_as_default_value {
         let inner_ty = inner_of_option_ty(ty);
@@ -179,6 +180,7 @@ fn field_expr_serialize_as(
 ) -> TokenStream {
     let field_name = &field.name;
     let column_name = field.column_name();
+    column_name.valid_ident();
     let column = quote!(#table_name::#column_name);
     if treat_none_as_default_value {
         if is_option_ty(ty) {
@@ -198,6 +200,7 @@ fn field_ty(
     treat_none_as_default_value: bool,
 ) -> TokenStream {
     let column_name = field.column_name();
+    column_name.valid_ident();
     let span = field.span;
     if treat_none_as_default_value {
         let inner_ty = inner_of_option_ty(&field.ty);
@@ -228,6 +231,7 @@ fn field_expr(
 ) -> TokenStream {
     let field_name = &field.name;
     let column_name = field.column_name();
+    column_name.valid_ident();
 
     let column: Expr = parse_quote!(#table_name::#column_name);
     if treat_none_as_default_value {


### PR DESCRIPTION
We accepted invalid identifier in some positions and emitted bad error messages while trying to expand code containing these identifiers. This commit adds some additional verification to check for those invalid identifiers and emits a better error message when they are found.