### PR TITLE
Fix #3541

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ## Unreleased 
 
+## [diesel_derives 2.0.2] 2023-03-13 
+
+## Fixed 
+
+* Fixing the fallout of a breaking change from `quote` by not using their internal API
+
 ## [2.0.3] 2023-01-24
 
 ## Fixed
@@ -1982,3 +1988,4 @@ queries or set `PIPES_AS_CONCAT` manually.
 [2.0.0]: https://github.com/diesel-rs/diesel/compare/v.1.4.0...v2.0.0
 [2.0.1]: https://github.com/diesel-rs/diesel/compare/v.2.0.0...v2.0.1
 [2.0.2]: https://github.com/diesel-rs/diesel/compare/v.2.0.1...v2.0.2
+[diesel_derives 2.0.2]: https://github.com/diesel-rs/diesel/compare/v.2.0.2...diesel_derives_v2.0.2

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_derives"
-version = "2.0.1"
+version = "2.0.2"
 license = "MIT OR Apache-2.0"
 description = "You should not use this crate directly, it is internal to Diesel."
 documentation = "https://diesel.rs/guides/"

--- a/diesel_derives/src/attrs.rs
+++ b/diesel_derives/src/attrs.rs
@@ -2,11 +2,11 @@ use std::fmt::{Display, Formatter};
 
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error::ResultExt;
-use quote::spanned::Spanned;
 use quote::ToTokens;
 use syn::parse::discouraged::Speculative;
 use syn::parse::{Parse, ParseStream, Parser, Result};
 use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{parenthesized, Attribute, Ident, LitBool, LitStr, Path, Type, TypePath};
 
@@ -141,7 +141,7 @@ impl Parse for FieldAttr {
 }
 
 impl Spanned for FieldAttr {
-    fn __span(&self) -> Span {
+    fn span(&self) -> Span {
         match self {
             FieldAttr::Embed(ident)
             | FieldAttr::ColumnName(ident, _)
@@ -240,7 +240,7 @@ impl Parse for StructAttr {
 }
 
 impl Spanned for StructAttr {
-    fn __span(&self) -> Span {
+    fn span(&self) -> Span {
         match self {
             StructAttr::Aggregate(ident)
             | StructAttr::NotSized(ident)
@@ -262,8 +262,6 @@ pub fn parse_attributes<T>(attrs: &[Attribute]) -> Vec<AttributeSpanWrapper<T>>
 where
     T: Parse + ParseDeprecated + Spanned,
 {
-    use syn::spanned::Spanned;
-
     attrs
         .iter()
         .flat_map(|attr| {

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -1,4 +1,5 @@
 use super::schema::*;
+#[cfg(not(feature = "mysql"))]
 use crate::schema_dsl::*;
 use diesel::*;
 
@@ -214,7 +215,8 @@ table! {
     }
 }
 
-#[cfg(not(feature = "sqlite"))]
+// the test is somehow broken on some mariadb versions
+#[cfg(not(any(feature = "sqlite", feature = "mysql")))]
 #[test]
 fn select_for_update_locks_selected_rows() {
     use self::users_select_for_update::dsl::*;


### PR DESCRIPTION
This commit fixes a breaking change of an non-public quote API by replacing the usage of this API with a stable API in syn

cc @diesel-rs/core I plan to release that as soon as the CI passes.