### PR TITLE
Add support for the array concat operation in the dsl

### DIFF
--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -370,6 +370,50 @@ pub trait PgArrayExpressionMethods: Expression + Sized {
     {
         ArrayIndex::new(self, other.as_expression())
     }
+
+    /// Concatenates two PostgreSQL Arrays using the `||` operator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         tags -> Array<VarChar>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)")
+    /// #         .execute(conn)
+    /// #         .unwrap();
+    /// #
+    /// diesel::insert_into(posts)
+    ///     .values(tags.eq(vec!["cool", "awesome"]))
+    ///     .execute(conn)?;
+    ///
+    /// let res = posts.select(tags.concat(vec!["amazing"])).load::<Vec<String>>(conn)?;
+    /// let expected_tags = vec!["cool", "awesome", "amazing"];
+    /// assert_eq!(expected_tags, res[0]);
+    /// #     Ok(())
+    /// # }
+    ///
+    fn concat<T>(self, other: T) -> dsl::ConcatArray<Self, T>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
+        Grouped(ConcatArray::new(self, other.as_expression()))
+    }
 }
 
 impl<T> PgArrayExpressionMethods for T

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -371,7 +371,9 @@ pub trait PgArrayExpressionMethods: Expression + Sized {
         ArrayIndex::new(self, other.as_expression())
     }
 
-    /// Concatenates two PostgreSQL Arrays using the `||` operator.
+    /// Creates a PostgreSQL `||` expression.
+    ///
+    /// This operator concatenates two Array values and returns Array value
     ///
     /// # Example
     ///

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -185,6 +185,6 @@ pub type LikeBinary<Lhs, Rhs> = Grouped<super::operators::LikeBinary<Lhs, AsExpr
 pub type NotLikeBinary<Lhs, Rhs> =
     Grouped<super::operators::NotLikeBinary<Lhs, AsExprOf<Rhs, Binary>>>;
 
-/// The return type of [`lhs.remove_by_path(rhs)`](super::expression_methods::PgArrayExpressionMethods::concat)
+/// The return type of [`lhs.concat(rhs)`](super::expression_methods::PgArrayExpressionMethods::concat)
 #[cfg(feature = "postgres_backend")]
 pub type ConcatArray<Lhs, Rhs> = Grouped<super::operators::ConcatArray<Lhs, AsExpr<Rhs, Lhs>>>;

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -184,3 +184,7 @@ pub type LikeBinary<Lhs, Rhs> = Grouped<super::operators::LikeBinary<Lhs, AsExpr
 #[cfg(feature = "postgres_backend")]
 pub type NotLikeBinary<Lhs, Rhs> =
     Grouped<super::operators::NotLikeBinary<Lhs, AsExprOf<Rhs, Binary>>>;
+
+/// The return type of [`lhs.remove_by_path(rhs)`](super::expression_methods::PgArrayExpressionMethods::concat)
+#[cfg(feature = "postgres_backend")]
+pub type ConcatArray<Lhs, Rhs> = Grouped<super::operators::ConcatArray<Lhs, AsExpr<Rhs, Lhs>>>;

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -52,6 +52,12 @@ infix_operator!(RemoveByPathFromJsonb, " #-", Jsonb, backend: Pg);
 infix_operator!(ConcatBinary, " || ", Binary, backend: Pg);
 infix_operator!(LikeBinary, " LIKE ", backend: Pg);
 infix_operator!(NotLikeBinary, " NOT LIKE ", backend: Pg);
+__diesel_infix_operator!(
+    ConcatArray,
+    " || ",
+    __diesel_internal_SameResultAsInput,
+    backend: Pg
+);
 
 #[derive(Debug, Clone, Copy, QueryId, DieselNumericOps, ValidGrouping)]
 #[doc(hidden)]

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "bigdecimal",
  "bitflags 2.2.1",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",

--- a/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
+++ b/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
@@ -13,5 +13,5 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and 124 others
+           and $N others
    = note: required for `{integer}` to implement `AsExpression<diesel::sql_types::Text>`


### PR DESCRIPTION
This adds support for the ` || ` operator on arrays. This feature was already requested in #1412 