### PR TITLE
Bump similar_asserts to 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'localhost';" -uroot -proot
-          echo "MYSQL_DATABASE_URL=mysql://root:root@localhost/diesel_test" >> $GITHUB_ENV
-          echo "MYSQL_EXAMPLE_DATABASE_URL=mysql://root:root@localhost/diesel_example" >> $GITHUB_ENV
-          echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://root:root@localhost/diesel_unit_test" >> $GITHUB_ENV
+          echo "MYSQL_DATABASE_URL=mysql://root:root@127.0.0.1/diesel_test" >> $GITHUB_ENV
+          echo "MYSQL_EXAMPLE_DATABASE_URL=mysql://root:root@127.0.0.1/diesel_example" >> $GITHUB_ENV
+          echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://root:root@127.0.0.1/diesel_unit_test" >> $GITHUB_ENV
 
       - name: Install postgres (MacOS)
         if: matrix.os == 'macos-13' && matrix.backend == 'postgres'
@@ -227,7 +227,8 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: cargo xtask run-tests ${{ matrix.backend }} $NO_DOC_TESTS $EXAMPLE_SCHEMA_CHECKS -- --no-fail-fast $FLAGS
+        run: |
+          cargo xtask run-tests ${{ matrix.backend }} $NO_DOC_TESTS $EXAMPLE_SCHEMA_CHECKS -- --no-fail-fast $FLAGS
 
       - name: Run diesel_benches
         if: runner.os == 'Linux'

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -461,6 +461,7 @@ mod tests {
     use std::sync::mpsc;
     use std::sync::Arc;
     use std::thread;
+    use std::time::Duration;
 
     use crate::r2d2::*;
     use crate::test_helpers::*;
@@ -636,6 +637,9 @@ mod tests {
         assert_eq!(release_count.load(Ordering::Relaxed), 2);
         assert_eq!(checkin_count.load(Ordering::Relaxed), 3);
         assert_eq!(checkout_count.load(Ordering::Relaxed), 3);
+        // this is required to workaround a segfault while shutting down
+        // the pool
+        std::thread::sleep(Duration::from_millis(100));
     }
 
     #[cfg(feature = "postgres")]

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -56,7 +56,7 @@ syn = { version = "2", features = ["visit"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
 thiserror = "1.0.10"
-similar-asserts = "1.5.0"
+similar-asserts = "1.6.0"
 
 [dependencies.diesel]
 version = "~2.2.0"

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -283,13 +283,11 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
                     .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
 
                 if schema.lines().ne(old_buf.lines()) {
-                    // it's fine to leak here, we will
-                    // exit the application anyway soon
                     let label = path.file_name().expect("We have a file name here");
-                    let label = label.to_string_lossy().into_owned().leak();
+                    let label = label.to_string_lossy();
                     println!(
                         "{}",
-                        SimpleDiff::from_str(&old_buf, &schema, label, "new schema")
+                        SimpleDiff::from_str(&old_buf, &schema, &label, "new schema")
                     );
                     return Err(crate::errors::Error::SchemaWouldChange(
                         path.display().to_string(),


### PR DESCRIPTION
This allows us to remove a call to `String::leak` as they relaxed the life time requirements on the one method we use.