### PR TITLE
Enable some numeric cast releated clippy lints and fix them in the code base

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -244,7 +244,10 @@
     clippy::enum_glob_use,
     clippy::if_not_else,
     clippy::items_after_statements,
-    clippy::used_underscore_binding
+    clippy::used_underscore_binding,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
 )]
 #![deny(unsafe_code)]
 #![cfg_attr(test, allow(clippy::map_unwrap_or, clippy::unwrap_used))]

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -178,7 +178,10 @@ impl Clone for BindData {
                 // written. At the time of writing this comment, the `BindData::bind_for_truncated_data`
                 // function is only called by `Binds::populate_dynamic_buffers` which ensures the corresponding
                 // invariant.
-                std::slice::from_raw_parts(ptr.as_ptr(), self.length as usize)
+                std::slice::from_raw_parts(
+                    ptr.as_ptr(),
+                    self.length.try_into().expect("usize is at least 32bit"),
+                )
             };
             let mut vec = slice.to_owned();
             let ptr = NonNull::new(vec.as_mut_ptr());
@@ -415,7 +418,10 @@ impl BindData {
                 // written. At the time of writing this comment, the `BindData::bind_for_truncated_data`
                 // function is only called by `Binds::populate_dynamic_buffers` which ensures the corresponding
                 // invariant.
-                std::slice::from_raw_parts(data.as_ptr(), self.length as usize)
+                std::slice::from_raw_parts(
+                    data.as_ptr(),
+                    self.length.try_into().expect("Usize is at least 32 bit"),
+                )
             };
             Some(MysqlValue::new_internal(slice, tpe))
         }
