### PR TITLE
Fix #3558

### DIFF
--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -293,24 +293,29 @@ impl<'stmt, 'query> BoundStatement<'stmt, 'query> {
                 .count(),
         );
         for (bind_idx, (bind, tpe)) in (1..).zip(binds) {
-            if matches!(
+            let is_borrowed_bind = matches!(
                 bind,
                 InternalSqliteBindValue::BorrowedString(_)
                     | InternalSqliteBindValue::BorrowedBinary(_)
-            ) {
-                // Store the id's of borrowed binds to unbind them on drop
-                self.binds_to_free.push((bind_idx, None));
-            }
+            );
 
             // It's safe to call bind here as:
             // * The type and value matches
             // * We ensure that corresponding buffers lives long enough below
             // * The statement is not used yet by `step` or anything else
             let res = unsafe { self.statement.bind(tpe, bind, bind_idx) }?;
+
+            // it's important to push these only after
+            // the call to bind succeded, otherwise we might attempt to
+            // call bind to an non-existing bind position in
+            // the destructor
             if let Some(ptr) = res {
                 // Store the id + pointer for a owned bind
                 // as we must unbind and free them on drop
                 self.binds_to_free.push((bind_idx, Some(ptr)));
+            } else if is_borrowed_bind {
+                // Store the id's of borrowed binds to unbind them on drop
+                self.binds_to_free.push((bind_idx, None));
             }
         }
         Ok(())
@@ -469,5 +474,32 @@ impl<'stmt, 'query> StatementUse<'stmt, 'query> {
             ffi::sqlite3_column_value(self.statement.statement.inner_statement.as_ptr(), idx)
         };
         NonNull::new(ptr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use crate::sql_types::Text;
+    use crate::SqliteConnection;
+
+    // this is a regression test for
+    // https://github.com/diesel-rs/diesel/issues/3558
+    #[test]
+    fn check_out_of_bounds_bind_does_not_panic_on_drop() {
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+        let e = crate::sql_query("SELECT '?'")
+            .bind::<Text, _>("foo")
+            .execute(&mut conn);
+
+        assert!(e.is_err());
+        let e = e.unwrap_err();
+        if let crate::result::Error::DatabaseError(crate::result::DatabaseErrorKind::Unknown, m) = e
+        {
+            assert_eq!(m.message(), "column index out of range");
+        } else {
+            panic!("Wrong error returned");
+        }
     }
 }


### PR DESCRIPTION
This commit fixes an issue where out of bound text/binary binds on `sql_query` using the sqlite backend causes a panic in an internal drop impl. It was caused that we pushed to the list of released binds before we actually checked whether that bind was possible or not. This caused us trying to bind to the same invalid bind again in the drop impl, while being on the normal error path. It's fixed by just moving the relevant push after the actual bind. In addition a regression test for this problem is added.