### PR TITLE
Improve error messages around AppearsInFromClause

### DIFF
--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -78,6 +78,10 @@ pub trait Table: QuerySource + AsQuery + Sized {
 /// context where referencing that table would be ambiguous (depending on the
 /// context and backend being used, this may or may not be something that would
 /// otherwise result in a runtime error).
+#[diagnostic::on_unimplemented(
+    note = "double check that `{QS}` and `{Self}` appear in the same `allow_tables_to_appear_in_same_query!` \ncall if both are tables",
+    note = "double check that any two aliases to the same table in `{QS}` and `{Self}` appear in the same `alias!` call"
+)]
 pub trait AppearsInFromClause<QS> {
     /// How many times does `Self` appear in `QS`?
     type Count;
@@ -97,8 +101,7 @@ pub trait AppearsInFromClause<QS> {
 /// - You are attempting to use two aliases to the same table in the same query, but they
 ///   were declared through different calls to [`alias!`](crate::alias)
 #[diagnostic::on_unimplemented(
-    note = "double check that `{T}` and `{Self}` appear in the same `allow_tables_to_appear_in_same_query!` \ncall if both are tables",
-    note = "double check that `{T}` and `{Self}` appear in the same `alias!` call if both \nare aliases to the same table"
+    note = "double check that `{T}` and `{Self}` appear in the same `allow_tables_to_appear_in_same_query!` \ncall if both are tables"
 )]
 pub trait TableNotEqual<T: Table>: Table {}
 

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.rs
@@ -14,6 +14,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
     use diesel::dsl::*;
     let source = users::table.select(sum(posts::id));

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
@@ -1,7 +1,7 @@
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:19:31
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
    |
-19 |     let source = users::table.select(sum(posts::id));
+21 |     let source = users::table.select(sum(posts::id));
    |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -17,9 +17,9 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:19:31
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
    |
-19 |     let source = users::table.select(sum(posts::id));
+21 |     let source = users::table.select(sum(posts::id));
    |                               ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
@@ -32,174 +32,81 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
    = note: required for `diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
    = note: required for `diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:19:31
-   |
-19 |     let source = users::table.select(sum(posts::id));
-   |                               ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:20:31
-   |
-20 |     let source = users::table.select(avg(posts::id));
-   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: `posts::columns::id` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             <posts::columns::id as SelectableExpression<posts::table>>
-             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
-             <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
-             <posts::columns::id as SelectableExpression<Only<posts::table>>>
-             <posts::columns::id as SelectableExpression<Tablesample<posts::table, TSM>>>
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:20:31
-   |
-20 |     let source = users::table.select(avg(posts::id));
-   |                               ^^^^^^ expected `Never`, found `Once`
-   |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:20:31
-   |
-20 |     let source = users::table.select(avg(posts::id));
-   |                               ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
-   |
-21 |     let source = users::table.select(max(posts::id));
-   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: `posts::columns::id` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             <posts::columns::id as SelectableExpression<posts::table>>
-             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, Inner>>>
-             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>>
-             <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
-             <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
-             <posts::columns::id as SelectableExpression<Only<posts::table>>>
-             <posts::columns::id as SelectableExpression<Tablesample<posts::table, TSM>>>
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
-   |
-21 |     let source = users::table.select(max(posts::id));
-   |                               ^^^^^^ expected `Never`, found `Once`
-   |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
-   |
-21 |     let source = users::table.select(max(posts::id));
-   |                               ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
 
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:22:31
    |
-22 |     let source = users::table.select(min(posts::id));
+22 |     let source = users::table.select(avg(posts::id));
+   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
+   |
+   = note: `posts::columns::id` is no valid selection for `users::table`
+   = help: the following other types implement trait `SelectableExpression<QS>`:
+             <posts::columns::id as SelectableExpression<posts::table>>
+             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, Inner>>>
+             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>>
+             <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
+             <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
+             <posts::columns::id as SelectableExpression<Tablesample<posts::table, TSM>>>
+   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
+
+error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:22:31
+   |
+22 |     let source = users::table.select(avg(posts::id));
+   |                               ^^^^^^ expected `Never`, found `Once`
+   |
+note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
+   |
+13 |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 1 redundant requirement hidden
+   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
+   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
+
+error[E0277]: Cannot select `posts::columns::id` from `users::table`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:23:31
+   |
+23 |     let source = users::table.select(max(posts::id));
+   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
+   |
+   = note: `posts::columns::id` is no valid selection for `users::table`
+   = help: the following other types implement trait `SelectableExpression<QS>`:
+             <posts::columns::id as SelectableExpression<posts::table>>
+             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, Inner>>>
+             <posts::columns::id as SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>>
+             <posts::columns::id as SelectableExpression<SelectStatement<FromClause<From>>>>
+             <posts::columns::id as SelectableExpression<JoinOn<Join, On>>>
+             <posts::columns::id as SelectableExpression<Only<posts::table>>>
+             <posts::columns::id as SelectableExpression<Tablesample<posts::table, TSM>>>
+   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
+
+error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:23:31
+   |
+23 |     let source = users::table.select(max(posts::id));
+   |                               ^^^^^^ expected `Never`, found `Once`
+   |
+note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
+   |
+13 |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 1 redundant requirement hidden
+   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
+   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
+
+error[E0277]: Cannot select `posts::columns::id` from `users::table`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:24:31
+   |
+24 |     let source = users::table.select(min(posts::id));
    |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -215,9 +122,9 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:22:31
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:24:31
    |
-22 |     let source = users::table.select(min(posts::id));
+24 |     let source = users::table.select(min(posts::id));
    |                               ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
@@ -226,37 +133,6 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
 13 |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:22:31
-   |
-22 |     let source = users::table.select(min(posts::id));
-   |                               ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
    = note: 1 redundant requirement hidden
    = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
    = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`

--- a/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -16,6 +16,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(stuff, more_stuff);
+
 #[derive(Queryable)]
 struct Stuff {
     id: i32,
@@ -27,6 +29,7 @@ fn main() {
 
     let mut conn = PgConnection::establish("").unwrap();
 
-    let _ = stuff.filter(name.eq(any(more_stuff::names)))
+    let _ = stuff
+        .filter(name.eq(any(more_stuff::names)))
         .load(&mut conn);
 }

--- a/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
+++ b/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
@@ -1,15 +1,15 @@
 warning: use of deprecated function `diesel::dsl::any`: Use `ExpressionMethods::eq_any` instead
-  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:30:34
+  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:33:25
    |
-30 |     let _ = stuff.filter(name.eq(any(more_stuff::names)))
-   |                                  ^^^
+33 |         .filter(name.eq(any(more_stuff::names)))
+   |                         ^^^
    |
    = note: `#[warn(deprecated)]` on by default
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:31:15
+  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:34:15
    |
