### PR TITLE
Fix a potential null pointer deref in the Sqlite backend

### DIFF
--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -456,6 +456,21 @@ impl fmt::Display for EmptyChangeset {
 
 impl StdError for EmptyChangeset {}
 
+/// Expected when you try to execute an empty query
+#[derive(Debug, Clone, Copy)]
+pub struct EmptyQuery;
+
+impl fmt::Display for EmptyQuery {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Detected an empty query. These are not supported by your database system"
+        )
+    }
+}
+
+impl StdError for EmptyQuery {}
+
 /// An error occurred while deserializing a field
 #[derive(Debug)]
 #[non_exhaustive]

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -952,4 +952,21 @@ mod tests {
         .unwrap();
         assert_eq!(res, Some(Vec::new()));
     }
+
+    #[test]
+    fn correctly_handle_empty_query() {
+        let check_empty_query_error = |r: crate::QueryResult<usize>| {
+            assert!(r.is_err());
+            let err = r.unwrap_err();
+            assert!(
+                matches!(err, crate::result::Error::QueryBuilderError(ref b) if b.is::<crate::result::EmptyQuery>()),
+                "Expected a query builder error, but got {err}"
+            );
+        };
+        let connection = &mut SqliteConnection::establish(":memory:").unwrap();
+        check_empty_query_error(crate::sql_query("").execute(connection));
+        check_empty_query_error(crate::sql_query("   ").execute(connection));
+        check_empty_query_error(crate::sql_query("\n\t").execute(connection));
+        check_empty_query_error(crate::sql_query("-- SELECT 1;").execute(connection));
+    }
 }


### PR DESCRIPTION
The documentation of `sqlite3_prepare_v3` states that:

> *ppStmt is left pointing to a compiled prepared statement that can be
executed using sqlite3_step(). If there is an error, *ppStmt is set to NULL. If the input text contains no SQL (if the input is an empty string or a comment) then *ppStmt is set to NULL. The calling procedure is responsible for deleting the compiled SQL statement using sqlite3_finalize() after it has finished with it. ppStmt may not be NULL.

We already guard against the error case there before constructing the `NonNull` pointer, we do not guard against empty statements yet. This commit fixes that particular issue + adds a test to check if the fix works as expected.

This fixes #4223