### PR TITLE
Allow `#[diesel(treat_none_as_{null, default_value} = …]` on fields

### DIFF
--- a/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.rs
@@ -1,0 +1,17 @@
+use diesel::prelude::*;
+
+table! {
+    users(id) {
+        id -> Integer,
+        name -> Nullable<Text>,
+    }
+}
+
+#[derive(Insertable)]
+struct User {
+    id: String,
+    #[diesel(embed, treat_none_as_default_value = true)]
+    name: Option<i32>,
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.stderr
@@ -1,0 +1,5 @@
+error: `embed` and `treat_none_as_default_value` are mutually exclusive
+  --> tests/fail/derive/bad_embed_treat_none_as_default_value.rs:13:7
+   |
+13 |     #[diesel(embed, treat_none_as_default_value = true)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.rs
@@ -32,4 +32,12 @@ struct UserForm3 {
     name: String,
 }
 
+#[derive(Insertable)]
+#[diesel(table_name = users)]
+struct UserForm4 {
+    id: i32,
+    #[diesel(treat_none_as_default_value = false)]
+    name: String,
+}
+
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.stderr
@@ -16,3 +16,9 @@ error: expected boolean literal
    |
 29 | #[diesel(treat_none_as_default_value = "foo")]
    |                                        ^^^^^
+
+error: expected `treat_none_as_default_value` field to be of type `Option<_>`
+  --> tests/fail/derive/bad_treat_none_as_default_value.rs:40:11
+   |
+40 |     name: String,
+   |           ^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.rs
@@ -32,4 +32,12 @@ struct UserForm3 {
     name: String,
 }
 
+#[derive(AsChangeset)]
+#[diesel(table_name = users)]
+struct UserForm4 {
+    id: i32,
+    #[diesel(treat_none_as_null = true)]
+    name: String,
+}
+
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.stderr
@@ -16,3 +16,9 @@ error: expected boolean literal
    |
 29 | #[diesel(treat_none_as_null = "foo")]
    |                               ^^^^^
+
+error: expected `treat_none_as_null` field to be of type `Option<_>`
+  --> tests/fail/derive/bad_treat_none_as_null.rs:40:11
+   |
+40 |     name: String,
+   |           ^^^^^^

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -45,6 +45,12 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let mut ref_field_assign = Vec::with_capacity(fields_for_update.len());
 
     for field in fields_for_update {
+        // Use field-level attr. with fallback to the struct-level one.
+        let treat_none_as_null = match &field.treat_none_as_null {
+            Some(attr) => attr.item,
+            None => treat_none_as_null,
+        };
+
         match field.serialize_as.as_ref() {
             Some(AttributeSpanWrapper { item: ty, .. }) => {
                 direct_field_ty.push(field_changeset_ty_serialize_as(

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::spanned::Spanned as _;
 use syn::{parse_quote, DeriveInput, Expr, Path, Result, Type};
 
 use crate::attrs::AttributeSpanWrapper;
@@ -47,7 +48,16 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     for field in fields_for_update {
         // Use field-level attr. with fallback to the struct-level one.
         let treat_none_as_null = match &field.treat_none_as_null {
-            Some(attr) => attr.item,
+            Some(attr) => {
+                if !is_option_ty(&field.ty) {
+                    return Err(syn::Error::new(
+                        field.ty.span(),
+                        "expected `treat_none_as_null` field to be of type `Option<_>`",
+                    ));
+                }
+
+                attr.item
+            }
             None => treat_none_as_null,
         };
 

--- a/diesel_derives/src/attrs.rs
+++ b/diesel_derives/src/attrs.rs
@@ -36,6 +36,9 @@ pub enum FieldAttr {
 
     ColumnName(Ident, SqlIdentifier),
     SqlType(Ident, TypePath),
+    TreatNoneAsDefaultValue(Ident, LitBool),
+    TreatNoneAsNull(Ident, LitBool),
+
     SerializeAs(Ident, TypePath),
     DeserializeAs(Ident, TypePath),
     SelectExpression(Ident, SelectExpr),
@@ -127,6 +130,14 @@ impl Parse for FieldAttr {
                 parse_eq(input, COLUMN_NAME_NOTE)?,
             )),
             "sql_type" => Ok(FieldAttr::SqlType(name, parse_eq(input, SQL_TYPE_NOTE)?)),
+            "treat_none_as_default_value" => Ok(FieldAttr::TreatNoneAsDefaultValue(
+                name,
+                parse_eq(input, TREAT_NONE_AS_DEFAULT_VALUE_NOTE)?,
+            )),
+            "treat_none_as_null" => Ok(FieldAttr::TreatNoneAsNull(
+                name,
+                parse_eq(input, TREAT_NONE_AS_NULL_NOTE)?,
+            )),
             "serialize_as" => Ok(FieldAttr::SerializeAs(
                 name,
                 parse_eq(input, SERIALIZE_AS_NOTE)?,
@@ -165,6 +176,8 @@ impl MySpanned for FieldAttr {
             FieldAttr::Embed(ident)
             | FieldAttr::ColumnName(ident, _)
             | FieldAttr::SqlType(ident, _)
+            | FieldAttr::TreatNoneAsNull(ident, _)
+            | FieldAttr::TreatNoneAsDefaultValue(ident, _)
             | FieldAttr::SerializeAs(ident, _)
             | FieldAttr::DeserializeAs(ident, _)
             | FieldAttr::SelectExpression(ident, _)

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -10,6 +10,8 @@ pub struct Field {
     pub name: FieldName,
     column_name: Option<AttributeSpanWrapper<SqlIdentifier>>,
     pub sql_type: Option<AttributeSpanWrapper<Type>>,
+    pub treat_none_as_default_value: Option<AttributeSpanWrapper<bool>>,
+    pub treat_none_as_null: Option<AttributeSpanWrapper<bool>>,
     pub serialize_as: Option<AttributeSpanWrapper<Type>>,
     pub deserialize_as: Option<AttributeSpanWrapper<Type>>,
     pub select_expression: Option<AttributeSpanWrapper<SelectExpr>>,
@@ -30,6 +32,8 @@ impl Field {
         let mut embed = None;
         let mut select_expression = None;
         let mut select_expression_type = None;
+        let mut treat_none_as_default_value = None;
+        let mut treat_none_as_null = None;
 
         for attr in parse_attributes(attrs)? {
             let attribute_span = attr.attribute_span;
@@ -45,6 +49,20 @@ impl Field {
                 FieldAttr::SqlType(_, value) => {
                     sql_type = Some(AttributeSpanWrapper {
                         item: Type::Path(value),
+                        attribute_span,
+                        ident_span,
+                    })
+                }
+                FieldAttr::TreatNoneAsDefaultValue(_, value) => {
+                    treat_none_as_default_value = Some(AttributeSpanWrapper {
+                        item: value.value,
+                        attribute_span,
+                        ident_span,
+                    })
+                }
+                FieldAttr::TreatNoneAsNull(_, value) => {
+                    treat_none_as_null = Some(AttributeSpanWrapper {
+                        item: value.value,
                         attribute_span,
                         ident_span,
                     })
@@ -103,6 +121,8 @@ impl Field {
             name,
             column_name,
             sql_type,
+            treat_none_as_default_value,
+            treat_none_as_null,
             serialize_as,
             deserialize_as,
             select_expression,

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -6,6 +6,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use quote::quote_spanned;
 use syn::parse_quote;
+use syn::spanned::Spanned as _;
 use syn::{DeriveInput, Expr, Path, Result, Type};
 
 pub fn derive(item: DeriveInput) -> Result<TokenStream> {
@@ -46,19 +47,28 @@ fn derive_into_single_table(
     for field in model.fields() {
         // Use field-level attr. with fallback to the struct-level one.
         let treat_none_as_default_value = match &field.treat_none_as_default_value {
-            Some(attr) => attr.item,
+            Some(attr) => {
+                if let Some(embed) = &field.embed {
+                    return Err(syn::Error::new(
+                        embed.attribute_span,
+                        "`embed` and `treat_none_as_default_value` are mutually exclusive",
+                    ));
+                }
+
+                if !is_option_ty(&field.ty) {
+                    return Err(syn::Error::new(
+                        field.ty.span(),
+                        "expected `treat_none_as_default_value` field to be of type `Option<_>`",
+                    ));
+                }
+
+                attr.item
+            }
             None => treat_none_as_default_value,
         };
 
         match (field.serialize_as.as_ref(), field.embed()) {
             (None, true) => {
-                if field.treat_none_as_default_value.is_some() {
-                    return Err(syn::Error::new(
-                        field.embed.as_ref().unwrap().attribute_span,
-                        "`embed` and `treat_none_as_default_value` are mutually exclusive",
-                    ));
-                }
-
                 direct_field_ty.push(field_ty_embed(field, None));
                 direct_field_assign.push(field_expr_embed(field, None));
                 ref_field_ty.push(field_ty_embed(field, Some(quote!(&'insert))));

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -102,6 +102,8 @@ mod valid_grouping;
 ///    field type, Diesel will convert the field into `SomeType` using `.into` and
 ///    serialize that instead. By default, this derive will serialize directly using
 ///    the actual field type.
+/// * `#[diesel(treat_none_as_null = true/false)]`, overrides the container-level
+///   `treat_none_as_null` attribute for the current field.
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(
@@ -330,6 +332,8 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 ///    field type, Diesel will convert the field into `SomeType` using `.into` and
 ///    serialize that instead. By default, this derive will serialize directly using
 ///    the actual field type.
+/// * `#[diesel(treat_none_as_default_value = true/false)]`, overrides the container-level
+///   `treat_none_as_default_value` attribute for the current field.
 ///
 /// # Examples
 ///

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -496,7 +496,8 @@ fn option_fields_are_assigned_null_when_specified() {
     #[diesel(table_name = users)]
     #[diesel(treat_none_as_null = true)]
     struct UserForm<'a> {
-        name: &'a str,
+        #[diesel(treat_none_as_null = false)]
+        name: Option<&'a str>,
         hair_color: Option<&'a str>,
     }
 
@@ -504,21 +505,21 @@ fn option_fields_are_assigned_null_when_specified() {
 
     update(users::table.find(1))
         .set(&UserForm {
-            name: "Jim",
+            name: None,
             hair_color: Some("blue"),
         })
         .execute(connection)
         .unwrap();
     update(users::table.find(2))
         .set(&UserForm {
-            name: "Ruby",
+            name: Some("Ruby"),
             hair_color: None,
         })
         .execute(connection)
         .unwrap();
 
     let expected = vec![
-        (1, String::from("Jim"), Some(String::from("blue"))),
+        (1, String::from("Sean"), Some(String::from("blue"))),
         (2, String::from("Ruby"), None),
     ];
     let actual = users::table.order(users::id).load(connection);


### PR DESCRIPTION
If present on a field, this will override the corresponding container-level attribute.

This restores feature parity with the old `diesel 1.x` versions, which allowed these two attributes on struct fields.