### PR TITLE
Prepare a 2.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ## Unreleased
 
+## [2.1.3] 2023-10-xx
+
+* Increased accidently decreased limit around element count in  `DISTINCT ON` and `ORDER BY` clauses again as that broke existing code
+
 ## [2.1.2] 2023-09-25
 
 ## Fixed

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel"
-version = "2.1.2"
+version = "2.1.3"
 license = "MIT OR Apache-2.0"
 description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"
 readme = "README.md"

--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -240,7 +240,7 @@ macro_rules! valid_ordering {
 // If we would generate these impls up to max_table_column_count tuple elements that
 // would be a really large number for 128 tuple elements (~64k trait impls)
 // It's fine to increase this number at some point in the future gradually
-diesel_derives::__diesel_for_each_tuple!(valid_ordering, 3);
+diesel_derives::__diesel_for_each_tuple!(valid_ordering, 5);
 
 /// A decorator trait for `OrderClause`
 /// It helps to have bounds on either Col, Asc<Col> and Desc<Col>.

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -9,12 +9,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -34,12 +34,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -59,12 +59,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -84,12 +84,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, DistinctOnClause<name>>` to implement `OrderDsl<columns::id>`
 note: required by a bound in `order_by`
@@ -109,12 +109,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -134,12 +134,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -159,12 +159,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -184,12 +184,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -209,12 +209,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
@@ -234,12 +234,12 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               <diesel::query_builder::order_clause::OrderClause<(T,)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>>
               <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Asc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T1, diesel::expression::operators::Desc<T2>)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>>
-              <diesel::query_builder::order_clause::OrderClause<(T0, T2, T1)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>>
+              <diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)> as query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>>
             and $N others
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, DistinctOnClause<name>>` to implement `OrderDsl<columns::id>`
 note: required by a bound in `order_by`


### PR DESCRIPTION
This fixes another issue around `DISTINCT ON` and `ORDER BY` clauses, as I accidentally decreased the maximal tuple size of those clauses from 5 to 3 in the last patch release. This release bumps the size to 5 again.

Relevant PR: #3811 

cc @diesel-rs/core 