### PR TITLE
Fix Using unsupported buffer type: 253 (parameter: 1) when trying to use the CLI

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.20", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.29.0", optional = true, features = ["bundled_bindings"] }
-mysqlclient-sys = { version = "0.2.5", optional = true }
+mysqlclient-sys = { git = "https://github.com/xiangzhai/mysqlclient-sys.git", branch = "macos", optional = true }
 pq-sys = { version = ">=0.4.0, <0.6.0", optional = true }
 pq-src = { version = "0.1", optional = true }
 quickcheck = { version = "1.0.3", optional = true }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.20", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.29.0", optional = true, features = ["bundled_bindings"] }
-mysqlclient-sys = { git = "https://github.com/xiangzhai/mysqlclient-sys.git", branch = "diesel-3929", optional = true }
+mysqlclient-sys = { git = "https://github.com/xiangzhai/mysqlclient-sys.git", branch = "diesel-3929", optional = true, features = ["buildtime_bindgen"] }
 pq-sys = { version = ">=0.4.0, <0.6.0", optional = true }
 pq-src = { version = "0.1", optional = true }
 quickcheck = { version = "1.0.3", optional = true }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.20", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.29.0", optional = true, features = ["bundled_bindings"] }
-mysqlclient-sys = { git = "https://github.com/xiangzhai/mysqlclient-sys.git", branch = "macos", optional = true }
+mysqlclient-sys = { git = "https://github.com/xiangzhai/mysqlclient-sys.git", branch = "rust-bindgen", optional = true }
 pq-sys = { version = ">=0.4.0, <0.6.0", optional = true }
 pq-src = { version = "0.1", optional = true }
 quickcheck = { version = "1.0.3", optional = true }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.20", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.29.0", optional = true, features = ["bundled_bindings"] }
-mysqlclient-sys = { git = "https://github.com/xiangzhai/mysqlclient-sys.git", branch = "rust-bindgen", optional = true }
+mysqlclient-sys = { git = "https://github.com/xiangzhai/mysqlclient-sys.git", branch = "diesel-3929", optional = true }
 pq-sys = { version = ">=0.4.0, <0.6.0", optional = true }
 pq-src = { version = "0.1", optional = true }
 quickcheck = { version = "1.0.3", optional = true }

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -154,11 +154,6 @@ impl From<u32> for Flags {
     }
 }
 
