### PR TITLE
implemets `upper`, `isempty`, `lower_inc`, `upper_inc`, `lower_inf`, `upper_inf` and `range_merge` functions for postgres

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -276,6 +276,48 @@ define_sql_function! {
 }
 
 define_sql_function! {
+    /// Returns if the range's lower bound inclusive.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// use diesel::dsl::lower_inf;
+    /// diesel::insert_into(posts)
+    ///     .values(&[
+    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
+    ///        versions.eq((Bound::Unbounded, Bound::Excluded(7))),
+    ///     ]).execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(lower_inf(versions))
+    ///     .load::<bool>(conn)?;
+    /// assert_eq!(vec![false, true], cool_posts);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "postgres_backend")]
+    fn lower_inf<T: RangeHelper>(range: T) -> Bool;
+}
+
+define_sql_function! {
     /// Returns range of integer.
     /// # Example
     ///

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -151,7 +151,7 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns if the range is empty.
+    /// Returns true if the range is empty.
     /// # Example
     ///
     /// ```rust
@@ -193,7 +193,7 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns if the range's lower bound inclusive.
+    /// Returns true if the range's lower bound is inclusive.
     /// # Example
     ///
     /// ```rust
@@ -235,7 +235,7 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns if the range's upper bound inclusive.
+    /// Returns true if the range's upper bound is inclusive.
     /// # Example
     ///
     /// ```rust
@@ -276,7 +276,7 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns if the range's lower bound inclusive.
+    /// Returns true if the range's lower bound is unbounded.
     /// # Example
     ///
     /// ```rust
@@ -318,7 +318,7 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns if the range's upper bound inclusive.
+    /// Returns true if the range's upper bound is unbounded.
     /// # Example
     ///
     /// ```rust

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -108,6 +108,49 @@ define_sql_function! {
 }
 
 define_sql_function! {
+    /// Returns the upper bound of the range.
+    /// if the range is empty or has no upper bound, it returns NULL.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// use diesel::dsl::upper;
+    /// diesel::insert_into(posts)
+    ///     .values(&[
+    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
+    ///        versions.eq((Bound::Included(5), Bound::Unbounded))
+    ///     ]).execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(upper(versions))
+    ///     .load::<Option<i32>>(conn)?;
+    /// assert_eq!(vec![Some(7), None], cool_posts);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "postgres_backend")]
+    fn upper<T: RangeHelper>(range: T) -> Nullable<<T as RangeHelper>::Inner>;
+}
+
+define_sql_function! {
     /// Returns range of integer.
     /// # Example
     ///

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -318,6 +318,48 @@ define_sql_function! {
 }
 
 define_sql_function! {
+    /// Returns if the range's upper bound inclusive.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// use diesel::dsl::upper_inf;
+    /// diesel::insert_into(posts)
+    ///     .values(&[
+    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
+    ///        versions.eq((Bound::Included(5),Bound::Unbounded)),
+    ///     ]).execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(upper_inf(versions))
+    ///     .load::<bool>(conn)?;
+    /// assert_eq!(vec![false, true], cool_posts);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "postgres_backend")]
+    fn upper_inf<T: RangeHelper>(range: T) -> Bool;
+}
+
+define_sql_function! {
     /// Returns range of integer.
     /// # Example
     ///

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -151,6 +151,48 @@ define_sql_function! {
 }
 
 define_sql_function! {
+    /// Returns if the range is empty.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// use diesel::dsl::isempty;
+    /// diesel::insert_into(posts)
+    ///     .values(&[
+    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
+    ///        versions.eq((Bound::Excluded(7), Bound::Excluded(7))),
+    ///     ]).execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(isempty(versions))
+    ///     .load::<bool>(conn)?;
+    /// assert_eq!(vec![false, true], cool_posts);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "postgres_backend")]
+    fn isempty<T: RangeHelper>(range: T) -> Bool;
+}
+
+define_sql_function! {
     /// Returns range of integer.
     /// # Example
     ///

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -235,6 +235,47 @@ define_sql_function! {
 }
 
 define_sql_function! {
+    /// Returns if the range's upper bound inclusive.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// use diesel::dsl::upper_inc;
+    /// diesel::insert_into(posts)
+    ///     .values(&[
+    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
+    ///     ]).execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(upper_inc(versions))
+    ///     .load::<bool>(conn)?;
+    /// assert_eq!(vec![false], cool_posts);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "postgres_backend")]
+    fn upper_inc<T: RangeHelper>(range: T) -> Bool;
+}
+
+define_sql_function! {
     /// Returns range of integer.
     /// # Example
     ///

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -193,6 +193,48 @@ define_sql_function! {
 }
 
 define_sql_function! {
+    /// Returns if the range's lower bound inclusive.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #     posts {
+    /// #         id -> Integer,
+    /// #         versions -> Range<Integer>,
+    /// #     }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::posts::dsl::*;
+    /// #     use std::collections::Bound;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
+    /// #
+    /// use diesel::dsl::lower_inc;
+    /// diesel::insert_into(posts)
+    ///     .values(&[
+    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
+    ///        versions.eq((Bound::Excluded(7), Bound::Excluded(7))),
+    ///     ]).execute(conn)?;
+    ///
+    /// let cool_posts = posts.select(lower_inc(versions))
+    ///     .load::<bool>(conn)?;
+    /// assert_eq!(vec![true, false], cool_posts);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "postgres_backend")]
+    fn lower_inc<T: RangeHelper>(range: T) -> Bool;
+}
+
+define_sql_function! {
     /// Returns range of integer.
     /// # Example
     ///


### PR DESCRIPTION
- **upper**
- **isempty**
- **lower_inc**
- **upper_inc**
- **lower_inf**
- **upper_inf**
- **range_merge**

Part of https://github.com/diesel-rs/diesel/issues/4092
