### PR TITLE
Enable `distinct_on` with `postgres_backend` instead of `postgres`

### DIFF
--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -173,7 +173,7 @@ pub trait QueryDsl: Sized {
     ///                    Animal::new("spider", None, 8)]), distinct_animals);
     /// # }
     /// ```
-    #[cfg(feature = "postgres")]
+    #[cfg(feature = "postgres_backend")]
     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     where
         Self: methods::DistinctOnDsl<Expr>,


### PR DESCRIPTION
I noticed when working with `QueryDsl` that the method `distinct_on` is only available when Diesel is compiled with the `postgres` feature.  
The trait this function is based on though is available when compiling the crate with `postgres_backend`.

This PR changes the cfg flag above the function declaration to `postgres_backend`.

The change shouldn't be breaking since the `postgres` feature enables the `postgres_backend` feature.