@@ -428,7 +434,10 @@ impl BindData {
     fn update_buffer_length(&mut self) {
         use std::cmp::min;
 
-        let actual_bytes_in_buffer = min(self.capacity, self.length as usize);
+        let actual_bytes_in_buffer = min(
+            self.capacity,
+            self.length.try_into().expect("Usize is at least 32 bit"),
+        );
         self.length = actual_bytes_in_buffer as libc::c_ulong;
     }
 
@@ -474,7 +483,8 @@ impl BindData {
                 self.bytes = None;
 
                 let offset = self.capacity;
-                let truncated_amount = self.length as usize - offset;
+                let truncated_amount =
+                    usize::try_from(self.length).expect("Usize is at least 32 bit") - offset;
 
                 debug_assert!(
                     truncated_amount > 0,
@@ -504,7 +514,7 @@ impl BindData {
                 // offset is zero here as we don't have a buffer yet
                 // we know the requested length here so we can just request
                 // the correct size
-                let mut vec = vec![0_u8; self.length as usize];
+                let mut vec = vec![0_u8; self.length.try_into().expect("usize is at least 32 bit")];
                 self.capacity = vec.capacity();
                 self.bytes = NonNull::new(vec.as_mut_ptr());
                 mem::forget(vec);

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -186,7 +186,7 @@ impl Connection for MysqlConnection {
                 // we have not called result yet, so calling `execute` is
                 // fine
                 let stmt_use = unsafe { stmt.execute() }?;
-                Ok(stmt_use.affected_rows())
+                stmt_use.affected_rows()
             }),
             &mut self.transaction_state,
             &mut self.instrumentation,

--- a/diesel/src/mysql/types/date_and_time/time.rs
+++ b/diesel/src/mysql/types/date_and_time/time.rs
@@ -15,7 +15,7 @@ fn to_time(dt: MysqlTime) -> Result<NaiveTime, Box<dyn std::error::Error>> {
         ("year", dt.year),
         ("month", dt.month),
         ("day", dt.day),
-        ("offset", dt.time_zone_displacement as u32),
+        ("offset", dt.time_zone_displacement.try_into()?),
     ] {
         if field != 0 {
             return Err(format!("Unable to convert {dt:?} to time: {name} must be 0").into());
@@ -63,7 +63,7 @@ fn to_primitive_datetime(dt: OffsetDateTime) -> PrimitiveDateTime {
 impl ToSql<Datetime, Mysql> for PrimitiveDateTime {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
         let mysql_time = MysqlTime {
-            year: self.year() as libc::c_uint,
+            year: self.year().try_into()?,
             month: self.month() as libc::c_uint,
             day: self.day() as libc::c_uint,
             hour: self.hour() as libc::c_uint,
@@ -171,7 +171,7 @@ impl FromSql<Time, Mysql> for NaiveTime {
 impl ToSql<Date, Mysql> for NaiveDate {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
         let mysql_time = MysqlTime {
-            year: self.year() as libc::c_uint,
+            year: self.year().try_into()?,
             month: self.month() as libc::c_uint,
             day: self.day() as libc::c_uint,
             hour: 0,

--- a/diesel/src/mysql/types/mod.rs
+++ b/diesel/src/mysql/types/mod.rs
@@ -25,7 +25,7 @@ impl ToSql<TinyInt, Mysql> for i8 {
 impl FromSql<TinyInt, Mysql> for i8 {
     fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         let bytes = value.as_bytes();
-        Ok(bytes[0] as i8)
+        Ok(i8::from_be_bytes([bytes[0]]))
     }
 }
 
@@ -69,12 +69,14 @@ where
 #[cfg(feature = "mysql_backend")]
 impl ToSql<Unsigned<TinyInt>, Mysql> for u8 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
-        ToSql::<TinyInt, Mysql>::to_sql(&(*self as i8), &mut out.reborrow())
+        out.write_u8(*self)?;
+        Ok(IsNull::No)
     }
 }
 
 #[cfg(feature = "mysql_backend")]
 impl FromSql<Unsigned<TinyInt>, Mysql> for u8 {
+    #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)] // that's what we want
     fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i8 = FromSql::<TinyInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u8)
@@ -84,12 +86,18 @@ impl FromSql<Unsigned<TinyInt>, Mysql> for u8 {
 #[cfg(feature = "mysql_backend")]
 impl ToSql<Unsigned<SmallInt>, Mysql> for u16 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
-        ToSql::<SmallInt, Mysql>::to_sql(&(*self as i16), &mut out.reborrow())
+        out.write_u16::<NativeEndian>(*self)?;
+        Ok(IsNull::No)
     }
 }
 
 #[cfg(feature = "mysql_backend")]
 impl FromSql<Unsigned<SmallInt>, Mysql> for u16 {
+    #[allow(
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation
+    )] // that's what we want
     fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i32 = FromSql::<Integer, Mysql>::from_sql(bytes)?;
         Ok(signed as u16)
@@ -99,12 +107,18 @@ impl FromSql<Unsigned<SmallInt>, Mysql> for u16 {
 #[cfg(feature = "mysql_backend")]
 impl ToSql<Unsigned<Integer>, Mysql> for u32 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
-        ToSql::<Integer, Mysql>::to_sql(&(*self as i32), &mut out.reborrow())
+        out.write_u32::<NativeEndian>(*self)?;
+        Ok(IsNull::No)
     }
 }
 
 #[cfg(feature = "mysql_backend")]
 impl FromSql<Unsigned<Integer>, Mysql> for u32 {
+    #[allow(
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation
+    )] // that's what we want
     fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i64 = FromSql::<BigInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u32)
@@ -114,12 +128,18 @@ impl FromSql<Unsigned<Integer>, Mysql> for u32 {
 #[cfg(feature = "mysql_backend")]
 impl ToSql<Unsigned<BigInt>, Mysql> for u64 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
-        ToSql::<BigInt, Mysql>::to_sql(&(*self as i64), &mut out.reborrow())
+        out.write_u64::<NativeEndian>(*self)?;
+        Ok(IsNull::No)
     }
 }
 
 #[cfg(feature = "mysql_backend")]
 impl FromSql<Unsigned<BigInt>, Mysql> for u64 {
+    #[allow(
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation
+    )] // that's what we want
     fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let signed: i64 = FromSql::<BigInt, Mysql>::from_sql(bytes)?;
         Ok(signed as u64)

--- a/diesel/src/mysql/types/primitives.rs
+++ b/diesel/src/mysql/types/primitives.rs
@@ -22,6 +22,7 @@ where
     }
 }
 
