### PR TITLE
Fix impl SqlOrd postgres > postgres_backend feature flag.

### DIFF
--- a/diesel/src/sql_types/ord.rs
+++ b/diesel/src/sql_types/ord.rs
@@ -15,9 +15,9 @@ impl SqlOrd for sql_types::Time {}
 impl SqlOrd for sql_types::Timestamp {}
 impl<T> SqlOrd for sql_types::Nullable<T> where T: SqlOrd + SqlType<IsNull = is_nullable::NotNull> {}
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "postgres_backend")]
 impl SqlOrd for sql_types::Timestamptz {}
-#[cfg(feature = "postgres")]
+#[cfg(feature = "postgres_backend")]
 impl<T: SqlOrd> SqlOrd for sql_types::Array<T> {}
 
 #[cfg(feature = "mysql_backend")]


### PR DESCRIPTION
First of all, thanks for your excellent work!

I believe the `SqlOrd` should be implemented if the `postgres_backend` is enabled, not `postgres`. Else the `SqlOrd` trait would not be implemented for these types if using `diesel-asyc`.