### PR TITLE
Fix all new unexpected_cfgs warnings

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,8 +31,8 @@ jobs:
         sudo apt-get -y install libmysqlclient-dev libsqlite3-dev libpq-dev
     - name: Build documentation
       env:
-        RUSTFLAGS: "--cfg doc_cfg"
-        RUSTDOCFLAGS: "--cfg doc_cfg"
+        RUSTFLAGS: "--cfg docsrs"
+        RUSTDOCFLAGS: "--cfg docsrs"
       run:
         cargo +nightly doc --manifest-path diesel/Cargo.toml --features "postgres sqlite mysql extras i-implement-a-third-party-backend-and-opt-into-breaking-changes" --workspace
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -74,5 +74,5 @@ time = ["diesel_derives/time", "dep:time"]
 [package.metadata.docs.rs]
 features = ["postgres", "mysql", "sqlite", "extras"]
 no-default-features = true
-rustc-args = ["--cfg", "doc_cfg"]
-rustdoc-args = ["--cfg", "doc_cfg"]
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -562,7 +562,7 @@ pub(crate) mod private {
     ///
     /// [`QueryFragment`]: crate::query_builder::QueryFragment
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub trait DieselReserveSpecialization {}
@@ -572,7 +572,7 @@ pub(crate) mod private {
     /// `i-implement-a-third-party-backend-and-opt-into-breaking-changes`
     /// feature flag.
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub trait TrustedBackend {}

--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -550,7 +550,7 @@ pub(crate) mod private {
 
     /// This trait restricts who can implement `Connection`
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub trait ConnectionSealed {}
@@ -559,7 +559,7 @@ pub(crate) mod private {
     /// to/from an `std::any::Any` reference. This is used internally by the `#[derive(MultiConnection)]`
     /// implementation
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub trait MultiConnectionHelper: super::Connection {

--- a/diesel/src/connection/statement_cache.rs
+++ b/diesel/src/connection/statement_cache.rs
@@ -108,7 +108,7 @@ use super::Instrumentation;
 /// A prepared statement cache
 #[allow(missing_debug_implementations, unreachable_pub)]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 pub struct StatementCache<DB: Backend, Statement> {
@@ -123,7 +123,7 @@ pub struct StatementCache<DB: Backend, Statement> {
 /// preparing the statement
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 #[allow(unreachable_pub)]
@@ -162,7 +162,7 @@ where
         all(feature = "sqlite", test)
     ))]
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub fn len(&self) -> usize {
@@ -251,7 +251,7 @@ where
 /// function as a function that simply returns a constant `String`.
 #[allow(unreachable_pub)]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 pub trait QueryFragmentForCachedStatement<DB> {
@@ -283,7 +283,7 @@ where
 /// that does not depend on [`ToOwned`]
 #[allow(missing_debug_implementations, unreachable_pub)]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 #[non_exhaustive]
@@ -323,7 +323,7 @@ impl<'a, T> DerefMut for MaybeCached<'a, T> {
 #[allow(missing_debug_implementations, unreachable_pub)]
 #[derive(Hash, PartialEq, Eq)]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 pub enum StatementCacheKey<DB: Backend> {

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -216,7 +216,7 @@
 //! - `32-column-tables`
 
 #![cfg_attr(feature = "unstable", feature(trait_alias))]
-#![cfg_attr(doc_cfg, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(feature = "128-column-tables", recursion_limit = "256")]
 // Built-in Lints
 #![warn(

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -22,7 +22,7 @@ pub struct PgValue<'a> {
 /// the implementation for `NonZeroU32` here instead
 /// of providing their own custom implementation
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 #[allow(unreachable_pub)]

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -287,7 +287,7 @@ where
         doc(hidden)
     )] // This is used by the `define_sql_function` macro
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub fn backend(&self) -> &DB {
@@ -300,7 +300,7 @@ where
         doc(hidden)
     )] // This is used by the `__diesel_column` macro
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub fn should_skip_from(&self) -> bool {

--- a/diesel/src/query_builder/limit_offset_clause.rs
+++ b/diesel/src/query_builder/limit_offset_clause.rs
@@ -6,7 +6,7 @@ use crate::query_builder::QueryId;
 /// This type is only relevant for implementing custom backends
 #[derive(Debug, Clone, Copy, QueryId)]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 pub struct LimitOffsetClause<Limit, Offset> {
@@ -21,7 +21,7 @@ pub struct LimitOffsetClause<Limit, Offset> {
 /// This type is only relevant for implementing custom backends
 #[allow(missing_debug_implementations)]
 #[cfg_attr(
-    doc_cfg,
+    docsrs,
     doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
 )]
 pub struct BoxedLimitOffsetClause<'a, DB> {

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -176,7 +176,7 @@ mod private {
     }
 
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     #[diagnostic::on_unimplemented(

--- a/diesel/src/row.rs
+++ b/diesel/src/row.rs
@@ -174,7 +174,7 @@ pub(crate) mod private {
 
     /// This trait restricts who can implement `Row`
     #[cfg_attr(
-        doc_cfg,
+        docsrs,
         doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
     )]
     pub trait RowSealed {}

--- a/diesel_derives/src/diesel_public_if.rs
+++ b/diesel_derives/src/diesel_public_if.rs
@@ -120,7 +120,7 @@ impl EntryWithVisibility {
             EntryWithVisibility::TraitFunction { meta, tail } if field_list.is_empty() => quote! {
                 #(#meta)*
                 #[cfg_attr(not(#cfg), doc(hidden))]
-                #[cfg_attr(doc_cfg, doc(cfg(#cfg)))]
+                #[cfg_attr(docsrs, doc(cfg(#cfg)))]
                 #tail
             },
             EntryWithVisibility::Item { meta, vis, tail } if field_list.is_empty() => {

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -699,7 +699,7 @@ fn mk_f64(f: DoubleWrapper) -> f64 {
 impl quickcheck::Arbitrary for DoubleWrapper {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
         let mut f = f64::arbitrary(g);
-        while (cfg!(feature = "sqlite") || cfg!(featuer = "mysql")) && f.is_nan() {
+        while (cfg!(feature = "sqlite") || cfg!(feature = "mysql")) && f.is_nan() {
             f = f64::arbitrary(g);
         }
         DoubleWrapper(f)


### PR DESCRIPTION
* There was one valid case in diesel_tests
* Switch from `doc_cfg` to `docsrs` for our custom doc cfg as the former is considered to be a custom thing (that would require a build script to whitelist) while the later is known by the compiler