### PR TITLE
Allow binding unsized types in AstPass::push_bind_param

### DIFF
--- a/diesel/src/query_builder/debug_query.rs
+++ b/diesel/src/query_builder/debug_query.rs
@@ -84,14 +84,14 @@ where
     T: QueryFragment<DB>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut buffer = Vec::new();
         let backend = DB::default();
+        let mut buffer = Vec::new();
         let ast_pass = AstPass::debug_binds(&mut buffer, &backend);
         self.query.walk_ast(ast_pass).map_err(|_| fmt::Error)?;
 
         let mut list = f.debug_list();
         for entry in buffer {
-            list.entry(entry);
+            list.entry(&entry);
         }
         list.finish()?;
         Ok(())

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -40,6 +40,8 @@ mod macros;
 mod only;
 mod order;
 mod perf_details;
+#[cfg(feature = "postgres")]
+mod query_fragment;
 mod raw_sql;
 mod schema;
 mod schema_dsl;

--- a/diesel_tests/tests/query_fragment.rs
+++ b/diesel_tests/tests/query_fragment.rs
@@ -1,0 +1,54 @@
+use crate::schema::connection;
+use diesel::pg::Pg;
+use diesel::query_builder::Query;
+use diesel::query_builder::{AstPass, QueryFragment, QueryId};
+use diesel::sql_types::Text;
+use diesel::{QueryResult, RunQueryDsl};
+
+#[derive(Debug, Clone)]
+pub struct LiteralSelect<'a> {
+    pub(crate) table_name: &'a str,
+    pub(crate) literal: String,
+}
+
+impl<'a> QueryFragment<Pg> for LiteralSelect<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        out.push_sql("select ");
+        out.push_bind_param::<Text, _>(self.literal.as_str())?;
+        out.push_sql("  from ");
+        out.push_sql(self.table_name);
+
+        Ok(())
+    }
+}
+
+impl<'a> QueryId for LiteralSelect<'a> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a, Conn> RunQueryDsl<Conn> for LiteralSelect<'a> {}
+
+impl<'a> Query for LiteralSelect<'a> {
+    type SqlType = Text;
+}
+
+#[test]
+fn literal_select_using_query_fragment() {
+    let connection = &mut connection();
+    diesel::sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .execute(connection)
+        .unwrap();
+
+    let expected_data = vec!["name".to_string(), "name".to_string()];
+
+    let query = LiteralSelect {
+        table_name: "users",
+        literal: "name".to_string(),
+    };
+    let actual_data: Vec<_> = query.load::<String>(connection).unwrap();
+    assert_eq!(expected_data, actual_data);
+}


### PR DESCRIPTION
This has the cost of some allocation overhead for `DebugQuery`, but it is convenient to be able to use `push_bind_param` with `str` and slices. In my particular use case this makes migrating to Diesel 2.0 easier.