### PR TITLE
Fix eq_any's nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `diesel::r2d2::TestCustomizer`, which allows users to customize their `diesel::r2d2::Pool`s
 in a way that makes the pools suitable for use in parallel tests.
 * Added `Json` and `Jsonb` support for the SQLite backend.
+* Fixed diesel thinking `a.eq_any(b)` was non-nullable even if `a` and `b` were nullable.
 
 ## [2.2.2] 2024-07-19
 

--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -1,9 +1,7 @@
 //! This module contains the query dsl node definitions
 //! for array comparison operations like `IN` and `NOT IN`
 
-use crate::backend::sql_dialect;
-use crate::backend::Backend;
-use crate::backend::SqlDialect;
+use crate::backend::{sql_dialect, Backend, SqlDialect};
 use crate::expression::subselect::Subselect;
 use crate::expression::{
     AppearsOnTable, AsExpression, Expression, SelectableExpression, TypedExpressionType,
@@ -15,8 +13,7 @@ use crate::query_builder::{
 };
 use crate::result::QueryResult;
 use crate::serialize::ToSql;
-use crate::sql_types::HasSqlType;
-use crate::sql_types::{Bool, SingleValue, SqlType};
+use crate::sql_types::{self, HasSqlType, SingleValue, SqlType};
 use std::marker::PhantomData;
 
 /// Query dsl node that represents a `left IN (values)`
@@ -75,16 +72,28 @@ impl<T, U> Expression for In<T, U>
 where
     T: Expression,
     U: Expression<SqlType = T::SqlType>,
+    T::SqlType: SqlType,
+    sql_types::is_nullable::IsSqlTypeNullable<T::SqlType>:
+        sql_types::MaybeNullableType<sql_types::Bool>,
 {
-    type SqlType = Bool;
+    type SqlType = sql_types::is_nullable::MaybeNullable<
+        sql_types::is_nullable::IsSqlTypeNullable<T::SqlType>,
+        sql_types::Bool,
+    >;
 }
 
 impl<T, U> Expression for NotIn<T, U>
 where
     T: Expression,
     U: Expression<SqlType = T::SqlType>,
+    T::SqlType: SqlType,
+    sql_types::is_nullable::IsSqlTypeNullable<T::SqlType>:
+        sql_types::MaybeNullableType<sql_types::Bool>,
 {
-    type SqlType = Bool;
+    type SqlType = sql_types::is_nullable::MaybeNullable<
+        sql_types::is_nullable::IsSqlTypeNullable<T::SqlType>,
+        sql_types::Bool,
+    >;
 }
 
 impl<T, U, DB> QueryFragment<DB> for In<T, U>

--- a/diesel_compile_tests/tests/fail/eq_any_is_nullable.rs
+++ b/diesel_compile_tests/tests/fail/eq_any_is_nullable.rs
@@ -1,0 +1,20 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users{
+       id -> Integer,
+       name -> Nullable<Text>,
+    }
+}
+
+fn main() {
+    let mut conn = PgConnection::establish("").unwrap();
+    // Should not be allowed because `users::name` is nullable, so the result of `eq_any` is
+    // nullable as well.
+    let _: Vec<bool> = users::table
+        .select(users::name.eq_any(["foo", "bar"]))
+        .load(&mut conn)
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/fail/eq_any_is_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/eq_any_is_nullable.stderr
@@ -1,0 +1,25 @@
+error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Nullable<Bool>` as `bool`
+  --> tests/fail/eq_any_is_nullable.rs:18:15
+   |
+18 |         .load(&mut conn)
+   |          ---- ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Nullable<Bool>, Pg>` is not implemented for `bool`, which is required by `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::grouped::Grouped<In<columns::name, Many<diesel::sql_types::Nullable<diesel::sql_types::Text>, &str>>>>>: LoadQuery<'_, _, _>`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = note: double check your type mappings via the documentation of `diesel::sql_types::Nullable<Bool>`
+   = help: the following other types implement trait `FromSql<A, DB>`:
+             `bool` implements `FromSql<Bool, Mysql>`
+             `bool` implements `FromSql<Bool, Pg>`
+             `bool` implements `FromSql<Bool, Sqlite>`
+   = note: required for `bool` to implement `Queryable<diesel::sql_types::Nullable<Bool>, Pg>`
+   = note: required for `bool` to implement `FromSqlRow<diesel::sql_types::Nullable<Bool>, Pg>`
+   = note: required for `diesel::sql_types::Nullable<Bool>` to implement `load_dsl::private::CompatibleType<bool, Pg>`
+   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::grouped::Grouped<In<columns::name, Many<diesel::sql_types::Nullable<diesel::sql_types::Text>, &str>>>>>` to implement `LoadQuery<'_, diesel::PgConnection, bool>`
+note: required by a bound in `diesel::RunQueryDsl::load`
+  --> $DIESEL/src/query_dsl/mod.rs
+   |
+   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+   |        ---- required by a bound in this associated function
+   |     where
+   |         Self: LoadQuery<'query, Conn, U>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`


### PR DESCRIPTION
PG returns null for IN expressions if LHS is null or if result depends on a NULL inner element of the array.
The return value of the IN & co expressions was incorrectly represented as non-nullable in this case.

While this is a breaking change, it should probably also be considered a bugfix, so we should be able to release it.