### PR TITLE
Implementing ToSql for [u8;N]

### DIFF
--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -116,7 +116,7 @@ mod foreign_impls {
     struct BinarySliceProxy([u8]);
 
     #[derive(AsExpression)]
-    #[diesel(foreign_derive, not_sized)]
+    #[diesel(foreign_derive)]
     #[diesel(sql_type = Binary)]
     struct BinaryArrayProxy<const N: usize>([u8; N]);
 }

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -175,6 +175,16 @@ where
     }
 }
 
+impl<DB, const N: usize> ToSql<sql_types::Binary, DB> for [u8; N]
+where
+    DB: Backend,
+    [u8]: ToSql<sql_types::Binary, DB>,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> serialize::Result {
+        self.as_slice().to_sql(out)
+    }
+}
+
 impl<DB> ToSql<sql_types::Binary, DB> for [u8]
 where
     for<'a> DB: Backend<BindCollector<'a> = RawBytesBindCollector<DB>>,

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -114,6 +114,11 @@ mod foreign_impls {
     #[diesel(foreign_derive, not_sized)]
     #[diesel(sql_type = Binary)]
     struct BinarySliceProxy([u8]);
+
+    #[derive(AsExpression)]
+    #[diesel(foreign_derive, not_sized)]
+    #[diesel(sql_type = Binary)]
+    struct BinaryArrayProxy<const N: usize>([u8; N]);
 }
 
 impl<ST, DB> FromSql<ST, DB> for String

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -610,6 +610,7 @@ fn binary_from_sql() {
 #[cfg(feature = "postgres")]
 fn bytes_to_sql_binary() {
     let invalid_utf8_bytes = vec![0x1Fu8, 0x8Bu8];
+    let invalid_utf8_array = [0x1Fu8, 0x8Bu8];
     assert!(query_to_sql_equality::<Binary, Vec<u8>>(
         "E'\\\\x1F8B'::bytea",
         invalid_utf8_bytes.clone()
@@ -620,7 +621,7 @@ fn bytes_to_sql_binary() {
     ));
     assert!(query_to_sql_equality::<Binary, &[u8; 2]>(
         "E'\\\\x1F8B'::bytea",
-        &invalid_utf8_bytes
+        &invalid_utf8_array
     ));
     assert!(!query_to_sql_equality::<Binary, &[u8]>(
         "''::bytea",

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -618,6 +618,10 @@ fn bytes_to_sql_binary() {
         "E'\\\\x1F8B'::bytea",
         &invalid_utf8_bytes
     ));
+    assert!(query_to_sql_equality::<Binary, &[u8; 2]>(
+        "E'\\\\x1F8B'::bytea",
+        &invalid_utf8_bytes
+    ));
     assert!(!query_to_sql_equality::<Binary, &[u8]>(
         "''::bytea",
         &invalid_utf8_bytes


### PR DESCRIPTION
Hi thanks for developing and supporting diesel.

This PR would allow to bind slices of arbitrary size to queries (my specific usecase is raw queries). It's mostly for convenience to prevent having to reshape types prior to sending them to diesel.

An alternative would be to implement it for all the `T: AsRef<[u8]>`.
