### PR TITLE
Correctly quote the table name in one of the `print-schema` queries

### DIFF
--- a/diesel_cli/src/infer_schema_internals/pg.rs
+++ b/diesel_cli/src/infer_schema_internals/pg.rs
@@ -61,8 +61,13 @@ pub fn determine_column_type(
 diesel::postfix_operator!(Regclass, "::regclass", sql_types::Oid, backend: Pg);
 
 fn regclass(table: &TableName) -> Regclass<AsExprOf<String, sql_types::Text>> {
+    let table_name = match table.schema {
+        Some(ref schema_name) => format!("\"{}\".\"{}\"", schema_name, table.sql_name),
+        None => format!("\"{}\"", table.sql_name),
+    };
+
     Regclass::new(<String as AsExpression<sql_types::Text>>::as_expression(
-        table.full_sql_name(),
+        table_name,
     ))
 }
 

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -315,6 +315,23 @@ fn print_schema_several_keys_with_compound_key() {
     test_print_schema("print_schema_several_keys_with_compound_key", vec![])
 }
 
+// some mysql versions concert quoted table names to lowercase
+// anyway
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+#[test]
+fn print_schema_quoted_table_name() {
+    test_print_schema("print_schema_quoted_table_name", vec![])
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn print_schema_quoted_schema_and_table_name() {
+    test_print_schema(
+        "print_schema_quoted_schema_and_table_name",
+        vec!["--schema", "CustomSchema"],
+    )
+}
+
 #[cfg(feature = "sqlite")]
 const BACKEND: &str = "sqlite";
 #[cfg(feature = "postgres")]

--- a/diesel_cli/tests/print_schema/print_schema_quoted_schema_and_table_name/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_schema_and_table_name/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+schema = "CustomSchema"

--- a/diesel_cli/tests/print_schema/print_schema_quoted_schema_and_table_name/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_schema_and_table_name/postgres/expected.snap
@@ -1,0 +1,14 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_quoted_schema_and_table_name"
+---
+// @generated automatically by Diesel CLI.
+
+pub mod CustomSchema {
+    diesel::table! {
+        CustomSchema.User (id) {
+            id -> Int4,
+        }
+    }
+}
+

--- a/diesel_cli/tests/print_schema/print_schema_quoted_schema_and_table_name/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_schema_and_table_name/postgres/schema.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA "CustomSchema";
+
+CREATE TABLE "CustomSchema"."User" (
+    id integer PRIMARY KEY NOT NULL
+);

--- a/diesel_cli/tests/print_schema/print_schema_quoted_table_name/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_table_name/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/print_schema/print_schema_quoted_table_name/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_table_name/postgres/expected.snap
@@ -1,0 +1,12 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_quoted_table_name"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    User (id) {
+        id -> Int4,
+    }
+}
+

--- a/diesel_cli/tests/print_schema/print_schema_quoted_table_name/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_table_name/postgres/schema.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "User" (
+    id integer PRIMARY KEY NOT NULL
+);

--- a/diesel_cli/tests/print_schema/print_schema_quoted_table_name/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_table_name/sqlite/expected.snap
@@ -1,0 +1,12 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_quoted_table_name"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    User (id) {
+        id -> Integer,
+    }
+}
+

--- a/diesel_cli/tests/print_schema/print_schema_quoted_table_name/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_quoted_table_name/sqlite/schema.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "User" (
+    id integer PRIMARY KEY NOT NULL
+);


### PR DESCRIPTION
We missed a quote in a table name before casting the table name to `regclass`. This causes postgres to coerce the table name to lowercase, which causes the query to seek for a non-existing table. This fixes #3673.