### PR TITLE
Add `Bool` type to MultiConnection

### DIFF
--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -582,6 +582,7 @@ fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStrea
             quote::quote!(diesel::sql_types::Binary),
             quote::quote!([u8]),
         ),
+        (quote::quote!(diesel::sql_types::Bool), quote::quote!(bool)),
     ]
     .into_iter()
     .map(|t| generate_to_sql_impls(t, connection_types));
@@ -606,6 +607,7 @@ fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStrea
             quote::quote!(diesel::sql_types::Binary),
             quote::quote!(Vec<u8>),
         ),
+        (quote::quote!(diesel::sql_types::Bool), quote::quote!(bool)),
     ]
     .into_iter()
     .map(generate_from_sql_impls);
@@ -1296,6 +1298,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         quote::quote!(diesel::sql_types::Date),
         quote::quote!(diesel::sql_types::Time),
         quote::quote!(diesel::sql_types::Timestamp),
+        quote::quote!(diesel::sql_types::Bool),
     ]
     .into_iter()
     .map(generate_has_sql_type_impls);


### PR DESCRIPTION
During trying to implement MultiConnection i found that the `Bool` type was missing.

This PR adds this type.