### PR TITLE
Fix #3579: Unexpected end of row when setup diesel

### DIFF
--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -1,7 +1,8 @@
 use std::error::Error;
 
-use diesel::deserialize::{self, FromStaticSqlRow, Queryable};
+use diesel::deserialize::{self, Queryable};
 use diesel::dsl::sql;
+use diesel::row::NamedRow;
 use diesel::sqlite::Sqlite;
 use diesel::*;
 
@@ -141,7 +142,10 @@ pub fn get_table_data(
     } else {
         format!("PRAGMA TABLE_INFO('{}')", &table.sql_name)
     };
-    let mut result = sql::<pragma_table_info::SqlType>(&query).load(conn)?;
+
+    // See: https://github.com/diesel-rs/diesel/issues/3579 as to why we use a direct
+    // `sql_query` with `QueryableByName` instead of using `sql::<pragma_table_info::SqlType>`.
+    let mut result = sql_query(query).load::<ColumnInformation>(conn)?;
     match column_sorting {
         ColumnSorting::OrdinalPosition => {}
         ColumnSorting::Name => {
@@ -153,15 +157,19 @@ pub fn get_table_data(
     Ok(result)
 }
 
-impl<ST> Queryable<ST, Sqlite> for ColumnInformation
-where
-    (i32, String, String, bool, Option<String>, bool, i32): FromStaticSqlRow<ST, Sqlite>,
-{
-    type Row = (i32, String, String, bool, Option<String>, bool, i32);
+impl QueryableByName<Sqlite> for ColumnInformation {
+    fn build<'a>(row: &impl NamedRow<'a, Sqlite>) -> deserialize::Result<Self> {
+        let column_name = NamedRow::get::<Text, String>(row, "name")?;
+        let type_name = NamedRow::get::<Text, String>(row, "type")?;
+        let notnull = NamedRow::get::<Bool, bool>(row, "notnull")?;
 
-    fn build(row: Self::Row) -> deserialize::Result<Self> {
-        Ok(ColumnInformation::new(
-            row.1, row.2, None, !row.3, None, None,
+        Ok(Self::new(
+            column_name,
+            type_name,
+            None,
+            !notnull,
+            None,
+            None,
         ))
     }
 }

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -18,18 +18,6 @@ table! {
 }
 
 table! {
-    pragma_table_info (cid) {
-        cid ->Integer,
-        name -> VarChar,
-        type_name -> VarChar,
-        notnull -> Bool,
-        dflt_value -> Nullable<VarChar>,
-        pk -> Bool,
-        hidden -> Integer,
-    }
-}
-
-table! {
     pragma_foreign_key_list {
         id -> Integer,
         seq -> Integer,


### PR DESCRIPTION
We use `PRAGMA table_info` for older versions of sqlite. This returns fewer columns that `PRAGMA table_xinfo` which we use in newer versions of sqlite, making the two code paths incompatbile with the `Queryable` implementations. We instead now use `sql_query` with an implementation of `QueryableByName` to return default values for the case of `PRAGMA table_info`.

Note this is a WIP implementation. It's my first contribution and dive into the diesel codebase so there is a good chance this is not the right way to do it.

## Questions
1. Should I use`derive` instead of a manual implementation of `QueryableByName`?

## Tests
1. Run `cargo test --features sqlite --no-default-features` successfully.
2. Run the shell script provided in #3579 .

## NOT TESTED!
I have not tested the case of an older sqlite version as described in #3579 as I currently do
not have a setup for this. I will refer to the author of the issue to test this branch for me.