### PR TITLE
Add support for `#[diesel(check_for_backend())]` to `#[derive(Queryab…

### DIFF
--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.rs
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.rs
@@ -1,0 +1,34 @@
+extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+#[derive(QueryableByName)]
+#[diesel(table_name = users)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+struct User {
+    id: String,
+    name: i32,
+}
+
+#[derive(QueryableByName)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+struct User2 {
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    id: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: i32,
+}
+
+fn main() {
+    let conn = &mut PgConnection::establish("…").unwrap();
+
+
+    let s = diesel::sql_query("…").load::<User>(conn);
+}

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
@@ -1,0 +1,65 @@
+error[E0277]: Cannot deserialize a value of the database type `diesel::sql_types::Text` as `i32`
+  --> tests/fail/broken_queryable_by_name.rs:17:5
+   |
+17 |     name: i32,
+   |     ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
+   |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Text`
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <i32 as FromSql<diesel::sql_types::Integer, Mysql>>
+             <i32 as FromSql<diesel::sql_types::Integer, Pg>>
+             <i32 as FromSql<diesel::sql_types::Integer, Sqlite>>
+   = note: required for `i32` to implement `Queryable<diesel::sql_types::Text, Pg>`
+   = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: Cannot deserialize a value of the database type `diesel::sql_types::Integer` as `*const str`
+  --> tests/fail/broken_queryable_by_name.rs:16:5
+   |
+16 |     id: String,
+   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
+   |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Integer`
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <*const str as FromSql<diesel::sql_types::Text, Mysql>>
+             <*const str as FromSql<diesel::sql_types::Text, Pg>>
+             <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
+   = note: required for `std::string::String` to implement `FromSql<diesel::sql_types::Integer, Pg>`
+   = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, Pg>`
+   = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: Cannot deserialize a value of the database type `diesel::sql_types::Text` as `i32`
+  --> tests/fail/broken_queryable_by_name.rs:26:5
+   |
+26 |     name: i32,
+   |     ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
+   |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Text`
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <i32 as FromSql<diesel::sql_types::Integer, Mysql>>
+             <i32 as FromSql<diesel::sql_types::Integer, Pg>>
+             <i32 as FromSql<diesel::sql_types::Integer, Sqlite>>
+   = note: required for `i32` to implement `Queryable<diesel::sql_types::Text, Pg>`
+   = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error[E0277]: Cannot deserialize a value of the database type `diesel::sql_types::Integer` as `*const str`
+  --> tests/fail/broken_queryable_by_name.rs:24:5
+   |
+24 |     id: String,
+   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
+   |
+   = note: Double check your type mappings via the documentation of `diesel::sql_types::Integer`
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             <*const str as FromSql<diesel::sql_types::Text, Mysql>>
+             <*const str as FromSql<diesel::sql_types::Text, Pg>>
+             <*const str as FromSql<diesel::sql_types::Text, Sqlite>>
+   = note: required for `std::string::String` to implement `FromSql<diesel::sql_types::Integer, Pg>`
+   = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, Pg>`
+   = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -661,6 +661,13 @@ pub fn derive_queryable(input: TokenStream) -> TokenStream {
 ///    columns for the specified table. The path is relative to the current module.
 ///    If no field attributes are specified the derive will use the sql type of
 ///    the corresponding column.
+/// * `#[diesel(check_for_backend(diesel::pg::Pg, diesel::mysql::Mysql))]`, instructs
+///    the derive to generate additional code to identify potential type mismatches.
+///    It accepts a list of backend types to check the types against. Using this option
+///    will result in much better error messages in cases where some types in your `QueryableByName`
+///    struct don't match. You need to specify the concrete database backend
+///    this specific struct is indented to be used with, as otherwise rustc can't correctly
+///    identify the required deserialization implementation.
 ///
 /// ## Optional field attributes
 ///


### PR DESCRIPTION
…leByName)]`

Similar to the support in `#[diesel(Selectable)]` this makes it much easier to debug potential field type mismatches by greatly improving the generated error messages.