### PR TITLE
Implements `int4range`

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -109,7 +109,6 @@ define_sql_function! {
 
 define_sql_function! {
     /// Returns range of integer.
-    /// if the range is empty or has no lower bound, it returns NULL.
     /// # Example
     ///
     /// ```rust

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -172,6 +172,7 @@ pub mod sql_types {
     /// used in functions int4range, int8range, numrange, tsrange, tstzrange, daterange.
     #[derive(Debug, Clone, Copy, diesel_derives::AsExpression)]
     #[diesel(sql_type = RangeBoundEnum)]
+    #[allow(clippy::enum_variant_names)]
     pub enum RangeBound {
         /// postgres '[]'
         LowerBoundInclusiveUpperBoundInclusive,

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -161,6 +161,28 @@ pub mod sql_types {
     #[doc(hidden)]
     pub type Tstzrange = Range<crate::sql_types::Timestamptz>;
 
+    /// This is a wrapper for [`RangeBound`] to represent range bounds: '[]', '(]', '[)', '()',
+    /// used in functions int4range, int8range, numrange, tsrange, tstzrange, daterange.
+    #[derive(Debug, Clone, Copy, QueryId, SqlType)]
+    #[cfg(feature = "postgres_backend")]
+    #[diesel(postgres_type(name = "text"))]
+    pub struct RangeBoundEnum;
+
+    /// Represent postgres range bounds: '[]', '(]', '[)', '()',
+    /// used in functions int4range, int8range, numrange, tsrange, tstzrange, daterange.
+    #[derive(Debug, Clone, Copy, diesel_derives::AsExpression)]
+    #[diesel(sql_type = RangeBoundEnum)]
+    pub enum RangeBound {
+        /// postgres '[]'
+        LowerBoundInclusiveUpperBoundInclusive,
+        /// postgres '[)'
+        LowerBoundInclusiveUpperBoundExclusive,
+        /// postgres '(]'
+        LowerBoundExclusiveUpperBoundInclusive,
+        /// postgres '()'
+        LowerBoundExclusiveUpperBoundExclusive,
+    }
+
     /// The [`Record`] (a.k.a. tuple) SQL type.
     ///
     /// ### [`ToSql`] impls

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -224,7 +224,7 @@ impl ToSql<RangeBoundEnum, Pg> for RangeBound {
             Self::LowerBoundInclusiveUpperBoundInclusive => "[]",
             Self::LowerBoundInclusiveUpperBoundExclusive => "[)",
             Self::LowerBoundExclusiveUpperBoundInclusive => "(]",
-            Self::LowerBoundExclusiveUpperBoundExclusive => "[]",
+            Self::LowerBoundExclusiveUpperBoundExclusive => "()",
         };
         out.write_all(literal.as_bytes())
             .map(|_| IsNull::No)

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -279,19 +279,28 @@ fn test_pg_jsonb_expression_methods() -> _ {
 #[cfg(feature = "postgres")]
 #[auto_type]
 fn test_pg_range_expression_methods() -> _ {
+    use diesel::sql_types::RangeBound;
+
     let my_range: (Bound<i32>, Bound<i32>) = (Bound::Included(2), Bound::Included(7));
 
     pg_extras::range
         .contains_range(my_range)
         .and(pg_extras::range.is_contained_by(my_range))
-    // `.contains()` cannot be supported here as
-    // the type level constraints are slightly different
-    // for `Range<>` than for the other types that provide a `contains()`
-    // function. We could likely support it by
-    // renaming the function to `.range_contains()` (or something similar)
-    // .contains(42_i32)
-    // this kind of free standing functions is not supported by auto_type yet
-    //.select(lower(pg_extras::range))
+        // `.contains()` cannot be supported here as
+        // the type level constraints are slightly different
+        // for `Range<>` than for the other types that provide a `contains()`
+        // function. We could likely support it by
+        // renaming the function to `.range_contains()` (or something similar)
+        // .contains(42_i32)
+        .select(
+            // this kind of free standing functions is not supported by auto_type yet
+            //lower(pg_extras::range),
+            int4range(
+                None,
+                Some(5i32),
+                RangeBound::LowerBoundInclusiveUpperBoundInclusive,
+            ),
+        )
 }
 
 #[cfg(feature = "postgres")]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -293,7 +293,7 @@ fn test_pg_range_expression_methods() -> _ {
     //.select(
     // this kind of free standing functions is not supported by auto_type yet
     //lower(pg_extras::range),
-    // The auto_trait also dind't like this one
+    // The auto_trait also didn't like this one
     //int4range(None, Some(5i32), RangeBound::LowerBoundInclusiveUpperBoundInclusive),
     //)
 }

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -279,28 +279,23 @@ fn test_pg_jsonb_expression_methods() -> _ {
 #[cfg(feature = "postgres")]
 #[auto_type]
 fn test_pg_range_expression_methods() -> _ {
-    use diesel::sql_types::RangeBound;
-
     let my_range: (Bound<i32>, Bound<i32>) = (Bound::Included(2), Bound::Included(7));
 
     pg_extras::range
         .contains_range(my_range)
         .and(pg_extras::range.is_contained_by(my_range))
-        // `.contains()` cannot be supported here as
-        // the type level constraints are slightly different
-        // for `Range<>` than for the other types that provide a `contains()`
-        // function. We could likely support it by
-        // renaming the function to `.range_contains()` (or something similar)
-        // .contains(42_i32)
-        .select(
-            // this kind of free standing functions is not supported by auto_type yet
-            //lower(pg_extras::range),
-            int4range(
-                None,
-                Some(5i32),
-                RangeBound::LowerBoundInclusiveUpperBoundInclusive,
-            ),
-        )
+    // `.contains()` cannot be supported here as
+    // the type level constraints are slightly different
+    // for `Range<>` than for the other types that provide a `contains()`
+    // function. We could likely support it by
+    // renaming the function to `.range_contains()` (or something similar)
+    // .contains(42_i32)
+    //.select(
+    // this kind of free standing functions is not supported by auto_type yet
+    //lower(pg_extras::range),
+    // The auto_trait also dind't like this one
+    //int4range(None, Some(5i32), RangeBound::LowerBoundInclusiveUpperBoundInclusive),
+    //)
 }
 
 #[cfg(feature = "postgres")]

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1449,6 +1449,18 @@ fn test_range_bound_enum_to_sql() {
         "'[]'",
         RangeBound::LowerBoundInclusiveUpperBoundInclusive
     ));
+    assert!(query_to_sql_equality::<RangeBoundEnum, RangeBound>(
+        "'[)'",
+        RangeBound::LowerBoundInclusiveUpperBoundExclusive
+    ));
+    assert!(query_to_sql_equality::<RangeBoundEnum, RangeBound>(
+        "'(]'",
+        RangeBound::LowerBoundExclusiveUpperBoundInclusive
+    ));
+    assert!(query_to_sql_equality::<RangeBoundEnum, RangeBound>(
+        "'()'",
+        RangeBound::LowerBoundExclusiveUpperBoundExclusive
+    ));
 }
 
 #[cfg(feature = "postgres")]

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1444,6 +1444,15 @@ fn test_range_to_sql() {
 
 #[cfg(feature = "postgres")]
 #[test]
+fn test_range_bound_enum_to_sql() {
+    assert!(query_to_sql_equality::<RangeBoundEnum, RangeBound>(
+        "'[]'",
+        RangeBound::LowerBoundInclusiveUpperBoundInclusive
+    ));
+}
+
+#[cfg(feature = "postgres")]
+#[test]
 fn test_inserting_ranges() {
     use std::collections::Bound;
 


### PR DESCRIPTION
This is adding support for `int4range(Nullable<Integer>, Nullable<Integer>, RangeBoundEnum) -> int4range` for https://github.com/diesel-rs/diesel/issues/4092