### PR TITLE
Update benchmarks

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -65,15 +65,15 @@ jobs:
 
       - name: Run Benchmarks (Postgres)
         if: matrix.backend == 'postgres'
-        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} rust_postgres futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio quaint quaint/postgresql quaint/serde-support serde diesel-async diesel-async/${{matrix.backend}}"
+        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "postgres sqlx-bench sqlx/postgres rust_postgres futures sea-orm sea-orm/sqlx-postgres criterion/async_tokio quaint quaint/postgresql quaint/serde-support serde diesel-async diesel-async/postgres"
 
       - name: Run Benchmarks (Sqlite)
         if: matrix.backend == 'sqlite'
-        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} tokio rusqlite futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio"
+        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "sqlite sqlx-bench sqlx/sqlite tokio rusqlite futures sea-orm sea-orm/sqlx-sqlite criterion/async_tokio"
 
       - name: Run Benchmarks (Mysql)
         if: matrix.backend == 'mysql'
-        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "${{matrix.backend}} sqlx-bench sqlx/${{matrix.backend}} tokio rustorm rustorm/with-${{matrix.backend}} rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-${{matrix.backend}} criterion/async_tokio quaint quaint/mysql quaint/serde-support serde diesel-async diesel-async/${{matrix.backend}}"
+        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "mysql sqlx-bench sqlx/mysql tokio rustorm rustorm/with-mysql rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-mysql criterion/async_tokio quaint quaint/mysql quaint/serde-support serde diesel-async diesel-async/mysql"
 
       - name: Push metrics
         env:

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -20,7 +20,7 @@ rustorm = {version = "0.20", optional = true}
 rustorm_dao = {version = "0.20", optional = true}
 quaint = {version = "=0.2.0-alpha.13", optional = true, features = ["uuid"]}
 serde = {version = "1", optional = true, features = ["derive"]}
-sea-orm = {version = "0.10", optional = true, features = ["runtime-tokio-rustls"]}
+sea-orm = {version = "0.11", optional = true, features = ["runtime-tokio-rustls"]}
 futures = {version = "0.3", optional = true}
 diesel-async = {version = "0.2", optional = true, default-features = false}
 criterion-perf-events = { version = "0.2", optional = true}
@@ -54,7 +54,7 @@ fast_run = []
 
 
 [patch.crates-io]
-quaint = {git = "https://github.com/prisma/quaint", rev = "e077df3"}
+quaint = {git = "https://github.com/prisma/prisma-engines", rev = "8f088bb"}
 diesel-async = { git = "https://github.com/weiznich/diesel_async", rev = "d9e219578a7e034c2714550a5a156c8e004896bc"}
 diesel = { path = "../diesel"}
 

--- a/diesel_bench/Readme.md
+++ b/diesel_bench/Readme.md
@@ -103,7 +103,7 @@ This benchmark tests how entities from a single table are loaded. Before startin
 
 ### `bench_medium_complex_query`
 
-This benchmark tests how entities from more than one table are loaded. Before starting the benchmark 1, 10, 1000, 10000 entries are inserted into the `users` table.  For this the `id` of the user is provided by the autoincrementing id, the `name` is set to `User {id}` and the `hair_color` is set to `"black"` for even id's, to `"brown"` otherwise. An implementation of this benchmark is expected to return a list of the type `(User, Option<Post>)` so that matching pairs of `User` and `Option<Post>` are returned. Though the `posts` table is empty the corresponding implementation needs to query both tables. 
+This benchmark tests how entities from more than one table are loaded. Before starting the benchmark 1, 10, 1000, 10000 entries are inserted into the `users` table.  For this the `id` of the user is provided by the autoincrementing id, the `name` is set to `User {id}` and the `hair_color` is set to `"black"` for even id's, to `"brown"` otherwise. An implementation of this benchmark is expected to return a list of the type `(User, Option<Post>)` filtered by `hair_color = "black"` so that matching pairs of `User` and `Option<Post>` are returned. Though the `posts` table is empty the corresponding implementation needs to query both tables. 
 
 ### `bench_insert`
 

--- a/diesel_bench/benches/diesel_async_benches.rs
+++ b/diesel_bench/benches/diesel_async_benches.rs
@@ -352,16 +352,23 @@ pub fn bench_medium_complex_query_queryable_by_name(b: &mut Bencher, size: usize
         }
         conn
     });
