### PR TITLE
Allow ~type inference on `And` and `Or` helper types

### DIFF
--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -5,6 +5,7 @@ use super::array_comparison::{AsInExpression, In, NotIn};
 use super::grouped::Grouped;
 use super::select_by::SelectBy;
 use super::{AsExpression, Expression};
+use crate::expression_methods::PreferredBoolSqlType;
 use crate::sql_types;
 
 /// The SQL type of an expression
@@ -94,12 +95,13 @@ pub type AssumeNotNull<Expr> = super::assume_not_null::AssumeNotNull<Expr>;
 
 /// The return type of
 /// [`lhs.and(rhs)`](crate::expression_methods::BoolExpressionMethods::and())
-pub type And<Lhs, Rhs, ST = sql_types::Bool> =
+pub type And<Lhs, Rhs, ST = <Rhs as PreferredBoolSqlType>::PreferredSqlType> =
     Grouped<super::operators::And<Lhs, AsExprOf<Rhs, ST>>>;
 
 /// The return type of
 /// [`lhs.or(rhs)`](crate::expression_methods::BoolExpressionMethods::or())
-pub type Or<Lhs, Rhs, ST = sql_types::Bool> = Grouped<super::operators::Or<Lhs, AsExprOf<Rhs, ST>>>;
+pub type Or<Lhs, Rhs, ST = <Rhs as PreferredBoolSqlType>::PreferredSqlType> =
+    Grouped<super::operators::Or<Lhs, AsExprOf<Rhs, ST>>>;
 
 /// The return type of
 /// [`lhs.escape('x')`](crate::expression_methods::EscapeExpressionMethods::escape())

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -126,29 +126,36 @@ pub trait PreferredBoolSqlType {
     /// That should be either `Bool` or `Nullable<Bool>`.
     type PreferredSqlType;
 }
+
 impl<E: Expression> PreferredBoolSqlType for E
 where
     E::SqlType: BoolOrNullableBool,
 {
     type PreferredSqlType = <E as Expression>::SqlType;
 }
+
 /// This impl has to live in Diesel because otherwise it would conflict with the blanket impl above
 /// because "diesel might add an implementation of Expression for bool"
 impl PreferredBoolSqlType for bool {
     type PreferredSqlType = sql_types::Bool;
 }
+
 impl PreferredBoolSqlType for &bool {
     type PreferredSqlType = sql_types::Bool;
 }
+
 impl PreferredBoolSqlType for &&bool {
     type PreferredSqlType = sql_types::Bool;
 }
+
 impl PreferredBoolSqlType for Option<bool> {
     type PreferredSqlType = sql_types::Nullable<sql_types::Bool>;
 }
+
 impl PreferredBoolSqlType for &Option<bool> {
     type PreferredSqlType = sql_types::Nullable<sql_types::Bool>;
 }
+
 impl PreferredBoolSqlType for &&Option<bool> {
     type PreferredSqlType = sql_types::Nullable<sql_types::Bool>;
 }

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -112,7 +112,7 @@ where
 ///
 /// It works with types that are [Expression]s and have a [`SqlType`](Expression::SqlType) that is
 /// either [`Bool`](sql_types::Bool) or [`Nullable<Bool>`](sql_types::Nullable), and with [`bool`]
-/// (and `&bool` and `&&bool`).
+/// (and `Option<bool>` and references to those).
 ///
 /// Cases where an additional type parameter would still have to be specified in the helper type
 /// generic parameters are:
@@ -142,4 +142,13 @@ impl PreferredBoolSqlType for &bool {
 }
 impl PreferredBoolSqlType for &&bool {
     type PreferredSqlType = sql_types::Bool;
+}
+impl PreferredBoolSqlType for Option<bool> {
+    type PreferredSqlType = sql_types::Nullable<sql_types::Bool>;
+}
+impl PreferredBoolSqlType for &Option<bool> {
+    type PreferredSqlType = sql_types::Nullable<sql_types::Bool>;
+}
+impl PreferredBoolSqlType for &&Option<bool> {
+    type PreferredSqlType = sql_types::Nullable<sql_types::Bool>;
 }

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -2,7 +2,7 @@ use crate::dsl;
 use crate::expression::grouped::Grouped;
 use crate::expression::operators::{And, Or};
 use crate::expression::{AsExpression, Expression, TypedExpressionType};
