### PR TITLE
Fix #3790

### DIFF
--- a/diesel_compile_tests/tests/fail/derive/selectable.rs
+++ b/diesel_compile_tests/tests/fail/derive/selectable.rs
@@ -41,4 +41,11 @@ struct User {
     no_tuple: i32,
 }
 
+#[derive(Selectable)]
+#[diesel(table_name = users)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+struct User1<'a> {
+    name: &'a str,
+}
+
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/selectable.stderr
@@ -1,3 +1,10 @@
+error: References are not supported in `Queryable` types
+       Consider using `std::borrow::Cow<'a, str>` instead
+  --> tests/fail/derive/selectable.rs:48:11
+   |
+48 |     name: &'a str,
+   |           ^^^^^^^
+
 error[E0412]: cannot find type `non_existing` in module `users`
   --> tests/fail/derive/selectable.rs:26:5
    |


### PR DESCRIPTION
This commit fixes an issue in `#[derive(Selectable)]` that caused generating invalid rust code for structs with lifetimes (and type parameters). It improves the derive to handle type parameters and lifetimes correctly. In addition it also improves the derive to generate an error if we find a reference, as plain references are not supported as load target by diesel.