### PR TITLE
Emit a better error message if a user writes a `table!` macro without

### DIFF
--- a/diesel_compile_tests/tests/fail/table_without_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.rs
@@ -1,0 +1,10 @@
+#[macro_use] extern crate diesel;
+
+table! {
+    user {
+        user_id -> Integer,
+        name -> Text,
+    }
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
@@ -1,0 +1,14 @@
+error: Neither an explict primary key found nor does an `id` column exist.
+       Consider explicitly defining a primary key.
+       For example for specifying `user_id` as primary key:
+
+       table! {
+           user (user_id) {
+               user_id -> Integer,
+               name -> Text,
+           }
+       }
+ --> tests/fail/table_without_primary_key.rs:4:5
+  |
+4 |     user {
+  |     ^^^^


### PR DESCRIPTION
`id` column and without explicit primary Key

Previously we did ignore that case, which resulted in the following error message:

```
error[E0412]: cannot find type `id` in this scope
 --> tests/fail/table_without_primary_key.rs:3:1
  |
3 | / table! {
4 | |     user {
5 | |         user_id -> Integer,
6 | |         name -> Text,
7 | |     }
8 | | }
  | |_^ help: a builtin type with a similar name exists: `i8`
  |
  = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find value `id` in this scope
 --> tests/fail/table_without_primary_key.rs:3:1
  |
3 | / table! {
4 | |     user {
5 | |         user_id -> Integer,
6 | |         name -> Text,
7 | |     }
8 | | }
  | |_^ not found in this scope
  |
  = help: consider importing this function:
          std::process::id
  = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This can be confusing for new users. This commit introduces an explicit check for that case and emits an targeted error messages that makes it hopefully clear what's the problem here. It also suggests to specify the first column as primary key.