### PR TITLE
Fix deserialization of empty PostgreSQL ranges

### DIFF
--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -578,3 +578,26 @@ where
 {
     const FIELD_COUNT: usize = <ST as crate::util::TupleSize>::SIZE;
 }
+
+/// A helper trait for giving a type a useful default value.
+///
+/// This is needed for types that can be used as range to represent the empty range as
+/// (Bound::Excluded(DEFAULT), Bound::Excluded(DEFAULT)).
+/// When possible, implementations of this trait should fall back to using std::default::Default.
+#[allow(dead_code)]
+pub(crate) trait Defaultable {
+    /// Returns the "default value" for a type.
+    fn default_value() -> Self;
+}
+
+// We cannot have this impl because rustc
+// then complains in third party crates that
+// diesel may implement `Default`in the future.
+// If we get negative trait impls at some point in time
+// it should be possible to make this work.
+//// Defaultable for types that has Default
+//impl<T: Default> Defaultable for T {
+//    fn default_value() -> Self {
+//        T::default()
+//    }
+//}

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -5,7 +5,7 @@ extern crate chrono;
 use self::chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
 use super::{PgDate, PgInterval, PgTime, PgTimestamp};
-use crate::deserialize::{self, FromSql};
+use crate::deserialize::{self, Defaultable, FromSql};
 use crate::pg::{Pg, PgValue};
 use crate::serialize::{self, Output, ToSql};
 use crate::sql_types::{Date, Interval, Time, Timestamp, Timestamptz};
@@ -62,6 +62,13 @@ impl ToSql<Timestamptz, Pg> for NaiveDateTime {
 }
 
 #[cfg(all(feature = "chrono", feature = "postgres_backend"))]
+impl Defaultable for NaiveDateTime {
+    fn default_value() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(all(feature = "chrono", feature = "postgres_backend"))]
 impl FromSql<Timestamptz, Pg> for DateTime<Utc> {
     fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let naive_date_time = <NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes)?;
@@ -70,10 +77,24 @@ impl FromSql<Timestamptz, Pg> for DateTime<Utc> {
 }
 
 #[cfg(all(feature = "chrono", feature = "postgres_backend"))]
+impl Defaultable for DateTime<Utc> {
+    fn default_value() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(all(feature = "chrono", feature = "postgres_backend"))]
 impl FromSql<Timestamptz, Pg> for DateTime<Local> {
     fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let naive_date_time = <NaiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes)?;
         Ok(Local::from_utc_datetime(&Local, &naive_date_time))
+    }
+}
+
+#[cfg(all(feature = "chrono", feature = "postgres_backend"))]
+impl Defaultable for DateTime<Local> {
+    fn default_value() -> Self {
+        Self::default()
     }
 }
 
@@ -136,6 +157,13 @@ impl FromSql<Date, Pg> for NaiveDate {
                 Err(error_message.into())
             }
         }
+    }
+}
+
+#[cfg(all(feature = "chrono", feature = "postgres_backend"))]
+impl Defaultable for NaiveDate {
+    fn default_value() -> Self {
+        Self::default()
     }
 }
 

--- a/diesel/src/pg/types/date_and_time/time.rs
+++ b/diesel/src/pg/types/date_and_time/time.rs
@@ -9,7 +9,7 @@ use self::time::{
 };
 
 use super::{PgDate, PgTime, PgTimestamp};
-use crate::deserialize::{self, FromSql};
+use crate::deserialize::{self, Defaultable, FromSql};
 use crate::pg::{Pg, PgValue};
 use crate::serialize::{self, Output, ToSql};
 use crate::sql_types::{Date, Time, Timestamp, Timestamptz};
@@ -58,6 +58,13 @@ impl ToSql<Timestamptz, Pg> for PrimitiveDateTime {
 }
 
 #[cfg(all(feature = "time", feature = "postgres_backend"))]
+impl Defaultable for PrimitiveDateTime {
+    fn default_value() -> Self {
+        PG_EPOCH
+    }
+}
+
+#[cfg(all(feature = "time", feature = "postgres_backend"))]
 impl FromSql<Timestamptz, Pg> for OffsetDateTime {
     fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let primitive_date_time = <PrimitiveDateTime as FromSql<Timestamptz, Pg>>::from_sql(bytes)?;
@@ -71,6 +78,13 @@ impl ToSql<Timestamptz, Pg> for OffsetDateTime {
         let as_utc = self.to_offset(UtcOffset::UTC);
         let primitive_date_time = PrimitiveDateTime::new(as_utc.date(), as_utc.time());
         ToSql::<Timestamptz, Pg>::to_sql(&primitive_date_time, &mut out.reborrow())
+    }
+}
+
+#[cfg(all(feature = "time", feature = "postgres_backend"))]
+impl Defaultable for OffsetDateTime {
+    fn default_value() -> Self {
+        datetime!(2000-01-01 0:00:00 UTC)
     }
 }
 
@@ -116,6 +130,13 @@ impl FromSql<Date, Pg> for NaiveDate {
                 Err(error_message.into())
             }
         }
+    }
+}
+
+#[cfg(all(feature = "time", feature = "postgres_backend"))]
+impl Defaultable for NaiveDate {
+    fn default_value() -> Self {
+        PG_EPOCH_DATE
     }
 }
 

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -1,4 +1,4 @@
-use crate::deserialize::{self, FromSql, FromSqlRow};
+use crate::deserialize::{self, Defaultable, FromSql, FromSqlRow};
 use crate::expression::AsExpression;
 use crate::pg::{Pg, PgValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
@@ -9,7 +9,7 @@ use std::error::Error;
 #[cfg(feature = "quickcheck")]
 mod quickcheck_impls;
 
-#[derive(Debug, Clone, PartialEq, Eq, AsExpression, FromSqlRow)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, AsExpression, FromSqlRow)]
 #[diesel(sql_type = sql_types::Numeric)]
 /// Represents a NUMERIC value, closely mirroring the PG wire protocol
 /// representation
@@ -33,6 +33,7 @@ pub enum PgNumeric {
         digits: Vec<i16>,
     },
     /// Not a number
+    #[default]
     NaN,
 }
 
