### PR TITLE
Fix sqlite timestamps

### DIFF
--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -332,12 +332,14 @@ pub struct Time;
 /// - [`std::time::SystemTime`][SystemTime] (PG only)
 /// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
 /// - [`time::PrimitiveDateTime`] with `feature = "time"`
+/// - [`time::OffsetDateTime`] with `feature = "time"` (MySQL only)
 ///
 /// ### [`FromSql`](crate::deserialize::FromSql) impls
 ///
 /// - [`std::time::SystemTime`][SystemTime] (PG only)
 /// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
 /// - [`time::PrimitiveDateTime`] with `feature = "time"`
+/// - [`time::OffsetDateTime`] with `feature = "time"` (MySQL only)
 ///
 /// [SystemTime]: std::time::SystemTime
 #[cfg_attr(

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -332,14 +332,12 @@ pub struct Time;
 /// - [`std::time::SystemTime`][SystemTime] (PG only)
 /// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
 /// - [`time::PrimitiveDateTime`] with `feature = "time"`
-/// - [`time::OffsetDateTime`] with `feature = "time"`
 ///
 /// ### [`FromSql`](crate::deserialize::FromSql) impls
 ///
 /// - [`std::time::SystemTime`][SystemTime] (PG only)
 /// - [`chrono::NaiveDateTime`][NaiveDateTime] with `feature = "chrono"`
 /// - [`time::PrimitiveDateTime`] with `feature = "time"`
-/// - [`time::OffsetDateTime`] with `feature = "time"`
 ///
 /// [SystemTime]: std::time::SystemTime
 #[cfg_attr(

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -8,13 +8,13 @@ use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::{Date, Time, Timestamp, TimestamptzSqlite};
 use crate::sqlite::Sqlite;
 
-// Warning to future editors:
-// Changes in the following formats need to be kept in sync
-// with the formats of the "time" module.
-// We do not need a distinction between whole second and
-// subsecond since %.f will only print the dot if needed.
-// We always print as many subsecond as his given to us,
-// this means the subsecond part can be 3, 6 or 9 digits.
+/// Warning to future editors:
+/// Changes in the following formats need to be kept in sync
+/// with the formats of the ["time"](super::time) module.
+/// We do not need a distinction between whole second and
+/// subsecond since %.f will only print the dot if needed.
+/// We always print as many subsecond as his given to us,
+/// this means the subsecond part can be 3, 6 or 9 digits.
 const DATE_FORMAT: &str = "%F";
 
 const ENCODE_TIME_FORMAT: &str = "%T%.f";

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -98,7 +98,9 @@ mod tests {
     extern crate chrono;
     extern crate time;
 
-    use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use chrono::{
+        DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc,
+    };
     use time::{
         macros::{date, datetime, offset, time},
         Date, OffsetDateTime, PrimitiveDateTime, Time,
@@ -133,6 +135,31 @@ mod tests {
         }
     }
 
+    fn eq_date(left: Date, right: NaiveDate) -> bool {
+        left.year() == right.year()
+            && left.month() as u8 == right.month() as u8
+            && left.day() == right.day() as u8
+    }
+
+    fn eq_time(left: Time, right: NaiveTime) -> bool {
+        left.hour() == right.hour() as u8
+            && left.minute() == right.minute() as u8
+            && left.second() == right.second() as u8
+            && left.nanosecond() == right.nanosecond()
+    }
+
+    fn eq_datetime(left: PrimitiveDateTime, right: NaiveDateTime) -> bool {
+        eq_date(left.date(), right.date()) && eq_time(left.time(), right.time())
+    }
+
+    fn eq_datetime_utc(left: OffsetDateTime, right: DateTime<Utc>) -> bool {
+        left.unix_timestamp_nanos() == right.timestamp_nanos() as i128
+    }
+
+    fn eq_datetime_offset(left: OffsetDateTime, right: DateTime<FixedOffset>) -> bool {
+        left.unix_timestamp_nanos() == right.timestamp_nanos() as i128
+    }
+
     fn create_tables(conn: &mut SqliteConnection) {
         crate::sql_query(
             "CREATE TABLE table_timestamp_tz(id INTEGER PRIMARY KEY, timestamp_with_tz TEXT);",
@@ -165,10 +192,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_date::table
+        let translated = table_date::table
             .select(table_date::date)
             .get_result::<NaiveDate>(conn)
             .unwrap();
+
+        assert!(eq_date(original, translated))
     }
 
     #[test]
@@ -183,10 +212,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_date::table
+        let translated = table_date::table
             .select(table_date::date)
             .get_result::<Date>(conn)
             .unwrap();
+
+        assert!(eq_date(translated, original))
     }
 
     #[test]
@@ -201,10 +232,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_time::table
+        let translated = table_time::table
             .select(table_time::time)
             .get_result::<NaiveTime>(conn)
             .unwrap();
+
+        assert!(eq_time(original, translated))
     }
 
     #[test]
