### PR TITLE
Fix #3506

### DIFF
--- a/diesel_cli/tests/database_reset.rs
+++ b/diesel_cli/tests/database_reset.rs
@@ -32,6 +32,7 @@ fn reset_runs_database_setup() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     assert!(db.table_exists("posts"));
@@ -102,6 +103,7 @@ fn reset_works_with_migration_dir_by_arg() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     assert!(db.table_exists("posts"));
@@ -133,6 +135,7 @@ fn reset_works_with_migration_dir_by_env() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     assert!(db.table_exists("posts"));
@@ -215,6 +218,7 @@ fn reset_respects_migrations_dir_from_diesel_toml() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     assert!(db.table_exists("users"));

--- a/diesel_cli/tests/database_setup.rs
+++ b/diesel_cli/tests/database_setup.rs
@@ -50,6 +50,7 @@ fn database_setup_runs_migrations_if_no_schema_table() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // sanity check
@@ -97,6 +98,7 @@ fn database_setup_respects_migration_dir_by_arg_to_database() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // sanity check
@@ -129,6 +131,7 @@ fn database_setup_respects_migration_dir_by_arg() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // sanity check
@@ -161,6 +164,7 @@ fn database_setup_respects_migration_dir_by_env() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // sanity check
@@ -200,6 +204,7 @@ fn database_setup_respects_migrations_dir_from_diesel_toml() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // sanity check

--- a/diesel_cli/tests/migration_list.rs
+++ b/diesel_cli/tests/migration_list.rs
@@ -19,6 +19,7 @@ fn migration_list_lists_pending_applied_migrations() {
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         Some("DROP TABLE users"),
+        None,
     );
 
     assert!(!db.table_exists("users"));
