### PR TITLE
Fix unused qualifications

### DIFF
--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -163,10 +163,8 @@ fn derive_into_single_table(
     };
 
     Ok(quote! {
-        #[allow(unused_qualifications)]
         #insert_owned
 
-        #[allow(unused_qualifications)]
         #insert_borrowed
 
         impl #impl_generics UndecoratedInsertRecord<#table_name::table>

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -7,6 +7,7 @@ use crate::field::{Field, FieldName};
 use crate::model::Model;
 use crate::util::wrap_in_dummy_mod;
 
+
 pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let model = Model::from_item(&item, false, false)?;
 
@@ -21,7 +22,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             let field_ty = &f.ty;
 
             if f.embed() {
-                Ok(quote!(<#field_ty as QueryableByName<__DB>>::build(row)?))
+                Ok(quote!(<#field_ty as diesel::deserialize::QueryableByName<__DB>>::build(row)?))
             } else {
                 let st = sql_type(f, &model)?;
                 let deserialize_ty = f.ty_for_deserialize();
@@ -50,7 +51,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         if field.embed() {
             where_clause
                 .predicates
-                .push(parse_quote_spanned!(span=> #field_ty: QueryableByName<__DB>));
+                .push(parse_quote_spanned!(span=> #field_ty: diesel::deserialize::QueryableByName<__DB>));
         } else {
             let st = sql_type(field, &model)?;
             where_clause.predicates.push(
@@ -83,20 +84,18 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(wrap_in_dummy_mod(quote! {
-        use diesel::deserialize::{self, QueryableByName};
-        use diesel::row::{NamedRow};
         use diesel::sql_types::Untyped;
 
-        impl #impl_generics QueryableByName<__DB>
+        impl #impl_generics diesel::deserialize::QueryableByName<__DB>
             for #struct_name #ty_generics
         #where_clause
         {
-            fn build<'__a>(row: &impl NamedRow<'__a, __DB>) -> deserialize::Result<Self>
+            fn build<'__a>(row: &impl diesel::row::NamedRow<'__a, __DB>) -> diesel::deserialize::Result<Self>
             {
                 #(
                     let mut #fields = #initial_field_expr;
                 )*
-                deserialize::Result::Ok(Self {
+                diesel::deserialize::Result::Ok(Self {
                     #(
                         #field_names: #fields,
                     )*

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -7,7 +7,6 @@ use crate::field::{Field, FieldName};
 use crate::model::Model;
 use crate::util::wrap_in_dummy_mod;
 
-
 pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let model = Model::from_item(&item, false, false)?;
 
@@ -51,7 +50,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         if field.embed() {
             where_clause
                 .predicates
-               .push(parse_quote_spanned!(span=> #field_ty: QueryableByName<__DB>));
+                .push(parse_quote_spanned!(span=> #field_ty: QueryableByName<__DB>));
         } else {
             let st = sql_type(field, &model)?;
             where_clause.predicates.push(

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -93,9 +93,10 @@ where
 }
 
 pub fn wrap_in_dummy_mod(item: TokenStream) -> TokenStream {
-    #[allow(unused_qualifications)] // Can remove if https://github.com/rust-lang/rust/issues/130277 gets done
+    // #[allow(unused_qualifications)] can be removed if https://github.com/rust-lang/rust/issues/130277 gets done
     quote! {
         #[allow(unused_imports)]
+        #[allow(unused_qualifications)]
         const _: () = {
             // This import is not actually redundant. When using diesel_derives
             // inside of diesel, `diesel` doesn't exist as an extern crate, and

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -93,9 +93,9 @@ where
 }
 
 pub fn wrap_in_dummy_mod(item: TokenStream) -> TokenStream {
+    #[allow(unused_qualifications)] // Can remove if https://github.com/rust-lang/rust/issues/130277 gets done
     quote! {
         #[allow(unused_imports)]
-        #[allow(unused_qualifications)] // Can remove if https://github.com/rust-lang/rust/issues/130277 gets done
         const _: () = {
             // This import is not actually redundant. When using diesel_derives
             // inside of diesel, `diesel` doesn't exist as an extern crate, and

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -95,7 +95,7 @@ where
 pub fn wrap_in_dummy_mod(item: TokenStream) -> TokenStream {
     quote! {
         #[allow(unused_imports)]
-        #[allow(unused_qualifications)]
+        #[allow(unused_qualifications)] // Can remove if https://github.com/rust-lang/rust/issues/130277 gets done
         const _: () = {
             // This import is not actually redundant. When using diesel_derives
             // inside of diesel, `diesel` doesn't exist as an extern crate, and

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -95,6 +95,7 @@ where
 pub fn wrap_in_dummy_mod(item: TokenStream) -> TokenStream {
     quote! {
         #[allow(unused_imports)]
+        #[allow(unused_qualifications)]
         const _: () = {
             // This import is not actually redundant. When using diesel_derives
             // inside of diesel, `diesel` doesn't exist as an extern crate, and


### PR DESCRIPTION
The unused_qualifications lint gets triggered even in the macros, an [issue](https://github.com/rust-lang/rust/issues/130277) was  openned on rust to update it but as for now this should prevent the lint from triggerring on macros.

Added #[allow(unused_qualifications)] directly in wrap_in_dummy_mod.
Removed #[allow(unused_qualifications)] from Insertable, reverting https://github.com/diesel-rs/diesel/pull/3353 as it will be taken care by the one on wrap_in_dummy_mod.