### PR TITLE
[Test] Disable Nagle's algorithm

### DIFF
--- a/diesel_bench/benches/wtx.rs
+++ b/diesel_bench/benches/wtx.rs
@@ -259,11 +259,13 @@ async fn connection() -> Executor<wtx::Error, ExecutorBuffer, TcpStream> {
         .expect("DATABASE_URL must be set in order to run tests");
     let uri = UriRef::new(url.as_str());
     let mut rng = Xorshift64::from(simple_seed());
+    let stream = TcpStream::connect(uri.host()).await.unwrap();
+    stream.set_nodelay(true);
     let mut conn = Executor::connect(
         &Config::from_uri(&uri).unwrap(),
         ExecutorBuffer::with_capacity((512, 8192, 512, 32), 32, &mut rng).unwrap(),
         &mut rng,
-        TcpStream::connect(uri.host()).await.unwrap(),
+        stream,
     )
     .await
     .unwrap();


### PR DESCRIPTION
Much to my surprise, almost all database clients apply `stream.set_nodelay(true)` by default.

`mysql`: https://github.com/blackbeam/rust-mysql-simple/blob/bdc32fae7f2869c29ca52284dff7bf19beeaca56/src/io/tcp.rs#L102
`sqlx`: https://github.com/launchbadge/sqlx/blob/1678b19a4672fd6a18b4891c53bf0b57638b92a4/sqlx-core/src/net/socket/mod.rs#L201
`tokio-postgres`: https://github.com/sfackler/rust-postgres/blob/6ae17e0f2d174fc4d5592ac7869909d7bdd346d9/tokio-postgres/src/connect_socket.rs#L27

If possible, I would like to see the impact of this parameter in the `wtx` project.
