### PR TITLE
Try out M1 Runners

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/audit@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -15,7 +15,7 @@ jobs:
         backend: ["postgres", "sqlite", "mysql"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install postgres (Linux)
         if: matrix.backend == 'postgres'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         rust: ["stable", "beta", "nightly"]
         backend: ["postgres", "sqlite", "mysql"]
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, macos-14, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
           key: ${{ runner.os }}-${{ matrix.backend }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Set environment variables
@@ -300,16 +297,13 @@ jobs:
     name: Compiletests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-09-21
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
           key: compile_test-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install dependencies
@@ -325,16 +319,13 @@ jobs:
     name: Check rustfmt style && run clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
           key: clippy-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install dependencies
@@ -405,16 +396,13 @@ jobs:
     name: Check sqlite bundled + Sqlite with asan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: "rust-src"
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
           key: sqlite_bundled-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Test diesel-cli
@@ -437,17 +425,14 @@ jobs:
     name: Check Minimal supported rust version (1.70.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.70.0
       - uses: dtolnay/rust-toolchain@nightly
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
           key: minimal_rust_version-cargo-${{ hashFiles('**/Cargo.toml') }}
       - name: Install dependencies
         run: |
@@ -471,7 +456,7 @@ jobs:
 
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check the spelling of the files in our repo
         uses: crate-ci/typos@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
       matrix:
         rust: ["stable", "beta", "nightly"]
         backend: ["postgres", "sqlite", "mysql"]
-        os: [ubuntu-latest, macos-latest, macos-14, windows-2019]
+        #os: [ubuntu-latest, macos-latest, macos-14, windows-2019]
+        os: [macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -118,10 +119,19 @@ jobs:
           echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://root:root@localhost/diesel_unit_test" >> $GITHUB_ENV
 
       - name: Install postgres (MacOS)
-        if: runner.os == 'macOS' && matrix.backend == 'postgres'
+        if: matrix.os == 'macos-latest' && matrix.backend == 'postgres'
         run: |
           initdb -D /usr/local/var/postgres
           pg_ctl -D /usr/local/var/postgres start
+          sleep 3
+          createuser -s postgres
+          echo "PG_DATABASE_URL=postgres://postgres@localhost/" >> $GITHUB_ENV
+          echo "PG_EXAMPLE_DATABASE_URL=postgres://postgres@localhost/diesel_example" >> $GITHUB_ENV
+      - name: Install postgres (MacOS M1)
+        if: matrix.os == 'macos-14' && matrix.backend == 'postgres'
+        run: |
+          brew install postgresql
+          brew services start postgresql@14
           sleep 3
           createuser -s postgres
           echo "PG_DATABASE_URL=postgres://postgres@localhost/" >> $GITHUB_ENV
@@ -134,7 +144,7 @@ jobs:
           echo "SQLITE_DATABASE_URL=/tmp/test.db" >> $GITHUB_ENV
 
       - name: Install mysql (MacOS)
-        if: runner.os == 'macOS' && matrix.backend == 'mysql'
+        if: matrix.os == 'macos-latest' && matrix.backend == 'mysql'
         run: |
           brew install mariadb@10.5
           /usr/local/opt/mariadb@10.5/bin/mysql_install_db
@@ -145,6 +155,20 @@ jobs:
           echo "MYSQL_EXAMPLE_DATABASE_URL=mysql://runner@localhost/diesel_example" >> $GITHUB_ENV
           echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://runner@localhost/diesel_unit_test" >> $GITHUB_ENV
           echo "MYSQLCLIENT_LIB_DIR=/usr/local/opt/mariadb@10.5/lib" >> $GITHUB_ENV
+
+      - name: Install mysql (MacOS M1)
+        if: matrix.os == 'macos-14' && matrix.backend == 'mysql'
+        run: |
+          brew install mariadb@10.5
+          ls /opt/homebrew/opt/mariadb@10.5
+          /opt/homebrew/opt/mariadb@10.5/bin/mysql_install_db
+          /opt/homebrew/opt/mariadb@10.5/bin/mysql.server start
+          sleep 3
+          /opt/homebrew/opt/mariadb@10.5/bin/mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'runner'@'localhost';" -urunner
+          echo "MYSQL_DATABASE_URL=mysql://runner@localhost/diesel_test" >> $GITHUB_ENV
+          echo "MYSQL_EXAMPLE_DATABASE_URL=mysql://runner@localhost/diesel_example" >> $GITHUB_ENV
+          echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://runner@localhost/diesel_unit_test" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_LIB_DIR=/opt/homebrew/opt/mariadb@10.5/lib" >> $GITHUB_ENV
 
       - name: Install sqlite (Windows)
         if: runner.os == 'Windows' && matrix.backend == 'sqlite'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
       matrix:
         rust: ["stable", "beta", "nightly"]
         backend: ["postgres", "sqlite", "mysql"]
-        #os: [ubuntu-latest, macos-latest, macos-14, windows-2019]
-        os: [macos-14]
+        os: [ubuntu-latest, macos-latest, macos-14, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,13 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Cache cargo registry
-      uses: actions/cache@v3
+      uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
         key: cargo-doc-cargo-${{ hashFiles('**/Cargo.toml') }}
     - name: Get the branch name
       id: current_branch

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -21,15 +21,11 @@ jobs:
         backend: ["postgres", "sqlite", "mysql"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: cache
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            diesel_bench/target
           key: metrics-${{matrix.backend}}-cargo-${{ hashFiles('diesel_bench/Cargo.toml')}}
 
       - name: Install postgres (Linux)

--- a/diesel_tests/tests/alias.rs
+++ b/diesel_tests/tests/alias.rs
@@ -20,6 +20,7 @@ fn selecting_basic_data() {
             user_alias.field(users::name),
             user_alias.field(users::hair_color),
         ))
+        .order(user_alias.field(users::name))
         .load(connection)
         .unwrap();
 

--- a/diesel_tests/tests/boxed_queries.rs
+++ b/diesel_tests/tests/boxed_queries.rs
@@ -37,7 +37,7 @@ fn boxed_queries_can_differ_conditionally() {
     }
 
     let source = |query| match query {
-        Query::All => users::table.into_boxed(),
+        Query::All => users::table.order(users::name.desc()).into_boxed(),
         Query::Ordered => users::table.order(users::name.desc()).into_boxed(),
         Query::One => users::table
             .filter(users::name.ne("jim"))
@@ -51,7 +51,7 @@ fn boxed_queries_can_differ_conditionally() {
     let jim = find_user_by_name("Jim", connection);
 
     let all = source(Query::All).load(connection);
-    let expected_data = vec![sean.clone(), tess.clone(), jim.clone()];
+    let expected_data = vec![tess.clone(), sean.clone(), jim.clone()];
     assert_eq!(Ok(expected_data), all);
 
     let ordered = source(Query::Ordered).load(connection);
@@ -69,6 +69,7 @@ fn boxed_queries_implement_select_dsl() {
     let data = users::table
         .into_boxed()
         .select(users::name)
+        .order(users::name)
         .load::<String>(connection);
     assert_eq!(Ok(vec!["Sean".into(), "Tess".into()]), data);
 }
@@ -92,7 +93,11 @@ fn boxed_queries_implement_filter_dsl() {
 #[test]
 fn boxed_queries_implement_limit_dsl() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
-    let data = users::table.into_boxed().limit(1).load(connection);
+    let data = users::table
+        .into_boxed()
+        .limit(1)
+        .order(users::id)
+        .load(connection);
     let expected_data = vec![find_user_by_name("Sean", connection)];
     assert_eq!(Ok(expected_data), data);
 }
@@ -104,6 +109,7 @@ fn boxed_queries_implement_offset_dsl() {
         .into_boxed()
         .limit(1)
         .offset(1)
+        .order(users::id)
         .load(connection);
     let expected_data = vec![find_user_by_name("Tess", connection)];
     assert_eq!(Ok(expected_data), data);
@@ -154,6 +160,7 @@ fn boxed_queries_implement_or_filter() {
         .into_boxed()
         .filter(users::name.eq("Sean"))
         .or_filter(users::name.eq("Tess"))
+        .order(users::name)
         .load(connection);
     let expected = vec![
         find_user_by_name("Sean", connection),

--- a/diesel_tests/tests/combination.rs
+++ b/diesel_tests/tests/combination.rs
@@ -13,7 +13,7 @@ fn union() {
         NewUser::new("Jim", None),
     ];
     insert_into(users).values(&data).execute(conn).unwrap();
-    let data = users.load::<User>(conn).unwrap();
+    let data = users.order(id).load::<User>(conn).unwrap();
     let sean = &data[0];
     let tess = &data[1];
     let jim = &data[2];
@@ -43,7 +43,7 @@ fn union_all() {
         NewUser::new("Jim", None),
     ];
     insert_into(users).values(&data).execute(conn).unwrap();
-    let data = users.load::<User>(conn).unwrap();
+    let data = users.order(id).load::<User>(conn).unwrap();
     let sean = &data[0];
     let tess = &data[1];
     let jim = &data[2];
@@ -75,10 +75,10 @@ fn intersect() {
         NewUser::new("Jim", None),
     ];
     insert_into(users).values(&data).execute(conn).unwrap();
-    let data = users.load::<User>(conn).unwrap();
-    let _sean = &data[0];
-    let tess = &data[1];
-    let _jim = &data[2];
+    let data = users.order(name).load::<User>(conn).unwrap();
+    let _sean = &data[1];
+    let tess = &data[2];
+    let _jim = &data[0];
 
     let expected_data = vec![User::new(tess.id, "Tess")];
     let data: Vec<_> = users
@@ -171,6 +171,7 @@ fn as_subquery_for_eq_in() {
     let out = posts::table
         .filter(posts::user_id.eq_any(subquery))
         .select(posts::title)
+        .order_by(posts::title)
         .load::<String>(conn)
         .unwrap();
 

--- a/diesel_tests/tests/deserialization.rs
+++ b/diesel_tests/tests/deserialization.rs
@@ -22,11 +22,17 @@ fn generated_queryable_allows_lifetimes() {
     };
     assert_eq!(
         Ok(expected_user),
-        users.select((id, name)).first(connection)
+        users.select((id, name)).order(id).first(connection)
     );
     assert_eq!(
-        users.select((id, name)).first::<CowUser<'_>>(connection),
-        users.select(CowUser::as_select()).first(connection)
+        users
+            .select((id, name))
+            .order(id)
+            .first::<CowUser<'_>>(connection),
+        users
+            .select(CowUser::as_select())
+            .order(id)
+            .first(connection)
     );
 }
 

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -178,7 +178,7 @@ fn distinct_of_multiple_columns() {
         .execute(&mut connection)
         .unwrap();
     let posts = posts::table
-        .order(posts::id)
+        .order(posts::title)
         .load::<Post>(&mut connection)
         .unwrap();
 

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -238,6 +238,7 @@ fn function_with_multiple_arguments() {
     let expected_data = vec!["black".to_string(), "Tess".to_string()];
     let data = users
         .select(coalesce(hair_color, name))
+        .order(id)
         .load::<String>(connection);
 
     assert_eq!(Ok(expected_data), data);

--- a/diesel_tests/tests/expressions/ops.rs
+++ b/diesel_tests/tests/expressions/ops.rs
@@ -8,11 +8,11 @@ fn adding_literal_to_column() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![2, 3];
-    let data = users.select(id + 1).load(connection);
+    let data = users.select(id + 1).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 
     let expected_data = vec![3, 4];
-    let data = users.select(id + 2).load(connection);
+    let data = users.select(id + 2).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 
@@ -36,7 +36,7 @@ fn adding_column_to_column() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![2, 4];
-    let data = users.select(id + id).load(connection);
+    let data = users.select(id + id).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 
@@ -47,7 +47,7 @@ fn adding_multiple_times() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![4, 5];
-    let data = users.select(id + 1 + 2).load(connection);
+    let data = users.select(id + 1 + 2).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 
@@ -58,7 +58,7 @@ fn subtracting_literal_from_column() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![0, 1];
-    let data = users.select(id - 1).load(connection);
+    let data = users.select(id - 1).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 
@@ -69,7 +69,7 @@ fn adding_then_subtracting() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![2, 3];
-    let data = users.select(id + 2 - 1).load(connection);
+    let data = users.select(id + 2 - 1).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 
@@ -80,7 +80,7 @@ fn multiplying_column() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![3, 6];
-    let data = users.select(id * 3).load(connection);
+    let data = users.select(id * 3).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 
@@ -91,7 +91,7 @@ fn dividing_column() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
 
     let expected_data = vec![0, 1];
-    let data = users.select(id / 2).load(connection);
+    let data = users.select(id / 2).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 
@@ -192,7 +192,7 @@ fn mix_and_match_all_numeric_ops() {
     .unwrap();
 
     let expected_data = vec![4, 6, 7, 9];
-    let data = users.select(id * 3 / 2 + 4 - 1).load(connection);
+    let data = users.select(id * 3 / 2 + 4 - 1).order(id).load(connection);
     assert_eq!(Ok(expected_data), data);
 }
 

--- a/diesel_tests/tests/insert_from_select.rs
+++ b/diesel_tests/tests/insert_from_select.rs
@@ -11,7 +11,10 @@ fn insert_from_table() {
         .execute(conn)
         .unwrap();
 
-    let data = posts.select((user_id, title, body)).load(conn);
+    let data = posts
+        .select((user_id, title, body))
+        .order(user_id)
+        .load(conn);
     let expected = vec![
         (1, String::from("Sean"), None::<String>),
         (2, String::from("Tess"), None),
@@ -29,7 +32,10 @@ fn insert_from_table_reference() {
         .execute(conn)
         .unwrap();
 
-    let data = posts.select((user_id, title, body)).load(conn);
+    let data = posts
+        .select((user_id, title, body))
+        .order(user_id)
+        .load(conn);
     let expected = vec![
         (1, String::from("Sean"), None::<String>),
         (2, String::from("Tess"), None),
@@ -50,7 +56,11 @@ fn insert_from_select() {
         .execute(conn)
         .unwrap();
 
-    let data = posts.select(title).load::<String>(conn).unwrap();
+    let data = posts
+        .select(title)
+        .order(title)
+        .load::<String>(conn)
+        .unwrap();
     let expected = vec!["Sean says hi", "Tess says hi"];
     assert_eq!(expected, data);
 }
@@ -68,7 +78,11 @@ fn insert_from_select_reference() {
         .execute(conn)
         .unwrap();
 
-    let data = posts.select(title).load::<String>(conn).unwrap();
+    let data = posts
+        .select(title)
+        .order(title)
+        .load::<String>(conn)
+        .unwrap();
     let expected = vec!["Sean says hi", "Tess says hi"];
     assert_eq!(expected, data);
 }
@@ -87,7 +101,11 @@ fn insert_from_boxed() {
         .execute(conn)
         .unwrap();
 
-    let data = posts.select(title).load::<String>(conn).unwrap();
+    let data = posts
+        .select(title)
+        .order(title)
+        .load::<String>(conn)
+        .unwrap();
     let expected = vec!["Sean says hi", "Tess says hi"];
     assert_eq!(expected, data);
 }
@@ -105,7 +123,11 @@ fn insert_from_boxed_reference() {
         .execute(conn)
         .unwrap();
 
-    let data = posts.select(title).load::<String>(conn).unwrap();
+    let data = posts
+        .select(title)
+        .order(title)
+        .load::<String>(conn)
+        .unwrap();
     let expected = vec!["Sean says hi", "Tess says hi"];
     assert_eq!(expected, data);
 }
@@ -255,7 +277,11 @@ fn on_conflict_do_nothing_with_select() {
         assert_eq!(0, inserted_rows);
     }
 
-    let data = posts.select(title).load::<String>(conn).unwrap();
+    let data = posts
+        .select(title)
+        .order(title)
+        .load::<String>(conn)
+        .unwrap();
     let expected = vec!["Sean says hi", "Tess says hi"];
     assert_eq!(expected, data);
 }

--- a/diesel_tests/tests/joins.rs
+++ b/diesel_tests/tests/joins.rs
@@ -20,7 +20,7 @@ fn belongs_to() {
     let tess_post = Post::new(2, 2, "World", None);
 
     let expected_data = vec![(seans_post, sean), (tess_post, tess)];
-    let source = posts::table.inner_join(users::table);
+    let source = posts::table.inner_join(users::table).order(posts::id);
     let actual_data: Vec<_> = source.load(connection).unwrap();
 
     assert_eq!(expected_data, actual_data);
@@ -40,8 +40,8 @@ fn select_single_from_join() {
     .unwrap();
 
     let source = posts::table.inner_join(users::table);
-    let select_name = source.select(users::name);
-    let select_title = source.select(posts::title);
+    let select_name = source.select(users::name).order(users::name);
+    let select_title = source.select(posts::title).order(posts::title);
 
     let expected_names = vec!["Sean".to_string(), "Tess".to_string()];
     let actual_names: Vec<String> = select_name.load(connection).unwrap();
@@ -75,7 +75,7 @@ fn select_multiple_from_join() {
         ("Sean".to_string(), "Hello".to_string()),
         ("Tess".to_string(), "World".to_string()),
     ];
-    let actual_data: Vec<_> = source.load(connection).unwrap();
+    let actual_data: Vec<_> = source.order(users::name).load(connection).unwrap();
 
     assert_eq!(expected_data, actual_data);
 }
@@ -102,7 +102,7 @@ fn join_boxed_query() {
         ("Sean".to_string(), "Hello".to_string()),
         ("Tess".to_string(), "World".to_string()),
     ];
-    let actual_data: Vec<_> = source.load(connection).unwrap();
+    let actual_data: Vec<_> = source.order(users::name).load(connection).unwrap();
 
     assert_eq!(expected_data, actual_data);
 }

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -12,10 +12,10 @@ fn order_by_column() {
         NewUser::new("Jim", None),
     ];
     insert_into(users).values(&data).execute(conn).unwrap();
-    let data = users.load::<User>(conn).unwrap();
-    let sean = &data[0];
-    let tess = &data[1];
-    let jim = &data[2];
+    let data = users.order(name).load::<User>(conn).unwrap();
+    let sean = &data[1];
+    let tess = &data[2];
+    let jim = &data[0];
 
     let expected_data = vec![
         User::new(jim.id, "Jim"),

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -29,7 +29,11 @@ fn selecting_a_struct() {
         .unwrap();
 
     let expected_users = vec![NewUser::new("Sean", None), NewUser::new("Tess", None)];
-    let actual_users: Vec<_> = users.select((name, hair_color)).load(connection).unwrap();
+    let actual_users: Vec<_> = users
+        .select((name, hair_color))
+        .order(name)
+        .load(connection)
+        .unwrap();
     assert_eq!(expected_users, actual_users);
 }
 
@@ -42,7 +46,7 @@ fn with_safe_select() {
         .execute(connection)
         .unwrap();
 
-    let select_name = users.select(name);
+    let select_name = users.select(name).order(name);
     let names: Vec<String> = select_name.load(connection).unwrap();
 
     assert_eq!(vec!["Sean".to_string(), "Tess".to_string()], names);
@@ -93,7 +97,7 @@ fn selecting_expression_with_bind_param() {
         .execute(connection)
         .unwrap();
 
-    let source = users.select(name.eq("Sean".to_string()));
+    let source = users.select(name.eq("Sean".to_string())).order(id);
     let expected_data = vec![true, false];
     let actual_data = source.load::<bool>(connection).unwrap();
 
@@ -165,7 +169,11 @@ fn selection_using_subselect() {
     use crate::schema::posts::dsl::*;
 
     let connection = &mut connection_with_sean_and_tess_in_users_table();
-    let ids: Vec<i32> = users::table.select(users::id).load(connection).unwrap();
+    let ids: Vec<i32> = users::table
+        .select(users::id)
+        .order(users::id)
+        .load(connection)
+        .unwrap();
     let query = format!(
         "INSERT INTO posts (user_id, title) VALUES ({}, 'Hello'), ({}, 'World')",
         ids[0], ids[1]

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -19,7 +19,11 @@ fn selecting_basic_data() {
             hair_color: None,
         },
     ];
-    let actual_data: Vec<_> = users.select(User::as_select()).load(connection).unwrap();
+    let actual_data: Vec<_> = users
+        .select(User::as_select())
+        .order(id)
+        .load(connection)
+        .unwrap();
     assert_eq!(expected_data, actual_data);
 }
 
@@ -109,7 +113,11 @@ fn selecting_columns_with_different_definition_order() {
 #[test]
 fn selection_using_subselect() {
     let connection = &mut connection_with_sean_and_tess_in_users_table();
-    let ids: Vec<i32> = users::table.select(users::id).load(connection).unwrap();
+    let ids: Vec<i32> = users::table
+        .select(users::id)
+        .order(users::id)
+        .load(connection)
+        .unwrap();
     let query = format!(
         "INSERT INTO posts (user_id, title) VALUES ({}, 'Hello'), ({}, 'World')",
         ids[0], ids[1]
@@ -213,6 +221,7 @@ fn mixed_selectable_and_plain_select() {
     ];
     let actual_data: Vec<_> = users
         .select((User::as_select(), name))
+        .order(id)
         .load(connection)
         .unwrap();
     assert_eq!(expected_data, actual_data);


### PR DESCRIPTION
This PR enables the experimental m1 runners (via macos-14). This hopefully enables us to run tests on aarch64-macos as well.

Github announcement: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

In addition this PR contains various maintenance items for the workflow scrips like updating actions and replacing deprecated actions. Also it contain a bunch of fixes for non-deterministic tests to prevent the CI failing randomly.