### PR TITLE
Add a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,5 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "diesel/reviewer"
+      - "diesel/reviewers"
     versioning-strategy: "widen"


### PR DESCRIPTION
This commit introduces a dependabot config to automate dependency updates. Hopefully the `version_strategy: widen` setting works, because that's want we want here