@@ -219,10 +252,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_time::table
+        let translated = table_time::table
             .select(table_time::time)
             .get_result::<Time>(conn)
             .unwrap();
+
+        assert!(eq_time(translated, original))
     }
 
     #[test]
@@ -240,10 +275,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_timestamp::table
+        let translated = table_timestamp::table
             .select(table_timestamp::timestamp)
             .get_result::<NaiveDateTime>(conn)
             .unwrap();
+
+        assert!(eq_datetime(original, translated))
     }
 
     #[test]
@@ -264,10 +301,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_timestamp::table
+        let translated = table_timestamp::table
             .select(table_timestamp::timestamp)
             .get_result::<PrimitiveDateTime>(conn)
             .unwrap();
+
+        assert!(eq_datetime(translated, original))
     }
 
     #[test]
@@ -285,10 +324,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_timestamp_tz::table
+        let translated = table_timestamp_tz::table
             .select(table_timestamp_tz::timestamp_with_tz)
             .get_result::<OffsetDateTime>(conn)
             .unwrap();
+
+        assert!(eq_datetime_utc(translated, original))
     }
 
     #[test]
@@ -306,10 +347,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_timestamp_tz::table
+        let translated = table_timestamp_tz::table
             .select(table_timestamp_tz::timestamp_with_tz)
             .get_result::<DateTime<Utc>>(conn)
             .unwrap();
+
+        assert!(eq_datetime_utc(original, translated))
     }
 
     #[test]
@@ -327,10 +370,12 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_timestamp_tz::table
+        let translated = table_timestamp_tz::table
             .select(table_timestamp_tz::timestamp_with_tz)
             .get_result::<OffsetDateTime>(conn)
             .unwrap();
+
+        assert!(eq_datetime_offset(translated, original))
     }
 
     #[test]
@@ -348,9 +393,11 @@ mod tests {
             .execute(conn)
             .unwrap();
 
-        table_timestamp_tz::table
+        let translated = table_timestamp_tz::table
             .select(table_timestamp_tz::timestamp_with_tz)
             .get_result::<DateTime<Utc>>(conn)
             .unwrap();
+
+        assert!(eq_datetime_utc(original, translated))
     }
 }

--- a/diesel/src/sqlite/types/date_and_time/time.rs
+++ b/diesel/src/sqlite/types/date_and_time/time.rs
@@ -15,22 +15,22 @@ use crate::sql_types::{Date, Time, Timestamp, TimestamptzSqlite};
 use crate::sqlite::Sqlite;
 
 const DATE_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day]");
