### PR TITLE
Fix span in proc macro

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -772,7 +772,7 @@ mod tests {
 
     fn to_value<ST, T>(
         bind: &BindData,
-    ) -> Result<T, Box<(dyn std::error::Error + Send + Sync + 'static)>>
+    ) -> Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>
     where
         T: FromSql<ST, crate::mysql::Mysql> + std::fmt::Debug,
     {

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
@@ -34,7 +34,8 @@ LL |         id -> Integer,
    = note: required for `sum<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:24:31
    |
@@ -71,7 +72,8 @@ LL |         id -> Integer,
    = note: required for `avg<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:27:31
    |
@@ -108,7 +110,8 @@ LL |         id -> Integer,
    = note: required for `max<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:30:31
    |
@@ -144,3 +147,5 @@ LL |         id -> Integer,
    = note: required for `min<Integer, id>` to implement `AppearsOnTable<users::table>`
    = note: required for `min<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
+++ b/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
@@ -34,4 +34,5 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     For more information about this error, try `rustc --explain E0271`.
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.stderr
@@ -14,4 +14,5 @@ LL |         title -> VarChar,
    = note: required for `Grouped<Eq<title, Bound<Text, &str>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>`
 
-   For more information about this error, try `rustc --explain E0271`.
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.stderr
@@ -14,4 +14,5 @@ LL |         title -> VarChar,
    = note: required for `diesel::expression::operators::Desc<posts::columns::title>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `OrderDsl<diesel::expression::operators::Desc<posts::columns::title>>`
 
-   For more information about this error, try `rustc --explain E0271`.
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
@@ -1,8 +1,11 @@
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:18:5
+  --> tests/fail/broken_queryable_by_name.rs:18:11
    |
+LL | #[derive(QueryableByName)]
+   |          --------------- in this derive macro expansion
+...
 LL |     name: i32,
-   |     ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
+   |           ^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Text`
    = note: `diesel::sql_query` requires the loading target to column names for loading values.
@@ -14,12 +17,16 @@ LL |     name: i32,
    = note: required for `i32` to implement `Queryable<diesel::sql_types::Text, Pg>`
    = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
    = help: see issue #48214
+   = note: this error originates in the derive macro `QueryableByName` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:16:5
+  --> tests/fail/broken_queryable_by_name.rs:16:9
    |
+LL | #[derive(QueryableByName)]
+   |          --------------- in this derive macro expansion
+...
 LL |     id: String,
-   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
+   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
    = note: `diesel::sql_query` requires the loading target to column names for loading values.
@@ -33,12 +40,16 @@ LL |     id: String,
    = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, Pg>`
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214
+   = note: this error originates in the derive macro `QueryableByName` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:29:5
+  --> tests/fail/broken_queryable_by_name.rs:29:11
    |
+LL | #[derive(QueryableByName)]
+   |          --------------- in this derive macro expansion
+...
 LL |     name: i32,
-   |     ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
+   |           ^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Text`
    = note: `diesel::sql_query` requires the loading target to column names for loading values.
@@ -50,12 +61,16 @@ LL |     name: i32,
    = note: required for `i32` to implement `Queryable<diesel::sql_types::Text, Pg>`
    = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
    = help: see issue #48214
+   = note: this error originates in the derive macro `QueryableByName` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:26:5
+  --> tests/fail/broken_queryable_by_name.rs:26:9
    |
+LL | #[derive(QueryableByName)]
+   |          --------------- in this derive macro expansion
+...
 LL |     id: String,
-   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
+   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
    = note: `diesel::sql_query` requires the loading target to column names for loading values.
@@ -69,6 +84,7 @@ LL |     id: String,
    = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, Pg>`
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214
+   = note: this error originates in the derive macro `QueryableByName` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Untyped: load_dsl::private::CompatibleType<User, _>` is not satisfied
     --> tests/fail/broken_queryable_by_name.rs:36:49

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
@@ -81,3 +81,5 @@ LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, Retu
 LL |     where
 LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
@@ -79,6 +79,9 @@ LL | #[derive(Insertable)]
 error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:16:5
    |
+LL | #[derive(Insertable)]
+   |          ---------- in this derive macro expansion
+...
 LL |     id: String,
    |     ^^ the trait `diesel::Expression` is not implemented for `std::string::String`
    |
@@ -93,10 +96,14 @@ LL |     id: String,
              Exists<T>
            and N others
    = note: required for `std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
+   = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:19:5
    |
+LL | #[derive(Insertable)]
+   |          ---------- in this derive macro expansion
+...
 LL |     name: i32,
    |     ^^^^ the trait `diesel::Expression` is not implemented for `i32`
    |
@@ -111,10 +118,14 @@ LL |     name: i32,
              Exists<T>
            and N others
    = note: required for `i32` to implement `AsExpression<diesel::sql_types::Text>`
+   = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:16:5
    |
+LL | #[derive(Insertable)]
+   |          ---------- in this derive macro expansion
+...
 LL |     id: String,
    |     ^^ the trait `diesel::Expression` is not implemented for `std::string::String`
    |
@@ -130,10 +141,14 @@ LL |     id: String,
            and N others
    = note: required for `&'insert std::string::String` to implement `diesel::Expression`
    = note: required for `&'insert std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
+   = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:19:5
    |
+LL | #[derive(Insertable)]
+   |          ---------- in this derive macro expansion
+...
 LL |     name: i32,
    |     ^^^^ the trait `diesel::Expression` is not implemented for `i32`
    |
@@ -149,4 +164,5 @@ LL |     name: i32,
            and N others
    = note: required for `&'insert i32` to implement `diesel::Expression`
    = note: required for `&'insert i32` to implement `AsExpression<diesel::sql_types::Text>`
+   = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/derive/unused_qualifications.rs
+++ b/diesel_compile_tests/tests/fail/derive/unused_qualifications.rs
@@ -1,0 +1,44 @@
+//@check-pass
+#![deny(unused_qualifications)]
+#![deny(warnings)]
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> Text,
+        user_id -> Integer,
+    }
+}
+
+#[derive(Queryable, QueryableByName, Selectable, Insertable, AsChangeset)]
+pub struct User {
+    id: i32,
+    name: String,
+}
+
+#[derive(Identifiable, Associations)]
+#[diesel(belongs_to(User))]
+pub struct Post {
+    id: i32,
+    user_id: i32,
+}
+
+#[derive(diesel::MultiConnection)]
+enum DbConnection {
+    Pg(PgConnection),
+    Sqlite(SqliteConnection),
+}
+
+#[diesel::dsl::auto_type]
+fn _test() -> _ {
+    users::table.select(users::id)
+}

