### PR TITLE
Fix new deprecated functions from chrono 0.4.35

### DIFF
--- a/diesel/src/mysql/types/date_and_time/chrono.rs
+++ b/diesel/src/mysql/types/date_and_time/chrono.rs
@@ -32,6 +32,7 @@ impl ToSql<Timestamp, Mysql> for NaiveDateTime {
             hour: self.hour() as libc::c_uint,
             minute: self.minute() as libc::c_uint,
             second: self.second() as libc::c_uint,
+            #[allow(deprecated)] // otherwise we would need to bump our minimal chrono version
             second_part: libc::c_ulong::from(self.timestamp_subsec_micros()),
             neg: false,
             time_type: MysqlTimestampType::MYSQL_TIMESTAMP_DATETIME,
@@ -162,11 +163,11 @@ mod tests {
     #[test]
     fn times_relative_to_now_encode_correctly() {
         let connection = &mut connection();
-        let time = Utc::now().naive_utc() + Duration::days(1);
+        let time = Utc::now().naive_utc() + Duration::try_days(1).unwrap();
         let query = select(now.lt(time));
         assert!(query.get_result::<bool>(connection).unwrap());
 
-        let time = Utc::now().naive_utc() - Duration::days(1);
+        let time = Utc::now().naive_utc() - Duration::try_days(1).unwrap();
         let query = select(now.gt(time));
         assert!(query.get_result::<bool>(connection).unwrap());
     }

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -75,6 +75,7 @@ fn parse_julian(julian_days: f64) -> Option<NaiveDateTime> {
     let timestamp = (julian_days - EPOCH_IN_JULIAN_DAYS) * SECONDS_IN_DAY;
     let seconds = timestamp as i64;
     let nanos = (timestamp.fract() * 1E9) as u32;
+    #[allow(deprecated)] // otherwise we would need to bump our minimal chrono version
     NaiveDateTime::from_timestamp_opt(seconds, nanos)
 }
 
@@ -325,11 +326,11 @@ mod tests {
     #[test]
     fn times_relative_to_now_encode_correctly() {
         let connection = &mut connection();
-        let time = Utc::now().naive_utc() + Duration::seconds(60);
+        let time = Utc::now().naive_utc() + Duration::try_seconds(60).unwrap();
         let query = select(now.lt(time));
         assert_eq!(Ok(true), query.get_result(connection));
 
-        let time = Utc::now().naive_utc() - Duration::seconds(600);
+        let time = Utc::now().naive_utc() - Duration::try_seconds(600).unwrap();
         let query = select(now.gt(time));
         assert_eq!(Ok(true), query.get_result(connection));
     }

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -465,7 +465,7 @@ mod mysql_types {
             t.hour(),
             t.minute(),
             t.second(),
-            t.timestamp_subsec_micros() as _,
+            t.and_utc().timestamp_subsec_micros() as _,
             false,
             MysqlTimestampType::MYSQL_TIMESTAMP_DATETIME,
             0,
@@ -481,7 +481,7 @@ mod mysql_types {
             t.hour(),
             t.minute(),
             t.second(),
-            t.timestamp_subsec_micros() as _,
+            t.and_utc().timestamp_subsec_micros() as _,
             false,
             MysqlTimestampType::MYSQL_TIMESTAMP_DATETIME,
             0,
@@ -508,10 +508,12 @@ mod mysql_types {
             .unwrap();
 
         if seconds != 0 {
-            seconds = earliest_mysql_date.timestamp()
-                + ((latest_mysql_date.timestamp() - earliest_mysql_date.timestamp()) % seconds);
+            seconds = earliest_mysql_date.and_utc().timestamp()
+                + ((latest_mysql_date.and_utc().timestamp()
+                    - earliest_mysql_date.and_utc().timestamp())
+                    % seconds);
         } else {
-            seconds = earliest_mysql_date.timestamp();
+            seconds = earliest_mysql_date.and_utc().timestamp();
         }
 
         let r = mk_naive_datetime((seconds, nanos));
@@ -607,7 +609,7 @@ pub fn mk_naive_datetime((mut secs, mut nano): (i64, u32)) -> NaiveDateTime {
         break;
     }
 
-    NaiveDateTime::from_timestamp_opt(secs, nano).unwrap()
+    DateTime::from_timestamp(secs, nano).unwrap().naive_utc()
 }
 
 pub fn mk_naive_time((mut seconds, mut nano): (u32, u32)) -> NaiveTime {
@@ -647,7 +649,7 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
     let num_days_representable = latest_chrono_date
         .signed_duration_since(earliest_pg_date)
         .num_days();
-    earliest_pg_date + Duration::days(days as i64 % num_days_representable)
+    earliest_pg_date + Duration::try_days(days as i64 % num_days_representable).unwrap()
 }
 
 #[cfg(feature = "mysql")]
@@ -657,7 +659,7 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
     let num_days_representable = latest_mysql_date
         .signed_duration_since(earliest_mysql_date)
         .num_days();
-    earliest_mysql_date + Duration::days(days as i64 % num_days_representable)
+    earliest_mysql_date + Duration::try_days(days as i64 % num_days_representable).unwrap()
 }
 
 #[cfg(feature = "sqlite")]
@@ -667,7 +669,7 @@ pub fn mk_naive_date(days: u32) -> NaiveDate {
     let num_days_representable = latest_sqlite_date
         .signed_duration_since(earliest_sqlite_date)
         .num_days();
-    earliest_sqlite_date + Duration::days(days as i64 % num_days_representable)
+    earliest_sqlite_date + Duration::try_days(days as i64 % num_days_representable).unwrap()
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
For the tests we switch to the suggested alternatives, for the real implementation we continue to use the deprecated functions as the suggested alternatives do not exist in our minimal supported chrono version.