### PR TITLE
Return Error From Postgres Float Deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 * The minimal officially supported rustc version is now 1.78.0
 * Deprecated `sql_function!` in favour of `define_sql_function!` which provides compatibility with `#[dsl::auto_type]`
+* Deserialization error messages now contain information about the field that failed to deserialize
 
 ## [2.1.0] 2023-05-26
 

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -542,6 +542,10 @@ where
 
         let field = row.get(0).ok_or(crate::result::UnexpectedEndOfRow)?;
         Ok(T::from_nullable_sql(field.value()).map_err(|e| {
+            if e.is::<crate::result::UnexpectedNullError>() {
+                return e;
+            }
+
             Box::new(DeserializeFieldError {
                 field_name: field.field_name().map(|s| s.to_string()),
                 error: e,

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -541,7 +541,7 @@ where
         use crate::row::Field;
 
         let field = row.get(0).ok_or(crate::result::UnexpectedEndOfRow)?;
-        Ok(T::from_nullable_sql(field.value()).map_err(|e| {
+        T::from_nullable_sql(field.value()).map_err(|e| {
             if e.is::<crate::result::UnexpectedNullError>() {
                 return e;
             }
@@ -550,7 +550,7 @@ where
                 field_name: field.field_name().map(|s| s.to_string()),
                 error: e,
             })
-        })?)
+        })
     }
 }
 

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -5,6 +5,7 @@ use std::result;
 
 use crate::backend::Backend;
 use crate::expression::select_by::SelectBy;
+use crate::result::DeserializeFieldError;
 use crate::row::{NamedRow, Row};
 use crate::sql_types::{SingleValue, SqlType, Untyped};
 use crate::Selectable;
@@ -540,9 +541,12 @@ where
         use crate::row::Field;
 
         let field = row.get(0).ok_or(crate::result::UnexpectedEndOfRow)?;
-        T::from_nullable_sql(field.value()).map_err(|e| {
-            format!("Error for field '{}': {:?}", field.field_name().unwrap(), e).into()
-        })
+        Ok(T::from_nullable_sql(field.value()).map_err(|e| {
+            Box::new(DeserializeFieldError {
+                field_name: field.field_name().map(|s| s.to_string()),
+                error: e,
+            })
+        })?)
     }
 }
 

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -541,6 +541,7 @@ where
 
         let field = row.get(0).ok_or(crate::result::UnexpectedEndOfRow)?;
         T::from_nullable_sql(field.value())
+            .map_err(|e| format!("Error for field {}: {:?}", field.field_name().unwrap(), e).into())
     }
 }
 

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -540,8 +540,9 @@ where
         use crate::row::Field;
 
         let field = row.get(0).ok_or(crate::result::UnexpectedEndOfRow)?;
-        T::from_nullable_sql(field.value())
-            .map_err(|e| format!("Error for field {}: {:?}", field.field_name().unwrap(), e).into())
+        T::from_nullable_sql(field.value()).map_err(|e| {
+            format!("Error for field '{}': {:?}", field.field_name().unwrap(), e).into()
+        })
     }
 }
 

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -148,6 +148,7 @@ impl PgResult {
         )
     }
 
