### PR TITLE
feat(diesel_cli) sqlite use "rowid" if no explicit primary key is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ default features enabled using some set of dependencies. Those set of dependenci
 an up to date version of the specific dependency. We check this by using the unstable `-Z minimal-version` cargo flag. 
 Increasing the minimal supported Rust version will always be coupled at least with a minor release.
 
-## Unreleased 
+## Unreleased
+
+### Added
+
+* Added automatic usage of all sqlite `rowid` aliases when no explicit primary key is defined for `print-schema`
 
 ## [2.1.0] 2023-05-26
 

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -434,3 +434,18 @@ fn load_foreign_key_constraints_loads_foreign_keys() {
     let fks = load_foreign_key_constraints(&mut connection, None).unwrap();
     assert_eq!(vec![fk_one, fk_two], fks);
 }
+
+#[test]
+fn all_rowid_aliases_used_empty_result() {
+    let mut connection = SqliteConnection::establish(":memory:").unwrap();
+
+    diesel::sql_query("CREATE TABLE table_1 (rowid TEXT, oid TEXT, _rowid_ TEXT)")
+        .execute(&mut connection)
+        .unwrap();
+
+    let table_1 = TableName::from_name("table_1");
+
+    let res = get_primary_keys(&mut connection, &table_1);
+    assert!(res.is_ok());
+    assert!(res.unwrap().is_empty());
+}

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -207,14 +207,20 @@ pub fn get_primary_keys(
     let results = sql::<pragma_table_info::SqlType>(&query).load::<FullTableInfo>(conn)?;
     let mut collected: Vec<String> = results
         .iter()
-        .filter_map(|i| if i.primary_key { Some(i.name.clone()) } else { None })
+        .filter_map(|i| {
+            if i.primary_key {
+                Some(i.name.clone())
+            } else {
+                None
+            }
+        })
         .collect();
     // SQLite tables without "WITHOUT ROWID" always have aliases for the implicit PRIMARY KEY "rowid" and its aliases
     // unless the user defines a column with those names, then the name in question refers to the created column
     // https://www.sqlite.org/rowidtable.html
     if collected.is_empty() {
         for alias in SQLITE_ROWID_ALIASES {
-            if results.iter().find(|v| &v.name.as_str() == alias).is_some() {
+            if results.iter().any(|v| &v.name.as_str() == alias) {
                 continue;
             }
 

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -200,10 +200,14 @@ pub fn get_primary_keys(
         format!("PRAGMA TABLE_INFO('{}')", &table.sql_name)
     };
     let results = sql::<pragma_table_info::SqlType>(&query).load::<FullTableInfo>(conn)?;
-    Ok(results
+    let mut collected: Vec<String> = results
         .into_iter()
         .filter_map(|i| if i.primary_key { Some(i.name) } else { None })
-        .collect())
+        .collect();
+    if collected.is_empty() {
+        collected.push("rowid".to_owned());
+    }
+    Ok(collected)
 }
 
 pub fn determine_column_type(

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+file = "src/schema.rs"

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/expected.snap
@@ -5,8 +5,25 @@ description: "Test: print_schema_sqlite_without_explicit_primary_key"
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    test (rowid) {
+    no_explicit (rowid) {
         rowid -> Integer,
         name -> Text,
+    }
+}
+
+diesel::table! {
+    with_explicit_rowid (oid) {
+        oid -> Integer,
+        name -> Text,
+        rowid -> Text,
+    }
+}
+
+diesel::table! {
+    with_explicit_rowid_oid (_rowid_) {
+        _rowid_ -> Integer,
+        name -> Text,
+        rowid -> Text,
+        oid -> Text,
     }
 }

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/expected.snap
@@ -1,0 +1,12 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_sqlite_without_explicit_primary_key"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    test (rowid) {
+        rowid -> Integer,
+        name -> Text,
+    }
+}

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/schema.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test (
+    name TEXT
+);

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/schema.sql
@@ -1,3 +1,14 @@
-CREATE TABLE test (
+CREATE TABLE no_explicit (
     name TEXT
+);
+
+CREATE TABLE with_explicit_rowid (
+    name TEXT,
+    rowid TEXT
+);
+
+CREATE TABLE with_explicit_rowid_oid (
+    name TEXT,
+    rowid TEXT,
+    oid TEXT
 );


### PR DESCRIPTION
This PR adds column `rowid` if no explicit primary key is present.

This currently works because all tables created without `WITHOUT ROWID` either have a explicit `PRIMARY KEY` or a `rowid` and tables with `WITHOUT ROWID` always have a `PRIMARY KEY`

this PR is marked as a WIP, because documentation is missing, and i am not sure where the proper place is to add documentation about this

fixes #3679