@@ -110,6 +111,13 @@ impl ToSql<sql_types::Numeric, Pg> for PgNumeric {
         }
 
         Ok(IsNull::No)
+    }
+}
+
+#[cfg(feature = "postgres_backend")]
+impl Defaultable for PgNumeric {
+    fn default_value() -> Self {
+        Self::default()
     }
 }
 

--- a/diesel/src/pg/types/integers.rs
+++ b/diesel/src/pg/types/integers.rs
@@ -1,4 +1,4 @@
-use crate::deserialize::{self, FromSql};
+use crate::deserialize::{self, Defaultable, FromSql};
 use crate::pg::{Pg, PgValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
 use crate::sql_types;
@@ -123,6 +123,20 @@ impl ToSql<sql_types::BigInt, Pg> for i64 {
         out.write_i64::<NetworkEndian>(*self)
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<_>)
+    }
+}
+
+#[cfg(feature = "postgres_backend")]
+impl Defaultable for i32 {
+    fn default_value() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "postgres_backend")]
+impl Defaultable for i64 {
+    fn default_value() -> Self {
+        Self::default()
     }
 }
 

--- a/diesel/src/pg/types/multirange.rs
+++ b/diesel/src/pg/types/multirange.rs
@@ -2,7 +2,7 @@ use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use std::io::Write;
 use std::ops::Bound;
 
-use crate::deserialize::{self, FromSql};
+use crate::deserialize::{self, Defaultable, FromSql};
 use crate::expression::bound::Bound as SqlBound;
 use crate::expression::AsExpression;
 use crate::pg::{Pg, PgTypeMetadata, PgValue};
@@ -68,7 +68,7 @@ multirange_as_expressions!(std::ops::RangeTo<T>);
 #[cfg(feature = "postgres_backend")]
 impl<T, ST> FromSql<Multirange<ST>, Pg> for Vec<(Bound<T>, Bound<T>)>
 where
-    T: FromSql<ST, Pg>,
+    T: FromSql<ST, Pg> + Defaultable,
 {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = value.as_bytes();

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -10,7 +10,7 @@ mod bigdecimal {
     use self::num_integer::Integer;
     use self::num_traits::{Signed, ToPrimitive, Zero};
 
-    use crate::deserialize::{self, FromSql};
+    use crate::deserialize::{self, Defaultable, FromSql};
     use crate::pg::data_types::PgNumeric;
     use crate::pg::{Pg, PgValue};
     use crate::serialize::{self, Output, ToSql};
@@ -166,6 +166,13 @@ mod bigdecimal {
     impl FromSql<Numeric, Pg> for BigDecimal {
         fn from_sql(numeric: PgValue<'_>) -> deserialize::Result<Self> {
             PgNumeric::from_sql(numeric)?.try_into()
+        }
+    }
+
+    #[cfg(all(feature = "postgres_backend", feature = "numeric"))]
+    impl Defaultable for BigDecimal {
+        fn default_value() -> Self {
+            Self::default()
         }
     }
 

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1422,10 +1422,45 @@ fn test_range_from_sql() {
         query_single_value::<Range<Int4>, (Bound<i32>, Bound<i32>)>(query)
     );
 
-    let query = "SELECT '(1,1]'::int4range";
+    let query = "SELECT '[2,1)'::int4range";
     assert!(sql::<Range<Int4>>(query)
         .load::<(Bound<i32>, Bound<i32>)>(connection)
         .is_err());
+
+    let query = "'empty'::int4range";
+    let expected_value = (Bound::Excluded(0), Bound::Excluded(0));
+    assert_eq!(
+        expected_value,
+        query_single_value::<Range<Int4>, (Bound<i32>, Bound<i32>)>(query)
+    );
+
+    let query = "'(1,1)'::int4range";
+    let expected_value = (Bound::Excluded(0), Bound::Excluded(0));
+    assert_eq!(
+        expected_value,
+        query_single_value::<Range<Int4>, (Bound<i32>, Bound<i32>)>(query)
+    );
+
+    let query = "'(1,1]'::int4range";
+    let expected_value = (Bound::Excluded(0), Bound::Excluded(0));
+    assert_eq!(
+        expected_value,
+        query_single_value::<Range<Int4>, (Bound<i32>, Bound<i32>)>(query)
+    );
+
+    let query = "'[1,1)'::int4range";
+    let expected_value = (Bound::Excluded(0), Bound::Excluded(0));
+    assert_eq!(
+        expected_value,
+        query_single_value::<Range<Int4>, (Bound<i32>, Bound<i32>)>(query)
+    );
+
+    let query = "'[1,1]'::int4range";
+    let expected_value = (Bound::Included(1), Bound::Excluded(2));
+    assert_eq!(
+        expected_value,
+        query_single_value::<Range<Int4>, (Bound<i32>, Bound<i32>)>(query)
+    );
 }
 
 #[cfg(feature = "postgres")]


### PR DESCRIPTION
In diesel empty ranges are represented as:

```
(
  Bound::Excluded(T::default()),
  Bound::Excluded(T::default()),
)
```