### PR TITLE
Extend the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,210 @@ You can come ask for help at
 For help with longer questions and discussion about the future of Diesel,
 open a discussion on [GitHub Discussions](https://github.com/diesel-rs/diesel/discussions).
 
+## Usage 
+
+### Simple queries 
+
+Simple queries are a complete breeze. Loading all users from a database:
+
+
+```rust
+users::table.load(&mut connection)
+```
+
+Executed SQL:
+
+```sql
+SELECT * FROM users;
+```
+
+Loading all the posts for a user:
+
+``` rust
+Post::belonging_to(user).load(&mut connection)
+```
+
+Executed SQL:
+
+```sql
+SELECT * FROM posts WHERE user_id = 1;
+```
+
+### Complex queries
+
+Diesel's powerful query builder helps you construct queries as simple or complex as
+you need, at zero cost.
+
+```rust
+let versions = Version::belonging_to(krate)
+  .select(id)
+  .order(num.desc())
+  .limit(5);
+let downloads = version_downloads
+  .filter(date.gt(now - 90.days()))
+  .filter(version_id.eq(any(versions)))
+  .order(date)
+  .load::<Download>(&mut conn)?;
+```
+
+Executed SQL:
+```sql
+SELECT version_downloads.*
+  WHERE date > (NOW() - '90 days')
+    AND version_id = ANY(
+      SELECT id FROM versions
+        WHERE crate_id = 1
+        ORDER BY num DESC
+        LIMIT 5
+    )
+  ORDER BY date
+```
+
+### Less boilerplate
+
+Diesel codegen generates boilerplate for you. It lets you focus on your business logic, not mapping to and from SQL rows.
+
+That means you can write this:
+
+```rust
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = downloads)]
+pub struct Download {
+    id: i32,
+    version_id: i32,
+    downloads: i32,
+    counted: i32,
+    date: SystemTime,
+}
+```
+
+Instead of this without Diesel:
+
+```rust
+pub struct Download {
+    id: i32,
+    version_id: i32,
+    downloads: i32,
+    counted: i32,
+    date: SystemTime,
+}
+
+impl Download {
+    fn from_row(row: &Row) -> Download {
+        Download {
+            id: row.get("id"),
+            version_id: row.get("version_id"),
+            downloads: row.get("downloads"),
+            counted: row.get("counted"),
+            date: row.get("date"),
+        }
+    }
+}
+```
+
+### Inserting data
+
+It's not just about reading data. Diesel makes it easy to use structs for new records.
+
+```rust
+#[derive(Insertable)]
+#[diesel(table_name = users)]
+struct NewUser<'a> {
+    name: &'a str,
+    hair_color: Option<&'a str>,
+}
+
+let new_users = vec![
+    NewUser { name: "Sean", hair_color: Some("Black") },
+    NewUser { name: "Gordon", hair_color: None },
+];
+
+insert_into(users)
+    .values(&new_users)
+    .execute(&mut connection);
+```
+
+Executed SQL:
+
+```sql
+INSERT INTO users (name, hair_color) VALUES
+  ('Sean', 'Black'),
+  ('Gordon', DEFAULT)
+```
+
+If you need data from the rows you inserted, just change `execute` to `get_result` or `get_results`. Diesel will take care of the rest.
+
+
+```rust
+let new_users = vec![
+    NewUser { name: "Sean", hair_color: Some("Black") },
+    NewUser { name: "Gordon", hair_color: None },
+];
+
+let inserted_users = insert_into(users)
+    .values(&new_users)
+    .get_results::<User>(&mut connection);
+```
+
+Executed SQL:
+
+```sql
+INSERT INTO users (name, hair_color) VALUES
+  ('Sean', 'Black'),
+  ('Gordon', DEFAULT)
+  RETURNING *
+```
+
+### Updating data
+Diesel's codegen can generate several ways to update a row, letting you encapsulate your logic in the way that makes sense for your app.
+
+Modifying a struct:
+
+```rust
+post.published = true;
+post.save_changes(&mut connection);
+```
+
+One-off batch changes:
+
+```rust
+update(users.filter(email.like("%@spammer.com")))
+    .set(banned.eq(true))
+    .execute(&mut connection)
+```
+
+Using a struct for encapsulation:
+
+```rust
+update(Settings::belonging_to(current_user))
+    .set(&settings_form)
+    .execute(&mut connection)
+```
+
+### Raw SQL 
+
+There will always be certain queries that are just easier to write as raw SQL, or can't be expressed with the query builder. Even in these cases, Diesel provides an easy to use API for writing raw SQL.
+
+```rust
+#[derive(QueryableByName)]
+#[diesel(table_name = users)]
+struct User {
+    id: i32,
+    name: String,
+    organization_id: i32,
+}
+
+// Using `include_str!` allows us to keep the SQL in a
+// separate file, where our editor can give us SQL specific
+// syntax highlighting.
+sql_query(include_str!("complex_users_by_organization.sql"))
+    .bind::<Integer, _>(organization_id)
+    .bind::<BigInt, _>(offset)
+    .bind::<BigInt, _>(limit)
+    .load::<User>(&mut conn)?;
+```
+
+
 ## Code of conduct
 
 Anyone who interacts with Diesel in any space, including but not limited to


### PR DESCRIPTION
This commit extends the readme as the old one is somehow too short for lib.rs to probably rank diesel as important crate. https://gitlab.com/crates.rs/crates.rs/-/issues/138

This commit just includes the code examples from the diesel.rs landing page.

[Rendered](https://github.com/weiznich/diesel/tree/better_readme#readme)