+
 const ENCODE_TIME_FORMAT_WHOLE_SECOND: &[FormatItem<'_>] =
     format_description!("[hour]:[minute]:[second]");
 const ENCODE_TIME_FORMAT_SUBSECOND: &[FormatItem<'_>] =
     format_description!("[hour]:[minute]:[second].[subsecond digits:6]");
 
 const TIME_FORMATS: [&[FormatItem<'_>]; 9] = [
-    // Most likely
+    // Most likely formats
     format_description!("[hour]:[minute]:[second].[subsecond]"),
+    format_description!("[hour]:[minute]:[second]"),
     // All other valid formats in order of increasing specificity
     format_description!("[hour]:[minute]"),
     format_description!("[hour]:[minute]Z"),
     format_description!("[hour]:[minute][offset_hour sign:mandatory]:[offset_minute]"),
-    format_description!("[hour]:[minute]:[second]"),
     format_description!("[hour]:[minute]:[second]Z"),
     format_description!("[hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"),
-    // here is where the most likely format would go according to the pattern
     format_description!("[hour]:[minute]:[second].[subsecond]Z"),
     format_description!(
         "[hour]:[minute]:[second].[subsecond][offset_hour sign:mandatory]:[offset_minute]"
@@ -49,19 +49,17 @@ const ENCODE_DATETIME_FORMAT_SUBSECOND: &[FormatItem<'_>] =
     format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3][offset_hour sign:mandatory]:[offset_minute]");
 
 const DATETIME_FORMATS: [&[FormatItem<'_>]; 18] = [
-    // Most likely format
+    // Most likely formats
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond][offset_hour sign:mandatory]:[offset_minute]"),
     format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]"),
-    // Other formats in order of increasing specificity
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"),
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]"),
+    // All other formats in order of increasing specificity
     format_description!("[year]-[month]-[day] [hour]:[minute]"),
     format_description!("[year]-[month]-[day] [hour]:[minute]Z"),
     format_description!("[year]-[month]-[day] [hour]:[minute][offset_hour sign:mandatory]:[offset_minute]"),
-    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]"),
     format_description!("[year]-[month]-[day] [hour]:[minute]:[second]Z"),
-    format_description!("[year]-[month]-[day] [hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"),
-    // here is where the most likely format would go according to the pattern
     format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]Z"),
-    format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond][offset_hour sign:mandatory]:[offset_minute]"),
-    // now the same thing, with T
     format_description!("[year]-[month]-[day]T[hour]:[minute]"),
     format_description!("[year]-[month]-[day]T[hour]:[minute]Z"),
     format_description!("[year]-[month]-[day]T[hour]:[minute][offset_hour sign:mandatory]:[offset_minute]"),

--- a/diesel/src/sqlite/types/date_and_time/time.rs
+++ b/diesel/src/sqlite/types/date_and_time/time.rs
@@ -14,13 +14,13 @@ use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types::{Date, Time, Timestamp, TimestamptzSqlite};
 use crate::sqlite::Sqlite;
 
-// Warning to future editors:
-// Changes in the following formats need to be kept in sync
-// with the formats of the "chrono" module.
-// We need a distinction between whole second and subsecond
-// since there is no format option to forgo the dot.
-// We always print as many subsecond as his given to us,
-// this means the subsecond part can be between 1 and 9 digits.
+/// Warning to future editors:
+/// Changes in the following formats need to be kept in sync
+/// with the formats of the ["chrono"](super::chrono) module.
+/// We need a distinction between whole second and subsecond
+/// since there is no format option to forgo the dot.
+/// We always print as many subsecond as his given to us,
+/// this means the subsecond part can be between 1 and 9 digits.
 const DATE_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day]");
 
 const ENCODE_TIME_FORMAT_WHOLE_SECOND: &[FormatItem<'_>] =


### PR DESCRIPTION
Fixes #3693 
Fixes #3320

This is a big change in the way we store and parse timestamp in sqlite.
- **(Major)** We don't ignore timezones anymore if they are present, I am unsure why this what put in place but it feels very very very wrong to me. The data written by diesel is always switched to UTC, but we can't assume the data in the database was written by us. We still fallback to a "naive" implementation if the timezone is missing. I had to remove "bad" tests since `1970-01-01 00:00+01:00` is not the same time as `1970-01-01 00:00Z` in my book. We still ignore the timezone if the user uses a "naive" datetime to read the data (I think that is fair, though we could verify with other ORM if they correct to UTC instead).
- Uniformity between time and chrono, the code looks more similar and the formats are the same so a user can switch library without any issue now (that was something I found in #3693)
- Fixed some documentation