### PR TITLE
feat/range contains range

### DIFF
--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -799,7 +799,7 @@ pub trait PgRangeExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
-    fn contains_range<T>(self, other: T) -> dsl::RangeContainsRange<Self, T>
+    fn contains_range<T>(self, other: T) -> dsl::ContainsRange<Self, T>
     where
         Self::SqlType: SqlType,
         T: AsExpression<Self::SqlType>,

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -744,7 +744,6 @@ pub trait PgRangeExpressionMethods: Expression + Sized {
     ///     .filter(versions.contains(1))
     ///     .load::<i32>(conn)?;
     /// assert!(amazing_posts.is_empty());
-    ///
     /// #     Ok(())
     /// # }
     /// ```
@@ -797,7 +796,6 @@ pub trait PgRangeExpressionMethods: Expression + Sized {
     ///     .filter(versions.contains_range((Bound::Included(2), Bound::Included(7))))
     ///     .load::<i32>(conn)?;
     /// assert!(amazing_posts.is_empty());
-    ///
     /// #     Ok(())
     /// # }
     /// ```

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -62,7 +62,7 @@ pub type RangeContains<Lhs, Rhs> = Grouped<
 /// The return type of [`lhs.contains(rhs)`](super::expression_methods::PgRangeExpressionMethods::contains_range)
 /// for range expressions
 #[cfg(feature = "postgres_backend")]
-pub type RangeContainsRange<Lhs, Rhs> = Contains<Lhs, Rhs>;
+pub type ContainsRange<Lhs, Rhs> = Contains<Lhs, Rhs>;
 
 /// The return type of [`lhs.is_contained_by(rhs)`](super::expression_methods::PgArrayExpressionMethods::is_contained_by)
 #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -59,6 +59,11 @@ pub type RangeContains<Lhs, Rhs> = Grouped<
     >,
 >;
 
+/// The return type of [`lhs.contains(rhs)`](super::expression_methods::PgRangeExpressionMethods::contains_range)
+/// for range expressions
+#[cfg(feature = "postgres_backend")]
+pub type RangeContainsRange<Lhs, Rhs> = Contains<Lhs, Rhs>;
+
 /// The return type of [`lhs.is_contained_by(rhs)`](super::expression_methods::PgArrayExpressionMethods::is_contained_by)
 #[cfg(feature = "postgres_backend")]
 pub type IsContainedBy<Lhs, Rhs> = Grouped<super::operators::IsContainedBy<Lhs, AsExpr<Rhs, Lhs>>>;

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -59,7 +59,7 @@ pub type RangeContains<Lhs, Rhs> = Grouped<
     >,
 >;
 
-/// The return type of [`lhs.contains(rhs)`](super::expression_methods::PgRangeExpressionMethods::contains_range)
+/// The return type of [`lhs.contains_range(rhs)`](super::expression_methods::PgRangeExpressionMethods::contains_range)
 /// for range expressions
 #[cfg(feature = "postgres_backend")]
 pub type ContainsRange<Lhs, Rhs> = Contains<Lhs, Rhs>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -288,6 +288,12 @@ fn test_pg_range_expression_methods() -> _ {
 
 #[cfg(feature = "postgres")]
 #[auto_type]
+fn test_pg_range_expression_methods() -> _ {
+    pg_extras::range.contains_range((Bound::Included(2i32), Bound::Included(7i32)))
+}
+
+#[cfg(feature = "postgres")]
+#[auto_type]
 fn test_pg_binary_expression_methods() -> _ {
     let b: &'static [u8] = &[];
     pg_extras::blob

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -289,6 +289,7 @@ fn test_pg_range_expression_methods() -> _ {
 #[cfg(feature = "postgres")]
 #[auto_type]
 fn test_pg_range_expression_methods() -> _ {
+    use std::ops::Bound;
     pg_extras::range.contains_range((Bound::Included(2i32), Bound::Included(7i32)))
 }
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -3,8 +3,6 @@ use diesel::dsl::*;
 use diesel::helper_types::*;
 use diesel::prelude::*;
 use diesel::sql_types;
-#[cfg(feature = "postgres")]
-use std::ops::Bound;
 
 table! {
     users {

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -3,6 +3,8 @@ use diesel::dsl::*;
 use diesel::helper_types::*;
 use diesel::prelude::*;
 use diesel::sql_types;
+#[cfg(feature = "postgres")]
+use std::ops::Bound;
 
 table! {
     users {
@@ -274,23 +276,16 @@ fn test_pg_jsonb_expression_methods() -> _ {
         .and(pg_extras::jsonb.is_contained_by(pg_extras::jsonb))
 }
 
-// `.contains()` cannot be supported here as
-// the type level constraints are slightly different
-// for `Range<>` than for the other types that provide a `contains()`
-// function. We could likely support it by
-// renaming the function to `.range_contains()` (or something similar)
-/*
 #[cfg(feature = "postgres")]
 #[auto_type]
 fn test_pg_range_expression_methods() -> _ {
-    pg_extras::range.contains(42_i32)
-}*/
-
-#[cfg(feature = "postgres")]
-#[auto_type]
-fn test_pg_range_expression_methods() -> _ {
-    use std::ops::Bound;
     pg_extras::range.contains_range((Bound::Included(2i32), Bound::Included(7i32)))
+    // `.contains()` cannot be supported here as
+    // the type level constraints are slightly different
+    // for `Range<>` than for the other types that provide a `contains()`
+    // function. We could likely support it by
+    // renaming the function to `.range_contains()` (or something similar)
+    // .contains(42_i32)
 }
 
 #[cfg(feature = "postgres")]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -276,17 +276,25 @@ fn test_pg_jsonb_expression_methods() -> _ {
         .and(pg_extras::jsonb.is_contained_by(pg_extras::jsonb))
 }
 
+/*
 #[cfg(feature = "postgres")]
 #[auto_type]
 fn test_pg_range_expression_methods() -> _ {
-    pg_extras::range.contains_range((Bound::Included(2i32), Bound::Included(7i32)))
-    // `.contains()` cannot be supported here as
-    // the type level constraints are slightly different
-    // for `Range<>` than for the other types that provide a `contains()`
-    // function. We could likely support it by
-    // renaming the function to `.range_contains()` (or something similar)
-    // .contains(42_i32)
+    pg_extras::range
+*/
+// `.contains_range` cannot be used because the macro
+// does not specify the correct variant `core::ops::Bound`.
+// .contains_range((Bound::Included(2i32), Bound::Included(7i32)))
+
+// `.contains()` cannot be supported here as
+// the type level constraints are slightly different
+// for `Range<>` than for the other types that provide a `contains()`
+// function. We could likely support it by
+// renaming the function to `.range_contains()` (or something similar)
+// .contains(42_i32)
+/*
 }
+*/
 
 #[cfg(feature = "postgres")]
 #[auto_type]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -3,6 +3,8 @@ use diesel::dsl::*;
 use diesel::helper_types::*;
 use diesel::prelude::*;
 use diesel::sql_types;
+#[cfg(feature = "postgres")]
+use std::ops::Bound;
 
 table! {
     users {
@@ -274,25 +276,20 @@ fn test_pg_jsonb_expression_methods() -> _ {
         .and(pg_extras::jsonb.is_contained_by(pg_extras::jsonb))
 }
 
-/*
 #[cfg(feature = "postgres")]
 #[auto_type]
 fn test_pg_range_expression_methods() -> _ {
-    pg_extras::range
-*/
-// `.contains_range` cannot be used because the macro
-// does not specify the correct variant `core::ops::Bound`.
-// .contains_range((Bound::Included(2i32), Bound::Included(7i32)))
+    let my_range: (Bound<i32>, Bound<i32>) = (Bound::Included(2), Bound::Included(7));
 
-// `.contains()` cannot be supported here as
-// the type level constraints are slightly different
-// for `Range<>` than for the other types that provide a `contains()`
-// function. We could likely support it by
-// renaming the function to `.range_contains()` (or something similar)
-// .contains(42_i32)
-/*
+    pg_extras::range.contains_range(my_range)
+
+    // `.contains()` cannot be supported here as
+    // the type level constraints are slightly different
+    // for `Range<>` than for the other types that provide a `contains()`
+    // function. We could likely support it by
+    // renaming the function to `.range_contains()` (or something similar)
+    // .contains(42_i32)
 }
-*/
 
 #[cfg(feature = "postgres")]
 #[auto_type]


### PR DESCRIPTION
Implements ` anyrange @> anyelement -> boolean` from https://github.com/diesel-rs/diesel/issues/4092
Following the helpful steps described by @weiznich 

## API Drawbacks
Currently the `‎PgArrayExpressionMethods::contains` receives `Array<T>`, so the Range API will be different using `contains` for a single element and `contains_range` for the range ([which was already noted here](https://github.com/diesel-rs/diesel/blob/99ef8bbdee614b8eb6560b00c4c1ead88fb0e737/diesel_derives/tests/auto_type.rs#L279))
Maybe it's possible to accept both `Range<T>` and `T` in the same function signature, but this is far from my knowledge, please let me know if it is possible!

This is also my first PR here, please let me know if I can do anything better!