### PR TITLE
Implement `array_cat` and `array_length` functions

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1025,7 +1025,7 @@ define_sql_function! {
 
 #[cfg(feature = "postgres_backend")]
 define_sql_function! {
-    /// Returns the length of the requested array dimension
+    /// Returns the length of the requested array
     ///
     /// # Example
     ///
@@ -1040,7 +1040,7 @@ define_sql_function! {
     /// #     use diesel::dsl::array_length;
     /// #     use diesel::sql_types::{Integer, Array};
     /// #     let connection = &mut establish_connection();
-    /// let result = diesel::select(array_length::<Array<Integer>, _>(vec![1, 2, 3], 1))
+    /// let result = diesel::select(array_length::<Array<Integer>, _, _>(vec![1, 2, 3], 1))
     ///     .get_result::<Option<i32>>(connection)?;
     /// assert_eq!(Some(3), result);
     /// #     Ok(())

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1012,15 +1012,21 @@ define_sql_function! {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::array_cat;
-    /// #     use diesel::sql_types::{Integer, Array};
+    /// #     use diesel::sql_types::{Integer, Array, Nullable};
     /// #     let connection = &mut establish_connection();
     /// let result = diesel::select(array_cat::<Array<Integer>, _, _, _>(vec![1, 2], vec![3, 4]))
     ///     .get_result::<Vec<i32>>(connection)?;
     /// assert_eq!(vec![1, 2, 3, 4], result);
+    ///
+    /// let nullable_result = diesel::select(array_cat::<Nullable<Array<_>>, _, _, _>(
+    ///     None::<Vec<i32>>,
+    ///     None::<Vec<i32>>
+    /// )).get_result::<Option<Vec<i32>>>(connection)?;
+    /// assert_eq!(vec![None], nullable_result);
     /// #     Ok(())
     /// # }
     /// ```
-    fn array_cat<Arr: ArrayOrNullableArray<Inner=T> + SingleValue, T: SingleValue>(a: Arr, b: Arr) -> Array<T>;
+    fn array_cat<Arr: ArrayOrNullableArray<Inner=T> + SingleValue, T: SingleValue>(a: Arr, b: Arr) -> Arr;
 }
 
 #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1060,11 +1060,11 @@ define_sql_function! {
     ///     .get_result::<Vec<i32>>(connection)?;
     /// assert_eq!(vec![1, 2, 3, 4], result);
     ///
-    /// let nullable_result = diesel::select(array_cat::<Nullable<Array<_>>, _, _, _>(
+    /// let nullable_result = diesel::select(array_cat::<Nullable<Array<Integer>>, _, _, _>(
     ///     None::<Vec<i32>>,
     ///     None::<Vec<i32>>
     /// )).get_result::<Option<Vec<i32>>>(connection)?;
-    /// assert_eq!(vec![None], nullable_result);
+    /// assert_eq!(None, nullable_result);
     /// #     Ok(())
     /// # }
     /// ```

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -996,3 +996,55 @@ define_sql_function! {
     ///
     fn cardinality<Arr:ArrayOrNullableArray + SingleValue>(a: Arr) -> Nullable<Integer>;
 }
+
+#[cfg(feature = "postgres_backend")]
+define_sql_function! {
+    /// Concatenates two arrays
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::array_cat;
+    /// #     use diesel::sql_types::{Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let result = diesel::select(array_cat::<Array<Integer>, _, _>(vec![1, 2], vec![3, 4]))
+    ///     .get_result::<Vec<i32>>(connection)?;
+    /// assert_eq!(vec![1, 2, 3, 4], result);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn array_cat<Arr: ArrayOrNullableArray<Inner=T> + SingleValue, T: SingleValue>(a: Arr, b: Arr) -> Array<T>;
+}
+
+#[cfg(feature = "postgres_backend")]
+define_sql_function! {
+    /// Returns the length of the requested array dimension
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::array_length;
+    /// #     use diesel::sql_types::{Integer, Array};
+    /// #     let connection = &mut establish_connection();
+    /// let result = diesel::select(array_length::<Array<Integer>, _>(vec![1, 2, 3], 1))
+    ///     .get_result::<Option<i32>>(connection)?;
+    /// assert_eq!(Some(3), result);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn array_length<Arr: ArrayOrNullableArray + SingleValue>(array: Arr, dimension: Integer) -> Nullable<Integer>;
+}

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1014,7 +1014,7 @@ define_sql_function! {
     /// #     use diesel::dsl::array_cat;
     /// #     use diesel::sql_types::{Integer, Array};
     /// #     let connection = &mut establish_connection();
-    /// let result = diesel::select(array_cat::<Array<Integer>, _, _>(vec![1, 2], vec![3, 4]))
+    /// let result = diesel::select(array_cat::<Array<Integer>, _, _, _>(vec![1, 2], vec![3, 4]))
     ///     .get_result::<Vec<i32>>(connection)?;
     /// assert_eq!(vec![1, 2, 3, 4], result);
     /// #     Ok(())

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1056,11 +1056,11 @@ define_sql_function! {
     /// #     use diesel::dsl::array_cat;
     /// #     use diesel::sql_types::{Integer, Array, Nullable};
     /// #     let connection = &mut establish_connection();
-    /// let result = diesel::select(array_cat::<Array<Integer>, _, _, _>(vec![1, 2], vec![3, 4]))
+    /// let result = diesel::select(array_cat::<Array<Integer>, _, _>(vec![1, 2], vec![3, 4]))
     ///     .get_result::<Vec<i32>>(connection)?;
     /// assert_eq!(vec![1, 2, 3, 4], result);
     ///
-    /// let nullable_result = diesel::select(array_cat::<Nullable<Array<Integer>>, _, _, _>(
+    /// let nullable_result = diesel::select(array_cat::<Nullable<Array<Integer>>, _, _>(
     ///     None::<Vec<i32>>,
     ///     None::<Vec<i32>>
     /// )).get_result::<Option<Vec<i32>>>(connection)?;
@@ -1068,7 +1068,7 @@ define_sql_function! {
     /// #     Ok(())
     /// # }
     /// ```
-    fn array_cat<Arr: ArrayOrNullableArray<Inner=T> + SingleValue, T: SingleValue>(a: Arr, b: Arr) -> Arr;
+    fn array_cat<Arr: ArrayOrNullableArray + SingleValue>(a: Arr, b: Arr) -> Arr;
 }
 
 #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -2,6 +2,7 @@ use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
 use crate::expression::Expression;
 use crate::pg::expression::expression_methods::private::{JsonIndex, JsonRemoveIndex};
+use crate::pg::expression::expression_methods::ArrayOrNullableArray;
 use crate::pg::types::sql_types::Array;
 use crate::sql_types::{Inet, Integer, VarChar};
 
@@ -407,7 +408,8 @@ pub type cardinality<A> = super::functions::cardinality<SqlTypeOf<A>, A>;
 /// Return type of [`array_cat(array_a, array_b)`](super::functions::array_cat())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
-pub type array_cat<A, B> = super::functions::array_cat<SqlTypeOf<A>, SqlTypeOf<B>, A, B>;
+pub type array_cat<A, B> =
+    super::functions::array_cat<SqlTypeOf<A>, <SqlTypeOf<A> as ArrayOrNullableArray>::Inner, A, B>;
 
 /// Return type of [`array_length(array, dimension)`](super::functions::array_length())
 #[allow(non_camel_case_types)]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -2,7 +2,6 @@ use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
 use crate::expression::Expression;
 use crate::pg::expression::expression_methods::private::{JsonIndex, JsonRemoveIndex};
-use crate::pg::expression::expression_methods::ArrayOrNullableArray;
 use crate::pg::types::sql_types::Array;
 use crate::sql_types::{Inet, Integer, VarChar};
 
@@ -413,8 +412,7 @@ pub type trim_array<A, N> = super::functions::trim_array<SqlTypeOf<A>, A, N>;
 /// Return type of [`array_cat(array_a, array_b)`](super::functions::array_cat())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
-pub type array_cat<A, B> =
-    super::functions::array_cat<SqlTypeOf<A>, <SqlTypeOf<A> as ArrayOrNullableArray>::Inner, A, B>;
+pub type array_cat<A, B> = super::functions::array_cat<SqlTypeOf<A>, A, B>;
 
 /// Return type of [`array_length(array, dimension)`](super::functions::array_length())
 #[allow(non_camel_case_types)]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -403,3 +403,13 @@ pub type array_remove<A, E> = super::functions::array_remove<SqlTypeOf<A>, SqlTy
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type cardinality<A> = super::functions::cardinality<SqlTypeOf<A>, A>;
+
+/// Return type of [`array_cat(array_a, array_b)`](super::functions::array_cat())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array_cat<A, B> = super::functions::array_cat<SqlTypeOf<A>, SqlTypeOf<B>, A, B>;
+
+/// Return type of [`array_length(array, dimension)`](super::functions::array_length())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array_length<A, D> = super::functions::array_length<SqlTypeOf<A>, A, D>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -421,6 +421,8 @@ fn postgres_functions() -> _ {
         array_to_string(pg_extras::array, pg_extras::name),
         array_to_string_with_null_string(pg_extras::array, pg_extras::name, pg_extras::name),
         cardinality(pg_extras::array),
+        array_cat(pg_extras::array, pg_extras::array),
+        array_length(pg_extras::array, 1_i32),
     )
 }
 


### PR DESCRIPTION
implemented `array_cat` and `array_length` functions for postgres under https://github.com/diesel-rs/diesel/issues/4153