### PR TITLE
Add the last missing range operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Added
 
 * Support for libsqlite3-sys 0.29.0
+* Add support for built-in PostgreSQL range operators and functions
 * Support for postgres multirange type
 
 ## [2.2.0] 2024-05-31

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -66,8 +66,10 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns the lower bound of the range.
-    /// if the range is empty or has no lower bound, it returns NULL.
+    /// Returns the lower bound of the range
+    ///
+    /// If the range is empty or has no lower bound, it returns NULL.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -109,8 +111,10 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns the upper bound of the range.
-    /// if the range is empty or has no upper bound, it returns NULL.
+    /// Returns the upper bound of the range
+    ///
+    /// If the range is empty or has no upper bound, it returns NULL.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -152,7 +156,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns true if the range is empty.
+    /// Returns true if the range is empty
+    ///
     /// # Example
     ///
     /// ```rust
@@ -194,7 +199,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns true if the range's lower bound is inclusive.
+    /// Returns true if the range's lower bound is inclusive
+    ///
     /// # Example
     ///
     /// ```rust
@@ -236,7 +242,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns true if the range's upper bound is inclusive.
+    /// Returns true if the range's upper bound is inclusive
+    ///
     /// # Example
     ///
     /// ```rust
@@ -277,7 +284,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns true if the range's lower bound is unbounded.
+    /// Returns true if the range's lower bound is unbounded
+    ///
     /// # Example
     ///
     /// ```rust
@@ -319,7 +327,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns true if the range's upper bound is unbounded.
+    /// Returns true if the range's upper bound is unbounded
+    ///
     /// # Example
     ///
     /// ```rust
@@ -361,7 +370,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns the smallest range which includes both of the given ranges.
+    /// Returns the smallest range which includes both of the given ranges
+    ///
     /// # Example
     ///
     /// ```rust
