### PR TITLE
Diesel query fragment type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Added
 
 * Added automatic usage of all sqlite `rowid` aliases when no explicit primary key is defined for `print-schema`
+* Added a `#[dsl::auto_type]` attribute macro, allowing to infer type of query fragment functions
+* Added the same type inference on `Selectable` derives, which allows skipping specifying `select_expression_type` most of the time, in turn enabling most queries to be written using just a `Selectable` derive.
 
 ## [2.1.0] 2023-05-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "diesel_migrations/migrations_macros",
     "diesel_dynamic_schema",
     "diesel_table_macro_syntax",
+    "dsl_auto_type",
     "examples/mysql/all_about_inserts",
     "examples/mysql/getting_started_step_1",
     "examples/mysql/getting_started_step_2",

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -123,6 +123,14 @@ pub type NotLike<Lhs, Rhs> = Grouped<super::operators::NotLike<Lhs, AsExprOf<Rhs
 /// Represents the return type of [`.as_select()`](crate::prelude::SelectableHelper::as_select)
 pub type AsSelect<Source, DB> = SelectBy<Source, DB>;
 
+/// The return type of [`alias.field(field)`](crate::query_source::Alias::field)
+pub type Field<Alias, Field> = Fields<Alias, Field>;
+
+/// The return type of [`alias.fields(fields)`](crate::query_source::Alias::fields)
+pub type Fields<Alias, Fields> = <Fields as crate::query_source::aliasing::FieldAliasMapper<
+    <Alias as crate::query_source::aliasing::GetAliasSourceFromAlias>::Source,
+>>::Out;
+
 // we allow unreachable_pub here
 // as rustc otherwise shows false positives
 // for every item in this module. We reexport

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -547,7 +547,9 @@ where
 /// If you want to avoid nesting types, you can use the
 /// [`Selectable`](derive@Selectable) derive macro's
 /// `select_expression` and `select_expression_type` attributes to
-/// flatten the fields.
+/// flatten the fields. If the `select_expression` is simple enough,
+/// it is not necessary to specify `select_expression_type`
+/// (most query fragments are supported for this).
 ///
 /// ```rust
 /// # include!("../doctest_setup.rs");
@@ -571,10 +573,8 @@ where
 ///     #[diesel(select_expression_type = users::columns::id)]
 ///     id: i32,
 ///     #[diesel(select_expression = users::columns::name)]
-///     #[diesel(select_expression_type = users::columns::name)]
 ///     name: String,
 ///     #[diesel(select_expression = posts::columns::title)]
-///     #[diesel(select_expression_type = posts::columns::title)]
 ///     title: String,
 /// }
 ///

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -330,6 +330,9 @@ pub mod dsl {
     pub use crate::query_builder::functions::{
         delete, insert_into, insert_or_ignore_into, replace_into, select, sql_query, update,
     };
+
+    #[doc(inline)]
+    pub use diesel_derives::auto_type;
 }
 
 pub mod helper_types {

--- a/diesel/src/query_source/aliasing/alias.rs
+++ b/diesel/src/query_source/aliasing/alias.rs
@@ -187,3 +187,13 @@ where
 {
     type Count = Never;
 }
+
+/// To be able to define `helper_types::Fields` with the ususal conventions
+///
+/// This type is intentionally not publically exported
+pub trait GetAliasSourceFromAlias {
+    type Source;
+}
+impl<S> GetAliasSourceFromAlias for Alias<S> {
+    type Source = S;
+}

--- a/diesel/src/query_source/aliasing/macros.rs
+++ b/diesel/src/query_source/aliasing/macros.rs
@@ -84,6 +84,10 @@ macro_rules! alias {
                 pub const $alias_name: Alias<$alias_ty> = $($table)::+ as $alias_name;
             )*
         }
+        $(
+            #[allow(non_camel_case_types)]
+            type $alias_name = $crate::query_source::Alias::<$alias_ty>;
+        )*
     };
     ($($vis: vis const $const_name: ident: Alias<$alias_ty: ident> = $($table: ident)::+ as $alias_sql_name: ident);* $(;)?) => {
         $crate::alias!(NoConst $($($table)::+ as $alias_sql_name: $vis $alias_ty,)*);

--- a/diesel/src/query_source/aliasing/macros.rs
+++ b/diesel/src/query_source/aliasing/macros.rs
@@ -84,10 +84,6 @@ macro_rules! alias {
                 pub const $alias_name: Alias<$alias_ty> = $($table)::+ as $alias_name;
             )*
         }
