### PR TITLE
Remove the unsound `SerializedDatabase::new` function

### DIFF
--- a/diesel/src/sqlite/connection/serialized_database.rs
+++ b/diesel/src/sqlite/connection/serialized_database.rs
@@ -13,7 +13,10 @@ pub struct SerializedDatabase {
 
 impl SerializedDatabase {
     /// Creates a new `SerializedDatabase` with the given data pointer and length.
-    pub fn new(data: *mut u8, len: usize) -> Self {
+    ///
+    /// SAFETY: The data pointer needs to be returned by sqlite
+    ///         and the length must match the underlying buffer pointer
+    pub(crate) unsafe fn new(data: *mut u8, len: usize) -> Self {
         Self { data, len }
     }
 


### PR DESCRIPTION
This commit removes the unsound `SerializedDatabase::new` function from the stable API. Semver explicitly allows breaking changes for critical bug fixes and I would classify fixing soundness bugs as critical so this should be fine to do.

Practical speaking I wouldn't expect anyone to use that function anyway as the only reasonable use of `SerializedDatabase` is to be produced bye the `SqliteConnection::serialize_database_to_buffer` function. The corresponding
`SqliteConnection::deserialize_readonly_database_from_buffer` function accepts a `&[u8]` buffer that can be allocated on the rust side. It looks like we just "missed" to mark this function as not-public.

Fixes #4108