### PR TITLE
Add space in "DISTINCT ON (...) "

### DIFF
--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -271,7 +271,7 @@ where
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("DISTINCT ON (");
         self.0.walk_ast(out.reborrow())?;
-        out.push_sql(")");
+        out.push_sql(") ");
         Ok(())
     }
 }


### PR DESCRIPTION
For prettier query string.
This is homogeneous to what we do with commas and joins.