-31 |         .load(&mut conn);
+34 |         .load(&mut conn);
    |          ---- ^^^^^^^^^ expected `Once`, found `Never`
    |          |
    |          required by a bound introduced by this call
@@ -20,52 +20,6 @@ note: required for `more_stuff::columns::names` to implement `AppearsOnTable<stu
 15 |         names -> Array<VarChar>,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 3 redundant requirements hidden
-   = note: required for `Grouped<Eq<name, Any<names>>>` to implement `AppearsOnTable<stuff::table>`
-   = note: required for `WhereClause<Grouped<Eq<name, Any<names>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<stuff::table>>`
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, WhereClause<...>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, WhereClause<...>>` to implement `LoadQuery<'_, _, _>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-   = note: consider using `--verbose` to print the full type name to the console
-   = note: consider using `--verbose` to print the full type name to the console
-   = note: consider using `--verbose` to print the full type name to the console
-   = note: consider using `--verbose` to print the full type name to the console
-
-error[E0277]: the trait bound `stuff::table: TableNotEqual<more_stuff::table>` is not satisfied
-  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:31:15
-   |
-31 |         .load(&mut conn);
-   |          ---- ^^^^^^^^^ the trait `TableNotEqual<more_stuff::table>` is not implemented for `stuff::table`, which is required by `SelectStatement<FromClause<stuff::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<stuff::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<stuff::columns::name, diesel::pg::expression::array_comparison::Any<more_stuff::columns::names>>>>>: LoadQuery<'_, _, _>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check that `more_stuff::table` and `stuff::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `more_stuff::table` and `stuff::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `stuff::table` to implement `AppearsInFromClause<more_stuff::table>`
-note: required for `more_stuff::columns::names` to implement `AppearsOnTable<stuff::table>`
-  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:15:9
-   |
-15 |         names -> Array<VarChar>,
-   |         ^^^^^
    = note: 3 redundant requirements hidden
    = note: required for `Grouped<Eq<name, Any<names>>>` to implement `AppearsOnTable<stuff::table>`
    = note: required for `WhereClause<Grouped<Eq<name, Any<names>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<stuff::table>>`

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::pg::Pg;
+use diesel::*;
 
 table! {
     users {
@@ -17,6 +17,10 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
-    users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
+    users::table
+        .into_boxed::<Pg>()
+        .filter(posts::title.eq("Hello"));
 }

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.stderr
@@ -1,8 +1,8 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/boxed_queries_require_selectable_expression_for_filter.rs:21:37
+  --> tests/fail/boxed_queries_require_selectable_expression_for_filter.rs:25:10
    |
-21 |     users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
-   |                                     ^^^^^^ expected `Never`, found `Once`
+25 |         .filter(posts::title.eq("Hello"));
+   |          ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
   --> tests/fail/boxed_queries_require_selectable_expression_for_filter.rs:16:9
@@ -10,37 +10,6 @@ note: required for `posts::columns::title` to implement `AppearsOnTable<users::t
 16 |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `Grouped<Eq<title, Bound<Text, &str>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>`
-   = note: consider using `--verbose` to print the full type name to the console
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/boxed_queries_require_selectable_expression_for_filter.rs:21:37
-   |
-21 |     users::table.into_boxed::<Pg>().filter(posts::title.eq("Hello"));
-   |                                     ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>: FilterDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/boxed_queries_require_selectable_expression_for_filter.rs:16:9
-   |
-16 |         title -> VarChar,
-   |         ^^^^^
    = note: 2 redundant requirements hidden
    = note: required for `Grouped<Eq<title, Bound<Text, &str>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>`

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.rs
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.rs
@@ -17,6 +17,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
     users::table.into_boxed::<Pg>().order(posts::title.desc());
 }

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/boxed_queries_require_selectable_expression_for_order.rs:21:37
+  --> tests/fail/boxed_queries_require_selectable_expression_for_order.rs:23:37
    |
-21 |     users::table.into_boxed::<Pg>().order(posts::title.desc());
+23 |     users::table.into_boxed::<Pg>().order(posts::title.desc());
    |                                     ^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
@@ -10,36 +10,6 @@ note: required for `posts::columns::title` to implement `AppearsOnTable<users::t
 16 |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::operators::Desc<posts::columns::title>` to implement `AppearsOnTable<users::table>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `OrderDsl<diesel::expression::operators::Desc<posts::columns::title>>`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/boxed_queries_require_selectable_expression_for_order.rs:21:37
-   |
-21 |     users::table.into_boxed::<Pg>().order(posts::title.desc());
-   |                                     ^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>: OrderDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/boxed_queries_require_selectable_expression_for_order.rs:16:9
-   |
-16 |         title -> VarChar,
-   |         ^^^^^
    = note: 1 redundant requirement hidden
    = note: required for `diesel::expression::operators::Desc<posts::columns::title>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `OrderDsl<diesel::expression::operators::Desc<posts::columns::title>>`

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
@@ -16,6 +16,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, bad);
+
 #[derive(Insertable)]
 #[diesel(table_name = users)]
 pub struct NewUser {

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
@@ -1,7 +1,7 @@
 error[E0277]: Cannot select `bad::columns::age` from `users::table`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:30:20
+  --> tests/fail/custom_returning_requires_selectable_expression.rs:32:20
    |
-30 |         .returning(bad::age);
+32 |         .returning(bad::age);
    |          --------- ^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`, which is required by `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<_>>: Query`
    |          |
    |          required by a bound introduced by this call
@@ -27,9 +27,9 @@ note: required by a bound in `UpdateStatement::<T, U, V>::returning`
    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: Cannot select `bad::columns::age` from `users::table`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:37:20
+  --> tests/fail/custom_returning_requires_selectable_expression.rs:39:20
    |
-37 |         .returning((name, bad::age));
+39 |         .returning((name, bad::age));
    |          --------- ^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`, which is required by `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<_>>: Query`
    |          |
    |          required by a bound introduced by this call
@@ -56,9 +56,9 @@ note: required by a bound in `InsertStatement::<T, U, Op>::returning`
    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:37:20
+  --> tests/fail/custom_returning_requires_selectable_expression.rs:39:20
    |
-37 |         .returning((name, bad::age));
+39 |         .returning((name, bad::age));
    |          --------- ^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
    |          |
    |          required by a bound introduced by this call
@@ -69,48 +69,6 @@ note: required for `bad::columns::age` to implement `AppearsOnTable<users::table
 15 |       age -> Integer,
    |       ^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<users::table>`
-   = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`
-   = note: required for `InsertStatement<table, ValuesClause<(DefaultableColumnInsertValue<...>,), ...>, ..., ...>` to implement `Query`
-note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
-   |     where
-   |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
-   |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
-   = note: consider using `--verbose` to print the full type name to the console
-
-error[E0277]: the trait bound `users::table: TableNotEqual<bad::table>` is not satisfied
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:37:20
-   |
-37 |         .returning((name, bad::age));
-   |          --------- ^^^^^^^^^^^^^^^^ the trait `TableNotEqual<bad::table>` is not implemented for `users::table`, which is required by `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<_>>: Query`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check that `bad::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `bad::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<bad::table>`
-note: required for `bad::columns::age` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
-   |
-15 |       age -> Integer,
-   |       ^^^
    = note: 1 redundant requirement hidden
    = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<users::table>`
    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`

--- a/diesel_compile_tests/tests/fail/derive/aliases.rs
+++ b/diesel_compile_tests/tests/fail/derive/aliases.rs
@@ -24,7 +24,7 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(users, posts);
+allow_tables_to_appear_in_same_query!(users, posts, pets);
 joinable!(posts -> users (author));
 
 pub fn check(conn: &mut PgConnection) {
@@ -54,6 +54,18 @@ pub fn check(conn: &mut PgConnection) {
         .inner_join(user_alias)
         .select(pets::id)
         .load::<i32>(conn)
+        .unwrap();
+
+    // Check how error message looks when aliases to the same table are declared separately
+    let post_alias_2 = alias!(posts as posts3);
+    let posts = post_alias
+        .inner_join(
+            post_alias_2.on(post_alias
+                .field(posts::author)
+                .eq(post_alias_2.field(posts::author))),
+        )
+        .select((post_alias.field(posts::id), post_alias_2.field(posts::id)))
+        .load::<(i32, i32)>(conn)
         .unwrap();
 }
 

--- a/diesel_compile_tests/tests/fail/derive/aliases.stderr
+++ b/diesel_compile_tests/tests/fail/derive/aliases.stderr
@@ -165,39 +165,6 @@ note: required by a bound in `diesel::RunQueryDsl::load`
    |         Self: LoadQuery<'query, Conn, U>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
-error[E0277]: the trait bound `Alias<users2>: AppearsInFromClause<pets::table>` is not satisfied
-  --> tests/fail/derive/aliases.rs:54:21
-   |
-54 |         .inner_join(user_alias)
-   |          ---------- ^^^^^^^^^^ the trait `AppearsInFromClause<pets::table>` is not implemented for `Alias<users2>`, which is required by `pets::table: JoinWithImplicitOnClause<_, Inner>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `AppearsInFromClause<QS>` is implemented for `Alias<S>`
-   = note: required for `query_source::joins::Join<pets::table, Alias<users2>, Inner>` to implement `AppearsInFromClause<pets::table>`
-note: required for `pets::columns::id` to implement `AppearsOnTable<query_source::joins::Join<pets::table, Alias<users2>, Inner>>`
-  --> tests/fail/derive/aliases.rs:23:9
-   |
-23 |         id -> Integer,
-   |         ^^
-   = note: 2 redundant requirements hidden
-   = note: required for `((pets::columns::id,), (AliasedField<users2, users::columns::id>, AliasedField<users2, users::columns::name>))` to implement `AppearsOnTable<query_source::joins::Join<pets::table, Alias<users2>, Inner>>`
-   = note: required for `query_source::joins::Join<pets::table, Alias<users2>, Inner>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<pets::table, Alias<users2>, Inner>, _>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<pets::table>>` to implement `InternalJoinDsl<Alias<users2>, Inner, _>`
-   = note: 1 redundant requirement hidden
-   = note: required for `pets::table` to implement `InternalJoinDsl<Alias<users2>, Inner, _>`
-   = note: required for `pets::table` to implement `JoinWithImplicitOnClause<Alias<users2>, Inner>`
-note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
-
 error[E0277]: the trait bound `users::table: JoinTo<pets::table>` is not satisfied
   --> tests/fail/derive/aliases.rs:54:10
    |
@@ -216,18 +183,98 @@ error[E0277]: the trait bound `users::table: JoinTo<pets::table>` is not satisfi
    = note: required for `Alias<users2>` to implement `JoinTo<pets::table>`
    = note: required for `pets::table` to implement `JoinWithImplicitOnClause<Alias<users2>, Inner>`
 
-error[E0599]: the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<table, Alias<users2>, Inner>, _>>>`, but its trait bounds were not satisfied
-  --> tests/fail/derive/aliases.rs:55:10
+error[E0277]: the trait bound `Alias<posts3>: AppearsInFromClause<Alias<posts2>>` is not satisfied
+  --> tests/fail/derive/aliases.rs:63:13
    |
-53 | /     pets::table
-54 | |         .inner_join(user_alias)
-55 | |         .select(pets::id)
+62 |           .inner_join(
+   |            ---------- required by a bound introduced by this call
+63 | /             post_alias_2.on(post_alias
+64 | |                 .field(posts::author)
+65 | |                 .eq(post_alias_2.field(posts::author))),
+   | |_______________________________________________________^ the trait `AppearsInFromClause<Alias<posts2>>` is not implemented for `Alias<posts3>`, which is required by `Alias<posts2>: JoinWithImplicitOnClause<_, Inner>`
+   |
+   = note: double check that `Alias<posts2>` and `Alias<posts3>` appear in the same `allow_tables_to_appear_in_same_query!`
+           call if both are tables
+   = note: double check that any two aliases to the same table in `Alias<posts2>` and `Alias<posts3>` appear in the same `alias!` call
+   = help: the trait `AppearsInFromClause<QS>` is implemented for `Alias<S>`
+   = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `AppearsInFromClause<Alias<posts2>>`
+   = note: required for `AliasedField<posts2, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: 2 redundant requirements hidden
+   = note: required for `((AliasedField<posts2, id>, AliasedField<posts2, author>, AliasedField<posts2, title>), (..., ..., ...))` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `QuerySource`
+   = note: 1 redundant requirement hidden
+   = note: required for `JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<Eq<AliasedField<posts2, author>, ...>>>` to implement `QuerySource`
+   = note: required for `SelectStatement<FromClause<Alias<posts2>>>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
+   = note: 1 redundant requirement hidden
+   = note: required for `Alias<posts2>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
+   = note: required for `Alias<posts2>` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<Alias<posts3>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>, Inner>`
+note: required by a bound in `inner_join`
+  --> $DIESEL/src/query_dsl/mod.rs
+   |
+   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+   |        ---------- required by a bound in this associated function
+   |     where
+   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+   = note: consider using `--verbose` to print the full type name to the console
+   = note: consider using `--verbose` to print the full type name to the console
+
+error[E0277]: the trait bound `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<Alias<posts3>>` is not satisfied
+  --> tests/fail/derive/aliases.rs:62:10
+   |
+62 |         .inner_join(
+   |          ^^^^^^^^^^ the trait `AppearsInFromClause<Alias<posts3>>` is not implemented for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>`, which is required by `SelectStatement<FromClause<Alias<posts2>>>: InternalJoinDsl<_, Inner, _>`
+   |
+   = note: double check that `Alias<posts3>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `allow_tables_to_appear_in_same_query!`
+           call if both are tables
+   = note: double check that any two aliases to the same table in `Alias<posts3>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `alias!` call
+   = help: the trait `AppearsInFromClause<T>` is implemented for `query_source::joins::Join<Left, Right, Kind>`
+   = note: required for `AliasedField<posts3, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: 2 redundant requirements hidden
+   = note: required for `((AliasedField<posts2, id>, AliasedField<posts2, author>, AliasedField<posts2, title>), (..., ..., ...))` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `QuerySource`
+   = note: 1 redundant requirement hidden
+   = note: required for `JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<Eq<AliasedField<posts2, author>, ...>>>` to implement `QuerySource`
+   = note: required for `SelectStatement<FromClause<Alias<posts2>>>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
+   = note: consider using `--verbose` to print the full type name to the console
+   = note: consider using `--verbose` to print the full type name to the console
+
+error[E0277]: the trait bound `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<Alias<posts2>>` is not satisfied
+  --> tests/fail/derive/aliases.rs:62:10
+   |
+62 |         .inner_join(
+   |          ^^^^^^^^^^ the trait `AppearsInFromClause<Alias<posts2>>` is not implemented for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>`, which is required by `SelectStatement<FromClause<Alias<posts2>>>: InternalJoinDsl<_, Inner, _>`
+   |
+   = note: double check that `Alias<posts2>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `allow_tables_to_appear_in_same_query!`
+           call if both are tables
+   = note: double check that any two aliases to the same table in `Alias<posts2>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `alias!` call
+   = help: the trait `AppearsInFromClause<T>` is implemented for `query_source::joins::Join<Left, Right, Kind>`
+   = note: required for `AliasedField<posts2, posts::columns::author>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: 2 redundant requirements hidden
+   = note: required for `Grouped<Eq<AliasedField<posts2, author>, AliasedField<posts3, author>>>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: required for `JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<Eq<AliasedField<posts2, author>, ...>>>` to implement `QuerySource`
+   = note: required for `SelectStatement<FromClause<Alias<posts2>>>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
+   = note: consider using `--verbose` to print the full type name to the console
+   = note: consider using `--verbose` to print the full type name to the console
+
+error[E0599]: the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<Eq<..., ...>>>>>`, but its trait bounds were not satisfied
+  --> tests/fail/derive/aliases.rs:67:10
+   |
+61 |       let posts = post_alias
+   |  _________________-
+62 | |         .inner_join(
+63 | |             post_alias_2.on(post_alias
+64 | |                 .field(posts::author)
+65 | |                 .eq(post_alias_2.field(posts::author))),
+66 | |         )
+67 | |         .select((post_alias.field(posts::id), post_alias_2.field(posts::id)))
    | |         -^^^^^^ private field, not a method
    | |_________|
    |
    |
+   = note: consider using `--verbose` to print the full type name to the console
    = note: the following trait bounds were not satisfied:
-           `&SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, Alias<users2>, Inner>, _>>>: Table`
-           which is required by `&SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, Alias<users2>, Inner>, _>>>: diesel::QueryDsl`
-           `&mut SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, Alias<users2>, Inner>, _>>>: Table`
-           which is required by `&mut SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, Alias<users2>, Inner>, _>>>: diesel::QueryDsl`
+           `&SelectStatement<FromClause<JoinOn<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>>>: Table`
+           which is required by `&SelectStatement<FromClause<JoinOn<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>>>: diesel::QueryDsl`
+           `&mut SelectStatement<FromClause<JoinOn<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>>>: Table`
+           which is required by `&mut SelectStatement<FromClause<JoinOn<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>>>: diesel::QueryDsl`

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
@@ -17,6 +17,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
     let mut connection = PgConnection::establish("postgres://foo").unwrap();
 

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
@@ -1,7 +1,7 @@
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:24:22
+  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:26:22
    |
-24 |         .distinct_on(posts::id)
+26 |         .distinct_on(posts::id)
    |          ----------- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `users::table: DistinctOnDsl<_>`
    |          |
    |          required by a bound introduced by this call
@@ -26,9 +26,9 @@ note: required by a bound in `diesel::QueryDsl::distinct_on`
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
 
 error[E0277]: Cannot select `users::columns::name` from `posts::table`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:28:10
+  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:30:10
    |
-28 |         .distinct_on((posts::name, users::name))
+30 |         .distinct_on((posts::name, users::name))
    |          ^^^^^^^^^^^ the trait `SelectableExpression<posts::table>` is not implemented for `users::columns::name`, which is required by `posts::table: DistinctOnDsl<_>`
    |
    = note: `users::columns::name` is no valid selection for `posts::table`
@@ -44,9 +44,9 @@ error[E0277]: Cannot select `users::columns::name` from `posts::table`
    = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:28:10
+  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:30:10
    |
-28 |         .distinct_on((posts::name, users::name))
+30 |         .distinct_on((posts::name, users::name))
    |          ^^^^^^^^^^^ expected `Never`, found `Once`
    |
 note: required for `users::columns::name` to implement `AppearsOnTable<posts::table>`
@@ -55,37 +55,6 @@ note: required for `users::columns::name` to implement `AppearsOnTable<posts::ta
 8  |         name -> VarChar,
    |         ^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `(posts::columns::name, users::columns::name)` to implement `AppearsOnTable<posts::table>`
-   = note: required for `(posts::columns::name, users::columns::name)` to implement `SelectableExpression<posts::table>`
-   = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
-
-error[E0277]: the trait bound `posts::table: TableNotEqual<users::table>` is not satisfied
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:28:10
-   |
-28 |         .distinct_on((posts::name, users::name))
-   |          ^^^^^^^^^^^ the trait `TableNotEqual<users::table>` is not implemented for `posts::table`, which is required by `posts::table: DistinctOnDsl<_>`
-   |
-   = note: double check that `users::table` and `posts::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `users::table` and `posts::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `posts::table` to implement `AppearsInFromClause<users::table>`
-note: required for `users::columns::name` to implement `AppearsOnTable<posts::table>`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:8:9
-   |
-8  |         name -> VarChar,
-   |         ^^^^
    = note: 1 redundant requirement hidden
    = note: required for `(posts::columns::name, users::columns::name)` to implement `AppearsOnTable<posts::table>`
    = note: required for `(posts::columns::name, users::columns::name)` to implement `SelectableExpression<posts::table>`

--- a/diesel_compile_tests/tests/fail/invalid_group_by.rs
+++ b/diesel_compile_tests/tests/fail/invalid_group_by.rs
@@ -16,6 +16,7 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
 allow_columns_to_appear_in_same_group_by_clause!(users::id, posts::id);
 
 fn main() {

--- a/diesel_compile_tests/tests/fail/invalid_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/invalid_group_by.stderr
@@ -1,21 +1,21 @@
-error[E0277]: the trait bound `FromClause<users::table>: AppearsInFromClause<posts::table>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:26:10
+error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/invalid_group_by.rs:27:10
    |
-26 |         .group_by(posts::id)
-   |          ^^^^^^^^ the trait `AppearsInFromClause<posts::table>` is not implemented for `FromClause<users::table>`, which is required by `SelectStatement<FromClause<users::table>>: GroupByDsl<_>`
+27 |         .group_by(posts::id)
+   |          ^^^^^^^^ expected `Never`, found `Once`
    |
-   = help: the trait `AppearsInFromClause<QS1>` is implemented for `FromClause<QS2>`
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<users::table>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
 15 |         id -> Integer,
    |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `GroupByDsl<posts::columns::id>`
 
 error[E0271]: type mismatch resolving `<id as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/invalid_group_by.rs:27:10
+  --> tests/fail/invalid_group_by.rs:28:10
    |
-27 |         .select(users::id)
+28 |         .select(users::id)
    |          ^^^^^^ type mismatch resolving `<id as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::No`
@@ -32,38 +32,38 @@ note: required for `users::columns::id` to implement `ValidGrouping<posts::colum
    = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0277]: the trait bound `FromClause<users::table>: AppearsInFromClause<posts::table>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:34:10
+error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/invalid_group_by.rs:35:10
    |
-34 |         .group_by(posts::id)
-   |          ^^^^^^^^ the trait `AppearsInFromClause<posts::table>` is not implemented for `FromClause<users::table>`, which is required by `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>: GroupByDsl<_>`
+35 |         .group_by(posts::id)
+   |          ^^^^^^^^ expected `Never`, found `Once`
    |
-   = help: the trait `AppearsInFromClause<QS1>` is implemented for `FromClause<QS2>`
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<users::table>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
 15 |         id -> Integer,
    |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>` to implement `GroupByDsl<posts::columns::id>`
 
-error[E0277]: the trait bound `FromClause<Alias<user1>>: AppearsInFromClause<posts::table>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:42:10
+error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/invalid_group_by.rs:43:10
    |
-42 |         .group_by(posts::id)
-   |          ^^^^^^^^ the trait `AppearsInFromClause<posts::table>` is not implemented for `FromClause<Alias<user1>>`, which is required by `SelectStatement<FromClause<Alias<user1>>>: GroupByDsl<_>`
+43 |         .group_by(posts::id)
+   |          ^^^^^^^^ expected `Never`, found `Once`
    |
-   = help: the trait `AppearsInFromClause<QS1>` is implemented for `FromClause<QS2>`
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
 15 |         id -> Integer,
    |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<Alias<user1>>>` to implement `GroupByDsl<posts::columns::id>`
 
 error[E0277]: the trait bound `AliasedField<user1, users::columns::id>: ValidGrouping<posts::columns::id>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:43:17
+  --> tests/fail/invalid_group_by.rs:44:17
    |
-43 |         .select(user_alias.field(users::id))
+44 |         .select(user_alias.field(users::id))
    |          ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<posts::columns::id>` is not implemented for `AliasedField<user1, users::columns::id>`, which is required by `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<Alias<user1>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>: SelectDsl<_>`
    |          |
    |          required by a bound introduced by this call
@@ -83,18 +83,18 @@ note: required by a bound in `diesel::QueryDsl::select`
    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<Alias<post1>>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:48:10
+  --> tests/fail/invalid_group_by.rs:49:10
    |
-48 |         .group_by(post_alias.field(posts::id))
+49 |         .group_by(post_alias.field(posts::id))
    |          ^^^^^^^^ expected `Never`, found `Once`
    |
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<users::table>>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
 
 error[E0277]: the trait bound `AliasedField<post1, posts::columns::id>: IsContainedInGroupBy<users::columns::id>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:49:10
+  --> tests/fail/invalid_group_by.rs:50:10
    |
-49 |         .select(users::id)
+50 |         .select(users::id)
    |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `AliasedField<post1, posts::columns::id>`, which is required by `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<AliasedField<post1, posts::columns::id>>>: SelectDsl<_>`
    |
    = help: the following other types implement trait `IsContainedInGroupBy<T>`:
@@ -115,20 +115,19 @@ note: required for `users::columns::id` to implement `ValidGrouping<AliasedField
    = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0277]: the trait bound `FromClause<Alias<user1>>: AppearsInFromClause<Alias<post1>>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:54:10
+error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<Alias<post1>>>::Count == Once`
+  --> tests/fail/invalid_group_by.rs:55:10
    |
-54 |         .group_by(post_alias.field(posts::id))
-   |          ^^^^^^^^ the trait `AppearsInFromClause<Alias<post1>>` is not implemented for `FromClause<Alias<user1>>`, which is required by `SelectStatement<FromClause<Alias<user1>>>: GroupByDsl<_>`
+55 |         .group_by(post_alias.field(posts::id))
+   |          ^^^^^^^^ expected `Never`, found `Once`
    |
-   = help: the trait `AppearsInFromClause<QS1>` is implemented for `FromClause<QS2>`
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
    = note: required for `SelectStatement<FromClause<Alias<user1>>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
 
 error[E0277]: the trait bound `AliasedField<user1, users::columns::id>: ValidGrouping<AliasedField<post1, posts::columns::id>>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:55:17
+  --> tests/fail/invalid_group_by.rs:56:17
    |
-55 |         .select(user_alias.field(users::id))
+56 |         .select(user_alias.field(users::id))
    |          ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<AliasedField<post1, posts::columns::id>>` is not implemented for `AliasedField<user1, users::columns::id>`, which is required by `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<Alias<user1>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<AliasedField<post1, posts::columns::id>>>: SelectDsl<_>`
    |          |
    |          required by a bound introduced by this call
@@ -147,35 +146,34 @@ note: required by a bound in `diesel::QueryDsl::select`
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0277]: the trait bound `FromClause<Alias<user1>>: AppearsInFromClause<posts::table>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:61:10
+error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/invalid_group_by.rs:62:10
    |
-61 |         .group_by(posts::id)
-   |          ^^^^^^^^ the trait `AppearsInFromClause<posts::table>` is not implemented for `FromClause<Alias<user1>>`, which is required by `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::SelectClause<AliasedField<user1, users::columns::id>>>: GroupByDsl<_>`
+62 |         .group_by(posts::id)
+   |          ^^^^^^^^ expected `Never`, found `Once`
    |
-   = help: the trait `AppearsInFromClause<QS1>` is implemented for `FromClause<QS2>`
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
 15 |         id -> Integer,
    |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::SelectClause<AliasedField<user1, users::columns::id>>>` to implement `GroupByDsl<posts::columns::id>`
 
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<Alias<post1>>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:67:10
+  --> tests/fail/invalid_group_by.rs:68:10
    |
-67 |         .group_by(post_alias.field(posts::id))
+68 |         .group_by(post_alias.field(posts::id))
    |          ^^^^^^^^ expected `Never`, found `Once`
    |
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<users::table>>`
    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
 
-error[E0277]: the trait bound `FromClause<Alias<user1>>: AppearsInFromClause<Alias<post1>>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:73:10
+error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<Alias<post1>>>::Count == Once`
+  --> tests/fail/invalid_group_by.rs:74:10
    |
-73 |         .group_by(post_alias.field(posts::id))
-   |          ^^^^^^^^ the trait `AppearsInFromClause<Alias<post1>>` is not implemented for `FromClause<Alias<user1>>`, which is required by `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::SelectClause<AliasedField<user1, users::columns::id>>>: GroupByDsl<_>`
+74 |         .group_by(post_alias.field(posts::id))
+   |          ^^^^^^^^ expected `Never`, found `Once`
    |
-   = help: the trait `AppearsInFromClause<QS1>` is implemented for `FromClause<QS2>`
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
    = note: required for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::SelectClause<AliasedField<user1, users::columns::id>>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`

--- a/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.rs
@@ -14,6 +14,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
     let source = users::table.order(posts::id);
 }

--- a/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/order_requires_column_from_same_table.rs:18:31
+  --> tests/fail/order_requires_column_from_same_table.rs:20:31
    |
-18 |     let source = users::table.order(posts::id);
+20 |     let source = users::table.order(posts::id);
    |                               ^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
@@ -10,32 +10,4 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
 13 |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `OrderDsl<posts::columns::id>`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/order_requires_column_from_same_table.rs:18:31
-   |
-18 |     let source = users::table.order(posts::id);
-   |                               ^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>>: OrderDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/order_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `OrderDsl<posts::columns::id>`

--- a/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.rs
@@ -17,6 +17,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 #[derive(Insertable)]
 #[diesel(table_name = users)]
 pub struct NewUser(#[diesel(column_name = name)] &'static str);
@@ -71,5 +73,7 @@ fn main() {
 
     // Excluded is only valid in upsert
     // FIXME: This should not compile
-    update(users).set(name.eq(excluded(name))).execute(&mut connection);
+    update(users)
+        .set(name.eq(excluded(name)))
+        .execute(&mut connection);
 }

--- a/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
+++ b/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
@@ -1,11 +1,11 @@
 error[E0599]: the method `execute` exists for struct `IncompleteDoUpdate<InsertStatement<table, ValuesClause<(DefaultableColumnInsertValue<...>,), ...>>, ...>`, but its trait bounds were not satisfied
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:42:10
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:44:10
    |
-38 | /     insert_into(users)
-39 | |         .values(&NewUser("Sean"))
-40 | |         .on_conflict(id)
-41 | |         .do_update()
-42 | |         .execute(&mut connection);
+40 | /     insert_into(users)
+41 | |         .values(&NewUser("Sean"))
+42 | |         .on_conflict(id)
+43 | |         .do_update()
+44 | |         .execute(&mut connection);
    | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
    | |_________|
    |
@@ -25,9 +25,9 @@ error[E0599]: the method `execute` exists for struct `IncompleteDoUpdate<InsertS
            which is required by `&mut IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: diesel::RunQueryDsl<_>`
 
 error[E0271]: type mismatch resolving `<Grouped<Eq<title, Bound<Text, &str>>> as AsChangeset>::Target == table`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:49:14
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:51:14
    |
-49 |         .set(posts::title.eq("Sean"));
+51 |         .set(posts::title.eq("Sean"));
    |          --- ^^^^^^^^^^^^^^^^^^^^^^^ expected `users::table`, found `posts::table`
    |          |
    |          required by a bound introduced by this call
@@ -54,9 +54,9 @@ note: `users::table` is defined in module `crate::users` of the current crate
 11 | | }
    | |_^
 note: the method call chain might not have had the expected associated types
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:49:27
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:51:27
    |
-49 |         .set(posts::title.eq("Sean"));
+51 |         .set(posts::title.eq("Sean"));
    |              ------------ ^^^^^^^^^^ `AsChangeset::Target` is `table` here
    |              |
    |              this expression has type `title`
@@ -71,9 +71,9 @@ note: required by a bound in `IncompleteDoUpdate::<InsertStatement<T, U, Op, Ret
    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:56:10
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:58:10
    |
-56 |         .set(name.eq(posts::title));
+58 |         .set(name.eq(posts::title));
    |          ^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
@@ -84,38 +84,10 @@ note: required for `posts::columns::title` to implement `AppearsOnTable<users::t
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`
 
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:56:10
-   |
-56 |         .set(name.eq(posts::title));
-   |          ^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>: AsChangeset`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:16:9
-   |
-16 |         title -> VarChar,
-   |         ^^^^^
-   = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`
-
 error[E0271]: type mismatch resolving `<title as Column>::Table == table`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:63:10
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:65:10
    |
-63 |         .set(name.eq(excluded(posts::title)));
+65 |         .set(name.eq(excluded(posts::title)));
    |          ^^^ type mismatch resolving `<title as Column>::Table == table`
    |
 note: expected this to be `posts::table`
@@ -148,9 +120,9 @@ note: `posts::table` is defined in module `crate::posts` of the current crate
    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Excluded<id> as Expression>::SqlType == Text`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:70:19
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:72:19
    |
-70 |         .set(name.eq(excluded(id)));
+72 |         .set(name.eq(excluded(id)));
    |                   ^^ expected `Integer`, found `Text`
    |
    = note: required for `diesel::query_builder::upsert::on_conflict_actions::Excluded<users::columns::id>` to implement `AsExpression<diesel::sql_types::Text>`

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -17,6 +17,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
     let stuff = users::table.select((posts::id, posts::user_id));
     let stuff = users::table.select((posts::id, users::name));

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
@@ -1,7 +1,7 @@
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:21:30
+  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
-21 |     let stuff = users::table.select((posts::id, posts::user_id));
+23 |     let stuff = users::table.select((posts::id, posts::user_id));
    |                              ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -17,9 +17,9 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
 
 error[E0277]: Cannot select `posts::columns::user_id` from `users::table`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:21:30
+  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
-21 |     let stuff = users::table.select((posts::id, posts::user_id));
+23 |     let stuff = users::table.select((posts::id, posts::user_id));
    |                              ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::user_id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
    |
    = note: `posts::columns::user_id` is no valid selection for `users::table`
@@ -35,9 +35,9 @@ error[E0277]: Cannot select `posts::columns::user_id` from `users::table`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:21:30
+  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
-21 |     let stuff = users::table.select((posts::id, posts::user_id));
+23 |     let stuff = users::table.select((posts::id, posts::user_id));
    |                              ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
@@ -51,41 +51,10 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
    = note: required for `(posts::columns::id, posts::columns::user_id)` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
 
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:21:30
-   |
-21 |     let stuff = users::table.select((posts::id, posts::user_id));
-   |                              ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:14:9
-   |
-14 |         id -> Integer,
-   |         ^^
-   = note: 1 redundant requirement hidden
-   = note: required for `(posts::columns::id, posts::columns::user_id)` to implement `AppearsOnTable<users::table>`
-   = note: required for `(posts::columns::id, posts::columns::user_id)` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
-
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:22:30
+  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:24:30
    |
-22 |     let stuff = users::table.select((posts::id, users::name));
+24 |     let stuff = users::table.select((posts::id, users::name));
    |                              ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -101,9 +70,9 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, users::columns::name)>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:22:30
+  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:24:30
    |
-22 |     let stuff = users::table.select((posts::id, users::name));
+24 |     let stuff = users::table.select((posts::id, users::name));
    |                              ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
@@ -112,37 +81,6 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
 14 |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `(posts::columns::id, users::columns::name)` to implement `AppearsOnTable<users::table>`
-   = note: required for `(posts::columns::id, users::columns::name)` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, users::columns::name)>`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:22:30
-   |
-22 |     let stuff = users::table.select((posts::id, users::name));
-   |                              ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>>: SelectDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:14:9
-   |
-14 |         id -> Integer,
-   |         ^^
    = note: 1 redundant requirement hidden
    = note: required for `(posts::columns::id, users::columns::name)` to implement `AppearsOnTable<users::table>`
    = note: required for `(posts::columns::id, users::columns::name)` to implement `SelectableExpression<users::table>`

--- a/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.rs
@@ -16,6 +16,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
     use self::users::dsl::*;
 

--- a/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<Grouped<Eq<title, Bound<Text, &str>>> as AsChangeset>::Target == table`
-  --> tests/fail/update_requires_column_be_from_same_table.rs:22:37
+  --> tests/fail/update_requires_column_be_from_same_table.rs:24:37
    |
-22 |     let command = update(users).set(posts::title.eq("Hello"));
+24 |     let command = update(users).set(posts::title.eq("Hello"));
    |                                 --- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `users::table`, found `posts::table`
    |                                 |
    |                                 required by a bound introduced by this call
@@ -28,9 +28,9 @@ note: `users::table` is defined in module `crate::users` of the current crate
 10 | | }
    | |_^
 note: the method call chain might not have had the expected associated types
-  --> tests/fail/update_requires_column_be_from_same_table.rs:22:50
+  --> tests/fail/update_requires_column_be_from_same_table.rs:24:50
    |
-22 |     let command = update(users).set(posts::title.eq("Hello"));
+24 |     let command = update(users).set(posts::title.eq("Hello"));
    |                                     ------------ ^^^^^^^^^^^ `AsChangeset::Target` is `table` here
    |                                     |
    |                                     this expression has type `title`
@@ -45,9 +45,9 @@ note: required by a bound in `UpdateStatement::<T, U>::set`
    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/update_requires_column_be_from_same_table.rs:23:33
+  --> tests/fail/update_requires_column_be_from_same_table.rs:25:33
    |
-23 |     let command = update(users).set(name.eq(posts::title));
+25 |     let command = update(users).set(name.eq(posts::title));
    |                                 ^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
@@ -56,32 +56,4 @@ note: required for `posts::columns::title` to implement `AppearsOnTable<users::t
 15 |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/update_requires_column_be_from_same_table.rs:23:33
-   |
-23 |     let command = update(users).set(name.eq(posts::title));
-   |                                 ^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>: AsChangeset`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/update_requires_column_be_from_same_table.rs:15:9
-   |
-15 |         title -> VarChar,
-   |         ^^^^^
    = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`

--- a/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.rs
+++ b/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.rs
@@ -14,6 +14,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 fn main() {
     // Sanity check: Valid update
     update(users::table).filter(users::id.eq(1));
@@ -22,6 +24,7 @@ fn main() {
 
     update(users::table).filter(posts::id.eq(1));
 
-    update(users::table).set(users::id.eq(1))
+    update(users::table)
+        .set(users::id.eq(1))
         .filter(posts::id.eq(1));
 }

--- a/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: IntoUpdateTarget` is not satisfied
-  --> tests/fail/update_requires_valid_where_clause.rs:21:12
+  --> tests/fail/update_requires_valid_where_clause.rs:23:12
    |
-21 |     update(users::table.filter(posts::id.eq(1)));
+23 |     update(users::table.filter(posts::id.eq(1)));
    |     ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoUpdateTarget` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, WhereClause<...>>`
    |     |
    |     required by a bound introduced by this call
@@ -14,14 +14,14 @@ note: required by a bound in `diesel::update`
    |                  ^^^^^^^^^^^^^^^^ required by this bound in `update`
 help: consider removing this method call, as the receiver has type `users::table` and `users::table: IntoUpdateTarget` trivially holds
    |
-21 -     update(users::table.filter(posts::id.eq(1)));
-21 +     update(users::table);
+23 -     update(users::table.filter(posts::id.eq(1)));
+23 +     update(users::table);
    |
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/update_requires_valid_where_clause.rs:23:26
+  --> tests/fail/update_requires_valid_where_clause.rs:25:26
    |
-23 |     update(users::table).filter(posts::id.eq(1));
+25 |     update(users::table).filter(posts::id.eq(1));
    |                          ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
@@ -35,41 +35,10 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/update_requires_valid_where_clause.rs:23:26
-   |
-23 |     update(users::table).filter(posts::id.eq(1));
-   |                          ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>: FilterDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/update_requires_valid_where_clause.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: 2 redundant requirements hidden
-   = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
-   = note: consider using `--verbose` to print the full type name to the console
-
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/update_requires_valid_where_clause.rs:26:10
+  --> tests/fail/update_requires_valid_where_clause.rs:29:10
    |
-26 |         .filter(posts::id.eq(1));
+29 |         .filter(posts::id.eq(1));
    |          ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
@@ -84,42 +53,10 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
    = note: consider using `--verbose` to print the full type name to the console
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/update_requires_valid_where_clause.rs:26:10
-   |
-26 |         .filter(posts::id.eq(1));
-   |          ^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::id>, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>: FilterDsl<_>`
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/update_requires_valid_where_clause.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: 2 redundant requirements hidden
-   = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `UpdateStatement<table, NoWhereClause, Assign<ColumnWrapperForUpdate<id>, Bound<Integer, i32>>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
-   = note: consider using `--verbose` to print the full type name to the console
-   = note: consider using `--verbose` to print the full type name to the console
-
 error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: IntoUpdateTarget` is not satisfied
-  --> tests/fail/update_requires_valid_where_clause.rs:21:5
+  --> tests/fail/update_requires_valid_where_clause.rs:23:5
    |
-21 |     update(users::table.filter(posts::id.eq(1)));
+23 |     update(users::table.filter(posts::id.eq(1)));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoUpdateTarget` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, WhereClause<...>>`
    |
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`

--- a/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.rs
+++ b/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.rs
@@ -17,6 +17,8 @@ table! {
     }
 }
 
+allow_tables_to_appear_in_same_query!(users, posts);
+
 #[derive(Queryable)]
 struct User {
     id: i32,

--- a/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
+++ b/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
@@ -1,15 +1,15 @@
 error[E0271]: type mismatch resolving `<foo<Bound<Integer, i32>> as Expression>::SqlType == Text`
-  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:35:38
+  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:37:38
    |
-35 |     let _ = users::table.filter(name.eq(foo(1)));
+37 |     let _ = users::table.filter(name.eq(foo(1)));
    |                                      ^^ expected `Integer`, found `Text`
    |
    = note: required for `foo_utils::foo<diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>` to implement `AsExpression<diesel::sql_types::Text>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:39:23
+  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:41:23
    |
-39 |         .load::<User>(&mut conn);
+41 |         .load::<User>(&mut conn);
    |          ----         ^^^^^^^^^ expected `Once`, found `Never`
    |          |
    |          required by a bound introduced by this call
@@ -20,51 +20,6 @@ note: required for `posts::columns::title` to implement `AppearsOnTable<users::t
 16 |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 3 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, bar_utils::bar<posts::columns::title>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `WhereClause<Grouped<Eq<name, bar<title>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, WhereClause<...>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, WhereClause<...>>` to implement `LoadQuery<'_, _, User>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-   = note: consider using `--verbose` to print the full type name to the console
-   = note: consider using `--verbose` to print the full type name to the console
-   = note: consider using `--verbose` to print the full type name to the console
-
-error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:39:23
-   |
-39 |         .load::<User>(&mut conn);
-   |          ----         ^^^^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `users::table`, which is required by `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, bar_utils::bar<posts::columns::title>>>>>: LoadQuery<'_, _, User>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check that `posts::table` and `users::table` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that `posts::table` and `users::table` appear in the same `alias!` call if both
-           are aliases to the same table
-   = help: the following other types implement trait `TableNotEqual<T>`:
-             <Only<pg::metadata_lookup::pg_namespace::table> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Only<pg::metadata_lookup::pg_type::table> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <Tablesample<pg::metadata_lookup::pg_namespace::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <Tablesample<pg::metadata_lookup::pg_type::table, TSM> as TableNotEqual<pg::metadata_lookup::pg_namespace::table>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Only<pg::metadata_lookup::pg_type::table>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<Tablesample<pg::metadata_lookup::pg_type::table, TSM>>>
-             <pg::metadata_lookup::pg_namespace::table as TableNotEqual<pg::metadata_lookup::pg_type::table>>
-             <pg::metadata_lookup::pg_type::table as TableNotEqual<Only<pg::metadata_lookup::pg_namespace::table>>>
-           and $N others
-   = note: required for `users::table` to implement `AppearsInFromClause<posts::table>`
-note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:16:9
-   |
-16 |         title -> VarChar,
-   |         ^^^^^
    = note: 3 redundant requirements hidden
    = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, bar_utils::bar<posts::columns::title>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `WhereClause<Grouped<Eq<name, bar<title>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`


### PR DESCRIPTION
Linked to #4008

Aliases to the same table not defined by the same `alias!` macro call turn out to actually not propagate up to `TableNotEqual`, instead they will lead to `AppearsInFromClause` erros directly.

This PR:
- Adds diagnostic notes to `AppearsInFromClause` unimplemented errors to account for the above
- Adds the corresponding compile test to `diesel_compile_tests/tests/fails/derive/aliases.rs`
- Removes mention of the aliases scenario from `TableNotEqual` (@weiznich does that look ok to you or did you actually encouter a case where it would propagate up to this?)
- Adds a bunch of `allow_tables_to_appear_in_same_query` in other compile tests where they were otherwise missing, but not the main source of error that we'd want to test there. This allows the error messages that we test to be more representative of what users would encounter, and otherwise makes the compilation not fail if something that should fail... fails to fail, successfully making the tests fail. 😁