### PR TITLE
time: sql_type for DateTimeProxy without backend

### DIFF
--- a/diesel/src/type_impls/date_and_time.rs
+++ b/diesel/src/type_impls/date_and_time.rs
@@ -79,8 +79,16 @@ mod time {
     #[cfg_attr(feature = "mysql_backend", diesel(sql_type = crate::sql_types::Datetime))]
     struct NaiveDateTimeProxy(PrimitiveDateTime);
 
-    #[derive(AsExpression, FromSqlRow)]
+    #[derive(FromSqlRow)]
     #[diesel(foreign_derive)]
+    #[cfg_attr(
+        any(
+            feature = "postgres_backend",
+            feature = "sqlite",
+            feature = "mysql_backend"
+        ),
+        derive(AsExpression)
+    )]
     #[cfg_attr(
         feature = "postgres_backend",
         diesel(sql_type = crate::sql_types::Timestamptz)


### PR DESCRIPTION
With the time feature enabled and no active database backend compilation fails because no sql_type is specified for DateTimeProxy.

This is fixed by only deriving AsExpression for DateTimeProxy when a
database backend is active.

Fixes #3733 