### PR TITLE
cli setup improvements

### DIFF
--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -144,9 +144,11 @@ fn create_config_file(
     let path = Config::file_path(matches);
     if !path.exists() {
         let source_content = include_str!("default_files/diesel.toml").to_string();
+        // convert the path to a valid toml string (escaping backslashes on windows)
+        let migrations_dir_toml_string = migrations_dir.display().to_string().replace('\\', "\\\\");
         let modified_content = source_content.replace(
             "dir = \"migrations\"",
-            &format!("dir = \"{}\"", migrations_dir.display()),
+            &format!("dir = \"{}\"", migrations_dir_toml_string),
         );
         let mut file = fs::File::create(path)?;
         file.write_all(modified_content.as_bytes())?;

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -183,7 +183,7 @@ fn generate_completions_command(matches: &ArgMatches) {
 /// Returns a `DatabaseError::ProjectRootNotFound` if no Cargo.toml is found.
 fn create_migrations_directory(path: &Path) -> Result<PathBuf, crate::errors::Error> {
     println!("Creating migrations directory at: {}", path.display());
-    fs::create_dir(path)?;
+    fs::create_dir_all(path)?;
     fs::File::create(path.join(".keep"))?;
     Ok(path.to_owned())
 }

--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -187,6 +187,25 @@ fn setup_writes_migration_dir_by_arg_to_config_file() {
 }
 
 #[test]
+#[cfg(windows)]
+fn setup_writes_migration_dir_by_arg_to_config_file_win() {
+    let p = project("setup_writes_migration_dir_by_arg_to_config_file_win").build();
+
+    // make sure the project builder doesn't create it for us
+    assert!(!p.has_file("migrations"));
+    assert!(!p.has_file("foo"));
+
+    let result = p.command("setup").arg("--migration-dir=foo\\bar").run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(!p.has_file("migrations"));
+    assert!(p.has_file("foo"));
+    assert!(p
+        .file_contents("diesel.toml")
+        .contains("dir = \"foo\\\\bar\""));
+}
+
+#[test]
 fn setup_works_with_migration_dir_by_env() {
     let p = project("setup_works_with_migration_dir_by_env").build();
 

--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -171,6 +171,22 @@ fn setup_works_with_migration_dir_by_arg() {
 }
 
 #[test]
+fn setup_writes_migration_dir_by_arg_to_config_file() {
+    let p = project("setup_writes_migration_dir_by_arg_to_config_file").build();
+
+    // make sure the project builder doesn't create it for us
+    assert!(!p.has_file("migrations"));
+    assert!(!p.has_file("foo"));
+
+    let result = p.command("setup").arg("--migration-dir=foo").run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(!p.has_file("migrations"));
+    assert!(p.has_file("foo"));
+    assert!(p.file_contents("diesel.toml").contains("dir = \"foo\""));
+}
+
+#[test]
 fn setup_works_with_migration_dir_by_env() {
     let p = project("setup_works_with_migration_dir_by_env").build();
 

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -45,7 +45,7 @@ impl ProjectBuilder {
         File::create(tempdir.path().join("Cargo.toml")).unwrap();
 
         for folder in self.folders {
-            fs::create_dir(tempdir.path().join(folder)).unwrap();
+            fs::create_dir_all(tempdir.path().join(folder)).unwrap();
         }
 
         for (file, contents) in self.files {


### PR DESCRIPTION
- cli: using fs::create_dir_all in create_migrations_directory
    
    To recursively create a directory and all of its parent components if they are missing.

- cli: writing the custom migration dir to the config file
- cli: fixing windows paths in toml strings and adding a specific test for that