### PR TITLE
Expose last_insert_id from Ok packet on MySQL

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -486,6 +486,19 @@ pub trait BoxableConnection<DB: Backend>: SimpleConnection + std::any::Any {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
+/// An extension of the [`Connection`](trait.Connection.html) trait that provides the value
+/// assigned to an inserted row with an auto-incremented ID column
+pub trait ConnectionWithReturningId: Connection {
+    /// The type that the connection implementation returns for IDs
+    type ReturnedId;
+
+    /// Execute a single INSERT statement given by a query and return the ID that the database
+    /// assigns
+    fn execute_returning_id<T>(&mut self, source: &T) -> QueryResult<Self::ReturnedId>
+    where
+        T: QueryFragment<Self::Backend> + QueryId;
+}
+
 impl<C> BoxableConnection<C::Backend> for C
 where
     C: Connection + std::any::Any,

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -160,6 +160,11 @@ impl<'a> StatementUse<'a> {
             .map_err(|e| Error::DeserializationError(Box::new(e)))
     }
 
+    /// SAFETY:  This should only be called for INSERT queries.
+    pub(in crate::mysql::connection) unsafe fn insert_id(&self) -> u64 {
+        ffi::mysql_stmt_insert_id(self.inner.stmt.as_ptr())
+    }
+
     /// This function should be called after `execute` only
     /// otherwise it's not guaranteed to return a valid result
     pub(in crate::mysql::connection) unsafe fn result_size(&mut self) -> QueryResult<usize> {

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,7 +1,9 @@
 use self::private::LoadIter;
 use super::RunQueryDsl;
 use crate::backend::Backend;
-use crate::connection::{Connection, DefaultLoadingMode, LoadConnection};
+use crate::connection::{
+    Connection, ConnectionWithReturningId, DefaultLoadingMode, LoadConnection,
+};
 use crate::deserialize::FromSqlRow;
 use crate::expression::QueryMetadata;
 use crate::query_builder::{AsQuery, QueryFragment, QueryId};
@@ -88,6 +90,34 @@ where
 {
     fn execute(query: T, conn: &mut Conn) -> Result<usize, Error> {
         conn.execute_returning_count(&query)
+    }
+}
+
+/// The `execute_with_returning_id` method
+///
+/// This is currently only implemented for [`MySQL`], because MySQL provides a
+/// `last_insert_id` field as part of its response packet to `INSERT` queries, but
+/// it's in a trait to avoid a backwards-incompatible change in the future if such
+/// functionality becomes available in other back-ends.
+///
+/// [`MySQL`]: crate::mysql::Mysql
+pub trait ExecuteInsertWithReturningId<
+    Conn: ConnectionWithReturningId<Backend = DB>,
+    DB: Backend = <Conn as Connection>::Backend,
+>: Sized
+{
+    /// Execute this command
+    fn execute_with_returning_id(query: Self, conn: &mut Conn) -> QueryResult<Conn::ReturnedId>;
+}
+
+impl<Conn, DB, T> ExecuteInsertWithReturningId<Conn, DB> for T
+where
+    Conn: ConnectionWithReturningId<Backend = DB>,
+    DB: Backend,
+    T: QueryFragment<DB> + QueryId,
+{
+    fn execute_with_returning_id(query: Self, conn: &mut Conn) -> QueryResult<Conn::ReturnedId> {
+        conn.execute_returning_id(&query)
     }
 }
 


### PR DESCRIPTION
Took a whack at implementing what we discussed in https://github.com/diesel-rs/diesel/discussions/3605 (finally); I'm sure I need to add some documentation at minimum.

Notably, I copied most of the body of `execute_returning_id()` from `execute_returning_count()`, not sure if that's how you want to handle that or not

Might have overabstracted; I implemented it using traits for extensibility.

I'll have a follow-up in `diesel_async` once this is merged.