### PR TITLE
Prepare to release diesel 2.2.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,7 @@
 Thanks for your interest in contributing to Diesel! We very much look forward to
 your suggestions, bug reports, and pull requests.
 
-We run an active [Gitter
-channel](https://gitter.im/diesel-rs/diesel) where you can ask Diesel-related questions and
+We run an active [discussion forum](https://github.com/diesel-rs/diesel/discussions) where you can ask Diesel-related questions and
 get help. Feel free to ask there before opening a GitHub issue or
 pull request.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # A safe, extensible ORM and Query Builder for Rust
 
 [![Build Status](https://github.com/diesel-rs/diesel/workflows/CI%20Tests/badge.svg)](https://github.com/diesel-rs/diesel/actions?query=workflow%3A%22CI+Tests%22+branch%3Amaster)
-[![Gitter](https://badges.gitter.im/diesel-rs/diesel.svg)](https://gitter.im/diesel-rs/diesel?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Crates.io](https://img.shields.io/crates/v/diesel.svg)](https://crates.io/crates/diesel)
 
 API Documentation: [latest release](https://docs.rs/diesel) – [master branch](https://docs.diesel.rs/master/diesel/index.html)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,8 @@ Guides on more specific features are coming soon.
 ## Getting help
 
 If you run into problems, Diesel has a very active Gitter room.
-You can come ask for help at
-[gitter.im/diesel-rs/diesel](https://gitter.im/diesel-rs/diesel).
-For help with longer questions and discussion about the future of Diesel,
-open a discussion on [GitHub Discussions](https://github.com/diesel-rs/diesel/discussions).
+You can come ask for help at in our [GitHub Discussions](https://github.com/diesel-rs/diesel/discussions) forum. 
+This is also the right place to propose new features or show your applications.
 
 ## Usage
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel"
-version = "2.2.5"
+version = "2.2.6"
 license = "MIT OR Apache-2.0"
 description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"
 readme = "README.md"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_cli"
-version = "2.2.5"
+version = "2.2.6"
 license = "MIT OR Apache-2.0"
 description = "Provides the CLI for the Diesel crate"
 readme = "README.md"

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-dynamic-schema"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 autotests = false

--- a/diesel_dynamic_schema/README.md
+++ b/diesel_dynamic_schema/README.md
@@ -4,7 +4,6 @@ Query schemas not known at compile time with Diesel
 ===================================================
 
 [![Build Status](https://travis-ci.org/diesel-rs/diesel.svg)](https://travis-ci.org/diesel-rs/diesel-dynamic-schema)
-[![Gitter](https://badges.gitter.im/diesel-rs/diesel.svg)](https://gitter.im/diesel-rs/diesel?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 API Documentation: [latest release](https://docs.rs/diesel-dynamic-schema)
 

--- a/diesel_dynamic_schema/src/lib.rs
+++ b/diesel_dynamic_schema/src/lib.rs
@@ -71,9 +71,9 @@
 //!
 //! ## Getting help
 //!
-//! If you run into problems, Diesel has a very active Gitter room.
+//! If you run into problems, Diesel has a very active discussion forum.
 //! You can come ask for help at
-//! [gitter.im/diesel-rs/diesel](https://gitter.im/diesel-rs/diesel)
+//! [github.com/diesel-rs/diesel/discussions](https://github.com/diesel-rs/diesel/discussions)
 
 // Built-in Lints
 #![warn(missing_docs)]

--- a/guide_drafts/trait_derives.md
+++ b/guide_drafts/trait_derives.md
@@ -960,9 +960,9 @@ error[E0599]: no function or associated item named `belonging_to` found for type
 Please check out other [official guides] and [docs]
 for more information on using the Diesel framework.
 
-If you have any questions, join our [gitter channel],
+If you have any questions, join our [discussion forum],
 the Diesel team is happy to help.
 
 [official guides]: https://diesel.rs/guides/
 [docs]: https://docs.diesel.rs
-[gitter channel]: https://gitter.im/diesel-rs/diesel
+[discussion forum]: https://github.com/diesel-rs/diesel/discussions


### PR DESCRIPTION
This PR removes more mentions of gitter from several Readmes. I would like to publish

* Diesel 2.2.6 to update the readme on crates.io
* Diesel-dynamic-schema 0.2.3 to update the readme + documentation
* Diesel-cli 2.2.6 to upload new diesel-cli binaries to the latest release