### PR TITLE
Add support for CASE WHEN ... ELSE ... END expression

### DIFF
--- a/diesel/src/expression/case_when.rs
+++ b/diesel/src/expression/case_when.rs
@@ -25,6 +25,12 @@ use super::{AsExpression, TypedExpressionType};
 /// assert_eq!(&[(1, 1), (2, 0)], users_with_name.as_slice());
 /// # }
 /// ```
+///
+/// Note that the SQL types of the `if_true` and `if_false` expressions should
+/// be equal. This includes whether they are wrapped in
+/// [`Nullable`](crate::sql_types::Nullable), so you may need to call
+/// [`nullable`](crate::expression_methods::NullableExpressionMethods::nullable)
+/// on one of them.
 pub fn case_when_else<C, T, F, ST>(
     condition: C,
     if_true: T,

--- a/diesel/src/expression/case_when.rs
+++ b/diesel/src/expression/case_when.rs
@@ -36,7 +36,7 @@ use super::{AsExpression, TypedExpressionType};
 /// use diesel::dsl::case_when;
 ///
 /// let users_with_name: Vec<(i32, i32)> = users
-///     .select((id, case_when(name.eq("Sean"), id).else_(0)))
+///     .select((id, case_when(name.eq("Sean"), id).otherwise(0)))
 ///     .load(connection)
 ///     .unwrap();
 ///
@@ -117,8 +117,10 @@ impl<Whens, E> CaseWhen<Whens, E> {
 impl<Whens> CaseWhen<Whens, NoElseExpression> {
     /// Sets the `ELSE` branch of the `CASE` expression
     ///
+    /// It is named this way because `else` is a reserved keyword in Rust
+    ///
     /// See the [`case_when`] documentation for more details.
-    pub fn else_<E>(self, if_no_other_branch_matched: E) -> helper_types::Else_<Self, E>
+    pub fn otherwise<E>(self, if_no_other_branch_matched: E) -> helper_types::Otherwise<Self, E>
     where
         Self: CaseWhenTypesExtractor<Whens = Whens, Else = NoElseExpression>,
         E: AsExpression<<Self as CaseWhenTypesExtractor>::OutputExpressionSpecifiedSqlType>,
@@ -184,8 +186,8 @@ mod non_public_types {
         pub(super) expr: E,
     }
 
-    /// Largely internal trait used to define the [`When`] and [`Else_`] type
-    /// aliases
+    /// Largely internal trait used to define the [`When`] and [`Otherwise`]
+    /// type aliases
     ///
     /// It should typically not be needed in user code unless writing extremely
     /// generic functions

--- a/diesel/src/expression/case_when.rs
+++ b/diesel/src/expression/case_when.rs
@@ -1,0 +1,128 @@
+use crate::expression::grouped::Grouped;
+use crate::expression::helper_types::case_when_else;
+use crate::expression::Expression;
+use crate::sql_types::{BoolOrNullableBool, SqlType};
+
+use super::{AsExpression, TypedExpressionType};
+
+/// Creates a SQL `CASE WHEN ... ELSE ... END` expression
+///
+/// # Example
+///
+/// ```rust
+/// # include!("../doctest_setup.rs");
+/// #
+/// # fn main() {
+/// #     use schema::users::dsl::*;
+/// #     let connection = &mut establish_connection();
+/// use diesel::dsl::case_when_else;
+///
+/// let users_with_name: Vec<(i32, i32)> = users
+///     .select((id, case_when_else(name.eq("Sean"), id, 0)))
+///     .load(connection)
+///     .unwrap();
+///
+/// assert_eq!(&[(1, 1), (2, 0)], users_with_name.as_slice());
+/// # }
+/// ```
+pub fn case_when_else<C, T, F, ST>(
+    condition: C,
+    if_true: T,
+    if_false: F,
+) -> case_when_else<C, T, F, ST>
+where
+    C: Expression,
+    <C as Expression>::SqlType: BoolOrNullableBool,
+    T: AsExpression<ST>,
+    F: AsExpression<ST>,
+    ST: SqlType + TypedExpressionType,
+{
+    CaseWhenElse {
+        condition: Grouped(condition),
+        if_true: Grouped(if_true.as_expression()),
+        if_false: Grouped(if_false.as_expression()),
+    }
+}
+
+pub(crate) use case_when_else_impl::CaseWhenElse;
+mod case_when_else_impl {
+    use diesel_derives::{DieselNumericOps, QueryId, ValidGrouping};
+
+    use crate::expression::{AppearsOnTable, Expression, SelectableExpression};
+    use crate::query_builder::{AstPass, QueryFragment};
+    use crate::query_source::aliasing;
+    use crate::sql_types::BoolOrNullableBool;
+
+    #[derive(Debug, Clone, Copy, QueryId, DieselNumericOps, ValidGrouping)]
+    pub struct CaseWhenElse<C, T, F> {
+        pub(super) condition: C,
+        pub(super) if_true: T,
+        pub(super) if_false: F,
+    }
+
+    impl<C, T, F, QS> SelectableExpression<QS> for CaseWhenElse<C, T, F>
+    where
+        CaseWhenElse<C, T, F>: AppearsOnTable<QS>,
+        C: SelectableExpression<QS>,
+        T: SelectableExpression<QS>,
+        F: SelectableExpression<QS>,
+    {
+    }
+
+    impl<C, T, F, QS> AppearsOnTable<QS> for CaseWhenElse<C, T, F>
+    where
+        CaseWhenElse<C, T, F>: Expression,
+        C: AppearsOnTable<QS>,
+        T: AppearsOnTable<QS>,
+        F: AppearsOnTable<QS>,
+    {
+    }
+
+    impl<C, T, F> Expression for CaseWhenElse<C, T, F>
+    where
+        C: Expression,
+        <C as Expression>::SqlType: BoolOrNullableBool,
+        T: Expression,
+        F: Expression<SqlType = <T as Expression>::SqlType>,
+    {
+        type SqlType = <T as Expression>::SqlType;
+    }
+    impl<C, T, F, DB> QueryFragment<DB> for CaseWhenElse<C, T, F>
+    where
+        C: QueryFragment<DB>,
+        T: QueryFragment<DB>,
+        F: QueryFragment<DB>,
+        DB: crate::backend::Backend,
+    {
+        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> crate::result::QueryResult<()> {
+            out.push_sql("CASE WHEN ");
+            self.condition.walk_ast(out.reborrow())?;
+            out.push_sql(" THEN ");
+            self.if_true.walk_ast(out.reborrow())?;
+            out.push_sql(" ELSE ");
+            self.if_false.walk_ast(out.reborrow())?;
+            out.push_sql(" END");
+            Ok(())
+        }
+    }
+    impl<S, C, T, F> aliasing::FieldAliasMapper<S> for CaseWhenElse<C, T, F>
+    where
+        S: aliasing::AliasSource,
+        C: aliasing::FieldAliasMapper<S>,
+        T: aliasing::FieldAliasMapper<S>,
+        F: aliasing::FieldAliasMapper<S>,
+    {
+        type Out = CaseWhenElse<
+            <C as aliasing::FieldAliasMapper<S>>::Out,
+            <T as aliasing::FieldAliasMapper<S>>::Out,
+            <F as aliasing::FieldAliasMapper<S>>::Out,
+        >;
+        fn map(self, alias: &aliasing::Alias<S>) -> Self::Out {
+            CaseWhenElse {
+                condition: self.condition.map(alias),
+                if_true: self.if_true.map(alias),
+                if_false: self.if_false.map(alias),
+            }
+        }
+    }
+}

--- a/diesel/src/expression/case_when.rs
+++ b/diesel/src/expression/case_when.rs
@@ -1,24 +1,42 @@
 use crate::expression::grouped::Grouped;
-use crate::expression::helper_types::case_when_else;
-use crate::expression::Expression;
+use crate::expression::{helper_types, Expression};
 use crate::sql_types::{BoolOrNullableBool, SqlType};
+use diesel_derives::{DieselNumericOps, QueryId, ValidGrouping};
 
 use super::{AsExpression, TypedExpressionType};
 
-/// Creates a SQL `CASE WHEN ... ELSE ... END` expression
+/// Creates a SQL `CASE WHEN ... END` expression
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// # include!("../doctest_setup.rs");
 /// #
 /// # fn main() {
 /// #     use schema::users::dsl::*;
 /// #     let connection = &mut establish_connection();
-/// use diesel::dsl::case_when_else;
+/// use diesel::dsl::case_when;
+///
+/// let users_with_name: Vec<(i32, Option<i32>)> = users
+///     .select((id, case_when(name.eq("Sean"), id)))
+///     .load(connection)
+///     .unwrap();
+///
+/// assert_eq!(&[(1, Some(1)), (2, None)], users_with_name.as_slice());
+/// # }
+/// ```
+///
+/// # `ELSE` clause
+/// ```
+/// # include!("../doctest_setup.rs");
+/// #
+/// # fn main() {
+/// #     use schema::users::dsl::*;
+/// #     let connection = &mut establish_connection();
+/// use diesel::dsl::case_when;
 ///
 /// let users_with_name: Vec<(i32, i32)> = users
-///     .select((id, case_when_else(name.eq("Sean"), id, 0)))
+///     .select((id, case_when(name.eq("Sean"), id).else_(0)))
 ///     .load(connection)
 ///     .unwrap();
 ///
@@ -26,108 +44,369 @@ use super::{AsExpression, TypedExpressionType};
 /// # }
 /// ```
 ///
-/// Note that the SQL types of the `if_true` and `if_false` expressions should
+/// Note that the SQL types of the `case_when` and `else` expressions should
 /// be equal. This includes whether they are wrapped in
 /// [`Nullable`](crate::sql_types::Nullable), so you may need to call
 /// [`nullable`](crate::expression_methods::NullableExpressionMethods::nullable)
 /// on one of them.
-pub fn case_when_else<C, T, F, ST>(
-    condition: C,
-    if_true: T,
-    if_false: F,
-) -> case_when_else<C, T, F, ST>
+///
+/// # More `WHEN` branches
+/// ```
+/// # include!("../doctest_setup.rs");
+/// #
+/// # fn main() {
+/// #     use schema::users::dsl::*;
+/// #     let connection = &mut establish_connection();
+/// use diesel::dsl::case_when;
+///
+/// let users_with_name: Vec<(i32, Option<i32>)> = users
+///     .select((id, case_when(name.eq("Sean"), id).when(name.eq("Tess"), 2)))
+///     .load(connection)
+///     .unwrap();
+///
+/// assert_eq!(&[(1, Some(1)), (2, Some(2))], users_with_name.as_slice());
+/// # }
+/// ```
+pub fn case_when<C, T, ST>(condition: C, if_true: T) -> helper_types::case_when<C, T, ST>
 where
     C: Expression,
     <C as Expression>::SqlType: BoolOrNullableBool,
     T: AsExpression<ST>,
-    F: AsExpression<ST>,
     ST: SqlType + TypedExpressionType,
 {
-    CaseWhenElse {
-        condition: Grouped(condition),
-        if_true: Grouped(if_true.as_expression()),
-        if_false: Grouped(if_false.as_expression()),
+    CaseWhen {
+        whens: CaseWhenConditionsLeaf {
+            when: Grouped(condition),
+            then: Grouped(if_true.as_expression()),
+        },
+        else_expr: NoElseExpression,
     }
 }
 
-pub(crate) use case_when_else_impl::CaseWhenElse;
-mod case_when_else_impl {
-    use diesel_derives::{DieselNumericOps, QueryId, ValidGrouping};
+/// A SQL `CASE WHEN ... END` expression
+#[derive(Debug, Clone, Copy, QueryId, DieselNumericOps, ValidGrouping)]
+pub struct CaseWhen<Whens, E> {
+    whens: Whens,
+    else_expr: E,
+}
 
-    use crate::expression::{AppearsOnTable, Expression, SelectableExpression};
-    use crate::query_builder::{AstPass, QueryFragment};
-    use crate::query_source::aliasing;
-    use crate::sql_types::BoolOrNullableBool;
-
-    #[derive(Debug, Clone, Copy, QueryId, DieselNumericOps, ValidGrouping)]
-    pub struct CaseWhenElse<C, T, F> {
-        pub(super) condition: C,
-        pub(super) if_true: T,
-        pub(super) if_false: F,
-    }
-
-    impl<C, T, F, QS> SelectableExpression<QS> for CaseWhenElse<C, T, F>
+impl<Whens, E> CaseWhen<Whens, E> {
+    /// Add an additional `WHEN ... THEN ...` branch to the `CASE` expression
+    ///
+    /// See the [`case_when`] documentation for more details.
+    pub fn when<C, T>(self, condition: C, if_true: T) -> helper_types::When<Self, C, T>
     where
-        CaseWhenElse<C, T, F>: AppearsOnTable<QS>,
-        C: SelectableExpression<QS>,
-        T: SelectableExpression<QS>,
-        F: SelectableExpression<QS>,
-    {
-    }
-
-    impl<C, T, F, QS> AppearsOnTable<QS> for CaseWhenElse<C, T, F>
-    where
-        CaseWhenElse<C, T, F>: Expression,
-        C: AppearsOnTable<QS>,
-        T: AppearsOnTable<QS>,
-        F: AppearsOnTable<QS>,
-    {
-    }
-
-    impl<C, T, F> Expression for CaseWhenElse<C, T, F>
-    where
+        Self: CaseWhenTypesExtractor<Whens = Whens, Else = E>,
         C: Expression,
         <C as Expression>::SqlType: BoolOrNullableBool,
-        T: Expression,
-        F: Expression<SqlType = <T as Expression>::SqlType>,
+        T: AsExpression<<Self as CaseWhenTypesExtractor>::OutputExpressionSpecifiedSqlType>,
     {
-        type SqlType = <T as Expression>::SqlType;
+        CaseWhen {
+            whens: CaseWhenConditionsIntermediateNode {
+                first_whens: self.whens,
+                last_when: CaseWhenConditionsLeaf {
+                    when: Grouped(condition),
+                    then: Grouped(if_true.as_expression()),
+                },
+            },
+            else_expr: self.else_expr,
+        }
     }
-    impl<C, T, F, DB> QueryFragment<DB> for CaseWhenElse<C, T, F>
+}
+
+impl<Whens> CaseWhen<Whens, NoElseExpression> {
+    /// Sets the `ELSE` branch of the `CASE` expression
+    ///
+    /// See the [`case_when`] documentation for more details.
+    pub fn else_<E>(self, if_no_other_branch_matched: E) -> helper_types::Else_<Self, E>
     where
-        C: QueryFragment<DB>,
-        T: QueryFragment<DB>,
-        F: QueryFragment<DB>,
-        DB: crate::backend::Backend,
+        Self: CaseWhenTypesExtractor<Whens = Whens, Else = NoElseExpression>,
+        E: AsExpression<<Self as CaseWhenTypesExtractor>::OutputExpressionSpecifiedSqlType>,
     {
-        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> crate::result::QueryResult<()> {
-            out.push_sql("CASE WHEN ");
-            self.condition.walk_ast(out.reborrow())?;
-            out.push_sql(" THEN ");
-            self.if_true.walk_ast(out.reborrow())?;
-            out.push_sql(" ELSE ");
-            self.if_false.walk_ast(out.reborrow())?;
+        CaseWhen {
+            whens: self.whens,
+            else_expr: ElseExpression {
+                expr: Grouped(if_no_other_branch_matched.as_expression()),
+            },
+        }
+    }
+}
+
+pub(crate) use non_public_types::*;
+mod non_public_types {
+    use super::CaseWhen;
+
+    use diesel_derives::{QueryId, ValidGrouping};
+
+    use crate::expression::{
+        AppearsOnTable, Expression, SelectableExpression, TypedExpressionType,
+    };
+    use crate::query_builder::{AstPass, QueryFragment};
+    use crate::query_source::aliasing;
+    use crate::sql_types::{BoolOrNullableBool, IntoNullable, SqlType};
+
+    #[derive(Debug, Clone, Copy, QueryId, ValidGrouping)]
+    pub struct CaseWhenConditionsLeaf<W, T> {
+        pub(super) when: W,
+        pub(super) then: T,
+    }
+
+    #[derive(Debug, Clone, Copy, QueryId, ValidGrouping)]
+    pub struct CaseWhenConditionsIntermediateNode<W, T, Whens> {
+        pub(super) first_whens: Whens,
+        pub(super) last_when: CaseWhenConditionsLeaf<W, T>,
+    }
+
+    pub trait CaseWhenConditions {
+        type OutputExpressionSpecifiedSqlType: SqlType + TypedExpressionType;
+    }
+    impl<W, T: Expression> CaseWhenConditions for CaseWhenConditionsLeaf<W, T>
+    where
+        <T as Expression>::SqlType: SqlType + TypedExpressionType,
+    {
+        type OutputExpressionSpecifiedSqlType = T::SqlType;
+    }
+    // This intentionally doesn't re-check inner `Whens` here, because this trait is
+    // only used to allow expression SQL type inference for `.when` calls so we
+    // want to make it as lightweight as possible for fast compilation. Actual
+    // guarantees are provided by the other implementations below
+    impl<W, T: Expression, Whens> CaseWhenConditions for CaseWhenConditionsIntermediateNode<W, T, Whens>
+    where
+        <T as Expression>::SqlType: SqlType + TypedExpressionType,
+    {
+        type OutputExpressionSpecifiedSqlType = T::SqlType;
+    }
+
+    #[derive(Debug, Clone, Copy, QueryId, ValidGrouping)]
+    pub struct NoElseExpression;
+    #[derive(Debug, Clone, Copy, QueryId, ValidGrouping)]
+    pub struct ElseExpression<E> {
+        pub(super) expr: E,
+    }
+
+    /// Largely internal trait used to define the [`When`] and [`Else_`] type
+    /// aliases
+    ///
+    /// It should typically not be needed in user code unless writing extremely
+    /// generic functions
+    pub trait CaseWhenTypesExtractor {
+        /// The
+        /// This may not be the actual output expression type: if there is no
+        /// `else` it will be made `Nullable`
+        type OutputExpressionSpecifiedSqlType: SqlType + TypedExpressionType;
+        type Whens;
+        type Else;
+    }
+    impl<Whens, E> CaseWhenTypesExtractor for CaseWhen<Whens, E>
+    where
+        Whens: CaseWhenConditions,
+    {
+        type OutputExpressionSpecifiedSqlType = Whens::OutputExpressionSpecifiedSqlType;
+        type Whens = Whens;
+        type Else = E;
+    }
+
+    impl<W, T, QS> SelectableExpression<QS> for CaseWhen<CaseWhenConditionsLeaf<W, T>, NoElseExpression>
+    where
+        CaseWhen<CaseWhenConditionsLeaf<W, T>, NoElseExpression>: AppearsOnTable<QS>,
+        W: SelectableExpression<QS>,
+        T: SelectableExpression<QS>,
+    {
+    }
+
+    impl<W, T, E, QS> SelectableExpression<QS>
+        for CaseWhen<CaseWhenConditionsLeaf<W, T>, ElseExpression<E>>
+    where
+        CaseWhen<CaseWhenConditionsLeaf<W, T>, ElseExpression<E>>: AppearsOnTable<QS>,
+        W: SelectableExpression<QS>,
+        T: SelectableExpression<QS>,
+        E: SelectableExpression<QS>,
+    {
+    }
+
+    impl<W, T, Whens, E, QS> SelectableExpression<QS>
+        for CaseWhen<CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+    where
+        Self: AppearsOnTable<QS>,
+        W: SelectableExpression<QS>,
+        T: SelectableExpression<QS>,
+        CaseWhen<Whens, E>: SelectableExpression<QS>,
+    {
+    }
+
+    impl<W, T, QS> AppearsOnTable<QS> for CaseWhen<CaseWhenConditionsLeaf<W, T>, NoElseExpression>
+    where
+        CaseWhen<CaseWhenConditionsLeaf<W, T>, NoElseExpression>: Expression,
+        W: AppearsOnTable<QS>,
+        T: AppearsOnTable<QS>,
+    {
+    }
+
+    impl<W, T, E, QS> AppearsOnTable<QS> for CaseWhen<CaseWhenConditionsLeaf<W, T>, ElseExpression<E>>
+    where
+        CaseWhen<CaseWhenConditionsLeaf<W, T>, ElseExpression<E>>: Expression,
+        W: AppearsOnTable<QS>,
+        T: AppearsOnTable<QS>,
+        E: AppearsOnTable<QS>,
+    {
+    }
+
+    impl<W, T, Whens, E, QS> AppearsOnTable<QS>
+        for CaseWhen<CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+    where
+        Self: Expression,
+        W: AppearsOnTable<QS>,
+        T: AppearsOnTable<QS>,
+        CaseWhen<Whens, E>: AppearsOnTable<QS>,
+    {
+    }
+
+    impl<W, T> Expression for CaseWhen<CaseWhenConditionsLeaf<W, T>, NoElseExpression>
+    where
+        W: Expression,
+        <W as Expression>::SqlType: BoolOrNullableBool,
+        T: Expression,
+        <T as Expression>::SqlType: IntoNullable,
+        <<T as Expression>::SqlType as IntoNullable>::Nullable: SqlType + TypedExpressionType,
+    {
+        type SqlType = <<T as Expression>::SqlType as IntoNullable>::Nullable;
+    }
+    impl<W, T, E> Expression for CaseWhen<CaseWhenConditionsLeaf<W, T>, ElseExpression<E>>
+    where
+        W: Expression,
+        <W as Expression>::SqlType: BoolOrNullableBool,
+        T: Expression,
+    {
+        type SqlType = T::SqlType;
+    }
+    impl<W, T, Whens, E> Expression for CaseWhen<CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+    where
+        CaseWhen<CaseWhenConditionsLeaf<W, T>, E>: Expression,
+        CaseWhen<Whens, E>: Expression<
+            SqlType = <CaseWhen<CaseWhenConditionsLeaf<W, T>, E> as Expression>::SqlType,
+        >,
+    {
+        type SqlType = <CaseWhen<CaseWhenConditionsLeaf<W, T>, E> as Expression>::SqlType;
+    }
+
+    impl<Whens, E, DB> QueryFragment<DB> for CaseWhen<Whens, E>
+    where
+        DB: crate::backend::Backend,
+        Whens: QueryFragment<DB>,
+        E: QueryFragment<DB>,
+    {
+        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> crate::QueryResult<()> {
+            out.push_sql("CASE");
+            self.whens.walk_ast(out.reborrow())?;
+            self.else_expr.walk_ast(out.reborrow())?;
             out.push_sql(" END");
             Ok(())
         }
     }
-    impl<S, C, T, F> aliasing::FieldAliasMapper<S> for CaseWhenElse<C, T, F>
+
+    impl<W, T, DB> QueryFragment<DB> for CaseWhenConditionsLeaf<W, T>
+    where
+        DB: crate::backend::Backend,
+        W: QueryFragment<DB>,
+        T: QueryFragment<DB>,
+    {
+        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> crate::QueryResult<()> {
+            out.push_sql(" WHEN ");
+            self.when.walk_ast(out.reborrow())?;
+            out.push_sql(" THEN ");
+            self.then.walk_ast(out.reborrow())?;
+            Ok(())
+        }
+    }
+
+    impl<W, T, Whens, DB> QueryFragment<DB> for CaseWhenConditionsIntermediateNode<W, T, Whens>
+    where
+        DB: crate::backend::Backend,
+        Whens: QueryFragment<DB>,
+        W: QueryFragment<DB>,
+        T: QueryFragment<DB>,
+    {
+        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> crate::QueryResult<()> {
+            self.first_whens.walk_ast(out.reborrow())?;
+            self.last_when.walk_ast(out.reborrow())?;
+            Ok(())
+        }
+    }
+
+    impl<DB> QueryFragment<DB> for NoElseExpression
+    where
+        DB: crate::backend::Backend,
+    {
+        fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> crate::result::QueryResult<()> {
+            let _ = out;
+            Ok(())
+        }
+    }
+    impl<E, DB> QueryFragment<DB> for ElseExpression<E>
+    where
+        E: QueryFragment<DB>,
+        DB: crate::backend::Backend,
+    {
+        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> crate::result::QueryResult<()> {
+            out.push_sql(" ELSE ");
+            self.expr.walk_ast(out.reborrow())?;
+            Ok(())
+        }
+    }
+
+    impl<S, Conditions, E> aliasing::FieldAliasMapper<S> for CaseWhen<Conditions, E>
     where
         S: aliasing::AliasSource,
-        C: aliasing::FieldAliasMapper<S>,
-        T: aliasing::FieldAliasMapper<S>,
-        F: aliasing::FieldAliasMapper<S>,
+        Conditions: aliasing::FieldAliasMapper<S>,
+        E: aliasing::FieldAliasMapper<S>,
     {
-        type Out = CaseWhenElse<
-            <C as aliasing::FieldAliasMapper<S>>::Out,
-            <T as aliasing::FieldAliasMapper<S>>::Out,
-            <F as aliasing::FieldAliasMapper<S>>::Out,
+        type Out = CaseWhen<
+            <Conditions as aliasing::FieldAliasMapper<S>>::Out,
+            <E as aliasing::FieldAliasMapper<S>>::Out,
         >;
         fn map(self, alias: &aliasing::Alias<S>) -> Self::Out {
-            CaseWhenElse {
-                condition: self.condition.map(alias),
-                if_true: self.if_true.map(alias),
-                if_false: self.if_false.map(alias),
+            CaseWhen {
+                whens: self.whens.map(alias),
+                else_expr: self.else_expr.map(alias),
+            }
+        }
+    }
+
+    impl<S, W, T> aliasing::FieldAliasMapper<S> for CaseWhenConditionsLeaf<W, T>
+    where
+        S: aliasing::AliasSource,
+        W: aliasing::FieldAliasMapper<S>,
+        T: aliasing::FieldAliasMapper<S>,
+    {
+        type Out = CaseWhenConditionsLeaf<
+            <W as aliasing::FieldAliasMapper<S>>::Out,
+            <T as aliasing::FieldAliasMapper<S>>::Out,
+        >;
+        fn map(self, alias: &aliasing::Alias<S>) -> Self::Out {
+            CaseWhenConditionsLeaf {
+                when: self.when.map(alias),
+                then: self.then.map(alias),
+            }
+        }
+    }
+
+    impl<S, W, T, Whens> aliasing::FieldAliasMapper<S>
+        for CaseWhenConditionsIntermediateNode<W, T, Whens>
+    where
+        S: aliasing::AliasSource,
+        W: aliasing::FieldAliasMapper<S>,
+        T: aliasing::FieldAliasMapper<S>,
+        Whens: aliasing::FieldAliasMapper<S>,
+    {
+        type Out = CaseWhenConditionsIntermediateNode<
+            <W as aliasing::FieldAliasMapper<S>>::Out,
+            <T as aliasing::FieldAliasMapper<S>>::Out,
+            <Whens as aliasing::FieldAliasMapper<S>>::Out,
+        >;
+        fn map(self, alias: &aliasing::Alias<S>) -> Self::Out {
+            CaseWhenConditionsIntermediateNode {
+                first_whens: self.first_whens.map(alias),
+                last_when: self.last_when.map(alias),
             }
         }
     }

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -5,6 +5,7 @@ use super::array_comparison::{AsInExpression, In, NotIn};
 use super::grouped::Grouped;
 use super::select_by::SelectBy;
 use super::{AsExpression, Expression};
+use crate::expression;
 use crate::expression_methods::PreferredBoolSqlType;
 use crate::sql_types;
 
@@ -120,14 +121,26 @@ pub type Like<Lhs, Rhs> = Grouped<super::operators::Like<Lhs, AsExprOf<Rhs, SqlT
 /// [`lhs.not_like(rhs)`](crate::expression_methods::TextExpressionMethods::not_like())
 pub type NotLike<Lhs, Rhs> = Grouped<super::operators::NotLike<Lhs, AsExprOf<Rhs, SqlTypeOf<Lhs>>>>;
 
-/// The return type of [`case_when_else()`](crate::expression::case_when::case_when_else)
+/// The return type of [`case_when()`](expression::case_when::case_when)
 #[allow(non_camel_case_types)]
-pub type case_when_else<C, T, F, ST = <T as Expression>::SqlType> =
-    crate::expression::case_when::CaseWhenElse<
+pub type case_when<C, T, ST = <T as Expression>::SqlType> = expression::case_when::CaseWhen<
+    expression::case_when::CaseWhenConditionsLeaf<Grouped<C>, Grouped<AsExprOf<T, ST>>>,
+    expression::case_when::NoElseExpression,
+>;
+/// The return type of [`case_when(...).when(...)`](expression::case_when::CaseWhen::when)
+pub type When<W, C, T> = expression::case_when::CaseWhen<
+    expression::case_when::CaseWhenConditionsIntermediateNode<
         Grouped<C>,
-        Grouped<AsExprOf<T, ST>>,
-        Grouped<AsExprOf<F, ST>>,
-    >;
+        Grouped<AsExprOf<T, <W as expression::case_when::CaseWhenTypesExtractor>::OutputExpressionSpecifiedSqlType>>,
+        <W as expression::case_when::CaseWhenTypesExtractor>::Whens,
+    >,
+    <W as expression::case_when::CaseWhenTypesExtractor>::Else,
+>;
+/// The return type of [`case_when(...).else_(...)`](expression::case_when::CaseWhen::else_)
+pub type Else_<W, E> = expression::case_when::CaseWhen<
+    <W as expression::case_when::CaseWhenTypesExtractor>::Whens,
+    expression::case_when::ElseExpression<Grouped<AsExprOf<E, <W as expression::case_when::CaseWhenTypesExtractor>::OutputExpressionSpecifiedSqlType>>>,
+>;
 
 /// Represents the return type of [`.as_select()`](crate::prelude::SelectableHelper::as_select)
 pub type AsSelect<Source, DB> = SelectBy<Source, DB>;

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -136,8 +136,8 @@ pub type When<W, C, T> = expression::case_when::CaseWhen<
     >,
     <W as expression::case_when::CaseWhenTypesExtractor>::Else,
 >;
-/// The return type of [`case_when(...).else_(...)`](expression::case_when::CaseWhen::else_)
-pub type Else_<W, E> = expression::case_when::CaseWhen<
+/// The return type of [`case_when(...).otherwise(...)`](expression::case_when::CaseWhen::otherwise)
+pub type Otherwise<W, E> = expression::case_when::CaseWhen<
     <W as expression::case_when::CaseWhenTypesExtractor>::Whens,
     expression::case_when::ElseExpression<Grouped<AsExprOf<E, <W as expression::case_when::CaseWhenTypesExtractor>::OutputExpressionSpecifiedSqlType>>>,
 >;

--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -120,6 +120,15 @@ pub type Like<Lhs, Rhs> = Grouped<super::operators::Like<Lhs, AsExprOf<Rhs, SqlT
 /// [`lhs.not_like(rhs)`](crate::expression_methods::TextExpressionMethods::not_like())
 pub type NotLike<Lhs, Rhs> = Grouped<super::operators::NotLike<Lhs, AsExprOf<Rhs, SqlTypeOf<Lhs>>>>;
 
+/// The return type of [`case_when_else()`](crate::expression::case_when::case_when_else)
+#[allow(non_camel_case_types)]
+pub type case_when_else<C, T, F, ST = <T as Expression>::SqlType> =
+    crate::expression::case_when::CaseWhenElse<
+        Grouped<C>,
+        Grouped<AsExprOf<T, ST>>,
+        Grouped<AsExprOf<F, ST>>,
+    >;
+
 /// Represents the return type of [`.as_select()`](crate::prelude::SelectableHelper::as_select)
 pub type AsSelect<Source, DB> = SelectBy<Source, DB>;
 

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -36,6 +36,7 @@ mod not;
 pub(crate) mod nullable;
 #[macro_use]
 pub(crate) mod operators;
+mod case_when;
 pub(crate) mod select_by;
 mod sql_literal;
 pub(crate) mod subselect;
@@ -51,6 +52,8 @@ pub use self::operators::Concat;
 pub(crate) mod dsl {
     use crate::dsl::SqlTypeOf;
 
+    #[doc(inline)]
+    pub use super::case_when::*;
     #[doc(inline)]
     pub use super::count::*;
     #[doc(inline)]


### PR DESCRIPTION
This is part of the SQL standard so the syntax is the same for all backends.
[PostgreSQL](https://www.postgresql.org/docs/current/functions-conditional.html#FUNCTIONS-CASE)
[MySQL](https://mariadb.com/kb/en/case-operator/)
[SQLite](https://www.sqlite.org/lang_expr.html#the_case_expression)

I'm not super happy with the amount of duplicated code compared to other operators, but because of how unusual the SQL writing is:
```rust
out.push_sql("CASE WHEN ");
self.condition.walk_ast(out.reborrow())?;
out.push_sql(" THEN ");
self.if_true.walk_ast(out.reborrow())?;
out.push_sql(" ELSE ");
self.if_false.walk_ast(out.reborrow())?;
out.push_sql(" END");
```

it didn't quite fit in the existing operators macros.

It may be possible to clear this duplication by creating derives for `SelectableExpression`/`AppearsOnTable`/`FieldAliasMapper`.

I have opted to keep it simple and not implemented the auto nullability propagation (which would be hard to implement with regards to its interactions with auto_type, introducing the same complex issues as we had with And/Or) so it's left up to the user to make the nullability of the `if_true` and the `if_false` match using `.nullable()` if necessary.