--- a/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.stderr
+++ b/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.stderr
@@ -26,7 +26,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:34:45
    |
@@ -43,7 +44,8 @@ LL |         id -> Integer,
    = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot box `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` for backend `Pg`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:37:50
    |
@@ -85,7 +87,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:48:10
    |
@@ -102,7 +105,8 @@ LL |         title -> VarChar,
    = note: required for `Grouped<Eq<name, title>>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot box `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` for backend `Pg`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:53:10
    |

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
@@ -75,6 +75,7 @@ LL |     fn find<PK>(self, id: PK) -> Find<Self, PK>
 LL |     where
 LL |         Self: methods::FindDsl<PK>,
     |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::find`
+    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
    --> tests/fail/find_requires_correct_type.rs:24:36

--- a/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.stderr
+++ b/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.stderr
@@ -21,7 +21,8 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
    = note: required for `(users::columns::id, posts::columns::user_id, CountStar)` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
    = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<posts::columns::user_id>` is not satisfied
   --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:29:10
    |
@@ -42,4 +43,5 @@ LL |         user_id -> Integer,
    = note: required for `(users::columns::id, posts::columns::user_id, CountStar)` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
    = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`
 
-   For more information about this error, try `rustc --explain E0277`.
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
@@ -45,7 +45,8 @@ LL |         id -> Integer,
    = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `HavingDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/having_cant_be_used_without_group_by.rs:49:10
    |
@@ -61,3 +62,5 @@ LL |         id -> Integer,
    = note: 2 redundant requirements hidden
    = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, Text, FromClause<table>, _, id>` to implement `HavingDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/invalid_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/invalid_group_by.stderr
@@ -11,6 +11,7 @@ LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `GroupByDsl<posts::columns::id>`
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<id as IsContainedInGroupBy<id>>::Output == Yes`
   --> tests/fail/invalid_group_by.rs:29:10
