### PR TITLE
Add implicit sqlite rowid columns to print-schema output

### DIFF
--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -269,6 +269,12 @@ fn print_schema_sqlite_implicit_foreign_key_reference() {
 }
 
 #[test]
+#[cfg(feature = "sqlite")]
+fn print_schema_sqlite_without_explicit_primary_key() {
+    test_print_schema("print_schema_sqlite_without_explicit_primary_key", vec![])
+}
+
+#[test]
 #[cfg(feature = "postgres")]
 fn print_schema_respects_type_name_case() {
     test_print_schema("print_schema_respects_type_name_case", vec!["--with-docs"])

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/expected.snap
@@ -7,23 +7,85 @@ description: "Test: print_schema_sqlite_without_explicit_primary_key"
 diesel::table! {
     no_explicit (rowid) {
         rowid -> Integer,
-        name -> Text,
+        name -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    with_explicit_aliased_rowid (id) {
+        id -> Nullable<Integer>,
+        name -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    with_explicit_aliased_rowid_not_null (id) {
+        id -> Integer,
+        name -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    with_explicit_pk_rowid (rowid) {
+        rowid -> Nullable<Integer>,
+        name -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    with_explicit_pk_rowid_autoincrement (rowid) {
+        rowid -> Nullable<Integer>,
+        name -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    with_explicit_pk_rowid_autoincrement_not_null (rowid) {
+        rowid -> Integer,
+        name -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    with_explicit_pk_rowid_not_null (rowid) {
+        rowid -> Integer,
+        name -> Nullable<Text>,
     }
 }
 
 diesel::table! {
     with_explicit_rowid (oid) {
         oid -> Integer,
-        name -> Text,
-        rowid -> Text,
+        name -> Nullable<Text>,
+        rowid -> Nullable<Text>,
     }
 }
 
 diesel::table! {
     with_explicit_rowid_oid (_rowid_) {
         _rowid_ -> Integer,
-        name -> Text,
-        rowid -> Text,
-        oid -> Text,
+        name -> Nullable<Text>,
+        rowid -> Nullable<Text>,
+        oid -> Nullable<Text>,
     }
 }
+
+diesel::table! {
+    without_rowid (word) {
+        word -> Text,
+        cnt -> Nullable<Integer>,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    no_explicit,
+    with_explicit_aliased_rowid,
+    with_explicit_aliased_rowid_not_null,
+    with_explicit_pk_rowid,
+    with_explicit_pk_rowid_autoincrement,
+    with_explicit_pk_rowid_autoincrement_not_null,
+    with_explicit_pk_rowid_not_null,
+    with_explicit_rowid,
+    with_explicit_rowid_oid,
+    without_rowid,
+);

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_without_explicit_primary_key/sqlite/schema.sql
@@ -12,3 +12,38 @@ CREATE TABLE with_explicit_rowid_oid (
     rowid TEXT,
     oid TEXT
 );
+
+CREATE TABLE with_explicit_pk_rowid (
+    rowid INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+CREATE TABLE with_explicit_pk_rowid_autoincrement (
+    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT
+);
+
+CREATE TABLE with_explicit_pk_rowid_not_null (
+    rowid INTEGER PRIMARY KEY NOT NULL,
+    name TEXT
+);
+
+CREATE TABLE with_explicit_pk_rowid_autoincrement_not_null (
+    rowid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name TEXT
+);
+
+CREATE TABLE with_explicit_aliased_rowid (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+CREATE TABLE with_explicit_aliased_rowid_not_null (
+    id INTEGER PRIMARY KEY NOT NULL,
+    name TEXT
+);
+
+CREATE TABLE without_rowid (
+    word TEXT PRIMARY KEY,
+    cnt INTEGER
+) WITHOUT ROWID;


### PR DESCRIPTION
Whenever sqlite uses an implicit rowid it also need to be added as column to the corresponding schema. This change fixes the implicit primary key generator added in #3680 which was never tested as the test added in this pull request never actually is run.

This change enables the test and enhances the schema printer to generate the missing column if the primary key is an implicit rowid column.

Related: #2149