### PR TITLE
Add create_if_missing variant for jsonb_set

### DIFF
--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -597,3 +597,9 @@ pub type jsonb_populate_record<B, J> =
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type jsonb_set<B, J, R> = super::functions::jsonb_set<SqlTypeOf<B>, SqlTypeOf<J>, B, J, R>;
+
+/// Return type of [`jsonb_set_create_if_missing(base, path, new_value, create_if_missing)`](super::functions::jsonb_set_create_if_missing())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type jsonb_set_create_if_missing<B, J, R, C> =
+    super::functions::jsonb_set_create_if_missing<SqlTypeOf<B>, SqlTypeOf<J>, B, J, R, C>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -54,6 +54,7 @@ table! {
         name -> Text,
         text_array -> Array<Text>,
         record -> Record<(Integer, Text, Date)>,
+        boolean -> Bool,
     }
 }
 
@@ -462,6 +463,12 @@ fn postgres_functions() -> _ {
         json_populate_record(pg_extras::record, pg_extras::json),
         jsonb_populate_record(pg_extras::record, pg_extras::jsonb),
         jsonb_set(pg_extras::jsonb, pg_extras::text_array, pg_extras::jsonb),
+        jsonb_set_create_if_missing(
+            pg_extras::jsonb,
+            pg_extras::text_array,
+            pg_extras::jsonb,
+            pg_extras::boolean,
+        ),
     )
 }
 


### PR DESCRIPTION
Adds `create_if_missing` support to Postgres `jsonb_set`.
https://github.com/diesel-rs/diesel/issues/4216 