### PR TITLE
Add a `xtask clippy` and `xtask tidy` subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,7 @@ concurrency:
 jobs:
   check_and_test:
     name: Check
-    needs:
-      [
-        sqlite_bundled,
-        rustfmt_and_clippy,
-        postgres_bundled,
-        mysql_bundled,
-        typos,
-      ]
+    needs: [sqlite_bundled, rustfmt_and_clippy, postgres_bundled, mysql_bundled]
     strategy:
       fail-fast: false
       matrix:
@@ -279,65 +272,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install libsqlite3-dev libpq-dev libmysqlclient-dev
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: typos
       - name: Set environment variables
         shell: bash
         run: |
           echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
           echo "RUSTDOCFLAGS=-D warnings" >> $GITHUB_ENV
-
-      - name: Remove potential newer clippy.toml from dependencies
-        run: |
-          cargo +stable update
-          cargo +stable fetch
-          find ~/.cargo/registry -iname "*clippy.toml" -delete
-
-      - name: Run clippy
-        run: |
-          cargo +stable clippy --tests --manifest-path diesel_table_macro_syntax/Cargo.toml
-          cargo +stable clippy --tests --manifest-path diesel_derives/Cargo.toml --features "postgres diesel/postgres"
-          cargo +stable clippy --tests --manifest-path diesel/Cargo.toml --features "postgres"
-          cargo +stable clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "postgres diesel/postgres"
-          cargo +stable clippy --tests --manifest-path diesel_migrations/migrations_internals/Cargo.toml
-          cargo +stable clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "postgres diesel/postgres"
-          cargo +stable clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "postgres diesel/postgres"
-          cargo +stable clippy --tests --manifest-path diesel_cli/Cargo.toml --features "postgres" --no-default-features
-          cargo +stable clippy --tests --manifest-path diesel_tests/Cargo.toml --features "postgres"
-          cargo +stable clippy --tests --manifest-path examples/postgres/getting_started_step_1/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/getting_started_step_2/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/getting_started_step_3/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/advanced-blog-cli/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/all_about_inserts/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/all_about_updates/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/custom_types/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/composite_types/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/postgres/relations/Cargo.toml
-
-          cargo +stable clippy --tests --manifest-path diesel_derives/Cargo.toml --features "sqlite diesel/sqlite"
-          cargo +stable clippy --tests --manifest-path diesel/Cargo.toml --features "sqlite"
-          cargo +stable clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "sqlite diesel/sqlite"
-          cargo +stable clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "sqlite diesel/sqlite"
-          cargo +stable clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "sqlite diesel/sqlite"
-          cargo +stable clippy --tests --manifest-path diesel_cli/Cargo.toml --features "sqlite" --no-default-features
-          cargo +stable clippy --tests --manifest-path diesel_tests/Cargo.toml --features "sqlite"
-          cargo +stable clippy --tests --manifest-path examples/sqlite/getting_started_step_1/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/sqlite/getting_started_step_2/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/sqlite/getting_started_step_3/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/sqlite/all_about_inserts/Cargo.toml
-
-          cargo +stable clippy --tests --manifest-path diesel_derives/Cargo.toml --features "mysql diesel/mysql"
-          cargo +stable clippy --tests --manifest-path diesel/Cargo.toml --features "mysql"
-          cargo +stable clippy --tests --manifest-path diesel_dynamic_schema/Cargo.toml --features "mysql diesel/mysql"
-          cargo +stable clippy --tests --manifest-path diesel_migrations/migrations_macros/Cargo.toml --features "mysql diesel/mysql"
-          cargo +stable clippy --tests --manifest-path diesel_migrations/Cargo.toml --features "mysql diesel/mysql"
-          cargo +stable clippy --tests --manifest-path diesel_cli/Cargo.toml --features "mysql" --no-default-features
-          cargo +stable clippy --tests --manifest-path diesel_tests/Cargo.toml --features "mysql"
-          cargo +stable clippy --tests --manifest-path examples/mysql/getting_started_step_1/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/mysql/getting_started_step_2/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/mysql/getting_started_step_3/Cargo.toml
-          cargo +stable clippy --tests --manifest-path examples/mysql/all_about_inserts/Cargo.toml
-
-      - name: Check formatting
-        run: cargo +stable fmt --all -- --check
+      - name: Run clippy + rustfmt
+        run: cargo xtask tidy --keep-going
 
   sqlite_bundled:
     name: Check sqlite bundled + Sqlite with asan
@@ -491,13 +436,3 @@ jobs:
         run: cargo +1.78.0 minimal-versions check -p diesel_migrations --all-features
       - name: Check diesel_cli
         run: cargo +1.78.0 minimal-versions check -p diesel_cli --features "default sqlite-bundled"
-
-  typos:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v4
-
-      - name: Check the spelling of the files in our repo
-        uses: crate-ci/typos@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,10 @@ Thank you! We'll try to respond as quickly as possible.
     ```bash
     $ docker-compose up
     ```
