### PR TITLE
implement json_object with separate keys and values arguments

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1656,6 +1656,51 @@ define_sql_function! {
 
 #[cfg(feature = "postgres_backend")]
 define_sql_function! {
+    /// This form of json_object takes keys and values pairwise from two separate arrays.
+    /// In all other respects it is identical to the one-argument form.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::json_object_with_keys_and_values;
+    /// #     use diesel::sql_types::{Array, Json, Nullable, Text};
+    /// #     use serde_json::Value;
+    /// #     let connection = &mut establish_connection();
+    /// let json = diesel::select(json_object_with_keys_and_values::<Array<Text>, _, _>(
+    ///             vec!["hello","John"],vec!["world","Doe"]))
+    ///             .get_result::<Value>(connection)?;
+    /// let expected:Value = serde_json::json!({"hello":"world","John":"Doe"});
+    /// assert_eq!(expected,json);
+    ///
+    /// let json = diesel::select(json_object_with_keys_and_values::<Nullable<Array<Text>>, _, _>(
+    ///             Some(vec!["hello","John"]),None::<Vec<String>>))
+    ///             .get_result::<Option<Value>>(connection)?;
+    /// assert_eq!(None::<Value>,json);
+    ///
+    /// let empty: Vec<String> = Vec::new();
+    /// let json = diesel::select(json_object_with_keys_and_values::<Array<Text>, _, _>(
+    ///             vec!["hello","John"],empty))
+    ///             .get_result::<Value>(connection);
+    /// assert!(json.is_err());
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[sql_name = "json_object"]
+    fn json_object_with_keys_and_values<Arr: TextArrayOrNullableTextArray + MaybeNullableValue<Json>>(
+        keys: Arr, values: Arr
+    ) -> Arr::Out;
+}
+
+#[cfg(feature = "postgres_backend")]
+define_sql_function! {
     /// Returns the type of the top-level json value as a text-string
     ///
     /// # Example

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1609,6 +1609,7 @@ define_sql_function! {
     fn to_jsonb<E: MaybeNullableValue<Jsonb>>(e: E) -> E::Out;
 }
 
+#[cfg(feature = "postgres_backend")]
 define_sql_function! {
     /// Builds a JSON object out of a text array. The array must have an even number of members,
     /// in which case they are taken as alternating key/value pairs

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -487,6 +487,12 @@ pub type to_jsonb<E> = super::functions::to_jsonb<SqlTypeOf<E>, E>;
 #[cfg(feature = "postgres_backend")]
 pub type json_object<A> = super::functions::json_object<SqlTypeOf<A>, A>;
 
+/// Return type of [`json_object_with_keys_and_values(text_array, text_array)`](super::functions::json_object_with_keys_and_values())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type json_object_with_keys_and_values<A> =
+    super::functions::json_object_with_keys_and_values<SqlTypeOf<A>, A, A>;
+
 /// Return type of [`json_typeof(json)`](super::functions::json_typeof())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -490,8 +490,8 @@ pub type json_object<A> = super::functions::json_object<SqlTypeOf<A>, A>;
 /// Return type of [`json_object_with_keys_and_values(text_array, text_array)`](super::functions::json_object_with_keys_and_values())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
-pub type json_object_with_keys_and_values<A> =
-    super::functions::json_object_with_keys_and_values<SqlTypeOf<A>, A, A>;
+pub type json_object_with_keys_and_values<K, V> =
+    super::functions::json_object_with_keys_and_values<SqlTypeOf<K>, K, V>;
 
 /// Return type of [`json_typeof(json)`](super::functions::json_typeof())
 #[allow(non_camel_case_types)]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -491,7 +491,7 @@ pub type json_object<A> = super::functions::json_object<SqlTypeOf<A>, A>;
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type json_object_with_keys_and_values<K, V> =
-    super::functions::json_object_with_keys_and_values<SqlTypeOf<K>, K, V>;
+    super::functions::json_object_with_keys_and_values<SqlTypeOf<K>, SqlTypeOf<V>, K, V>;
 
 /// Return type of [`json_typeof(json)`](super::functions::json_typeof())
 #[allow(non_camel_case_types)]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -438,12 +438,12 @@ fn postgres_functions() -> _ {
         to_json(pg_extras::id),
         to_jsonb(pg_extras::id),
         json_object(pg_extras::text_array),
+        json_object_with_keys_and_values(pg_extras::text_array),
         json_typeof(pg_extras::json),
         jsonb_typeof(pg_extras::jsonb),
         jsonb_pretty(pg_extras::jsonb),
         json_strip_nulls(pg_extras::json),
         jsonb_strip_nulls(pg_extras::jsonb),
-        json_object_with_keys_and_values(pg_extras::text_array, pg_extras::text_array),
     )
 }
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -438,7 +438,7 @@ fn postgres_functions() -> _ {
         to_json(pg_extras::id),
         to_jsonb(pg_extras::id),
         json_object(pg_extras::text_array),
-        json_object_with_keys_and_values(pg_extras::text_array),
+        json_object_with_keys_and_values(pg_extras::text_array, pg_extras::text_array),
         json_typeof(pg_extras::json),
         jsonb_typeof(pg_extras::jsonb),
         jsonb_pretty(pg_extras::jsonb),

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -443,6 +443,7 @@ fn postgres_functions() -> _ {
         jsonb_pretty(pg_extras::jsonb),
         json_strip_nulls(pg_extras::json),
         jsonb_strip_nulls(pg_extras::jsonb),
+        json_object_with_keys_and_values(pg_extras::text_array, pg_extras::text_array),
     )
 }
 


### PR DESCRIPTION
added support for `json_object(keys[],values[])` under [#4216](https://github.com/diesel-rs/diesel/issues/4216)