### PR TITLE
Fix the tidy command

### DIFF
--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -361,7 +361,8 @@ pub type array_append<A, E> = super::functions::array_append<SqlTypeOf<A>, SqlTy
 /// Return type of [`array_replace(array, element, replace_with)`](super::functions::array_replace())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
-pub type array_replace<A, E, R> = super::functions::array_replace<SqlTypeOf<A>, SqlTypeOf<E>, A, E, R>;
+pub type array_replace<A, E, R> =
+    super::functions::array_replace<SqlTypeOf<A>, SqlTypeOf<E>, A, E, R>;
 
 /// Return type of [`array_dims(array)`](super::functions::array_append())
 #[allow(non_camel_case_types)]

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -210,23 +210,15 @@ pub fn build_cli() -> Command {
         .alias("db")
         .arg(migration_dir_arg())
         .about("A group of commands for setting up and resetting your database.")
-        .subcommand(
-            Command::new("setup")
-                .arg(no_default_migration_arg())
-                .about(
-                    "Creates the database specified in your DATABASE_URL, and \
+        .subcommand(Command::new("setup").arg(no_default_migration_arg()).about(
+            "Creates the database specified in your DATABASE_URL, and \
                      then runs any existing migrations.",
-                )
-        )
-        .subcommand(
-            Command::new("reset")
-                .arg(no_default_migration_arg())
-                .about(
-                    "Resets your database by dropping the database specified \
+        ))
+        .subcommand(Command::new("reset").arg(no_default_migration_arg()).about(
+            "Resets your database by dropping the database specified \
                      in your DATABASE_URL and then running `diesel database \
                      setup`.",
-                )
-        )
+        ))
         .subcommand(
             Command::new("drop")
                 .about("Drops the database specified in your DATABASE_URL.")

--- a/diesel_cli/tests/database_setup.rs
+++ b/diesel_cli/tests/database_setup.rs
@@ -271,7 +271,8 @@ fn database_setup_no_default_migrations() {
     // sanity check
     assert!(!db.exists());
 
-    let result = p.command("database")
+    let result = p
+        .command("database")
         .arg("setup")
         .arg("--no-default-migration")
         .run();

--- a/xtask/src/tidy.rs
+++ b/xtask/src/tidy.rs
@@ -15,6 +15,7 @@ pub struct TidyArgs {
 
 impl TidyArgs {
     pub(crate) fn run(&self) {
+        let mut success = true;
         let metadata = MetadataCommand::default().exec().unwrap();
         let mut command = Command::new("cargo");
 
@@ -34,6 +35,8 @@ impl TidyArgs {
             println!("\t Run `cargo fmt --all` to format the source code");
             if !self.keep_going {
                 std::process::exit(1);
+            } else {
+                success = false;
             }
         }
 
@@ -53,6 +56,8 @@ impl TidyArgs {
             println!("\t Run `typos -w` to address some of the issues");
             if !self.keep_going {
                 std::process::exit(1);
+            } else {
+                success = false;
             }
         }
 
@@ -65,6 +70,10 @@ impl TidyArgs {
         .run();
 
         println!();
-        println!("All checks were successful. Ready to submit the code!");
+        if success {
+            println!("All checks were successful. Ready to submit the code!");
+        } else {
+            std::process::exit(1);
+        }
     }
 }


### PR DESCRIPTION
We did not return a non-zero exit code before if the format or typos check failed. This commit fixes that problem and fixes any broken formating that happened in the mean-time.