### PR TITLE
add lower(Range) function

### DIFF
--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -2450,7 +2450,8 @@ where
 
 pub(in crate::pg) mod private {
     use crate::sql_types::{
-        Array, Binary, Cidr, Inet, Integer, Json, Jsonb, Nullable, Range, SqlType, Text,
+        Array, Binary, Cidr, Inet, Integer, Json, Jsonb, Nullable, Range, SingleValue, SqlType,
+        Text,
     };
     use crate::{Expression, IntoSql};
 
@@ -2492,13 +2493,14 @@ pub(in crate::pg) mod private {
 
     /// Marker trait used to extract the inner type
     /// of our `Range<T>` sql type, used to implement `PgRangeExpressionMethods`
-    pub trait RangeHelper: SqlType {
-        type Inner;
+    pub trait RangeHelper: SqlType + SingleValue {
+        type Inner: SingleValue;
     }
 
     impl<ST> RangeHelper for Range<ST>
     where
         Self: 'static,
+        ST: SingleValue,
     {
         type Inner = ST;
     }

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -104,5 +104,5 @@ define_sql_function! {
     /// # }
     /// ```
     #[cfg(feature = "postgres_backend")]
-    fn lower<T: RangeHelper<Inner: SingleValue> + SingleValue>(range: T) -> Nullable<<T as RangeHelper>::Inner>;
+    fn lower<T: RangeHelper>(range: T) -> Nullable<<T as RangeHelper>::Inner>;
 }

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1,6 +1,7 @@
 //! PostgreSQL specific functions
 
 use super::expression_methods::InetOrCidr;
+use super::expression_methods::RangeHelper;
 use crate::expression::functions::define_sql_function;
 use crate::sql_types::*;
 
@@ -61,4 +62,47 @@ define_sql_function! {
     /// netmask are set to zero.
     #[cfg(feature = "postgres_backend")]
     fn set_masklen<T: InetOrCidr + SingleValue>(addr: T, len: Integer) -> T;
+}
+
+define_sql_function! {
+    /// Returns the lower bound of the range.
+    /// if the range is empty or has no lower bound, it returns NULL.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// use diesel::dsl::lower;
+    /// diesel::insert_into(posts)
+    ///     .values(&[
+    ///        versions.eq((Bound::Included(5), Bound::Included(7))),
+    ///        versions.eq((Bound::Unbounded, Bound::Included(7)))
+    ///     ]).execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(lower(versions))
+    ///     .load::<Option<i32>>(conn)?;
+    /// assert_eq!(vec![Some(5), None], cool_posts);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "postgres_backend")]
+    fn lower<T: RangeHelper<Inner: SingleValue> + SingleValue>(range: T) -> Nullable<<T as RangeHelper>::Inner>;
 }

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -281,14 +281,15 @@ fn test_pg_jsonb_expression_methods() -> _ {
 fn test_pg_range_expression_methods() -> _ {
     let my_range: (Bound<i32>, Bound<i32>) = (Bound::Included(2), Bound::Included(7));
 
-    pg_extras::range.contains_range(my_range)
-
-    // `.contains()` cannot be supported here as
-    // the type level constraints are slightly different
-    // for `Range<>` than for the other types that provide a `contains()`
-    // function. We could likely support it by
-    // renaming the function to `.range_contains()` (or something similar)
-    // .contains(42_i32)
+    pg_extras::range
+        .contains_range(my_range)
+        // `.contains()` cannot be supported here as
+        // the type level constraints are slightly different
+        // for `Range<>` than for the other types that provide a `contains()`
+        // function. We could likely support it by
+        // renaming the function to `.range_contains()` (or something similar)
+        // .contains(42_i32)
+        .select(lower(pg_extras::range))
 }
 
 #[cfg(feature = "postgres")]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -281,15 +281,15 @@ fn test_pg_jsonb_expression_methods() -> _ {
 fn test_pg_range_expression_methods() -> _ {
     let my_range: (Bound<i32>, Bound<i32>) = (Bound::Included(2), Bound::Included(7));
 
-    pg_extras::range
-        .contains_range(my_range)
-        // `.contains()` cannot be supported here as
-        // the type level constraints are slightly different
-        // for `Range<>` than for the other types that provide a `contains()`
-        // function. We could likely support it by
-        // renaming the function to `.range_contains()` (or something similar)
-        // .contains(42_i32)
-        .select(lower(pg_extras::range))
+    pg_extras::range.contains_range(my_range)
+    // `.contains()` cannot be supported here as
+    // the type level constraints are slightly different
+    // for `Range<>` than for the other types that provide a `contains()`
+    // function. We could likely support it by
+    // renaming the function to `.range_contains()` (or something similar)
+    // .contains(42_i32)
+    // this kind of free standing functions is not supported by auto_type yet
+    //.select(lower(pg_extras::range))
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
This is adding support for `lower(anyrange) -> any`, part of https://github.com/diesel-rs/diesel/issues/4092
Added method operation and auto test.

This function has the same name as `lower(text)`, maybe we want a specific name to not overlap in the future, like `lower_range`.