### PR TITLE
implements to_sql `diesel::Range` to `std::Range*`

### DIFF
--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -135,6 +135,11 @@ pub mod sql_types {
     /// ### [`ToSql`] impls
     ///
     /// - [`(Bound<T>, Bound<T>)`][bound] for any `T` which implements `ToSql<ST>`.
+    /// - [`Range<T>`][std::range] for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeInclusive<T>`] for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeFrom<T>`] for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeTo<T>`] for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeToInclusive<T>`] for any `T` which implements `ToSql<ST>`.
     ///
     /// ### [`FromSql`] impls
     ///
@@ -143,6 +148,11 @@ pub mod sql_types {
     /// [`ToSql`]: crate::serialize::ToSql
     /// [`FromSql`]: crate::deserialize::FromSql
     /// [bound]: std::collections::Bound
+    /// [std::range]: std::ops::Range
+    /// [`RangeInclusive<T>`]: std::ops::RangeInclusive
+    /// [`RangeFrom<T>`]: std::ops::RangeFrom
+    /// [`RangeTo<T>`]: std::ops::RangeTo
+    /// [`RangeToInclusive<T>`]: std::ops::RangeToInclusive
     /// [`Range`]: https://www.postgresql.org/docs/current/rangetypes.html
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
     #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -135,11 +135,11 @@ pub mod sql_types {
     /// ### [`ToSql`] impls
     ///
     /// - [`(Bound<T>, Bound<T>)`][bound] for any `T` which implements `ToSql<ST>`.
-    /// - [`Range<T>`][std::range] for any `T` which implements `ToSql<ST>`.
-    /// - [`RangeInclusive<T>`] for any `T` which implements `ToSql<ST>`.
-    /// - [`RangeFrom<T>`] for any `T` which implements `ToSql<ST>`.
-    /// - [`RangeTo<T>`] for any `T` which implements `ToSql<ST>`.
-    /// - [`RangeToInclusive<T>`] for any `T` which implements `ToSql<ST>`.
+    /// - [`Range<T>`][std::range] (aka `start..end`) for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeInclusive<T>`] (aka `start..=end`) for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeFrom<T>`] (aka `start..`) for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeTo<T>`] (aka `..end`) for any `T` which implements `ToSql<ST>`.
+    /// - [`RangeToInclusive<T>`] (aka `..=end`) for any `T` which implements `ToSql<ST>`.
     ///
     /// ### [`FromSql`] impls
     ///

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -24,41 +24,26 @@ bitflags::bitflags! {
     }
 }
 
-#[cfg(feature = "postgres_backend")]
-impl<ST: 'static, T> AsExpression<Range<ST>> for (Bound<T>, Bound<T>) {
-    type Expression = SqlBound<Range<ST>, Self>;
+macro_rules! range_as_expression {
+    ($ty:ty; $sql_type:ty) => {
+        #[cfg(feature = "postgres_backend")]
+        // this simplifies the macro implementation
+        // as some macro calls use this lifetime
+        #[allow(clippy::extra_unused_lifetimes)]
+        impl<'a, 'b, ST: 'static, T> AsExpression<$sql_type> for $ty {
+            type Expression = SqlBound<$sql_type, Self>;
 
-    fn as_expression(self) -> Self::Expression {
-        SqlBound::new(self)
-    }
+            fn as_expression(self) -> Self::Expression {
+                SqlBound::new(self)
+            }
+        }
+    };
 }
 
