### PR TITLE
Fixed a potential panic in SQLite row iterators

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -54,6 +54,7 @@ cfg-if = "1"
 dotenvy = "0.15"
 ipnetwork = ">=0.12.2, <0.21.0"
 quickcheck = "1.0.3"
+tempfile = "3.10.1"
 
 [features]
 default = ["with-deprecated", "32-column-tables"]

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -92,7 +92,7 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
     fn next(&mut self) -> Option<Self::Item> {
         use PrivateStatementIterator::{NotStarted, Started};
         match &mut self.inner {
-            NotStarted(ref mut stmt) if stmt.is_some() => {
+            NotStarted(ref mut stmt @ Some(_)) => {
                 let mut stmt = stmt
                     .take()
                     .expect("It must be there because we checked that above");
@@ -161,12 +161,12 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
                     )
                 }
             }
-            NotStarted(_) => unreachable!(
-                "You've reached an impossible internal state. \
-                             If you ever see this error message please open \
-                             an issue at https://github.com/diesel-rs/diesel \
-                             providing example code how to trigger this error."
-            ),
+            NotStarted(_s) => {
+                // we likely got an error while executing the other
+                // `NotStarted` branch above. In this case we just want to stop
+                // iterating here
+                None
+            }
         }
     }
 }


### PR DESCRIPTION
This commit fixes a potential panic in sqlite row iterator if the first iteration step returns an error. We return now a `None` value there instead of panicing as the iterator "ends" at that point.