### PR TITLE
Do not implicitly convert `std::io::Error` to our CLI Error type

### DIFF
--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -56,7 +56,8 @@ impl Config {
         let path = Self::file_path(matches);
 
         if path.exists() {
-            let content = fs::read_to_string(&path)?;
+            let content = fs::read_to_string(&path)
+                .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
             let mut result = toml::from_str::<Self>(&content)?;
             result.set_relative_path_base(
                 path.parent()

--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -9,9 +9,7 @@ use diesel_migrations::FileBasedMigrations;
 
 use std::env;
 #[cfg(feature = "postgres")]
-use std::fs::{self, File};
-#[cfg(feature = "postgres")]
-use std::io::Write;
+use std::fs::{self};
 use std::path::Path;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -242,11 +240,21 @@ fn create_default_migration_if_needed(
     match Backend::for_url(database_url) {
         #[cfg(feature = "postgres")]
         Backend::Pg => {
-            fs::create_dir_all(&initial_migration_path)?;
-            let mut up_sql = File::create(initial_migration_path.join("up.sql"))?;
-            up_sql.write_all(include_bytes!("setup_sql/postgres/initial_setup/up.sql"))?;
-            let mut down_sql = File::create(initial_migration_path.join("down.sql"))?;
-            down_sql.write_all(include_bytes!("setup_sql/postgres/initial_setup/down.sql"))?;
+            fs::create_dir_all(&initial_migration_path).map_err(|e| {
+                crate::errors::Error::IoError(e, Some(initial_migration_path.clone()))
+            })?;
+            let up_sql_file = initial_migration_path.join("up.sql");
+            std::fs::write(
+                &up_sql_file,
+                include_bytes!("setup_sql/postgres/initial_setup/up.sql"),
+            )
+            .map_err(|e| crate::errors::Error::IoError(e, Some(up_sql_file.clone())))?;
+            let down_sql_file = initial_migration_path.join("down.sql");
+            std::fs::write(
+                &down_sql_file,
+                include_bytes!("setup_sql/postgres/initial_setup/down.sql"),
+            )
+            .map_err(|e| crate::errors::Error::IoError(e, Some(down_sql_file.clone())))?;
         }
         _ => {} // No default migration for this backend
     }
@@ -296,7 +304,9 @@ fn drop_database(database_url: &str) -> Result<(), crate::errors::Error> {
         Backend::Sqlite => {
             if Path::new(database_url).exists() {
                 println!("Dropping database: {database_url}");
-                std::fs::remove_file(database_url)?;
+                std::fs::remove_file(database_url).map_err(|e| {
+                    crate::errors::Error::IoError(e, Some(std::path::PathBuf::from(database_url)))
+                })?;
             }
         }
         #[cfg(feature = "mysql")]

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -18,8 +18,8 @@ pub enum Error {
     ProjectRootNotFound(PathBuf),
     #[error("The --database-url argument must be passed, or the DATABASE_URL environment variable must be set.")]
     DatabaseUrlMissing,
-    #[error("Encountered an IO error: {0}")]
-    IoError(#[from] std::io::Error),
+    #[error("Encountered an IO error: {0} {}", print_optional_path(.1))]
+    IoError(#[source] std::io::Error, Option<PathBuf>),
     #[error("Failed to execute a database query: {0}")]
     QueryError(#[from] diesel::result::Error),
     #[error("Failed to run migrations: {0}")]
@@ -62,4 +62,10 @@ pub enum Error {
     ClapMatchesError(#[from] clap::parser::MatchesError),
     #[error("No `[print_schema.{0}]` entries in your diesel.toml")]
     NoSchemaKeyFound(String),
+}
+
+fn print_optional_path(path: &Option<PathBuf>) -> String {
+    path.as_ref()
+        .map(|p| format!(" for `{}`", p.display()))
+        .unwrap_or_default()
 }

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -150,8 +150,10 @@ fn create_config_file(
             "dir = \"migrations\"",
             &format!("dir = \"{}\"", migrations_dir_toml_string),
         );
-        let mut file = fs::File::create(path)?;
-        file.write_all(modified_content.as_bytes())?;
+        let mut file = fs::File::create(&path)
+            .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
+        file.write_all(modified_content.as_bytes())
+            .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
     }
 
     Ok(())
@@ -193,13 +195,15 @@ fn generate_completions_command(matches: &ArgMatches) {
 /// Returns a `DatabaseError::ProjectRootNotFound` if no Cargo.toml is found.
 fn create_migrations_directory(path: &Path) -> Result<PathBuf, crate::errors::Error> {
     println!("Creating migrations directory at: {}", path.display());
-    fs::create_dir_all(path)?;
-    fs::File::create(path.join(".keep"))?;
+    fs::create_dir_all(path)
+        .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
+    let keep_path = path.join(".keep");
+    fs::File::create(&keep_path).map_err(|e| crate::errors::Error::IoError(e, Some(keep_path)))?;
     Ok(path.to_owned())
 }
 
 fn find_project_root() -> Result<PathBuf, crate::errors::Error> {
-    let current_dir = env::current_dir()?;
+    let current_dir = env::current_dir().map_err(|e| crate::errors::Error::IoError(e, None))?;
     search_for_directory_containing_file(&current_dir, "diesel.toml")
         .or_else(|_| search_for_directory_containing_file(&current_dir, "Cargo.toml"))
 }
@@ -260,8 +264,6 @@ fn run_infer_schema(matches: &ArgMatches) -> Result<(), crate::errors::Error> {
 
 #[tracing::instrument]
 fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate::errors::Error> {
-    use std::io::Read;
-
     tracing::debug!("Regenerate schema if required");
 
     let config = Config::read(matches)?.print_schema;
@@ -269,16 +271,16 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
         if let Some(ref path) = config.file {
             let mut connection = InferConnection::from_matches(matches)?;
             if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)?;
+                fs::create_dir_all(parent)
+                    .map_err(|e| crate::errors::Error::IoError(e, Some(parent.to_owned())))?;
             }
 
             if matches.get_flag("LOCKED_SCHEMA") {
                 let mut buf = Vec::new();
                 print_schema::run_print_schema(&mut connection, config, &mut buf)?;
 
-                let mut old_buf = Vec::new();
-                let mut file = fs::File::open(path)?;
-                file.read_to_end(&mut old_buf)?;
+                let old_buf = std::fs::read(path)
+                    .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
 
                 if buf != old_buf {
                     return Err(crate::errors::Error::SchemaWouldChange(
@@ -286,11 +288,9 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
                     ));
                 }
             } else {
-                use std::io::Write;
-
-                let mut file = fs::File::create(path)?;
                 let schema = print_schema::output_schema(&mut connection, config)?;
-                file.write_all(schema.as_bytes())?;
+                std::fs::write(path, schema.as_bytes())
+                    .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
             }
         }
     }

--- a/diesel_cli/src/migrations/diff_schema.rs
+++ b/diesel_cli/src/migrations/diff_schema.rs
@@ -4,8 +4,6 @@ use diesel::query_builder::QueryBuilder;
 use diesel::QueryResult;
 use diesel_table_macro_syntax::{ColumnDef, TableDecl};
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use syn::visit::Visit;
 
@@ -37,9 +35,9 @@ pub fn generate_sql_based_on_diff_schema(
     let project_root = crate::find_project_root()?;
 
     let schema_path = project_root.join(schema_file_path);
-    let mut schema_file = File::open(schema_path)?;
-    let mut content = String::new();
-    schema_file.read_to_string(&mut content)?;
+    let content = std::fs::read_to_string(&schema_path)
+        .map_err(|e| crate::errors::Error::IoError(e, Some(schema_path.clone())))?;
+
     let syn_file = syn::parse_file(&content)?;
 
     let mut tables_from_schema = SchemaCollector::default();

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -48,7 +48,9 @@ pub fn run_print_schema<W: IoWrite>(
 ) -> Result<(), crate::errors::Error> {
     let schema = output_schema(connection, config)?;
 
-    output.write_all(schema.as_bytes())?;
+    output
+        .write_all(schema.as_bytes())
+        .map_err(|e| crate::errors::Error::IoError(e, None))?;
     Ok(())
 }
 
@@ -272,7 +274,7 @@ pub fn output_schema(
                     patch_file.display(),
                     e
                 );
-                return Err(e.into());
+                return Err(crate::errors::Error::IoError(e, Some(patch_file.clone())));
             }
         };
         let patch = diffy::Patch::from_str(&patch)?;


### PR DESCRIPTION
This commit changes our CLI tool to always explicitly include paths in the IO related error messages by enforcing that you cannot implicitly construct our own Error type from a `io::Error` (e.g. via `?`). Instead an explicit conversion is required, which allows to specify the relevant path