### PR TITLE
Use appropriate postgres datatype as foreign key

### DIFF
--- a/examples/postgres/relations/migrations/2023-02-08-193718_create_pages/up.sql
+++ b/examples/postgres/relations/migrations/2023-02-08-193718_create_pages/up.sql
@@ -3,5 +3,5 @@ CREATE TABLE pages (
   id SERIAL PRIMARY KEY,
   page_number INT NOT NULL,
   content TEXT NOT NULL,
-  book_id SERIAL REFERENCES books(id)
+  book_id INTEGER REFERENCES books(id)
 );

--- a/examples/postgres/relations/migrations/2023-02-08-193718_create_pages/up.sql
+++ b/examples/postgres/relations/migrations/2023-02-08-193718_create_pages/up.sql
@@ -3,5 +3,5 @@ CREATE TABLE pages (
   id SERIAL PRIMARY KEY,
   page_number INT NOT NULL,
   content TEXT NOT NULL,
-  book_id INTEGER REFERENCES books(id)
+  book_id INTEGER NOT NULL REFERENCES books(id)
 );


### PR DESCRIPTION
PostgreSQL foreign key should be a true datatype.

SERIAL would cause postgres to create a sequence and use setval() as default.

https://www.postgresql.org/docs/15/datatype-numeric.html#DATATYPE-SERIAL