### PR TITLE
Implement `array_prepend` and `array_remove`

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -831,3 +831,37 @@ define_sql_function! {
     /// ```
     fn array_prepend<T: SingleValue, Arr: ArrayOrNullableArray<Inner=T> + SingleValue>(e: T, a: Arr) -> Array<T>;
 }
+
+#[cfg(feature = "postgres_backend")]
+define_sql_function! {
+    /// Removes all elements equal to the given value from the array
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::array_remove;
+    /// #     use diesel::sql_types::{Nullable, Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let ints = diesel::select(array_remove::<Array<_>, Integer, _, _>(vec![1, 2, 3, 2], 2))
+    ///     .get_result::<Option<Vec<i32>>>(connection)?;
+    /// assert_eq!(Some(vec![1, 3]), ints);
+
+    /// let ints = diesel::select(array_remove::<Array<_>, Nullable<Integer>, _, _>(vec![None, Some(1), Some(2), None, Some(4)], None::<i32>))
+    ///     .get_result::<Option<Vec<Option<i32>>>>(connection)?;
+    /// assert_eq!(Some(vec![Some(1), Some(2), Some(4)]), ints);
+
+    /// let ints = diesel::select(array_remove::<Nullable<Array<_>>, Nullable<Integer>, _, _>(None::<Vec<i32>>, None::<i32>))
+    ///     .get_result::<Option<Vec<Option<i32>>>>(connection)?;
+    /// assert_eq!(None, ints);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn array_remove<Arr: ArrayOrNullableArray<Inner=T> + SingleValue, T: SingleValue>(a: Arr, e: T) -> Nullable<Array<T>>;
+}

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -793,3 +793,41 @@ define_sql_function! {
     ///
     fn array_dims<Arr:ArrayOrNullableArray<> + SingleValue>(arr:Arr) -> Text;
 }
+
+#[cfg(feature = "postgres_backend")]
+define_sql_function! {
+    /// Prepends an element to the beginning of an array
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::array_prepend;
+    /// #     use diesel::sql_types::{Nullable, Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let ints = diesel::select(array_prepend::<Integer, Array<_>, _, _>(3, vec![1, 2]))
+    ///     .get_result::<Vec<i32>>(connection)?;
+    /// assert_eq!(vec![3, 1, 2], ints);
+    ///
+    /// let ints = diesel::select(array_prepend::<Nullable<Integer>, Array<_>, _, _>(None::<i32>, vec![Some(1), Some(2)]))
+    ///     .get_result::<Vec<Option<i32>>>(connection)?;
+    /// assert_eq!(vec![None, Some(1), Some(2)], ints);
+    ///
+    /// let ints = diesel::select(array_prepend::<Integer, Nullable<Array<_>>, _, _>(3, None::<Vec<i32>>))
+    ///     .get_result::<Vec<i32>>(connection)?;
+    /// assert_eq!(vec![3], ints);
+    ///
+    /// let ints = diesel::select(array_prepend::<Nullable<Integer>, Nullable<Array<_>>, _, _>(None::<i32>, None::<Vec<i32>>))
+    ///     .get_result::<Vec<Option<i32>>>(connection)?;
+    /// assert_eq!(vec![None], ints);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn array_prepend<T: SingleValue, Arr: ArrayOrNullableArray<Inner=T> + SingleValue>(e: T, a: Arr) -> Array<T>;
+}

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -850,18 +850,18 @@ define_sql_function! {
     /// #     use diesel::sql_types::{Nullable, Integer, Array};
     /// #     let connection = &mut establish_connection();
     /// let ints = diesel::select(array_remove::<Array<_>, Integer, _, _>(vec![1, 2, 3, 2], 2))
-    ///     .get_result::<Option<Vec<i32>>>(connection)?;
-    /// assert_eq!(Some(vec![1, 3]), ints);
-
+    ///     .get_result::<Vec<i32>>(connection)?;
+    /// assert_eq!(vec![1, 3], ints);
+    ///
     /// let ints = diesel::select(array_remove::<Array<_>, Nullable<Integer>, _, _>(vec![None, Some(1), Some(2), None, Some(4)], None::<i32>))
-    ///     .get_result::<Option<Vec<Option<i32>>>>(connection)?;
-    /// assert_eq!(Some(vec![Some(1), Some(2), Some(4)]), ints);
-
+    ///     .get_result::<Vec<Option<i32>>>(connection)?;
+    /// assert_eq!(vec![Some(1), Some(2), Some(4)], ints);
+    ///
     /// let ints = diesel::select(array_remove::<Nullable<Array<_>>, Nullable<Integer>, _, _>(None::<Vec<i32>>, None::<i32>))
     ///     .get_result::<Option<Vec<Option<i32>>>>(connection)?;
     /// assert_eq!(None, ints);
     /// #     Ok(())
     /// # }
     /// ```
-    fn array_remove<Arr: ArrayOrNullableArray<Inner=T> + SingleValue, T: SingleValue>(a: Arr, e: T) -> Nullable<Array<T>>;
+    fn array_remove<Arr: ArrayOrNullableArray<Inner=T> + SingleValue, T: SingleValue>(a: Arr, e: T) -> Arr;
 }

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -372,3 +372,8 @@ pub type array_dims<A> = super::functions::array_dims<SqlTypeOf<A>, A>;
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type array_prepend<E, A> = super::functions::array_prepend<SqlTypeOf<E>, SqlTypeOf<A>, E, A>;
+
+/// Return type of [`array_remove(array, element)`](super::functions::array_remove())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array_remove<A, E> = super::functions::array_remove<SqlTypeOf<A>, SqlTypeOf<E>, A, E>;

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -367,3 +367,8 @@ pub type array_replace<A, E, R> = super::functions::array_replace<SqlTypeOf<A>, 
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type array_dims<A> = super::functions::array_dims<SqlTypeOf<A>, A>;
+
+/// Return type of [`array_prepend(element, array)`](super::functions::array_prepend())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array_prepend<E, A> = super::functions::array_prepend<SqlTypeOf<E>, SqlTypeOf<A>, E, A>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -416,6 +416,7 @@ fn postgres_functions() -> _ {
         array_replace(pg_extras::array, pg_extras::id, pg_extras::id),
         array_dims(pg_extras::array),
         array_prepend(pg_extras::id, pg_extras::array),
+        array_remove(pg_extras::array, pg_extras::id),
     )
 }
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -415,6 +415,7 @@ fn postgres_functions() -> _ {
         array_append(pg_extras::array, pg_extras::id),
         array_replace(pg_extras::array, pg_extras::id, pg_extras::id),
         array_dims(pg_extras::array),
+        array_prepend(pg_extras::id, pg_extras::array),
     )
 }
 


### PR DESCRIPTION
Implementing `array_prepend` and `array_remove` functions for Postgres under #4153

using specs https://www.postgresql.org/docs/current/functions-array.html