### PR TITLE
Adds unsigned type for post id received from the terminal in examples

### DIFF
--- a/examples/mysql/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/mysql/getting_started_step_3/src/bin/publish_post.rs
@@ -9,7 +9,7 @@ fn main() {
     let id = args()
         .nth(1)
         .expect("publish_post requires a post id")
-        .parse::<i32>()
+        .parse::<u32>()
         .expect("Invalid ID");
     let connection = &mut establish_connection();
 

--- a/examples/postgres/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/postgres/getting_started_step_3/src/bin/publish_post.rs
@@ -9,7 +9,7 @@ fn main() {
     let id = args()
         .nth(1)
         .expect("publish_post requires a post id")
-        .parse::<i32>()
+        .parse::<u32>()
         .expect("Invalid ID");
     let connection = &mut establish_connection();
 

--- a/examples/sqlite/getting_started_step_3/src/bin/publish_post.rs
+++ b/examples/sqlite/getting_started_step_3/src/bin/publish_post.rs
@@ -9,7 +9,7 @@ fn main() {
     let id = args()
         .nth(1)
         .expect("publish_post requires a post id")
-        .parse::<i32>()
+        .parse::<u32>()
         .expect("Invalid ID");
     let connection = &mut establish_connection();
 


### PR DESCRIPTION
The idea of this pull request is to let Rust's type system communicate that a valid ID can't be signed.