### PR TITLE
Use postgres_backend feature flag for SupportsCombinationClause impl 

### DIFF
--- a/diesel/src/query_builder/combination_clause.rs
+++ b/diesel/src/query_builder/combination_clause.rs
@@ -234,7 +234,7 @@ pub trait SupportsCombinationClause<Combinator, Rule> {}
 /// Wrapper used to wrap rhs sql in parenthesis when supported by backend
 pub struct ParenthesisWrapper<T>(T);
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "postgres_backend")]
 mod postgres {
     use super::*;
     use crate::pg::Pg;


### PR DESCRIPTION
I found that I couldn't compile queries that contained `CombineDSL::union` and `CombineDSL::union_all` expressions with the `postgres` feature flag replaced with `postgres_backend` while switching to `diesel-async`. 

I believe that this is a simple change to allow use of the `CombineDsl` trait with just the `postgres_backend` feature. In a quick search along with personal experience from making the feature-flag switch in my project, I didn't come across other cases where `postgres` is used instead of `postgres_backend` as a feature-gate.