-#[cfg(feature = "postgres_backend")]
-impl<'a, ST: 'static, T> AsExpression<Range<ST>> for &'a (Bound<T>, Bound<T>) {
-    type Expression = SqlBound<Range<ST>, Self>;
-
-    fn as_expression(self) -> Self::Expression {
-        SqlBound::new(self)
-    }
-}
-
-#[cfg(feature = "postgres_backend")]
-impl<ST: 'static, T> AsExpression<Nullable<Range<ST>>> for (Bound<T>, Bound<T>) {
-    type Expression = SqlBound<Nullable<Range<ST>>, Self>;
-
-    fn as_expression(self) -> Self::Expression {
-        SqlBound::new(self)
-    }
-}
-
-#[cfg(feature = "postgres_backend")]
-impl<'a, ST: 'static, T> AsExpression<Nullable<Range<ST>>> for &'a (Bound<T>, Bound<T>) {
-    type Expression = SqlBound<Nullable<Range<ST>>, Self>;
-
-    fn as_expression(self) -> Self::Expression {
-        SqlBound::new(self)
-    }
-}
+range_as_expression!((Bound<T>, Bound<T>); Range<ST>);
+range_as_expression!(&'a (Bound<T>, Bound<T>); Range<ST>);
+range_as_expression!((Bound<T>, Bound<T>); Nullable<Range<ST>>);
+range_as_expression!(&'a (Bound<T>, Bound<T>); Nullable<Range<ST>>);
 
 #[cfg(feature = "postgres_backend")]
 impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -30,7 +30,7 @@ macro_rules! range_as_expression {
         // this simplifies the macro implementation
         // as some macro calls use this lifetime
         #[allow(clippy::extra_unused_lifetimes)]
-        impl<'a, 'b, ST: 'static, T> AsExpression<$sql_type> for $ty {
+        impl<'a, ST: 'static, T> AsExpression<$sql_type> for $ty {
             type Expression = SqlBound<$sql_type, Self>;
 
             fn as_expression(self) -> Self::Expression {

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -45,6 +45,31 @@ range_as_expression!(&'a (Bound<T>, Bound<T>); Range<ST>);
 range_as_expression!((Bound<T>, Bound<T>); Nullable<Range<ST>>);
 range_as_expression!(&'a (Bound<T>, Bound<T>); Nullable<Range<ST>>);
 
+range_as_expression!(std::ops::Range<T>; Range<ST>);
+range_as_expression!(&'a std::ops::Range<T>; Range<ST>);
+range_as_expression!(std::ops::Range<T>; Nullable<Range<ST>>);
+range_as_expression!(&'a std::ops::Range<T>; Nullable<Range<ST>>);
+
+range_as_expression!(std::ops::RangeInclusive<T>; Range<ST>);
+range_as_expression!(&'a std::ops::RangeInclusive<T>; Range<ST>);
+range_as_expression!(std::ops::RangeInclusive<T>; Nullable<Range<ST>>);
+range_as_expression!(&'a std::ops::RangeInclusive<T>; Nullable<Range<ST>>);
+
+range_as_expression!(std::ops::RangeToInclusive<T>; Range<ST>);
+range_as_expression!(&'a std::ops::RangeToInclusive<T>; Range<ST>);
+range_as_expression!(std::ops::RangeToInclusive<T>; Nullable<Range<ST>>);
+range_as_expression!(&'a std::ops::RangeToInclusive<T>; Nullable<Range<ST>>);
+
+range_as_expression!(std::ops::RangeFrom<T>; Range<ST>);
+range_as_expression!(&'a std::ops::RangeFrom<T>; Range<ST>);
+range_as_expression!(std::ops::RangeFrom<T>; Nullable<Range<ST>>);
+range_as_expression!(&'a std::ops::RangeFrom<T>; Nullable<Range<ST>>);
+
+range_as_expression!(std::ops::RangeTo<T>; Range<ST>);
+range_as_expression!(&'a std::ops::RangeTo<T>; Range<ST>);
+range_as_expression!(std::ops::RangeTo<T>; Nullable<Range<ST>>);
+range_as_expression!(&'a std::ops::RangeTo<T>; Nullable<Range<ST>>);
+
 #[cfg(feature = "postgres_backend")]
 impl<T, ST> FromSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
@@ -97,68 +122,110 @@ where
 }
 
 #[cfg(feature = "postgres_backend")]
+fn to_sql<ST, T>(
+    start: Bound<&T>,
+    end: Bound<&T>,
+    out: &mut Output<'_, '_, Pg>,
+) -> serialize::Result
+where
+    T: ToSql<ST, Pg>,
+{
+    let mut flags = match start {
+        Bound::Included(_) => RangeFlags::LB_INC,
+        Bound::Excluded(_) => RangeFlags::empty(),
+        Bound::Unbounded => RangeFlags::LB_INF,
+    };
+
+    flags |= match end {
+        Bound::Included(_) => RangeFlags::UB_INC,
+        Bound::Excluded(_) => RangeFlags::empty(),
+        Bound::Unbounded => RangeFlags::UB_INF,
+    };
+
+    out.write_u8(flags.bits())?;
+
+    let mut buffer = Vec::new();
+
+    match start {
+        Bound::Included(ref value) | Bound::Excluded(ref value) => {
+            {
+                let mut inner_buffer = Output::new(ByteWrapper(&mut buffer), out.metadata_lookup());
+                value.to_sql(&mut inner_buffer)?;
+            }
+            out.write_u32::<NetworkEndian>(buffer.len() as u32)?;
+            out.write_all(&buffer)?;
+            buffer.clear();
+        }
+        Bound::Unbounded => {}
+    }
+
+    match end {
+        Bound::Included(ref value) | Bound::Excluded(ref value) => {
+            {
+                let mut inner_buffer = Output::new(ByteWrapper(&mut buffer), out.metadata_lookup());
+                value.to_sql(&mut inner_buffer)?;
+            }
+            out.write_u32::<NetworkEndian>(buffer.len() as u32)?;
+            out.write_all(&buffer)?;
+        }
+        Bound::Unbounded => {}
+    }
+
+    Ok(IsNull::No)
+}
+
+#[cfg(feature = "postgres_backend")]
 impl<ST, T> ToSql<Range<ST>, Pg> for (Bound<T>, Bound<T>)
 where
     T: ToSql<ST, Pg>,
 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
-        let mut flags = match self.0 {
-            Bound::Included(_) => RangeFlags::LB_INC,
-            Bound::Excluded(_) => RangeFlags::empty(),
-            Bound::Unbounded => RangeFlags::LB_INF,
-        };
-
-        flags |= match self.1 {
-            Bound::Included(_) => RangeFlags::UB_INC,
-            Bound::Excluded(_) => RangeFlags::empty(),
-            Bound::Unbounded => RangeFlags::UB_INF,
-        };
-
-        out.write_u8(flags.bits())?;
-
-        let mut buffer = Vec::new();
-
-        match self.0 {
-            Bound::Included(ref value) | Bound::Excluded(ref value) => {
-                {
-                    let mut inner_buffer =
-                        Output::new(ByteWrapper(&mut buffer), out.metadata_lookup());
-                    value.to_sql(&mut inner_buffer)?;
-                }
-                out.write_u32::<NetworkEndian>(buffer.len() as u32)?;
-                out.write_all(&buffer)?;
-                buffer.clear();
-            }
-            Bound::Unbounded => {}
-        }
-
-        match self.1 {
-            Bound::Included(ref value) | Bound::Excluded(ref value) => {
-                {
-                    let mut inner_buffer =
-                        Output::new(ByteWrapper(&mut buffer), out.metadata_lookup());
-                    value.to_sql(&mut inner_buffer)?;
-                }
-                out.write_u32::<NetworkEndian>(buffer.len() as u32)?;
-                out.write_all(&buffer)?;
-            }
-            Bound::Unbounded => {}
-        }
-
-        Ok(IsNull::No)
+        to_sql(self.0.as_ref(), self.1.as_ref(), out)
     }
 }
 
-#[cfg(feature = "postgres_backend")]
-impl<ST, T> ToSql<Nullable<Range<ST>>, Pg> for (Bound<T>, Bound<T>)
-where
-    ST: 'static,
-    (Bound<T>, Bound<T>): ToSql<Range<ST>, Pg>,
-{
-    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
-        ToSql::<Range<ST>, Pg>::to_sql(self, out)
-    }
+use std::ops::RangeBounds;
+macro_rules! range_std_to_sql {
+    ($ty:ty) => {
+        #[cfg(feature = "postgres_backend")]
+        impl<ST, T> ToSql<Range<ST>, Pg> for $ty
+        where
+            ST: 'static,
+            T: ToSql<ST, Pg>,
+        {
+            fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+                to_sql(self.start_bound(), self.end_bound(), out)
+            }
+        }
+    };
 }
+
+range_std_to_sql!(std::ops::Range<T>);
+range_std_to_sql!(std::ops::RangeInclusive<T>);
+range_std_to_sql!(std::ops::RangeFrom<T>);
+range_std_to_sql!(std::ops::RangeTo<T>);
+range_std_to_sql!(std::ops::RangeToInclusive<T>);
+
+macro_rules! range_to_sql_nullable {
+    ($ty:ty) => {
+        #[cfg(feature = "postgres_backend")]
+        impl<ST, T> ToSql<Nullable<Range<ST>>, Pg> for $ty
+        where
+            ST: 'static,
+            $ty: ToSql<Range<ST>, Pg>,
+        {
+            fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+                ToSql::<Range<ST>, Pg>::to_sql(self, out)
+            }
+        }
+    };
+}
+range_to_sql_nullable!((Bound<T>, Bound<T>));
+range_to_sql_nullable!(std::ops::Range<T>);
+range_to_sql_nullable!(std::ops::RangeInclusive<T>);
+range_to_sql_nullable!(std::ops::RangeFrom<T>);
+range_to_sql_nullable!(std::ops::RangeTo<T>);
+range_to_sql_nullable!(std::ops::RangeToInclusive<T>);
 
 #[cfg(feature = "postgres_backend")]
 impl HasSqlType<Int4range> for Pg {

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1434,12 +1434,47 @@ fn test_range_to_sql() {
     use std::collections::Bound;
 
     let expected_value = "'[1,2]'::int4range";
-    let value = (Bound::Included(1), Bound::Excluded(3));
+    let value = (Bound::Included(1), Bound::Included(2));
     assert!(query_to_sql_equality::<Range<Int4>, (Bound<i32>, Bound<i32>)>(expected_value, value));
+    let value = 1..=2;
+    assert!(query_to_sql_equality::<
+        Range<Int4>,
+        std::ops::RangeInclusive<i32>,
+    >(expected_value, value));
 
     let expected_value = "'(1,2]'::int4range";
-    let value = (Bound::Included(2), Bound::Excluded(3));
+    let value = (Bound::Excluded(1), Bound::Included(2));
     assert!(query_to_sql_equality::<Range<Int4>, (Bound<i32>, Bound<i32>)>(expected_value, value));
+
+    let expected_value = "'[1,2)'::int4range";
+    let value = (Bound::Included(1), Bound::Excluded(2));
+    assert!(query_to_sql_equality::<Range<Int4>, (Bound<i32>, Bound<i32>)>(expected_value, value));
+    let value = 1..2;
+    assert!(query_to_sql_equality::<Range<Int4>, std::ops::Range<i32>>(
+        expected_value,
+        value
+    ));
+
+    let expected_value = "'(,2)'::int4range";
+    let value = (Bound::Unbounded, Bound::Excluded(2));
+    assert!(query_to_sql_equality::<Range<Int4>, (Bound<i32>, Bound<i32>)>(expected_value, value));
+    let value = ..2;
+    assert!(query_to_sql_equality::<Range<Int4>, std::ops::RangeTo<i32>>(expected_value, value));
+
+    let expected_value = "'(,2]'::int4range";
+    let value = (Bound::Unbounded, Bound::Included(2));
+    assert!(query_to_sql_equality::<Range<Int4>, (Bound<i32>, Bound<i32>)>(expected_value, value));
+    let value = ..=2;
+    assert!(query_to_sql_equality::<
+        Range<Int4>,
+        std::ops::RangeToInclusive<i32>,
+    >(expected_value, value));
+
+    let expected_value = "'[1,)'::int4range";
+    let value = (Bound::Included(1), Bound::Unbounded);
+    assert!(query_to_sql_equality::<Range<Int4>, (Bound<i32>, Bound<i32>)>(expected_value, value));
+    let value = 1..;
+    assert!(query_to_sql_equality::<Range<Int4>, std::ops::RangeFrom<i32>>(expected_value, value));
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
With this PR we can now use `1..` instead `(Bound::Inclded(1), Bound::Unbounded)` for all `std::ops::Range.*<T>`.

I only didn't implement the `RangeFull` because it does not have a type so I didn't know how to keep the contraint in `T`.
