### PR TITLE
Auto type binary operators

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -651,6 +651,11 @@ pub mod helper_types {
     #[allow(non_camel_case_types)] // required for `#[auto_type]`
     pub type insert_into<T> = crate::query_builder::IncompleteInsertStatement<T>;
 
+    /// Represents the return type of [`diesel::update`]
+    #[allow(non_camel_case_types)] // required for `#[auto_type]`
+    pub type update<T> =
+        UpdateStatement<<T as HasTable>::Table, <T as IntoUpdateTarget>::WhereClause>;
+
     /// Represents the return type of [`diesel::insert_or_ignore_into`]
     #[allow(non_camel_case_types)] // required for `#[auto_type]`
     pub type insert_or_ignore_into<T> = crate::query_builder::IncompleteInsertOrIgnoreStatement<T>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -481,6 +481,15 @@ fn delete_returning() -> _ {
     delete(users::table).returning(users::id)
 }
 
+#[cfg(feature = "postgres")]
+#[auto_type]
+fn update_and_binary_operator_and_block() -> _ {
+    update(pg_extras::table).set(pg_extras::timestamp.eq(pg_extras::timestamp + {
+        let v: diesel::data_types::PgInterval = 1.year();
+        v
+    }))
+}
+
 // #[auto_type]
 // fn test_sql_fragment() -> _ {
 //     sql("foo")


### PR DESCRIPTION
This adds support for type inference of e.g. `some_timestamptz_column - some_pginterval_expression`.

Also adds support for `update(...)` expression (I found myself needing it for the test).