### PR TITLE
Suppress unused_import if no backend is enabled

### DIFF
--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -10,6 +10,7 @@ use std::ops::Range;
 pub use self::private::{PartialRow, RowSealed};
 
 #[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
+#[allow(unused_imports)]
 pub(crate) use self::private::{PartialRow, RowSealed};
 
 /// Representing a way to index into database rows


### PR DESCRIPTION
Minimal reproduction: `cargo check -p diesel --no-default-features`

```console
   Compiling proc-macro2 v1.0.64
   Compiling quote v1.0.29
   Compiling unicode-ident v1.0.11
   Compiling syn v2.0.26
   Compiling diesel_table_macro_syntax v0.1.0 (/Users/namjh/dev/personal/diesel/diesel_table_macro_syntax)
   Compiling diesel_derives v2.1.0 (/Users/namjh/dev/personal/diesel/diesel_derives)
    Checking diesel v2.1.0 (/Users/namjh/dev/personal/diesel/diesel)
warning: unused import: `RowSealed`
  --> diesel/src/row.rs:13:44
   |
13 | pub(crate) use self::private::{PartialRow, RowSealed};
   |                                            ^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `diesel` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 6.88s
```