### PR TITLE
Expose more of the transaction manager

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -16,8 +16,8 @@ use crate::result::*;
 use std::fmt::Debug;
 
 pub use self::transaction_manager::{
-    AnsiTransactionManager, TransactionDepthChange, TransactionManager, TransactionManagerStatus,
-    ValidTransactionManagerStatus,
+    AnsiTransactionManager, InTransactionStatus, TransactionDepthChange, TransactionManager,
+    TransactionManagerStatus, ValidTransactionManagerStatus,
 };
 
 #[diesel_derives::__diesel_public_if(


### PR DESCRIPTION
This commit exposes more internals of the transaction manager so that different connection implementations can reuse the existing building blocks. This is mainly to improve the connection implementations provided by diesel-async