### PR TITLE
Bump pq-sys to 0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   check_and_test:
     name: Check
-    needs: [sqlite_bundled, rustfmt_and_clippy]
+    needs: [sqlite_bundled, rustfmt_and_clippy, postgres_bundled]
     strategy:
       fail-fast: false
       matrix:
@@ -444,6 +444,44 @@ jobs:
           RUSTFLAGS: -Zsanitizer=address
           ASAN_OPTIONS: detect_stack_use_after_return=1
         run: cargo +nightly -Z build-std test --manifest-path diesel/Cargo.toml --no-default-features --features "sqlite extras libsqlite3-sys libsqlite3-sys/bundled libsqlite3-sys/with-asan" --target x86_64-unknown-linux-gnu
+  postgres_bundled:
+    name: Check postgres bundled + Postgres with asan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: "rust-src"
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: postgres_bundled-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install postgres (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev postgresql valgrind
+          echo "host    all             all             127.0.0.1/32            md5" > sudo tee -a /etc/postgresql/10/main/pg_hba.conf
+          sudo service postgresql restart && sleep 3
+          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+          sudo service postgresql restart && sleep 3
+          echo "PG_DATABASE_URL=postgres://postgres:postgres@localhost/" >> $GITHUB_ENV
+          echo $PG_DATABASE_URL
+
+      - name: Test diesel-cli
+        run: cargo +nightly test --manifest-path diesel_cli/Cargo.toml --no-default-features --features "postgres-bundled"
+
+      - name: Run diesel_tests with ASAN enabled
+        env:
+          RUSTFLAGS: -Zsanitizer=address
+          ASAN_OPTIONS: detect_stack_use_after_return=1
+        run: cargo +nightly -Z build-std test --manifest-path diesel_tests/Cargo.toml --no-default-features --features "postgres pq-sys pq-sys/bundled pq-src/with-asan" --target x86_64-unknown-linux-gnu
+
+      - name: Run diesel tests with ASAN enabled
+        env:
+          RUSTDOCFLAGS: -Zsanitizer=address
+          RUSTFLAGS: -Zsanitizer=address
+          ASAN_OPTIONS: detect_stack_use_after_return=1
+        run: cargo +nightly -Z build-std test --manifest-path diesel/Cargo.toml --no-default-features --features "postgres pq-sys pq-sys/bundled pq-src/with-asan" --target x86_64-unknown-linux-gnu
 
   minimal_rust_version:
     name: Check Minimal supported rust version (1.70.0)
@@ -471,7 +509,7 @@ jobs:
       - name: Check diesel_migrations
         run: cargo +1.70.0 minimal-versions check -p diesel_migrations --all-features
       - name: Check diesel_cli
-        run: cargo +1.70.0 minimal-versions check -p diesel_cli --all-features
+        run: cargo +1.70.0 minimal-versions check -p diesel_cli --features "default sqlite-bundled"
 
   typos:
     name: Spell Check with Typos

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -18,7 +18,8 @@ chrono = { version = "0.4.20", optional = true, default-features = false, featur
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.29.0", optional = true, features = ["bundled_bindings"] }
 mysqlclient-sys = { version = "0.2.5", optional = true }
-pq-sys = { version = "0.4.0", optional = true }
+pq-sys = { version = ">=0.4.0, <0.6.0", optional = true }
+pq-src = { version = "0.1", optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 serde_json = { version = ">=0.8.0, <2.0", optional = true }
 url = { version = "2.1.0", optional = true }

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -63,14 +63,14 @@ impl FromSql<sql_types::Numeric, Pg> for PgNumeric {
 
         match sign {
             0 => Ok(PgNumeric::Positive {
-                weight: weight,
-                scale: scale,
-                digits: digits,
+                weight,
+                scale,
+                digits,
             }),
             0x4000 => Ok(PgNumeric::Negative {
-                weight: weight,
-                scale: scale,
-                digits: digits,
+                weight,
+                scale,
+                digits,
             }),
             0xC000 => Ok(PgNumeric::NaN),
             invalid => Err(Box::new(InvalidNumericSign(invalid))),

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1.0.0", features = ["derive"] }
 toml = "0.8"
 url = { version = "2.2.2" }
 libsqlite3-sys = { version = ">=0.17.2, <0.29.0", optional = true }
+pq-sys = { version = ">=0.4, <0.6.0", optional = true }
 diffy = "0.3.0"
 regex = "1.0.6"
 serde_regex = "1.1"
@@ -61,13 +62,14 @@ postgres = ["diesel/postgres", "uses_information_schema"]
 sqlite = ["diesel/sqlite"]
 mysql = ["diesel/mysql", "uses_information_schema"]
 sqlite-bundled = ["sqlite", "libsqlite3-sys/bundled"]
+postgres-bundled = ["postgres", "pq-sys/bundled"]
 uses_information_schema = []
 
 [[test]]
 name = "tests"
 
 [package.metadata.dist]
-features = ["sqlite-bundled"]
+features = ["sqlite-bundled", "postgres-bundled"]
 
 [package.metadata.dist.dependencies.apt]
 libpq-dev = '*'

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -22,6 +22,8 @@ ipnetwork = ">=0.12.2, <0.21.0"
 bigdecimal = ">= 0.0.13, < 0.5.0"
 rand = "0.8.4"
 libsqlite3-sys = { version = "0.28", optional = true }
+pq-sys = { version = "0.5", optional = true }
+pq-src = { version = "0.1.1", optional = true }
 
 [features]
 default = []

--- a/examples/postgres/composite_types/Cargo.toml
+++ b/examples/postgres/composite_types/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "2.1", features = ["postgres" ] }
+diesel = { version = "2.1", path = "../../../diesel", features = ["postgres" ] }
 dotenvy = "0.15"


### PR DESCRIPTION
This commit increases the maximal supported version of pq-sys to include support for 0.5. That release contains bundling support for libpq and support for building with address sanitizers enabled. This PR adds the relevant features to diesel_cli to allow using the bundling support + it adds a CI job for also running tests with address sanitizers enabled.