### PR TITLE
Change the order of generic arguments for InsertValues

### DIFF
--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -115,7 +115,7 @@ where
     }
 }
 
-pub trait InsertValues<T: Table, DB: Backend>: QueryFragment<DB> {
+pub trait InsertValues<DB: Backend, T: Table>: QueryFragment<DB> {
     fn column_names(&self, out: AstPass<'_, '_, DB>) -> QueryResult<()>;
 }
 
@@ -154,7 +154,7 @@ impl<T> Default for DefaultableColumnInsertValue<T> {
     }
 }
 
-impl<Col, Expr, DB> InsertValues<Col::Table, DB>
+impl<Col, Expr, DB> InsertValues<DB, Col::Table>
     for DefaultableColumnInsertValue<ColumnInsertValue<Col, Expr>>
 where
     DB: Backend + SqlDialect<InsertWithDefaultKeyword = sql_dialect::default_keyword_for_insert::IsoSqlDefaultKeyword>,
@@ -168,7 +168,7 @@ where
     }
 }
 
-impl<Col, Expr, DB> InsertValues<Col::Table, DB> for ColumnInsertValue<Col, Expr>
+impl<Col, Expr, DB> InsertValues<DB, Col::Table> for ColumnInsertValue<Col, Expr>
 where
     DB: Backend,
     Col: Column,
@@ -218,7 +218,7 @@ where
 }
 
 #[cfg(feature = "sqlite")]
-impl<Col, Expr> InsertValues<Col::Table, crate::sqlite::Sqlite>
+impl<Col, Expr> InsertValues<crate::sqlite::Sqlite, Col::Table>
     for DefaultableColumnInsertValue<ColumnInsertValue<Col, Expr>>
 where
     Col: Column,

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -235,7 +235,7 @@ where
     T: Table + Copy + QueryId + 'static,
     T::FromClause: QueryFragment<Sqlite>,
     Op: Copy + QueryId + QueryFragment<Sqlite>,
-    V: InsertValues<T, Sqlite> + CanInsertInSingleQuery<Sqlite> + QueryId,
+    V: InsertValues<Sqlite, T> + CanInsertInSingleQuery<Sqlite> + QueryId,
 {
     fn execute((Yes, query): Self, conn: &mut C) -> QueryResult<usize> {
         conn.transaction(|conn| {

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -455,7 +455,7 @@ impl<T, Tab, DB> QueryFragment<DB> for ValuesClause<T, Tab>
 where
     DB: Backend,
     Tab: Table,
-    T: InsertValues<Tab, DB>,
+    T: InsertValues<DB, Tab>,
     DefaultValues: QueryFragment<DB>,
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -156,11 +156,11 @@ macro_rules! tuple_impls {
             }
 
             #[allow(unused_assignments)]
-            impl<$($T,)+ Tab, __DB> InsertValues<Tab, __DB> for ($($T,)+)
+            impl<$($T,)+ Tab, __DB> InsertValues<__DB, Tab> for ($($T,)+)
             where
                 Tab: Table,
                 __DB: Backend,
-                $($T: InsertValues<Tab, __DB>,)+
+                $($T: InsertValues<__DB, Tab>,)+
             {
                 fn column_names(&self, mut out: AstPass<'_, '_, __DB>) -> QueryResult<()> {
                     let mut needs_comma = false;

--- a/diesel_compile_tests/tests/fail/columns_cannot_be_rhs_of_insert.stderr
+++ b/diesel_compile_tests/tests/fail/columns_cannot_be_rhs_of_insert.stderr
@@ -14,7 +14,7 @@ note: required for `columns::hair_color` to implement `AppearsOnTable<NoFromClau
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
    = note: required for `&columns::hair_color` to implement `AppearsOnTable<NoFromClause>`
-   = note: required for `ColumnInsertValue<columns::name, &columns::hair_color>` to implement `InsertValues<users::table, _>`
+   = note: required for `ColumnInsertValue<columns::name, &columns::hair_color>` to implement `InsertValues<_, users::table>`
    = note: required for `diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::name, &columns::hair_color>, users::table>` to implement `QueryFragment<_>`
    = note: 1 redundant requirement hidden
    = note: required for `InsertStatement<table, ValuesClause<ColumnInsertValue<name, &hair_color>, table>>` to implement `QueryFragment<_>`

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -1195,7 +1195,7 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
         let ty = c.ty;
         quote::quote! {
             super::backend::MultiBackend::#ident(_) => {
-                <Self as diesel::insertable::InsertValues<Col::Table, <#ty as diesel::connection::Connection>::Backend>>::column_names(
+                <Self as diesel::insertable::InsertValues<<#ty as diesel::connection::Connection>::Backend, Col::Table>>::column_names(
                     &self,
                     out.cast_database(
                         super::bind_collector::MultiBindCollector::#lower_ident,
@@ -1214,7 +1214,7 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
     let insert_values_backend_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>: diesel::insertable::InsertValues<Col::Table, <#ty as diesel::connection::Connection>::Backend>
+            diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>: diesel::insertable::InsertValues<<#ty as diesel::connection::Connection>::Backend, Col::Table>
         }
     });
 
@@ -1405,7 +1405,7 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
             }
         }
 
-        impl<Col, Expr> diesel::insertable::InsertValues<Col::Table, super::multi_connection_impl::backend::MultiBackend>
+        impl<Col, Expr> diesel::insertable::InsertValues<super::multi_connection_impl::backend::MultiBackend, Col::Table>
             for diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>
         where
             Col: diesel::prelude::Column,


### PR DESCRIPTION
This commit changes to order of generic arguments for the `InsertValues` trait. This allows us to generate a sound impl of that trait via `#[derive(MultiConnection)]` that will be accepted by future rust compiler versions as well. This works as the backend type is this case local, while the table type is generic. By having first the backend type and then the table type we first have the local type, which is allowed according to the rust coherence rules.

This is no breaking change as `InsertValues` is not part of the public API: https://docs.diesel.rs/2.1.x/diesel/index.html?search=insertvalues

This fixes #4035