### PR TITLE
Add clippy::pedantic for star import

### DIFF
--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -555,6 +555,7 @@ impl<'a> Display for TableDefinition<'a> {
                 {
                     if already_imported_custom_types.insert(&ct.rust_name) {
                         if !has_written_import {
+                            writeln!(out, "#[allow(clippy::pedantic)]")?;
                             writeln!(out, "use diesel::sql_types::*;")?;
                         }
                         writeln!(out, "use super::sql_types::{};", ct.rust_name)?;

--- a/diesel_cli/tests/print_schema/print_schema_custom_types_check_default_derives/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types_check_default_derives/postgres/expected.snap
@@ -24,6 +24,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::MyType;
     use super::sql_types::MyType2;

--- a/diesel_cli/tests/print_schema/print_schema_custom_types_overriding_derives_works/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types_overriding_derives_works/postgres/expected.snap
@@ -24,6 +24,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::MyType;
     use super::sql_types::MyType2;

--- a/diesel_cli/tests/print_schema/print_schema_default_is_to_generate_custom_types/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_default_is_to_generate_custom_types/postgres/expected.snap
@@ -24,6 +24,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::MyType;
     use super::sql_types::MyType2;

--- a/diesel_cli/tests/print_schema/print_schema_respects_type_name_case/postgres/expected.rs
+++ b/diesel_cli/tests/print_schema/print_schema_respects_type_name_case/postgres/expected.rs
@@ -20,6 +20,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::MyType;
     use super::sql_types::MyType2;

--- a/diesel_cli/tests/print_schema/print_schema_respects_type_name_case/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_respects_type_name_case/postgres/expected.snap
@@ -24,6 +24,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::MyType;
     use super::sql_types::MyType2;

--- a/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_custom_type/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_custom_type/postgres/expected.snap
@@ -18,6 +18,7 @@ pub mod custom_schema {
     }
 
     diesel::table! {
+        #[allow(clippy::pedantic)]
         use diesel::sql_types::*;
         use super::sql_types::MyEnum;
 

--- a/diesel_cli/tests/print_schema/print_schema_type_renaming/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_type_renaming/postgres/expected.snap
@@ -17,6 +17,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::UserJob;
 

--- a/diesel_cli/tests/print_schema/print_schema_with_enum_set_types/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_enum_set_types/mysql/expected.snap
@@ -26,6 +26,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::Users1UserStateEnum;
     use super::sql_types::Users1EnabledFeaturesSet;

--- a/diesel_cli/tests/print_schema/print_schema_with_enum_set_types/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_enum_set_types/postgres/expected.snap
@@ -24,6 +24,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::SomeEnum;
     use super::sql_types::SomeEnum2;

--- a/examples/postgres/custom_types/src/schema.rs
+++ b/examples/postgres/custom_types/src/schema.rs
@@ -7,6 +7,7 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    #[allow(clippy::pedantic)]
     use diesel::sql_types::*;
     use super::sql_types::Language;
 


### PR DESCRIPTION
To fix:

```
warning: usage of wildcard import
   --> src/models/schema_gen.rs:174:9
    |
174 |     use diesel::sql_types::*;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `diesel::sql_types::{Nullable, Text, Timestamptz, Uuid, Varchar}`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_imports
```

For now, I added a `patch_file` to my `diesel.toml` configuration, but I figured it'd be nicer for all if it's added automatically.

Or perhaps there's a better way that a reviewer will recommend :)