### PR TITLE
Extend range functions to support nullable and multirange

### DIFF
--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -3485,10 +3485,16 @@ pub(in crate::pg) mod private {
         message = "`{Self}` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Nullable<Range<_>>`",
         note = "try to provide an expression that produces one of the expected sql types"
     )]
-    pub trait RangeOrNullableRange {}
+    pub trait RangeOrNullableRange {
+        type Inner: SingleValue;
+    }
 
-    impl<ST> RangeOrNullableRange for Range<ST> {}
-    impl<ST> RangeOrNullableRange for Nullable<Range<ST>> {}
+    impl<ST: SingleValue> RangeOrNullableRange for Range<ST> {
+        type Inner = ST;
+    }
+    impl<ST: SingleValue> RangeOrNullableRange for Nullable<Range<ST>> {
+        type Inner = ST;
+    }
 
     /// Marker trait used to implement `PgRangeExpressionMethods` on the appropriate
     /// types. Once coherence takes associated types into account, we can remove

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -2,8 +2,8 @@
 
 pub(in crate::pg) use self::private::{
     ArrayOrNullableArray, InetOrCidr, JsonIndex, JsonOrNullableJsonOrJsonbOrNullableJsonb,
-    JsonRemoveIndex, JsonbOrNullableJsonb, MultirangeOrRangeMaybeNullable, RangeHelper,
-    RangeOrNullableRange, TextOrNullableText,
+    JsonRemoveIndex, JsonbOrNullableJsonb, MultirangeOrNullableMultirange,
+    MultirangeOrRangeMaybeNullable, RangeHelper, RangeOrNullableRange, TextOrNullableText,
 };
 use super::date_and_time::{AtTimeZone, DateTimeLike};
 use super::operators::*;
