### PR TITLE
fix(diesel_cli): use separate lines for multiple annotations

### DIFF
--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -697,20 +697,11 @@ impl<'a> Display for ColumnDefinitions<'a> {
                 }
 
                 // Write out attributes
-                if column.rust_name != column.sql_name || column.ty.max_length.is_some() {
-                    let mut is_first = true;
-                    write!(out, r#"#["#)?;
-                    if column.rust_name != column.sql_name {
-                        write!(out, r#"sql_name = {:?}"#, column.sql_name)?;
-                        is_first = false;
-                    }
-                    if let Some(max_length) = column.ty.max_length {
-                        if !is_first {
-                            write!(out, ", ")?;
-                        }
-                        write!(out, "max_length = {}", max_length)?;
-                    }
-                    writeln!(out, r#"]"#)?;
+                if column.rust_name != column.sql_name {
+                    writeln!(out, r#"#[sql_name = "{}"]"#, column.sql_name)?;
+                }
+                if let Some(max_length) = column.ty.max_length {
+                    writeln!(out, r#"#[max_length = {}]"#, max_length)?;
                 }
 
                 writeln!(out, "{} -> {},", column.rust_name, column_type)?;

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -252,6 +252,12 @@ fn print_schema_generated_columns_with_generated_always() {
 
 #[test]
 #[cfg(feature = "postgres")]
+fn print_schema_multiple_annotations() {
+    test_print_schema("print_schema_multiple_annotations", vec![])
+}
+
+#[test]
+#[cfg(feature = "postgres")]
 fn print_schema_array_type() {
     test_print_schema("print_schema_array_type", vec![])
 }

--- a/diesel_cli/tests/print_schema/print_schema_multiple_annotations/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_multiple_annotations/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = false

--- a/diesel_cli/tests/print_schema/print_schema_multiple_annotations/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_multiple_annotations/postgres/expected.snap
@@ -1,0 +1,15 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_multiple_annotations"
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    example (id) {
+        id -> Int4,
+        #[sql_name = "type"]
+        #[max_length = 10]
+        type_ -> Nullable<Varchar>,
+    }
+}
+

--- a/diesel_cli/tests/print_schema/print_schema_multiple_annotations/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_multiple_annotations/postgres/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE example (
+    id SERIAL PRIMARY KEY,
+    "type" VARCHAR(10)
+);


### PR DESCRIPTION
We were running into a compilation error from diesel-derives where we had both a `sql_name` and `max_length` annotation for the same property, which would generate something like this:

```rust
diesel::table! {
    example (id) {
        id -> Uuid,
        #[sql_name = "type", max_length = 200]
        type_ -> Nullable<Varchar>,
    }
}
```

and would throw a compilation error like this:

```
error: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
       Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
```

_note: this isn't yet tested locally, as I've had trouble getting this repo running locally_

This should result in something like the following, which wouldn't fail to compile:

```rust
diesel::table! {
    example (id) {
        id -> Uuid,
        #[sql_name = "type"]
        #[max_length = 200]
        type_ -> Nullable<Varchar>,
    }
}
```