### PR TITLE
Add sqlite functions `json` and `jsonb`

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -25,6 +25,7 @@ byteorder = { version = "1.0", optional = true }
 chrono = { version = "0.4.20", optional = true, default-features = false, features = ["clock", "std"] }
 libc = { version = "0.2.0", optional = true }
 libsqlite3-sys = { version = ">=0.17.2, <0.31.0", optional = true, features = ["bundled_bindings"] }
+rusqlite = { version = "0.32.0", features = ["bundled"] }
 mysqlclient-sys = { version = ">=0.2.5, <0.5.0",  optional = true }
 mysqlclient-src = { version = "0.1.0", optional = true }
 pq-sys = { version = ">=0.4.0, <0.7.0", optional = true }

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -74,6 +74,9 @@ pub(crate) mod dsl {
     #[cfg(feature = "postgres_backend")]
     pub use crate::pg::expression::dsl::*;
 
+    #[cfg(feature = "sqlite")]
+    pub use crate::sqlite::expression::dsl::*;
+
     /// The return type of [`count(expr)`](crate::dsl::count())
     pub type count<Expr> = super::count::count<SqlTypeOf<Expr>, Expr>;
 

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1,0 +1,114 @@
+//! SQLite specific functions
+use crate::expression::functions::define_sql_function;
+use crate::sql_types::*;
+use crate::sqlite::expression::expression_methods::JsonOrNullableJsonOrJsonbOrNullableJsonb;
+use crate::sqlite::expression::expression_methods::MaybeNullableValue;
+
+#[cfg(feature = "sqlite")]
+define_sql_function! {
+    /// Verifies that its argument is a valid JSON string or JSONB blob and returns a minified
+    /// version of that JSON string with all unnecessary whitespace removed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::json;
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
+    /// #     let connection = &mut establish_connection();
+    /// 
+    /// let result = diesel::select(json::<Json, _>(json!({"a": "b", "c": 1})))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"{"a":"b","c":1}"#, result);
+    ///
+    /// let result = diesel::select(json::<Json, _>(json!({ "this" : "is", "a": [ "test" ] })))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"{"a":["test"],"this":"is"}"#, result);
+    ///
+    /// let result = diesel::select(json::<Nullable<Json>, _>(None::<Value>))
+    ///     .get_result::<Option<String>>(connection)?;
+    ///
+    /// assert!(result.is_none());
+    ///
+    /// let result = diesel::select(json::<Jsonb, _>(json!({"a": "b", "c": 1})))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"{"a":"b","c":1}"#, result);
+    ///
+    /// let result = diesel::select(json::<Jsonb, _>(json!({ "this" : "is", "a": [ "test" ] })))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"{"a":["test"],"this":"is"}"#, result);
+    ///
+    /// let result = diesel::select(json::<Nullable<Jsonb>, _>(None::<Value>))
+    ///     .get_result::<Option<String>>(connection)?;
+    ///
+    /// assert!(result.is_none());
+    ///
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn json<E: JsonOrNullableJsonOrJsonbOrNullableJsonb + SingleValue + MaybeNullableValue<Text>>(e: E) -> E::Out;
+}
+
+#[cfg(feature = "sqlite")]
+define_sql_function! {
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::jsonb;
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let result = diesel::select(jsonb::<Json, _>(json!({"a": "b", "c": 1})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a": "b", "c": 1}), result);
+    /// println!("json abc1");
+    ///
+    /// let result = diesel::select(jsonb::<Jsonb, _>(json!({"a": "b", "c": 1})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a": "b", "c": 1}), result);
+    /// println!("jsonb abc1");
+    ///
+    /// let result = diesel::select(jsonb::<Nullable<Json>, _>(None::<Value>))
+    ///     .get_result::<Option<Value>>(connection)?;
+    ///
+    /// assert!(result.is_none());
+    /// println!("json null");
+    /// 
+    /// let result = diesel::select(jsonb::<Nullable<Jsonb>, _>(None::<Value>))
+    ///     .get_result::<Option<Value>>(connection)?;
+    ///
+    /// assert!(result.is_none());
+    /// println!("jsonb null");
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn jsonb<E: JsonOrNullableJsonOrJsonbOrNullableJsonb + SingleValue + MaybeNullableValue<Jsonb>>(e: E) -> E::Out;
+}

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -1,4 +1,4 @@
-use crate::dsl::AsExpr;
+use crate::dsl::{AsExpr, SqlTypeOf};
 use crate::expression::grouped::Grouped;
 
 /// The return type of `lhs.is(rhs)`.
@@ -6,3 +6,13 @@ pub type Is<Lhs, Rhs> = Grouped<super::operators::Is<Lhs, AsExpr<Rhs, Lhs>>>;
 
 /// The return type of `lhs.is_not(rhs)`.
 pub type IsNot<Lhs, Rhs> = Grouped<super::operators::IsNot<Lhs, AsExpr<Rhs, Lhs>>>;
+
+/// Return type of [`json(json)`](super::functions::json())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json<E> = super::functions::json<SqlTypeOf<E>, E>;
+
+/// Return type of [`jsonb(json)`](super::functions::jsonb())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type jsonb<E> = super::functions::jsonb<SqlTypeOf<E>, E>;

--- a/diesel/src/sqlite/expression/mod.rs
+++ b/diesel/src/sqlite/expression/mod.rs
@@ -5,5 +5,16 @@
 //! kept separate purely for documentation purposes.
 
 pub(crate) mod expression_methods;
+pub mod functions;
 pub(crate) mod helper_types;
 mod operators;
+
+/// SQLite specific expression DSL methods.
+/// 
+/// This module will be glob imported by
+/// [`diesel::dsl`](crate::dsl) when compiled with the `feature =
+/// "postgres"` flag.
+pub mod dsl {
+    #[doc(inline)]
+    pub use super::functions::*;
+}

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -6,7 +6,7 @@
 
 pub(crate) mod backend;
 mod connection;
-pub(crate) mod expression;
+pub mod expression;
 
 pub mod query_builder;
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -57,6 +57,16 @@ table! {
     }
 }
 
+#[cfg(feature = "sqlite")]
+table! {
+    sqlite_extras {
+        id -> Integer,
+        text -> Text,
+        json -> Json,
+        jsonb -> Jsonb,
+    }
+}
+
 joinable!(posts -> users(user_id));
 joinable!(posts2 -> users(user_id));
 joinable!(posts3 -> users(user_id));
@@ -462,6 +472,18 @@ fn postgres_functions() -> _ {
         json_populate_record(pg_extras::record, pg_extras::json),
         jsonb_populate_record(pg_extras::record, pg_extras::jsonb),
         jsonb_set(pg_extras::jsonb, pg_extras::text_array, pg_extras::jsonb),
+    )
+}
+
+#[cfg(feature = "sqlite")]
+#[auto_type]
+fn sqlite_functions() -> _ {
+    use diesel::sqlite::expression::functions::{json, jsonb};
+    (
+        json(sqlite_extras::json),
+        json(sqlite_extras::jsonb),
+        jsonb(sqlite_extras::json),
+        jsonb(sqlite_extras::jsonb),
     )
 }
 


### PR DESCRIPTION
Add SQLite functions `json` and `jsonb` according to issue #4366 .

Following the implementation of PostgreSQL binding, mod declaration statements were added and modified in files such as diesel/src/sqlite/mod.rs and diesel/src/sqlite/expression/mod.rs to facilitate subsequent contributors' coding and testing.

NOTE: testing on sqlite 3.47.2 and dependency libsqlite-sys 0.30.1 failed with no such function: jsonb. Given that sqlite 3.47.2 already had jsonb available, the problem is within the SQLite binding crate. It seems that libsqlite-sys crate does not support jsonb currently, but corresponding ergonomic wrapper rusqlite does and fits well. The `rusqlite` dependency might be removed in the future if libsqlite-sys adds support for JSONB related functions. For now, I add it to make everything work well.

See this for more info: https://github.com/rusqlite/rusqlite/issues/1453