### PR TITLE
Fix #[derive(AsExpression, FromSqlRow)] to work with defaulted type params

### DIFF
--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::parse_quote;
 use syn::DeriveInput;
 use syn::Result;
 
@@ -18,19 +19,29 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
     let struct_ty = ty_for_foreign_derive(&item, &model)?;
 
-    let (impl_generics, ..) = item.generics.split_for_impl();
-    let lifetimes = item.generics.lifetimes().collect::<Vec<_>>();
-    let ty_params = item.generics.type_params().collect::<Vec<_>>();
-    let const_params = item.generics.const_params().collect::<Vec<_>>();
+    // type generics are already handled by `ty_for_foreign_derive`
+    let (impl_generics_plain, _, where_clause_plain) = item.generics.split_for_impl();
+
+    let mut generics = item.generics.clone();
+    generics.params.push(parse_quote!('__expr));
+
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+
+    let mut generics2 = generics.clone();
+    generics2.params.push(parse_quote!('__expr2));
+    let (impl_generics2, _, where_clause2) = generics2.split_for_impl();
 
     let tokens = model.sql_types.iter().map(|sql_type| {
-        let lifetimes = &lifetimes;
-        let ty_params = &ty_params;
-        let const_params = &const_params;
+
+        let mut to_sql_generics = item.generics.clone();
+        to_sql_generics.params.push(parse_quote!(__DB));
+        to_sql_generics.make_where_clause().predicates.push(parse_quote!(__DB: diesel::backend::Backend));
+        to_sql_generics.make_where_clause().predicates.push(parse_quote!(Self: ToSql<#sql_type, __DB>));
+        let (to_sql_impl_generics, _, to_sql_where_clause) = to_sql_generics.split_for_impl();
 
         let tokens = quote!(
-            impl<'expr, #(#lifetimes,)* #(#ty_params,)* #(#const_params,)*> AsExpression<#sql_type>
-                for &'expr #struct_ty
+            impl #impl_generics AsExpression<#sql_type>
+                for &'__expr #struct_ty #where_clause
             {
                 type Expression = Bound<#sql_type, Self>;
 
@@ -39,8 +50,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 }
             }
 
-            impl<'expr, #(#lifetimes,)* #(#ty_params,)* #(#const_params,)*> AsExpression<Nullable<#sql_type>>
-                for &'expr #struct_ty
+            impl #impl_generics AsExpression<Nullable<#sql_type>>
+                for &'__expr #struct_ty #where_clause
             {
                 type Expression = Bound<Nullable<#sql_type>, Self>;
 
@@ -49,8 +60,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 }
             }
 
-            impl<'expr2, 'expr, #(#lifetimes,)* #(#ty_params,)* #(#const_params,)*> AsExpression<#sql_type>
-                for &'expr2 &'expr #struct_ty
+            impl #impl_generics2 AsExpression<#sql_type>
+                for &'__expr2 &'__expr #struct_ty #where_clause2
             {
                 type Expression = Bound<#sql_type, Self>;
 
@@ -59,8 +70,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 }
             }
 
-            impl<'expr2, 'expr, #(#lifetimes,)* #(#ty_params,)* #(#const_params,)*> AsExpression<Nullable<#sql_type>>
-                for &'expr2 &'expr #struct_ty
+            impl #impl_generics2 AsExpression<Nullable<#sql_type>>
+                for &'__expr2 &'__expr #struct_ty #where_clause2
             {
                 type Expression = Bound<Nullable<#sql_type>, Self>;
 
@@ -69,11 +80,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 }
             }
 
-            impl<#(#lifetimes,)* #(#ty_params,)* __DB,  #(#const_params,)*> diesel::serialize::ToSql<Nullable<#sql_type>, __DB>
-                for #struct_ty
-            where
-                __DB: diesel::backend::Backend,
-                Self: ToSql<#sql_type, __DB>,
+            impl #to_sql_impl_generics diesel::serialize::ToSql<Nullable<#sql_type>, __DB>
+                for #struct_ty #to_sql_where_clause
             {
                 fn to_sql<'__b>(&'__b self, out: &mut Output<'__b, '_, __DB>) -> serialize::Result
                 {
@@ -88,7 +96,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             quote!(
                 #tokens
 
-                impl #impl_generics AsExpression<#sql_type> for #struct_ty {
+                impl #impl_generics_plain AsExpression<#sql_type> for #struct_ty #where_clause_plain {
                     type Expression = Bound<#sql_type, Self>;
 
                     fn as_expression(self) -> Self::Expression {
@@ -96,7 +104,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                     }
                 }
 
-                impl #impl_generics AsExpression<Nullable<#sql_type>> for #struct_ty {
+                impl #impl_generics_plain AsExpression<Nullable<#sql_type>> for #struct_ty #where_clause_plain {
                     type Expression = Bound<Nullable<#sql_type>, Self>;
 
                     fn as_expression(self) -> Self::Expression {

--- a/diesel_derives/tests/as_expression.rs
+++ b/diesel_derives/tests/as_expression.rs
@@ -2,6 +2,7 @@ use diesel::backend::Backend;
 use diesel::deserialize::{FromSql, FromSqlRow};
 use diesel::expression::AsExpression;
 use diesel::serialize::{Output, ToSql};
+use diesel::sql_types::Binary;
 use diesel::sql_types::Text;
 use diesel::*;
 use std::convert::TryInto;
@@ -58,3 +59,9 @@ fn struct_with_sql_type() {
         .get_result(conn);
     assert!(data.is_err());
 }
+
+// check that defaulted type parameters compile correctly
+// This is a regression test for https://github.com/diesel-rs/diesel/issues/3902
+#[derive(AsExpression, FromSqlRow)]
+#[diesel(sql_type = Binary)]
+pub struct Ewkb<B: AsRef<[u8]> = Vec<u8>>(pub B);


### PR DESCRIPTION
This commit fixes the code for `#[derive(AsExpression, FromSqlRow)]` to support defaulted type parameters correctly. For this we need to use `syn::Generics::split_for_impl()` to generate the right generic list for us. This requires a bit of restructuring to push our own generics/lifetimes onto that list as required.

Fixes #3902