-        $(
-            #[allow(non_camel_case_types)]
-            type $alias_name = $crate::query_source::Alias::<$alias_ty>;
-        )*
     };
     ($($vis: vis const $const_name: ident: Alias<$alias_ty: ident> = $($table: ident)::+ as $alias_sql_name: ident);* $(;)?) => {
         $crate::alias!(NoConst $($($table)::+ as $alias_sql_name: $vis $alias_ty,)*);
@@ -95,6 +91,9 @@ macro_rules! alias {
             #[allow(non_upper_case_globals)]
             $vis const $const_name: $crate::query_source::Alias::<$alias_ty> =
                 $crate::query_source::Alias::new($alias_ty { table: $($table)::+::table });
+
+            #[allow(non_camel_case_types)]
+            $vis type $const_name = $crate::query_source::Alias::<$alias_ty>;
         )*
     };
     (NoConst $($($table: ident)::+ as $alias_sql_name: ident: $vis: vis $alias_ty: ident),* $(,)?) => {

--- a/diesel/src/query_source/aliasing/mod.rs
+++ b/diesel/src/query_source/aliasing/mod.rs
@@ -24,6 +24,8 @@ pub use aliased_field::AliasedField;
 #[doc(hidden)] // This is used by the table macro
 pub use field_alias_mapper::{FieldAliasMapper, FieldAliasMapperAssociatedTypesDisjointnessTrick};
 
+pub(crate) use alias::GetAliasSourceFromAlias;
+
 /// Types created by the `alias!` macro that serve to distinguish between aliases implement
 /// this trait.
 ///

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -63,6 +63,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "diesel"
 version = "2.1.0"
 dependencies = [
@@ -101,17 +136,42 @@ name = "diesel_derives"
 version = "2.1.0"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "diesel_table_macro_syntax"
 version = "0.1.0"
 dependencies = [
- "syn 2.0.8",
+ "syn 2.0.16",
 ]
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.0"
+dependencies = [
+ "darling",
+ "either",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -128,6 +188,18 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -322,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -414,6 +486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/diesel_compile_tests/tests/fail/auto_type.rs
+++ b/diesel_compile_tests/tests/fail/auto_type.rs
@@ -1,0 +1,75 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        user_id -> Integer,
+    }
+}
+
+joinable!(posts -> users (user_id));
+
+#[dsl::auto_type]
+fn user_has_post_with_id_greater_than(id_greater_than: i32) -> _ {
+    dsl::exists(
+        posts::table
+            .filter(posts::user_id.eq(users::id))
+            .filter(posts::id.gt(id_greater_than)),
+    )
+}
+
+#[dsl::auto_type]
+fn users_with_posts_with_id_greater_than(id_greater_than: i32) -> _ {
+    // This fails because the macro infers the type of
+    // `user_has_post_with_id_greater_than(id_greater_than)` to be
+    // `user_has_post_with_id_greater_than<i32>`
+    users::table
+        .filter(user_has_post_with_id_greater_than(id_greater_than))
+        .select(users::name)
+}
+
+#[dsl::auto_type]
+fn user_has_post_with_id_greater_than_2() -> _ {
+    // We check here that only the error on n shows, and that it shows only once
+    // (Litterals must have type suffix for auto_type, e.g. 2i64), and that it's properly spanned
+    // (on the `2`)
+    let n = 2;
+    let m = 3;
+    dsl::exists(
+        posts::table
+            .filter(posts::user_id.eq(users::id))
+            .filter(posts::id.gt(n).or(posts::id.gt(n))),
+    )
+}
+
+#[dsl::auto_type]
+fn less_arguments_than_generics() -> _ {
+    posts::user_id.eq::<_>()
+}
+
+#[derive(Queryable, Selectable)]
+struct User {
+    id: i32,
+    name: String,
+    #[diesel(select_expression = dsl::exists(
+        posts::table
+            .filter(posts::user_id.eq(users::id))
+            .filter(posts::id.gt(2)),
+    ))]
+    user_has_post_with_id_greater_than_2: bool,
+}
+
+fn main() {
+    let mut conn = &mut PgConnection::establish("connection-url").unwrap();
+
+    users_with_posts_with_id_greater_than(2).load::<String>(conn)?;
+}