+#[allow(clippy::cast_possible_truncation)] // that's what we want here
 fn f32_to_i64(f: f32) -> deserialize::Result<i64> {
     if f <= i64::MAX as f32 && f >= i64::MIN as f32 {
         Ok(f.trunc() as i64)
@@ -32,6 +33,7 @@ fn f32_to_i64(f: f32) -> deserialize::Result<i64> {
     }
 }
 
+#[allow(clippy::cast_possible_truncation)] // that's what we want here
 fn f64_to_i64(f: f64) -> deserialize::Result<i64> {
     if f <= i64::MAX as f64 && f >= i64::MIN as f64 {
         Ok(f.trunc() as i64)
@@ -128,6 +130,8 @@ impl FromSql<Float, Mysql> for f32 {
             NumericRepresentation::Medium(x) => Ok(x as Self),
             NumericRepresentation::Big(x) => Ok(x as Self),
             NumericRepresentation::Float(x) => Ok(x),
+            // there is currently no way to do this in a better way
+            #[allow(clippy::cast_possible_truncation)]
             NumericRepresentation::Double(x) => Ok(x as Self),
             NumericRepresentation::Decimal(bytes) => Ok(str::from_utf8(bytes)?.parse()?),
         }

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -60,7 +60,7 @@ impl<'a> MysqlValue<'a> {
     pub(crate) fn numeric_value(&self) -> deserialize::Result<NumericRepresentation<'_>> {
         Ok(match self.tpe {
             MysqlType::UnsignedTiny | MysqlType::Tiny => {
-                NumericRepresentation::Tiny(self.raw[0] as i8)
+                NumericRepresentation::Tiny(self.raw[0].try_into()?)
             }
             MysqlType::UnsignedShort | MysqlType::Short => {
                 NumericRepresentation::Small(i16::from_ne_bytes((&self.raw[..2]).try_into()?))

--- a/diesel/src/pg/connection/copy.rs
+++ b/diesel/src/pg/connection/copy.rs
@@ -102,7 +102,10 @@ impl<'conn> BufRead for CopyToBuffer<'conn> {
                 let len =
                     pq_sys::PQgetCopyData(self.conn.internal_connection.as_ptr(), &mut self.ptr, 0);
                 match len {
-                    len if len >= 0 => self.len = len as usize + 1,
+                    len if len >= 0 => {
+                        self.len = 1 + usize::try_from(len)
+                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+                    }
                     -1 => self.len = 0,
                     _ => {
                         let error = self.conn.last_error_message();

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -147,7 +147,9 @@ impl RawConnection {
                 pq_sys::PQputCopyData(
                     self.internal_connection.as_ptr(),
                     c.as_ptr() as *const libc::c_char,
-                    c.len() as libc::c_int,
+                    c.len()
+                        .try_into()
+                        .map_err(|e| Error::SerializationError(Box::new(e)))?,
                 )
             };
             if res != 1 {

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -16,8 +16,8 @@ use std::cell::OnceCell;
 #[allow(missing_debug_implementations)]
 pub struct PgResult {
     internal_result: RawResult,
-    column_count: usize,
-    row_count: usize,
+    column_count: libc::c_int,
+    row_count: libc::c_int,
     // We store field names as pointer
     // as we cannot put a correct lifetime here
     // The value is valid as long as we haven't freed `RawResult`
@@ -34,8 +34,8 @@ impl PgResult {
             | ExecStatusType::PGRES_COPY_IN
             | ExecStatusType::PGRES_COPY_OUT
             | ExecStatusType::PGRES_TUPLES_OK => {
-                let column_count = unsafe { PQnfields(internal_result.as_ptr()) as usize };
-                let row_count = unsafe { PQntuples(internal_result.as_ptr()) as usize };
+                let column_count = unsafe { PQnfields(internal_result.as_ptr()) };
+                let row_count = unsafe { PQntuples(internal_result.as_ptr()) };
                 Ok(PgResult {
                     internal_result,
                     column_count,
@@ -109,6 +109,8 @@ impl PgResult {
 
     pub(super) fn num_rows(&self) -> usize {
         self.row_count
+            .try_into()
+            .expect("Diesel expects to run on at a least 32 bit OS")
     }
 
     pub(super) fn get_row(self: Rc<Self>, idx: usize) -> PgRow {
@@ -119,29 +121,38 @@ impl PgResult {
         if self.is_null(row_idx, col_idx) {
             None
         } else {
-            let row_idx = row_idx as libc::c_int;
-            let col_idx = col_idx as libc::c_int;
+            let row_idx = row_idx.try_into().ok()?;
+            let col_idx = col_idx.try_into().ok()?;
             unsafe {
                 let value_ptr =
                     PQgetvalue(self.internal_result.as_ptr(), row_idx, col_idx) as *const u8;
                 let num_bytes = PQgetlength(self.internal_result.as_ptr(), row_idx, col_idx);
-                Some(slice::from_raw_parts(value_ptr, num_bytes as usize))
+                Some(slice::from_raw_parts(
+                    value_ptr,
+                    num_bytes
+                        .try_into()
+                        .expect("Diesel expects at least a 32 bit operating system"),
+                ))
             }
         }
     }
 
     pub(super) fn is_null(&self, row_idx: usize, col_idx: usize) -> bool {
-        unsafe {
-            0 != PQgetisnull(
-                self.internal_result.as_ptr(),
-                row_idx as libc::c_int,
-                col_idx as libc::c_int,
-            )
-        }
+        let row_idx = row_idx
+            .try_into()
+            .expect("Row indices are expected to fit into 32 bit");
+        let col_idx = col_idx
+            .try_into()
+            .expect("Column indices are expected to fit into 32 bit");
+
+        unsafe { 0 != PQgetisnull(self.internal_result.as_ptr(), row_idx, col_idx) }
     }
 
     pub(in crate::pg) fn column_type(&self, col_idx: usize) -> NonZeroU32 {
-        let type_oid = unsafe { PQftype(self.internal_result.as_ptr(), col_idx as libc::c_int) };
+        let col_idx = col_idx
+            .try_into()
+            .expect("Column indices are expected to fit into 32 bit");
+        let type_oid = unsafe { PQftype(self.internal_result.as_ptr(), col_idx) };
         NonZeroU32::new(type_oid).expect(
             "Got a zero oid from postgres. If you see this error message \
              please report it as issue on the diesel github bug tracker.",
@@ -181,6 +192,8 @@ impl PgResult {
 
     pub(super) fn column_count(&self) -> usize {
         self.column_count
+            .try_into()
+            .expect("Diesel expects to run on a at least 32 bit OS")
     }
 }
 

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -108,9 +108,10 @@ impl PgResult {
     }
 
     pub(super) fn num_rows(&self) -> usize {
-        self.row_count
-            .try_into()
-            .expect("Diesel expects to run on at a least 32 bit OS")
+        self.row_count.try_into().expect(
+            "Diesel expects to run on a >= 32 bit OS \
+                (or libpq is giving out negative row count)",
+        )
     }
 
     pub(super) fn get_row(self: Rc<Self>, idx: usize) -> PgRow {
@@ -149,7 +150,7 @@ impl PgResult {
     }
 
     pub(in crate::pg) fn column_type(&self, col_idx: usize) -> NonZeroU32 {
-        let col_idx = col_idx
+        let col_idx: i32 = col_idx
             .try_into()
             .expect("Column indices are expected to fit into 32 bit");
         let type_oid = unsafe { PQftype(self.internal_result.as_ptr(), col_idx) };
@@ -191,9 +192,10 @@ impl PgResult {
     }
 
     pub(super) fn column_count(&self) -> usize {
-        self.column_count
-            .try_into()
-            .expect("Diesel expects to run on a at least 32 bit OS")
+        self.column_count.try_into().expect(
+            "Diesel expects to run on a >= 32 bit OS \
+                (or libpq is giving out negative column count)",
+        )
     }
 }
 

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -36,7 +36,7 @@ impl Statement {
             .map(|data| data.as_ref().map(|d| d.len().try_into()).unwrap_or(Ok(0)))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
-        let param_count = params_pointer
+        let param_count: libc::c_int = params_pointer
             .len()
             .try_into()
             .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
@@ -71,7 +71,7 @@ impl Statement {
             .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
 
         let internal_result = unsafe {
-            let param_count = param_types
+            let param_count: libc::c_int = param_types
                 .len()
                 .try_into()
                 .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;

--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -33,12 +33,17 @@ impl Statement {
             .collect::<Vec<_>>();
         let param_lengths = param_data
             .iter()
-            .map(|data| data.as_ref().map(|d| d.len() as libc::c_int).unwrap_or(0))
-            .collect::<Vec<_>>();
+            .map(|data| data.as_ref().map(|d| d.len().try_into()).unwrap_or(Ok(0)))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
+        let param_count = params_pointer
+            .len()
+            .try_into()
+            .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
         unsafe {
             raw_connection.send_query_prepared(
                 self.name.as_ptr(),
-                params_pointer.len() as libc::c_int,
+                param_count,
                 params_pointer.as_ptr(),
                 param_lengths.as_ptr(),
                 self.param_formats.as_ptr(),
@@ -66,10 +71,14 @@ impl Statement {
             .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
 
         let internal_result = unsafe {
+            let param_count = param_types
+                .len()
+                .try_into()
+                .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
             raw_connection.prepare(
                 name.as_ptr(),
                 sql.as_ptr(),
-                param_types.len() as libc::c_int,
+                param_count,
                 param_types_to_ptr(Some(&param_types_vec)),
             )
         };

--- a/diesel/src/pg/expression/extensions/interval_dsl.rs
+++ b/diesel/src/pg/expression/extensions/interval_dsl.rs
@@ -213,14 +213,19 @@ impl IntervalDsl for i64 {
     }
 
     fn days(self) -> PgInterval {
-        (self as i32).days()
+        i32::try_from(self)
+            .expect("Maximal supported day interval size is 32 bit")
+            .days()
     }
 
     fn months(self) -> PgInterval {
-        (self as i32).months()
+        i32::try_from(self)
+            .expect("Maximal supported month interval size is 32 bit")
+            .months()
     }
 }
 
+#[allow(clippy::cast_possible_truncation)] // we want to truncate
 impl IntervalDsl for f64 {
     fn microseconds(self) -> PgInterval {
         (self.round() as i64).microseconds()

--- a/diesel/src/pg/query_builder/copy/copy_to.rs
+++ b/diesel/src/pg/query_builder/copy/copy_to.rs
@@ -332,12 +332,13 @@ where
                 format!("Unexpected flag value: {flags_backward_incompatible:x}").into(),
             ));
         }
-        let header_size = i32::from_be_bytes(
+        let header_size = usize::try_from(i32::from_be_bytes(
             (&buffer[super::COPY_MAGIC_HEADER.len() + 4..super::COPY_MAGIC_HEADER.len() + 8])
                 .try_into()
                 .expect("Exactly 4 byte"),
-        );
-        out.consume(super::COPY_MAGIC_HEADER.len() + 8 + header_size as usize);
+        ))
+        .map_err(|e| crate::result::Error::DeserializationError(Box::new(e)))?;
+        out.consume(super::COPY_MAGIC_HEADER.len() + 8 + header_size);
         let mut len = None;
         Ok(std::iter::from_fn(move || {
             if let Some(len) = len {
@@ -351,7 +352,13 @@ where
             let tuple_count =
                 i16::from_be_bytes((&buffer[..2]).try_into().expect("Exactly 2 bytes"));
             if tuple_count > 0 {
-                let mut buffers = Vec::with_capacity(tuple_count as usize);
+                let tuple_count = match usize::try_from(tuple_count) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        return Some(Err(crate::result::Error::DeserializationError(Box::new(e))))
+                    }
+                };
+                let mut buffers = Vec::with_capacity(tuple_count);
                 let mut offset = 2;
                 for _t in 0..tuple_count {
                     let data_size = i32::from_be_bytes(
@@ -359,11 +366,21 @@ where
                             .try_into()
                             .expect("Exactly 4 bytes"),
                     );
+
                     if data_size < 0 {
                         buffers.push(None);
                     } else {
-                        buffers.push(Some(&buffer[offset + 4..offset + 4 + data_size as usize]));
-                        offset = offset + 4 + data_size as usize;
+                        match usize::try_from(data_size) {
+                            Ok(data_size) => {
+                                buffers.push(Some(&buffer[offset + 4..offset + 4 + data_size]));
+                                offset = offset + 4 + data_size;
+                            }
+                            Err(e) => {
+                                return Some(Err(crate::result::Error::DeserializationError(
+                                    Box::new(e),
+                                )));
+                            }
+                        }
                     }
                 }
 

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -49,7 +49,7 @@ where
                 if has_null && elem_size == -1 {
                     T::from_nullable_sql(None)
                 } else {
-                    let (elem_bytes, new_bytes) = bytes.split_at(elem_size as usize);
+                    let (elem_bytes, new_bytes) = bytes.split_at(elem_size.try_into()?);
                     bytes = new_bytes;
                     T::from_sql(PgValue::new_internal(elem_bytes, &value))
                 }
@@ -116,7 +116,7 @@ where
             };
 
             if let IsNull::No = is_null {
-                out.write_i32::<NetworkEndian>(buffer.len() as i32)?;
+                out.write_i32::<NetworkEndian>(buffer.len().try_into()?)?;
                 out.write_all(&buffer)?;
                 buffer.clear();
             } else {

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -116,7 +116,7 @@ fn pg_epoch_date() -> NaiveDate {
 impl ToSql<Date, Pg> for NaiveDate {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
         let days_since_epoch = self.signed_duration_since(pg_epoch_date()).num_days();
-        ToSql::<Date, Pg>::to_sql(&PgDate(days_since_epoch as i32), &mut out.reborrow())
+        ToSql::<Date, Pg>::to_sql(&PgDate(days_since_epoch.try_into()?), &mut out.reborrow())
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/quickcheck_impls.rs
+++ b/diesel/src/pg/types/date_and_time/quickcheck_impls.rs
@@ -1,6 +1,10 @@
-extern crate quickcheck;
-
-use self::quickcheck::{Arbitrary, Gen};
+// it's test code
+#![allow(
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
+use quickcheck::{Arbitrary, Gen};
 
 use super::{PgDate, PgInterval, PgTime, PgTimestamp};
 

--- a/diesel/src/pg/types/date_and_time/std_time.rs
+++ b/diesel/src/pg/types/date_and_time/std_time.rs
@@ -18,9 +18,9 @@ impl ToSql<sql_types::Timestamp, Pg> for SystemTime {
             Err(time_err) => (true, time_err.duration()),
         };
         let time_since_epoch = if before_epoch {
-            -(duration_to_usecs(duration) as i64)
+            -(i64::try_from(duration_to_usecs(duration))?)
         } else {
-            duration_to_usecs(duration) as i64
+            duration_to_usecs(duration).try_into()?
         };
         ToSql::<sql_types::BigInt, Pg>::to_sql(&time_since_epoch, &mut out.reborrow())
     }

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -101,7 +101,7 @@ impl ToSql<sql_types::Numeric, Pg> for PgNumeric {
             PgNumeric::Positive { scale, .. } | PgNumeric::Negative { scale, .. } => scale,
             PgNumeric::NaN => 0,
         };
-        out.write_u16::<NetworkEndian>(digits.len() as u16)?;
+        out.write_u16::<NetworkEndian>(digits.len().try_into()?)?;
         out.write_i16::<NetworkEndian>(weight)?;
         out.write_u16::<NetworkEndian>(sign)?;
         out.write_u16::<NetworkEndian>(scale)?;

--- a/diesel/src/pg/types/floats/quickcheck_impls.rs
+++ b/diesel/src/pg/types/floats/quickcheck_impls.rs
@@ -1,6 +1,6 @@
-extern crate quickcheck;
+#![allow(clippy::cast_sign_loss)] // test code
 
-use self::quickcheck::{Arbitrary, Gen};
+use quickcheck::{Arbitrary, Gen};
 
 use super::PgNumeric;
 

--- a/diesel/src/pg/types/ipnet_address.rs
+++ b/diesel/src/pg/types/ipnet_address.rs
@@ -16,6 +16,8 @@ const AF_INET: u8 = 2;
 // Maybe not used, but defining to follow Rust's libstd/net/sys
 #[cfg(target_os = "redox")]
 const AF_INET: u8 = 1;
+
+#[allow(clippy::cast_possible_truncation)] // it's 2
 #[cfg(not(any(windows, target_os = "redox")))]
 const AF_INET: u8 = libc::AF_INET as u8;
 

--- a/diesel/src/pg/types/network_address.rs
+++ b/diesel/src/pg/types/network_address.rs
@@ -17,6 +17,8 @@ const AF_INET: u8 = 2;
 // Maybe not used, but defining to follow Rust's libstd/net/sys
 #[cfg(target_os = "redox")]
 const AF_INET: u8 = 1;
+
+#[allow(clippy::cast_possible_truncation)] // it's 2
 #[cfg(not(any(windows, target_os = "redox")))]
 const AF_INET: u8 = libc::AF_INET as u8;
 

--- a/diesel/src/pg/types/ranges.rs
+++ b/diesel/src/pg/types/ranges.rs
@@ -153,7 +153,7 @@ where
                 let mut inner_buffer = Output::new(ByteWrapper(&mut buffer), out.metadata_lookup());
                 value.to_sql(&mut inner_buffer)?;
             }
-            out.write_u32::<NetworkEndian>(buffer.len() as u32)?;
+            out.write_u32::<NetworkEndian>(buffer.len().try_into()?)?;
             out.write_all(&buffer)?;
             buffer.clear();
         }
@@ -166,7 +166,7 @@ where
                 let mut inner_buffer = Output::new(ByteWrapper(&mut buffer), out.metadata_lookup());
                 value.to_sql(&mut inner_buffer)?;
             }
-            out.write_u32::<NetworkEndian>(buffer.len() as u32)?;
+            out.write_u32::<NetworkEndian>(buffer.len().try_into()?)?;
             out.write_all(&buffer)?;
         }
         Bound::Unbounded => {}

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -52,7 +52,7 @@ macro_rules! tuple_impls {
                     if num_bytes == -1 {
                         $T::from_nullable_sql(None)?
                     } else {
-                        let (elem_bytes, new_bytes) = bytes.split_at(num_bytes as usize);
+                        let (elem_bytes, new_bytes) = bytes.split_at(num_bytes.try_into()?);
                         bytes = new_bytes;
                         $T::from_sql(PgValue::new_internal(
                             elem_bytes,
@@ -117,7 +117,7 @@ macro_rules! tuple_impls {
                     };
 
                     if let IsNull::No = is_null {
-                        out.write_i32::<NetworkEndian>(buffer.len() as i32)?;
+                        out.write_i32::<NetworkEndian>(buffer.len().try_into()?)?;
                         out.write_all(&buffer)?;
                         buffer.clear();
                     } else {

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -202,10 +202,10 @@ impl<'a> Row<'a, Sqlite> for FunctionRow<'a> {
         'a: 'b,
         Self: crate::row::RowIndex<I>,
     {
-        let idx = self.idx(idx)?;
+        let col_idx = self.idx(idx)?;
         Some(FunctionArgument {
             args: self.args.borrow(),
-            col_idx: idx as i32,
+            col_idx,
         })
     }
 
@@ -232,7 +232,7 @@ impl<'a, 'b> RowIndex<&'a str> for FunctionRow<'b> {
 
 struct FunctionArgument<'a> {
     args: Ref<'a, ManuallyDrop<PrivateSqliteRow<'a, 'static>>>,
-    col_idx: i32,
+    col_idx: usize,
 }
 
 impl<'a> Field<'a, Sqlite> for FunctionArgument<'a> {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -185,9 +185,11 @@ impl Connection for SqliteConnection {
         T: QueryFragment<Self::Backend> + QueryId,
     {
         let statement_use = self.prepared_query(source)?;
-        statement_use
-            .run()
-            .map(|_| self.raw_connection.rows_affected_by_last_query())
+        statement_use.run().and_then(|_| {
+            self.raw_connection
+                .rows_affected_by_last_query()
+                .map_err(Error::DeserializationError)
+        })
     }
 
     fn transaction_state(&mut self) -> &mut AnsiTransactionManager

--- a/diesel/src/sqlite/connection/owned_row.rs
+++ b/diesel/src/sqlite/connection/owned_row.rs
@@ -41,7 +41,7 @@ impl<'a> Row<'a, Sqlite> for OwnedSqliteRow {
         let idx = self.idx(idx)?;
         Some(OwnedSqliteField {
             row: self,
-            col_idx: i32::try_from(idx).ok()?,
+            col_idx: idx,
         })
     }
 
@@ -71,14 +71,14 @@ impl<'idx> RowIndex<&'idx str> for OwnedSqliteRow {
 #[allow(missing_debug_implementations)]
 pub struct OwnedSqliteField<'row> {
     pub(super) row: &'row OwnedSqliteRow,
-    pub(super) col_idx: i32,
+    pub(super) col_idx: usize,
 }
 
 impl<'row> Field<'row, Sqlite> for OwnedSqliteField<'row> {
     fn field_name(&self) -> Option<&str> {
         self.row
             .column_names
-            .get(self.col_idx as usize)
+            .get(self.col_idx)
             .and_then(|o| o.as_ref().map(|s| s.as_ref()))
     }
 

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -420,7 +420,7 @@ where
     static NULL_CTX_ERR: &str =
         "We've written the aggregator to the aggregate context, but it could not be retrieved.";
 
-    let n_bytes = std::mem::size_of::<OptionalAggregator<A>>()
+    let n_bytes: i32 = std::mem::size_of::<OptionalAggregator<A>>()
         .try_into()
         .expect("Aggregate context should be larger than 2^32");
     let aggregate_context = unsafe {
@@ -525,7 +525,7 @@ extern "C" fn run_aggregator_final_function<ArgsSqlType, RetSqlType, Args, Ret, 
 }
 
 unsafe fn context_error_str(ctx: *mut ffi::sqlite3_context, error: &str) {
-    let len = error
+    let len: i32 = error
         .len()
         .try_into()
         .expect("Trying to set a error message with more than 2^32 byte is not supported");

--- a/diesel/src/sqlite/connection/row.rs
+++ b/diesel/src/sqlite/connection/row.rs
@@ -343,6 +343,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "returning_clauses_for_sqlite_3_35")]
+    #[allow(clippy::cast_sign_loss)]
     fn parallel_iter_with_error() {
         use crate::connection::Connection;
         use crate::connection::LoadConnection;

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -104,7 +104,10 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
                     Err(e) => Some(Err(e)),
                     Ok(false) => None,
                     Ok(true) => {
-                        let field_count = stmt.column_count() as usize;
+                        let field_count = stmt
+                            .column_count()
+                            .try_into()
+                            .expect("Diesel expects to run at least on a 32 bit platform");
                         self.field_count = field_count;
                         let inner = Rc::new(RefCell::new(PrivateSqliteRow::Direct(stmt)));
                         self.inner = Started(inner.clone());

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -73,7 +73,10 @@ fn parse_julian(julian_days: f64) -> Option<NaiveDateTime> {
     const EPOCH_IN_JULIAN_DAYS: f64 = 2_440_587.5;
     const SECONDS_IN_DAY: f64 = 86400.0;
     let timestamp = (julian_days - EPOCH_IN_JULIAN_DAYS) * SECONDS_IN_DAY;
-    let seconds = timestamp as i64;
+    #[allow(clippy::cast_possible_truncation)] // we want to truncate
+    let seconds = timestamp.trunc() as i64;
+    // that's not true, `fract` is always > 0
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     let nanos = (timestamp.fract() * 1E9) as u32;
     #[allow(deprecated)] // otherwise we would need to bump our minimal chrono version
     NaiveDateTime::from_timestamp_opt(seconds, nanos)

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -94,6 +94,7 @@ impl ToSql<sql_types::TimestamptzSqlite, Sqlite> for String {
 }
 
 #[cfg(all(test, feature = "chrono", feature = "time"))]
+#[allow(clippy::cast_possible_truncation)] // it's a test
 mod tests {
     extern crate chrono;
     extern crate time;

--- a/diesel/src/sqlite/types/date_and_time/time.rs
+++ b/diesel/src/sqlite/types/date_and_time/time.rs
@@ -131,6 +131,7 @@ fn parse_julian(julian_days: f64) -> Result<PrimitiveDateTime, ComponentRange> {
     const EPOCH_IN_JULIAN_DAYS: f64 = 2_440_587.5;
     const SECONDS_IN_DAY: f64 = 86400.0;
     let timestamp = (julian_days - EPOCH_IN_JULIAN_DAYS) * SECONDS_IN_DAY;
+    #[allow(clippy::cast_possible_truncation)] // we multiply by 1E9 to prevent that
     OffsetDateTime::from_unix_timestamp_nanos((timestamp * 1E9) as i128).map(naive_utc)
 }
 

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -54,6 +54,7 @@ impl Queryable<sql_types::Binary, Sqlite> for *const [u8] {
 }
 
 #[cfg(feature = "sqlite")]
+#[allow(clippy::cast_possible_truncation)] // we want to truncate here
 impl FromSql<sql_types::SmallInt, Sqlite> for i16 {
     fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_integer() as i16)
@@ -82,6 +83,7 @@ impl FromSql<sql_types::BigInt, Sqlite> for i64 {
 }
 
 #[cfg(feature = "sqlite")]
+#[allow(clippy::cast_possible_truncation)] // we want to truncate here
 impl FromSql<sql_types::Float, Sqlite> for f32 {
     fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_double() as f32)


### PR DESCRIPTION

* clippy::cast_possible_wrap
* clippy::cast_possible_truncation
* clippy::cast_sign_loss

These lints can point to serious problems if you hit one of the edge cases in low level unsafe/byte shuffling code

This is a reaction to
https://media.defcon.org/DEF%20CON%2032/DEF%20CON%2032%20presentations/DEF%20CON%2032%20-%20Paul%20Gerste%20-%20SQL%20Injection%20Isn't%20Dead%20Smuggling%20Queries%20at%20the%20Protocol%20Level.pdf

It fixes several places that could be possibly exploited by specially crafted values.