### PR TITLE
Add a new `#[allow(missing_docs)]`

### DIFF
--- a/diesel/src/test_helpers.rs
+++ b/diesel/src/test_helpers.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)] // test only module
 extern crate dotenvy;
 
 use crate::prelude::*;


### PR DESCRIPTION
This commit adds a new `#[allow(missing_docs)]` attribute to supress a new warning on rustc +beta for our test code. We do not really care about doc comments there.