### PR TITLE
docs(README): change "eq(any(" to "eq_any("

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ let versions = Version::belonging_to(krate)
   .limit(5);
 let downloads = version_downloads
   .filter(date.gt(now - 90.days()))
-  .filter(version_id.eq(any(versions)))
+  .filter(version_id.eq_any(versions))
   .order(date)
   .load::<Download>(&mut conn)?;
 ```


### PR DESCRIPTION
change a readme example `.eq(any(` to be `.eq_any(`, because (from what i can tell) in diesel 2.x there does not exist a `any` function