### PR TITLE
Fix pq_sys::PQputCopyData call

### DIFF
--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -146,8 +146,8 @@ impl RawConnection {
             let res = unsafe {
                 pq_sys::PQputCopyData(
                     self.internal_connection.as_ptr(),
-                    c.as_ptr() as *const i8,
-                    c.len() as i32,
+                    c.as_ptr() as *const libc::c_char,
+                    c.len() as libc::c_int,
                 )
             };
             if res != 1 {


### PR DESCRIPTION
`c_char` is `u8` on `aarch64`, so this PR fixes a compilation error.