### PR TITLE
docs: add mention of requirement to implement `ToSql`

### DIFF
--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -136,6 +136,8 @@ pub fn derive_as_changeset(input: TokenStream) -> TokenStream {
 /// you can specify this by adding the annotation `#[diesel(not_sized)]`
 /// as attribute on the type. This will skip the impls for non-reference types.
 ///
+/// Using this derive requires implementing the `ToSql` trait for your type.
+///
 /// # Attributes:
 ///
 /// ## Required container attributes


### PR DESCRIPTION
After failing to use the `AsExpression` derive I felt the need to add this to the relevant docs.