@@ -31,7 +32,7 @@ note: required for `users::columns::id` to implement `ValidGrouping<posts::colum
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
-      = note: this error originates in the macro `__static_cond` which comes from the expansion of the macro `allow_columns_to_appear_in_same_group_by_clause` (in Nightly builds, run with -Z macro-backtrace for more info)
+      = note: this error originates in the macro `__static_cond` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/invalid_group_by.rs:37:10
@@ -47,7 +48,8 @@ LL |         id -> Integer,
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<table>, SelectClause<id>>` to implement `GroupByDsl<posts::columns::id>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/invalid_group_by.rs:46:10
    |
@@ -61,6 +63,7 @@ LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<Alias<user1>>>` to implement `GroupByDsl<posts::columns::id>`
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AliasedField<user1, users::columns::id>: ValidGrouping<posts::columns::id>` is not satisfied
    --> tests/fail/invalid_group_by.rs:48:17
@@ -117,7 +120,8 @@ note: required for `users::columns::id` to implement `ValidGrouping<AliasedField
    |         ^^
    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<Alias<post1>>>::Count == Once`
   --> tests/fail/invalid_group_by.rs:62:10
    |
@@ -163,7 +167,8 @@ LL |         id -> Integer,
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<Alias<user1>>, SelectClause<...>>` to implement `GroupByDsl<posts::columns::id>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<Alias<post1>>>::Count == Once`
   --> tests/fail/invalid_group_by.rs:78:10
    |

--- a/diesel_compile_tests/tests/fail/invalid_joins.stderr
+++ b/diesel_compile_tests/tests/fail/invalid_joins.stderr
@@ -30,7 +30,8 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
   --> tests/fail/invalid_joins.rs:41:26
    |
@@ -48,7 +49,8 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
    --> tests/fail/invalid_joins.rs:47:21
     |
@@ -81,7 +83,8 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
   --> tests/fail/invalid_joins.rs:47:10
    |
@@ -99,7 +102,8 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
    --> tests/fail/invalid_joins.rs:54:9
     |
@@ -135,7 +139,8 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
   --> tests/fail/invalid_joins.rs:52:26
    |
@@ -153,7 +158,8 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
    --> tests/fail/invalid_joins.rs:63:21
     |
@@ -184,7 +190,8 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
    --> tests/fail/invalid_joins.rs:72:36
     |
@@ -217,7 +224,8 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
   --> tests/fail/invalid_joins.rs:72:26
    |
@@ -235,7 +243,8 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
    --> tests/fail/invalid_joins.rs:78:20
     |
@@ -268,7 +277,8 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
   --> tests/fail/invalid_joins.rs:78:10
    |
@@ -286,7 +296,8 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
    --> tests/fail/invalid_joins.rs:85:9
     |
@@ -322,7 +333,8 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
   --> tests/fail/invalid_joins.rs:83:26
    |
@@ -340,7 +352,8 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
    --> tests/fail/invalid_joins.rs:94:20
     |
@@ -371,4 +384,5 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
  
-    For more information about this error, try `rustc --explain E0271`.
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/join_with_explicit_on_requires_valid_boolean_expression.stderr
+++ b/diesel_compile_tests/tests/fail/join_with_explicit_on_requires_valid_boolean_expression.stderr
@@ -15,7 +15,8 @@ LL |         id -> Integer,
    = note: required for `JoinOn<Join<table, table, Inner>, Grouped<Eq<id, id>>>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<posts::table, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, comments::columns::id>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
    --> tests/fail/join_with_explicit_on_requires_valid_boolean_expression.rs:34:37
     |

--- a/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
+++ b/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
@@ -13,4 +13,5 @@ note: an implementation of `std::ops::Add` might be missing for `columns::name`
    |         ^^^^ must implement `std::ops::Add`
 note: the trait `std::ops::Add` must be implemented
   --> /rustc/0000000000000000000000000000000000000000/library/core/src/ops/arith.rs:78:1
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 For more information about this error, try `rustc --explain E0369`.

--- a/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.stderr
@@ -11,4 +11,5 @@ LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `OrderDsl<posts::columns::id>`
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
+++ b/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
@@ -82,6 +82,7 @@ LL |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<title as Column>::Table == table`
   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:68:10

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
@@ -54,7 +54,8 @@ LL |         title -> Text,
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:52:18
    |
@@ -111,7 +112,8 @@ LL |         title -> Text,
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:56:31
    |
@@ -199,7 +201,8 @@ LL |         title -> Text,
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:75:18
    |
@@ -256,7 +259,8 @@ LL |         title -> Text,
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:79:31
    |
@@ -344,7 +348,8 @@ LL |         title -> Text,
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:98:18
    |
@@ -401,7 +406,8 @@ LL |         title -> Text,
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:102:31
     |
