### PR TITLE
Fix typo in code example

### DIFF
--- a/examples/postgres/getting_started_step_1/src/lib.rs
+++ b/examples/postgres/getting_started_step_1/src/lib.rs
@@ -2,7 +2,7 @@ pub mod models;
 pub mod schema;
 
 use diesel::prelude::*;
-use dotenvy::dotenv;
+use dotenv::dotenv;
 use std::env;
 
 pub fn establish_connection() -> PgConnection {


### PR DESCRIPTION
`dotenvy` should be `dotenv`