### PR TITLE
Add a spell checking step to the CI and fix all spelling errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,3 +461,15 @@ jobs:
         run: cargo +1.66.0 minimal-versions check -p diesel_migrations --all-features
       - name: Check diesel_cli
         run: cargo +1.66.0 minimal-versions check -p diesel_cli --all-features
+
+  typos:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v3
+
+      - name: Check the spelling of the files in our repo
+        uses: crate-ci/typos@master

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,23 @@
+[default]
+extend-ignore-re = [
+    # that's a ipv6
+    "2001:4f8:3:ba",
+    # that is just strangly cased
+    "dO_nOt_cHaNgE_cAsE", "fOoBaR",
+    # that is the name of a book author
+    "michael_ende", "Michael Ende",
+    # That's an actual money unit (include the commet to only match that part)
+    "Fils;  // 1/1000th unit of Dinar",
+    # That's a name (include the expression to only match the relevant part)
+    "name\\.eq\\(\"Claus\"\\)",
+    # thats a test for a typo,
+    "cannot find value `titel` in module `posts`",
+    "cannot find type `titel` in module `posts`",
+    "[0-9]+[[:space]]+|[[:space:]]+titel: String",
+]
+
+[type.md]
+extend-ignore-re = [
+    # occurs in the changelog
+    "derive\\(Queriable\\)", "`Queriable`"
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ### Changed
 
-* The minimal offically supported rustc version is now 1.66.0
+* The minimal officially supported rustc version is now 1.66.0
 
 ## [2.1.0] 2023-05-26
 
@@ -258,7 +258,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
   and a bound to `QueryableByName<DB>` with `FromSqlRow<Untyped, DB>`. 
 
 * CLI flags of `only-tables` and `except-tables` are now interpreted as regular expressions.
-  Similarly, `only_tabels` and `except_tables` in `diesel.toml` are treated as regular expressions.
+  Similarly, `only_tables` and `except_tables` in `diesel.toml` are treated as regular expressions.
 
 * Now you can sort column fields by name with the `column-sorting` option. 
   It can be set to either `ordinal_position` (default) or `name`.

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -326,7 +326,7 @@ pub trait SqlDialect: self::private::TrustedBackend {
 // * The backend fixed/introduced a bug that requires special handling
 // * We got some edge case wrong with sharing the implementation between backends
 //
-// By not exposing these types publically we are able to change the exact definitions later on
+// By not exposing these types publicly we are able to change the exact definitions later on
 // as users cannot write trait bounds that ensure that a specific type is used in place of
 // an existing associated type.
 #[diesel_derives::__diesel_public_if(

--- a/diesel/src/connection/transaction_manager.rs
+++ b/diesel/src/connection/transaction_manager.rs
@@ -211,7 +211,7 @@ impl TransactionManagerStatus {
     public_fields(in_transaction)
 )]
 pub struct ValidTransactionManagerStatus {
-    /// Inner status, or `None` if no transaction is runnin
+    /// Inner status, or `None` if no transaction is running
     in_transaction: Option<InTransactionStatus>,
 }
 

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -164,12 +164,12 @@
 //! copy of `libpq` for your target architecture. This features implies `postgres_backend`
 //! - `mysql`: This feature enables the idesel mysql backend. Enabling this feature requires a compatible copy
 //! of `libmysqlclient` for your target architecture. This feature implies `mysql_backend`
-//! - `postgres_backend`: This feature enables those parts of diesels postgres backend, that are not dependend
+//! - `postgres_backend`: This feature enables those parts of diesels postgres backend, that are not dependent
 //! on `libpq`. Diesel does not provide any connection implementation with only this feature enabled.
 //! This feature can be used to implement a custom implementation of diesels `Connection` trait for the
 //! postgres backend outside of diesel itself, while reusing the existing query dsl extensions for the
 //! postgres backend
-//! - `mysql_backend`: This feature enables those parts of diesels mysql backend, that are not dependend
+//! - `mysql_backend`: This feature enables those parts of diesels mysql backend, that are not dependent
 //! on `libmysqlclient`. Diesel does not provide any connection implementation with only this feature enabled.
 //! This feature can be used to implement a custom implementation of diesels `Connection` trait for the
 //! mysql backend outside of diesel itself, while reusing the existing query dsl extensions for the

--- a/diesel/src/mysql/types/date_and_time/time.rs
+++ b/diesel/src/mysql/types/date_and_time/time.rs
@@ -123,7 +123,7 @@ impl FromSql<Datetime, Mysql> for OffsetDateTime {
     }
 }
 
