### PR TITLE
Allow to configure the used alias syntax

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -306,6 +306,17 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "See [`sql_dialect::select_statement_syntax`] for provided default implementations"
     )]
     type SelectStatementSyntax;
+
+    /// Configures how this backend structures `SELECT` queries
+    ///
+    /// This allows backends to provide custom [`QueryFragment`](crate::query_builder::QueryFragment)
+    /// implementations for [`Alias<T>`](crate::query_source::Alias)
+    ///
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::alias_syntax`] for provided default implementations"
+    )]
+    type AliasSyntax;
 }
 
 /// This module contains all options provided by diesel to configure the [`SqlDialect`] trait.
@@ -515,6 +526,18 @@ pub(crate) mod sql_dialect {
         /// ANSI select statement structure
         #[derive(Debug, Copy, Clone)]
         pub struct AnsiSqlSelectStatement;
+    }
+
+    /// This module contains all reusable options to configure
+    /// [`SqlDialect::AliasSyntax`]
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub mod alias_syntax {
+        /// Indicates that this backend uses `table AS alias` for
+        /// defining table aliases
+        #[derive(Debug, Copy, Clone)]
+        pub struct AsAliasSyntax;
     }
 }
 

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -88,6 +88,7 @@ impl SqlDialect for Mysql {
     type ArrayComparison = sql_dialect::array_comparison::AnsiSqlArrayComparison;
 
     type ConcatClause = MysqlConcatClause;
+    type AliasSyntax = sql_dialect::alias_syntax::AsAliasSyntax;
 }
 
 impl DieselReserveSpecialization for Mysql {}

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -139,6 +139,7 @@ impl SqlDialect for Pg {
 
     type ExistsSyntax = sql_dialect::exists_syntax::AnsiSqlExistsSyntax;
     type ArrayComparison = PgStyleArrayComparison;
+    type AliasSyntax = sql_dialect::alias_syntax::AsAliasSyntax;
 }
 
 impl DieselReserveSpecialization for Pg {}

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -66,6 +66,7 @@ impl SqlDialect for Sqlite {
 
     type ExistsSyntax = sql_dialect::exists_syntax::AnsiSqlExistsSyntax;
     type ArrayComparison = sql_dialect::array_comparison::AnsiSqlArrayComparison;
+    type AliasSyntax = sql_dialect::alias_syntax::AsAliasSyntax;
 }
 
 impl DieselReserveSpecialization for Sqlite {}

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -1035,6 +1035,10 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
         quote::quote! {
             <Tab, V, QId, const HAS_STATIC_QUERY_ID: bool> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiBatchInsertSupport>
                 for diesel::internal::derives::multiconnection::BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>
+        },
+        quote::quote! {
+            <S> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiAliasSyntax>
+                for diesel::query_source::Alias<S>
         }
     ])
     .map(|t| generate_queryfragment_impls(t, &query_fragment_bounds));
@@ -1414,6 +1418,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         pub struct MultiArrayComparisonSyntax;
         pub struct MultiConcatClauseSyntax;
         pub struct MultiSelectStatementSyntax;
+        pub struct MultiAliasSyntax;
 
         impl diesel::backend::SqlDialect for MultiBackend {
             type ReturningClause = MultiReturningClause;
@@ -1427,6 +1432,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
             type ArrayComparison = MultiArrayComparisonSyntax;
             type ConcatClause = MultiConcatClauseSyntax;
             type SelectStatementSyntax = MultiSelectStatementSyntax;
+            type AliasSyntax = MultiAliasSyntax;
         }
 
         impl diesel::internal::derives::multiconnection::TrustedBackend for MultiBackend {}


### PR DESCRIPTION
This change is required because some database backends (oracle…) do not support the `table AS alias` syntax. They instead use a different syntax. To allow those backends to customize the `QueryFragment` impl for `Alias` we introduce another flag in `SqlDialect` that allows to customize the relevant impl.