### PR TITLE
Implement serialization/de-serialization support for `chrono::Duration`

### DIFF
--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -200,10 +200,12 @@ mod tests {
 
     use self::chrono::{Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};
 
+    use super::{DAYS_PER_MONTH, NANOSECONDS_PER_MICROSECOND, SECONDS_PER_DAY};
+
     use crate::dsl::{now, sql};
     use crate::prelude::*;
     use crate::select;
-    use crate::sql_types::{Date, Time, Timestamp, Timestamptz};
+    use crate::sql_types::{Date, Interval, Time, Timestamp, Timestamptz};
     use crate::test_helpers::connection;
 
     #[test]
@@ -396,15 +398,18 @@ mod tests {
     fn duration_encode_correctly() {
         let connection = &mut connection();
         let query = select(
-            sql::<Interval>("'60 days 1 minute 123456 microseconds'").eq(TEST_DURATION.unwrap()),
+            sql::<Interval>("'60 days 1 minute 123456 microseconds'::interval")
+                .eq(TEST_DURATION.unwrap()),
         );
         assert!(query.get_result::<bool>(connection).unwrap());
         let query = select(
-            sql::<Interval>("'2 months 1 minute 123456 microseconds'").eq(TEST_DURATION.unwrap()),
+            sql::<Interval>("'2 months 1 minute 123456 microseconds'::interval")
+                .eq(TEST_DURATION.unwrap()),
         );
         assert!(query.get_result::<bool>(connection).unwrap());
         let query = select(
-            sql::<Interval>("'5184060 seconds 123456 microseconds'").eq(TEST_DURATION.unwrap()),
+            sql::<Interval>("'5184060 seconds 123456 microseconds'::interval")
+                .eq(TEST_DURATION.unwrap()),
         );
         assert!(query.get_result::<bool>(connection).unwrap());
     }
@@ -412,17 +417,24 @@ mod tests {
     #[test]
     fn duration_decode_correctly() {
         let connection = &mut connection();
-        let query = select(sql::<Interval>("'60 days 1 minute 123456 microseconds'"));
+
+        let query = select(sql::<Interval>(
+            "'60 days 1 minute 123456 microseconds'::interval",
+        ));
         assert_eq!(
             Ok(TEST_DURATION.unwrap()),
             query.get_result::<Duration>(connection)
         );
-        let query = select(sql::<Interval>("'2 months 1 minute 123456 microseconds'"));
+        let query = select(sql::<Interval>(
+            "'2 months 1 minute 123456 microseconds'::interval",
+        ));
         assert_eq!(
             Ok(TEST_DURATION.unwrap()),
             query.get_result::<Duration>(connection)
         );
-        let query = select(sql::<Interval>("'5184060 seconds 123456 microseconds'"));
+        let query = select(sql::<Interval>(
+            "'5184060 seconds 123456 microseconds'::interval",
+        ));
         assert_eq!(
             Ok(TEST_DURATION.unwrap()),
             query.get_result::<Duration>(connection)

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -385,4 +385,47 @@ mod tests {
             query.get_result::<NaiveDate>(connection)
         );
     }
+
+    const TEST_DURATION: Option<Duration> = Duration::new(
+        // 2 months, 1 minute and 123456 microseconds;
+        2 * SECONDS_PER_DAY * (DAYS_PER_MONTH as i64) + 60,
+        123456 * NANOSECONDS_PER_MICROSECOND,
+    );
+
+    #[test]
+    fn duration_encode_correctly() {
+        let connection = &mut connection();
+        let query = select(
+            sql::<Interval>("'60 days 1 minute 123456 microseconds'").eq(TEST_DURATION.unwrap()),
+        );
+        assert!(query.get_result::<bool>(connection).unwrap());
+        let query = select(
+            sql::<Interval>("'2 months 1 minute 123456 microseconds'").eq(TEST_DURATION.unwrap()),
+        );
+        assert!(query.get_result::<bool>(connection).unwrap());
+        let query = select(
+            sql::<Interval>("'5184060 seconds 123456 microseconds'").eq(TEST_DURATION.unwrap()),
+        );
+        assert!(query.get_result::<bool>(connection).unwrap());
+    }
+
+    #[test]
+    fn duration_decode_correctly() {
+        let connection = &mut connection();
+        let query = select(sql::<Interval>("'60 days 1 minute 123456 microseconds'"));
+        assert_eq!(
+            Ok(TEST_DURATION.unwrap()),
+            query.get_result::<Duration>(connection)
+        );
+        let query = select(sql::<Interval>("'2 months 1 minute 123456 microseconds'"));
+        assert_eq!(
+            Ok(TEST_DURATION.unwrap()),
+            query.get_result::<Duration>(connection)
+        );
+        let query = select(sql::<Interval>("'5184060 seconds 123456 microseconds'"));
+        assert_eq!(
+            Ok(TEST_DURATION.unwrap()),
+            query.get_result::<Duration>(connection)
+        );
+    }
 }

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -382,6 +382,15 @@ mod tests {
                 "60 days 1 minute 123456 microseconds",
                 "2 months 1 minute 123456 microseconds",
                 "5184060 seconds 123456 microseconds",
+                "60 days 60123456 microseconds",
+                "59 days 24 hours 60.123456 seconds",
+                "60 0:01:00.123456",
+                "58 48:01:00.123456",
+                "P0Y2M0DT0H1M0.123456S",
+                "0-2 0:01:00.123456",
+                "P0000-02-00T00:01:00.123456",
+                "1440:01:00.123456",
+                "1 month 30 days 0.5 minutes 30.123456 seconds",
             ],
         )
     }

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -142,7 +142,6 @@ impl FromSql<Date, Pg> for NaiveDate {
 const DAYS_PER_MONTH: i32 = 30;
 const SECONDS_PER_DAY: i64 = 60 * 60 * 24;
 const MICROSECONDS_PER_SECOND: i64 = 1_000_000;
-const NANOSECONDS_PER_MICROSECOND: u32 = 1_000;
 
 #[cfg(all(feature = "chrono", feature = "postgres_backend"))]
 impl ToSql<Interval, Pg> for Duration {
@@ -178,18 +177,7 @@ impl FromSql<Interval, Pg> for Duration {
         // For reference, please read `justify_interval` from this page.
         // https://www.postgresql.org/docs/current/functions-datetime.html
         let days = interval.months * DAYS_PER_MONTH + interval.days;
-        let seconds =
-            (days as i64) * SECONDS_PER_DAY + interval.microseconds / MICROSECONDS_PER_SECOND;
-        let microseconds = (interval.microseconds % MICROSECONDS_PER_SECOND) as u32;
-        if let Some(v) = Duration::new(seconds, microseconds * NANOSECONDS_PER_MICROSECOND) {
-            Ok(v)
-        } else {
-            Err(format!(
-                "Failed to create duration from given time numbers; {} seconds, {} microseconds",
-                seconds, microseconds
-            )
-            .into())
-        }
+        Ok(Duration::days(days as i64) + Duration::microseconds(interval.microseconds))
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -200,8 +200,6 @@ mod tests {
 
     use self::chrono::{Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone, Utc};
 
-    use super::{DAYS_PER_MONTH, NANOSECONDS_PER_MICROSECOND, SECONDS_PER_DAY};
-
     use crate::dsl::{now, sql};
     use crate::prelude::*;
     use crate::select;
@@ -388,28 +386,27 @@ mod tests {
         );
     }
 
-    const TEST_DURATION: Option<Duration> = Duration::new(
-        // 2 months, 1 minute and 123456 microseconds;
-        2 * SECONDS_PER_DAY * (DAYS_PER_MONTH as i64) + 60,
-        123456 * NANOSECONDS_PER_MICROSECOND,
-    );
+    /// Get test duration.
+    fn get_test_duration() -> Duration {
+        Duration::days(60) + Duration::minutes(1) + Duration::microseconds(123456)
+    }
 
     #[test]
     fn duration_encode_correctly() {
         let connection = &mut connection();
         let query = select(
             sql::<Interval>("'60 days 1 minute 123456 microseconds'::interval")
-                .eq(TEST_DURATION.unwrap()),
+                .eq(get_test_duration()),
         );
         assert!(query.get_result::<bool>(connection).unwrap());
         let query = select(
             sql::<Interval>("'2 months 1 minute 123456 microseconds'::interval")
-                .eq(TEST_DURATION.unwrap()),
+                .eq(get_test_duration()),
         );
         assert!(query.get_result::<bool>(connection).unwrap());
         let query = select(
             sql::<Interval>("'5184060 seconds 123456 microseconds'::interval")
-                .eq(TEST_DURATION.unwrap()),
+                .eq(get_test_duration()),
         );
         assert!(query.get_result::<bool>(connection).unwrap());
     }
@@ -417,26 +414,25 @@ mod tests {
     #[test]
     fn duration_decode_correctly() {
         let connection = &mut connection();
-
         let query = select(sql::<Interval>(
             "'60 days 1 minute 123456 microseconds'::interval",
         ));
         assert_eq!(
-            Ok(TEST_DURATION.unwrap()),
+            Ok(get_test_duration()),
             query.get_result::<Duration>(connection)
         );
         let query = select(sql::<Interval>(
             "'2 months 1 minute 123456 microseconds'::interval",
         ));
         assert_eq!(
-            Ok(TEST_DURATION.unwrap()),
+            Ok(get_test_duration()),
             query.get_result::<Duration>(connection)
         );
         let query = select(sql::<Interval>(
             "'5184060 seconds 123456 microseconds'::interval",
         ));
         assert_eq!(
-            Ok(TEST_DURATION.unwrap()),
+            Ok(get_test_duration()),
             query.get_result::<Duration>(connection)
         );
     }

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -293,13 +293,16 @@ pub struct Date;
 /// ### [`ToSql`](crate::serialize::ToSql) impls
 ///
 /// - [`PgInterval`] which can be constructed using [`IntervalDsl`]
+/// - [`chrono::Duration`][Duration] with `feature = "chrono"`
 ///
 /// ### [`FromSql`](crate::deserialize::FromSql) impls
 ///
 /// - [`PgInterval`] which can be constructed using [`IntervalDsl`]
+/// - [`chrono::Duration`][Duration] with `feature = "chrono"`
 ///
 /// [`PgInterval`]: ../pg/data_types/struct.PgInterval.html
 /// [`IntervalDsl`]: ../pg/expression/extensions/trait.IntervalDsl.html
+/// [`Duration`]: https://docs.rs/chrono/*/chrono/type.Duration.html
 #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
 #[diesel(postgres_type(oid = 1186, array_oid = 1187))]
 pub struct Interval;

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -302,7 +302,7 @@ pub struct Date;
 ///
 /// [`PgInterval`]: ../pg/data_types/struct.PgInterval.html
 /// [`IntervalDsl`]: ../pg/expression/extensions/trait.IntervalDsl.html
-/// [`Duration`]: https://docs.rs/chrono/*/chrono/type.Duration.html
+/// [Duration]: https://docs.rs/chrono/*/chrono/type.Duration.html
 #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
 #[diesel(postgres_type(oid = 1186, array_oid = 1187))]
 pub struct Interval;

--- a/diesel/src/type_impls/date_and_time.rs
+++ b/diesel/src/type_impls/date_and_time.rs
@@ -15,7 +15,7 @@ mod chrono {
     use self::chrono::*;
     use crate::deserialize::FromSqlRow;
     use crate::expression::AsExpression;
-    use crate::sql_types::{Date, Time, Timestamp};
+    use crate::sql_types::{Date, Interval, Time, Timestamp};
 
     #[derive(AsExpression, FromSqlRow)]
     #[diesel(foreign_derive)]
@@ -49,6 +49,11 @@ mod chrono {
     )]
     #[cfg_attr(feature = "sqlite", diesel(sql_type = crate::sql_types::TimestamptzSqlite))]
     struct DateTimeProxy<Tz: TimeZone>(DateTime<Tz>);
+
+    #[derive(AsExpression, FromSqlRow)]
+    #[diesel(foreign_derive)]
+    #[diesel(sql_type = Interval)]
+    struct DurationProxy(Duration);
 }
 
 #[cfg(feature = "time")]


### PR DESCRIPTION
This PR implements the feature which https://github.com/diesel-rs/diesel/pull/1610 tried before. The purpose of this PR is essentially make users possible to directly load/unload `chrono::Duration` type to freely use timedelta types.