### PR TITLE
Remove cargo's audit allowlist that is no longer needed

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,0 @@
-[advisories]
-ignore = [
-    # we cannot do much here without an update from chrono + we do not call any affected function
-    "RUSTSEC-2020-0159"
-] 

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.20", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.0.2", features = ["cargo", "string"] }
 clap_complete = "4"
 dotenvy = "0.15"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 assert_matches = "1.0.1"
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.20", default-features = false, features = ["clock", "std"] }
 diesel = { path = "../diesel", default-features = false, features = ["quickcheck", "chrono", "uuid", "serde_json", "ipnet-address", "network-address", "numeric", "with-deprecated"] }
 diesel_migrations = { path = "../diesel_migrations" }
 dotenvy = "0.15"

--- a/examples/mysql/all_about_inserts/Cargo.toml
+++ b/examples/mysql/all_about_inserts/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["mysql", "chrono"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.20", default-features = false, features = ["clock", "std"] }
 
 [lib]
 doc = false

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 bcrypt = "0.10.1"
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.20", default-features = false, features = ["clock", "std"] }
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["postgres", "chrono"] }
 dotenvy = "0.15"
 structopt = "0.3"

--- a/examples/sqlite/all_about_inserts/Cargo.toml
+++ b/examples/sqlite/all_about_inserts/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.0.0", path = "../../../diesel", features = ["sqlite", "chrono"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.20", default-features = false, features = ["clock", "std"] }
 
 [lib]
 doc = false


### PR DESCRIPTION
The allowlist item has been introduced by #2928 & #2955. The item is no longer needed after chrono has been fixed on 0.4.20 in #3264.