### PR TITLE
Add is_contained_by to PgRangeExpressionMethods

### DIFF
--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -806,6 +806,57 @@ pub trait PgRangeExpressionMethods: Expression + Sized {
     {
         Grouped(Contains::new(self, other.as_expression()))
     }
+
+    /// Creates a PostgreSQL `<@` expression.
+    ///
+    /// This operator returns whether a range is contained by a specific element
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// diesel::insert_into(posts)
+    ///     .values(versions.eq((Bound::Included(5), Bound::Unbounded)))
+    ///     .execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(id)
+    ///     .filter(versions.is_contained_by((Bound::Included(1), Bound::Unbounded)))
+    ///     .load::<i32>(conn)?;
+    /// assert_eq!(vec![1], cool_posts);
+    ///
+    /// let amazing_posts = posts.select(id)
+    ///     .filter(versions.is_contained_by((Bound::Included(1), Bound::Included(2))))
+    ///     .load::<i32>(conn)?;
+    /// assert!(amazing_posts.is_empty());
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn is_contained_by<T>(self, other: T) -> dsl::IsContainedByRange<Self, T>
+    where
+        Self::SqlType: SqlType,
+        T: AsExpression<Self::SqlType>,
+    {
+        Grouped(IsContainedBy::new(self, other.as_expression()))
+    }
 }
 
 impl<T> PgRangeExpressionMethods for T

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -850,6 +850,7 @@ pub trait PgRangeExpressionMethods: Expression + Sized {
     /// #     Ok(())
     /// # }
     /// ```
+    #[allow(clippy::wrong_self_convention)] // This is named after the sql operator
     fn is_contained_by<T>(self, other: T) -> dsl::IsContainedByRange<Self, T>
     where
         Self::SqlType: SqlType,

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -851,7 +851,7 @@ pub trait PgRangeExpressionMethods: Expression + Sized {
     /// # }
     /// ```
     #[allow(clippy::wrong_self_convention)] // This is named after the sql operator
-    fn is_contained_by<T>(self, other: T) -> dsl::IsContainedByRange<Self, T>
+    fn is_contained_by<T>(self, other: T) -> dsl::IsContainedBy<Self, T>
     where
         Self::SqlType: SqlType,
         T: AsExpression<Self::SqlType>,

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -64,6 +64,11 @@ pub type RangeContains<Lhs, Rhs> = Grouped<
 #[cfg(feature = "postgres_backend")]
 pub type ContainsRange<Lhs, Rhs> = Contains<Lhs, Rhs>;
 
+/// The return type of [`lhs.is_contained_by(rhs)`](super::expression_methods::PgRangeExpressionMethods::is_contained_by)
+#[cfg(feature = "postgres_backend")]
+pub type IsContainedByRange<Lhs, Rhs> =
+    Grouped<super::operators::IsContainedBy<Lhs, AsExpr<Rhs, Lhs>>>;
+
 /// The return type of [`lhs.is_contained_by(rhs)`](super::expression_methods::PgArrayExpressionMethods::is_contained_by)
 #[cfg(feature = "postgres_backend")]
 pub type IsContainedBy<Lhs, Rhs> = Grouped<super::operators::IsContainedBy<Lhs, AsExpr<Rhs, Lhs>>>;

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -64,12 +64,8 @@ pub type RangeContains<Lhs, Rhs> = Grouped<
 #[cfg(feature = "postgres_backend")]
 pub type ContainsRange<Lhs, Rhs> = Contains<Lhs, Rhs>;
 
-/// The return type of [`lhs.is_contained_by(rhs)`](super::expression_methods::PgRangeExpressionMethods::is_contained_by)
-#[cfg(feature = "postgres_backend")]
-pub type IsContainedByRange<Lhs, Rhs> =
-    Grouped<super::operators::IsContainedBy<Lhs, AsExpr<Rhs, Lhs>>>;
-
-/// The return type of [`lhs.is_contained_by(rhs)`](super::expression_methods::PgArrayExpressionMethods::is_contained_by)
+/// The return type of [`lhs.range_is_contained_by(rhs)`](super::expression_methods::PgRangeExpressionMethods::is_contained_by)
+/// and [`lhs.is_contained_by(rhs)`](super::expression_methods::PgArrayExpressionMethods::is_contained_by)
 #[cfg(feature = "postgres_backend")]
 pub type IsContainedBy<Lhs, Rhs> = Grouped<super::operators::IsContainedBy<Lhs, AsExpr<Rhs, Lhs>>>;
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -281,7 +281,9 @@ fn test_pg_jsonb_expression_methods() -> _ {
 fn test_pg_range_expression_methods() -> _ {
     let my_range: (Bound<i32>, Bound<i32>) = (Bound::Included(2), Bound::Included(7));
 
-    pg_extras::range.contains_range(my_range)
+    pg_extras::range
+        .contains_range(my_range)
+        .and(pg_extras::range.is_contained_by(my_range))
 
     // `.contains()` cannot be supported here as
     // the type level constraints are slightly different


### PR DESCRIPTION
This is adding support for `anyrange <@ anyrange -> boolean` for #4092 
Added helper type, method operation, and auto test

This is my first PR, let me know if there's anything I need to add to this or anything I should do different in the future