@@ -453,7 +459,8 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::title` from `pets::table`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:111:18
     |
@@ -478,7 +485,8 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<SelectStatement<...> as AppearsInFromClause<...>>::Count == Never`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:119:18
     |
@@ -499,7 +507,8 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::title` from `pets::table`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:119:18
     |
@@ -524,7 +533,8 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:123:31
     |
@@ -612,7 +622,8 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:140:18
     |
@@ -669,7 +680,8 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:144:31
     |

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
@@ -38,7 +38,8 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
   --> tests/fail/select_requires_valid_grouping.rs:93:10
    |
@@ -81,7 +82,8 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<(id, title) as IsContainedInGroupBy<id>>::Output == Yes`
    --> tests/fail/select_requires_valid_grouping.rs:102:10
     |
@@ -98,7 +100,8 @@ note: required for `posts::columns::id` to implement `ValidGrouping<(users::colu
     = note: required for `((users::columns::id, users::columns::name, users::columns::hair_color), posts::columns::id)` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
     = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), posts::columns::id)>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<comments::columns::id>` is not satisfied
    --> tests/fail/select_requires_valid_grouping.rs:107:10
     |
@@ -123,7 +126,8 @@ note: required for `comments::columns::id` to implement `ValidGrouping<(users::c
     = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
     = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<comments::columns::id>` is not satisfied
    --> tests/fail/select_requires_valid_grouping.rs:107:10
     |
@@ -149,3 +153,5 @@ note: required for `comments::columns::id` to implement `ValidGrouping<(users::c
     = note: 2 redundant requirements hidden
     = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
     = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/selectable.rs
+++ b/diesel_compile_tests/tests/fail/selectable.rs
@@ -16,6 +16,8 @@ table! {
         user_id -> Integer,
     }
 }
+//~^^^^^^^ ERROR: cannot find type `titel` in module `posts`
+//~| ERROR: cannot find value `titel` in module `posts`
 
 joinable!(posts -> users(user_id));
 allow_tables_to_appear_in_same_query!(users, posts);
@@ -51,8 +53,6 @@ struct PostWithWrongField {
     id: i32,
     // There is a typo here:
     titel: String,
-    //~^ ERROR: cannot find type `titel` in module `posts`
-    //~| ERROR: cannot find value `titel` in module `posts`
 }
 
 #[derive(Selectable)]

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `titel` in module `posts`
-  --> tests/fail/selectable.rs:53:5
+  --> tests/fail/selectable.rs:55:5
    |
 LL |         title -> Text,
    |         ----- similarly named struct `title` defined here
@@ -8,7 +8,7 @@ LL |     titel: String,
    |     ^^^^^ help: a struct with a similar name exists: `title`
 
 error[E0425]: cannot find value `titel` in module `posts`
-  --> tests/fail/selectable.rs:53:5
+  --> tests/fail/selectable.rs:55:5
    |
 LL |         title -> Text,
    |         ----- similarly named unit struct `title` defined here
@@ -83,7 +83,8 @@ note: required for `posts::columns::id` to implement `SelectableExpression<query
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::title` from `users::table`
    --> tests/fail/selectable.rs:165:10
     |
@@ -108,7 +109,8 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
     --> tests/fail/selectable.rs:169:15
      |
@@ -189,7 +191,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::title` from `users::table`
     --> tests/fail/selectable.rs:169:15
      |
@@ -226,7 +229,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::id>` is not satisfied
    --> tests/fail/selectable.rs:179:10
     |
@@ -247,7 +251,8 @@ note: required for `users::columns::id` to implement `ValidGrouping<posts::colum
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `ValidGrouping<posts::columns::id>`
     = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::name>` is not satisfied
    --> tests/fail/selectable.rs:179:10
     |
@@ -268,7 +273,8 @@ note: required for `users::columns::name` to implement `ValidGrouping<posts::col
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `ValidGrouping<posts::columns::id>`
     = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/selectable.rs:188:10
     |
@@ -378,7 +384,8 @@ LL |     where
 LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::id` from `users::table`
     --> tests/fail/selectable.rs:201:15
      |
@@ -473,7 +480,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/selectable.rs:211:20
     |
@@ -565,7 +573,8 @@ LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, Retur
 LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
  
-    
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::id` from `users::table`
     --> tests/fail/selectable.rs:215:15
      |
@@ -660,7 +669,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/selectable.rs:224:20
     |