-// delegate timestamp column to datetime colum for offset datetimes
+// delegate timestamp column to datetime column for offset datetimes
 #[cfg(all(feature = "time", feature = "mysql_backend"))]
 impl ToSql<Timestamp, Mysql> for OffsetDateTime {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {

--- a/diesel/src/mysql/types/primitives.rs
+++ b/diesel/src/mysql/types/primitives.rs
@@ -13,10 +13,10 @@ where
     T::Err: Error + Send + Sync + 'static,
 {
     let string = str::from_utf8(bytes)?;
-    let mut splited = string.split('.');
-    let integer_portion = splited.next().unwrap_or_default();
-    let _decimal_portion = splited.next().unwrap_or_default();
-    if splited.next().is_some() {
+    let mut split = string.split('.');
+    let integer_portion = split.next().unwrap_or_default();
+    let _decimal_portion = split.next().unwrap_or_default();
+    if split.next().is_some() {
         Err(format!("Invalid decimal format: {string:?}").into())
     } else {
         Ok(integer_portion.parse()?)

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -1178,7 +1178,7 @@ pub trait PgNetExpressionMethods: Expression + Sized {
 
     /// Creates a PostgreSQL `-` expression.
     ///
-    /// This operator substracts an address from an address to compute the distance between the two
+    /// This operator subtracts an address from an address to compute the distance between the two
     ///
     /// # Example
     ///

--- a/diesel/src/pg/metadata_lookup.rs
+++ b/diesel/src/pg/metadata_lookup.rs
@@ -150,7 +150,7 @@ impl<'a> PgMetadataCacheKey<'a> {
     }
 
     /// Convert the possibly borrowed version of this metadata cache key
-    /// into a lifetime independ owned version
+    /// into a lifetime independent owned version
     pub fn into_owned(self) -> PgMetadataCacheKey<'static> {
         let PgMetadataCacheKey { schema, type_name } = self;
         PgMetadataCacheKey {

--- a/diesel/src/query_builder/combination_clause.rs
+++ b/diesel/src/query_builder/combination_clause.rs
@@ -287,7 +287,7 @@ mod sqlite {
 
     impl<T: QueryFragment<Sqlite>> QueryFragment<Sqlite> for ParenthesisWrapper<T> {
         fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
-            // SQLite does not support parenthesis around Ths
+            // SQLite does not support parenthesis around this clause
             // we can emulate this by construct a fake outer
             // SELECT * FROM (inner_query) statement
             out.push_sql("SELECT * FROM (");

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -1563,7 +1563,7 @@ pub trait RunQueryDsl<Conn>: Sized {
     ///
     /// They may provide additional modes. Checkout the documentation of the concrete
     /// connection types for details. For connection implementations that provide
-    /// more than one loading mode it is **required** to specify this generic paramater.
+    /// more than one loading mode it is **required** to specify this generic parameter.
     /// This is currently true for `PgConnection`.
     ///
     /// When this method is called on [`sql_query`],

--- a/diesel/src/query_source/aliasing/alias.rs
+++ b/diesel/src/query_source/aliasing/alias.rs
@@ -204,9 +204,9 @@ where
     type Count = Never;
 }
 
-/// To be able to define `helper_types::Fields` with the ususal conventions
+/// To be able to define `helper_types::Fields` with the usual conventions
 ///
-/// This type is intentionally not publically exported
+/// This type is intentionally not publicly exported
 pub trait GetAliasSourceFromAlias {
     type Source;
 }

--- a/diesel/src/query_source/aliasing/macros.rs
+++ b/diesel/src/query_source/aliasing/macros.rs
@@ -26,7 +26,7 @@
 /// ```
 ///
 ///
-/// Make type expressable
+/// Make type expressible
 /// ---------------------
 /// It may sometimes be useful to declare an alias at the module level, in such a way that the type
 /// of a query using it can be expressed (to not declare it anonymously).

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -94,7 +94,7 @@ pub trait Row<'a, DB: Backend>:
 
 /// Represents a single field in a database row.
 ///
-/// This trait allows retrieving information on the name of the colum and on the value of the
+/// This trait allows retrieving information on the name of the column and on the value of the
 /// field.
 pub trait Field<'a, DB: Backend> {
     /// The name of the current field

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -577,7 +577,7 @@ pub mod is_nullable {
 
     /// No, this type cannot be null as it is marked as `NOT NULL` at database level
     ///
-    /// This should be choosen for basically all manual impls of `SqlType`
+    /// This should be chosen for basically all manual impls of `SqlType`
     /// beside implementing your own `Nullable<>` wrapper type
     #[derive(Debug, Clone, Copy)]
     pub struct NotNull;

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -223,8 +223,8 @@ impl Drop for Statement {
 // * https://github.com/rust-lang/unsafe-code-guidelines/issues/194
 struct BoundStatement<'stmt, 'query> {
     statement: MaybeCached<'stmt, Statement>,
-    // we need to store the query here to ensure none does
-    // drop it till the end ot the statement
+    // we need to store the query here to ensure no one does
+    // drop it till the end of the statement
     // We use a boxed queryfragment here just to erase the
     // generic type, we use NonNull to communicate
     // that this is a shared buffer

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -380,7 +380,7 @@ fn run_generate_migration_test(test_name: &str, args: Vec<&str>, p: Project) {
         insta::assert_snapshot!("expected", result);
     });
 
-    // revert the migration and compare the schema to the inital one
+    // revert the migration and compare the schema to the initial one
     let result = p.command("migration").arg("revert").run();
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
 

--- a/diesel_compile_tests/tests/fail/auto_type.rs
+++ b/diesel_compile_tests/tests/fail/auto_type.rs
@@ -40,7 +40,7 @@ fn users_with_posts_with_id_greater_than(id_greater_than: i32) -> _ {
 #[dsl::auto_type]
 fn user_has_post_with_id_greater_than_2() -> _ {
     // We check here that only the error on n shows, and that it shows only once
-    // (Litterals must have type suffix for auto_type, e.g. 2i64), and that it's properly spanned
+    // (Literals must have type suffix for auto_type, e.g. 2i64), and that it's properly spanned
     // (on the `2`)
     let n = 2;
     let m = 3;

--- a/diesel_compile_tests/tests/fail/auto_type.stderr
+++ b/diesel_compile_tests/tests/fail/auto_type.stderr
@@ -1,4 +1,4 @@
-error: Litterals must have type suffix for auto_type, e.g. 2i64
+error: Literals must have type suffix for auto_type, e.g. 2i64
   --> tests/fail/auto_type.rs:45:13
    |
 45 |     let n = 2;
@@ -10,7 +10,7 @@ error: auto_type: Can't infer generic argument because there is no function argu
 56 |     posts::user_id.eq::<_>()
    |                         ^
 
-error: Litterals must have type suffix for auto_type, e.g. 2i64
+error: Literals must have type suffix for auto_type, e.g. 2i64
   --> tests/fail/auto_type.rs:66:34
    |
 66 |             .filter(posts::id.gt(2)),

--- a/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.rs
+++ b/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.rs
@@ -39,14 +39,14 @@ struct UserWrongOrder {
 }
 
 #[derive(Queryable)]
-struct UserTypeMissmatch {
+struct UserTypeMismatch {
     id: i32,
     name: i32,
     bio: Option<String>,
 }
 
 #[derive(Queryable)]
-struct UserNullableTypeMissmatch {
+struct UserNullableTypeMismatch {
     id: i32,
     name: String,
     bio: Option<String>,
@@ -62,9 +62,9 @@ fn test(conn: &mut PgConnection) {
 
     let _ = users::table.load::<UserWrongOrder>(conn);
 
-    let _ = users::table.load::<UserTypeMissmatch>(conn);
+    let _ = users::table.load::<UserTypeMismatch>(conn);
 
-    let _ = users::table.load::<UserNullableTypeMissmatch>(conn);
+    let _ = users::table.load::<UserNullableTypeMismatch>(conn);
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
+++ b/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserWithToFewFields, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_missmatch.rs:59:54
+  --> tests/fail/derive/queryable_type_mismatch.rs:59:54
    |
 59 |     let _ = users::table.load::<UserWithToFewFields>(conn);
    |                          ----                        ^^^^ the trait `load_dsl::private::CompatibleType<UserWithToFewFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
@@ -27,7 +27,7 @@ note: required by a bound in `diesel::RunQueryDsl::load`
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
 error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserWithToManyFields, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_missmatch.rs:61:55
+  --> tests/fail/derive/queryable_type_mismatch.rs:61:55
    |
 61 |     let _ = users::table.load::<UserWithToManyFields>(conn);
    |                          ----                         ^^^^ the trait `load_dsl::private::CompatibleType<UserWithToManyFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
@@ -55,7 +55,7 @@ note: required by a bound in `diesel::RunQueryDsl::load`
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
 error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserWrongOrder, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_missmatch.rs:63:49
+  --> tests/fail/derive/queryable_type_mismatch.rs:63:49
    |
 63 |     let _ = users::table.load::<UserWrongOrder>(conn);
    |                          ----                   ^^^^ the trait `load_dsl::private::CompatibleType<UserWrongOrder, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
@@ -82,11 +82,11 @@ note: required by a bound in `diesel::RunQueryDsl::load`
    |         Self: LoadQuery<'query, Conn, U>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserTypeMissmatch, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_missmatch.rs:65:52
+error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserTypeMismatch, _>` is not satisfied
+  --> tests/fail/derive/queryable_type_mismatch.rs:65:51
    |
-65 |     let _ = users::table.load::<UserTypeMissmatch>(conn);
-   |                          ----                      ^^^^ the trait `load_dsl::private::CompatibleType<UserTypeMissmatch, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
+65 |     let _ = users::table.load::<UserTypeMismatch>(conn);
+   |                          ----                     ^^^^ the trait `load_dsl::private::CompatibleType<UserTypeMismatch, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    |                          |
    |                          required by a bound introduced by this call
    |
@@ -100,7 +100,7 @@ error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::T
              (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
              (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
            and $N others
-   = note: required for `users::table` to implement `LoadQuery<'_, _, UserTypeMissmatch>`
+   = note: required for `users::table` to implement `LoadQuery<'_, _, UserTypeMismatch>`
 note: required by a bound in `diesel::RunQueryDsl::load`
   --> $DIESEL/src/query_dsl/mod.rs
    |

--- a/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
@@ -1,4 +1,4 @@
-error: Neither an explict primary key found nor does an `id` column exist.
+error: Neither an explicit primary key found nor does an `id` column exist.
        Consider explicitly defining a primary key.
        For example for specifying `user_id` as primary key:
 

--- a/diesel_derives/src/table.rs
+++ b/diesel_derives/src/table.rs
@@ -56,7 +56,7 @@ pub(crate) fn expand(input: TableDecl) -> TokenStream {
         }
         None => {
             let mut message = format!(
-                "Neither an explict primary key found nor does an `id` column exist.\n\
+                "Neither an explicit primary key found nor does an `id` column exist.\n\
                  Consider explicitly defining a primary key. \n\
                  For example for specifying `{}` as primary key:\n\n\
                  table! {{\n",

--- a/diesel_tests/tests/alias.rs
+++ b/diesel_tests/tests/alias.rs
@@ -100,7 +100,7 @@ fn select_multiple_from_join() {
         .load::<(String, i32)>(connection)
         .unwrap();
 
-    // using mutiple aliases for the same table works if they are declared in the same alias call
+    // using multiple aliases for the same table works if they are declared in the same alias call
     let (user1_alias, user2_alias, _post_alias) =
         alias!(users as user1, users as user2, posts as post1,);
 

--- a/diesel_tests/tests/custom_types.rs
+++ b/diesel_tests/tests/custom_types.rs
@@ -175,7 +175,7 @@ struct PublicTy;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(name = "ty"))]
-struct InferedTy;
+struct InferredTy;
 
 #[test]
 fn custom_type_schema_inference() {
@@ -202,11 +202,11 @@ fn custom_type_schema_inference() {
 
     let other_ty = <Pg as HasSqlType<OtherTy>>::metadata(conn);
     let public_ty = <Pg as HasSqlType<PublicTy>>::metadata(conn);
-    let infered_ty = <Pg as HasSqlType<InferedTy>>::metadata(conn);
+    let inferred_ty = <Pg as HasSqlType<InferredTy>>::metadata(conn);
     let _ = dbg!(other_ty.oid());
     let _ = dbg!(public_ty.oid());
-    let _ = dbg!(infered_ty.oid());
+    let _ = dbg!(inferred_ty.oid());
 
-    assert_eq!(other_ty.oid().unwrap(), infered_ty.oid().unwrap());
+    assert_eq!(other_ty.oid().unwrap(), inferred_ty.oid().unwrap());
     assert_ne!(public_ty.oid().unwrap(), other_ty.oid().unwrap());
 }

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -277,7 +277,7 @@ fn distinct_of_multiple_columns() {
 
     assert_eq!(Ok(expected), data);
 
-    // with arbitary expressions
+    // with arbitrary expressions
 
     let data = posts::table
         .left_join(users::table)

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -484,7 +484,7 @@ fn filter_subselect_with_boxed_query() {
 fn filter_subselect_with_nullable_column() {
     use crate::schema_dsl::*;
     table! {
-        heros {
+        heroes {
             id -> Integer,
             name -> Text,
             home_world -> Nullable<Integer>,
@@ -497,7 +497,7 @@ fn filter_subselect_with_nullable_column() {
         }
     }
 
-    allow_tables_to_appear_in_same_query!(heros, home_worlds);
+    allow_tables_to_appear_in_same_query!(heroes, home_worlds);
 
     #[derive(Debug, Queryable, PartialEq)]
     struct Hero {
@@ -518,7 +518,7 @@ fn filter_subselect_with_nullable_column() {
     .unwrap();
 
     create_table(
-        "heros",
+        "heroes",
         (
             integer("id").primary_key().auto_increment(),
             string("name").not_null(),
@@ -532,17 +532,17 @@ fn filter_subselect_with_nullable_column() {
         .values(home_worlds::name.eq("Tatooine"))
         .execute(connection)
         .unwrap();
-    ::diesel::insert_into(heros::table)
+    ::diesel::insert_into(heroes::table)
         .values((
-            heros::name.eq("Luke Skywalker"),
-            heros::home_world.eq(Some(1)),
+            heroes::name.eq("Luke Skywalker"),
+            heroes::home_world.eq(Some(1)),
         ))
         .execute(connection)
         .unwrap();
-    ::diesel::insert_into(heros::table)
+    ::diesel::insert_into(heroes::table)
         .values((
-            heros::name.eq("R2D2"),
-            heros::home_world.eq::<Option<i32>>(None),
+            heroes::name.eq("R2D2"),
+            heroes::home_world.eq::<Option<i32>>(None),
         ))
         .execute(connection)
         .unwrap();
@@ -553,16 +553,16 @@ fn filter_subselect_with_nullable_column() {
         home_world: Some(1),
     }];
 
-    let query = heros::table
-        .filter(heros::home_world.eq_any(home_worlds::table.select(home_worlds::id).nullable()))
+    let query = heroes::table
+        .filter(heroes::home_world.eq_any(home_worlds::table.select(home_worlds::id).nullable()))
         .load::<Hero>(connection)
         .unwrap();
 
     assert_eq!(query, expected);
 
-    let query = heros::table
+    let query = heroes::table
         .filter(
-            heros::home_world.eq_any(
+            heroes::home_world.eq_any(
                 home_worlds::table
                     .select(home_worlds::id)
                     .into_boxed()
@@ -574,9 +574,9 @@ fn filter_subselect_with_nullable_column() {
 
     assert_eq!(query, expected);
 
-    let query = heros::table
+    let query = heroes::table
         .filter(
-            heros::home_world.eq_any(
+            heroes::home_world.eq_any(
                 home_worlds::table
                     .select(home_worlds::id)
                     .nullable()

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -185,7 +185,7 @@ fn selection_using_subselect() {
 }
 
 table! {
-    users_select_for_update_modifieres {
+    users_select_for_update_modifiers {
         id -> Integer,
         name -> Text,
         hair_color -> Nullable<Text>,
@@ -295,7 +295,7 @@ fn select_for_update_locks_selected_rows() {
 #[cfg(feature = "postgres")]
 #[test]
 fn select_for_update_modifiers() {
-    use self::users_select_for_update_modifieres::dsl::*;
+    use self::users_select_for_update_modifiers::dsl::*;
 
     // We need to actually commit some data for the
     // test
@@ -304,11 +304,11 @@ fn select_for_update_modifiers() {
     let conn_3 = &mut connection();
 
     // Recreate the table
-    diesel::sql_query("DROP TABLE IF EXISTS users_select_for_update_modifieres")
+    diesel::sql_query("DROP TABLE IF EXISTS users_select_for_update_modifiers")
         .execute(conn_1)
         .unwrap();
     create_table(
-        "users_select_for_update_modifieres",
+        "users_select_for_update_modifiers",
         (
             integer("id").primary_key().auto_increment(),
             string("name").not_null(),
@@ -321,7 +321,7 @@ fn select_for_update_modifiers() {
     // Add some test data
     diesel::sql_query(
         "
-            INSERT INTO users_select_for_update_modifieres (name)
+            INSERT INTO users_select_for_update_modifiers (name)
             VALUES ('Sean'), ('Tess')
             ",
     )
@@ -332,7 +332,7 @@ fn select_for_update_modifiers() {
     conn_1.begin_test_transaction().unwrap();
 
     // Lock the "Sean" row
-    let _sean = users_select_for_update_modifieres
+    let _sean = users_select_for_update_modifiers
         .order(name)
         .for_update()
         .first::<User>(conn_1)
@@ -342,7 +342,7 @@ fn select_for_update_modifiers() {
     diesel::sql_query("SET STATEMENT_TIMEOUT TO 1000")
         .execute(conn_2)
         .unwrap();
-    let result = users_select_for_update_modifieres
+    let result = users_select_for_update_modifiers
         .order(name)
         .for_update()
         .no_wait()
@@ -355,7 +355,7 @@ fn select_for_update_modifiers() {
     }
 
     // Try to access the "Sean" row with `SKIP LOCKED`
-    let tess = users_select_for_update_modifieres
+    let tess = users_select_for_update_modifiers
         .order(name)
         .for_update()
         .skip_locked()

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -352,7 +352,7 @@ mod pg_types {
             }
         }
         // Strip of nano second precision as postgres
-        // does not accuratly handle them
+        // does not accurately handle them
         let nanos = (r.nanosecond() / 1000) * 1000;
         r.with_nanosecond(nanos).unwrap()
     }
@@ -361,7 +361,7 @@ mod pg_types {
         let time = mk_naive_time(data);
 
         // Strip of nano second precision as postgres
-        // does not accuratly handle them
+        // does not accurately handle them
         let nanos = (time.nanosecond() / 1000) * 1000;
         time.with_nanosecond(nanos).unwrap()
     }
@@ -517,7 +517,7 @@ mod mysql_types {
         let r = mk_naive_datetime((seconds, nanos));
 
         // Strip of nano second precision as mysql
-        // does not accuratly handle them
+        // does not accurately handle them
         let nanos = (r.nanosecond() / 1000) * 1000;
         r.with_nanosecond(nanos).unwrap()
     }
@@ -547,7 +547,7 @@ mod mysql_types {
         }
 
         // Strip of nano second precision as mysql
-        // does not accuratly handle them
+        // does not accurately handle them
         let nanos = (r.nanosecond() / 1000) * 1000;
         r.with_nanosecond(nanos).unwrap()
     }

--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -226,8 +226,8 @@ impl TypeInferrer<'_> {
                 syn::Lit::ByteStr(_) => parse_quote_spanned!(lit.span()=> &'static [u8]),
                 syn::Lit::Byte(_) => parse_quote_spanned!(lit.span()=> u8),
                 syn::Lit::Char(_) => parse_quote_spanned!(lit.span()=> char),
-                syn::Lit::Int(lit_int) => litteral_type(&lit_int.token())?,
-                syn::Lit::Float(lit_float) => litteral_type(&lit_float.token())?,
+                syn::Lit::Int(lit_int) => literal_type(&lit_int.token())?,
+                syn::Lit::Float(lit_float) => literal_type(&lit_float.token())?,
                 syn::Lit::Bool(_) => parse_quote_spanned!(lit.span()=> bool),
                 _ => {
                     return Err(syn::Error::new(
@@ -310,16 +310,16 @@ impl TypeInferrer<'_> {
     }
 }
 
-fn litteral_type(t: &proc_macro2::Literal) -> Result<syn::Type, syn::Error> {
+fn literal_type(t: &proc_macro2::Literal) -> Result<syn::Type, syn::Error> {
     let val = t.to_string();
     let type_suffix = &val[val
         .find(|c: char| !c.is_ascii_digit() && c != '_')
         .ok_or_else(|| {
             syn::Error::new_spanned(
                 t,
-                format_args!("Litterals must have type suffix for auto_type, e.g. {val}i64"),
+                format_args!("Literals must have type suffix for auto_type, e.g. {val}i64"),
             )
         })?..];
     syn::parse_str(type_suffix)
-        .map_err(|_| syn::Error::new_spanned(t, "Invalid type suffix for litteral"))
+        .map_err(|_| syn::Error::new_spanned(t, "Invalid type suffix for literal"))
 }

--- a/examples/mysql/getting_started_step_3/src/bin/get_post.rs
+++ b/examples/mysql/getting_started_step_3/src/bin/get_post.rs
@@ -23,6 +23,6 @@ fn main() {
     match post {
         Ok(Some(post)) => println!("Post with id: {} has a title: {}", post.id, post.title),
         Ok(None) => println!("Unable to find post {}", post_id),
-        Err(_) => println!("An error occured while fetching post {}", post_id),
+        Err(_) => println!("An error occurred while fetching post {}", post_id),
     }
 }

--- a/examples/postgres/getting_started_step_3/src/bin/get_post.rs
+++ b/examples/postgres/getting_started_step_3/src/bin/get_post.rs
@@ -23,6 +23,6 @@ fn main() {
     match post {
         Ok(Some(post)) => println!("Post with id: {} has a title: {}", post.id, post.title),
         Ok(None) => println!("Unable to find post {}", post_id),
-        Err(_) => println!("An error occured while fetching post {}", post_id),
+        Err(_) => println!("An error occurred while fetching post {}", post_id),
     }
 }

--- a/examples/sqlite/getting_started_step_3/src/bin/get_post.rs
+++ b/examples/sqlite/getting_started_step_3/src/bin/get_post.rs
@@ -23,6 +23,6 @@ fn main() {
     match post {
         Ok(Some(post)) => println!("Post with id: {} has a title: {}", post.id, post.title),
         Ok(None) => println!("Unable to find post {}", post_id),
-        Err(_) => println!("An error occured while fetching post {}", post_id),
+        Err(_) => println!("An error occurred while fetching post {}", post_id),
     }
 }


### PR DESCRIPTION
This PR adds an spelling check to the CI. In addition it fixes all the reported errors (or flags them as allowed.)