### PR TITLE
add skip_insertion attribute for Insertable derive macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added automatic usage of all sqlite `rowid` aliases when no explicit primary key is defined for `print-schema`
 * Added a `#[dsl::auto_type]` attribute macro, allowing to infer type of query fragment functions
 * Added the same type inference on `Selectable` derives, which allows skipping specifying `select_expression_type` most of the time, in turn enabling most queries to be written using just a `Selectable` derive.
+* Added an optional `#[diesel(skip_insertion)]` field attribute to the `Insertable` derive macro, allowing fields which map to generated columns to be skipped during insertion.
 
 ### Changed
 

--- a/diesel_derives/src/attrs.rs
+++ b/diesel_derives/src/attrs.rs
@@ -32,6 +32,7 @@ pub struct AttributeSpanWrapper<T> {
 
 pub enum FieldAttr {
     Embed(Ident),
+    SkipInsertion(Ident),
 
     ColumnName(Ident, SqlIdentifier),
     SqlType(Ident, TypePath),
@@ -123,6 +124,7 @@ impl Parse for FieldAttr {
 
         match &*name_str {
             "embed" => Ok(FieldAttr::Embed(name)),
+            "skip_insertion" => Ok(FieldAttr::SkipInsertion(name)),
 
             "column_name" => Ok(FieldAttr::ColumnName(
                 name,
@@ -173,6 +175,7 @@ impl MySpanned for FieldAttr {
     fn span(&self) -> Span {
         match self {
             FieldAttr::Embed(ident)
+            | FieldAttr::SkipInsertion(ident)
             | FieldAttr::ColumnName(ident, _)
             | FieldAttr::SqlType(ident, _)
             | FieldAttr::TreatNoneAsNull(ident, _)

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -17,6 +17,7 @@ pub struct Field {
     pub select_expression: Option<AttributeSpanWrapper<Expr>>,
     pub select_expression_type: Option<AttributeSpanWrapper<Type>>,
     pub embed: Option<AttributeSpanWrapper<bool>>,
+    pub skip_insertion: Option<AttributeSpanWrapper<bool>>,
 }
 
 impl Field {
@@ -30,6 +31,7 @@ impl Field {
         let mut serialize_as = None;
         let mut deserialize_as = None;
         let mut embed = None;
+        let mut skip_insertion = None;
         let mut select_expression = None;
         let mut select_expression_type = None;
         let mut treat_none_as_default_value = None;
@@ -102,6 +104,13 @@ impl Field {
                         ident_span,
                     })
                 }
+                FieldAttr::SkipInsertion(_) => {
+                    skip_insertion = Some(AttributeSpanWrapper {
+                        item: true,
+                        attribute_span,
+                        ident_span,
+                    })
+                }
             }
         }
 
@@ -128,6 +137,7 @@ impl Field {
             select_expression,
             select_expression_type,
             embed,
+            skip_insertion,
         })
     }
 
@@ -156,6 +166,13 @@ impl Field {
 
     pub(crate) fn embed(&self) -> bool {
         self.embed.as_ref().map(|a| a.item).unwrap_or(false)
+    }
+
+    pub(crate) fn skip_insertion(&self) -> bool {
+        self.skip_insertion
+            .as_ref()
+            .map(|a| a.item)
+            .unwrap_or(false)
     }
 }
 

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -45,6 +45,10 @@ fn derive_into_single_table(
     let mut ref_field_assign = Vec::with_capacity(model.fields().len());
 
     for field in model.fields() {
+        // skip this field while generating the insertion
+        if let true = field.skip_insertion() {
+            continue;
+        }
         // Use field-level attr. with fallback to the struct-level one.
         let treat_none_as_default_value = match &field.treat_none_as_default_value {
             Some(attr) => {

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -46,7 +46,7 @@ fn derive_into_single_table(
 
     for field in model.fields() {
         // skip this field while generating the insertion
-        if let true = field.skip_insertion() {
+        if field.skip_insertion() {
             continue;
         }
         // Use field-level attr. with fallback to the struct-level one.

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -334,6 +334,8 @@ pub fn derive_identifiable(input: TokenStream) -> TokenStream {
 ///    the actual field type.
 /// * `#[diesel(treat_none_as_default_value = true/false)]`, overrides the container-level
 ///   `treat_none_as_default_value` attribute for the current field.
+/// * `#[diesel(skip_insertion)]`, skips insertion of this field. Useful for working with
+///    generated columns.
 ///
 /// # Examples
 ///

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -469,7 +469,7 @@ fn insert_with_generated_column() {
         "CREATE TABLE user_with_last_names (
         first_name VARCHAR NOT NULL PRIMARY KEY,
         last_name VARCHAR NOT NULL,
-        full_NAME VARCHAR GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
+        full_name VARCHAR GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
     )",
     )
     .execute(connection)
@@ -477,7 +477,7 @@ fn insert_with_generated_column() {
     let new_users: &[_] = &[UserWithLastName {
         first_name: "Sean".to_string(),
         last_name: "Black".to_string(),
-        ..Default::default()
+        full_name: "This field not inserted".to_string(),
     }];
     let count = insert_into(users)
         .values(new_users)

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -458,7 +458,6 @@ fn insert_with_generated_column() {
     use crate::schema::user_with_last_names::table as users;
     #[derive(Debug, Queryable, Insertable, Selectable, Default)]
     struct UserWithLastName {
-        id: i32,
         first_name: String,
         last_name: String,
         #[diesel(skip_insertion)]
@@ -468,8 +467,7 @@ fn insert_with_generated_column() {
     let connection = &mut connection();
     diesel::sql_query(
         "CREATE TABLE user_with_last_names (
-        id SERIAL PRIMARY KEY,
-        first_name VARCHAR NOT NULL,
+        first_name VARCHAR NOT NULL PRIMARY KEY,
         last_name VARCHAR NOT NULL,
         full_NAME VARCHAR GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
     )",

--- a/diesel_tests/tests/schema/pg_schema.rs
+++ b/diesel_tests/tests/schema/pg_schema.rs
@@ -176,6 +176,15 @@ table! {
 }
 
 table! {
+    user_with_last_names (id) {
+        id -> Int4,
+        first_name -> Varchar,
+        last_name -> Varchar,
+        full_name -> Varchar,
+    }
+}
+
+table! {
     with_keywords (fn_) {
         #[sql_name = "fn"]
         fn_ -> Int4,

--- a/diesel_tests/tests/schema/pg_schema.rs
+++ b/diesel_tests/tests/schema/pg_schema.rs
@@ -176,8 +176,7 @@ table! {
 }
 
 table! {
-    user_with_last_names (id) {
-        id -> Int4,
+    user_with_last_names (first_name) {
         first_name -> Varchar,
         last_name -> Varchar,
         full_name -> Varchar,


### PR DESCRIPTION
Address a subset of #860, specifically related to the `Insertable` derive macro. It's currently fairly painful to use `Insertable` for tables with generated columns, this pr allows fields to be skipped during insertion. 