@@ -400,11 +410,12 @@ define_sql_function! {
     /// # }
     /// ```
     #[cfg(feature = "postgres_backend")]
-    fn range_merge<T: RangeHelper>(lhs: T, rhs: T) -> Range<<T as RangeHelper>::Inner>;
+    fn range_merge<T1: RangeHelper, T2: RangeHelper<Inner = T1::Inner>>(lhs: T1, rhs: T2) -> Range<T1::Inner>;
 }
 
 define_sql_function! {
-    /// Returns range of integer.
+    /// Returns range of integer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -451,7 +462,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns range of integer.
+    /// Returns range of big ints
+    ///
     /// # Example
     ///
     /// ```rust
@@ -498,7 +510,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns range of number.
+    /// Returns range of numeric values
+    ///
     /// # Example
     ///
     /// ```rust
@@ -548,7 +561,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns range of timestamp without timezone.
+    /// Returns range of timestamps without timezone
+    ///
     /// # Example
     ///
     /// ```rust
@@ -598,7 +612,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns range of timestamp with timezone.
+    /// Returns range of timestamps with timezone
+    ///
     /// # Example
     ///
     /// ```rust
@@ -646,7 +661,8 @@ define_sql_function! {
 }
 
 define_sql_function! {
-    /// Returns range of date.
+    /// Returns range of dates
+    ///
     /// # Example
     ///
     /// ```rust
@@ -697,7 +713,8 @@ define_sql_function! {
 
 #[cfg(feature = "postgres_backend")]
 define_sql_function! {
-    /// Append an element to the end of an array.
+    /// Append an element to the end of an array
+    ///
     /// # Example
     ///
     /// ```rust

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -60,11 +60,17 @@ pub type RangeContains<Lhs, Rhs> = Grouped<
     >,
 >;
 
-/// The return type of [`lhs.range_not_extends_right_to(rhs)`](super::expression_methods::PgRangeExpressionMethods::range_not_extends_right_to)
+/// The return type of [`lhs.range_extends_right_to(rhs)`](super::expression_methods::PgRangeExpressionMethods::range_extends_right_to)
 /// for range expressions
 #[cfg(feature = "postgres_backend")]
-pub type RangeNotExtendsRightTo<Lhs, Rhs> =
-    Grouped<super::operators::NotExtendsRightTo<Lhs, AsExpr<Rhs, Lhs>>>;
+pub type RangeExtendsRightTo<Lhs, Rhs> =
+    Grouped<super::operators::ExtendsRightTo<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// The return type of [`lhs.range_extends_left_to(rhs)`](super::expression_methods::PgRangeExpressionMethods::range_extends_left_to)
+/// for range expressions
+#[cfg(feature = "postgres_backend")]
+pub type RangeExtendsLeftTo<Lhs, Rhs> =
+    Grouped<super::operators::ExtendsLeftTo<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of [`lhs.contains_range(rhs)`](super::expression_methods::PgRangeExpressionMethods::contains_range)
 /// for range expressions
@@ -75,6 +81,12 @@ pub type ContainsRange<Lhs, Rhs> = Contains<Lhs, Rhs>;
 /// and [`lhs.is_contained_by(rhs)`](super::expression_methods::PgArrayExpressionMethods::is_contained_by)
 #[cfg(feature = "postgres_backend")]
 pub type IsContainedBy<Lhs, Rhs> = Grouped<super::operators::IsContainedBy<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// The return type of [`lhs.is_contained_by_range(rhs)`](super::expression_methods::PgExpressionMethods::is_contained_by_range)
+#[cfg(feature = "postgres_backend")]
+pub type IsContainedByRange<Lhs, Rhs> = Grouped<
+    super::operators::IsContainedBy<Lhs, AsExprOf<Rhs, diesel::sql_types::Range<SqlTypeOf<Lhs>>>>,
+>;
 
 /// The return type of [`lhs.range_is_contained_by(rhs)`](super::expression_methods::PgRangeExpressionMethods::lesser_than)
 #[cfg(feature = "postgres_backend")]
@@ -101,6 +113,10 @@ pub type Difference<Lhs, Rhs> = Grouped<super::operators::DifferenceRange<Lhs, A
 
 #[doc(hidden)] // used by `#[auto_type]`
 pub type DifferenceRange<Lhs, Rhs> = Difference<Lhs, Rhs>;
+
+/// The return type of [`lhs.range_adjacent(rhs)`](super::expression_methods::PgRangeExpressionMethods::range_adjacent)
+#[cfg(feature = "postgres_backend")]
+pub type RangeAdjacent<Lhs, Rhs> = Grouped<super::operators::RangeAdjacent<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of [`lhs.intersection_range(rhs)`](super::expression_methods::PgRangeExpressionMethods::intersection_range)
 #[cfg(feature = "postgres_backend")]
@@ -291,3 +307,48 @@ pub type NotLikeBinary<Lhs, Rhs> = crate::dsl::NotLike<Lhs, Rhs>;
 #[doc(hidden)]
 #[deprecated(note = "Use `dsl::Concat` instead")]
 pub type ConcatArray<Lhs, Rhs> = crate::dsl::Concat<Lhs, Rhs>;
+
+/// Return type of [`lower(range)`](super::functions::lower())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type lower<R> = super::functions::lower<SqlTypeOf<R>, R>;
+
+/// Return type of [`upper(range)`](super::functions::upper())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type upper<R> = super::functions::upper<SqlTypeOf<R>, R>;
+
+/// Return type of [`isempty(range)`](super::functions::isempty())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type isempty<R> = super::functions::isempty<SqlTypeOf<R>, R>;
+
+/// Return type of [`lower_inc(range)`](super::functions::lower_inc())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type lower_inc<R> = super::functions::lower_inc<SqlTypeOf<R>, R>;
+
+/// Return type of [`upper_inc(range)`](super::functions::upper_inc())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type upper_inc<R> = super::functions::upper_inc<SqlTypeOf<R>, R>;
+
+/// Return type of [`lower_inf(range)`](super::functions::lower_inf())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type lower_inf<R> = super::functions::lower_inf<SqlTypeOf<R>, R>;
+
+/// Return type of [`upper_inf(range)`](super::functions::upper_inf())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type upper_inf<R> = super::functions::upper_inf<SqlTypeOf<R>, R>;
+
+/// Return type of [`range_merge(range_a, range_b)`](super::functions::range_merge())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type range_merge<R1, R2> = super::functions::range_merge<SqlTypeOf<R1>, SqlTypeOf<R2>, R1, R2>;
+
+/// Return type of [`array_append(array, element)`](super::functions::array_append())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array_append<A, E> = super::functions::array_append<SqlTypeOf<A>, SqlTypeOf<E>, A, E>;

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -15,7 +15,8 @@ infix_operator!(OverlapsWith, " && ", backend: Pg);
 infix_operator!(Contains, " @> ", backend: Pg);
 infix_operator!(IsContainedBy, " <@ ", backend: Pg);
 infix_operator!(ILike, " ILIKE ", backend: Pg);
-infix_operator!(NotExtendsRightTo, " &< ", backend: Pg);
+infix_operator!(ExtendsRightTo, " &< ", backend: Pg);
+infix_operator!(ExtendsLeftTo, " &> ", backend: Pg);
 infix_operator!(NotILike, " NOT ILIKE ", backend: Pg);
 infix_operator!(SimilarTo, " SIMILAR TO ", backend: Pg);
 infix_operator!(NotSimilarTo, " NOT SIMILAR TO ", backend: Pg);
@@ -31,6 +32,7 @@ infix_operator!(DifferenceNet, " - ", Bigint, backend: Pg);
 infix_operator!(HasKeyJsonb, " ? ", backend: Pg);
 infix_operator!(HasAnyKeyJsonb, " ?| ", backend: Pg);
 infix_operator!(HasAllKeysJsonb, " ?& ", backend: Pg);
+infix_operator!(RangeAdjacent, " -|- ", backend: Pg);
 infix_operator!(RemoveFromJsonb, " - ", Jsonb, backend: Pg);
 __diesel_infix_operator!(
     RetrieveAsObjectJson,

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -11,6 +11,9 @@ table! {
         id -> Integer,
         name -> Text,
         time -> Timestamp,
+        bigint -> BigInt,
+        numeric -> Numeric,
+        date -> Date,
     }
 }
 
@@ -46,6 +49,7 @@ table! {
         blob -> Binary,
         timestamp -> Timestamp,
         range -> Range<Integer>,
+        timestamptz -> Timestamptz,
     }
 }
 
@@ -287,7 +291,9 @@ fn test_pg_range_expression_methods() -> _ {
         .and(pg_extras::range.overlaps_with(my_range))
         .and(pg_extras::range.lesser_than(my_range))
         .and(pg_extras::range.greater_than(my_range))
-        .and(pg_extras::range.range_not_extends_right_to(my_range))
+        .and(pg_extras::range.range_extends_right_to(my_range))
+        .and(pg_extras::range.range_extends_left_to(my_range))
+        .and(pg_extras::id.is_contained_by_range(my_range))
         .and(
             pg_extras::range
                 .union_range(pg_extras::range)
@@ -309,12 +315,6 @@ fn test_pg_range_expression_methods() -> _ {
     // function. We could likely support it by
     // renaming the function to `.range_contains()` (or something similar)
     // .contains(42_i32)
-    //.select(
-    // this kind of free standing functions is not supported by auto_type yet
-    //lower(pg_extras::range),
-    // The auto_trait also didn't like this one
-    //int4range(None, Some(5i32), RangeBound::LowerBoundInclusiveUpperBoundInclusive),
-    //)
 }
 
 #[cfg(feature = "postgres")]
@@ -384,6 +384,34 @@ fn test_normal_functions() -> _ {
             .otherwise(users::id),
         case_when(users::id.eq(1_i32), users::id).otherwise(users::id),
     ))
+}
+
+#[cfg(feature = "postgres")]
+#[auto_type]
+fn postgres_functions() -> _ {
+    let bound: sql_types::RangeBound =
+        sql_types::RangeBound::LowerBoundExclusiveUpperBoundExclusive;
+    (
+        lower(pg_extras::range),
+        upper(pg_extras::range),
+        isempty(pg_extras::range),
+        lower_inc(pg_extras::range),
+        upper_inc(pg_extras::range),
+        lower_inf(pg_extras::range),
+        upper_inf(pg_extras::range),
+        range_merge(pg_extras::range, pg_extras::range),
+        int4range(users::id.nullable(), users::id.nullable(), bound),
+        int8range(users::bigint.nullable(), users::bigint.nullable(), bound),
+        numrange(users::numeric.nullable(), users::numeric.nullable(), bound),
+        daterange(users::date.nullable(), users::date.nullable(), bound),
+        tsrange(users::time.nullable(), users::time.nullable(), bound),
+        tstzrange(
+            pg_extras::timestamptz.nullable(),
+            pg_extras::timestamptz.nullable(),
+            bound,
+        ),
+        array_append(pg_extras::array, pg_extras::id),
+    )
 }
 
 #[auto_type]


### PR DESCRIPTION
This commit adds the last missing range operators.

Additionally it fixes the `#[auto_type]` support for the existing range functions. It also goes over the documentation again and fixes minor inconsistencies there. Finally a change log entry is added.

Fixes #4092