### PR TITLE
bumping diesel version to 2.1.1

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.1"
 license = "MIT OR Apache-2.0"
 description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"
 readme = "README.md"


### PR DESCRIPTION
bumping diesel version to 2.1.1 as this is the minimum required version by diesel-async@main