### PR TITLE
working on json_path_exists

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -2191,3 +2191,8 @@ define_sql_function! {
         values: Arr2
     ) -> Arr2::Out;
 }
+
+#[cfg(feature = "postgres_backend")]
+define_sql_function!{
+    fn jsonb_path_exists<J: JsonbOrNullableJsonb + SingleValue, >(jsonb:J,path:Jsonb);
+}

--- a/diesel/src/pg/types/json_path.rs
+++ b/diesel/src/pg/types/json_path.rs
@@ -1,0 +1,43 @@
+use std::fmt::{Debug, Display};
+use std::io::Write;
+use std::str;
+use std::str::FromStr;
+use crate::{deserialize, serialize, sql_types};
+use crate::deserialize::FromSql;
+use crate::pg::Pg;
+use crate::serialize::{Output, ToSql};
+
+#[cfg(all(feature = "postgres_backend", feature = "serde_json"))]
+impl FromSql<sql_types::Jsonpath, Pg> for jsonpath_rust::JsonPath {
+    fn from_sql(value: Pg::RawValue<'_>) -> deserialize::Result<Self> {
+        let str = str::from_utf8(value.as_bytes()).map_err(|_| "Invalid path".into())?;
+        jsonpath_rust::JsonPath::from_str(str).map_err(|_| "Invalid path".into())
+    }
+}
+
+impl ToSql<sql_types::Jsonpath, Pg> for jsonpath_rust::JsonPath {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use jsonpath_rust::JsonPath;
+
+    use crate::pg::Pg;
+    use crate::query_builder::bind_collector::ByteWrapper;
+    use crate::serialize::{Output, ToSql};
+    use crate::sql_types;
+
+    #[test]
+    fn json_to_sql() {
+        let mut buffer = Vec::new();
+        let mut bytes = Output::test(ByteWrapper(&mut buffer));
+        let test_json_path = jsonpath_rust::path!("$.abc");
+        ToSql::<sql_types::Jsonpath, Pg>::to_sql(&test_json_path, &mut bytes).unwrap();
+        assert_eq!(buffer, b"$.abc");
+    }
+}

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -22,6 +22,7 @@ mod ranges;
 mod record;
 #[cfg(feature = "uuid")]
 mod uuid;
+mod json_path;
 
 /// PostgreSQL specific SQL types
 ///
@@ -681,6 +682,13 @@ pub mod sql_types {
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
     #[diesel(postgres_type(name = "citext"))]
     pub struct Citext;
+
+
+    /// The [`Jsonpath`] SQL type. This is a PostgreSQL specific type.
+    #[cfg(feature = "postgres_backend")]
+    #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
+    #[diesel(postgres_type(name = "jsonpath"))]
+    pub struct Jsonpath;
 }
 
 mod ops {


### PR DESCRIPTION
@weiznich I was trying to implement the `jsonb_path_exists` function. One of its argument is of type `Jsonpath`. Currently there is no such type in diesel, so I tried to implement it using the `jsonpath_rust` crate. 

I implemented the `FromSql` trait for it, but I could not figure out how to implement the `ToSql` trait. I'd appreciate if you could take a look and help me with this or maybe i am going completely in the wrong direction with this?