### PR TITLE
Add ability to specify `ssl_cert` and `ssl_key` for MySql

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -19,7 +19,17 @@ use crate::RunQueryDsl;
 #[cfg(feature = "mysql")]
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 /// A connection to a MySQL database. Connection URLs should be in the form
-/// `mysql://[user[:password]@]host/database_name`
+/// `mysql://[user[:password]@]host/database_name[?unix_socket=socket-path&ssl_mode=SSL_MODE*&ssl_ca=/etc/ssl/certs/ca-certificates.crt&ssl_cert=/etc/ssl/certs/client-cert.crt&ssl_key=/etc/ssl/certs/client-key.crt]`
+///
+///* `host` can be an IP address or a hostname. If it is set to `localhost`, a connection
+///   will be attempted through the socket at `/tmp/mysql.sock`. If you want to connect to
+///   a local server via TCP (e.g. docker containers), use `0.0.0.0` or `127.0.0.1` instead.
+/// * `unix_socket` expects the path to the unix socket
+/// * `ssl_ca` accepts a path to the system's certificate roots
+/// * `ssl_cert` accepts a path to the client's certificate file
+/// * `ssl_key` accepts a path to the client's private key file
+/// * `ssl_mode` expects a value defined for MySQL client command option `--ssl-mode`
+/// See <https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode>
 ///
 /// # Supported loading model implementations
 ///

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -120,13 +120,15 @@ impl Connection for MysqlConnection {
 
     /// Establishes a new connection to the MySQL database
     /// `database_url` may be enhanced by GET parameters
-    /// `mysql://[user[:password]@]host[:port]/database_name[?unix_socket=socket-path&ssl_mode=SSL_MODE*&ssl_ca=/etc/ssl/certs/ca-certificates.crt]`
+    /// `mysql://[user[:password]@]host[:port]/database_name[?unix_socket=socket-path&ssl_mode=SSL_MODE*&ssl_ca=/etc/ssl/certs/ca-certificates.crt&ssl_cert=/etc/ssl/certs/client-cert.crt&ssl_key=/etc/ssl/certs/client-key.crt]`
     ///
     /// * `host` can be an IP address or a hostname. If it is set to `localhost`, a connection
     ///   will be attempted through the socket at `/tmp/mysql.sock`. If you want to connect to
     ///   a local server via TCP (e.g. docker containers), use `0.0.0.0` or `127.0.0.1` instead.
     /// * `unix_socket` expects the path to the unix socket
     /// * `ssl_ca` accepts a path to the system's certificate roots
+    /// * `ssl_cert` accepts a path to the client's certificate file
+    /// * `ssl_key` accepts a path to the client's private key file
     /// * `ssl_mode` expects a value defined for MySQL client command option `--ssl-mode`
     /// See <https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode>
     fn establish(database_url: &str) -> ConnectionResult<Self> {

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -54,6 +54,12 @@ impl RawConnection {
         if let Some(ssl_ca) = connection_options.ssl_ca() {
             self.set_ssl_ca(ssl_ca)
         }
+        if let Some(ssl_cert) = connection_options.ssl_cert() {
+            self.set_ssl_cert(ssl_cert)
+        }
+        if let Some(ssl_key) = connection_options.ssl_key() {
+            self.set_ssl_key(ssl_key)
+        }
 
         unsafe {
             // Make sure you don't use the fake one!
@@ -196,6 +202,26 @@ impl RawConnection {
                 self.0.as_ptr(),
                 mysqlclient_sys::mysql_option::MYSQL_OPT_SSL_CA,
                 ssl_ca.as_ptr() as *const std::ffi::c_void,
+            )
+        };
+    }
+
+    fn set_ssl_cert(&self, ssl_cert: &CStr) {
+        unsafe {
+            mysqlclient_sys::mysql_options(
+                self.0.as_ptr(),
+                mysqlclient_sys::mysql_option::MYSQL_OPT_SSL_CERT,
+                ssl_cert.as_ptr() as *const std::ffi::c_void,
+            )
+        };
+    }
+
+    fn set_ssl_key(&self, ssl_key: &CStr) {
+        unsafe {
+            mysqlclient_sys::mysql_options(
+                self.0.as_ptr(),
+                mysqlclient_sys::mysql_option::MYSQL_OPT_SSL_KEY,
+                ssl_key.as_ptr() as *const std::ffi::c_void,
             )
         };
     }

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -51,6 +51,8 @@ pub(super) struct ConnectionOptions {
     client_flags: CapabilityFlags,
     ssl_mode: Option<mysql_ssl_mode>,
     ssl_ca: Option<CString>,
+    ssl_cert: Option<CString>,
+    ssl_key: Option<CString>,
 }
 
 impl ConnectionOptions {
@@ -79,6 +81,16 @@ impl ConnectionOptions {
         };
 
         let ssl_ca = match query_pairs.get("ssl_ca") {
+            Some(v) => Some(CString::new(v.as_bytes())?),
+            _ => None,
+        };
+
+        let ssl_cert = match query_pairs.get("ssl_cert") {
+            Some(v) => Some(CString::new(v.as_bytes())?),
+            _ => None,
+        };
+
+        let ssl_key = match query_pairs.get("ssl_key") {
             Some(v) => Some(CString::new(v.as_bytes())?),
             _ => None,
         };
@@ -131,6 +143,8 @@ impl ConnectionOptions {
             ssl_mode,
             unix_socket,
             ssl_ca,
+            ssl_cert,
+            ssl_key,
         })
     }
 
@@ -160,6 +174,14 @@ impl ConnectionOptions {
 
     pub(super) fn ssl_ca(&self) -> Option<&CStr> {
         self.ssl_ca.as_deref()
+    }
+
+    pub(super) fn ssl_cert(&self) -> Option<&CStr> {
+        self.ssl_cert.as_deref()
+    }
+
+    pub(super) fn ssl_key(&self) -> Option<&CStr> {
+        self.ssl_key.as_deref()
     }
 
     pub(super) fn client_flags(&self) -> CapabilityFlags {

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -346,6 +346,54 @@ fn ssl_ca_tests() {
 }
 
 #[test]
+fn ssl_cert_tests() {
+    let ssl_cert = "/etc/ssl/certs/client-cert.crt";
+    let username = "foo";
+    let password = "bar";
+    let db_url = format!("mysql://{username}:{password}@localhost?ssl_cert={ssl_cert}");
+    let conn_opts = ConnectionOptions::parse(db_url.as_str()).unwrap();
+    let cstring = |s| CString::new(s).unwrap();
+    assert_eq!(Some(cstring("localhost")), conn_opts.host);
+    assert_eq!(None, conn_opts.port);
+    assert_eq!(cstring(username), conn_opts.user);
+    assert_eq!(cstring(password), conn_opts.password.unwrap());
+    assert_eq!(CString::new(ssl_cert).unwrap(), conn_opts.ssl_cert.unwrap());
+
+    let url_with_unix_str_and_ssl_cert = format!(
+        "mysql://{username}:{password}@localhost?unix_socket=/var/run/mysqld.sock&ssl_cert={ssl_cert}"
+    );
+
+    let conn_opts2 = ConnectionOptions::parse(url_with_unix_str_and_ssl_cert.as_str()).unwrap();
+    assert_eq!(None, conn_opts2.host);
+    assert_eq!(None, conn_opts2.port);
+    assert_eq!(CString::new(ssl_cert).unwrap(), conn_opts2.ssl_cert.unwrap());
+}
+
+#[test]
+fn ssl_key_tests() {
+    let ssl_key = "/etc/ssl/certs/client-key.crt";
+    let username = "foo";
+    let password = "bar";
+    let db_url = format!("mysql://{username}:{password}@localhost?ssl_key={ssl_key}");
+    let conn_opts = ConnectionOptions::parse(db_url.as_str()).unwrap();
+    let cstring = |s| CString::new(s).unwrap();
+    assert_eq!(Some(cstring("localhost")), conn_opts.host);
+    assert_eq!(None, conn_opts.port);
+    assert_eq!(cstring(username), conn_opts.user);
+    assert_eq!(cstring(password), conn_opts.password.unwrap());
+    assert_eq!(CString::new(ssl_key).unwrap(), conn_opts.ssl_key.unwrap());
+
+    let url_with_unix_str_and_ssl_key = format!(
+        "mysql://{username}:{password}@localhost?unix_socket=/var/run/mysqld.sock&ssl_key={ssl_key}"
+    );
+
+    let conn_opts2 = ConnectionOptions::parse(url_with_unix_str_and_ssl_key.as_str()).unwrap();
+    assert_eq!(None, conn_opts2.host);
+    assert_eq!(None, conn_opts2.port);
+    assert_eq!(CString::new(ssl_key).unwrap(), conn_opts2.ssl_key.unwrap());
+}
+
+#[test]
 fn ssl_mode() {
     let ssl_mode = |url| ConnectionOptions::parse(url).unwrap().ssl_mode();
     assert_eq!(ssl_mode("mysql://localhost"), None);

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -366,7 +366,10 @@ fn ssl_cert_tests() {
     let conn_opts2 = ConnectionOptions::parse(url_with_unix_str_and_ssl_cert.as_str()).unwrap();
     assert_eq!(None, conn_opts2.host);
     assert_eq!(None, conn_opts2.port);
-    assert_eq!(CString::new(ssl_cert).unwrap(), conn_opts2.ssl_cert.unwrap());
+    assert_eq!(
+        CString::new(ssl_cert).unwrap(),
+        conn_opts2.ssl_cert.unwrap()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Also updated docs for `MysqlConnection` per https://github.com/diesel-rs/diesel/discussions/3624#discussioncomment-5869196