### PR TITLE
Add a `diesel::dsl::Returning` typedef

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -673,6 +673,13 @@ pub mod helper_types {
         <U as crate::query_builder::update_statement::UpdateAutoTypeHelper>::Where,
         <V as crate::AsChangeset>::Changeset,
     >;
+
+    /// Represents the return type of
+    /// [`InsertStatement::returning`](crate::query_builder::InsertStatement::returning),
+    /// [`UpdateStatement::returning`] and
+    /// [`DeleteStatement::returning`](crate::query_builder::DeleteStatement::returning)
+    pub type Returning<Q, S> =
+        <Q as crate::query_builder::returning_clause::ReturningClauseHelper<S>>::WithReturning;
 }
 
 pub mod prelude {

--- a/diesel/src/query_builder/returning_clause.rs
+++ b/diesel/src/query_builder/returning_clause.rs
@@ -1,7 +1,11 @@
+use super::DeleteStatement;
+use super::InsertStatement;
+use super::UpdateStatement;
 use super::{AstPass, QueryFragment};
 use crate::backend::{Backend, DieselReserveSpecialization};
 use crate::query_builder::QueryId;
 use crate::result::QueryResult;
+use crate::QuerySource;
 
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct NoReturningClause;
@@ -51,4 +55,29 @@ where
         self.0.walk_ast(out.reborrow())?;
         Ok(())
     }
+}
+
+pub trait ReturningClauseHelper<S> {
+    type WithReturning;
+}
+
+impl<S, T, U, Op> ReturningClauseHelper<S> for InsertStatement<T, U, Op>
+where
+    T: QuerySource,
+{
+    type WithReturning = InsertStatement<T, U, Op, ReturningClause<S>>;
+}
+
+impl<S, T, U, V> ReturningClauseHelper<S> for UpdateStatement<T, U, V>
+where
+    T: QuerySource,
+{
+    type WithReturning = UpdateStatement<T, U, V, ReturningClause<S>>;
+}
+
+impl<S, T, U> ReturningClauseHelper<S> for DeleteStatement<T, U>
+where
+    T: QuerySource,
+{
+    type WithReturning = DeleteStatement<T, U, ReturningClause<S>>;
 }

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -378,6 +378,18 @@ fn with_const_generics<const N: i32>() -> _ {
     users::id.eq(N)
 }
 
+#[auto_type]
+fn insert_returning() -> _ {
+    insert_into(users::table)
+        .values(users::id.eq(42_i32))
+        .returning(users::id)
+}
+
+#[auto_type]
+fn delete_returning() -> _ {
+    delete(users::table).returning(users::id)
+}
+
 // #[auto_type]
 // fn test_sql_fragment() -> _ {
 //     sql("foo")


### PR DESCRIPTION
This enables support for `#[auto_type]` for insert/delete statements with returning clauses. It also allows to specify the type of update statements with returning clauses.