### PR TITLE
Fix inserting values with `#[derive(Insertable)]` and `#[derive(MultiConnection)]`

### DIFF
--- a/diesel_derives/tests/multiconnection.rs
+++ b/diesel_derives/tests/multiconnection.rs
@@ -12,7 +12,7 @@ pub enum InferConnection {
     Mysql(MysqlConnection),
 }
 
-#[derive(Queryable, Selectable)]
+#[derive(Queryable, Selectable, Insertable, AsChangeset)]
 pub struct User {
     pub id: i32,
     pub name: String,
@@ -93,9 +93,23 @@ fn check_queries_work() {
         .values((users::id.eq(42), users::name.eq("John")))
         .execute(&mut conn)
         .unwrap();
+    diesel::insert_into(users::table)
+        .values(User {
+            id: 43,
+            name: "Jane".into(),
+        })
+        .execute(&mut conn)
+        .unwrap();
     // update
     diesel::update(users::table)
         .set(users::name.eq("John"))
+        .execute(&mut conn)
+        .unwrap();
+    diesel::update(users::table.find(42))
+        .set(User {
+            id: 42,
+            name: "Jane".into(),
+        })
         .execute(&mut conn)
         .unwrap();
 


### PR DESCRIPTION
This commit adds a missing impl that prevented inserts to `#[derive(MultiConnection)]` types if the corresponding struct used `#[derive(Insertable)]`