### PR TITLE
Convert primary keys to serialize_as type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ### Added
 
+* Fixed `#[derive(Identifiable)]` ignoring attribute `#[diesel(serialize_as)]` on primary keys
 * Added embedded struct support for `AsChangeset` via `#[diesel(embed)]`
 * Support for libsqlite3-sys 0.30.0
 * Add support for built-in PostgreSQL range operators and functions

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -31,7 +31,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         } = &model.find_column(pk)?;
         if let Some(AttributeSpanWrapper { item: ty, .. }) = serialize_as.as_ref() {
             field_ty.push(quote!(#ty));
-            field_name.push(quote!(::std::convert::Into::<#ty>::into(self.#name)));
+            field_name.push(quote!(::std::convert::Into::<#ty>::into(self.#name.clone())));
         } else {
             field_ty.push(quote!(&'ident #ty));
             field_name.push(quote!(&self.#name));

--- a/diesel_derives/src/identifiable.rs
+++ b/diesel_derives/src/identifiable.rs
@@ -4,6 +4,8 @@ use syn::parse_quote;
 use syn::DeriveInput;
 use syn::Result;
 
+use crate::attrs::AttributeSpanWrapper;
+use crate::field::Field;
 use crate::model::Model;
 use crate::util::wrap_in_dummy_mod;
 
@@ -21,9 +23,19 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let mut field_ty = Vec::new();
     let mut field_name = Vec::new();
     for pk in model.primary_key_names.iter() {
-        let f = model.find_column(pk)?;
-        field_ty.push(&f.ty);
-        field_name.push(&f.name);
+        let Field {
+            ty,
+            name,
+            serialize_as,
+            ..
+        } = &model.find_column(pk)?;
+        if let Some(AttributeSpanWrapper { item: ty, .. }) = serialize_as.as_ref() {
+            field_ty.push(quote!(#ty));
+            field_name.push(quote!(::std::convert::Into::<#ty>::into(self.#name)));
+        } else {
+            field_ty.push(quote!(&'ident #ty));
+            field_name.push(quote!(&self.#name));
+        }
     }
 
     Ok(wrap_in_dummy_mod(quote! {
@@ -42,20 +54,20 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         impl #ref_generics Identifiable for &'ident #struct_name #ty_generics
         #where_clause
         {
-            type Id = (#(&'ident #field_ty),*);
+            type Id = (#(#field_ty),*);
 
             fn id(self) -> Self::Id {
-                (#(&self.#field_name),*)
+                (#(#field_name),*)
             }
         }
 
         impl #ref_generics Identifiable for &'_ &'ident #struct_name #ty_generics
             #where_clause
         {
-            type Id = (#(&'ident #field_ty),*);
+            type Id = (#(#field_ty),*);
 
             fn id(self) -> Self::Id {
-                (#(&self.#field_name),*)
+                (#(#field_name),*)
             }
         }
     }))

--- a/diesel_derives/tests/identifiable.rs
+++ b/diesel_derives/tests/identifiable.rs
@@ -166,12 +166,10 @@ fn derive_identifiable_with_pk_serialize_as() {
     struct Foo {
         #[diesel(serialize_as = MyI32)]
         id: i32,
-        #[allow(dead_code)]
-        foo: i32,
     }
 
-    let foo1 = Foo { id: 1, foo: 2 };
-    let foo2 = Foo { id: 2, foo: 3 };
+    let foo1 = Foo { id: 1 };
+    let foo2 = Foo { id: 2 };
     assert_eq!(MyI32(1), foo1.id());
     assert_eq!(MyI32(2), foo2.id());
 }

--- a/diesel_derives/tests/identifiable.rs
+++ b/diesel_derives/tests/identifiable.rs
@@ -150,3 +150,28 @@ fn derive_identifiable_with_composite_pk() {
     assert_eq!((&2, &3), foo1.id());
     assert_eq!((&6, &7), foo2.id());
 }
+
+#[test]
+fn derive_identifiable_with_pk_serialize_as() {
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct MyI32(i32);
+
+    impl From<i32> for MyI32 {
+        fn from(value: i32) -> Self {
+            MyI32(value)
+        }
+    }
+
+    #[derive(Identifiable)]
+    struct Foo {
+        #[diesel(serialize_as = MyI32)]
+        id: i32,
+        #[allow(dead_code)]
+        foo: i32,
+    }
+
+    let foo1 = Foo { id: 1, foo: 2 };
+    let foo2 = Foo { id: 2, foo: 3 };
+    assert_eq!(MyI32(1), foo1.id());
+    assert_eq!(MyI32(2), foo2.id());
+}

--- a/diesel_derives/tests/identifiable.rs
+++ b/diesel_derives/tests/identifiable.rs
@@ -173,3 +173,26 @@ fn derive_identifiable_with_pk_serialize_as() {
     assert_eq!(MyI32(1), foo1.id());
     assert_eq!(MyI32(2), foo2.id());
 }
+
+#[test]
+fn derive_identifiable_with_non_copy_pk_serialize() {
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct MyString(String);
+
+    impl From<String> for MyString {
+        fn from(value: String) -> Self {
+            MyString(value)
+        }
+    }
+
+    #[derive(Identifiable)]
+    struct Foo {
+        #[diesel(serialize_as = MyString)]
+        id: String,
+    }
+
+    let foo1 = Foo { id: "1".to_owned() };
+    let foo2 = Foo { id: "2".to_owned() };
+    assert_eq!(MyString("1".to_owned()), foo1.id());
+    assert_eq!(MyString("2".to_owned()), foo2.id());
+}


### PR DESCRIPTION
I've got a newtype on oxydized_money::Currency to implement ToSql/FromSql/...

I recently added a table with a composite primary key which included a currency column, and I'm expecting to be able to use it the same way I used another id.

```rust
#[derive(Debug, Queryable, Selectable, Identifiable)]
#[diesel(table_name = monthly_stats)]
#[diesel(primary_key(year, month, currency))]
#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
pub struct MonthlyStats {
    pub year: i32,
    pub month: i32,
    #[diesel(deserialize_as = db::Decimal)]
    pub amount: Decimal,
    #[diesel(deserialize_as = db::Currency, serialize_as = db::Currency)]
    pub currency: Currency,
}
```

Everything seems fine, until I try to compile the following instruction:

```rust
        diesel::update(&*self)
            .set(monthly_stats::amount.eq(db::Decimal::from(self.amount)))
            .execute(conn)?;
```

> error[E0277]: the trait bound `SelectStatement<FromClause<monthly_stats::table>>: FilterDsl<expression::grouped::Grouped<expression::operators::And<expression::grouped::Grouped<expression::operators::Eq<monthly_stats::columns::year, expression::bound::Bound<diesel::sql_types::Integer, &i32>>>, expression::grouped::Grouped<expression::operators::And<expression::grouped::Grouped<expression::operators::Eq<monthly_stats::columns::month, expression::bound::Bound<diesel::sql_types::Integer, &i32>>>, expression::grouped::Grouped<expression::operators::Eq<monthly_stats::columns::currency, &oxydized_money::Currency>>>>>>>` is not satisfied

Or as explained a few lines later:
> note: required by a bound in `update`
> `  pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {`
>  the trait `diesel::Expression` is not implemented for `oxydized_money::Currency`, which is required by `&MonthlyStats: IntoUpdateTarget`

I can fix that by implementing `Identifiable` and `HasTable` manually, or by compiling against the provided patch

It works because my type is `Copy`, but at the same time this isn't uncommon for id types.

When it's not copy, I get something like:

> cannot move out of `self.field` which is behind a shared reference
> move occurs because `self.field` has type `MyType`, which does not implement the `Copy` trait

Plus some advice on implementing `Clone`, if it's not already `Clone`.

I could maybe find a way of ensuring the type is `Copy` if you think it's better that way, but if we go this way we might as well relax the `AsChangeset` & `Insertable` restriction on `serialize_as` for the same reasons, so it would be a bigger change.

Tell me what you think