### PR TITLE
CLI: Better error reporting for missing patch file

### DIFF
--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -256,7 +256,17 @@ pub fn output_schema(
             "Found patch file to apply to the generated schema"
         );
         tracing::trace!(?out, "Schema before applying patch file");
-        let patch = std::fs::read_to_string(patch_file)?;
+        let patch = match std::fs::read_to_string(patch_file) {
+            Ok(patch) => patch,
+            Err(e) => {
+                eprintln!(
+                    "Failed to read patch file at {}: {}",
+                    patch_file.display(),
+                    e
+                );
+                return Err(e.into());
+            }
+        };
         let patch = diffy::Patch::from_str(&patch)?;
 
         out = diffy::apply(&out, &patch)?;


### PR DESCRIPTION
When a patch file - specified in the config - doesn't exist, the CLI error message is very opaque:

```
$ diesel print-schema
Encountered an IO error: No such file or directory (os error 2)
```

I had to clone the repo and add debug print statements until I found the culprit: The patch file.

This MR adds an explicit error message that can help to find the cause of the error.

```
$ diesel print-schema
Failed to read patch file at /.../src/schema.patch: No such file or directory (os error 2)
Encountered an IO error: No such file or directory (os error 2)
```

(By the way, it might be worthwhile to start using `anyhow` in the CLI project. It allows attaching context to errors, and printing them with a traceback. For CLI applications, this is a great improvement in my experience.)