### PR TITLE
Update the getting started examples to use `Selectable` + `check_for_backend`

### DIFF
--- a/examples/mysql/getting_started_step_1/src/bin/show_posts.rs
+++ b/examples/mysql/getting_started_step_1/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/mysql/getting_started_step_1/src/models.rs
+++ b/examples/mysql/getting_started_step_1/src/models.rs
@@ -1,6 +1,8 @@
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = crate::schema::posts)]
+#[diesel(check_for_backend(diesel::mysql::Mysql))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/mysql/getting_started_step_2/src/bin/show_posts.rs
+++ b/examples/mysql/getting_started_step_2/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/mysql/getting_started_step_2/src/models.rs
+++ b/examples/mysql/getting_started_step_2/src/models.rs
@@ -1,7 +1,9 @@
 use crate::schema::posts;
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = posts)]
+#[diesel(check_for_backend(diesel::mysql::Mysql))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/mysql/getting_started_step_3/src/bin/show_posts.rs
+++ b/examples/mysql/getting_started_step_3/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/mysql/getting_started_step_3/src/models.rs
+++ b/examples/mysql/getting_started_step_3/src/models.rs
@@ -1,7 +1,9 @@
 use crate::schema::posts;
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = posts)]
+#[diesel(check_for_backend(diesel::mysql::Mysql))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/postgres/getting_started_step_1/src/bin/show_posts.rs
+++ b/examples/postgres/getting_started_step_1/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/postgres/getting_started_step_1/src/models.rs
+++ b/examples/postgres/getting_started_step_1/src/models.rs
@@ -1,6 +1,8 @@
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = crate::schema::posts)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/postgres/getting_started_step_2/src/bin/show_posts.rs
+++ b/examples/postgres/getting_started_step_2/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/postgres/getting_started_step_2/src/lib.rs
+++ b/examples/postgres/getting_started_step_2/src/lib.rs
@@ -22,6 +22,7 @@ pub fn create_post(conn: &mut PgConnection, title: &str, body: &str) -> Post {
 
     diesel::insert_into(posts::table)
         .values(&new_post)
+        .returning(Post::as_returning())
         .get_result(conn)
         .expect("Error saving new post")
 }

--- a/examples/postgres/getting_started_step_2/src/models.rs
+++ b/examples/postgres/getting_started_step_2/src/models.rs
@@ -1,7 +1,9 @@
 use crate::schema::posts;
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = posts)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/postgres/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/postgres/getting_started_step_3/src/bin/publish_post.rs
@@ -15,7 +15,8 @@ fn main() {
 
     let post = diesel::update(posts.find(id))
         .set(published.eq(true))
-        .get_result::<Post>(connection)
+        .returning(Post::as_returning())
+        .get_result(connection)
         .unwrap();
     println!("Published post {}", post.title);
 }

--- a/examples/postgres/getting_started_step_3/src/bin/show_posts.rs
+++ b/examples/postgres/getting_started_step_3/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/postgres/getting_started_step_3/src/lib.rs
+++ b/examples/postgres/getting_started_step_3/src/lib.rs
@@ -22,6 +22,7 @@ pub fn create_post(conn: &mut PgConnection, title: &str, body: &str) -> Post {
 
     diesel::insert_into(posts::table)
         .values(&new_post)
+        .returning(Post::as_returning())
         .get_result(conn)
         .expect("Error saving new post")
 }

--- a/examples/postgres/getting_started_step_3/src/models.rs
+++ b/examples/postgres/getting_started_step_3/src/models.rs
@@ -1,7 +1,9 @@
 use crate::schema::posts;
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = posts)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/sqlite/getting_started_step_1/src/bin/show_posts.rs
+++ b/examples/sqlite/getting_started_step_1/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/sqlite/getting_started_step_1/src/models.rs
+++ b/examples/sqlite/getting_started_step_1/src/models.rs
@@ -1,6 +1,8 @@
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = crate::schema::posts)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
+diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite", "returning_clauses_for_sqlite_3_35"] }
 dotenvy = "0.15"
 
 [[bin]]

--- a/examples/sqlite/getting_started_step_2/src/bin/show_posts.rs
+++ b/examples/sqlite/getting_started_step_2/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/sqlite/getting_started_step_2/src/bin/write_post.rs
+++ b/examples/sqlite/getting_started_step_2/src/bin/write_post.rs
@@ -12,8 +12,8 @@ fn main() {
     let mut body = String::new();
     stdin().read_to_string(&mut body).unwrap();
 
-    let _ = create_post(connection, title, &body);
-    println!("\nSaved draft {title}");
+    let post = create_post(connection, title, &body);
+    println!("\nSaved draft {title} with id {}", post.id);
 }
 
 #[cfg(not(windows))]