@@ -67,7 +68,7 @@ fn migration_list_lists_migrations_ordered_by_timestamp() {
     p.command("setup").run();
 
     let tag1 = format!("{}_initial", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag1, "", Some(""));
+    p.create_migration(&tag1, "", Some(""), None);
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -76,7 +77,7 @@ fn migration_list_lists_migrations_ordered_by_timestamp() {
     sleep(Duration::from_millis(1100));
 
     let tag2 = format!("{}_alter", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag2, "", Some(""));
+    p.create_migration(&tag2, "", Some(""), None);
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -93,23 +94,23 @@ fn migration_list_orders_unknown_timestamps_last() {
     p.command("setup").run();
 
     let tag1 = format!("{}_migration1", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag1, "", Some(""));
+    p.create_migration(&tag1, "", Some(""), None);
 
     let tag4 = "abc_migration4";
-    p.create_migration(tag4, "", Some(""));
+    p.create_migration(tag4, "", Some(""), None);
 
     let tag5 = "zzz_migration5";
-    p.create_migration(tag5, "", Some(""));
+    p.create_migration(tag5, "", Some(""), None);
 
     sleep(Duration::from_millis(1100));
 
     let tag2 = format!("{}_migration2", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag2, "", Some(""));
+    p.create_migration(&tag2, "", Some(""), None);
 
     sleep(Duration::from_millis(1100));
 
     let tag3 = format!("{}_migration3", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag3, "", Some(""));
+    p.create_migration(&tag3, "", Some(""), None);
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -126,22 +127,22 @@ fn migration_list_orders_nontimestamp_versions_alphabetically() {
     p.command("setup").run();
 
     let tag4 = "a_migration";
-    p.create_migration(tag4, "", Some(""));
+    p.create_migration(tag4, "", Some(""), None);
 
     let tag6 = "bc_migration";
-    p.create_migration(tag6, "", Some(""));
+    p.create_migration(tag6, "", Some(""), None);
 
     let tag5 = "aa_migration";
-    p.create_migration(tag5, "", Some(""));
+    p.create_migration(tag5, "", Some(""), None);
 
     let tag1 = "!wow_migration";
-    p.create_migration(tag1, "", Some(""));
+    p.create_migration(tag1, "", Some(""), None);
 
     let tag3 = "7letters";
-    p.create_migration(tag3, "", Some(""));
+    p.create_migration(tag3, "", Some(""), None);
 
     let tag2 = format!("{}_stamped_migration", Utc::now().format(TIMESTAMP_FORMAT));
-    p.create_migration(&tag2, "", Some(""));
+    p.create_migration(&tag2, "", Some(""), None);
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -158,10 +159,10 @@ fn migration_list_orders_old_and_new_timestamp_forms_mixed_correctly() {
     p.command("setup").run();
 
     let tag1 = "20170505070309_migration";
-    p.create_migration(tag1, "", Some(""));
+    p.create_migration(tag1, "", Some(""), None);
 
     let tag2 = "2017-11-23-064836_migration";
-    p.create_migration(tag2, "", Some(""));
+    p.create_migration(tag2, "", Some(""), None);
 
     let result = p.command("migration").arg("list").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
@@ -190,6 +191,7 @@ fn migration_list_respects_migrations_dir_from_diesel_toml() {
         "12345_create_users_table",
         "CREATE TABLE users (id INTEGER PRIMARY KEY)",
         Some("DROP TABLE users"),
+        None,
     );
 
     assert!(!db.table_exists("users"));

--- a/diesel_cli/tests/migration_revert.rs
+++ b/diesel_cli/tests/migration_revert.rs
@@ -11,6 +11,7 @@ fn migration_revert_runs_the_last_migration_down() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // Make sure the project is setup
@@ -39,6 +40,7 @@ fn migration_revert_respects_migration_dir_var() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // Make sure the project is setup.
@@ -71,6 +73,7 @@ fn migration_revert_respects_migration_dir_env() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // Make sure the project is setup.
@@ -113,6 +116,7 @@ fn migration_revert_respects_migration_dir_from_diesel_toml() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // Make sure the project is setup.
@@ -142,18 +146,21 @@ fn migration_revert_runs_the_last_two_migration_down() {
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE customers"),
+        None,
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE contracts"),
+        None,
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE bills"),
+        None,
     );
 
     // Make sure the project is setup
@@ -195,18 +202,21 @@ fn migration_revert_all_runs_the_migrations_down() {
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE customers"),
+        None,
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE contracts"),
+        None,
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE bills"),
+        None,
     );
 
     // Make sure the project is setup
@@ -245,6 +255,7 @@ fn migration_revert_with_zero_should_not_revert_any_migration() {
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE customers"),
+        None,
     );
 
     // Make sure the project is setup
@@ -307,18 +318,21 @@ fn migration_revert_with_more_than_max_should_revert_all() {
         "2017-08-31-210424_create_customers",
         "CREATE TABLE customers ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE customers"),
+        None,
     );
 
     p.create_migration(
         "2017-09-03-210424_create_contracts",
         "CREATE TABLE contracts ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE contracts"),
+        None,
     );
 
     p.create_migration(
         "2017-09-12-210424_create_bills",
         "CREATE TABLE bills ( id INTEGER PRIMARY KEY )",
         Some("DROP TABLE bills"),
+        None,
     );
 
     // Make sure the project is setup
@@ -361,6 +375,7 @@ fn migration_revert_gives_reasonable_error_message_on_missing_down() {
     p.create_migration(
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
+        None,
         None,
     );
 

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -367,7 +367,7 @@ fn test_print_schema_config(test_name: &str, test_path: &Path, schema: String) {
     let p = p.build();
 
     p.command("setup").run();
-    p.create_migration("12345_create_schema", &schema, None);
+    p.create_migration("12345_create_schema", &schema, None, None);
     let result = p.command("migration").arg("run").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
 

--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -89,6 +89,7 @@ fn setup_runs_migrations_if_no_schema_table() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     // sanity check
@@ -117,6 +118,7 @@ fn setup_doesnt_run_migrations_if_schema_table_exists() {
         "12345_create_users_table",
         "CREATE TABLE users ( id INTEGER )",
         Some("DROP TABLE users"),
+        None,
     );
 
     let result = p.command("setup").run();

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -156,8 +156,8 @@ impl Project {
         migration_path.display().to_string()
     }
 
-    pub fn create_migration(&self, name: &str, up: &str, down: Option<&str>) {
-        self.create_migration_in_directory("migrations", name, up, down);
+    pub fn create_migration(&self, name: &str, up: &str, down: Option<&str>, config: Option<&str>) {
+        self.create_migration_in_directory("migrations", name, up, down, config);
     }
 
     pub fn create_migration_in_directory(
@@ -166,6 +166,7 @@ impl Project {
         name: &str,
         up: &str,
         down: Option<&str>,
+        config: Option<&str>,
     ) {
         let migration_path = self.directory.path().join(directory).join(name);
         fs::create_dir(&migration_path)
@@ -176,6 +177,11 @@ impl Project {
         if let Some(down) = down {
             let mut down_file = fs::File::create(migration_path.join("down.sql")).unwrap();
             down_file.write_all(down.as_bytes()).unwrap();
+        }
+
+        if let Some(config) = config {
+            let mut metadata_file = fs::File::create(migration_path.join("metadata.toml")).unwrap();
+            metadata_file.write_all(config.as_bytes()).unwrap();
         }
     }
 }


### PR DESCRIPTION
This commit fixes #3506 by not running the diesel migration redo command in a transaction if any affected transaction specifies `run_in_transaction = false`.

It also adds some tests for this case.