### PR TITLE
Moveable binds and rows

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -14,6 +14,7 @@ use crate::backend::Backend;
 use crate::expression::QueryMetadata;
 use crate::query_builder::{Query, QueryFragment, QueryId};
 use crate::result::*;
+use crate::sql_types::TypeMetadata;
 use std::fmt::Debug;
 
 #[doc(inline)]
@@ -442,6 +443,15 @@ pub trait LoadConnection<B = DefaultLoadingMode>: Connection {
     where
         T: Query + QueryFragment<Self::Backend> + QueryId + 'query,
         Self::Backend: QueryMetadata<T::SqlType>;
+}
+
+/// Describes a connection with an underlying [`crate::sql_types::TypeMetadata::MetadataLookup`]
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+pub trait WithMetadataLookup: Connection {
+    /// Retrieves the underlying metadata lookup
+    fn metadata_lookup(&mut self) -> &mut <Self::Backend as TypeMetadata>::MetadataLookup;
 }
 
 /// A variant of the [`Connection`](trait.Connection.html) trait that is

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::backend::Backend;
-use crate::query_builder::{BindCollector, QueryBuilder};
+use crate::query_builder::{BindCollector, MoveableBindCollector, QueryBuilder};
 use crate::result::QueryResult;
 use crate::serialize::ToSql;
 use crate::sql_types::HasSqlType;
@@ -246,6 +246,35 @@ where
             }
             AstPassInternals::ToSql(ref mut out, _) => {
                 out.push_bind_param_value_only();
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Push bind collector values from its data onto the query
+    ///
+    /// This method works with [MoveableBindCollector] data [MoveableBindCollector::BindData]
+    /// and is used with already collected query meaning its SQL is already built and its
+    /// bind data already collected.
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub(crate) fn push_bind_collector_data<MD>(
+        &mut self,
+        bind_collector_data: &MD,
+    ) -> QueryResult<()>
+    where
+        DB: Backend,
+        for<'bc> DB::BindCollector<'bc>: MoveableBindCollector<DB, BindData = MD>,
+    {
+        match self.internals {
+            AstPassInternals::CollectBinds {
+                ref mut collector,
+                metadata_lookup: _,
+            } => collector.append_bind_data(bind_collector_data),
+            AstPassInternals::DebugBinds(ref mut f) => {
+                f.push(Box::new("Opaque bind collector data"))
             }
             _ => {}
         }

--- a/diesel/src/query_builder/collected_query.rs
+++ b/diesel/src/query_builder/collected_query.rs
@@ -1,0 +1,51 @@
+use super::{AstPass, MoveableBindCollector, Query, QueryFragment, QueryId};
+use crate::backend::{Backend, DieselReserveSpecialization};
+use crate::result::QueryResult;
+use crate::sql_types::Untyped;
+
+#[derive(Debug)]
+#[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
+/// A SQL query variant with already collected bind data which can be moved
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+pub struct CollectedQuery<T> {
+    sql: String,
+    safe_to_cache_prepared: bool,
+    bind_data: T,
+}
+
+impl<T> CollectedQuery<T> {
+    /// Builds a [CollectedQuery] with movable bind data
+    pub fn new(sql: String, safe_to_cache_prepared: bool, bind_data: T) -> Self {
+        Self {
+            sql,
+            safe_to_cache_prepared,
+            bind_data,
+        }
+    }
+}
+
+impl<DB, T> QueryFragment<DB> for CollectedQuery<T>
+where
+    DB: Backend + DieselReserveSpecialization,
+    for<'a> <DB as Backend>::BindCollector<'a>: MoveableBindCollector<DB, BindData = T>,
+{
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        if !self.safe_to_cache_prepared {
+            pass.unsafe_to_cache_prepared();
+        }
+        pass.push_sql(&self.sql);
+        pass.push_bind_collector_data::<T>(&self.bind_data)
+    }
+}
+
+impl<T> QueryId for CollectedQuery<T> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<T> Query for CollectedQuery<T> {
+    type SqlType = Untyped;
+}

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -11,6 +11,7 @@ mod clause_macro;
 
 pub(crate) mod ast_pass;
 pub mod bind_collector;
+mod collected_query;
 pub(crate) mod combination_clause;
 mod debug_query;
 mod delete_statement;
@@ -37,7 +38,9 @@ pub(crate) mod where_clause;
 #[doc(inline)]
 pub use self::ast_pass::AstPass;
 #[doc(inline)]
-pub use self::bind_collector::BindCollector;
+pub use self::bind_collector::{BindCollector, MoveableBindCollector};
+#[doc(inline)]
+pub use self::collected_query::CollectedQuery;
 #[doc(inline)]
 pub use self::debug_query::DebugQuery;
 #[doc(inline)]

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -148,6 +148,18 @@ where
     }
 }
 