@@ -3494,6 +3494,27 @@ pub(in crate::pg) mod private {
     }
     impl<ST: SingleValue> RangeOrNullableRange for Nullable<Range<ST>> {
         type Inner = ST;
+    }
+
+    /// Marker trait used to implement `PgRangeExpressionMethods` on the appropriate
+    /// types. Once coherence takes associated types into account, we can remove
+    /// this trait.
+    #[diagnostic::on_unimplemented(
+        message = "`{Self}` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Nullable<Range<_>>`",
+        note = "try to provide an expression that produces one of the expected sql types"
+    )]
+    pub trait MultirangeOrNullableMultirange {
+        type Inner: SingleValue;
+        type Range: SingleValue;
+    }
+
+    impl<ST: SingleValue> MultirangeOrNullableMultirange for Multirange<ST> {
+        type Inner = ST;
+        type Range = Range<ST>;
+    }
+    impl<ST: SingleValue> MultirangeOrNullableMultirange for Nullable<Multirange<ST>> {
+        type Inner = ST;
+        type Range = Nullable<Range<ST>>;
     }
 
     /// Marker trait used to implement `PgRangeExpressionMethods` on the appropriate

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -222,38 +222,29 @@ define_sql_function! {
     /// ```rust
     /// # include!("../../doctest_setup.rs");
     /// #
-    /// # table! {
-    /// #     posts {
-    /// #         id -> Integer,
-    /// #         versions -> Range<Integer>,
-    /// #     }
-    /// # }
-    /// #
     /// # fn main() {
     /// #     run_test().unwrap();
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use self::posts::dsl::*;
+    /// # use diesel::pg::sql_types::{Range, Multirange};
+    /// # use diesel::dsl::upper_inc;
     /// #     use std::collections::Bound;
-    /// #     let conn = &mut establish_connection();
-    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
-    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
-    /// #
-    /// use diesel::dsl::upper_inc;
-    /// diesel::insert_into(posts)
-    ///     .values(&[
-    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
-    ///     ]).execute(conn)?;
+    /// #     use diesel::sql_types::{Nullable, Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let int = diesel::select(upper_inc::<Range<Integer>,  _>(1..5)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     ///
-    /// let cool_posts = posts.select(upper_inc(versions))
-    ///     .load::<bool>(conn)?;
-    /// assert_eq!(vec![false], cool_posts);
+    /// let int = diesel::select(upper_inc::<Nullable<Range<Integer>>, _>(None::<std::ops::Range<i32>>)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(None, int);
+    ///
+    /// let int = diesel::select(upper_inc::<Multirange<Integer>, _>(vec![5..7])).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     /// #     Ok(())
     /// # }
     /// ```
     #[cfg(feature = "postgres_backend")]
-    fn upper_inc<T: RangeHelper>(range: T) -> Bool;
+    fn upper_inc<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<Bool>;
 }
 
 define_sql_function! {

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -255,39 +255,32 @@ define_sql_function! {
     /// ```rust
     /// # include!("../../doctest_setup.rs");
     /// #
-    /// # table! {
-    /// #     posts {
-    /// #         id -> Integer,
-    /// #         versions -> Range<Integer>,
-    /// #     }
-    /// # }
-    /// #
     /// # fn main() {
     /// #     run_test().unwrap();
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use self::posts::dsl::*;
+    /// # use diesel::pg::sql_types::{Range, Multirange};
+    /// # use diesel::dsl::lower_inf;
     /// #     use std::collections::Bound;
-    /// #     let conn = &mut establish_connection();
-    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
-    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
-    /// #
-    /// use diesel::dsl::lower_inf;
-    /// diesel::insert_into(posts)
-    ///     .values(&[
-    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
-    ///        versions.eq((Bound::Unbounded, Bound::Excluded(7))),
-    ///     ]).execute(conn)?;
+    /// #     use diesel::sql_types::{Nullable, Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let int = diesel::select(lower_inf::<Range<Integer>,  _>(1..5)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     ///
-    /// let cool_posts = posts.select(lower_inf(versions))
-    ///     .load::<bool>(conn)?;
-    /// assert_eq!(vec![false, true], cool_posts);
+    /// let int = diesel::select(lower_inf::<Range<Integer>,  _>(..5)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(true), int);
+    ///
+    /// let int = diesel::select(lower_inf::<Nullable<Range<Integer>>, _>(None::<std::ops::Range<i32>>)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(None, int);
+    ///
+    /// let int = diesel::select(lower_inf::<Multirange<Integer>, _>(vec![5..7])).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     /// #     Ok(())
     /// # }
     /// ```
     #[cfg(feature = "postgres_backend")]
-    fn lower_inf<T: RangeHelper>(range: T) -> Bool;
+    fn lower_inf<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<Bool>;
 }
 
 define_sql_function! {

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -150,39 +150,32 @@ define_sql_function! {
     /// ```rust
     /// # include!("../../doctest_setup.rs");
     /// #
-    /// # table! {
-    /// #     posts {
-    /// #         id -> Integer,
-    /// #         versions -> Range<Integer>,
-    /// #     }
-    /// # }
-    /// #
     /// # fn main() {
     /// #     run_test().unwrap();
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use self::posts::dsl::*;
+    /// # use diesel::pg::sql_types::{Range, Multirange};
+    /// # use diesel::dsl::isempty;
     /// #     use std::collections::Bound;
-    /// #     let conn = &mut establish_connection();
-    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
-    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
-    /// #
-    /// use diesel::dsl::isempty;
-    /// diesel::insert_into(posts)
-    ///     .values(&[
-    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
-    ///        versions.eq((Bound::Excluded(7), Bound::Excluded(7))),
-    ///     ]).execute(conn)?;
+    /// #     use diesel::sql_types::{Nullable, Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let int = diesel::select(isempty::<Range<Integer>,  _>(1..5)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     ///
-    /// let cool_posts = posts.select(isempty(versions))
-    ///     .load::<bool>(conn)?;
-    /// assert_eq!(vec![false, true], cool_posts);
+    /// let int = diesel::select(isempty::<Range<Integer>, _>(1..1)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(true), int);
+    ///
+    /// let int = diesel::select(isempty::<Nullable<Range<Integer>>, _>(None::<std::ops::Range<i32>>)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(None, int);
+    ///
+    /// let int = diesel::select(isempty::<Multirange<Integer>, _>(vec![5..7])).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     /// #     Ok(())
     /// # }
     /// ```
     #[cfg(feature = "postgres_backend")]
-    fn isempty<T: RangeHelper>(range: T) -> Bool;
+    fn isempty<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<Bool>;
 }
 
 define_sql_function! {

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -291,39 +291,32 @@ define_sql_function! {
     /// ```rust
     /// # include!("../../doctest_setup.rs");
     /// #
-    /// # table! {
-    /// #     posts {
-    /// #         id -> Integer,
-    /// #         versions -> Range<Integer>,
-    /// #     }
-    /// # }
-    /// #
     /// # fn main() {
     /// #     run_test().unwrap();
     /// # }
     /// #
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use self::posts::dsl::*;
+    /// # use diesel::pg::sql_types::{Range, Multirange};
+    /// # use diesel::dsl::upper_inf;
     /// #     use std::collections::Bound;
-    /// #     let conn = &mut establish_connection();
-    /// #     diesel::sql_query("DROP TABLE IF EXISTS posts").execute(conn).unwrap();
-    /// #     diesel::sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, versions INT4RANGE NOT NULL)").execute(conn).unwrap();
-    /// #
-    /// use diesel::dsl::upper_inf;
-    /// diesel::insert_into(posts)
-    ///     .values(&[
-    ///        versions.eq((Bound::Included(5), Bound::Excluded(7))),
-    ///        versions.eq((Bound::Included(5),Bound::Unbounded)),
-    ///     ]).execute(conn)?;
+    /// #     use diesel::sql_types::{Nullable, Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let int = diesel::select(upper_inf::<Range<Integer>,  _>(1..5)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     ///
-    /// let cool_posts = posts.select(upper_inf(versions))
-    ///     .load::<bool>(conn)?;
-    /// assert_eq!(vec![false, true], cool_posts);
+    /// let int = diesel::select(upper_inf::<Range<Integer>,  _>(1..)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(true), int);
+    ///
+    /// let int = diesel::select(upper_inf::<Nullable<Range<Integer>>, _>(None::<std::ops::Range<i32>>)).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(None, int);
+    ///
+    /// let int = diesel::select(upper_inf::<Multirange<Integer>, _>(vec![5..7])).get_result::<Option<bool>>(connection)?;
+    /// assert_eq!(Some(false), int);
     /// #     Ok(())
     /// # }
     /// ```
     #[cfg(feature = "postgres_backend")]
-    fn upper_inf<T: RangeHelper>(range: T) -> Bool;
+    fn upper_inf<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<Bool>;
 }
 
 define_sql_function! {

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -95,7 +95,7 @@ define_sql_function! {
     /// let int = diesel::select(lower::<Nullable<Range<_>>, _>(None::<std::ops::Range<i32>>)).get_result::<Option<i32>>(connection)?;
     /// assert_eq!(None, int);
     ///
-    /// let int = diesel::select(lower::<Multirange<_>, _>(vec![(Bound::Included(5), Bound::Included(7))])).get_result::<Option<i32>>(connection)?;
+    /// let int = diesel::select(lower::<Multirange<_>, _>(vec![5..7])).get_result::<Option<i32>>(connection)?;
     /// assert_eq!(Some(5), int);
     /// #     Ok(())
     /// # }

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -348,6 +348,11 @@ pub type upper_inf<R> = super::functions::upper_inf<SqlTypeOf<R>, R>;
 #[cfg(feature = "postgres_backend")]
 pub type range_merge<R1, R2> = super::functions::range_merge<SqlTypeOf<R1>, SqlTypeOf<R2>, R1, R2>;
 
+/// Return type of [`multirange_merge(multirange)`](super::functions::multirange_merge())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type multirange_merge<R> = super::functions::multirange_merge<SqlTypeOf<R>, R>;
+
 /// Return type of [`array_append(array, element)`](super::functions::array_append())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -49,6 +49,7 @@ table! {
         blob -> Binary,
         timestamp -> Timestamp,
         range -> Range<Integer>,
+        multirange -> Multirange<Integer>,
         timestamptz -> Timestamptz,
     }
 }
@@ -400,6 +401,7 @@ fn postgres_functions() -> _ {
         lower_inf(pg_extras::range),
         upper_inf(pg_extras::range),
         range_merge(pg_extras::range, pg_extras::range),
+        multirange_merge(pg_extras::multirange),
         int4range(users::id.nullable(), users::id.nullable(), bound),
         int8range(users::bigint.nullable(), users::bigint.nullable(), bound),
         numrange(users::numeric.nullable(), users::numeric.nullable(), bound),


### PR DESCRIPTION
This PR extends the range functions to suportt multirange and nullable types, folowing the behavior of the[ postgres functions](https://www.postgresql.org/docs/current/functions-range.html#RANGE-FUNCTIONS-TABLE)

Please review after #4182 and #4179 be merged
