### PR TITLE
When using `.optional()`, convert a `QueryBuilderError` into `None`

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -719,7 +719,10 @@ pub mod prelude {
     #[doc(inline)]
     pub use crate::query_source::{Column, JoinTo, QuerySource, Table};
     #[doc(inline)]
-    pub use crate::result::{ConnectionError, ConnectionResult, OptionalExtension, QueryResult};
+    pub use crate::result::{
+        ConnectionError, ConnectionResult, OptionalEmptyChangesetExtension, OptionalExtension,
+        QueryResult,
+    };
     #[doc(inline)]
     pub use diesel_derives::table_proc as table;
 

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -11,6 +11,7 @@ use crate::query_builder::where_clause::*;
 use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
 use crate::query_dsl::RunQueryDsl;
 use crate::query_source::Table;
+use crate::result::EmptyChangeset;
 use crate::result::Error::QueryBuilderError;
 use crate::{query_builder::*, QuerySource};
 
@@ -198,9 +199,7 @@ where
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         if self.values.is_noop(out.backend())? {
-            return Err(QueryBuilderError(
-                "There are no changes to save. This query cannot be built".into(),
-            ));
+            return Err(QueryBuilderError(Box::new(EmptyChangeset)));
         }
 
         out.unsafe_to_cache_prepared();

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -45,8 +45,6 @@ pub enum Error {
     /// An example of when this error could occur is if you are attempting to
     /// construct an update statement with no changes (e.g. all fields on the
     /// struct are `None`).
-    ///
-    /// When using `optional_empty_changeset`, this error is turned into `None`.
     QueryBuilderError(Box<dyn StdError + Send + Sync>),
 
     /// An error occurred deserializing the data being sent to the database.
@@ -441,7 +439,9 @@ impl fmt::Display for UnexpectedEndOfRow {
 
 impl StdError for UnexpectedEndOfRow {}
 
-/// Expected when an update has no changes to save
+/// Expected when an update has no changes to save.
+///
+/// When using `optional_empty_changeset`, this error is turned into `None`.
 #[derive(Debug, Clone, Copy)]
 pub struct EmptyChangeset;
 

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -46,7 +46,7 @@ pub enum Error {
     /// construct an update statement with no changes (e.g. all fields on the
     /// struct are `None`).
     ///
-    /// When using [`optional`], this error is turned into `None`.
+    /// When using `optional`, this error is turned into `None`.
     QueryBuilderError(Box<dyn StdError + Send + Sync>),
 
     /// An error occurred deserializing the data being sent to the database.

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -288,7 +288,7 @@ pub trait OptionalExtension<T> {
     /// ```rust
     /// use diesel::{QueryResult, OptionalExtension, result::Error::QueryBuilderError, result::EmptyChangeset};
     /// let result: QueryResult<i32> = Err(QueryBuilderError(Box::new(EmptyChangeset)));
-    /// assert_eq!(Ok(None), result.optional());
+    /// assert_eq!(Ok(None), result.optional_empty_changeset());
     /// ```
     fn optional_empty_changeset(self) -> Result<Option<T>, Error>;
 }

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -46,7 +46,7 @@ pub enum Error {
     /// construct an update statement with no changes (e.g. all fields on the
     /// struct are `None`).
     ///
-    /// When using `optional`, this error is turned into `None`.
+    /// When using `optional_empty_changeset`, this error is turned into `None`.
     QueryBuilderError(Box<dyn StdError + Send + Sync>),
 
     /// An error occurred deserializing the data being sent to the database.

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -279,7 +279,20 @@ pub trait OptionalExtension<T> {
     /// assert_eq!(Ok(None), result.optional());
     /// ```
     fn optional(self) -> Result<Option<T>, Error>;
+}
 
+impl<T> OptionalExtension<T> for QueryResult<T> {
+    fn optional(self) -> Result<Option<T>, Error> {
+        match self {
+            Ok(value) => Ok(Some(value)),
+            Err(Error::NotFound) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// See the [method documentation](OptionalEmptyChangesetExtension::optional_empty_changeset).
+pub trait OptionalEmptyChangesetExtension<T> {
     /// By default, Diesel treats an empty update as a `QueryBuilderError`. This method will
     /// convert that error into `None`.
     ///
@@ -293,14 +306,7 @@ pub trait OptionalExtension<T> {
     fn optional_empty_changeset(self) -> Result<Option<T>, Error>;
 }
 
-impl<T> OptionalExtension<T> for QueryResult<T> {
-    fn optional(self) -> Result<Option<T>, Error> {
-        match self {
-            Ok(value) => Ok(Some(value)),
-            Err(Error::NotFound) => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
+impl<T> OptionalEmptyChangesetExtension<T> for QueryResult<T> {
     fn optional_empty_changeset(self) -> Result<Option<T>, Error> {
         match self {
             Ok(value) => Ok(Some(value)),

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -281,7 +281,7 @@ pub trait OptionalExtension<T> {
     /// let result: QueryResult<i32> = Err(NotFound);
     /// assert_eq!(Ok(None), result.optional());
 
-    /// let result: QueryResult<i32> = Err(QueryBuilderError);
+    /// let result: QueryResult<i32> = Err(QueryBuilderError("No changes to save"));
     /// assert_eq!(Ok(None), result.optional());
     /// ```
     fn optional(self) -> Result<Option<T>, Error>;

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -290,7 +290,6 @@ pub trait OptionalExtension<T> {
     /// let result: QueryResult<i32> = Err(QueryBuilderError(Box::new(EmptyChangeset)));
     /// assert_eq!(Ok(None), result.optional());
     /// ```
-    ///
     fn optional_empty_changeset(self) -> Result<Option<T>, Error>;
 }
 

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -268,7 +268,7 @@ pub trait OptionalExtension<T> {
     /// # Example
     ///
     /// ```rust
-    /// use diesel::{QueryResult, NotFound, OptionalExtension, result::Error::QueryBuilderError};
+    /// use diesel::{QueryResult, NotFound, OptionalExtension};
     ///
     /// let result: QueryResult<i32> = Ok(1);
     /// assert_eq!(Ok(Some(1)), result.optional());

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -273,7 +273,7 @@ pub trait OptionalExtension<T> {
     /// # Example
     ///
     /// ```rust
-    /// use diesel::{QueryResult, NotFound, OptionalExtension, QueryBuilderError};
+    /// use diesel::{QueryResult, NotFound, OptionalExtension, result::Error::QueryBuilderError};
     ///
     /// let result: QueryResult<i32> = Ok(1);
     /// assert_eq!(Ok(Some(1)), result.optional());

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -299,7 +299,7 @@ pub trait OptionalEmptyChangesetExtension<T> {
     /// # Example
     ///
     /// ```rust
-    /// use diesel::{QueryResult, OptionalExtension, result::Error::QueryBuilderError, result::EmptyChangeset};
+    /// use diesel::{QueryResult, OptionalEmptyChangesetExtension, result::Error::QueryBuilderError, result::EmptyChangeset};
     /// let result: QueryResult<i32> = Err(QueryBuilderError(Box::new(EmptyChangeset)));
     /// assert_eq!(Ok(None), result.optional_empty_changeset());
     /// ```

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -281,7 +281,7 @@ pub trait OptionalExtension<T> {
     /// let result: QueryResult<i32> = Err(NotFound);
     /// assert_eq!(Ok(None), result.optional());
 
-    /// let result: QueryResult<i32> = Err(QueryBuilderError("No changes to save"));
+    /// let result: QueryResult<i32> = Err(QueryBuilderError("No changes to save".into()));
     /// assert_eq!(Ok(None), result.optional());
     /// ```
     fn optional(self) -> Result<Option<T>, Error>;

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -214,7 +214,6 @@ fn sql_syntax_is_correct_when_option_field_comes_mixed_with_non_option() {
 }
 
 #[test]
-#[should_panic(expected = "There are no changes to save.")]
 fn update_with_no_changes() {
     #[derive(AsChangeset)]
     #[diesel(table_name = users)]
@@ -228,14 +227,12 @@ fn update_with_no_changes() {
         name: None,
         hair_color: None,
     };
-    update(users::table)
-        .set(&changes)
-        .execute(connection)
-        .unwrap();
+    let update_result = update(users::table).set(&changes).execute(connection);
+    assert!(update_result.is_err());
 }
 
 #[test]
-fn update_with_empty_changes_and_optional() {
+fn update_with_optional_empty_changeset() {
     #[derive(AsChangeset)]
     #[diesel(table_name = users)]
     struct Changes {
@@ -251,7 +248,7 @@ fn update_with_empty_changes_and_optional() {
     let update_result = update(users::table)
         .set(&changes)
         .execute(connection)
-        .optional()
+        .optional_empty_changeset()
         .unwrap();
     assert_eq!(None, update_result);
 }

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -235,6 +235,28 @@ fn update_with_no_changes() {
 }
 
 #[test]
+fn update_with_empty_changes_and_optional() {
+    #[derive(AsChangeset)]
+    #[diesel(table_name = users)]
+    struct Changes {
+        name: Option<String>,
+        hair_color: Option<String>,
+    }
+
+    let connection = &mut connection();
+    let changes = Changes {
+        name: None,
+        hair_color: None,
+    };
+    let update_result = update(users::table)
+        .set(&changes)
+        .execute(connection)
+        .optional()
+        .unwrap();
+    assert_eq!(None, update_result);
+}
+
+#[test]
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 fn upsert_with_no_changes_executes_do_nothing() {
     #[derive(AsChangeset)]


### PR DESCRIPTION
This is my first diesel PR, I apologize in advance for any issues. Let me know of any documentation I missed, tests I should add, or anything I can do to improve it.

I also had to comment a few tests in `bin/test` to get this to pass, which leads me to believe the `main` branch has some unaddressed errors which might fail CI before reaching the test I added.

Related discussion: https://github.com/diesel-rs/diesel/discussions/4018