--- a/examples/sqlite/getting_started_step_2/src/lib.rs
+++ b/examples/sqlite/getting_started_step_2/src/lib.rs
@@ -3,6 +3,7 @@ pub mod schema;
 
 use diesel::prelude::*;
 use dotenvy::dotenv;
+use models::Post;
 use std::env;
 
 use self::models::NewPost;
@@ -15,13 +16,14 @@ pub fn establish_connection() -> SqliteConnection {
         .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }
 
-pub fn create_post(conn: &mut SqliteConnection, title: &str, body: &str) -> usize {
+pub fn create_post(conn: &mut SqliteConnection, title: &str, body: &str) -> Post {
     use crate::schema::posts;
 
     let new_post = NewPost { title, body };
 
     diesel::insert_into(posts::table)
         .values(&new_post)
-        .execute(conn)
+        .returning(Post::as_returning())
+        .get_result(conn)
         .expect("Error saving new post")
 }

--- a/examples/sqlite/getting_started_step_2/src/models.rs
+++ b/examples/sqlite/getting_started_step_2/src/models.rs
@@ -1,7 +1,9 @@
 use super::schema::posts;
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = posts)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct Post {
     pub id: i32,
     pub title: String,

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite"] }
+diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite", "returning_clauses_for_sqlite_3_35"] }
 dotenvy = "0.15"
 
 [[bin]]

--- a/examples/sqlite/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/sqlite/getting_started_step_3/src/bin/publish_post.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel_demo_step_3_sqlite::models::Post;
 use diesel_demo_step_3_sqlite::*;
 use std::env::args;
 
@@ -12,15 +13,11 @@ fn main() {
         .expect("Invalid ID");
     let connection = &mut establish_connection();
 
-    let _ = diesel::update(posts.find(id))
+    let post = diesel::update(posts.find(id))
         .set(published.eq(true))
-        .execute(connection)
+        .returning(Post::as_returning())
+        .get_result(connection)
         .unwrap();
-
-    let post: models::Post = posts
-        .find(id)
-        .first(connection)
-        .unwrap_or_else(|_| panic!("Unable to find post {}", id));
 
     println!("Published post {}", post.title);
 }

--- a/examples/sqlite/getting_started_step_3/src/bin/show_posts.rs
+++ b/examples/sqlite/getting_started_step_3/src/bin/show_posts.rs
@@ -9,7 +9,8 @@ fn main() {
     let results = posts
         .filter(published.eq(true))
         .limit(5)
-        .load::<Post>(connection)
+        .select(Post::as_select())
+        .load(connection)
         .expect("Error loading posts");
 
     println!("Displaying {} posts", results.len());

--- a/examples/sqlite/getting_started_step_3/src/lib.rs
+++ b/examples/sqlite/getting_started_step_3/src/lib.rs
@@ -5,7 +5,7 @@ use diesel::prelude::*;
 use dotenvy::dotenv;
 use std::env;
 
-use models::NewPost;
+use crate::models::{NewPost, Post};
 
 pub fn establish_connection() -> SqliteConnection {
     dotenv().ok();
@@ -15,13 +15,14 @@ pub fn establish_connection() -> SqliteConnection {
         .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }
 
-pub fn create_post(conn: &mut SqliteConnection, title: &str, body: &str) -> usize {
+pub fn create_post(conn: &mut SqliteConnection, title: &str, body: &str) -> Post {
     use crate::schema::posts;
 
     let new_post = NewPost { title, body };
 
     diesel::insert_into(posts::table)
         .values(&new_post)
-        .execute(conn)
+        .returning(Post::as_returning())
+        .get_result(conn)
         .expect("Error saving new post")
 }

--- a/examples/sqlite/getting_started_step_3/src/models.rs
+++ b/examples/sqlite/getting_started_step_3/src/models.rs
@@ -1,7 +1,9 @@
 use super::schema::posts;
 use diesel::prelude::*;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = posts)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct Post {
     pub id: i32,
     pub title: String,


### PR DESCRIPTION
That should prevent users from running into nasty compile errors if they try to modify these examples slightly. Will update the guide on the webpage in a separate PR.