### PR TITLE
getting started integration tests

### DIFF
--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -10,6 +10,9 @@ diesel = { version = "2.1.0", path = "../../../diesel", features = ["sqlite", "r
 dotenvy = "0.15"
 libsqlite3-sys = { version = "0.28.0", features = ["bundled"] }
 
+[dev-dependencies]
+assert_cmd = "2.0.14"
+
 [[bin]]
 name = "show_posts"
 doc = false

--- a/examples/sqlite/getting_started_step_2/tests/step_2.rs
+++ b/examples/sqlite/getting_started_step_2/tests/step_2.rs
@@ -1,0 +1,16 @@
+use assert_cmd::Command;
+
+#[test]
+fn write_post() {
+    let _ = Command::cargo_bin("write_post")
+        .unwrap()
+        .write_stdin("Test Title\ntest text\n1 2 3")
+        .assert()
+        .append_context("write_post", "")
+        .stdout("What would you like your title to be?\n\nOk! Let's write Test Title (Press CTRL+D when finished)\n\n\nSaved draft Test Title with id 1\n");
+    let _ = Command::cargo_bin("show_posts")
+        .unwrap()
+        .assert()
+        .append_context("show_posts", "")
+        .stdout("Displaying 0 posts\n");
+}


### PR DESCRIPTION
Working on adding integration tests per #777 . I've created a quick example of how I'm planning to implement this in examples/sqlite/getting_started_step_2 . Initial thought is to add a tests directory with a test that uses assert_cmd to run the relevant binaries for each step. Considering writing in some calls to diesel to examine the database as well, let me know if that's the correct route or if just verifying binary output is sufficient.

In examples/sqlite/getting_started_step_2 I ran the following to test
echo "DATABASE_URL=file:/tmp/test.db" > .env; rm -f /tmp/test.db ; diesel migration run; cargo test; rm -f .env