### PR TITLE
implement jsonb_object (both variants)

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -1669,9 +1669,11 @@ define_sql_function! {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
     /// #     run_test().unwrap();
     /// # }
     /// #
+    /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::json_object_with_keys_and_values;
     /// #     use diesel::sql_types::{Array, Json, Nullable, Text};
@@ -1913,9 +1915,11 @@ define_sql_function! {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
     /// #     run_test().unwrap();
     /// # }
     /// #
+    /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::json_strip_nulls;
     /// #     use diesel::sql_types::{Json, Nullable};
@@ -1957,9 +1961,11 @@ define_sql_function! {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
     /// #     run_test().unwrap();
     /// # }
     /// #
+    /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::jsonb_strip_nulls;
     /// #     use diesel::sql_types::{Jsonb, Nullable};
@@ -2092,9 +2098,11 @@ define_sql_function! {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
     /// #     run_test().unwrap();
     /// # }
     /// #
+    /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::jsonb_object;
     /// #     use diesel::sql_types::{Array, Json, Nullable, Text};
@@ -2144,9 +2152,11 @@ define_sql_function! {
     /// # include!("../../doctest_setup.rs");
     /// #
     /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
     /// #     run_test().unwrap();
     /// # }
     /// #
+    /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::jsonb_object_with_keys_and_values;
     /// #     use diesel::sql_types::{Array, Nullable, Text};

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -2103,21 +2103,27 @@ define_sql_function! {
     /// let jsonb = diesel::select(jsonb_object::<Array<Text>,_>(vec!["hello","world"]))
     ///                 .get_result::<Value>(connection)?;
     /// let expected:Value = serde_json::json!({"hello":"world"});
-    /// assert_eq!(expected,jsonb);
+    /// assert_eq!(expected, jsonb);
     ///
-    /// let jsonb = diesel::select(jsonb_object::<Array<Text>,_>(vec!["hello","world","John","Doe"]))
+    /// let jsonb = diesel::select(jsonb_object::<Array<Text>, _>(vec!["hello","world","John","Doe"]))
     ///                 .get_result::<Value>(connection)?;
     /// let expected:Value = serde_json::json!({"hello": "world","John": "Doe"});
-    /// assert_eq!(expected,jsonb);
+    /// assert_eq!(expected, jsonb);
     ///
-    /// let jsonb = diesel::select(jsonb_object::<Array<Text>,_>(vec!["hello","world","John"]))
-    ///                 .get_result::<Value>(connection);
-    /// assert!(jsonb.is_err());
+    /// let jsonb = diesel::select(jsonb_object::<Nullable<Array<Text>>, _>(None::<Vec<String>>))
+    ///                 .get_result::<Option<Value>>(connection)?;
+    /// assert!(jsonb.is_none());
     ///
     /// let empty:Vec<String> = Vec::new();
     /// let jsonb = diesel::select(jsonb_object::<Array<Nullable<Text>>,_>(empty))
+    ///                 .get_result::<Value>(connection)?;
+    /// let expected = serde_json::json!({});
+    /// assert_eq!(expected, jsonb);
+    ///
+    /// let jsonb = diesel::select(jsonb_object::<Array<Text>, _>(vec!["hello","world","John"]))
     ///                 .get_result::<Value>(connection);
     /// assert!(jsonb.is_err());
+    ///
     ///
     /// #     Ok(())
     /// # }
@@ -2146,19 +2152,19 @@ define_sql_function! {
     /// #     use diesel::sql_types::{Array, Nullable, Text};
     /// #     use serde_json::Value;
     /// #     let connection = &mut establish_connection();
-    /// let jsonb = diesel::select(jsonb_object_with_keys_and_values::<Array<Text>, _, _>(
+    /// let jsonb = diesel::select(jsonb_object_with_keys_and_values::<Array<Text>, Array<Text>, _, _>(
     ///             vec!["hello","John"],vec!["world","Doe"]))
     ///             .get_result::<Value>(connection)?;
     /// let expected:Value = serde_json::json!({"hello":"world","John":"Doe"});
-    /// assert_eq!(expected,jsonb);
+    /// assert_eq!(expected, jsonb);
     ///
-    /// let jsonb = diesel::select(jsonb_object_with_keys_and_values::<Nullable<Array<Text>>, _, _>(
+    /// let jsonb = diesel::select(jsonb_object_with_keys_and_values::<Nullable<Array<Text>>, Nullable<Array<Text>>, _, _>(
     ///             Some(vec!["hello","John"]),None::<Vec<String>>))
     ///             .get_result::<Option<Value>>(connection)?;
     /// assert_eq!(None::<Value>,jsonb);
     ///
     /// let empty: Vec<String> = Vec::new();
-    /// let jsonb = diesel::select(jsonb_object_with_keys_and_values::<Array<Text>, _, _>(
+    /// let jsonb = diesel::select(jsonb_object_with_keys_and_values::<Array<Text>, Array<Text>, _, _>(
     ///             vec!["hello","John"],empty))
     ///             .get_result::<Value>(connection);
     /// assert!(jsonb.is_err());
@@ -2167,7 +2173,11 @@ define_sql_function! {
     /// # }
     /// ```
     #[sql_name = "jsonb_object"]
-    fn jsonb_object_with_keys_and_values<Arr: TextArrayOrNullableTextArray + MaybeNullableValue<Jsonb>>(
-        keys: Arr, values: Arr
-    ) -> Arr::Out;
+    fn jsonb_object_with_keys_and_values<
+        Arr1: TextArrayOrNullableTextArray + SingleValue,
+        Arr2: TextArrayOrNullableTextArray + CombinedNullableValue<Arr1, Jsonb>
+    >(
+        keys: Arr1,
+        values: Arr2
+    ) -> Arr2::Out;
 }

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -527,3 +527,14 @@ pub type json_array_length<E> = super::functions::json_array_length<SqlTypeOf<E>
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type jsonb_array_length<E> = super::functions::jsonb_array_length<SqlTypeOf<E>, E>;
+
+/// Return type of [`jsonb_object(text_array)`](super::functions::jsonb_object())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type jsonb_object<A> = super::functions::jsonb_object<SqlTypeOf<A>, A>;
+
+/// Return type of [`jsonb_object_with_keys_and_values(text_array, text_array)`](super::functions::jsonb_object_with_keys_and_values())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type jsonb_object_with_keys_and_values<K, V> =
+    super::functions::jsonb_object_with_keys_and_values<SqlTypeOf<K>, K, V>;

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -537,4 +537,4 @@ pub type jsonb_object<A> = super::functions::jsonb_object<SqlTypeOf<A>, A>;
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type jsonb_object_with_keys_and_values<K, V> =
-    super::functions::jsonb_object_with_keys_and_values<SqlTypeOf<K>, K, V>;
+    super::functions::jsonb_object_with_keys_and_values<SqlTypeOf<K>, SqlTypeOf<V>, K, V>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -446,6 +446,8 @@ fn postgres_functions() -> _ {
         jsonb_strip_nulls(pg_extras::jsonb),
         json_array_length(pg_extras::json),
         jsonb_array_length(pg_extras::jsonb),
+        jsonb_object(pg_extras::text_array),
+        jsonb_object_with_keys_and_values(pg_extras::text_array, pg_extras::text_array),
     )
 }
 


### PR DESCRIPTION
added support for `jsonb_object(text[])` and `jsonb_object(keys[], values[])` under [#4216](https://github.com/diesel-rs/diesel/issues/4216)