@@ -746,6 +756,7 @@ LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, Returnin
 LL |     where
 LL |         E: SelectableExpression<T>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot select `posts::columns::id` from `users::table`
     --> tests/fail/selectable.rs:228:15
@@ -841,7 +852,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0599]: the function or associated item `as_select` exists for struct `UserWithoutSelectable`, but its trait bounds were not satisfied
    --> tests/fail/selectable.rs:236:40
     |

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
   --> tests/fail/selectable_with_typemisamatch.rs:18:11
    |
+LL | #[derive(Selectable, Queryable)]
+   |          ---------- in this derive macro expansion
+...
 LL |     name: i32,
    |           ^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
@@ -14,10 +17,14 @@ LL |     name: i32,
    = note: required for `i32` to implement `diesel::Queryable<diesel::sql_types::Text, Pg>`
    = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
    = help: see issue #48214
+   = note: this error originates in the derive macro `Selectable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
   --> tests/fail/selectable_with_typemisamatch.rs:16:9
    |
+LL | #[derive(Selectable, Queryable)]
+   |          ---------- in this derive macro expansion
+...
 LL |     id: String,
    |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
@@ -33,10 +40,14 @@ LL |     id: String,
    = note: required for `std::string::String` to implement `diesel::Queryable<diesel::sql_types::Integer, Pg>`
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214
+   = note: this error originates in the derive macro `Selectable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(String, i32): FromStaticSqlRow<(Integer, Text), Pg>` is not satisfied
   --> tests/fail/selectable_with_typemisamatch.rs:34:17
    |
+LL | #[derive(Selectable, Queryable)]
+   |          ---------- in this derive macro expansion
+...
 LL |     embed_user: User,
    |                 ^^^^ the trait `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not implemented for `(std::string::String, i32)`
    |
@@ -61,7 +72,7 @@ LL | struct User {
    = note: required for `User` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
    = help: see issue #48214
 
-      = note: this error originates in the derive macro `Queryable` (in Nightly builds, run with -Z macro-backtrace for more info)
+      = note: this error originates in the derive macro `Selectable` which comes from the expansion of the derive macro `Queryable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<User, _>: load_dsl::private::CompatibleType<_, _>` is not satisfied
     --> tests/fail/selectable_with_typemisamatch.rs:43:15

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
@@ -50,6 +50,7 @@ LL |         id -> Integer,
    = note: required for `(posts::columns::id, posts::columns::user_id)` to implement `AppearsOnTable<users::table>`
    = note: required for `(posts::columns::id, posts::columns::user_id)` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:27:30
@@ -85,3 +86,4 @@ LL |         id -> Integer,
    = note: required for `(posts::columns::id, users::columns::name)` to implement `AppearsOnTable<users::table>`
    = note: required for `(posts::columns::id, users::columns::name)` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, users::columns::name)>`
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/subselect_cannot_reference_random_tables.stderr
+++ b/diesel_compile_tests/tests/fail/subselect_cannot_reference_random_tables.stderr
@@ -43,7 +43,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
     --> tests/fail/subselect_cannot_reference_random_tables.rs:39:25
      |
@@ -75,7 +76,8 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
     --> tests/fail/subselect_cannot_reference_random_tables.rs:44:25
      |
@@ -107,4 +109,5 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     For more information about this error, try `rustc --explain E0271`.
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/table_column_names.stderr
+++ b/diesel_compile_tests/tests/fail/table_column_names.stderr
@@ -5,3 +5,5 @@ error: column `users` cannot be named the same as it's table.
   |
 LL |         users -> Integer,
   |         ^^^^^
+  |
+  = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
@@ -14,3 +14,5 @@ error: neither an explicit primary key found nor does an `id` column exist.
   |
 LL |     user {
   |     ^^^^
+  |
+  = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.stderr
@@ -57,4 +57,5 @@ LL |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`
+   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
@@ -36,7 +36,8 @@ LL |         id -> Integer,
    = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/update_requires_valid_where_clause.rs:32:10
    |
@@ -53,7 +54,8 @@ LL |         id -> Integer,
    = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
-   
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: IntoUpdateTarget` is not satisfied
   --> tests/fail/update_requires_valid_where_clause.rs:23:5
    |

--- a/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
+++ b/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
@@ -39,4 +39,5 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     For more information about this error, try `rustc --explain E0271`.
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned as _;
 use syn::{parse_quote, DeriveInput, Expr, Path, Result, Type};
@@ -27,7 +27,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
     if fields_for_update.is_empty() {
         return Err(syn::Error::new(
-            proc_macro2::Span::call_site(),
+            proc_macro2::Span::mixed_site(),
             "deriving `AsChangeset` on a structure that only contains primary keys isn't supported.\n\
              help: if you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.\n\
              note: `#[derive(AsChangeset)]` never changes the primary key of a row."