--- a/diesel_compile_tests/tests/fail/auto_type.stderr
+++ b/diesel_compile_tests/tests/fail/auto_type.stderr
@@ -1,0 +1,60 @@
+error: Litterals must have type suffix for auto_type, e.g. 2i64
+  --> tests/fail/auto_type.rs:45:13
+   |
+45 |     let n = 2;
+   |             ^
+
+error: auto_type: Can't infer generic argument because there is no function argument to infer from (less function arguments than generic arguments)
+  --> tests/fail/auto_type.rs:56:25
+   |
+56 |     posts::user_id.eq::<_>()
+   |                         ^
+
+error: Litterals must have type suffix for auto_type, e.g. 2i64
+  --> tests/fail/auto_type.rs:66:34
+   |
+66 |             .filter(posts::id.gt(2)),
+   |                                  ^
+
+error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> tests/fail/auto_type.rs:36:17
+   |
+30 |   #[dsl::auto_type]
+   |  __________________-
+31 | | fn users_with_posts_with_id_greater_than(id_greater_than: i32) -> _ {
+32 | |     // This fails because the macro infers the type of
+33 | |     // `user_has_post_with_id_greater_than(id_greater_than)` to be
+34 | |     // `user_has_post_with_id_greater_than<i32>`
+35 | |     users::table
+36 | |         .filter(user_has_post_with_id_greater_than(id_greater_than))
+   | |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   | |_________________|________________________________|
+   |                   |                                help: remove these generics
+   |                   expected 0 generic arguments
+   |
+note: type alias defined here, with 0 generic parameters
+  --> tests/fail/auto_type.rs:22:4
+   |
+22 | fn user_has_post_with_id_greater_than(id_greater_than: i32) -> _ {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
+  --> tests/fail/auto_type.rs:45:13
+   |
+45 |     let n = 2;
+   |             ^
+   |             |
+   |             not allowed in type signatures
+   |             not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
+  --> tests/fail/auto_type.rs:56:25
+   |
+56 |     posts::user_id.eq::<_>()
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> tests/fail/auto_type.rs:66:34
+   |
+66 |             .filter(posts::id.gt(2)),
+   |                                  ^ not allowed in type signatures

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -15,7 +15,8 @@ edition = "2021"
 syn = { version = "2.0", features = ["derive", "fold", "full"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.27"
-diesel_table_macro_syntax = {version = "0.1",  path = "../diesel_table_macro_syntax"}
+diesel_table_macro_syntax = {version = "0.1", path = "../diesel_table_macro_syntax"}
+dsl_auto_type = { version = "0.1", path = "../dsl_auto_type" }
 
 [dev-dependencies]
 cfg-if = "1"

--- a/diesel_derives/src/attrs.rs
+++ b/diesel_derives/src/attrs.rs
@@ -7,7 +7,7 @@ use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::Comma;
-use syn::{Attribute, Ident, LitBool, LitStr, Path, Type, TypePath};
+use syn::{Attribute, Expr, Ident, LitBool, LitStr, Path, Type, TypePath};
 
 use crate::deprecated::ParseDeprecated;
 use crate::parsers::{BelongsTo, MysqlType, PostgresType, SqliteType};
@@ -18,7 +18,6 @@ use crate::util::{
     TABLE_NAME_NOTE, TREAT_NONE_AS_DEFAULT_VALUE_NOTE, TREAT_NONE_AS_NULL_NOTE,
 };
 
-use crate::field::SelectExpr;
 use crate::util::{parse_paren_list, CHECK_FOR_BACKEND_NOTE};
 
 pub trait MySpanned {
@@ -38,7 +37,7 @@ pub enum FieldAttr {
     SqlType(Ident, TypePath),
     SerializeAs(Ident, TypePath),
     DeserializeAs(Ident, TypePath),
-    SelectExpression(Ident, SelectExpr),
+    SelectExpression(Ident, Expr),
     SelectExpressionType(Ident, Type),
 }
 

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use syn::spanned::Spanned;
-use syn::{Field as SynField, Ident, Index, Result, Type};
+use syn::{Expr, Field as SynField, Ident, Index, Result, Type};
 
 use crate::attrs::{parse_attributes, AttributeSpanWrapper, FieldAttr, SqlIdentifier};
 
@@ -12,7 +12,7 @@ pub struct Field {
     pub sql_type: Option<AttributeSpanWrapper<Type>>,
     pub serialize_as: Option<AttributeSpanWrapper<Type>>,
     pub deserialize_as: Option<AttributeSpanWrapper<Type>>,
-    pub select_expression: Option<AttributeSpanWrapper<SelectExpr>>,
+    pub select_expression: Option<AttributeSpanWrapper<Expr>>,
     pub select_expression_type: Option<AttributeSpanWrapper<Type>>,
     pub embed: Option<AttributeSpanWrapper<bool>>,
 }
@@ -149,48 +149,6 @@ impl quote::ToTokens for FieldName {
         match *self {
             FieldName::Named(ref x) => x.to_tokens(tokens),
             FieldName::Unnamed(ref x) => x.to_tokens(tokens),
-        }
-    }
-}
-
-/// We use this instead of directly `syn::Expr` to reduce compilation time
-///
-/// `syn::Expr` does not properly support tuples when `syn/full` feature is
-/// not enabled, and that feature slightly increases compilation time
-#[allow(clippy::large_enum_variant)]
-pub enum SelectExpr {
-    Expr(syn::Expr),
-    Tuple {
-        paren_token: syn::token::Paren,
-        content: proc_macro2::TokenStream,
-    },
-}
-
-impl quote::ToTokens for SelectExpr {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            SelectExpr::Expr(ref e) => e.to_tokens(tokens),
-            SelectExpr::Tuple {
-                ref paren_token,
-                ref content,
-            } => paren_token.surround(tokens, |tokens| content.to_tokens(tokens)),
-        }
-    }
-}
-
-impl syn::parse::Parse for SelectExpr {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let lookahead = input.lookahead1();
-
-        if lookahead.peek(syn::token::Paren) {
-            let content;
-            let paren_token = syn::parenthesized!(content in input);
-            Ok(Self::Tuple {
-                paren_token,
-                content: content.parse()?,
-            })
-        } else {
-            input.parse::<syn::Expr>().map(Self::Expr)
         }
     }
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -883,7 +883,8 @@ pub fn derive_queryable_by_name(input: TokenStream) -> TokenStream {
 ///   It may be used in conjunction with `select_expression_type` (described below)
 /// * `#[diesel(select_expression_type = the_custom_select_expression_type]`, should be used
 ///   in conjunction with `select_expression` (described above) if the type is too complex
-///   for diesel to infer it automatically.
+///   for diesel to infer it automatically. This will be required if select_expression is a custom
+///   function call that doesn't have the corresponding associated type defined at the same path.
 ///   Example use (this would actually be inferred):
 ///   `#[diesel(select_expression_type = dsl::IsNotNull<my_table::some_field>)]`
 #[proc_macro_derive(Selectable, attributes(diesel))]

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -1692,7 +1692,18 @@ pub fn derive_multiconnection(input: TokenStream) -> TokenStream {
 /// macro:
 /// - `#[auto_type(no_type_alias)]` to disable the generation of the type alias.
 /// - `#[auto_type(dsl_path = "path::to::dsl")]` to change the path where the
-///   macro will look for type aliases for methods.
+///     macro will look for type aliases for methods. This is required if you mix your own
+///   custom query dsl extensions with diesel types. In that case, you may use this argument to
+///   reference a module defined like so:
+///   ```ignore
+///   mod dsl {
+///       /// export all of diesel dsl
+///       pub use diesel::dsl::*;
+///    
+///       /// Export your extension types here
+///       pub use crate::your_extension::dsl::YourType;
+///    }
+///    ```
 /// - `#[auto_type(method_type_case = "snake_case")]` to change the case of the
 ///   method type alias.
 /// - `#[auto_type(function_type_case = "snake_case")]` to change the case of

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -22,10 +22,8 @@ extern crate proc_macro2;
 extern crate quote;
 extern crate syn;
 
-use {
-    proc_macro::TokenStream,
-    syn::{parse_macro_input, parse_quote},
-};
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, parse_quote};
 
 mod attrs;
 mod deprecated;

--- a/dsl_auto_type/Cargo.toml
+++ b/dsl_auto_type/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dsl_auto_type"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+description = "Automatically expand query fragment types for factoring as functions"
+documentation = "https://docs.rs/crate/diesel_migrations"
+homepage = "https://diesel.rs"
+edition = "2021"
+rust-version = "1.65.0"
+
+[dependencies]
+darling = "0.20"
+either = "1"
+heck = "0.4"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["extra-traits", "full", "derive", "parsing"] }
+
+[dev-dependencies]
+diesel = { path = "../diesel" }

--- a/dsl_auto_type/LICENSE-APACHE
+++ b/dsl_auto_type/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/dsl_auto_type/LICENSE-MIT
+++ b/dsl_auto_type/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/dsl_auto_type/src/auto_type/case.rs
+++ b/dsl_auto_type/src/auto_type/case.rs
@@ -1,0 +1,49 @@
+use {heck::*, proc_macro2::Span, syn::Ident};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Case {
+    DoNotChange,
+    UpperCamel,
+    Pascal,
+    LowerCamel,
+    Snake,
+    ShoutySnake,
+}
+
+impl Case {
+    pub(crate) fn ident_with_case(self, ident: &Ident) -> syn::Ident {
+        let s = ident.to_string();
+        let cased_s: String = match self {
+            Case::DoNotChange => s,
+            Case::UpperCamel => s.to_upper_camel_case(),
+            Case::Pascal => s.to_pascal_case(),
+            Case::LowerCamel => s.to_lower_camel_case(),
+            Case::Snake => s.to_snake_case(),
+            Case::ShoutySnake => s.to_shouty_snake_case(),
+        };
+        Ident::new(&cased_s, ident.span())
+    }
+}
+
+impl Case {
+    pub(crate) fn from_str(s: &str, span: Span) -> Result<Self, syn::Error> {
+        Ok(match s {
+            "dO_nOt_cHaNgE_cAsE" => Case::DoNotChange,
+            "UpperCamelCase" => Case::UpperCamel,
+            "PascalCase" => Case::Pascal,
+            "lowerCamelCase" => Case::LowerCamel,
+            "snake_case" => Case::Snake,
+            "SHOUTY_SNAKE_CASE" => Case::ShoutySnake,
+            other => {
+                return Err(syn::Error::new(
+                    span,
+                    format_args!(
+                        "Unknown case: {other}, expected one of: \
+                            `PascalCase`, `snake_case`, `UpperCamelCase`, `lowerCamelCase`, \
+                            `SHOUTY_SNAKE_CASE`, `dO_nOt_cHaNgE_cAsE`"
+                    ),
+                ))
+            }
+        })
+    }
+}

--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -1,0 +1,314 @@
+use super::*;
+
+pub use super::settings_builder::InferrerSettingsBuilder;
+
+pub fn infer_expression_type(
+    expr: &syn::Expr,
+    type_hint: Option<&syn::Type>,
+    inferrer_settings: &InferrerSettings,
+) -> (syn::Type, Vec<syn::Error>) {
+    let local_variables_map = LocalVariablesMap {
+        inferrer_settings,
+        map: Default::default(),
+    };
+    let inferrer = local_variables_map.inferrer();
+    let type_ = inferrer.infer_expression_type(expr, type_hint);
+
+    let errors = inferrer
+        .into_errors()
+        .into_iter()
+        .filter_map(|rc| {
+            // Extracting from the `Rc` only if it's the last reference is an elegant way to
+            // deduplicate errors For this to work it is necessary that the rest of
+            // the errors (those from the local variables map that weren't used) are
+            // dropped before, which is the case here, and that we are iterating on the
+            // errors in an owned manner.
+            Rc::try_unwrap(rc).ok()
+        })
+        .collect();
+    (type_, errors)
+}
+
+pub struct InferrerSettings {
+    pub(crate) dsl_path: syn::Path,
+    pub(crate) method_types_case: Case,
+    pub(crate) function_types_case: Case,
+}
+
+impl<'a> LocalVariablesMap<'a> {
+    pub(crate) fn inferrer(&'a self) -> TypeInferrer<'a> {
+        TypeInferrer {
+            local_variables_map: self,
+            errors: Default::default(),
+        }
+    }
+}
+
+pub(crate) struct TypeInferrer<'s> {
+    local_variables_map: &'s LocalVariablesMap<'s>,
+    errors: std::cell::RefCell<Vec<Rc<syn::Error>>>,
+}
+
+impl TypeInferrer<'_> {
+    /// Calls `try_infer_expression_type` and falls back to `_` if it fails,
+    /// collecting the error for display
+    pub(crate) fn infer_expression_type(
+        &self,
+        expr: &syn::Expr,
+        type_hint: Option<&syn::Type>,
+    ) -> syn::Type {
+        let inferred = self.try_infer_expression_type(expr, type_hint);
+
+        match inferred {
+            Ok(t) => t,
+            Err(e) => self.register_error(e),
+        }
+    }
+    fn register_error(&self, error: syn::Error) -> syn::Type {
+        self.errors.borrow_mut().push(Rc::new(error));
+        parse_quote!(_)
+    }
+    fn try_infer_expression_type(
+        &self,
+        expr: &syn::Expr,
+        type_hint: Option<&syn::Type>,
+    ) -> Result<syn::Type, syn::Error> {
+        let expression_type: syn::Type = match (
+            expr,
+            type_hint.filter(|h| !matches!(h, syn::Type::Infer(_))),
+        ) {
+            (
+                syn::Expr::Tuple(syn::ExprTuple {
+                    elems: expr_elems, ..
+                }),
+                Some(syn::Type::Tuple(
+                    type_tuple @ syn::TypeTuple {
+                        elems: type_elems, ..
+                    },
+                )),
+            ) => {
+                if type_elems.len() != expr_elems.len() {
+                    return Err(syn::Error::new(
+                        type_tuple.span(),
+                        "auto_type: tuple type and its \
+                            expression have different number of elements",
+                    ));
+                }
+                syn::Type::Tuple(syn::TypeTuple {
+                    elems: type_elems
+                        .iter()
+                        .zip(expr_elems.iter())
+                        .map(|(type_, expr)| self.infer_expression_type(expr, Some(type_)))
+                        .collect(),
+                    ..type_tuple.clone()
+                })
+            }
+            (syn::Expr::Tuple(syn::ExprTuple { elems, .. }), None) => {
+                syn::Type::Tuple(syn::TypeTuple {
+                    elems: elems
+                        .iter()
+                        .map(|e| self.infer_expression_type(e, None))
+                        .collect(),
+                    paren_token: Default::default(),
+                })
+            }
+            (syn::Expr::Path(syn::ExprPath { path, .. }), None) => {
+                // This is either a local variable or we should assume that the type exists at
+                // the same path as the function (with applied casing for last segment)
+                if let Some(LetStatementInferredType { type_, errors }) =
+                    path.get_ident().and_then(|path_single_ident| {
+                        self.local_variables_map.map.get(path_single_ident)
+                    })
+                {
+                    // Since we are using this type for the computation of the current type, any
+                    // errors encountered there are relevant here
+                    self.errors.borrow_mut().extend(errors.iter().cloned());
+                    type_.clone()
+                } else {
+                    syn::Type::Path(syn::TypePath {
+                        path: path.clone(),
+                        qself: None,
+                    })
+                }
+            }
+            (syn::Expr::Call(syn::ExprCall { func, args, .. }), None) => {
+                let unsupported_function_type =
+                    || syn::Error::new_spanned(&**func, "unsupported function type for auto_type");
+                let func_type = self.try_infer_expression_type(func, None)?;
+                // First we extract the type of the function
+                let mut type_path = match func_type {
+                    syn::Type::Path(syn::TypePath { path, .. }) => path,
+                    _ => return Err(unsupported_function_type()),
+                };
+                // Then we update the case if specified
+                if self
+                    .local_variables_map
+                    .inferrer_settings
+                    .function_types_case
+                    != Case::DoNotChange
+                {
+                    if let Some(last) = type_path.segments.last_mut() {
+                        last.ident = self
+                            .local_variables_map
+                            .inferrer_settings
+                            .function_types_case
+                            .ident_with_case(&last.ident);
+                    }
+                }
+                // Then we will add the generic arguments
+                let last_segment = type_path
+                    .segments
+                    .last_mut()
+                    .ok_or_else(unsupported_function_type)?;
+                last_segment.arguments = self.infer_generics_or_use_hints(
+                    None,
+                    args,
+                    match &last_segment.arguments {
+                        syn::PathArguments::None => None,
+                        syn::PathArguments::AngleBracketed(ab) => Some(ab),
+                        syn::PathArguments::Parenthesized(_) => {
+                            return Err(unsupported_function_type())
+                        }
+                    },
+                )?;
+                syn::Type::Path(syn::TypePath {
+                    path: type_path,
+                    qself: None,
+                })
+            }
+            (
+                syn::Expr::MethodCall(syn::ExprMethodCall {
+                    receiver,
+                    method,
+                    turbofish,
+                    args,
+                    ..
+                }),
+                None,
+            ) => syn::Type::Path(syn::TypePath {
+                path: syn::Path {
+                    segments: self
+                        .local_variables_map
+                        .inferrer_settings
+                        .dsl_path
+                        .segments
+                        .iter()
+                        .cloned()
+                        .chain([syn::PathSegment {
+                            ident: self
+                                .local_variables_map
+                                .inferrer_settings
+                                .method_types_case
+                                .ident_with_case(method),
+                            arguments: self.infer_generics_or_use_hints(
+                                Some(syn::GenericArgument::Type(
+                                    self.infer_expression_type(receiver, None),
+                                )),
+                                args,
+                                turbofish.as_ref(),
+                            )?,
+                        }])
+                        .collect(),
+                    leading_colon: None,
+                },
+                qself: None,
+            }),
+            (syn::Expr::Lit(syn::ExprLit { lit, .. }), None) => match lit {
+                syn::Lit::Str(_) => parse_quote!(&'static str),
+                syn::Lit::ByteStr(_) => parse_quote!(&'static [u8]),
+                syn::Lit::Byte(_) => parse_quote!(u8),
+                syn::Lit::Char(_) => parse_quote!(char),
+                syn::Lit::Int(lit_int) => litteral_type(&lit_int.token())?,
+                syn::Lit::Float(lit_float) => litteral_type(&lit_float.token())?,
+                syn::Lit::Bool(_) => parse_quote!(bool),
+                _ => {
+                    return Err(syn::Error::new(
+                        lit.span(),
+                        "unsupported literal for auto_type",
+                    ))
+                }
+            },
+            (_, None) => {
+                return Err(syn::Error::new(
+                    expr.span(),
+                    "unsupported expression for auto_type",
+                ))
+            }
+            (_, Some(type_hint)) => type_hint.clone(),
+        };
+        Ok(expression_type)
+    }
+
+    /// `infer` is always supposed to be a syn::Type::Infer
+    fn infer_generics_or_use_hints(
+        &self,
+        add_first: Option<syn::GenericArgument>,
+        args: &syn::punctuated::Punctuated<syn::Expr, Token![,]>,
+        hint: Option<&syn::AngleBracketedGenericArguments>,
+    ) -> Result<syn::PathArguments, syn::Error> {
+        let arguments = syn::AngleBracketedGenericArguments {
+            args: add_first
+                .into_iter()
+                .chain(match hint {
+                    None => {
+                        // We should infer
+                        Either::Left(args.iter().map(|e| {
+                            syn::GenericArgument::Type(self.infer_expression_type(e, None))
+                        }))
+                    }
+                    Some(hint_or_override) => Either::Right(
+                        hint_or_override
+                            .args
+                            .iter()
+                            .zip(args.iter().map(Some).chain((0..).map(|_| None)))
+                            .map(|(hint, expr)| match (hint, expr) {
+                                (syn::GenericArgument::Type(type_hint), Some(expr)) => {
+                                    syn::GenericArgument::Type(
+                                        self.infer_expression_type(expr, Some(type_hint)),
+                                    )
+                                }
+                                (
+                                    generic_argument @ syn::GenericArgument::Type(syn::Type::Infer(
+                                        _,
+                                    )),
+                                    None,
+                                ) => syn::GenericArgument::Type(self.register_error(
+                                    syn::Error::new_spanned(
+                                        generic_argument,
+                                        "auto_type: Can't infer generic argument because \
+                                            there is no function argument to infer from \
+                                            (less function arguments than generic arguments)",
+                                    ),
+                                )),
+                                (generic_argument, _) => generic_argument.clone(),
+                            }),
+                    ),
+                })
+                .collect(),
+            colon2_token: None, // there is no colon2 in types, only in function calls
+            lt_token: Default::default(),
+            gt_token: Default::default(),
+        };
+        Ok(if arguments.args.is_empty() {
+            syn::PathArguments::None
+        } else {
+            syn::PathArguments::AngleBracketed(arguments)
+        })
+    }
+
+    pub(crate) fn into_errors(self) -> Vec<Rc<syn::Error>> {
+        self.errors.into_inner()
+    }
+}
+
+fn litteral_type(t: &proc_macro2::Literal) -> Result<syn::Type, syn::Error> {
+    let val = t.to_string();
+    let type_suffix = &val[val.find(|c: char| !c.is_ascii_digit()).ok_or_else(|| {
+        syn::Error::new_spanned(
+            t,
+            format_args!("Litterals must have type suffix for auto_type, e.g. {val}i64"),
+        )
+    })?..];
+    syn::parse_str(type_suffix)
+        .map_err(|_| syn::Error::new_spanned(t, "Invalid type suffix for litteral"))
+}

--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -115,8 +115,11 @@ impl TypeInferrer<'_> {
             (syn::Expr::Path(syn::ExprPath { path, .. }), None) => {
                 // This is either a local variable or we should assume that the type exists at
                 // the same path as the function (with applied casing for last segment)
-                if let Some(LetStatementInferredType { type_, errors }) =
-                    path.get_ident().and_then(|path_single_ident| {
+                let path_is_ident = path.get_ident();
+                if path_is_ident.map_or(false, |ident| ident == "self") {
+                    parse_quote!(Self)
+                } else if let Some(LetStatementInferredType { type_, errors }) = path_is_ident
+                    .and_then(|path_single_ident| {
                         self.local_variables_map.map.get(path_single_ident)
                     })
                 {

--- a/dsl_auto_type/src/auto_type/local_variables_map.rs
+++ b/dsl_auto_type/src/auto_type/local_variables_map.rs
@@ -50,7 +50,7 @@ impl<'a> LocalVariablesMap<'a> {
                             errors: Vec::new(),
                         },
                         (None, None) => LetStatementInferredType {
-                            type_: parse_quote!(_),
+                            type_: parse_quote_spanned!(pat_ident.span()=> _),
                             errors: vec![Rc::new(syn::Error::new_spanned(
                                 pat_ident,
                                 "auto_type: Let statement with no type ascription \

--- a/dsl_auto_type/src/auto_type/local_variables_map.rs
+++ b/dsl_auto_type/src/auto_type/local_variables_map.rs
@@ -1,0 +1,98 @@
+use super::*;
+
+pub(crate) struct LocalVariablesMap<'a> {
+    pub(crate) inferrer_settings: &'a InferrerSettings,
+    pub(crate) map: HashMap<&'a Ident, LetStatementInferredType>,
+}
+pub(crate) struct LetStatementInferredType {
+    pub(crate) type_: Type,
+    pub(crate) errors: Vec<Rc<syn::Error>>,
+}
+
+impl<'a> LocalVariablesMap<'a> {
+    pub(crate) fn process_pat(
+        &mut self,
+        pat: &'a syn::Pat,
+        type_ascription: Option<&'a Type>,
+        local_init_expression: Option<&'a syn::Expr>,
+    ) -> Result<(), syn::Error> {
+        // Either the let statement hints the type or we have to infer it
+        // Either the let statement is a simple assignment or a destructuring assignment
+        match pat {
+            syn::Pat::Type(pat_type) => {
+                self.process_pat(
+                    &pat_type.pat,
+                    Some(match type_ascription {
+                        None => &pat_type.ty,
+                        Some(type_ascription) => {
+                            return Err(syn::Error::new(
+                                type_ascription.span(),
+                                "auto_type: unexpected double type ascription",
+                            ))
+                        }
+                    }),
+                    local_init_expression,
+                )?;
+            }
+            syn::Pat::Ident(pat_ident) => {
+                self.map.insert(
+                    &pat_ident.ident,
+                    match (type_ascription, local_init_expression) {
+                        (opt_type_ascription, Some(expr)) => {
+                            let inferrer = self.inferrer();
+                            LetStatementInferredType {
+                                type_: inferrer.infer_expression_type(expr, opt_type_ascription),
+                                errors: inferrer.into_errors(),
+                            }
+                        }
+                        (Some(type_ascription), None) => LetStatementInferredType {
+                            type_: type_ascription.clone(),
+                            errors: Vec::new(),
+                        },
+                        (None, None) => LetStatementInferredType {
+                            type_: parse_quote!(_),
+                            errors: vec![Rc::new(syn::Error::new_spanned(
+                                pat_ident,
+                                "auto_type: Let statement with no type ascription \
+                                    and no initializer expression is not supported",
+                            ))],
+                        },
+                    },
+                );
+            }
+            syn::Pat::Tuple(pat_tuple) => {
+                if let Some(type_ascription) = type_ascription {
+                    if let Type::Tuple(type_tuple) = type_ascription {
+                        if pat_tuple.elems.len() != type_tuple.elems.len() {
+                            return Err(syn::Error::new(
+                                type_ascription.span(),
+                                "auto_type: tuple let assignment and its \
+                                    type ascription have different number of elements",
+                            ));
+                        }
+                    }
+                }
+                for (i, pat) in pat_tuple.elems.iter().enumerate() {
+                    self.process_pat(
+                        pat,
+                        match type_ascription {
+                            Some(Type::Tuple(type_tuple)) => Some(&type_tuple.elems[i]),
+                            _ => None,
+                        },
+                        match local_init_expression {
+                            Some(syn::Expr::Tuple(expr_tuple)) => Some(&expr_tuple.elems[i]),
+                            _ => None,
+                        },
+                    )?;
+                }
+            }
+            _ => {
+                // We won't be able to infer these, at the same time we don't
+                // want to error because there may be valid user
+                // code using these, and we won't need it if these variables
+                // are not needed to infer the type of the final expression.
+            }
+        };
+        Ok(())
+    }
+}

--- a/dsl_auto_type/src/auto_type/mod.rs
+++ b/dsl_auto_type/src/auto_type/mod.rs
@@ -9,7 +9,7 @@ use {
     proc_macro2::{Span, TokenStream},
     quote::quote,
     std::{collections::HashMap, rc::Rc},
-    syn::{parse_quote, spanned::Spanned, Ident, ItemFn, Token, Type},
+    syn::{parse_quote, parse_quote_spanned, spanned::Spanned, Ident, ItemFn, Token, Type},
 };
 
 use local_variables_map::*;

--- a/dsl_auto_type/src/auto_type/mod.rs
+++ b/dsl_auto_type/src/auto_type/mod.rs
@@ -1,0 +1,201 @@
+mod case;
+pub mod expression_type_inference;
+mod local_variables_map;
+mod settings_builder;
+
+use {
+    darling::{util::SpannedValue, FromMeta},
+    either::Either,
+    proc_macro2::{Span, TokenStream},
+    quote::quote,
+    std::{collections::HashMap, rc::Rc},
+    syn::{parse_quote, spanned::Spanned, Ident, ItemFn, Token, Type},
+};
+
+use local_variables_map::*;
+
+pub use {
+    case::Case, expression_type_inference::InferrerSettings,
+    settings_builder::DeriveSettingsBuilder,
+};
+
+pub struct DeriveSettings {
+    default_dsl_path: syn::Path,
+    default_method_type_case: Case,
+    default_function_type_case: Case,
+    default_generate_type_alias: bool,
+}
+
+#[derive(darling::FromMeta)]
+struct DeriveParameters {
+    /// Can be overridden to provide custom DSLs
+    dsl_path: Option<syn::Path>,
+    type_alias: darling::util::Flag,
+    no_type_alias: darling::util::Flag,
+    type_name: Option<syn::Ident>,
+    type_case: Option<SpannedValue<String>>,
+}
+
+pub(crate) fn auto_type_impl(
+    attr: TokenStream,
+    input: &TokenStream,
+    derive_settings: DeriveSettings,
+) -> Result<TokenStream, crate::Error> {
+    let settings_input: DeriveParameters =
+        DeriveParameters::from_list(&darling::ast::NestedMeta::parse_meta_list(attr)?)?;
+
+    let mut input_function = syn::parse2::<ItemFn>(input.clone())?;
+
+    let inferrer_settings = InferrerSettings {
+        dsl_path: settings_input
+            .dsl_path
+            .unwrap_or(derive_settings.default_dsl_path),
+        method_types_case: derive_settings.default_method_type_case,
+        function_types_case: derive_settings.default_function_type_case,
+    };
+
+    let function_name = &input_function.sig.ident;
+    let type_alias = match (
+        settings_input.type_alias.is_present(),
+        settings_input.no_type_alias.is_present(),
+        derive_settings.default_generate_type_alias,
+    ) {
+        (false, false, b) => b,
+        (true, false, _) => true,
+        (false, true, _) => false,
+        (true, true, _) => {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "type_alias and no_type_alias are mutually exclusive",
+            )
+            .into())
+        }
+    };
+    let type_alias: Option<syn::Ident> = match (
+        type_alias,
+        settings_input.type_name,
+        settings_input.type_case,
+    ) {
+        (false, None, None) => None,
+        (true, None, None) => {
+            // By default be consistent with call expressions, for when other will refer
+            // this query fragment in another auto_type function
+            Some(
+                inferrer_settings
+                    .function_types_case
+                    .ident_with_case(function_name),
+            )
+        }
+        (_, Some(ident), None) => Some(ident),
+        (_, None, Some(case)) => {
+            let case = Case::from_str(case.as_str(), case.span())?;
+            Some(case.ident_with_case(function_name))
+        }
+        (_, Some(_), Some(type_case)) => {
+            return Err(syn::Error::new(
+                type_case.span(),
+                "type_name and type_case are mutually exclusive",
+            )
+            .into())
+        }
+    };
+
+    let last_statement = input_function.block.stmts.last().ok_or_else(|| {
+        syn::Error::new(
+            input_function.span(),
+            "function body should not be empty for auto_type",
+        )
+    })?;
+    let (return_type, errors) = match input_function.sig.output {
+        syn::ReturnType::Type(_, return_type) if matches!(*return_type, Type::Infer(_)) => {
+            // Let's process intermediate let statements
+
+            let mut local_variables_map = LocalVariablesMap {
+                inferrer_settings: &inferrer_settings,
+                map: Default::default(),
+            };
+            for function_param in &input_function.sig.inputs {
+                if let syn::FnArg::Typed(syn::PatType { pat, ty, .. }) = function_param {
+                    local_variables_map.process_pat(pat, Some(ty), None)?
+                };
+            }
+            for statement in &input_function.block.stmts[0..input_function.block.stmts.len() - 1] {
+                if let syn::Stmt::Local(local) = statement {
+                    local_variables_map.process_pat(
+                        &local.pat,
+                        None,
+                        local.init.as_ref().map(|local_init| &*local_init.expr),
+                    )?
+                };
+            }
+
+            // Now we can process the last statement
+            let return_expression = match last_statement {
+                syn::Stmt::Expr(expr, None) => expr,
+                syn::Stmt::Expr(
+                    syn::Expr::Return(syn::ExprReturn {
+                        expr: Some(expr), ..
+                    }),
+                    _,
+                ) => &**expr,
+                _ => {
+                    return Err(syn::Error::new(
+                        last_statement.span(),
+                        "last statement should be an expression for auto_type",
+                    )
+                    .into())
+                }
+            };
+            let inferrer = local_variables_map.inferrer();
+            (
+                inferrer.infer_expression_type(return_expression, None),
+                inferrer.into_errors(),
+            )
+        }
+        syn::ReturnType::Type(_, return_type) if type_alias.is_some() => {
+            // User only wants us to generate a type alias for the return type but we don't
+            // have anything to infer
+            (*return_type, Vec::new())
+        }
+        _ => {
+            return Err(syn::Error::new(
+                input_function.sig.output.span(),
+                "Function return type should be explicitly specified as `-> _` for auto_type",
+            )
+            .into())
+        }
+    };
+
+    let type_alias = match type_alias {
+        Some(type_alias) => {
+            let vis = &input_function.vis;
+            input_function.sig.output = parse_quote!(-> #type_alias);
+            quote! {
+                #[allow(non_camel_case_types)]
+                #vis type #type_alias = #return_type;
+            }
+        }
+        None => {
+            input_function.sig.output = parse_quote!(-> #return_type);
+            quote! {}
+        }
+    };
+
+    let mut res = quote! {
+        #type_alias
+        #input_function
+    };
+
+    for error in errors {
+        // Extracting from the `Rc` only if it's the last reference is an elegant way to
+        // deduplicate errors For this to work it is necessary that the rest of
+        // the errors (those from the local variables map that weren't used) are
+        // dropped before, which is the case here, and that we are iterating on the
+        // errors in an owned manner.
+        if let Ok(error) = Rc::try_unwrap(error) {
+            res.extend(error.into_compile_error());
+        }
+    }
+
+    Ok(res)
+}

--- a/dsl_auto_type/src/auto_type/settings_builder.rs
+++ b/dsl_auto_type/src/auto_type/settings_builder.rs
@@ -1,0 +1,93 @@
+use syn::parse_quote;
+
+use super::{case::Case, DeriveSettings, InferrerSettings};
+
+#[derive(Default)]
+pub struct DeriveSettingsBuilder {
+    inner: DeriveSettings,
+}
+
+impl DeriveSettingsBuilder {
+    pub fn default_dsl_path(mut self, path: syn::Path) -> Self {
+        self.inner.default_dsl_path = path;
+        self
+    }
+
+    pub fn default_generate_type_alias(mut self, generate_type_alias: bool) -> Self {
+        self.inner.default_generate_type_alias = generate_type_alias;
+        self
+    }
+
+    pub fn default_method_type_case(mut self, case: Case) -> Self {
+        self.inner.default_method_type_case = case;
+        self
+    }
+
+    pub fn default_function_type_case(mut self, case: Case) -> Self {
+        self.inner.default_function_type_case = case;
+        self
+    }
+
+    pub fn build(self) -> DeriveSettings {
+        self.inner
+    }
+}
+
+impl DeriveSettings {
+    pub fn builder() -> DeriveSettingsBuilder {
+        DeriveSettingsBuilder::default()
+    }
+}
+
+impl Default for DeriveSettings {
+    fn default() -> Self {
+        Self {
+            default_method_type_case: Case::UpperCamel,
+            default_function_type_case: Case::DoNotChange,
+            default_dsl_path: parse_quote!(dsl),
+            default_generate_type_alias: true,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct InferrerSettingsBuilder {
+    inner: InferrerSettings,
+}
+
+impl InferrerSettingsBuilder {
+    pub fn dsl_path(mut self, path: syn::Path) -> Self {
+        self.inner.dsl_path = path;
+        self
+    }
+
+    pub fn method_types_case(mut self, case: Case) -> Self {
+        self.inner.method_types_case = case;
+        self
+    }
+
+    pub fn function_types_case(mut self, case: Case) -> Self {
+        self.inner.function_types_case = case;
+        self
+    }
+
+    pub fn build(self) -> InferrerSettings {
+        self.inner
+    }
+}
+
+impl InferrerSettings {
+    pub fn builder() -> InferrerSettingsBuilder {
+        InferrerSettingsBuilder::default()
+    }
+}
+
+impl Default for InferrerSettings {
+    fn default() -> Self {
+        Self {
+            method_types_case: Case::UpperCamel,
+            function_types_case: Case::DoNotChange,
+            dsl_path: parse_quote!(dsl),
+        }
+    }
+}

--- a/dsl_auto_type/src/lib.rs
+++ b/dsl_auto_type/src/lib.rs
@@ -1,0 +1,43 @@
+pub mod auto_type;
+
+use proc_macro2::TokenStream;
+
+pub use auto_type::{Case, DeriveSettings};
+
+enum Error {
+    Syn(syn::Error),
+    Darling(darling::Error),
+}
+
+pub fn auto_type_proc_macro_attribute(
+    attr: TokenStream,
+    input: TokenStream,
+    config: auto_type::DeriveSettings,
+) -> TokenStream {
+    match auto_type::auto_type_impl(attr, &input, config) {
+        Ok(token_stream) => token_stream,
+        Err(e) => {
+            let mut out = input;
+            match e {
+                Error::Syn(e) => {
+                    out.extend(e.into_compile_error());
+                }
+                Error::Darling(e) => {
+                    out.extend(e.write_errors());
+                }
+            }
+            out
+        }
+    }
+}
+
+impl From<syn::Error> for Error {
+    fn from(e: syn::Error) -> Self {
+        Error::Syn(e)
+    }
+}
+impl From<darling::Error> for Error {
+    fn from(e: darling::Error) -> Self {
+        Error::Darling(e)
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/diesel-rs/diesel/discussions/3661

This introduces:
- The `#[dsl::auto_type]` attribute macro, allowing to infer type of query fragment functions
- Using the same type inference on `Selectable` derives, which allows skipping specifying `select_expression_type` most of the time, in turn enabling most queries to be written using just a `Selectable` derive.