### PR TITLE
Add missing repository field to internal crates

### DIFF
--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT OR Apache-2.0"
 description = "Migration management for diesel"
 documentation = "https://docs.rs/crate/diesel_migrations"
 homepage = "https://diesel.rs"
+repository = "https://github.com/diesel-rs/diesel"
 edition = "2021"
 rust-version.workspace = true
 

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.1.0"
 license = "MIT OR Apache-2.0"
 description = "Internal implementation of diesels migration mechanism"
 homepage = "https://diesel.rs"
+repository = "https://github.com/diesel-rs/diesel"
 rust-version.workspace = true
 edition = "2021"
 

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.1.0"
 license = "MIT OR Apache-2.0"
 description = "Codegeneration macros for diesels embedded migrations"
 homepage = "https://diesel.rs"
+repository = "https://github.com/diesel-rs/diesel"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
Hi! While scraping crates.io I've found `diesel_migrations`, `migrations_internals` and `migrations_macros` to be missing `repository` fields. This PR adds them.