### PR TITLE
Parenthesized expression support in #[dsl::auto_type]

### DIFF
--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -91,6 +91,9 @@ impl TypeInferrer<'_> {
             (syn::Expr::Group(syn::ExprGroup { expr, .. }), type_hint) => {
                 return self.try_infer_expression_type(expr, type_hint)
             }
+            (syn::Expr::Paren(syn::ExprParen { expr, .. }), type_hint) => {
+                return self.try_infer_expression_type(expr, type_hint)
+            }
             (
                 syn::Expr::Tuple(syn::ExprTuple {
                     elems: expr_elems, ..


### PR DESCRIPTION
For some reason rust-analyzer seems to pass this instead of invisible group delimiters in macro expansions sometimes, resulting in errors in rust-analyzer but not rustc if this is not supported.
(Also that is trivial to support and may be something useful in other scenarios anyway.)