+/// A row that can be turned into an owned version
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+pub trait IntoOwnedRow<'a, DB: Backend>: Row<'a, DB> {
+    /// The owned version of the row
+    type OwnedRow: Row<'a, DB> + Send + 'static;
+
+    /// Turn the row into its owned version
+    fn into_owned(self) -> Self::OwnedRow;
+}
+
 // These traits are not part of the public API
 // because:
 // * we want to control who can implement `Row` (for `RowSealed`)

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -28,7 +28,7 @@ use crate::expression::QueryMetadata;
 use crate::query_builder::*;
 use crate::result::*;
 use crate::serialize::ToSql;
-use crate::sql_types::HasSqlType;
+use crate::sql_types::{HasSqlType, TypeMetadata};
 use crate::sqlite::Sqlite;
 
 /// Connections for the SQLite backend. Unlike other backends, SQLite supported
@@ -217,6 +217,15 @@ impl LoadConnection<DefaultLoadingMode> for SqliteConnection {
         let statement = self.prepared_query(source)?;
 
         Ok(StatementIterator::new(statement))
+    }
+}
+
+static mut SQLITE_METADATA_LOOKUP: () = ();
+
+impl WithMetadataLookup for SqliteConnection {
+    fn metadata_lookup(&mut self) -> &mut <Sqlite as TypeMetadata>::MetadataLookup {
+        // safe since it's a unit type
+        unsafe { &mut SQLITE_METADATA_LOOKUP }
     }
 }
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -2,6 +2,7 @@ extern crate libsqlite3_sys as ffi;
 
 mod bind_collector;
 mod functions;
+mod owned_row;
 mod raw;
 mod row;
 mod serialized_database;

--- a/diesel/src/sqlite/connection/owned_row.rs
+++ b/diesel/src/sqlite/connection/owned_row.rs
@@ -1,0 +1,90 @@
+use super::sqlite_value::{OwnedSqliteValue, SqliteValue};
+use crate::backend::Backend;
+use crate::row::{Field, PartialRow, Row, RowIndex, RowSealed};
+use crate::sqlite::Sqlite;
+
+#[derive(Debug)]
+pub struct OwnedSqliteRow {
+    pub(super) values: Vec<Option<OwnedSqliteValue>>,
+    column_names: Box<[Option<String>]>,
+}
+
+impl OwnedSqliteRow {
+    pub(super) fn new(
+        values: Vec<Option<OwnedSqliteValue>>,
+        column_names: Box<[Option<String>]>,
+    ) -> Self {
+        OwnedSqliteRow {
+            values,
+            column_names,
+        }
+    }
+}
+
+impl RowSealed for OwnedSqliteRow {}
+
+impl<'a> Row<'a, Sqlite> for OwnedSqliteRow {
+    type Field<'field> = OwnedSqliteField<'field> where 'a: 'field, Self: 'field;
+    type InnerPartialRow = Self;
+
+    fn field_count(&self) -> usize {
+        self.values.len()
+    }
+
+    fn get<'field, I>(&'field self, idx: I) -> Option<Self::Field<'field>>
+    where
+        'a: 'field,
+        Self: RowIndex<I>,
+    {
+        let idx = self.idx(idx)?;
+        Some(OwnedSqliteField {
+            row: self,
+            col_idx: i32::try_from(idx).ok()?,
+        })
+    }
+
+    fn partial_row(&self, range: std::ops::Range<usize>) -> PartialRow<'_, Self::InnerPartialRow> {
+        PartialRow::new(self, range)
+    }
+}
+
+impl RowIndex<usize> for OwnedSqliteRow {
+    fn idx(&self, idx: usize) -> Option<usize> {
+        if idx < self.field_count() {
+            Some(idx)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'idx> RowIndex<&'idx str> for OwnedSqliteRow {
+    fn idx(&self, field_name: &'idx str) -> Option<usize> {
+        self.column_names
+            .iter()
+            .position(|n| n.as_ref().map(|s| s as &str) == Some(field_name))
+    }
+}
+
+#[allow(missing_debug_implementations)]
+pub struct OwnedSqliteField<'row> {
+    pub(super) row: &'row OwnedSqliteRow,
+    pub(super) col_idx: i32,
+}
+
+impl<'row> Field<'row, Sqlite> for OwnedSqliteField<'row> {
+    fn field_name(&self) -> Option<&str> {
+        self.row
+            .column_names
+            .get(self.col_idx as usize)
+            .and_then(|o| o.as_ref().map(|s| s.as_ref()))
+    }
+
+    fn is_null(&self) -> bool {
+        self.value().is_none()
+    }
+
+    fn value(&self) -> Option<<Sqlite as Backend>::RawValue<'row>> {
+        SqliteValue::from_owned_row(self.row, self.col_idx)
+    }
+}


### PR DESCRIPTION
In the context of diesel_async, an async connection would also like to be used with sqlite. To enable creating an async connection wrapping a syn connection some types needs to be moveable and/or owned.

This PR adds support for moveable binds and owned row in core Diesel types as well as the sqlite connection and backend.

Support for postgres was tested at compile time but crashed due to invalid `Rc` constraints. That would need some deeper look to properly implement but doesn't seem to be blocking.