### PR TITLE
Add support for syn 2.0.40's new Expr::Group to dsl::auto_type

### DIFF
--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -82,6 +82,9 @@ impl TypeInferrer<'_> {
             expr,
             type_hint.filter(|h| !matches!(h, syn::Type::Infer(_))),
         ) {
+            (syn::Expr::Group(syn::ExprGroup { expr, .. }), type_hint) => {
+                return self.try_infer_expression_type(expr, type_hint)
+            }
             (
                 syn::Expr::Tuple(syn::ExprTuple {
                     elems: expr_elems, ..


### PR DESCRIPTION
This expression may get yielded when parsing `$a: expr` from other macros.