### PR TITLE
Update README to indicate that diesel supports MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Supported databases:
 1. [PostgreSQL](https://docs.diesel.rs/master/diesel/pg/index.html)
 2. [MySQL](https://docs.diesel.rs/master/diesel/mysql/index.html)
 3. [SQLite](https://docs.diesel.rs/master/diesel/sqlite/index.html)
+4. [MariaDB](https://docs.diesel.rs/master/diesel/mysql/index.html) - Uses the same setup as MySQL.
 
 You can configure the database backend in `Cargo.toml`:
 


### PR DESCRIPTION
Description
=========
Diesel was tested against MariaDB 11.4, and worked out of the box using the MySQL setup instructions and example.

Testing
======
1. Installing rust:

    ```
    curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh
    ```

2. Ensuring rust can be found in the PATH for the terminal session:

    ```
    . "$HOME/.cargo/env"
    ```

3. Then follow the diesel instructions: https://diesel.rs/guides/getting-started. The following tweak had to be made since MariaDB was not installed in a standard location:

    ```
    RUSTFLAGS='-L /github/MariaDB/installations/11.4/lib' cargo install diesel_cli --no-default-features --features mysql
    ```
4. Run the MySQL example in https://github.com/lottaquestions/diesel/tree/master/examples/mysql/getting_started_step_3:
   4.1 Write  a post
    ```
    export RUSTFLAGS='-L /github/MariaDB/installations/11.4/lib'
    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/github/MariaDB/installations/11.4/lib cargo run --bin write_post
    ```
   4.2 Publish a post
    ```
    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/github/MariaDB/installations/11.4/lib cargo run --bin publish_post 1
    ```
   4.3 Get a post
    ```
    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/github/MariaDB/installations/11.4/lib cargo run --bin get_post 1
    ```
   4.4 Show posts
    ```
    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/github/MariaDB/installations/11.4/lib cargo run --bin show_posts
    ```
5. Query the MariaDB database directly to show that the schema was created correctly and that the data was correctly inserted in the database:
    ```
    MariaDB [(none)]> show databases;
    +--------------------+
    | Database           |
    +--------------------+
    | diesel_demo        |
    | information_schema |
    | mysql              |
    | performance_schema |
    | sys                |
    | test               |
    +--------------------+
    6 rows in set (0.002 sec)
     
    MariaDB [(none)]> use diesel_demo;
    Database changed
    MariaDB [diesel_demo]> show tables
        -> ;
    +----------------------------+
    | Tables_in_diesel_demo      |
    +----------------------------+
    | __diesel_schema_migrations |
    +----------------------------+
    1 row in set (0.002 sec)
     
    MariaDB [diesel_demo]> select * from __diesel_schema_migrations limit 10;
    +----------------+---------------------+
    | version        | run_on              |
    +----------------+---------------------+
    | 20240314204819 | 2024-03-14 16:49:18 |
    +----------------+---------------------+
    1 row in set (0.001 sec)
     
    MariaDB [diesel_demo]> show tables;
    +----------------------------+
    | Tables_in_diesel_demo      |
    +----------------------------+
    | __diesel_schema_migrations |
    | posts                      |
    +----------------------------+
    2 rows in set (0.002 sec)
     
    MariaDB [diesel_demo]> select * from posts;
    +----+------------------+-------------------------------------------------------+-----------+
    | id | title            | body                                                  | published |
    +----+------------------+-------------------------------------------------------+-----------+
    |  1 | Diesel test demo | This test proves that Diesel works with MariaDB 11.4
     |         1 |
    +----+------------------+-------------------------------------------------------+-----------+
    1 row in set (0.002 sec)
    ```

