### PR TITLE
Fix an issue with `serialize_as` and optional types

### DIFF
--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -228,7 +228,7 @@ fn field_expr_serialize_as(
     let column = quote!(#table_name::#column_name);
     if treat_none_as_default_value {
         if is_option_ty(ty) {
-            Ok(quote!(self.#field_name.map(|x| #column.eq(::std::convert::Into::<#ty>::into(x)))))
+            Ok(quote!(::std::convert::Into::<#ty>::into(self.#field_name).map(|v| #column.eq(v))))
         } else {
             Ok(
                 quote!(std::option::Option::Some(#column.eq(::std::convert::Into::<#ty>::into(self.#field_name)))),


### PR DESCRIPTION
This commit fixes an issue that prevents using optional target types with `#[diesel(serialize_as = Option<…>)]`