### PR TITLE
Drop gitter from the docs

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -137,9 +137,8 @@
 //! ## Getting help
 //!
 //! If you run into problems, Diesel has an active community.
-//! Either open a new [discussion] thread at diesel github repository or
-//! use the active Gitter room at
-//! [gitter.im/diesel-rs/diesel](https://gitter.im/diesel-rs/diesel)
+//! Open a new [discussion] thread at diesel github repository
+//! and we will try to help you
 //!
 //! [discussion]: https://github.com/diesel-rs/diesel/discussions/categories/q-a
 //!


### PR DESCRIPTION
Our gitter channel has a spam problem and we do not have admin rights anymore due to whatever matrix bugs we hit. The channel therefore become unmaintainable. Given that we should drop it from our documentation.