### PR TITLE
Update benchmark dependencies 

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run Benchmarks (Sqlite)
         if: matrix.backend == 'sqlite'
-        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "sqlite sqlx-bench sqlx/sqlite tokio rusqlite futures sea-orm sea-orm/sqlx-sqlite criterion/async_tokio fast_run"
+        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "sqlite sqlx-bench sqlx/sqlite tokio rusqlite futures sea-orm sea-orm/sqlx-sqlite criterion/async_tokio"
 
       - name: Run Benchmarks (Mysql)
         if: matrix.backend == 'mysql'
@@ -88,6 +88,11 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           df -h
           rm diesel_bench/target/release -rf
+          # delete unwanted files from criterion
+          find diesel_bench/target/criterion/ -iname '*.json' -delete
+          find diesel_bench/target/criterion/ -type d -name "base" -exec rm -rv {} \; || true
+          find diesel_bench/target/criterion/ -type d -empty -delete
+          # free some space on the runner
           df -h
           sudo rm -rf /usr/share/dotnet
           df -h

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run Benchmarks (Sqlite)
         if: matrix.backend == 'sqlite'
-        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "sqlite sqlx-bench sqlx/sqlite tokio rusqlite futures sea-orm sea-orm/sqlx-sqlite criterion/async_tokio"
+        run: cargo +stable bench --manifest-path diesel_bench/Cargo.toml --no-default-features --features "sqlite sqlx-bench sqlx/sqlite tokio rusqlite futures sea-orm sea-orm/sqlx-sqlite criterion/async_tokio fast_run"
 
       - name: Run Benchmarks (Mysql)
         if: matrix.backend == 'mysql'
@@ -97,6 +97,7 @@ jobs:
           df -h
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
+          pwd
           git clone --depth 1 git@github.com:diesel-rs/metrics.git
           df -h
 

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -11,16 +11,16 @@ autobenches = false
 [dependencies]
 dotenvy = "0.15"
 criterion = {version = "0.3.2", default-features = false, features = ["csv_output", "cargo_bench_support"]}
-sqlx = {version = "0.6", features = ["runtime-tokio-rustls"], optional = true}
+sqlx = {version = "0.7", features = ["runtime-tokio-rustls"], optional = true}
 tokio = {version = "1", optional = true}
-rusqlite = {version = "0.27", optional = true}
+rusqlite = {version = "0.29", optional = true}
 rust_postgres = {version = "0.19", optional = true, package = "postgres"}
 rust_mysql = {version = "23.0", optional = true, package = "mysql"}
 rustorm = {version = "0.20", optional = true}
 rustorm_dao = {version = "0.20", optional = true}
 quaint = {version = "=0.2.0-alpha.13", optional = true, features = ["uuid"]}
 serde = {version = "1", optional = true, features = ["derive"]}
-sea-orm = {version = "0.11", optional = true, features = ["runtime-tokio-rustls"]}
+sea-orm = {  git = "https://github.com/SeaQL/sea-orm/", branch = "sqlx-v0.7", optional = true, features = ["runtime-tokio-rustls"]}
 futures = {version = "0.3", optional = true}
 diesel-async = {version = "0.2", optional = true, default-features = false}
 criterion-perf-events = { version = "0.2", optional = true}
@@ -57,4 +57,3 @@ fast_run = []
 quaint = {git = "https://github.com/prisma/prisma-engines", rev = "8f088bb"}
 diesel-async = { git = "https://github.com/weiznich/diesel_async", rev = "d9e219578a7e034c2714550a5a156c8e004896bc"}
 diesel = { path = "../diesel"}
-

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -10,7 +10,7 @@ autobenches = false
 
 [dependencies]
 dotenvy = "0.15"
-criterion = {version = "0.3.2", default-features = false, features = ["csv_output", "cargo_bench_support"]}
+criterion = {version = "0.5", default-features = false, features = ["csv_output", "cargo_bench_support"]}
 sqlx = {version = "0.7", features = ["runtime-tokio-rustls"], optional = true}
 tokio = {version = "1", optional = true}
 rusqlite = {version = "0.29", optional = true}

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -20,7 +20,7 @@ rustorm = {version = "0.20", optional = true}
 rustorm_dao = {version = "0.20", optional = true}
 quaint = {version = "=0.2.0-alpha.13", optional = true, features = ["uuid"]}
 serde = {version = "1", optional = true, features = ["derive"]}