+    
+5. Install [cargo-nextest](https://nexte.st/) via `cargo install cargo-nextest`
 
-5. Now, try running the test suite to confirm everything works for you locally
+6. Now, try running the test suite to confirm everything works for you locally
    by executing `cargo xtask run-tests`. (Initially, this will take a while to compile
    everything.) In addition, if you want to compile and test a crate separately, 
    you can refer to the commands printed and executed by `cargo xtask run-tests`. Additionally you 
@@ -130,40 +132,15 @@ To run rustfmt tests locally:
    rustup component add rustfmt
    rustup component add clippy
    ```
-   
-3. Install [cargo-nextest](https://nexte.st/) via `cargo install cargo-nextest`
 
-4. Run clippy using cargo from the root of your diesel repo.
-   ```
-   cargo clippy --all
-   ```
-   Each PR needs to compile without warning.
+3. Install [typos](https://github.com/crate-ci/typos) via `cargo install typos`
 
-5. Run rustfmt using cargo from the root of your diesel repo.
-
-   To see changes that need to be made, run
-
-   ```
-   cargo fmt --all -- --check
-   ```
-
-   If all code is properly formatted (e.g. if you have not made any changes),
-   this should run without error or output.
-   If your code needs to be reformatted,
-   you will see a diff between your code and properly formatted code.
-   If you see code here that you didn't make any changes to
-   then you are probably running the wrong version of rustfmt.
-   Once you are ready to apply the formatting changes, run
-
-   ```
-   cargo fmt --all
-   ```
-
-   You won't see any output, but all your files will be corrected.
+4. Use `cargo xtask tidy` to check if your changes follow the expected code style.
+   This will run `cargo fmt --check`, `typos` and `cargo clippy` internally. See `cargo xtask tidy --help`
+   for additional options.
 
 You can also use rustfmt to make corrections or highlight issues in your editor.
 Check out [their README](https://github.com/rust-lang/rustfmt) for details.
-
 
 ### Common Abbreviations
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -1013,7 +1013,7 @@ mod tests {
         assert!(!time_col.flags.contains(Flags::NUM_FLAG));
         assert_eq!(
             to_value::<Time, chrono::NaiveTime>(time_col).unwrap(),
-            chrono::NaiveTime::from_hms_opt(23, 01, 01).unwrap()
+            chrono::NaiveTime::from_hms_opt(23, 1, 1).unwrap()
         );
 
         let year_col = &results[16].0;

--- a/diesel/src/pg/query_builder/copy/copy_to.rs
+++ b/diesel/src/pg/query_builder/copy/copy_to.rs
@@ -273,10 +273,7 @@ where
         C::get_buffer(out)
     }
 
-    fn execute<'conn, T>(
-        &'conn mut self,
-        command: CopyToCommand<T>,
-    ) -> QueryResult<Self::CopyToBuffer<'conn>>
+    fn execute<T>(&mut self, command: CopyToCommand<T>) -> QueryResult<Self::CopyToBuffer<'_>>
     where
         T: CopyTarget,
     {

--- a/xtask/src/clippy.rs
+++ b/xtask/src/clippy.rs
@@ -1,0 +1,81 @@
+use std::process::{Command, Stdio};
+
+use cargo_metadata::{Metadata, MetadataCommand};
+
+use crate::Backend;
+
+#[derive(Debug, clap::Args)]
+pub struct ClippyArgs {
+    /// Run clippy for a specific backend
+    #[clap(default_value_t = Backend::All)]
+    pub backend: Backend,
+    /// do not abort running if we encounter an error
+    /// while running clippy for all backends
+    #[clap(long = "keep-going")]
+    pub keep_going: bool,
+    /// additional flags passed to cargo clippy
+    ///
+    /// This is useful for passing custom arguments like `cargo clippy --fix`
+    pub flags: Vec<String>,
+}
+
+impl ClippyArgs {
+    pub(crate) fn run(&self) {
+        let metadata = MetadataCommand::default().exec().unwrap();
+        let failed = if matches!(self.backend, Backend::All) {
+            let mut failed = false;
+            for backend in Backend::ALL {
+                if !self.run_for_backend(*backend, &metadata) {
+                    failed = true;
+                    if !self.keep_going {
+                        break;
+                    }
+                }
+            }
+            failed
+        } else {
+            !self.run_for_backend(self.backend, &metadata)
+        };
+        if failed {
+            std::process::exit(1);
+        }
+    }
+
+    fn run_for_backend(&self, backend: Backend, metadata: &Metadata) -> bool {
+        let exclude = crate::utils::get_exclude_for_backend(&backend.to_string(), metadata);
+        let flags = [
+            "-F".into(),
+            format!("diesel/{backend}"),
+            "-F".into(),
+            format!("diesel_derives/{backend}"),
+            "-F".into(),
+            format!("diesel_cli/{backend}"),
+            "-F".into(),
+            format!("diesel_tests/{backend}"),
+            "-F".into(),
+            format!("diesel-dynamic-schema/{backend}"),
+        ];
+        let mut command = Command::new("cargo");
+
+        command
+            .args([
+                "clippy",
+                "--workspace",
+                "--no-default-features",
+                "--all-targets",
+            ])
+            .args(exclude)
+            .args(flags)
+            .args(["-F", "diesel/extras", "-F", "diesel/with-deprecated"])
+            .args(&self.flags)
+            .current_dir(&metadata.workspace_root);
+
+        println!("Run clippy via `{command:?}`");
+        command
+            .stderr(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .status()
+            .unwrap()
+            .success()
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,10 @@ use std::fmt::Display;
 
 use clap::{Parser, ValueEnum};
 
+mod clippy;
 mod tests;
+mod tidy;
+mod utils;
 
 #[derive(Debug, Parser)]
 enum Commands {
@@ -10,12 +13,23 @@ enum Commands {
     ///
     /// Requires `cargo-nextest` to be installed
     RunTests(tests::TestArgs),
+    /// Run clippy on all crates
+    Clippy(clippy::ClippyArgs),
+    /// Perform a set of preliminary checks
+    ///
+    /// This command will execute `cargo fmt --check` to verify that
+    /// the code is formatted, `typos` to check for spelling errors
+    /// and it will execute `xtask clippy` to verify that the code
+    /// compiles without warning
+    Tidy(tidy::TidyArgs),
 }
 
 impl Commands {
     fn run(self) {
         match self {
             Commands::RunTests(test_args) => test_args.run(),
+            Commands::Clippy(clippy) => clippy.run(),
+            Commands::Tidy(tidy) => tidy.run(),
         }
     }
 }
@@ -26,6 +40,10 @@ enum Backend {
     Sqlite,
     Mysql,
     All,
+}
+
+impl Backend {
+    const ALL: &'static [Self] = &[Backend::Postgres, Backend::Sqlite, Backend::Mysql];
 }
 
 impl Display for Backend {

--- a/xtask/src/tidy.rs
+++ b/xtask/src/tidy.rs
@@ -1,0 +1,70 @@
+use std::process::{Command, Stdio};
+
+use cargo_metadata::MetadataCommand;
+
+use crate::clippy::ClippyArgs;
+use crate::Backend;
+
+#[derive(Debug, clap::Args)]
+pub struct TidyArgs {
+    /// do not abort running if we encounter an error
+    /// while running the checks
+    #[clap(long = "keep-going")]
+    keep_going: bool,
+}
+
+impl TidyArgs {
+    pub(crate) fn run(&self) {
+        let metadata = MetadataCommand::default().exec().unwrap();
+        let mut command = Command::new("cargo");
+
+        command
+            .args(["fmt", "--all", "--check"])
+            .current_dir(&metadata.workspace_root);
+
+        println!("Check code formatting with `{command:?}`");
+        let status = command
+            .stdout(Stdio::inherit())
+            .stdin(Stdio::inherit())
+            .status()
+            .unwrap();
+
+        if !status.success() {
+            println!("Code format issues detected!");
+            println!("\t Run `cargo fmt --all` to format the source code");
+            if !self.keep_going {
+                std::process::exit(1);
+            }
+        }
+
+        let mut command = Command::new("typos");
+
+        command.current_dir(metadata.workspace_root);
+        println!("Check source code for spelling mistakes with `{command:?}`");
+
+        let status = command
+            .stdout(Stdio::inherit())
+            .stdin(Stdio::inherit())
+            .status()
+            .unwrap();
+
+        if !status.success() {
+            println!("Spelling issues detected!");
+            println!("\t Run `typos -w` to address some of the issues");
+            if !self.keep_going {
+                std::process::exit(1);
+            }
+        }
+
+        println!("Run clippy: ");
+        ClippyArgs {
+            backend: Backend::All,
+            keep_going: self.keep_going,
+            flags: Vec::new(),
+        }
+        .run();
+
+        println!();
+        println!("All checks were successful. Ready to submit the code!");
+    }
+}

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -1,0 +1,20 @@
+use cargo_metadata::Metadata;
+
+pub fn get_exclude_for_backend<'a>(backend: &str, metadata: &'a Metadata) -> Vec<&'a str> {
+    let examples = metadata.workspace_root.join("examples");
+    let backend_examples = examples.join(backend);
+    metadata
+        .workspace_packages()
+        .into_iter()
+        .filter_map(move |p| {
+            if p.manifest_path.starts_with(&examples)
+                && !p.manifest_path.starts_with(&backend_examples)
+            {
+                Some(["--exclude", &p.name])
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .collect()
+}


### PR DESCRIPTION
The clippy subcommand just runs clippy for all workspace crates for a specific backend (or all backends) with the right set of feature flags.

The `tidy` subcommand runs `cargo fmt --check`, `typos` and clippy for all backends to provide an easy precheck before pushing the code.

This commit also adjusts the CI to use the `cargo xtask tidy` command instead and the contributor gide to point to the new commends.