### PR TITLE
Refactor the statement cache abstraction

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -753,7 +753,7 @@ fn known_buffer_size_for_ffi_type(tpe: ffi::enum_field_types) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::connection::statement_cache::MaybeCached;
+    use crate::connection::statement_cache::{MaybeCached, PrepareForCache};
     use crate::deserialize::FromSql;
     use crate::mysql::connection::stmt::Statement;
     use crate::prelude::*;
@@ -1247,7 +1247,10 @@ mod tests {
         conn: &MysqlConnection,
         bind_tpe: impl Into<(ffi::enum_field_types, Flags)>,
     ) -> BindData {
-        let stmt: Statement = conn.raw_connection.prepare(query).unwrap();
+        let stmt: Statement = conn
+            .raw_connection
+            .prepare(query, PrepareForCache::No, &[])
+            .unwrap();
         let stmt = MaybeCached::CannotCache(stmt);
 
         let bind = BindData::from_tpe_and_flags(bind_tpe.into());
@@ -1266,7 +1269,10 @@ mod tests {
         id: i32,
         (mut field, tpe): (Vec<u8>, impl Into<(ffi::enum_field_types, Flags)>),
     ) {
-        let mut stmt = conn.raw_connection.prepare(query).unwrap();
+        let mut stmt = conn
+            .raw_connection
+            .prepare(query, PrepareForCache::No, &[])
+            .unwrap();
         let length = field.len() as _;
         let (tpe, flags) = tpe.into();
         let capacity = field.capacity();

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -299,7 +299,8 @@ fn prepared_query<'a, T: QueryFragment<Mysql> + QueryId>(
         source,
         &Mysql,
         &[],
-        |sql, _| raw_connection.prepare(sql),
+        &*raw_connection,
+        RawConnection::prepare,
         instrumentation,
     )?;
 

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -5,8 +5,10 @@ use std::os::raw as libc;
 use std::ptr::{self, NonNull};
 use std::sync::Once;
 
+use super::statement_cache::PrepareForCache;
 use super::stmt::Statement;
 use super::url::ConnectionOptions;
+use crate::mysql::MysqlType;
 use crate::result::{ConnectionError, ConnectionResult, QueryResult};
 
 pub(super) struct RawConnection(NonNull<ffi::MYSQL>);
@@ -141,7 +143,12 @@ impl RawConnection {
         result
     }
 
-    pub(super) fn prepare(&self, query: &str) -> QueryResult<Statement> {
+    pub(super) fn prepare(
+        &self,
+        query: &str,
+        _: PrepareForCache,
+        _: &[MysqlType],
+    ) -> QueryResult<Statement> {
         let stmt = unsafe { ffi::mysql_stmt_init(self.0.as_ptr()) };
         // It is documented that the only reason `mysql_stmt_init` will fail
         // is because of OOM.

--- a/diesel/src/mysql/connection/stmt/mod.rs
+++ b/diesel/src/mysql/connection/stmt/mod.rs
@@ -21,6 +21,10 @@ pub struct Statement {
     input_binds: Option<PreparedStatementBinds>,
 }
 
+// mysql connection can be shared between threads according to libmysqlclients documentation
+#[allow(unsafe_code)]
+unsafe impl Send for Statement {}
+
 impl Statement {
     pub(crate) fn new(stmt: NonNull<ffi::MYSQL_STMT>) -> Self {
         Statement {

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -5,8 +5,6 @@ mod result;
 mod row;
 mod stmt;
 
-use statement_cache::PrepareForCache;
-
 use self::copy::{CopyFromSink, CopyToBuffer};
 use self::cursor::*;
 use self::private::ConnectionAndTransactionManager;
@@ -512,13 +510,8 @@ impl PgConnection {
             &source,
             &Pg,
             &metadata,
-            |sql, is_cached| {
-                let query_name = match is_cached {
-                    PrepareForCache::Yes { counter } => Some(format!("__diesel_stmt_{counter}")),
-                    PrepareForCache::No => None,
-                };
-                Statement::prepare(conn, sql, query_name.as_deref(), &metadata)
-            },
+            conn,
+            Statement::prepare,
             &mut *self.connection_and_transaction_manager.instrumentation,
         );
         if !execute_returning_count {

--- a/diesel/src/query_builder/order_clause.rs
+++ b/diesel/src/query_builder/order_clause.rs
@@ -1,4 +1,10 @@
-simple_clause!(NoOrderClause, OrderClause, " ORDER BY ");
+simple_clause!(
+    /// DSL node that represents that no order clause is set
+    NoOrderClause,
+    /// DSL node that represents that an order clause is set
+    OrderClause,
+    " ORDER BY "
+);
 
 impl<'a, DB, Expr> From<OrderClause<Expr>> for Option<Box<dyn QueryFragment<DB> + Send + 'a>>
 where

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -373,7 +373,8 @@ impl SqliteConnection {
             &source,
             &Sqlite,
             &[],
-            |sql, is_cached| Statement::prepare(raw_connection, sql, is_cached),
+            raw_connection,
+            Statement::prepare,
             &mut *self.instrumentation,
         ) {
             Ok(statement) => statement,

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -22,11 +22,18 @@ pub(super) struct Statement {
     inner_statement: NonNull<ffi::sqlite3_stmt>,
 }
 
+// This relies on the invariant that RawConnection or Statement are never
+// leaked. If a reference to one of those was held on a different thread, this
+// would not be thread safe.
+#[allow(unsafe_code)]
+unsafe impl Send for Statement {}
+
 impl Statement {
     pub(super) fn prepare(
         raw_connection: &RawConnection,
         sql: &str,
         is_cached: PrepareForCache,
+        _: &[SqliteType],
     ) -> QueryResult<Self> {
         let mut stmt = ptr::null_mut();
         let mut unused_portion = ptr::null();

--- a/diesel_tests/tests/distinct.rs
+++ b/diesel_tests/tests/distinct.rs
@@ -212,15 +212,18 @@ fn distinct_of_multiple_columns() {
         .inner_join(users::table)
         .order(users::id)
         .distinct_on((users::id, posts::body))
-        .load(&mut connection);
-    let expected = vec![
-        (posts[0].clone(), sean.clone()),
-        (posts[1].clone(), sean.clone()),
-        (posts[4].clone(), tess.clone()),
-        (posts[7].clone(), tess.clone()),
-    ];
+        .load::<(Post, User)>(&mut connection)
+        .unwrap();
 
-    assert_eq!(Ok(expected), data);
+    assert_eq!(data.len(), 4);
+    assert_eq!(data[0].1, sean);
+    assert_eq!(data[1].1, sean);
+    assert_eq!(data[2].1, tess);
+    assert_eq!(data[3].1, tess);
+    assert_eq!(data[0].0.body, Some("1".into()));
+    assert_eq!(data[1].0.body, Some("2".into()));
+    assert_eq!(data[2].0.body, Some("1".into()));
+    assert_eq!(data[3].0.body, Some("2".into()));
 
     // multi order by
     // multi distinct on
@@ -283,41 +286,46 @@ fn distinct_of_multiple_columns() {
         .left_join(users::table)
         .order((users::id.nullable(), posts::body.nullable().desc()))
         .distinct_on((users::id.nullable(), posts::body.nullable()))
-        .load(&mut connection);
+        .load::<(Post, Option<User>)>(&mut connection)
+        .unwrap();
 
-    let expected = vec![
-        (posts[1].clone(), Some(sean.clone())),
-        (posts[0].clone(), Some(sean.clone())),
-        (posts[7].clone(), Some(tess.clone())),
-        (posts[6].clone(), Some(tess.clone())),
-    ];
-
-    assert_eq!(Ok(expected), data);
+    assert_eq!(data.len(), 4);
+    assert_eq!(data[0].1, Some(sean.clone()));
+    assert_eq!(data[1].1, Some(sean.clone()));
+    assert_eq!(data[2].1, Some(tess.clone()));
+    assert_eq!(data[3].1, Some(tess.clone()));
+    assert_eq!(data[0].0.body, Some("2".into()));
+    assert_eq!(data[1].0.body, Some("1".into()));
+    assert_eq!(data[2].0.body, Some("2".into()));
+    assert_eq!(data[3].0.body, Some("1".into()));
 
     let data = posts::table
         .left_join(users::table)
         .order((users::id.nullable(), posts::body.nullable().desc()))
         .distinct_on(users::id.nullable())
-        .load(&mut connection);
+        .load::<(Post, Option<User>)>(&mut connection)
+        .unwrap();
 
-    let expected = vec![
-        (posts[1].clone(), Some(sean.clone())),
-        (posts[7].clone(), Some(tess.clone())),
-    ];
-
-    assert_eq!(Ok(expected), data);
+    assert_eq!(data.len(), 2);
+    assert_eq!(data[0].1, Some(sean.clone()));
+    assert_eq!(data[1].1, Some(tess.clone()));
+    assert_eq!(data[0].0.body, Some("2".into()));
+    assert_eq!(data[1].0.body, Some("2".into()));
 
     let data = posts::table
         .left_join(users::table)
         .order(users::id.nullable())
         .distinct_on((users::id.nullable(), posts::body.nullable()))
-        .load(&mut connection);
+        .load::<(Post, Option<User>)>(&mut connection)
+        .unwrap();
 
-    let expected = vec![
-        (posts[0].clone(), Some(sean.clone())),
-        (posts[1].clone(), Some(sean)),
-        (posts[4].clone(), Some(tess.clone())),
-        (posts[7].clone(), Some(tess)),
-    ];
-    assert_eq!(Ok(expected), data);
+    assert_eq!(data.len(), 4);
+    assert_eq!(data[0].1, Some(sean.clone()));
+    assert_eq!(data[1].1, Some(sean.clone()));
+    assert_eq!(data[2].1, Some(tess.clone()));
+    assert_eq!(data[3].1, Some(tess.clone()));
+    assert_eq!(data[0].0.body, Some("1".into()));
+    assert_eq!(data[1].0.body, Some("2".into()));
+    assert_eq!(data[2].0.body, Some("1".into()));
+    assert_eq!(data[3].0.body, Some("2".into()));
 }


### PR DESCRIPTION
This commit refactors the statement cache abstraction so that it is now
possible to have a common statement cache implementation for diesel and
diesel-async. For this we need to abstract the
`StatementCache::cached_statement` method in such a way that it accepts
prepare functions that either return a `QueryResult<Statement>` or a
`impl Future<Output = QueryResult<Statement>>` depending on if the cache
is used in the sync or async implementation. 

For this we introduce a helper trait that allows us to apply certain
simple operations to both types. Diesel itself ships with an
implementation of that trait for `QueryResult<Statement>` while
diesel-async provides an implementation for the future variant.

As part of this change I also changed the caching strategy
implementations to not handle caching on their own as that would
require having the generic return type in the strategy trait as well 
which in turn would require having it on the statement cache as well,
which is not desirably. The strategy trait now only handles looking up
the cache key and returns something that indicates if the strategy
allows to cache the key (by exposing the hashmap `Entry` type) or not.


See the corresponding diesel-async PR for the actual usage there: https://github.com/weiznich/diesel_async/pull/206