+    #[inline(always)] // benchmarks indicate a ~1.7% improvement in instruction count for this
     pub(super) fn column_name(&self, col_idx: usize) -> Option<&str> {
         self.column_name_map
             .get_or_init(|| {

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -119,11 +119,19 @@ impl FromSql<sql_types::Float, Pg> for f32 {
         let mut bytes = value.as_bytes();
 
         if bytes.len() < 4 {
-            return deserialize::Result::Err("Received less than 4 bytes while decoding an f32. Was a numeric accidentally marked as float?".into());
+            return deserialize::Result::Err(
+                "Received less than 4 bytes while decoding an f32. \
+                 Was a numeric accidentally marked as float?"
+                    .into(),
+            );
         }
 
         if bytes.len() > 4 {
-            return deserialize::Result::Err("Received more than 4 bytes while decoding an f32. Was a double accidentally marked as float?".into());
+            return deserialize::Result::Err(
+                "Received more than 4 bytes while decoding an f32. \
+                 Was a double accidentally marked as float?"
+                    .into(),
+            );
         }
 
         bytes
@@ -138,11 +146,19 @@ impl FromSql<sql_types::Double, Pg> for f64 {
         let mut bytes = value.as_bytes();
 
         if bytes.len() < 8 {
-            return deserialize::Result::Err("Received less than 8 bytes while decoding an f64. Was a float accidentally marked as double?".into());
+            return deserialize::Result::Err(
+                "Received less than 8 bytes while decoding an f64. \
+                    Was a float accidentally marked as double?"
+                    .into(),
+            );
         }
 
         if bytes.len() > 8 {
-            return deserialize::Result::Err("Received more than 8 bytes while decoding an f64. Was a numeric accidentally marked as double?".into());
+            return deserialize::Result::Err(
+                "Received more than 8 bytes while decoding an f64. \
+                    Was a numeric accidentally marked as double?"
+                    .into(),
+            );
         }
 
         bytes

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -118,15 +118,12 @@ impl FromSql<sql_types::Float, Pg> for f32 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
 
-        #[cfg(debug_assertions)]
-        {
-            if bytes.len() < 4 {
-                return deserialize::Result::Err("Received less than 4 bytes while decoding an f32. Was a numeric accidentally marked as float?".into());
-            }
+        if bytes.len() < 4 {
+            return deserialize::Result::Err("Received less than 4 bytes while decoding an f32. Was a numeric accidentally marked as float?".into());
+        }
 
-            if bytes.len() > 4 {
-                return deserialize::Result::Err("Received more than 4 bytes while decoding an f32. Was a double accidentally marked as float?".into());
-            }
+        if bytes.len() > 4 {
+            return deserialize::Result::Err("Received more than 4 bytes while decoding an f32. Was a double accidentally marked as float?".into());
         }
 
         bytes
@@ -140,15 +137,12 @@ impl FromSql<sql_types::Double, Pg> for f64 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
 
-        #[cfg(debug_assertions)]
-        {
-            if bytes.len() < 8 {
-                return deserialize::Result::Err("Received less than 8 bytes while decoding an f64. Was a float accidentally marked as double?".into());
-            }
+        if bytes.len() < 8 {
+            return deserialize::Result::Err("Received less than 8 bytes while decoding an f64. Was a float accidentally marked as double?".into());
+        }
 
-            if bytes.len() > 8 {
-                return deserialize::Result::Err("Received more than 8 bytes while decoding an f64. Was a numeric accidentally marked as double?".into());
-            }
+        if bytes.len() > 8 {
+            return deserialize::Result::Err("Received more than 8 bytes while decoding an f64. Was a numeric accidentally marked as double?".into());
         }
 
         bytes

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -118,12 +118,15 @@ impl FromSql<sql_types::Float, Pg> for f32 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
 
-        if (bytes.len() < 4) {
-            return Err(Box::new("Received less than 4 bytes while decoding an f32. Was a numeric accidentally marked as float?"));
-        }
+        #[cfg(debug_assertions)]
+        {
+            if bytes.len() < 4 {
+                return deserialize::Result::Err("Received less than 4 bytes while decoding an f32. Was a numeric accidentally marked as float?".into());
+            }
 
-        if (bytes.len() > 4) {
-            return Err(Box::new("Received more than 4 bytes while decoding an f32. Was a double accidentally marked as float?"));
+            if bytes.len() > 4 {
+                return deserialize::Result::Err("Received more than 4 bytes while decoding an f32. Was a double accidentally marked as float?".into());
+            }
         }
 
         bytes
@@ -137,12 +140,15 @@ impl FromSql<sql_types::Double, Pg> for f64 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
 
-        if bytes.len() < 8 {
-            return Err(Box::new("Received less than 8 bytes while decoding an f64. Was a float accidentally marked as double?"));
-        }
+        #[cfg(debug_assertions)]
+        {
+            if bytes.len() < 8 {
+                return deserialize::Result::Err("Received less than 8 bytes while decoding an f64. Was a float accidentally marked as double?".into());
+            }
 
-        if bytes.len() > 8 {
-            return Err(Box::new("Received more than 8 bytes while decoding an f64. Was a numeric accidentally marked as double?"));
+            if bytes.len() > 8 {
+                return deserialize::Result::Err("Received more than 8 bytes while decoding an f64. Was a numeric accidentally marked as double?".into());
+            }
         }
 
         bytes

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -25,17 +25,21 @@ impl ToSql<sql_types::Oid, Pg> for u32 {
 impl FromSql<sql_types::SmallInt, Pg> for i16 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
-        debug_assert!(
-            bytes.len() <= 2,
-            "Received more than 2 bytes decoding i16. \
-             Was an Integer expression accidentally identified as SmallInt?"
-        );
-        debug_assert!(
-            bytes.len() >= 2,
-            "Received fewer than 2 bytes decoding i16. \
-             Was an expression of a different type accidentally identified \
-             as SmallInt?"
-        );
+        if bytes.len() < 2 {
+            return deserialize::Result::Err(
+                "Received less than 2 bytes while decoding an i16. \
+                    Was an expression of a different type accidentally marked as SmallInt?"
+                    .into(),
+            );
+        }
+
+        if bytes.len() > 2 {
+            return deserialize::Result::Err(
+                "Received more than 2 bytes while decoding an i16. \
+                    Was an Integer expression accidentally marked as SmallInt?"
+                    .into(),
+            );
+        }
         bytes
             .read_i16::<NetworkEndian>()
             .map_err(|e| Box::new(e) as Box<_>)
@@ -46,16 +50,21 @@ impl FromSql<sql_types::SmallInt, Pg> for i16 {
 impl FromSql<sql_types::Integer, Pg> for i32 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
-        debug_assert!(
-            bytes.len() <= 4,
-            "Received more than 4 bytes decoding i32. \
-             Was a BigInt expression accidentally identified as Integer?"
-        );
-        debug_assert!(
-            bytes.len() >= 4,
-            "Received fewer than 4 bytes decoding i32. \
-             Was a SmallInt expression accidentally identified as Integer?"
-        );
+        if bytes.len() < 4 {
+            return deserialize::Result::Err(
+                "Received less than 4 bytes while decoding an i32. \
+                    Was an SmallInt expression accidentally marked as Integer?"
+                    .into(),
+            );
+        }
+
+        if bytes.len() > 4 {
+            return deserialize::Result::Err(
+                "Received more than 4 bytes while decoding an i32. \
+                    Was an BigInt expression accidentally marked as Integer?"
+                    .into(),
+            );
+        }
         bytes
             .read_i32::<NetworkEndian>()
             .map_err(|e| Box::new(e) as Box<_>)
@@ -66,16 +75,21 @@ impl FromSql<sql_types::Integer, Pg> for i32 {
 impl FromSql<sql_types::BigInt, Pg> for i64 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
-        debug_assert!(
-            bytes.len() <= 8,
-            "Received more than 8 bytes decoding i64. \
-             Was an expression of a different type misidentified as BigInt?"
-        );
-        debug_assert!(
-            bytes.len() >= 8,
-            "Received fewer than 8 bytes decoding i64. \
-             Was an Integer expression misidentified as BigInt?"
-        );
+        if bytes.len() < 8 {
+            return deserialize::Result::Err(
+                "Received less than 8 bytes while decoding an i64. \
+                    Was an Integer expression accidentally marked as BigInt?"
+                    .into(),
+            );
+        }
+
+        if bytes.len() > 8 {
+            return deserialize::Result::Err(
+                "Received more than 8 bytes while decoding an i64. \
+                    Was an expression of a different type expression accidentally marked as BigInt?"
+                    .into(),
+            );
+        }
         bytes
             .read_i64::<NetworkEndian>()
             .map_err(|e| Box::new(e) as Box<_>)

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -23,21 +23,20 @@ impl ToSql<sql_types::Oid, Pg> for u32 {
 
 #[cfg(feature = "postgres_backend")]
 impl FromSql<sql_types::SmallInt, Pg> for i16 {
+    #[inline(always)]
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
         if bytes.len() < 2 {
-            return deserialize::Result::Err(
+            return emit_size_error(
                 "Received less than 2 bytes while decoding an i16. \
-                    Was an expression of a different type accidentally marked as SmallInt?"
-                    .into(),
+                    Was an expression of a different type accidentally marked as SmallInt?",
             );
         }
 
         if bytes.len() > 2 {
-            return deserialize::Result::Err(
+            return emit_size_error(
                 "Received more than 2 bytes while decoding an i16. \
-                    Was an Integer expression accidentally marked as SmallInt?"
-                    .into(),
+                    Was an Integer expression accidentally marked as SmallInt?",
             );
         }
         bytes
@@ -48,21 +47,20 @@ impl FromSql<sql_types::SmallInt, Pg> for i16 {
 
 #[cfg(feature = "postgres_backend")]
 impl FromSql<sql_types::Integer, Pg> for i32 {
+    #[inline(always)]
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
         if bytes.len() < 4 {
-            return deserialize::Result::Err(
+            return emit_size_error(
                 "Received less than 4 bytes while decoding an i32. \
-                    Was an SmallInt expression accidentally marked as Integer?"
-                    .into(),
+                    Was an SmallInt expression accidentally marked as Integer?",
             );
         }
 
         if bytes.len() > 4 {
-            return deserialize::Result::Err(
+            return emit_size_error(
                 "Received more than 4 bytes while decoding an i32. \
-                    Was an BigInt expression accidentally marked as Integer?"
-                    .into(),
+                    Was an BigInt expression accidentally marked as Integer?",
             );
         }
         bytes
@@ -71,23 +69,28 @@ impl FromSql<sql_types::Integer, Pg> for i32 {
     }
 }
 
+#[cold]
+#[inline(never)]
+fn emit_size_error<T>(var_name: &str) -> deserialize::Result<T> {
+    deserialize::Result::Err(var_name.into())
+}
+
 #[cfg(feature = "postgres_backend")]
 impl FromSql<sql_types::BigInt, Pg> for i64 {
+    #[inline(always)]
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();
         if bytes.len() < 8 {
-            return deserialize::Result::Err(
+            return emit_size_error(
                 "Received less than 8 bytes while decoding an i64. \
-                    Was an Integer expression accidentally marked as BigInt?"
-                    .into(),
+                    Was an Integer expression accidentally marked as BigInt?",
             );
         }
 
         if bytes.len() > 8 {
-            return deserialize::Result::Err(
+            return emit_size_error(
                 "Received more than 8 bytes while decoding an i64. \
                     Was an expression of a different type expression accidentally marked as BigInt?"
-                    .into(),
             );
         }
         bytes

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -458,6 +458,7 @@ impl StdError for EmptyChangeset {}
 
 /// An error occurred while deserializing a field
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct DeserializeFieldError {
     /// The name of the field that failed to deserialize
     pub field_name: Option<String>,

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -455,3 +455,32 @@ impl fmt::Display for EmptyChangeset {
 }
 
 impl StdError for EmptyChangeset {}
+
+/// An error occurred while deserializing a field
+#[derive(Debug)]
+pub struct DeserializeFieldError {
+    /// The name of the field that failed to deserialize
+    pub field_name: Option<String>,
+    /// The error that occurred while deserializing the field
+    pub error: Box<dyn StdError + Send + Sync>,
+}
+
+impl StdError for DeserializeFieldError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&*self.error)
+    }
+}
+
+impl fmt::Display for DeserializeFieldError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ref field_name) = self.field_name {
+            write!(
+                f,
+                "Error deserializing field '{}': {}",
+                field_name, self.error
+            )
+        } else {
+            write!(f, "Error deserializing field: {}", self.error)
+        }
+    }
+}

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -466,6 +466,20 @@ pub struct DeserializeFieldError {
     pub error: Box<dyn StdError + Send + Sync>,
 }
 
+impl DeserializeFieldError {
+    #[cold]
+    pub(crate) fn new<'a, F, DB>(field: F, error: Box<dyn std::error::Error + Send + Sync>) -> Self
+    where
+        DB: crate::backend::Backend,
+        F: crate::row::Field<'a, DB>,
+    {
+        DeserializeFieldError {
+            field_name: field.field_name().map(|s| s.to_string()),
+            error,
+        }
+    }
+}
+
 impl StdError for DeserializeFieldError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         Some(&*self.error)

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -71,6 +71,7 @@ fast_run = []
 
 [profile.release]
 lto = true
+debug = true
 codegen-units = 1
 
 [patch.crates-io]


### PR DESCRIPTION
I had an error where I was getting the debug assertion panic on a table and I had no idea what field was causing the issue. Here's a modification I made to ensure that any deserialization errors get passed up the chain with the field name without panicking in order to properly diagnose where my issue is happening.

I don't know if his is wanted or not, but thought I'd make the PR in case it is. Happy to do more modifications if necessary.