### PR TITLE
Add a missing type def

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -369,6 +369,7 @@ pub mod helper_types {
     use super::query_dsl::methods::*;
     use super::query_dsl::*;
     use super::query_source::{aliasing, joins};
+    use crate::dsl::CountStar;
     use crate::query_builder::select_clause::SelectClause;
 
     #[doc(inline)]
@@ -699,6 +700,9 @@ pub mod helper_types {
     /// [`DeleteStatement::returning`](crate::query_builder::DeleteStatement::returning)
     pub type Returning<Q, S> =
         <Q as crate::query_builder::returning_clause::ReturningClauseHelper<S>>::WithReturning;
+
+    #[doc(hidden)] // used for `QueryDsl::count`
+    pub type Count<Q> = Select<Q, CountStar>;
 }
 
 pub mod prelude {

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -503,6 +503,11 @@ fn update_and_binary_operator_and_block() -> _ {
     }))
 }
 
+#[auto_type]
+fn count_query() -> _ {
+    users::table.count()
+}
+
 // #[auto_type]
 // fn test_sql_fragment() -> _ {
 //     sql("foo")


### PR DESCRIPTION
This commit adds a missing type-def that allows now to use `table.count()` with `#[auto_type]`

Found and reported by @Turbo87