-#[cfg(target_os = "linux")]
-static FALSE: ffi::my_bool = 0;
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-static FALSE: ffi::my_bool = false;
-
 #[derive(Debug)]
 pub(super) struct BindData {
     tpe: ffi::enum_field_types,
@@ -394,13 +389,13 @@ impl BindData {
             length,
             capacity,
             flags,
-            is_null: FALSE,
-            is_truncated: Some(FALSE),
+            is_null: ffi::my_bool::default(),
+            is_truncated: Some(ffi::my_bool::default()),
         }
     }
 
     fn is_truncated(&self) -> bool {
-        self.is_truncated.unwrap_or(FALSE) != FALSE
+        self.is_truncated.unwrap_or(ffi::my_bool::default()) != ffi::my_bool::default()
     }
 
     fn is_fixed_size_buffer(&self) -> bool {
@@ -428,7 +423,7 @@ impl BindData {
     }
 
     pub(super) fn is_null(&self) -> bool {
-        self.is_null != FALSE
+        self.is_null != ffi::my_bool::default()
     }
 
     fn update_buffer_length(&mut self) {

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -156,7 +156,7 @@ impl From<u32> for Flags {
 
 #[cfg(target_os = "linux")]
 static FALSE: ffi::my_bool = 0;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 static FALSE: ffi::my_bool = false;
 
 #[derive(Debug)]

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -712,18 +712,10 @@ impl From<(ffi::enum_field_types, Flags)> for MysqlType {
                  the diesel github repo."
             ),
 
-            enum_field_types::MYSQL_TYPE_INVALID => unreachable!(
-                "Used for replication only"
-            ),
-
-            // Currently just a placeholder
-            enum_field_types::MYSQL_TYPE_BOOL => unreachable!(
-                "Currently just a placeholder"
-            ),
-
-            // Used for replication only
-            enum_field_types::MYSQL_TYPE_TYPED_ARRAY => unreachable!(
-                "Used for replication only"
+            _ => unreachable!(
+                "MYSQL_TYPE_INVALID enumerate value is 243 \
+                 MYSQL_TYPE_BOOL Currently just a placeholder \
+                 MYSQL_TYPE_TYPED_ARRAY Used for replication only."
             ),
         }
     }

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -13,7 +13,7 @@ pub(super) struct RawConnection(NonNull<ffi::MYSQL>);
 
 #[cfg(target_os = "linux")]
 static FALSE: ffi::my_bool = 0;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 static FALSE: ffi::my_bool = false;
 
 impl RawConnection {

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -175,7 +175,7 @@ impl RawConnection {
     }
 
     fn more_results(&self) -> bool {
-        unsafe { ffi::mysql_more_results(self.0.as_ptr()) != 0 }
+        unsafe { ffi::mysql_more_results(self.0.as_ptr()) != false }
     }
 
     fn next_result(&self) -> QueryResult<()> {

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -183,7 +183,7 @@ impl RawConnection {
         self.did_an_error_occur()
     }
 
-    fn set_ssl_mode(&self, ssl_mode: mysqlclient_sys::mysql_ssl_mode) {
+    fn set_ssl_mode(&self, ssl_mode: mysqlclient_sys::z_mysql_ssl_mode) {
         let v = ssl_mode as u32;
         let v_ptr: *const u32 = &v;
         let n = ptr::NonNull::new(v_ptr as *mut u32).expect("NonNull::new failed");

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -11,11 +11,6 @@ use crate::result::{ConnectionError, ConnectionResult, QueryResult};
 
 pub(super) struct RawConnection(NonNull<ffi::MYSQL>);
 
-#[cfg(target_os = "linux")]
-static FALSE: ffi::my_bool = 0;
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-static FALSE: ffi::my_bool = false;
-
 impl RawConnection {
     pub(super) fn new() -> Self {
         perform_thread_unsafe_library_initialization();
@@ -180,7 +175,7 @@ impl RawConnection {
     }
 
     fn more_results(&self) -> bool {
-        unsafe { ffi::mysql_more_results(self.0.as_ptr()) != FALSE }
+        unsafe { ffi::mysql_more_results(self.0.as_ptr()) != ffi::my_bool::default() }
     }
 
     fn next_result(&self) -> QueryResult<()> {

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -11,6 +11,11 @@ use crate::result::{ConnectionError, ConnectionResult, QueryResult};
 
 pub(super) struct RawConnection(NonNull<ffi::MYSQL>);
 
+#[cfg(target_os = "linux")]
+static FALSE: ffi::my_bool = 0;
+#[cfg(target_os = "macos")]
+static FALSE: ffi::my_bool = false;
+
 impl RawConnection {
     pub(super) fn new() -> Self {
         perform_thread_unsafe_library_initialization();
@@ -175,7 +180,7 @@ impl RawConnection {
     }
 
     fn more_results(&self) -> bool {
-        unsafe { ffi::mysql_more_results(self.0.as_ptr()) != false }
+        unsafe { ffi::mysql_more_results(self.0.as_ptr()) != FALSE }
     }
 
     fn next_result(&self) -> QueryResult<()> {
@@ -183,7 +188,7 @@ impl RawConnection {
         self.did_an_error_occur()
     }
 
-    fn set_ssl_mode(&self, ssl_mode: mysqlclient_sys::z_mysql_ssl_mode) {
+    fn set_ssl_mode(&self, ssl_mode: mysqlclient_sys::mysql_ssl_mode) {
         let v = ssl_mode as u32;
         let v_ptr: *const u32 = &v;
         let n = ptr::NonNull::new(v_ptr as *mut u32).expect("NonNull::new failed");

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -8,7 +8,7 @@ use std::ffi::{CStr, CString};
 
 use crate::result::{ConnectionError, ConnectionResult};
 
-use mysqlclient_sys::mysql_ssl_mode;
+use mysqlclient_sys::z_mysql_ssl_mode;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy)]
@@ -49,7 +49,7 @@ pub(super) struct ConnectionOptions {
     port: Option<u16>,
     unix_socket: Option<CString>,
     client_flags: CapabilityFlags,
-    ssl_mode: Option<mysql_ssl_mode>,
+    ssl_mode: Option<z_mysql_ssl_mode>,
     ssl_ca: Option<CString>,
     ssl_cert: Option<CString>,
     ssl_key: Option<CString>,
@@ -98,11 +98,11 @@ impl ConnectionOptions {
         let ssl_mode = match query_pairs.get("ssl_mode") {
             Some(v) => {
                 let ssl_mode = match v.to_lowercase().as_str() {
-                    "disabled" => mysql_ssl_mode::SSL_MODE_DISABLED,
-                    "preferred" => mysql_ssl_mode::SSL_MODE_PREFERRED,
-                    "required" => mysql_ssl_mode::SSL_MODE_REQUIRED,
-                    "verify_ca" => mysql_ssl_mode::SSL_MODE_VERIFY_CA,
-                    "verify_identity" => mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY,
+                    "disabled" => z_mysql_ssl_mode::SSL_MODE_DISABLED,
+                    "preferred" => z_mysql_ssl_mode::SSL_MODE_PREFERRED,
+                    "required" => z_mysql_ssl_mode::SSL_MODE_REQUIRED,
+                    "verify_ca" => z_mysql_ssl_mode::SSL_MODE_VERIFY_CA,
+                    "verify_identity" => z_mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY,
                     _ => {
                         let msg = "unknown ssl_mode";
                         return Err(ConnectionError::InvalidConnectionUrl(msg.into()));
@@ -188,7 +188,7 @@ impl ConnectionOptions {
         self.client_flags
     }
 
-    pub(super) fn ssl_mode(&self) -> Option<mysql_ssl_mode> {
+    pub(super) fn ssl_mode(&self) -> Option<z_mysql_ssl_mode> {
         self.ssl_mode
     }
 }
@@ -402,22 +402,22 @@ fn ssl_mode() {
     assert_eq!(ssl_mode("mysql://localhost"), None);
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=disabled"),
-        Some(mysql_ssl_mode::SSL_MODE_DISABLED)
+        Some(z_mysql_ssl_mode::SSL_MODE_DISABLED)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=PREFERRED"),
-        Some(mysql_ssl_mode::SSL_MODE_PREFERRED)
+        Some(z_mysql_ssl_mode::SSL_MODE_PREFERRED)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=required"),
-        Some(mysql_ssl_mode::SSL_MODE_REQUIRED)
+        Some(z_mysql_ssl_mode::SSL_MODE_REQUIRED)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=VERIFY_CA"),
-        Some(mysql_ssl_mode::SSL_MODE_VERIFY_CA)
+        Some(z_mysql_ssl_mode::SSL_MODE_VERIFY_CA)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=verify_identity"),
-        Some(mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY)
+        Some(z_mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY)
     );
 }

--- a/diesel/src/mysql/connection/url.rs
+++ b/diesel/src/mysql/connection/url.rs
@@ -8,7 +8,7 @@ use std::ffi::{CStr, CString};
 
 use crate::result::{ConnectionError, ConnectionResult};
 
-use mysqlclient_sys::z_mysql_ssl_mode;
+use mysqlclient_sys::mysql_ssl_mode;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy)]
@@ -49,7 +49,7 @@ pub(super) struct ConnectionOptions {
     port: Option<u16>,
     unix_socket: Option<CString>,
     client_flags: CapabilityFlags,
-    ssl_mode: Option<z_mysql_ssl_mode>,
+    ssl_mode: Option<mysql_ssl_mode>,
     ssl_ca: Option<CString>,
     ssl_cert: Option<CString>,
     ssl_key: Option<CString>,
@@ -98,11 +98,11 @@ impl ConnectionOptions {
         let ssl_mode = match query_pairs.get("ssl_mode") {
             Some(v) => {
                 let ssl_mode = match v.to_lowercase().as_str() {
-                    "disabled" => z_mysql_ssl_mode::SSL_MODE_DISABLED,
-                    "preferred" => z_mysql_ssl_mode::SSL_MODE_PREFERRED,
-                    "required" => z_mysql_ssl_mode::SSL_MODE_REQUIRED,
-                    "verify_ca" => z_mysql_ssl_mode::SSL_MODE_VERIFY_CA,
-                    "verify_identity" => z_mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY,
+                    "disabled" => mysql_ssl_mode::SSL_MODE_DISABLED,
+                    "preferred" => mysql_ssl_mode::SSL_MODE_PREFERRED,
+                    "required" => mysql_ssl_mode::SSL_MODE_REQUIRED,
+                    "verify_ca" => mysql_ssl_mode::SSL_MODE_VERIFY_CA,
+                    "verify_identity" => mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY,
                     _ => {
                         let msg = "unknown ssl_mode";
                         return Err(ConnectionError::InvalidConnectionUrl(msg.into()));
@@ -188,7 +188,7 @@ impl ConnectionOptions {
         self.client_flags
     }
 
-    pub(super) fn ssl_mode(&self) -> Option<z_mysql_ssl_mode> {
+    pub(super) fn ssl_mode(&self) -> Option<mysql_ssl_mode> {
         self.ssl_mode
     }
 }
@@ -402,22 +402,22 @@ fn ssl_mode() {
     assert_eq!(ssl_mode("mysql://localhost"), None);
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=disabled"),
-        Some(z_mysql_ssl_mode::SSL_MODE_DISABLED)
+        Some(mysql_ssl_mode::SSL_MODE_DISABLED)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=PREFERRED"),
-        Some(z_mysql_ssl_mode::SSL_MODE_PREFERRED)
+        Some(mysql_ssl_mode::SSL_MODE_PREFERRED)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=required"),
-        Some(z_mysql_ssl_mode::SSL_MODE_REQUIRED)
+        Some(mysql_ssl_mode::SSL_MODE_REQUIRED)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=VERIFY_CA"),
-        Some(z_mysql_ssl_mode::SSL_MODE_VERIFY_CA)
+        Some(mysql_ssl_mode::SSL_MODE_VERIFY_CA)
     );
     assert_eq!(
         ssl_mode("mysql://localhost?ssl_mode=verify_identity"),
-        Some(z_mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY)
+        Some(mysql_ssl_mode::SSL_MODE_VERIFY_IDENTITY)
     );
 }


### PR DESCRIPTION
Hi @weiznich 

`brew install mysql-client` for macOS will install mysql-client 8.3, but `diesel` CLI thrown such error to Apple fans: https://github.com/diesel-rs/diesel/issues/3929

```
Using unsupported buffer type: 253 (parameter: 1)
```

I autogen [mysqlclient-sys](https://github.com/xiangzhai/mysqlclient-sys) by [rust-bindgen](https://rust-lang.github.io/rust-bindgen/) to support new and old versions about MySQL. And adjusted `diesel` to meet the `diff`.

Could you review the patch please?

Thanks,
Leslie Zhai