+    #[cfg(feature = "postgres")]
+    let bind = "$1";
+    #[cfg(feature = "mysql")]
+    let bind = "?";
 
+    let query = format!(
+        "SELECT u.id, u.name, u.hair_color, p.id, p.user_id, p.title, p.body \
+         FROM users as u LEFT JOIN posts as p on u.id = p.user_id WHERE u.hair_color = {bind}"
+    );
+    let query = &query;
     b.iter(|| {
         runtime.block_on(async {
-            diesel::sql_query(
-                "SELECT u.id, u.name, u.hair_color, p.id, p.user_id, p.title, p.body \
-             FROM users as u LEFT JOIN posts as p on u.id = p.user_id",
-            )
-            .load::<(User, Option<Post>)>(&mut conn)
-            .await
-            .unwrap()
+            diesel::sql_query(query)
+                .bind::<diesel::sql_types::Text, _>("black")
+                .load::<(User, Option<Post>)>(&mut conn)
+                .await
+                .unwrap()
         })
     })
 }

--- a/diesel_bench/benches/mysql_benches.rs
+++ b/diesel_bench/benches/mysql_benches.rs
@@ -102,29 +102,33 @@ pub fn bench_medium_complex_query_by_id(b: &mut Bencher, size: usize) {
     let query = conn
         .prep(
             "SELECT u.id, u.name, u.hair_color, p.id, p.user_id, p.title, p.body \
-             FROM users as u LEFT JOIN posts as p on u.id = p.user_id",
+             FROM users as u LEFT JOIN posts as p on u.id = p.user_id WHERE u.hair_color = ?",
         )
         .unwrap();
 
     b.iter(|| {
-        conn.exec_map(&query, Params::Empty, |mut row: Row| {
-            let user = User {
-                id: row.take(0).unwrap(),
-                name: row.take(1).unwrap(),
-                hair_color: row.take(2).unwrap(),
-            };
-            let post = if let Some(id) = row.take(3).unwrap() {
-                Some(Post {
-                    id,
-                    user_id: row.take(4).unwrap(),
-                    title: row.take(5).unwrap(),
-                    body: row.take(6).unwrap(),
-                })
-            } else {
-                None
-            };
-            (user, post)
-        })
+        conn.exec_map(
+            &query,
+            Params::Positional(vec!["black".into()]),
+            |mut row: Row| {
+                let user = User {
+                    id: row.take(0).unwrap(),
+                    name: row.take(1).unwrap(),
+                    hair_color: row.take(2).unwrap(),
+                };
+                let post = if let Some(id) = row.take(3).unwrap() {
+                    Some(Post {
+                        id,
+                        user_id: row.take(4).unwrap(),
+                        title: row.take(5).unwrap(),
+                        body: row.take(6).unwrap(),
+                    })
+                } else {
+                    None
+                };
+                (user, post)
+            },
+        )
         .unwrap()
     })
 }

