### PR TITLE
Deny unsafe code

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -202,6 +202,7 @@
     clippy::items_after_statements,
     clippy::used_underscore_binding
 )]
+#![deny(unsafe_code)]
 #![cfg_attr(test, allow(clippy::map_unwrap_or, clippy::unwrap_used))]
 
 extern crate diesel_derives;

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // module uses ffi
 use mysqlclient_sys as ffi;
 use std::mem;
 use std::mem::MaybeUninit;

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -1,5 +1,5 @@
-extern crate mysqlclient_sys as ffi;
-
+#![allow(unsafe_code)] // module uses ffi
+use mysqlclient_sys as ffi;
 use std::ffi::CStr;
 use std::os::raw as libc;
 use std::ptr::{self, NonNull};

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,5 +1,4 @@
 #![allow(unsafe_code)] // module uses ffi
-                       //
 use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // module uses ffi
+                       //
 use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 

--- a/diesel/src/mysql/connection/stmt/metadata.rs
+++ b/diesel/src/mysql/connection/stmt/metadata.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // module uses ffi
 use std::ffi::CStr;
 use std::ptr::NonNull;
 use std::slice;

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -1,8 +1,5 @@
-extern crate mysqlclient_sys as ffi;
-
-pub(super) mod iterator;
-mod metadata;
-
+#![allow(unsafe_code)] // module uses ffi
+use mysqlclient_sys as ffi;
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::os::raw as libc;
@@ -12,6 +9,9 @@ use super::bind::{OutputBinds, PreparedStatementBinds};
 use crate::connection::statement_cache::MaybeCached;
 use crate::mysql::MysqlType;
 use crate::result::{DatabaseErrorKind, Error, QueryResult};
+
+pub(super) mod iterator;
+mod metadata;
 
 pub(super) use self::metadata::{MysqlFieldMetadata, StatementMetadata};
 

