### PR TITLE
print diff if print-schema fails due to mismatch with --locked-schema flag

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -56,6 +56,7 @@ syn = { version = "2", features = ["visit"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
 thiserror = "1.0.10"
+similar-asserts = "1.5.0"
 
 [dependencies.diesel]
 version = "~2.2.0"

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -283,9 +283,13 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
                     .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
 
                 if schema.lines().ne(old_buf.lines()) {
+                    // it's fine to leak here, we will
+                    // exit the application anyway soon
+                    let label = path.file_name().expect("We have a file name here");
+                    let label = label.to_string_lossy().into_owned().leak();
                     println!(
                         "{}",
-                        SimpleDiff::from_str(&schema, &old_buf, "new schema", "schema in file")
+                        SimpleDiff::from_str(&old_buf, &schema, label, "new schema")
                     );
                     return Err(crate::errors::Error::SchemaWouldChange(
                         path.display().to_string(),

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -30,6 +30,7 @@ use database::InferConnection;
 use diesel::backend::Backend;
 use diesel::Connection;
 use diesel_migrations::{FileBasedMigrations, HarnessWithOutput, MigrationHarness};
+use similar_asserts::SimpleDiff;
 use std::error::Error;
 use std::io::stdout;
 use std::path::{Path, PathBuf};
@@ -282,6 +283,10 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
                     .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
 
                 if schema.lines().ne(old_buf.lines()) {
+                    println!(
+                        "{}",
+                        SimpleDiff::from_str(&schema, &old_buf, "new schema", "schema in file")
+                    );
                     return Err(crate::errors::Error::SchemaWouldChange(
                         path.display().to_string(),
                     ));


### PR DESCRIPTION
using similar-asserts to print a diff if print-schema fails with the --locked-schema flag provided due to a mismatch

fixes #4208 