@@ -173,7 +173,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
 fn field_changeset_ty_embed(field: &Field, lifetime: Option<TokenStream>) -> TokenStream {
     let field_ty = &field.ty;
-    let span = field.span;
+    let span = Span::mixed_site().located_at(field.span);
     quote_spanned!(span=> #lifetime #field_ty)
 }
 

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -12,7 +12,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
     if model.sql_types.is_empty() {
         return Err(syn::Error::new(
-            proc_macro2::Span::call_site(),
+            proc_macro2::Span::mixed_site(),
             "at least one `sql_type` is needed for deriving `AsExpression` on a structure.",
         ));
     }

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -13,7 +13,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
     if model.belongs_to.is_empty() {
         return Err(syn::Error::new(
-            proc_macro2::Span::call_site(),
+            proc_macro2::Span::mixed_site(),
             "at least one `belongs_to` is needed for deriving `Associations` on a structure.",
         ));
     }

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -127,11 +127,11 @@ impl Field {
             Some(x) => FieldName::Named(x),
             None => FieldName::Unnamed(index.into()),
         };
-
         let span = match name {
             FieldName::Named(ref ident) => ident.span(),
             FieldName::Unnamed(_) => ty.span(),
         };
+        let span = Span::mixed_site().located_at(span);
 
         Ok(Self {
             ty: ty.clone(),

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -2,7 +2,7 @@ use crate::attrs::AttributeSpanWrapper;
 use crate::field::Field;
 use crate::model::Model;
 use crate::util::{inner_of_option_ty, is_option_ty, wrap_in_dummy_mod};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use quote::quote_spanned;
 use syn::parse_quote;
@@ -173,7 +173,7 @@ fn derive_into_single_table(
 
 fn field_ty_embed(field: &Field, lifetime: Option<TokenStream>) -> TokenStream {
     let field_ty = &field.ty;
-    let span = field.span;
+    let span = Span::mixed_site().located_at(field.span);
     quote_spanned!(span=> #lifetime #field_ty)
 }
 
@@ -189,7 +189,7 @@ fn field_ty_serialize_as(
     treat_none_as_default_value: bool,
 ) -> Result<TokenStream> {
     let column_name = field.column_name()?.to_ident()?;
-    let span = field.span;
+    let span = Span::mixed_site().located_at(field.span);
     if treat_none_as_default_value {
         let inner_ty = inner_of_option_ty(ty);
 
@@ -242,7 +242,7 @@ fn field_ty(
     treat_none_as_default_value: bool,
 ) -> Result<TokenStream> {
     let column_name = field.column_name()?.to_ident()?;
-    let span = field.span;
+    let span = Span::mixed_site().located_at(field.span);
     if treat_none_as_default_value {
         let inner_ty = inner_of_option_ty(&field.ty);
 

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -52,7 +52,7 @@ impl Model {
             }) => Some(unnamed),
             _ if !allow_unit_structs => {
                 return Err(syn::Error::new(
-                    proc_macro2::Span::call_site(),
+                    proc_macro2::Span::mixed_site(),
                     "this derive can only be used on non-unit structs",
                 ));
             }
@@ -60,7 +60,7 @@ impl Model {
         };
 
         let mut table_names = vec![];
-        let mut primary_key_names = vec![Ident::new("id", Span::call_site())];
+        let mut primary_key_names = vec![Ident::new("id", Span::mixed_site())];
         let mut treat_none_as_default_value = None;
         let mut treat_none_as_null = None;
         let mut belongs_to = vec![];

--- a/diesel_derives/src/queryable.rs
+++ b/diesel_derives/src/queryable.rs
@@ -22,7 +22,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     });
     let sql_type = &(0..model.fields().len())
         .map(|i| {
-            let i = Ident::new(&format!("__ST{i}"), Span::call_site());
+            let i = Ident::new(&format!("__ST{i}"), Span::mixed_site());
             quote!(#i)
         })
         .collect::<Vec<_>>();
@@ -33,7 +33,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         .params
         .push(parse_quote!(__DB: diesel::backend::Backend));
     for id in 0..model.fields().len() {
-        let ident = Ident::new(&format!("__ST{id}"), Span::call_site());
+        let ident = Ident::new(&format!("__ST{id}"), Span::mixed_site());
         generics.params.push(parse_quote!(#ident));
     }
     {

--- a/diesel_derives/src/sql_type.rs
+++ b/diesel_derives/src/sql_type.rs
@@ -46,7 +46,7 @@ fn sqlite_tokens(item: &DeriveInput, model: &Model) -> Option<TokenStream> {
     model
         .sqlite_type
         .as_ref()
-        .map(|sqlite_type| Ident::new(&sqlite_type.name.value(), Span::call_site()))
+        .map(|sqlite_type| Ident::new(&sqlite_type.name.value(), Span::mixed_site()))
         .and_then(|ty| {
             if cfg!(not(feature = "sqlite")) {
                 return None;
@@ -72,7 +72,7 @@ fn mysql_tokens(item: &DeriveInput, model: &Model) -> Option<TokenStream> {
     model
         .mysql_type
         .as_ref()
-        .map(|mysql_type| Ident::new(&mysql_type.name.value(), Span::call_site()))
+        .map(|mysql_type| Ident::new(&mysql_type.name.value(), Span::mixed_site()))
         .and_then(|ty| {
             if cfg!(not(feature = "mysql")) {
                 return None;

--- a/diesel_derives/src/table.rs
+++ b/diesel_derives/src/table.rs
@@ -1,5 +1,5 @@
 use diesel_table_macro_syntax::{ColumnDef, TableDecl};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use syn::parse_quote;
 use syn::Ident;
 
@@ -46,10 +46,10 @@ pub(crate) fn expand(input: TableDecl) -> TokenStream {
     let primary_key: TokenStream = match input.primary_keys.as_ref() {
         None if column_names.contains(&&syn::Ident::new(
             DEFAULT_PRIMARY_KEY_NAME,
-            proc_macro2::Span::call_site(),
+            proc_macro2::Span::mixed_site(),
         )) =>
         {
-            let id = syn::Ident::new(DEFAULT_PRIMARY_KEY_NAME, proc_macro2::Span::call_site());
+            let id = syn::Ident::new(DEFAULT_PRIMARY_KEY_NAME, proc_macro2::Span::mixed_site());
             parse_quote! {
                 #id
             }
@@ -78,7 +78,7 @@ pub(crate) fn expand(input: TableDecl) -> TokenStream {
             }
             message += "\t}\n}";
 
-            let span = input.table_name.span();
+            let span = Span::mixed_site().located_at(input.table_name.span());
             return quote::quote_spanned! {span=>
                 compile_error!(#message);
             };
@@ -131,7 +131,7 @@ pub(crate) fn expand(input: TableDecl) -> TokenStream {
     let reexport_column_from_dsl = input.column_defs.iter().map(|c| {
         let column_name = &c.column_name;
         if c.column_name == *table_name {
-            let span = c.column_name.span();
+            let span = Span::mixed_site().located_at(c.column_name.span());
             let message = format!(
                 "column `{column_name}` cannot be named the same as it's table.\n\
                  you may use `#[sql_name = \"{column_name}\"]` to reference the table's \
@@ -529,15 +529,15 @@ fn generate_valid_grouping_for_table_columns(table: &TableDecl) -> Vec<TokenStre
     for (id, right_col) in table.column_defs.iter().enumerate() {
         for left_col in table.column_defs.iter().skip(id) {
             let right_to_left = if Some(left_col.column_name.to_string()) == primary_key {
-                Ident::new("Yes", proc_macro2::Span::call_site())
+                Ident::new("Yes", proc_macro2::Span::mixed_site())
             } else {
-                Ident::new("No", proc_macro2::Span::call_site())
+                Ident::new("No", proc_macro2::Span::mixed_site())
             };
 
             let left_to_right = if Some(right_col.column_name.to_string()) == primary_key {
-                Ident::new("Yes", proc_macro2::Span::call_site())
+                Ident::new("Yes", proc_macro2::Span::mixed_site())
             } else {
-                Ident::new("No", proc_macro2::Span::call_site())
+                Ident::new("No", proc_macro2::Span::mixed_site())
             };
 
             let left_col = &left_col.column_name;
@@ -686,7 +686,7 @@ fn generate_op_impl(op: &str, tpe: &syn::Ident) -> TokenStream {
 fn expand_column_def(column_def: &ColumnDef) -> TokenStream {
     // TODO get a better span here as soon as that's
     // possible using stable rust
-    let span = column_def.column_name.span();
+    let span = Span::mixed_site().located_at(column_def.column_name.span());
     let meta = &column_def.meta;
     let column_name = &column_def.column_name;
     let sql_name = &column_def.sql_name;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl diesel::query_builder::AsChangeset for User {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(AsExpression)]\n#[diesel(sql_type = diesel::sql_type::Integer)]\nenum Foo {\n    Bar,\n    Baz,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl<'__expr> diesel::expression::AsExpression<diesel::sql_type::Integer>

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(Associations)]\n#[diesel(belongs_to(User))]\nstruct Post {\n    id: i32,\n    title: String,\n    user_id: i32,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl<__FK> diesel::associations::BelongsTo<User> for Post

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__diesel_numeric_ops_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__diesel_numeric_ops_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(DieselNumericOps)]\nstruct NumericColumn;\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     use diesel::internal::derives::numeric_ops as ops;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__from_sql_row_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__from_sql_row_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(FromSqlRow)]\nenum Foo {\n    Bar,\n    Baz,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl<__DB, __ST> diesel::deserialize::Queryable<__ST, __DB> for Foo

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(Identifiable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl diesel::associations::HasTable for User {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(Insertable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl diesel::insertable::Insertable<users::table> for User {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(QueryId)]\nstruct Query;\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     #[allow(non_camel_case_types)]

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(Queryable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     use diesel::row::{Row as _, Field as _};

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(QueryableByName)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl<__DB: diesel::backend::Backend> diesel::deserialize::QueryableByName<__DB>

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__selectable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__selectable_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(Selectable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     use diesel::expression::Selectable;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mysql).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mysql).snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\n#[diesel(mysql_type(name = \"Integer\"))]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl diesel::sql_types::SqlType for Integer {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (postgres).snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\n#[diesel(mysql_type(name = \"Integer\"))]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl diesel::sql_types::SqlType for Integer {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (sqlite).snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\n#[diesel(mysql_type(name = \"Integer\"))]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl diesel::sql_types::SqlType for Integer {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__valid_grouping_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__valid_grouping_1.snap
@@ -4,8 +4,6 @@ expression: out
 info:
   input: "#[derive(ValidGrouping)]\nstruct Query;\n"
 ---
-#[allow(unused_imports)]
-#[allow(unused_qualifications)]
 const _: () = {
     use diesel;
     impl<__GroupByClause> diesel::expression::ValidGrouping<__GroupByClause> for Query {

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -93,10 +93,7 @@ where
 }
 
 pub fn wrap_in_dummy_mod(item: TokenStream) -> TokenStream {
-    // #[allow(unused_qualifications)] can be removed if https://github.com/rust-lang/rust/issues/130277 gets done
     quote! {
-        #[allow(unused_imports)]
-        #[allow(unused_qualifications)]
         const _: () = {
             // This import is not actually redundant. When using diesel_derives
             // inside of diesel, `diesel` doesn't exist as an extern crate, and
@@ -154,12 +151,12 @@ pub fn ty_for_foreign_derive(item: &DeriveInput, model: &Model) -> Result<Type> 
             Data::Struct(ref body) => match body.fields.iter().next() {
                 Some(field) => Ok(field.ty.clone()),
                 None => Err(syn::Error::new(
-                    proc_macro2::Span::call_site(),
+                    proc_macro2::Span::mixed_site(),
                     "foreign_derive requires at least one field",
                 )),
             },
             _ => Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
+                proc_macro2::Span::mixed_site(),
                 "foreign_derive can only be used with structs",
             )),
         }

--- a/dsl_auto_type/src/auto_type/mod.rs
+++ b/dsl_auto_type/src/auto_type/mod.rs
@@ -66,7 +66,7 @@ pub(crate) fn auto_type_impl(
         (false, true, _) => false,
         (true, true, _) => {
             return Err(syn::Error::new(
-                Span::call_site(),
+                Span::mixed_site(),
                 "type_alias and no_type_alias are mutually exclusive",
             )
             .into())


### PR DESCRIPTION
Follow up of https://github.com/rust-lang/rust/issues/130277 that was initially handled in https://github.com/diesel-rs/diesel/pull/4259. The rust team pointed out that the macro was not correctly setting the span and proposed a fix, being the use of Span::mixed_site instead of coping directly the span of the field.

The #[allow(unused_qualifications)] is still here in the wrap_in_dummy_mod as it is hard to make sure the lint is correctly done in every proc macro. 