--- a/diesel_bench/benches/postgres_benches.rs
+++ b/diesel_bench/benches/postgres_benches.rs
@@ -121,13 +121,13 @@ pub fn bench_medium_complex_query_by_id(b: &mut Bencher, size: usize) {
     let query = client
         .prepare(
             "SELECT u.id, u.name, u.hair_color, p.id, p.user_id, p.title, p.body \
-             FROM users as u LEFT JOIN posts as p on u.id = p.user_id",
+             FROM users as u LEFT JOIN posts as p on u.id = p.user_id WHERE u.hair_color = $1",
         )
         .unwrap();
 
     b.iter(|| {
         client
-            .query_raw(&query, NO_PARAMS)
+            .query_raw(&query, &[&"black"])
             .unwrap()
             .map(|row| {
                 let user = User {

--- a/diesel_bench/benches/quaint_benches.rs
+++ b/diesel_bench/benches/quaint_benches.rs
@@ -126,7 +126,7 @@ fn insert_users(
 
     if cfg!(feature = "sqlite") {
         rt.block_on(async {
-            let transaction = conn.start_transaction().await.unwrap();
+            let transaction = conn.start_transaction(None).await.unwrap();
 
             for i in 0..size {
                 let insert = Insert::single_into("users")
@@ -188,7 +188,8 @@ pub fn bench_medium_complex_query(b: &mut Bencher, size: usize) {
                     ("p", "user_id").into(),
                     ("p", "title").into(),
                     ("p", "body").into(),
-                ]);
+                ])
+                .so_that(("u", "hair_color").equals("black"));
             let result_set = conn.select(select).await.unwrap();
             quaint::serde::from_rows::<UserWithPost>(result_set)
                 .unwrap()
@@ -269,7 +270,7 @@ pub fn loading_associations_sequentially(b: &mut Bencher) {
         rt.block_on(async { conn.insert(insert_posts.build()).await.unwrap() });
     } else {
         rt.block_on(async {
-            let transaction = conn.start_transaction().await.unwrap();
+            let transaction = conn.start_transaction(None).await.unwrap();
 
             for user in all_users {
                 for i in 0..10 {
@@ -306,7 +307,7 @@ pub fn loading_associations_sequentially(b: &mut Bencher) {
         rt.block_on(async { conn.insert(insert_comments.build()).await.unwrap() });
     } else {
         rt.block_on(async {
-            let transaction = conn.start_transaction().await.unwrap();
+            let transaction = conn.start_transaction(None).await.unwrap();
 
             for post in all_posts {
                 for i in 0..10 {

--- a/diesel_bench/benches/rusqlite_benches.rs
+++ b/diesel_bench/benches/rusqlite_benches.rs
@@ -160,12 +160,12 @@ pub fn bench_medium_complex_query_by_id(b: &mut Bencher, size: usize) {
 
     let mut query = conn.prepare(
         "SELECT u.id as myuser_id, u.name, u.hair_color, p.id as post_id, p.user_id , p.title, p.body \
-         FROM users as u LEFT JOIN posts as p on u.id = p.user_id"
+         FROM users as u LEFT JOIN posts as p on u.id = p.user_id WHERE u.hair_color = ?"
     ).unwrap();
 
     b.iter(|| {
         query
-            .query_map([], |row| {
+            .query_map([&"black"], |row| {
                 let user = User::from_row_by_id(row);
                 let post = if let Some(id) = row.get(4).unwrap() {
                     Some(Post {

--- a/diesel_bench/benches/rust_orm_benches.rs
+++ b/diesel_bench/benches/rust_orm_benches.rs
@@ -214,14 +214,20 @@ pub fn bench_medium_complex_query(b: &mut Bencher, size: usize) {
         Some(if i % 2 == 0 { "black" } else { "brown" }.into())
     });
 
+    #[cfg(feature = "postgres")]
+    let bind = "$";
+    #[cfg(any(feature = "sqlite", feature = "mysql"))]
+    let bind = "?";
+
+    let query = format!(
+        "SELECT u.id as myuser_id, u.name, u.hair_color, p.id as post_id, \
+         p.user_id, p.title, p.body FROM users as u \
+         LEFT JOIN posts as p ON u.id = p.user_id WHERE u.name = {bind}"
+    );
+
     b.iter(|| {
-        em.execute_sql_with_return::<for_load::UserWithPost>(
-            "SELECT u.id as myuser_id, u.name, u.hair_color, p.id as post_id, \
-             p.user_id, p.title, p.body FROM users as u \
-             LEFT JOIN posts as p ON u.id = p.user_id",
-            &[],
-        )
-        .unwrap()
+        em.execute_sql_with_return::<for_load::UserWithPost>(&query, &[&"black"])
+            .unwrap()
     });
 }
 

--- a/diesel_bench/benches/sea_orm_benches/mod.rs
+++ b/diesel_bench/benches/sea_orm_benches/mod.rs
@@ -143,6 +143,7 @@ pub fn bench_medium_complex_query(b: &mut Bencher, size: usize) {
     b.to_async(&rt).iter(|| async {
         let r: Vec<(self::users::Model, Option<self::posts::Model>)> = User::find()
             .find_also_related(Post)
+            .filter(self::users::Column::HairColor.eq("black"))
             .all(&conn)
             .await
             .unwrap();


### PR DESCRIPTION
* Update outdated dependencies where possible (sea-orm 0.11, some minor updates)
* Improve the `metrics.yaml` file so that it's now easier to copy these commands
* Add missing where clauses to some cases of the medium_complex_query benchmarks