### PR TITLE
Implement array_ndims function

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1380,14 +1380,10 @@ define_sql_function! {
     /// #     use diesel::sql_types::{Nullable, Array, Integer};
     /// #     let connection = &mut establish_connection();
     ///
-    /// let dims = diesel::select(array_ndims::<Array<_>, _>(vec![1, 2]))
+    ///  // diesel currently only supports 1D arrays
+    /// let dims = diesel::select(array_ndims::<Array<Integer>, _>(vec![1, 2]))
     ///     .get_result::<i32>(connection)?;
     /// assert_eq!(1, dims);
-    ///
-    /// let dims = diesel::select(array_ndims::<Array<_>, _>(vec![vec![1, 2], vec![3, 4]]))
-    ///     .get_result::<i32>(connection)?;
-    /// assert_eq!(2, dims);
-    ///
     ///
     /// #     Ok(())
     /// # }

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1361,3 +1361,36 @@ define_sql_function! {
         elem: E,
     ) -> Nullable<Array<Integer>>;
 }
+
+#[cfg(feature = "postgres_backend")]
+define_sql_function! {
+    /// Returns the number of dimensions of the array
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::array_ndims;
+    /// #     use diesel::sql_types::{Nullable, Array, Integer};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let dims = diesel::select(array_ndims::<Array<_>, _>(vec![1, 2]))
+    ///     .get_result::<i32>(connection)?;
+    /// assert_eq!(1, dims);
+    ///
+    /// let dims = diesel::select(array_ndims::<Array<_>, _>(vec![vec![1, 2], vec![3, 4]]))
+    ///     .get_result::<i32>(connection)?;
+    /// assert_eq!(2, dims);
+    ///
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn array_ndims<Arr: ArrayOrNullableArray + SingleValue>(arr: Arr) -> Integer;
+}

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -451,3 +451,8 @@ pub type array_position_with_subscript<A, E, S> =
 #[cfg(feature = "postgres_backend")]
 pub type array_positions<A, E> =
     super::functions::array_positions<SqlTypeOf<A>, SqlTypeOf<E>, A, E>;
+
+/// Return type of [`array_ndims(array)`](super::functions::array_ndims())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array_ndims<A> = super::functions::array_ndims<SqlTypeOf<A>, A>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -430,6 +430,7 @@ fn postgres_functions() -> _ {
         array_position(pg_extras::array, pg_extras::id),
         array_position_with_subscript(pg_extras::array, pg_extras::id, pg_extras::id),
         array_positions(pg_extras::array, pg_extras::id),
+        array_ndims(pg_extras::array),
     )
 }
 


### PR DESCRIPTION
Adding support for `array_ndims` array [postgresql ](https://www.postgresql.org/docs/current/functions-array.html) function.
Connected issue: https://github.com/diesel-rs/diesel/issues/4153