-use crate::sql_types::{BoolOrNullableBool, SqlType};
+use crate::sql_types::{self, BoolOrNullableBool, SqlType};
 
 /// Methods present on boolean expressions
 pub trait BoolExpressionMethods: Expression + Sized {
@@ -102,4 +102,44 @@ where
     T: Expression,
     T::SqlType: BoolOrNullableBool,
 {
+}
+
+/// Allow ~type inference on [And](crate::helper_types::And) and [Or](crate::helper_types::Or)
+/// helper types
+///
+/// This is used to be statistically correct as last generic parameter of `dsl::And` and `dsl::Or`
+/// without having to specify an additional type parameter.
+///
+/// It works with types that are [Expression]s and have a [`SqlType`](Expression::SqlType) that is
+/// either [`Bool`](sql_types::Bool) or [`Nullable<Bool>`](sql_types::Nullable), and with [`bool`]
+/// (and `&bool` and `&&bool`).
+///
+/// Cases where an additional type parameter would still have to be specified in the helper type
+/// generic parameters are:
+/// - If this trait isn't implemented for the `other` parameter of the expression
+///   (in that case the user (you?) probably wants to implement it)
+/// - If the user actually was using the not-preferred implementation of `AsExpression`
+///   (e.g. towards `Nullable<Bool>` instead of `Bool`)
+pub trait PreferredBoolSqlType {
+    /// The preferred `Bool` SQL type for this AsExpression implementation.
+    ///
+    /// That should be either `Bool` or `Nullable<Bool>`.
+    type PreferredSqlType;
+}
+impl<E: Expression> PreferredBoolSqlType for E
+where
+    E::SqlType: BoolOrNullableBool,
+{
+    type PreferredSqlType = <E as Expression>::SqlType;
+}
+/// This impl has to live in Diesel because otherwise it would conflict with the blanket impl above
+/// because "diesel might add an implementation of Expression for bool"
+impl PreferredBoolSqlType for bool {
+    type PreferredSqlType = sql_types::Bool;
+}
+impl PreferredBoolSqlType for &bool {
+    type PreferredSqlType = sql_types::Bool;
+}
+impl PreferredBoolSqlType for &&bool {
+    type PreferredSqlType = sql_types::Bool;
 }

--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -11,7 +11,7 @@ mod global_expression_methods;
 mod text_expression_methods;
 
 #[doc(inline)]
-pub use self::bool_expression_methods::BoolExpressionMethods;
+pub use self::bool_expression_methods::{BoolExpressionMethods, PreferredBoolSqlType};
 #[doc(hidden)]
 pub use self::eq_all::EqAll;
 #[doc(inline)]


### PR DESCRIPTION
This is [particularly useful for query fragment functions type inference](https://github.com/diesel-rs/diesel/discussions/3661#discussioncomment-6180421) (you probably want to read that discussion first).

It works with types that are `Expression`s and have a `SqlType` that is either `Bool` or `Nullable<Bool>`, with `bool` (and `&bool` and `&&bool`), and with custom user types provided they implement this trait (otherwise they would just have to specify manually).

Latest design discussions on why we currently have this constraint: https://github.com/diesel-rs/diesel/issues/2589#issuecomment-748238464

Cases where an additional type parameter would still have to be specified in the helper type generic parameters are:
- If this trait isn't implemented for the `other` parameter of the expression - this is technically a breaking change, but a user would have to be using a custom type that has `AsExpression<Bool>` but **not** `Expression<SqlType=Bool>` as `other` **and** have written `dsl::And/Or<x, ThatCustomType>` without the explicit 3rd parameter somewhere for it to actually break. I would estimate that to be unlikely enough that we can fake the non-breaking change, especially in the light of its use for `diesel_auto_type`/`Selectable`.
- If the user actually was using the not-preferred implementation of `AsExpression` (e.g. towards `Nullable<Bool>` instead of `Bool`) - this is not a breaking change, because in that case the user is already overriding the 3rd generic parameter.