### PR TITLE
Fix and/or function argument to compile check bool expression

### DIFF
--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -92,6 +92,7 @@ pub trait BoolExpressionMethods: Expression + Sized {
         Self::SqlType: SqlType,
         ST: SqlType + TypedExpressionType,
         T: AsExpression<ST>,
+        <T::Expression as Expression>::SqlType: BoolOrNullableBool,
         Or<Self, T::Expression>: Expression,
     {
         Grouped(Or::new(self, other.as_expression()))

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -43,6 +43,7 @@ pub trait BoolExpressionMethods: Expression + Sized {
         Self::SqlType: SqlType,
         ST: SqlType + TypedExpressionType,
         T: AsExpression<ST>,
+        <T::Expression as Expression>::SqlType: BoolOrNullableBool,
         And<Self, T::Expression>: Expression,
     {
         Grouped(And::new(self, other.as_expression()))

--- a/diesel/src/expression_methods/bool_expression_methods.rs
+++ b/diesel/src/expression_methods/bool_expression_methods.rs
@@ -41,9 +41,8 @@ pub trait BoolExpressionMethods: Expression + Sized {
     fn and<T, ST>(self, other: T) -> dsl::And<Self, T, ST>
     where
         Self::SqlType: SqlType,
-        ST: SqlType + TypedExpressionType,
+        ST: SqlType + TypedExpressionType + BoolOrNullableBool,
         T: AsExpression<ST>,
-        <T::Expression as Expression>::SqlType: BoolOrNullableBool,
         And<Self, T::Expression>: Expression,
     {
         Grouped(And::new(self, other.as_expression()))
@@ -90,9 +89,8 @@ pub trait BoolExpressionMethods: Expression + Sized {
     fn or<T, ST>(self, other: T) -> dsl::Or<Self, T, ST>
     where
         Self::SqlType: SqlType,
-        ST: SqlType + TypedExpressionType,
+        ST: SqlType + TypedExpressionType + BoolOrNullableBool,
         T: AsExpression<ST>,
-        <T::Expression as Expression>::SqlType: BoolOrNullableBool,
         Or<Self, T::Expression>: Expression,
     {
         Grouped(Or::new(self, other.as_expression()))

--- a/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs
+++ b/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs
@@ -1,0 +1,19 @@
+extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+fn main() {
+    let conn = &mut PgConnection::establish("…").unwrap();
+    users::table
+        .filter(users::id.eq(1).and(users::id).or(users::id))
+        .select(users::id)
+        .execute(conn)
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.stderr
+++ b/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.stderr
@@ -1,10 +1,8 @@
 error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
-  --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:37
+  --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:33
    |
 15 |         .filter(users::id.eq(1).and(users::id).or(users::id))
-   |                                 --- ^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
-   |                                 |
-   |                                 required by a bound introduced by this call
+   |                                 ^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
    |
    = note: try to provide an expression that produces one of the expected sql types
    = help: the following other types implement trait `BoolOrNullableBool`:
@@ -16,16 +14,14 @@ note: required by a bound in `diesel::BoolExpressionMethods::and`
    |     fn and<T, ST>(self, other: T) -> dsl::And<Self, T, ST>
    |        --- required by a bound in this associated function
 ...
-   |         <T::Expression as Expression>::SqlType: BoolOrNullableBool,
-   |                                                 ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::and`
+   |         ST: SqlType + TypedExpressionType + BoolOrNullableBool,
+   |                                             ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::and`
 
 error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
-  --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:51
+  --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:48
    |
 15 |         .filter(users::id.eq(1).and(users::id).or(users::id))
-   |                                                -- ^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
-   |                                                |
-   |                                                required by a bound introduced by this call
+   |                                                ^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
    |
    = note: try to provide an expression that produces one of the expected sql types
    = help: the following other types implement trait `BoolOrNullableBool`:
@@ -37,5 +33,5 @@ note: required by a bound in `diesel::BoolExpressionMethods::or`
    |     fn or<T, ST>(self, other: T) -> dsl::Or<Self, T, ST>
    |        -- required by a bound in this associated function
 ...
-   |         <T::Expression as Expression>::SqlType: BoolOrNullableBool,
-   |                                                 ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::or`
+   |         ST: SqlType + TypedExpressionType + BoolOrNullableBool,
+   |                                             ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::or`

--- a/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.stderr
+++ b/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.stderr
@@ -1,0 +1,41 @@
+error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
+  --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:37
+   |
+15 |         .filter(users::id.eq(1).and(users::id).or(users::id))
+   |                                 --- ^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
+   |                                 |
+   |                                 required by a bound introduced by this call
+   |
+   = note: try to provide an expression that produces one of the expected sql types
+   = help: the following other types implement trait `BoolOrNullableBool`:
+             Bool
+             Nullable<Bool>
+note: required by a bound in `diesel::BoolExpressionMethods::and`
+  --> $DIESEL/src/expression_methods/bool_expression_methods.rs
+   |
+   |     fn and<T, ST>(self, other: T) -> dsl::And<Self, T, ST>
+   |        --- required by a bound in this associated function
+...
+   |         <T::Expression as Expression>::SqlType: BoolOrNullableBool,
+   |                                                 ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::and`
+
+error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
+  --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:51
+   |
+15 |         .filter(users::id.eq(1).and(users::id).or(users::id))
+   |                                                -- ^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
+   |                                                |
+   |                                                required by a bound introduced by this call
+   |
+   = note: try to provide an expression that produces one of the expected sql types
+   = help: the following other types implement trait `BoolOrNullableBool`:
+             Bool
+             Nullable<Bool>
+note: required by a bound in `diesel::BoolExpressionMethods::or`
+  --> $DIESEL/src/expression_methods/bool_expression_methods.rs
+   |
+   |     fn or<T, ST>(self, other: T) -> dsl::Or<Self, T, ST>
+   |        -- required by a bound in this associated function
+...
+   |         <T::Expression as Expression>::SqlType: BoolOrNullableBool,
+   |                                                 ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::or`

--- a/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
+++ b/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
@@ -13,6 +13,3 @@ note: an implementation of `std::ops::Add` might be missing for `columns::name`
    |         ^^^^ must implement `std::ops::Add`
 note: the trait `std::ops::Add` must be implemented
   --> $RUST/core/src/ops/arith.rs
-   |
-   | pub trait Add<Rhs = Self> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
+++ b/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
@@ -13,3 +13,6 @@ note: an implementation of `std::ops::Add` might be missing for `columns::name`
    |         ^^^^ must implement `std::ops::Add`
 note: the trait `std::ops::Add` must be implemented
   --> $RUST/core/src/ops/arith.rs
+   |
+   | pub trait Add<Rhs = Self> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently if you try putting any sort of expression in a and function of diesel it will not be detected at compile time but will raise an error at runtime