### PR TITLE
feat: added `diesel::r2d2::TestCustomizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Support for libsqlite3-sys 0.29.0
 * Add support for built-in PostgreSQL range operators and functions
 * Support for postgres multirange type
+* Added `diesel::r2d2::TestCustomizer`, which allows users to customize their `diesel::r2d2::Pool`s
+in a way that makes the pools suitable for use in parallel tests.
 
 ## [2.2.0] 2024-05-31
 


### PR DESCRIPTION
Closes https://github.com/diesel-rs/diesel/issues/4152

Let me know if you need me to make any improvements. I am unsure about the Error mapping. The problem I solved there was:
* the `Pool::builder` requires a connection customizer's error to be `ConnectionManager::Error`, which is `diesel::r2d2::Error`
* the return value from `begin_test_transaction()` is `QueryResult`, which error is `diesel::result::Error`

Hence the mapping, but I wonder if this is even correct for diesel. Let me know if you need me to make any adjustments here and with the docs!