### PR TITLE
implements std::ops::Range to Multirange toSql

### DIFF
--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -178,8 +178,8 @@ pub mod sql_types {
     ///
     /// ### [`ToSql`] impls
     ///
-    /// - [`Vec<(Bound<T>, Bound<T>)>`][Vec] for any `T` which implements `ToSql<ST>`
-    /// - [`&[T]`][slice] for any `T` which implements `ToSql<ST>`
+    /// - [`Vec<T>`][Vec] for any `T` which `Range<T>` implements `ToSql<ST>`
+    /// - [`&[T]`][slice] for any `T` which `Range<T>` implements `ToSql<ST>`
     ///
     /// ### [`FromSql`] impls
     ///

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1534,6 +1534,13 @@ fn test_multirange_to_sql() {
         Multirange<Int4>,
         Vec<(Bound<i32>, Bound<i32>)>,
     >(expected_value, value));
+
+    let expected_value = "'{[5,8)}'::int4multirange";
+    let value = vec![5..8];
+    assert!(query_to_sql_equality::<
+        Multirange<Int4>,
+        Vec<(std::ops::Range<i32>)>,
+    >(expected_value, value));
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
Implements #4112 for #4159

Unfortunately It doesn't allow diferente types in the same vec, e.g. `vec![..0, 4..7, 9..]`