-sea-orm = {  git = "https://github.com/SeaQL/sea-orm/", branch = "sqlx-v0.7", optional = true, features = ["runtime-tokio-rustls"]}
+sea-orm = {  git = "https://github.com/SeaQL/sea-orm/", branch = "master", optional = true, features = ["runtime-tokio-rustls"]}
 futures = {version = "0.3", optional = true}
 diesel-async = {version = "0.2", optional = true, default-features = false}
 criterion-perf-events = { version = "0.2", optional = true}

--- a/diesel_bench/benches/sea_orm_benches/mod.rs
+++ b/diesel_bench/benches/sea_orm_benches/mod.rs
@@ -16,7 +16,10 @@ use self::users::Entity as User;
 fn connection() -> (sqlx::PgPool, DatabaseConnection, Runtime) {
     use sea_orm::SqlxPostgresConnector;
 
-    let rt = Runtime::new().expect("Failed to start runtime");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to start runtime");
 
     dotenvy::dotenv().ok();
     let connection_url = dotenvy::var("PG_DATABASE_URL")
@@ -43,7 +46,10 @@ fn connection() -> (sqlx::MySqlPool, DatabaseConnection, Runtime) {
     use futures::StreamExt;
     use sea_orm::SqlxMySqlConnector;
 
-    let rt = Runtime::new().expect("Failed to start runtime");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to start runtime");
 
     dotenvy::dotenv().ok();
     let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
@@ -73,7 +79,10 @@ fn connection() -> (sqlx::MySqlPool, DatabaseConnection, Runtime) {
 fn connection() -> (sqlx::SqlitePool, DatabaseConnection, Runtime) {
     use sea_orm::SqlxSqliteConnector;
 
-    let rt = Runtime::new().expect("Failed to start runtime");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to start runtime");
     dotenvy::dotenv().ok();
 
     let (pool, db) = rt.block_on(async {

--- a/diesel_bench/benches/sqlx_benches.rs
+++ b/diesel_bench/benches/sqlx_benches.rs
@@ -70,7 +70,10 @@ type Connection = sqlx::PgConnection;
 fn connection() -> (Runtime, Connection) {
     use sqlx::Connection;
 
-    let runtime = Runtime::new().expect("Failed to create runtime");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create runtime");
 
     dotenvy::dotenv().ok();
     let connection_url = dotenvy::var("POSTGRES_DATABASE_URL")
@@ -101,7 +104,10 @@ fn connection() -> (Runtime, Connection) {
 fn connection() -> (Runtime, Connection) {
     use sqlx::Connection;
 
-    let runtime = Runtime::new().expect("Failed to create runtime");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create runtime");
 
     dotenvy::dotenv().ok();
     let connection_url = dotenvy::var("MYSQL_DATABASE_URL")
@@ -142,7 +148,10 @@ fn connection() -> (Runtime, Connection) {
 fn connection() -> (Runtime, Connection) {
     use sqlx::Connection;
 
-    let runtime = Runtime::new().expect("Failed to create runtime");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create runtime");
 
     let conn = runtime.block_on(async {
         let mut conn = sqlx::SqliteConnection::connect("sqlite::memory:")
@@ -418,7 +427,7 @@ pub fn loading_associations_sequentially(b: &mut Bencher) {
                         .bind(user.id)
                         .bind(None::<String>);
 
-                    insert_query.execute(&mut conn).await.unwrap();
+                    insert_query.execute(&mut *conn).await.unwrap();
                 }
             }
 
@@ -477,7 +486,7 @@ pub fn loading_associations_sequentially(b: &mut Bencher) {
                         .bind(format!("Comment {} on post {}", i, post.id))
                         .bind(post.id);
 
-                    insert_query.execute(&mut conn).await.unwrap();
+                    insert_query.execute(&mut *conn).await.unwrap();
                 }
             }
 


### PR DESCRIPTION
This PR updates sqlx, rusqlite and sea-orm in our benchmark dependencies. It also improves the metrics script to only push the relevant files (to keep the metrics repo small)