### PR TITLE
Change incorrect uses of mysql feature to mysql_backend

### DIFF
--- a/diesel/src/query_builder/combination_clause.rs
+++ b/diesel/src/query_builder/combination_clause.rs
@@ -258,7 +258,7 @@ mod postgres {
     impl SupportsCombinationClause<Except, All> for Pg {}
 }
 
-#[cfg(feature = "mysql")]
+#[cfg(feature = "mysql_backend")]
 mod mysql {
     use super::*;
     use crate::mysql::Mysql;

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -499,7 +499,7 @@ mod private {
         }
     }
 
-    #[cfg(feature = "mysql")]
+    #[cfg(feature = "mysql_backend")]
     impl QueryFragment<crate::mysql::Mysql> for InsertOrIgnore {
         fn walk_ast<'b>(
             &'b self,
@@ -524,7 +524,7 @@ mod private {
         }
     }
 
-    #[cfg(feature = "mysql")]
+    #[cfg(feature = "mysql_backend")]
     impl QueryFragment<crate::mysql::Mysql> for Replace {
         fn walk_ast<'b>(
             &'b self,

--- a/diesel/src/sql_types/fold.rs
+++ b/diesel/src/sql_types/fold.rs
@@ -39,7 +39,7 @@ foldable_impls! {
     sql_types::Interval => (sql_types::Interval, sql_types::Interval),
 }
 
-#[cfg(feature = "mysql")]
+#[cfg(feature = "mysql_backend")]
 foldable_impls! {
     sql_types::Unsigned<sql_types::SmallInt> => (sql_types::Unsigned<sql_types::BigInt>, sql_types::Numeric),
     sql_types::Unsigned<sql_types::Integer> => (sql_types::Unsigned<sql_types::BigInt>, sql_types::Numeric),

--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -20,11 +20,11 @@ impl SqlOrd for sql_types::Timestamptz {}
 #[cfg(feature = "postgres")]
 impl<T: SqlOrd> SqlOrd for sql_types::Array<T> {}
 
-#[cfg(feature = "mysql")]
+#[cfg(feature = "mysql_backend")]
 impl SqlOrd for sql_types::Datetime {}
-#[cfg(feature = "mysql")]
+#[cfg(feature = "mysql_backend")]
 impl SqlOrd for sql_types::Unsigned<sql_types::SmallInt> {}
-#[cfg(feature = "mysql")]
+#[cfg(feature = "mysql_backend")]
 impl SqlOrd for sql_types::Unsigned<sql_types::Integer> {}
-#[cfg(feature = "mysql")]
+#[cfg(feature = "mysql_backend")]
 impl SqlOrd for sql_types::Unsigned<sql_types::BigInt> {}


### PR DESCRIPTION
As noted [here](https://github.com/weiznich/diesel_async/issues/70), some MySQL types are unavailable when compiling with `mysql_backend` when they should be, instead using `mysql`.

`InsertOrIgnore` is the only one I've personally run in to, but I did a full repo search and there were 3 other files that looked like they might also require changing too, but I am not certain – so please do check those closely.