### PR TITLE
chore: replace dev-dependencies by dev-dependencies

### DIFF
--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.1.0", path = "../../../diesel", features = ["mysql"] }
 dotenvy = "0.15"
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.1.0", path = "../../../diesel", features = ["mysql"] }
 dotenvy = "0.15"
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.1.0", path = "../../../diesel", features = ["mysql"] }
 dotenvy = "0.15"
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.1.0", path = "../../../diesel", features = ["postgres"] }
 dotenvy = "0.15"
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.1.0", path = "../../../diesel", features = ["postgres"] }
 dotenvy = "0.15"
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2.1.0", path = "../../../diesel", features = ["postgres"] }
 dotenvy = "0.15"
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -11,7 +11,7 @@ diesel = { version = "2.1.0", path = "../../../diesel", features = ["sqlite"] }
 dotenvy = "0.15"
 libsqlite3-sys = { version = "0.28.0", features = ["bundled"] }
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -10,7 +10,7 @@ diesel = { version = "2.1.0", path = "../../../diesel", features = ["sqlite", "r
 dotenvy = "0.15"
 libsqlite3-sys = { version = "0.28.0", features = ["bundled"] }
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -10,7 +10,7 @@ diesel = { version = "2.1.0", path = "../../../diesel", features = ["sqlite", "r
 dotenvy = "0.15"
 libsqlite3-sys = { version = "0.28.0", features = ["bundled"] }
 
-[dev_dependencies]
+[dev-dependencies]
 assert_cmd = "2.0.14"
 
 [[bin]]


### PR DESCRIPTION
Hi!  I was trying to build the repo for the first time and noticed these warnings:
```bash
warning: /home/[...]/diesel/examples/mysql/getting_started_step_1/Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
(in the `diesel_demo_step_1_mysql` package)
warning: /home/[...]/diesel/examples/postgres/getting_started_step_3/Cargo.toml: `dev_dependencies` is deprecated in favor of `dev-dependencies` and will not work in the 2024 edition
(in the `diesel_demo_step_3_pg` package)
# ...
```
I double-checked in the [cargo repo](https://github.com/rust-lang/cargo/pull/13804).

And looks simple, so I'm fixing these here

Thanks!