### PR TITLE
Allow the r2d2 ConnectionManager to change URL dynamically

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -139,6 +139,14 @@ impl<T> ConnectionManager<T> {
             _marker: PhantomData,
         }
     }
+
+    /// Modifies the URL which was supplied at initialization.
+    ///
+    /// This does not update any state for existing connections,
+    /// but this new URL is used for new connections that are created.
+    pub fn update_database_url<S: Into<String>>(&mut self, database_url: S) {
+        self.database_url = database_url.into();
+    }
 }
 
 /// The error used when managing connections with `r2d2`.


### PR DESCRIPTION
# Why

https://github.com/oxidecomputer/omicron/issues/3763 has *all* the context for why I'm putting this PR up, but the short story is:

- For databases with distributed backends, it's often a requirement that the "set of nodes queried" by Diesel changes over time. In the example issue above, this is for CockroachDB, where we query one of many nodes. But new nodes can be added, and existing nodes can go offline.
- In cases where one of those nodes is known to go offline, it's nice to be able to update the URL being accessed without disrupting all existing connections that are currently communicating with healthy nodes.
- We're using SRV-based DNS records, which libpq does not interpret, so "just refer to a DNS name" doesn't really work that well to find the database. My expectation is that someone trying to do this would use DNS resolution "above Diesel", and then call this new `update_database_url` function to change which backend(s) are being accessed.

# What

This PR adds a single function to modify the URL for accessing the database within the `ConnectionManager`. This field `database_url` is only used in one spot: in the implementation of `ManageConnection::connect`, when creating new connections.