### PR TITLE
Add support for subselects to the `array(...)` function

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -1041,18 +1041,12 @@ impl<'a, QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
     type IsAggregate = IsAggregate;
 }
 
-/// Converts a tuple of values into a tuple of Diesel expressions.
-///
-/// This trait is similar to [`AsExpression`], but it operates on tuples.
-/// The expressions must all be of the same SQL type.
-///
-pub trait AsExpressionList<ST> {
-    /// The final output expression
-    type Expression;
-
-    /// Perform the conversion
-    // That's public API, we cannot change
-    // that to appease clippy
-    #[allow(clippy::wrong_self_convention)]
-    fn as_expression_list(self) -> Self::Expression;
-}
+// Some amount of backwards-compat
+// We used to require `AsExpressionList` on the `array` function.
+// Now we require `IntoArrayExpression` instead, which means something very different.
+// However for most people just checking this bound to call `array`, this won't break.
+// Only people who directly implement `AsExpressionList` would break, but I expect that to be
+// nobody.
+#[doc(hidden)]
+#[cfg(feature = "postgres_backend")]
+pub use crate::pg::expression::array::IntoArrayExpression as AsExpressionList;

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -11,10 +11,10 @@ use crate::query_builder::{
 use crate::sql_types::{self, SqlType};
 use std::marker::PhantomData;
 
-/// Creates an `ARRAY[...]` expression.
+/// Creates an `ARRAY[e1, e2, ...]` or `ARRAY(subselect)` expression.
 ///
 /// The argument should be a tuple of expressions which can be represented by the
-/// same SQL type.
+/// same SQL type, or a subquery.
 ///
 /// # Examples
 ///

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -74,6 +74,18 @@ pub trait IntoArrayExpression<ST: SqlType + TypedExpressionType> {
     fn into_array_expression(self) -> Self::ArrayExpression;
 }
 
+impl<ST, T> IntoArrayExpression<ST> for T
+where
+    T: AsExpression<sql_types::Array<ST>>,
+    ST: SqlType + TypedExpressionType + 'static,
+{
+    type ArrayExpression = <T as AsExpression<sql_types::Array<ST>>>::Expression;
+
+    fn into_array_expression(self) -> Self::ArrayExpression {
+        <T as AsExpression<sql_types::Array<ST>>>::as_expression(self)
+    }
+}
+
 /// An ARRAY[...] literal.
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct ArrayLiteral<T, ST> {

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -65,6 +65,11 @@ pub type array<ST, T> = <T as IntoArrayExpression<ST>>::ArrayExpression;
 /// Trait for types which can be converted into an expression of type `Array`
 ///
 /// This includes tuples of expressions with the same SQL type, and subselects with a single column.
+#[diagnostic::on_unimplemented(
+    message = "Cannot convert `{Self}` into an expression of type `Array<{ST}>`",
+    note = "`the trait bound `{Self}: IntoArrayExpression<{ST}>` is not satisfied. \
+        (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)"
+)]
 pub trait IntoArrayExpression<ST: SqlType + TypedExpressionType> {
     /// Type of the expression returned by [AsArrayExpression::as_in_expression]
     type ArrayExpression: Expression<SqlType = sql_types::Array<ST>>;

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -1,3 +1,4 @@
+use crate::dsl;
 use crate::expression::subselect::Subselect;
 use crate::expression::{
     AppearsOnTable, AsExpression, Expression, SelectableExpression, TypedExpressionType,
@@ -48,7 +49,7 @@ use std::marker::PhantomData;
 /// #     Ok(())
 /// # }
 /// ```
-pub fn array<ST, T>(elements: T) -> <T as IntoArrayExpression<ST>>::ArrayExpression
+pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
 where
     T: IntoArrayExpression<ST>,
     ST: SqlType + TypedExpressionType,

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -57,6 +57,12 @@ where
     elements.into_array_expression()
 }
 
+/// Return type of [`array(tuple_or_subselect)`](super::dsl::array)
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array<ST, T> = <T as IntoArrayExpression<ST>>::ArrayExpression;
+
+/// Trait for types which can be converted into an expression of type `Array`
 pub trait IntoArrayExpression<ST: SqlType + TypedExpressionType> {
     /// Type of the expression returned by [AsArrayExpression::as_in_expression]
     type ArrayExpression: Expression<SqlType = sql_types::Array<ST>>;

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -63,6 +63,8 @@ where
 pub type array<ST, T> = <T as IntoArrayExpression<ST>>::ArrayExpression;
 
 /// Trait for types which can be converted into an expression of type `Array`
+///
+/// This includes tuples of expressions with the same SQL type, and subselects with a single column.
 pub trait IntoArrayExpression<ST: SqlType + TypedExpressionType> {
     /// Type of the expression returned by [AsArrayExpression::as_in_expression]
     type ArrayExpression: Expression<SqlType = sql_types::Array<ST>>;

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -43,7 +43,7 @@ use std::marker::PhantomData;
 /// assert_eq!(expected, ids);
 ///
 /// let ids = diesel::select(array(users.select(id)))
-///     .get_results::<Vec<i32>>(connection)?;
+///     .first::<Vec<i32>>(connection)?;
 /// assert_eq!(vec![1, 2], ids);
 /// #     Ok(())
 /// # }

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -1,17 +1,15 @@
+use crate::expression::subselect::Subselect;
 use crate::expression::{
-    AppearsOnTable, AsExpressionList, Expression, SelectableExpression, ValidGrouping,
+    AppearsOnTable, AsExpressionList, Expression, SelectableExpression, TypedExpressionType,
+    ValidGrouping,
 };
 use crate::pg::Pg;
-use crate::query_builder::{AstPass, QueryFragment, QueryId};
-use crate::sql_types;
+use crate::query_builder::combination_clause::CombinationClause;
+use crate::query_builder::{
+    AstPass, BoxedSelectStatement, QueryFragment, QueryId, SelectQuery, SelectStatement,
+};
+use crate::sql_types::{self, SqlType};
 use std::marker::PhantomData;
-
-/// An ARRAY[...] literal.
-#[derive(Debug, Clone, Copy, QueryId)]
-pub struct ArrayLiteral<T, ST> {
-    elements: T,
-    _marker: PhantomData<ST>,
-}
 
 /// Creates an `ARRAY[...]` expression.
 ///
@@ -43,18 +41,52 @@ pub struct ArrayLiteral<T, ST> {
 ///     vec![2, 4],
 /// ];
 /// assert_eq!(expected, ids);
+///
+/// let ids = diesel::select(array(users.select(id)))
+///     .get_results::<Vec<i32>>(connection)?;
+/// assert_eq!(vec![1, 2], ids);
 /// #     Ok(())
 /// # }
 /// ```
 #[cfg(feature = "postgres_backend")]
-pub fn array<ST, T>(elements: T) -> ArrayLiteral<T::Expression, ST>
+pub fn array<ST, T>(elements: T) -> <T as IntoArrayExpression<ST>>::ArrayExpression
+where
+    T: IntoArrayExpression<ST>,
+    ST: SqlType + TypedExpressionType,
+{
+    elements.into_array_expression()
+}
+
+pub trait IntoArrayExpression<ST: SqlType + TypedExpressionType> {
+    /// Type of the expression returned by [AsArrayExpression::as_in_expression]
+    type ArrayExpression: Expression<SqlType = sql_types::Array<ST>>;
+
+    /// Construct the diesel query dsl representation of
+    /// the `ARRAY (values)` clause for the given type
+    fn into_array_expression(self) -> Self::ArrayExpression;
+}
+
+impl<ST, T> IntoArrayExpression<ST> for T
 where
     T: AsExpressionList<ST>,
+    ST: SqlType + TypedExpressionType,
+    T::Expression: Expression<SqlType = ST>,
 {
-    ArrayLiteral {
-        elements: elements.as_expression_list(),
-        _marker: PhantomData,
+    type ArrayExpression = ArrayLiteral<T::Expression, ST>;
+
+    fn into_array_expression(self) -> Self::ArrayExpression {
+        ArrayLiteral {
+            elements: self.as_expression_list(),
+            _marker: PhantomData,
+        }
     }
+}
+
+/// An ARRAY[...] literal.
+#[derive(Debug, Clone, Copy, QueryId)]
+pub struct ArrayLiteral<T, ST> {
+    elements: T,
+    _marker: PhantomData<ST>,
 }
 
 impl<T, ST> Expression for ArrayLiteral<T, ST>
@@ -92,6 +124,102 @@ where
 }
 
 impl<T, ST, GB> ValidGrouping<GB> for ArrayLiteral<T, ST>
+where
+    T: ValidGrouping<GB>,
+{
+    type IsAggregate = T::IsAggregate;
+}
+
+impl<ST, F, S, D, W, O, LOf, G, H, LC> IntoArrayExpression<ST>
+    for SelectStatement<F, S, D, W, O, LOf, G, H, LC>
+where
+    ST: SqlType + TypedExpressionType,
+    ArraySubselect<Self, ST>: Expression<SqlType = sql_types::Array<ST>>,
+    Self: SelectQuery<SqlType = ST>,
+{
+    type ArrayExpression = ArraySubselect<Self, ST>;
+
+    fn into_array_expression(self) -> Self::ArrayExpression {
+        ArraySubselect::new(self)
+    }
+}
+
+impl<'a, ST, QS, DB, GB> IntoArrayExpression<ST> for BoxedSelectStatement<'a, ST, QS, DB, GB>
+where
+    ST: SqlType + TypedExpressionType,
+    ArraySubselect<BoxedSelectStatement<'a, ST, QS, DB, GB>, ST>:
+        Expression<SqlType = sql_types::Array<ST>>,
+{
+    type ArrayExpression = ArraySubselect<Self, ST>;
+
+    fn into_array_expression(self) -> Self::ArrayExpression {
+        ArraySubselect::new(self)
+    }
+}
+
+impl<ST, Combinator, Rule, Source, Rhs> IntoArrayExpression<ST>
+    for CombinationClause<Combinator, Rule, Source, Rhs>
+where
+    ST: SqlType + TypedExpressionType,
+    Self: SelectQuery<SqlType = ST>,
+    ArraySubselect<Self, ST>: Expression<SqlType = sql_types::Array<ST>>,
+{
+    type ArrayExpression = ArraySubselect<Self, ST>;
+
+    fn into_array_expression(self) -> Self::ArrayExpression {
+        ArraySubselect::new(self)
+    }
+}
+
+/// An ARRAY(...) subselect.
+#[derive(Debug, Clone, Copy, QueryId)]
+pub struct ArraySubselect<T, ST> {
+    elements: Subselect<T, ST>,
+}
+
+impl<T, ST> ArraySubselect<T, ST> {
+    pub(crate) fn new(elements: T) -> Self {
+        Self {
+            elements: Subselect::new(elements),
+        }
+    }
+}
+
+impl<T, ST> Expression for ArraySubselect<T, ST>
+where
+    ST: 'static,
+    T: Expression,
+{
+    type SqlType = sql_types::Array<ST>;
+}
+
+impl<T, ST> QueryFragment<Pg> for ArraySubselect<T, ST>
+where
+    T: QueryFragment<Pg>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> crate::result::QueryResult<()> {
+        out.push_sql("ARRAY[");
+        QueryFragment::walk_ast(&self.elements, out.reborrow())?;
+        out.push_sql("]");
+        Ok(())
+    }
+}
+
+impl<T, ST, QS> SelectableExpression<QS> for ArraySubselect<T, ST>
+where
+    T: SelectableExpression<QS>,
+    ArraySubselect<T, ST>: AppearsOnTable<QS>,
+{
+}
+
+impl<T, ST, QS> AppearsOnTable<QS> for ArraySubselect<T, ST>
+where
+    T: AppearsOnTable<QS>,
+    ArraySubselect<T, ST>: Expression,
+{
+}
+
+impl<T, ST, GB> ValidGrouping<GB> for ArraySubselect<T, ST>
 where
     T: ValidGrouping<GB>,
 {

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -130,6 +130,17 @@ where
 
 impl_selectable_expression!(All<Expr>);
 
+/// Deprecated trait used for implementing `any` and `all` (which are themselves deprecated).
+///
+/// It has several quirks:
+/// - `All<Expr: Expression<SqlType = Array<ST>>>` pretends to be an expression of type `ST`,
+///   but it's in fact some custom that can really be only used in combination with the `=`
+///   operator in some select places.
+/// - Implementations that use Subelect below are lying: they pretend to be expressions of type
+///   `Array<ST>`, but they're actually subselects, which are processed differently by Postgres
+///   and may result in different query plans.
+///   The `IntoArrayExpression` trait represents this more accurately, actually building an
+///   actual expression of type array from a subselect (by wrapping it in `ARRAY(subselect)`).
 pub trait AsArrayExpression<ST: 'static> {
     type Expression: Expression<SqlType = Array<ST>>;
 

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,7 +1,6 @@
 use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
 use crate::expression::Expression;
-use crate::pg::expression::array::IntoArrayExpression;
 use crate::pg::expression::expression_methods::private::{JsonIndex, JsonRemoveIndex};
 use crate::pg::types::sql_types::Array;
 use crate::sql_types::{Inet, Integer, VarChar};
@@ -340,11 +339,6 @@ pub type NotLikeBinary<Lhs, Rhs> = crate::dsl::NotLike<Lhs, Rhs>;
 #[doc(hidden)]
 #[deprecated(note = "Use `dsl::Concat` instead")]
 pub type ConcatArray<Lhs, Rhs> = crate::dsl::Concat<Lhs, Rhs>;
-
-/// Return type of [`array(tuple_or_subselect)`](super::dsl::array)
-#[allow(non_camel_case_types)]
-#[cfg(feature = "postgres_backend")]
-pub type array<ST, T> = <T as IntoArrayExpression<ST>>::ArrayExpression;
 
 /// Return type of [`array_to_string_with_null_string(arr, delim, null_str)`](super::functions::array_to_string_with_null_string)
 #[allow(non_camel_case_types)]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,6 +1,7 @@
 use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
 use crate::expression::Expression;
+use crate::pg::expression::array::IntoArrayExpression;
 use crate::pg::expression::expression_methods::private::{JsonIndex, JsonRemoveIndex};
 use crate::pg::types::sql_types::Array;
 use crate::sql_types::{Inet, Integer, VarChar};
@@ -339,6 +340,11 @@ pub type NotLikeBinary<Lhs, Rhs> = crate::dsl::NotLike<Lhs, Rhs>;
 #[doc(hidden)]
 #[deprecated(note = "Use `dsl::Concat` instead")]
 pub type ConcatArray<Lhs, Rhs> = crate::dsl::Concat<Lhs, Rhs>;
+
+/// Return type of [`array(tuple_or_subselect)`](super::dsl::array)
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type array<ST, T> = <T as IntoArrayExpression<ST>>::ArrayExpression;
 
 /// Return type of [`array_to_string_with_null_string(arr, delim, null_str)`](super::functions::array_to_string_with_null_string)
 #[allow(non_camel_case_types)]

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -27,7 +27,7 @@ pub mod dsl {
     pub use super::array_comparison::{all, any};
 
     #[doc(inline)]
-    pub use super::array::array;
+    pub use super::array::{array, IntoArrayExpression};
 
     #[doc(inline)]
     pub use super::extensions::*;

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -4,9 +4,8 @@ use crate::deserialize::{
     self, FromSqlRow, FromStaticSqlRow, Queryable, SqlTypeOrSelectable, StaticallySizedRow,
 };
 use crate::expression::{
-    is_contained_in_group_by, AppearsOnTable, AsExpression, AsExpressionList, Expression,
-    IsContainedInGroupBy, MixedAggregates, QueryMetadata, Selectable, SelectableExpression,
-    TypedExpressionType, ValidGrouping,
+    is_contained_in_group_by, AppearsOnTable, Expression, IsContainedInGroupBy, MixedAggregates,
+    QueryMetadata, Selectable, SelectableExpression, TypedExpressionType, ValidGrouping,
 };
 use crate::insertable::{CanInsertInSingleQuery, InsertValues, Insertable, InsertableOptionHelper};
 use crate::query_builder::*;
@@ -236,17 +235,6 @@ macro_rules! tuple_impls {
                 fn tuple_append(self, next: Next) -> Self::Output {
                     let ($($T,)+) = self;
                     ($($T,)+ next)
-                }
-            }
-
-            impl<$($T,)+ ST> AsExpressionList<ST> for ($($T,)+) where
-                $($T: AsExpression<ST>,)+
-                ST: SqlType + TypedExpressionType,
-            {
-                type Expression = ($($T::Expression,)+);
-
-                fn as_expression_list(self) -> Self::Expression {
-                    ($(self.$idx.as_expression(),)+)
                 }
             }
 

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -223,12 +223,13 @@ note: required by a bound in `diesel::dsl::array`
   |     T: IntoArrayExpression<ST>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
-error[E0277]: the trait bound `(f64, f64): AsExpressionList<diesel::sql_types::Integer>` is not satisfied
+error[E0277]: Cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
  --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
   |
 9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
   |            ^^^^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(f64, f64)`
   |
+  = note: `the trait bound `(f64, f64): IntoArrayExpression<diesel::sql_types::Integer>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
   = help: the following other types implement trait `AsExpressionList<ST>`:
             (T0, T1)
             (T0, T1, T2)

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -217,8 +217,25 @@ error[E0277]: the trait bound `f64: diesel::Expression` is not satisfied
 note: required by a bound in `diesel::dsl::array`
  --> $DIESEL/src/pg/expression/array.rs
   |
-  | pub fn array<ST, T>(elements: T) -> ArrayLiteral<T::Expression, ST>
+  | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
   |        ----- required by a bound in this function
   | where
-  |     T: AsExpressionList<ST>,
-  |        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+  |     T: IntoArrayExpression<ST>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+
+error[E0277]: the trait bound `(f64, f64): AsExpressionList<diesel::sql_types::Integer>` is not satisfied
+ --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
+  |
+9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+  |            ^^^^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(f64, f64)`
+  |
+  = help: the following other types implement trait `AsExpressionList<ST>`:
+            (T0, T1)
+            (T0, T1, T2)
+            (T0, T1, T2, T3)
+            (T0, T1, T2, T3, T4)
+            (T0, T1, T2, T3, T4, T5)
+            (T0, T1, T2, T3, T4, T5, T6)
+            (T0, T1, T2, T3, T4, T5, T6, T7)
+            (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+          and $N others

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -217,11 +217,11 @@ error[E0277]: the trait bound `f64: diesel::Expression` is not satisfied
 note: required by a bound in `diesel::dsl::array`
   --> $DIESEL/src/pg/expression/array.rs
    |
-   | pub fn array<ST, T>(elements: T) -> ArrayLiteral<T::Expression, ST>
+   | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
    |        ----- required by a bound in this function
    | where
-   |     T: AsExpressionList<ST>,
-   |        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+   |     T: IntoArrayExpression<ST>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
 error[E0277]: Cannot select `{integer}` from `NoFromClause`
   --> tests/fail/array_expressions_must_be_same_type.rs:18:12
@@ -442,8 +442,42 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
 note: required by a bound in `diesel::dsl::array`
   --> $DIESEL/src/pg/expression/array.rs
    |
-   | pub fn array<ST, T>(elements: T) -> ArrayLiteral<T::Expression, ST>
+   | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
    |        ----- required by a bound in this function
    | where
-   |     T: AsExpressionList<ST>,
-   |        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+   |     T: IntoArrayExpression<ST>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+
+error[E0277]: the trait bound `(i32, f64): AsExpressionList<diesel::sql_types::Integer>` is not satisfied
+  --> tests/fail/array_expressions_must_be_same_type.rs:15:12
+   |
+15 |     select(array((1, 3f64)))
+   |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(i32, f64)`
+   |
+   = help: the following other types implement trait `AsExpressionList<ST>`:
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+             (T0, T1, T2, T3, T4, T5, T6)
+             (T0, T1, T2, T3, T4, T5, T6, T7)
+             (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+           and $N others
+
+error[E0277]: the trait bound `({integer}, f64): AsExpressionList<diesel::sql_types::Double>` is not satisfied
+  --> tests/fail/array_expressions_must_be_same_type.rs:18:12
+   |
+18 |     select(array((1, 3f64)))
+   |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Double>` is not implemented for `({integer}, f64)`
+   |
+   = help: the following other types implement trait `AsExpressionList<ST>`:
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+             (T0, T1, T2, T3, T4, T5, T6)
+             (T0, T1, T2, T3, T4, T5, T6, T7)
+             (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+           and $N others

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -448,12 +448,13 @@ note: required by a bound in `diesel::dsl::array`
    |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
-error[E0277]: the trait bound `(i32, f64): AsExpressionList<diesel::sql_types::Integer>` is not satisfied
+error[E0277]: Cannot convert `(i32, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
   --> tests/fail/array_expressions_must_be_same_type.rs:15:12
    |
 15 |     select(array((1, 3f64)))
    |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(i32, f64)`
    |
+   = note: `the trait bound `(i32, f64): IntoArrayExpression<diesel::sql_types::Integer>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
    = help: the following other types implement trait `AsExpressionList<ST>`:
              (T0, T1)
              (T0, T1, T2)
@@ -465,12 +466,13 @@ error[E0277]: the trait bound `(i32, f64): AsExpressionList<diesel::sql_types::I
              (T0, T1, T2, T3, T4, T5, T6, T7, T8)
            and $N others
 
-error[E0277]: the trait bound `({integer}, f64): AsExpressionList<diesel::sql_types::Double>` is not satisfied
+error[E0277]: Cannot convert `({integer}, f64)` into an expression of type `Array<diesel::sql_types::Double>`
   --> tests/fail/array_expressions_must_be_same_type.rs:18:12
    |
 18 |     select(array((1, 3f64)))
    |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Double>` is not implemented for `({integer}, f64)`
    |
+   = note: `the trait bound `({integer}, f64): IntoArrayExpression<diesel::sql_types::Double>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
    = help: the following other types implement trait `AsExpressionList<ST>`:
              (T0, T1)
              (T0, T1, T2)

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -473,15 +473,15 @@ fn test_arrays_c() {
     use self::numbers::table as numbers;
 
     let connection = &mut connection();
-    diesel::sql_query("INSERT INTO numbers (n) VALUES (7)")
+    diesel::sql_query("INSERT INTO numbers (n) VALUES (7), (8)")
         .execute(connection)
         .unwrap();
 
-    let value = diesel::select(array(numbers.select(n)))
+    let value = diesel::select(array(numbers.select(n).order_by(n)))
         .first::<Vec<i32>>(connection)
         .unwrap();
 
-    assert_eq!(value, vec![7]);
+    assert_eq!(value, vec![7, 8]);
 }
 
 #[test]

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -467,6 +467,24 @@ fn test_arrays_b() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
+fn test_arrays_c() {
+    use self::numbers::columns::*;
+    use self::numbers::table as numbers;
+
+    let connection = &mut connection();
+    diesel::sql_query("INSERT INTO numbers (n) VALUES (7)")
+        .execute(connection)
+        .unwrap();
+
+    let value = diesel::select(array(numbers.select(n)))
+        .first::<Vec<i32>>(connection)
+        .unwrap();
+
+    assert_eq!(value, vec![7]);
+}
+
+#[test]
 fn test_operator_precedence() {
     use self::numbers;
 


### PR DESCRIPTION
As underlined [here](https://github.com/diesel-rs/diesel/pull/4350#pullrequestreview-2447144357), there are cases where `= ANY(array)` does not behave the same as `= ANY(subquery)`, so it may be useful to explicitly convert a subquery into an array.

This PR allows doing this.

It's technically a breaking change, but only to the extent to which people implemented the `AsExpressionList` trait manually, which seems unlikely enough.