### PR TITLE
Add support for block expressions to #[dsl::auto_type]

### DIFF
--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -155,7 +155,11 @@ fn test_delete() -> _ {
 
 #[auto_type]
 fn test_delete_2() -> _ {
-    delete(users::table.find(1_i32))
+    delete(users::table.find({
+        // Test that type ascriptions via nested blocks work
+        let id: i32 = 1;
+        id
+    }))
 }
 
 #[auto_type]


### PR DESCRIPTION
This allows inline annotations of the form:
```rust
some_expression_that_auto_type_can_infer({ let x: TypeThatAutoTypeCantInfer = abc(); x })
```

That will work even with `select_expression` in `Selectable` implementations, which before didn't provide a way to provide type annotations.