### PR TITLE
chore: allow `unused_qualifcatons` for table

### DIFF
--- a/diesel_derives/src/table.rs
+++ b/diesel_derives/src/table.rs
@@ -211,7 +211,7 @@ pub(crate) fn expand(input: TableDecl) -> TokenStream {
 
     quote::quote! {
         #(#meta)*
-        #[allow(unused_imports, dead_code, unreachable_pub)]
+        #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
         pub mod #table_name {
             use ::diesel;
             pub use self::columns::*;


### PR DESCRIPTION
I'm submitting this PR as a result of our discussion on Discord.

This PR addresses an issue where the [unused_qualifications lint](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.UNUSED_QUALIFICATIONS.html), when used in combination with `diesel`, would generate warnings for schema.rs. With this change, such warnings should no longer appear.