### PR TITLE
Fix compile fails on target `aarch64-unknown-linux-gnu` with feature mysql

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -222,7 +222,7 @@ impl Drop for BindData {
 impl BindData {
     fn for_input((tpe, data): (MysqlType, Option<Vec<u8>>)) -> Self {
         let (tpe, flags) = tpe.into();
-        let is_null = i8::from(data.is_none());
+        let is_null = ffi::my_bool::from(data.is_none());
         let mut bytes = data.unwrap_or_default();
         let ptr = NonNull::new(bytes.as_mut_ptr());
         let len = bytes.len() as libc::c_ulong;


### PR DESCRIPTION
Current diesel has this conversion
```rust
    fn for_input((tpe, data): (MysqlType, Option<Vec<u8>>)) -> Self {
        let (tpe, flags) = tpe.into();
        let is_null = i8::from(data.is_none());
        let mut bytes = data.unwrap_or_default();
        let ptr = NonNull::new(bytes.as_mut_ptr());
        let len = bytes.len() as libc::c_ulong;
        let capacity = bytes.capacity();
        mem::forget(bytes);
        Self {
            tpe,
            bytes: ptr,
            length: len,
            capacity,
            flags,
            is_null,
            is_truncated: None,
        }
    }
```
Notice that `is_null` has type `mysqlclient_sys::my_bool = std::os::raw::c_char` but it receives an `i8`. On certain platforms, `aarch64-unknown-linux-gnu` in this case, `c_char` is `u8` thus compile failes.

This PR fix this.
