### PR TITLE
Monomorphization of 'cached_statement'

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.1"
 license = "MIT OR Apache-2.0"
 description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"
 readme = "README.md"

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel"
-version = "2.1.1"
+version = "2.1.0"
 license = "MIT OR Apache-2.0"
 description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"
 readme = "README.md"

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -177,29 +177,9 @@ where
     /// parameter indicates if the constructed prepared statement will be cached or not.
     /// See the [module](self) documentation for details
     /// about which statements are cached and which are not cached.
+    // Note: This function is intentionally monomorphic over the "source" type.
     #[allow(unreachable_pub)]
-    pub fn cached_statement<T, F>(
-        &mut self,
-        source: &T,
-        backend: &DB,
-        bind_types: &[DB::TypeMetadata],
-        prepare_fn: F,
-    ) -> QueryResult<MaybeCached<'_, Statement>>
-    where
-        T: QueryFragment<DB> + QueryId,
-        F: FnOnce(&str, PrepareForCache) -> QueryResult<Statement>,
-    {
-        let mut f = Some(prepare_fn);
-        self.cached_statement_inner(T::query_id(), source, backend, bind_types, &mut |s, p| {
-            let f = f.take().unwrap();
-            f(s, p)
-        })
-    }
-
-    // Note: This function is a direct implementation of "cached_statement", but
-    // it is intentionally monomorphic over the "source" type.
-    #[inline(never)]
-    fn cached_statement_inner(
+    pub fn cached_statement(
         &mut self,
         maybe_type_id: Option<TypeId>,
         source: &dyn QueryFragment<DB>,
@@ -307,7 +287,6 @@ where
 {
     /// Create a new statement cache key for the given query source
     // Note: Intentionally monomorphic over source.
-    #[inline(never)]
     #[allow(unreachable_pub)]
     pub fn for_source(
         maybe_type_id: Option<TypeId>,
@@ -332,7 +311,6 @@ where
     /// This is an optimization that may skip constructing the query string
     /// twice if it's already part of the current cache key
     // Note: Intentionally monomorphic over source.
-    #[inline(never)]
     #[allow(unreachable_pub)]
     pub fn sql(&self, source: &dyn QueryFragment<DB>, backend: &DB) -> QueryResult<Cow<'_, str>> {
         match *self {
@@ -342,7 +320,6 @@ where
     }
 
     // Note: Intentionally monomorphic over source.
-    #[inline(never)]
     fn construct_sql(source: &dyn QueryFragment<DB>, backend: &DB) -> QueryResult<String> {
         let mut query_builder = DB::QueryBuilder::default();
         source.to_sql(&mut query_builder, backend)?;

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -248,8 +248,10 @@ fn prepared_query<'a, T: QueryFragment<Mysql> + QueryId>(
     statement_cache: &'a mut StatementCache<Mysql, Statement>,
     raw_connection: &'a mut RawConnection,
 ) -> QueryResult<MaybeCached<'a, Statement>> {
-    let mut stmt = statement_cache
-        .cached_statement(source, &Mysql, &[], |sql, _| raw_connection.prepare(sql))?;
+    let mut stmt =
+        statement_cache.cached_statement(T::query_id(), source, &Mysql, &[], &mut |sql, _| {
+            raw_connection.prepare(sql)
+        })?;
     let mut bind_collector = RawBytesBindCollector::new();
     source.collect_binds(&mut bind_collector, &mut (), &Mysql)?;
     let binds = bind_collector

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -356,7 +356,7 @@ impl PgConnection {
         let cache_len = self.statement_cache.len();
         let cache = &mut self.statement_cache;
         let conn = &mut self.connection_and_transaction_manager.raw_connection;
-        let query = cache.cached_statement(source, &Pg, &metadata, |sql, _| {
+        let query = cache.cached_statement(T::query_id(), source, &Pg, &metadata, &mut |sql, _| {
             let query_name = if source.is_safe_to_cache_prepared(&Pg)? {
                 Some(format!("__diesel_stmt_{cache_len}"))
             } else {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -308,9 +308,13 @@ impl SqliteConnection {
     {
         let raw_connection = &self.raw_connection;
         let cache = &mut self.statement_cache;
-        let statement = cache.cached_statement(&source, &Sqlite, &[], |sql, is_cached| {
-            Statement::prepare(raw_connection, sql, is_cached)
-        })?;
+        let statement = cache.cached_statement(
+            T::query_id(),
+            &source,
+            &Sqlite,
+            &[],
+            &mut |sql, is_cached| Statement::prepare(raw_connection, sql, is_cached),
+        )?;
 
         StatementUse::bind(statement, source)
     }

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -23,7 +23,7 @@ serde = {version = "1", optional = true, features = ["derive"]}
 sea-orm = {  git = "https://github.com/SeaQL/sea-orm/", branch = "master", optional = true, features = ["runtime-tokio-rustls"]}
 futures = {version = "0.3", optional = true}
 diesel-async = {version = "0.2", optional = true, default-features = false}
-criterion-perf-events = { version = "0.2", optional = true}
+criterion-perf-events = { version = "0.4", optional = true}
 perfcnt = {version = "0.8", optional = true}
 
 [dependencies.diesel]


### PR DESCRIPTION
For context, see: https://matklad.github.io/2021/09/04/fast-rust-builds.html#Keeping-Instantiations-In-Check

This PR attempts to preserve the API used by the statement_cache, but attempts to monomorphize over the underlying `QueryFragment + QueryId` type.

The generics in the statement cache appear to be:

1. The DB backend
2. The `QueryFragment + QueryId` type

Although it probably makes sense to preserve being generic over the backend, duplicating this code for each query type results in a noticeable binary bloat. In a debug build of https://github.com/oxidecomputer/omicron , this change reduces the binary size by ~620 KiB.

I'm putting forward this PR as a bit of an experiment -- I think there are many other spots (for example, over the connection types) where we're generic over the `QueryFragment + QueryId` types, and for which we generate a significant amount of code for each query. I think, in the limit, it should be possible to generate this code "once per backend", and monomorphize more of the "per-query" codepaths.