### PR TITLE
Optimise the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
         with:
           components: clippy, rustfmt
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -408,7 +408,7 @@ jobs:
         with:
           components: "rust-src"
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -441,7 +441,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
       - name: Cache cargo registry
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   check_and_test:
     name: Check
+    needs: [sqlite_bundled, rustfmt_and_clippy]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This commit tries to reduce the time to get feedback whether or not a build fails by only running all the tests on all platforms if basic checks succeed. For that we first run the rustfmt + clippy check (that builds basically all the code) and the `sqlite bundled` check (that runs most of the tests on linux + sqlite).