--- a/diesel/src/mysql/types/date_and_time/mod.rs
+++ b/diesel/src/mysql/types/date_and_time/mod.rs
@@ -115,6 +115,7 @@ macro_rules! mysql_time_impls {
     ($ty:ty) => {
         #[cfg(feature = "mysql_backend")]
         impl ToSql<$ty, Mysql> for MysqlTime {
+            #[allow(unsafe_code)] // pointer cast
             fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
                 let bytes = unsafe {
                     let bytes_ptr = self as *const MysqlTime as *const u8;

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -39,6 +39,7 @@ impl<'a> MysqlValue<'a> {
     // so clippy is clearly wrong here
     // https://github.com/rust-lang/rust-clippy/issues/2881
     #[allow(dead_code, clippy::cast_ptr_alignment)]
+    #[allow(unsafe_code)] // pointer cast
     pub(crate) fn time_value(&self) -> deserialize::Result<MysqlTime> {
         match self.tpe {
             MysqlType::Time | MysqlType::Date | MysqlType::DateTime | MysqlType::Timestamp => {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -119,9 +119,12 @@ pub struct PgConnection {
     connection_and_transaction_manager: ConnectionAndTransactionManager,
 }
 
+// according to libpq documentation a connection can be transfered to other threads
+#[allow(unsafe_code)]
 unsafe impl Send for PgConnection {}
 
 impl SimpleConnection for PgConnection {
+    #[allow(unsafe_code)] // use of unsafe function
     fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
         let query = CString::new(query)?;
         let inner_result = unsafe {

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_arguments)]
+#![allow(unsafe_code)] // ffi code
 
 extern crate pq_sys;
 

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ffi code
 extern crate pq_sys;
 
 use self::pq_sys::*;

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ffi code
 extern crate pq_sys;
 
 use std::ffi::CString;

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -55,6 +55,7 @@ impl TypeOidLookup for NonZeroU32 {
 impl<'a> PgValue<'a> {
     #[cfg(test)]
     pub(crate) fn for_test(raw_value: &'a [u8]) -> Self {
+        #[allow(unsafe_code)] // that's actual safe
         static FAKE_OID: NonZeroU32 = unsafe {
             // 42 != 0, so this is actually safe
             NonZeroU32::new_unchecked(42)

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -63,6 +63,7 @@ where
     }
 }
 
+#[allow(unsafe_code)] // cast to transparent wrapper type
 impl<'a, T, V, QId, Op, const STATIC_QUERY_ID: bool> DebugQueryHelper<No>
     for DebugQuery<'a, InsertStatement<T, BatchInsert<V, T, QId, STATIC_QUERY_ID>, Op>, Sqlite>
 where

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -128,6 +128,7 @@ impl<T> fmt::Debug for ConnectionManager<T> {
     }
 }
 
+#[allow(unsafe_code)] // we do not actually hold a reference to `T`
 unsafe impl<T: Send + 'static> Sync for ConnectionManager<T> {}
 
 impl<T> ConnectionManager<T> {

--- a/diesel/src/sqlite/connection/bind_collector.rs
+++ b/diesel/src/sqlite/connection/bind_collector.rs
@@ -124,6 +124,7 @@ impl std::fmt::Display for InternalSqliteBindValue<'_> {
 }
 
 impl InternalSqliteBindValue<'_> {
+    #[allow(unsafe_code)] // ffi function calls
     pub(in crate::sqlite) fn result_of(self, ctx: &mut libsqlite3_sys::sqlite3_context) {
         use libsqlite3_sys as ffi;
         use std::os::raw as libc;

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -130,6 +130,7 @@ struct FunctionRow<'a> {
 }
 
 impl<'a> Drop for FunctionRow<'a> {
+    #[allow(unsafe_code)] // manual drop calls
     fn drop(&mut self) {
         if let Some(args) = Rc::get_mut(&mut self.args) {
             if let PrivateSqliteRow::Duplicated { column_names, .. } =
@@ -146,6 +147,7 @@ impl<'a> Drop for FunctionRow<'a> {
 }
 
 impl<'a> FunctionRow<'a> {
+    #[allow(unsafe_code)] // complicated ptr cast
     fn new(args: &mut [*mut ffi::sqlite3_value]) -> Self {
         let lengths = args.len();
         let args = unsafe {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -125,6 +125,7 @@ pub struct SqliteConnection {
 // This relies on the invariant that RawConnection or Statement are never
 // leaked. If a reference to one of those was held on a different thread, this
 // would not be thread safe.
+#[allow(unsafe_code)]
 unsafe impl Send for SqliteConnection {}
 
 impl SimpleConnection for SqliteConnection {

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ffi calls
 extern crate libsqlite3_sys as ffi;
 
 use std::ffi::{CString, NulError};

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)] // ffi calls
 extern crate libsqlite3_sys as ffi;
 
 use std::cell::Ref;

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -14,6 +14,7 @@ pub struct StatementIterator<'stmt, 'query> {
 
 impl<'stmt, 'query> StatementIterator<'stmt, 'query> {
     #[cold]
+    #[allow(unsafe_code)] // call to unsafe function
     fn handle_duplicated_row_case(
         outer_last_row: &mut Rc<RefCell<PrivateSqliteRow<'stmt, 'query>>>,
         column_names: &mut Option<Rc<[Option<String>]>>,
@@ -90,6 +91,7 @@ impl<'stmt, 'query> StatementIterator<'stmt, 'query> {
 impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
     type Item = QueryResult<SqliteRow<'stmt, 'query>>;
 
+    #[allow(unsafe_code)] // call to unsafe function
     fn next(&mut self) -> Option<Self::Item> {
         use PrivateStatementIterator::{NotStarted, Started};
         match &mut self.inner {

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -1,5 +1,4 @@
-extern crate libsqlite3_sys as ffi;
-
+#![allow(unsafe_code)] // fii code
 use super::bind_collector::{InternalSqliteBindValue, SqliteBindCollector};
 use super::raw::RawConnection;
 use super::sqlite_value::OwnedSqliteValue;
@@ -9,6 +8,7 @@ use crate::result::Error::DatabaseError;
 use crate::result::*;
 use crate::sqlite::{Sqlite, SqliteType};
 use crate::util::OnceCell;
+use libsqlite3_sys as ffi;
 use std::ffi::{CStr, CString};
 use std::io::{stderr, Write};
 use std::os::raw as libc;

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -121,6 +121,7 @@ where
     DB: Backend,
     *const str: FromSql<ST, DB>,
 {
+    #[allow(unsafe_code)] // ptr dereferencing
     fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
         let str_ptr = <*const str as FromSql<ST, DB>>::from_sql(bytes)?;
         // We know that the pointer impl will never return null
@@ -155,6 +156,7 @@ where
     DB: Backend,
     *const [u8]: FromSql<ST, DB>,
 {
+    #[allow(unsafe_code)] // ptr dereferencing
     fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
         let slice_ptr = <*const [u8] as FromSql<ST, DB>>::from_sql(bytes)?;
         // We know that the pointer impl will never return null

--- a/diesel/src/util/once_cell.rs
+++ b/diesel/src/util/once_cell.rs
@@ -1,3 +1,5 @@
+// copied from rust-stdlib
+#![allow(unsafe_code)]
 // This is a copy of the unstable `OnceCell` implementation in rusts std-library
 // https://github.com/rust-lang/rust/blob/1160cf864f2a0014e3442367e1b96496bfbeadf4/library/core/src/lazy.rs#L8-L276
 //


### PR DESCRIPTION
This commit denies unsafe code. It allows the usage of unsafe code only in specific locations and add some comments why it's allowed there. I hope that this helps in the future to detect new unsafe code locations and discuss there need.