### PR TITLE
Make typos check hidden files too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
           cargo +stable clippy --tests --manifest-path examples/mysql/getting_started_step_3/Cargo.toml
           cargo +stable clippy --tests --manifest-path examples/mysql/all_about_inserts/Cargo.toml
 
-      - name: Check formating
+      - name: Check formatting
         run: cargo +stable fmt --all -- --check
 
   sqlite_bundled:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,9 @@
+[files]
+extend-exclude = [
+    ".git/",
+]
+ignore-hidden = false
+
 [default]
 extend-ignore-re = [
     # that's a ipv6


### PR DESCRIPTION
`typos` is a filesystem-based tool, not git-based.

With this PR it will check dot files and directories.
