### PR TITLE
Help cargo to break dependency cycle caused by dev deps

### DIFF
--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -23,7 +23,6 @@ cfg-if = "1"
 dotenvy = "0.15"
 
 [dev-dependencies.diesel]
-version = "~2.1.0"
 path = "../diesel"
 
 [lib]

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -22,12 +22,10 @@ dotenvy = "0.15"
 cfg-if = "1.0.0"
 
 [dev-dependencies.diesel]
-version = "~2.1.0"
 path = "../../diesel"
 default-features = false
 
 [dev-dependencies.diesel_migrations]
-version = "~2.1.0"
 path = "../"
 default-features = false
 

--- a/examples/postgres/advanced-blog-cli/Cargo.toml
+++ b/examples/postgres/advanced-blog-cli/Cargo.toml
@@ -14,7 +14,7 @@ tempfile = "3.1.0"
 
 [dev-dependencies]
 assert_matches = "1.1"
-diesel_migrations = { version = "2.1.0", features = ["postgres"], path = "../../../diesel_migrations" }
+diesel_migrations = { features = ["postgres"], path = "../../../diesel_migrations" }
 lazy_static = "1.0"
 
 [[bin]]


### PR DESCRIPTION
Cargo can automatically remove `path` dependencies when publishing when they don't have a `version` specified. 

This way it should be possible to publish crates without editing their `Cargo.toml`, and therefore keep their [vcs metadata](https://github.com/rust-lang/cargo/issues/13695).