### PR TITLE
docs(pg): unhide docs from some type aliases

### DIFF
--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -236,7 +236,6 @@ pub mod sql_types {
     pub struct Uuid;
 
     /// Alias for `Binary`, to ensure `infer_schema!` works
-    #[doc(hidden)]
     pub type Bytea = crate::sql_types::Binary;
 
     #[doc(hidden)]
@@ -422,7 +421,6 @@ pub mod sql_types {
     #[diesel(postgres_type(oid = 829, array_oid = 1040))]
     pub struct MacAddr;
 
-    #[doc(hidden)]
     /// Alias for `MacAddr` to be able to use it with `infer_schema`.
     pub type Macaddr = MacAddr;
 

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -235,7 +235,7 @@ pub mod sql_types {
     #[diesel(postgres_type(oid = 2950, array_oid = 2951))]
     pub struct Uuid;
 
-    /// Alias for `Binary`, to ensure `infer_schema!` works
+    /// Alias for `Binary`, to ensure `diesel print-schema` works
     pub type Bytea = crate::sql_types::Binary;
 
     #[doc(hidden)]
@@ -421,7 +421,7 @@ pub mod sql_types {
     #[diesel(postgres_type(oid = 829, array_oid = 1040))]
     pub struct MacAddr;
 
-    /// Alias for `MacAddr` to be able to use it with `infer_schema`.
+    /// Alias for `MacAddr` to be able to use it with `diesel print-schema`.
     pub type Macaddr = MacAddr;
 
     /// The [`INET`](https://www.postgresql.org/docs/current/static/datatype-net-types.html) SQL type. This type can only be used with `feature = "network-address"` or `feature = "ipnet-address"`.


### PR DESCRIPTION
Removed `#[doc(hidden)]` from 2 PostgreSQL type aliases, as discussed on matrix