### PR TITLE
Fixes #4349

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -27,7 +27,10 @@ use std::marker::PhantomData;
 /// `IN` expression.
 ///
 /// The postgres backend provided a specialized implementation
-/// by using `left = ANY(values)` as optimized variant instead.
+/// by using `left = ANY(values)` as optimized variant instead
+/// if this is possible. For cases where this is not possible
+/// like for example if values is a vector of arrays we
+/// generate an ordinary `IN` expression instead.
 #[derive(Debug, Copy, Clone, QueryId, ValidGrouping)]
 #[non_exhaustive]
 pub struct In<T, U> {
@@ -47,7 +50,10 @@ pub struct In<T, U> {
 /// `NOT IN` expression.0
 ///
 /// The postgres backend provided a specialized implementation
-/// by using `left = ALL(values)` as optimized variant instead.
+/// by using `left != ALL(values)` as optimized variant instead
+/// if this is possible. For cases where this is not possible
+/// like for example if values is a vector of arrays we
+/// generate a ordinary `NOT IN` expression instead
 #[derive(Debug, Copy, Clone, QueryId, ValidGrouping)]
 #[non_exhaustive]
 pub struct NotIn<T, U> {

--- a/diesel/src/expression/subselect.rs
+++ b/diesel/src/expression/subselect.rs
@@ -42,6 +42,9 @@ impl<T, ST: SqlType> InExpression for Subselect<T, ST> {
     fn is_empty(&self) -> bool {
         false
     }
+    fn is_array(&self) -> bool {
+        false
+    }
 }
 
 impl<T, ST, QS> SelectableExpression<QS> for Subselect<T, ST>

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -107,7 +107,9 @@ pub trait ExpressionMethods: Expression + Sized {
     /// query will use the cache (assuming the subquery
     /// itself is safe to cache).
     /// On PostgreSQL, this method automatically performs a `= ANY()`
-    /// query.
+    /// query if this is possible. For cases where this is not possible
+    /// like for example if values is a vector of arrays we
+    /// generate an ordinary `IN` expression instead.
     ///
     /// # Example
     ///
@@ -149,7 +151,10 @@ pub trait ExpressionMethods: Expression + Sized {
     ///
     /// Queries using this method will not be
     /// placed in the prepared statement cache. On PostgreSQL, this
-    /// method automatically performs a `!= ALL()` query.
+    /// method automatically performs a `!= ALL()` query if this is possible.
+    /// For cases where this is not possible
+    /// like for example if values is a vector of arrays we
+    /// generate an ordinary `NOT IN` expression instead.
     ///
     /// # Example
     ///

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -195,6 +195,7 @@ where
     ST: SqlType,
 {
     type InExpression = Self;
+
     fn as_in_expression(self) -> Self::InExpression {
         self
     }
@@ -319,6 +320,7 @@ where
     ST: SqlType,
 {
     type InExpression = Self;
+
     fn as_in_expression(self) -> Self::InExpression {
         self
     }

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -178,7 +178,13 @@ where
     ST: SqlType,
 {
     type SqlType = ST;
+
     fn is_empty(&self) -> bool {
+        false
+    }
+
+    fn is_array(&self) -> bool {
+        // we want to use the `= ANY(_)` syntax
         false
     }
 }
@@ -296,7 +302,13 @@ where
     ST: SqlType,
 {
     type SqlType = ST;
+
     fn is_empty(&self) -> bool {
+        false
+    }
+
+    fn is_array(&self) -> bool {
+        // we want to use the `= ANY(_)` syntax
         false
     }
 }

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -676,6 +676,9 @@ pub trait SqlType: 'static {
     ///
     /// ['is_nullable`]: is_nullable
     type IsNull: OneIsNullable<is_nullable::IsNullable> + OneIsNullable<is_nullable::NotNull>;
+
+    #[doc(hidden)]
+    const IS_ARRAY: bool = false;
 }
 
 /// Is one value of `IsNull` nullable?

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -338,6 +338,21 @@ fn filter_array_by_in() {
     assert_eq!(result, &[] as &[i32]);
 }
 
+#[test]
+#[cfg(feature = "postgres")]
+fn filter_array_by_not_in() {
+    use crate::schema::posts::dsl::*;
+
+    let connection: &mut PgConnection = &mut connection();
+    let tag_combinations_to_look_for: &[&[&str]] = &[&["foo"], &["foo", "bar"], &["baz"]];
+    let result: Vec<i32> = posts
+        .filter(tags.ne_all(tag_combinations_to_look_for))
+        .select(id)
+        .load(connection)
+        .unwrap();
+    assert_eq!(result, &[] as &[i32]);
+}
+
 fn connection_with_3_users() -> TestConnection {
     let mut connection = connection_with_sean_and_tess_in_users_table();
     diesel::sql_query("INSERT INTO users (id, name) VALUES (3, 'Jim')")

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -323,6 +323,21 @@ fn filter_by_in_explicit_array() {
     );
 }
 
+#[test]
+#[cfg(feature = "postgres")]
+fn filter_array_by_in() {
+    use crate::schema::posts::dsl::*;
+
+    let connection: &mut PgConnection = &mut connection();
+    let tag_combinations_to_look_for: &[&[&str]] = &[&["foo"], &["foo", "bar"], &["baz"]];
+    let result: Vec<i32> = posts
+        .filter(tags.eq_any(tag_combinations_to_look_for))
+        .select(id)
+        .load(connection)
+        .unwrap();
+    assert_eq!(result, &[] as &[i32]);
+}
+
 fn connection_with_3_users() -> TestConnection {
     let mut connection = connection_with_sean_and_tess_in_users_table();
     diesel::sql_query("INSERT INTO users (id, name) VALUES (3, 'Jim')")


### PR DESCRIPTION
This commit fixes an issue that allowed to trigger a runtime error by
passing an array of arrays to `.eq_any()`. We rewrite queries containing
`IN` expressions to `= ANY()` on postgresql as that more
efficient (allows caching + allows binding all values at once). That's
not possible for arrays of arrays as we do not support nested arrays
yet.

The fix introduces an associated constant for the `SqlType` trait that
tracks if a SQL type is a `Array<T>` or not. This information is then
used to conditionally generate the "right" SQL. By defaulting to `false`
while adding this constant we do not break existing code. We use the
derive to set the right value based on the type name.

cc @Ten0 

(I would suggest to include that PR in the patch release as well)