### PR TITLE
Add SQLite function `json_pretty`

### DIFF
--- a/diesel/src/sqlite/expression/expression_methods.rs
+++ b/diesel/src/sqlite/expression/expression_methods.rs
@@ -2,6 +2,7 @@
 
 pub(in crate::sqlite) use self::private::{
     BinaryOrNullableBinary, MaybeNullableValue, TextOrNullableText,
+    TextOrNullableTextOrBinaryOrNullableBinary,
 };
 use super::operators::*;
 use crate::dsl;
@@ -106,6 +107,16 @@ pub(in crate::sqlite) mod private {
 
     impl BinaryOrNullableBinary for Binary {}
     impl BinaryOrNullableBinary for Nullable<Binary> {}
+
+    #[diagnostic::on_unimplemented(
+        message = "`{Self}` is not `diesel::sql_types::Text`, `diesel::sql_types::Nullable<Text>`, `diesel::sql_types::Binary` or `diesel::sql_types::Nullable<Binary>`",
+        note = "try to provide an expression that produces one of the expected sql types"
+    )]
+    pub trait TextOrNullableTextOrBinaryOrNullableBinary {}
+    impl TextOrNullableTextOrBinaryOrNullableBinary for Text {}
+    impl TextOrNullableTextOrBinaryOrNullableBinary for Nullable<Text> {}
+    impl TextOrNullableTextOrBinaryOrNullableBinary for Binary {}
+    impl TextOrNullableTextOrBinaryOrNullableBinary for Nullable<Binary> {}
 
     pub trait MaybeNullableValue<T>: SingleValue {
         type Out: SingleValue;

--- a/diesel/src/sqlite/expression/expression_methods.rs
+++ b/diesel/src/sqlite/expression/expression_methods.rs
@@ -1,8 +1,8 @@
 //! Sqlite specific expression methods.
 
 pub(in crate::sqlite) use self::private::{
-    BinaryOrNullableBinary, MaybeNullableValue, TextOrNullableText,
-    TextOrNullableTextOrBinaryOrNullableBinary,
+    BinaryOrNullableBinary, JsonOrNullableJsonOrJsonbOrNullableJsonb, MaybeNullableValue,
+    TextOrNullableText,
 };
 use super::operators::*;
 use crate::dsl;
@@ -88,7 +88,7 @@ pub trait SqliteExpressionMethods: Expression + Sized {
 impl<T: Expression> SqliteExpressionMethods for T {}
 
 pub(in crate::sqlite) mod private {
-    use crate::sql_types::{Binary, MaybeNullableType, Nullable, SingleValue, Text};
+    use crate::sql_types::{Binary, Json, Jsonb, MaybeNullableType, Nullable, SingleValue, Text};
 
     #[diagnostic::on_unimplemented(
         message = "`{Self}` is neither `diesel::sql_types::Text` nor `diesel::sql_types::Nullable<Text>`",
@@ -109,14 +109,14 @@ pub(in crate::sqlite) mod private {
     impl BinaryOrNullableBinary for Nullable<Binary> {}
 
     #[diagnostic::on_unimplemented(
-        message = "`{Self}` is not `diesel::sql_types::Text`, `diesel::sql_types::Nullable<Text>`, `diesel::sql_types::Binary` or `diesel::sql_types::Nullable<Binary>`",
+        message = "`{Self}` is neither `diesel::sql_types::Json`, `diesel::sql_types::Jsonb`, `diesel::sql_types::Nullable<Json>` nor `diesel::sql_types::Nullable<Jsonb>`",
         note = "try to provide an expression that produces one of the expected sql types"
     )]
-    pub trait TextOrNullableTextOrBinaryOrNullableBinary {}
-    impl TextOrNullableTextOrBinaryOrNullableBinary for Text {}
-    impl TextOrNullableTextOrBinaryOrNullableBinary for Nullable<Text> {}
-    impl TextOrNullableTextOrBinaryOrNullableBinary for Binary {}
-    impl TextOrNullableTextOrBinaryOrNullableBinary for Nullable<Binary> {}
+    pub trait JsonOrNullableJsonOrJsonbOrNullableJsonb {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Json {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Nullable<Json> {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Jsonb {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Nullable<Jsonb> {}
 
     pub trait MaybeNullableValue<T>: SingleValue {
         type Out: SingleValue;

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -4,6 +4,7 @@ use crate::sql_types::*;
 use crate::sqlite::expression::expression_methods::BinaryOrNullableBinary;
 use crate::sqlite::expression::expression_methods::MaybeNullableValue;
 use crate::sqlite::expression::expression_methods::TextOrNullableText;
+use crate::sqlite::expression::expression_methods::TextOrNullableTextOrBinaryOrNullableBinary;
 
 #[cfg(feature = "sqlite")]
 define_sql_function! {
@@ -104,4 +105,95 @@ define_sql_function! {
     /// # }
     /// ```
     fn jsonb<E: BinaryOrNullableBinary + MaybeNullableValue<Jsonb>>(e: E) -> E::Out;
+}
+
+#[cfg(feature = "sqlite")]
+define_sql_function! {
+    /// Converts the given json value to pretty-printed, indented text
+    ///
+    /// /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::json_pretty;
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Text, Binary, Nullable};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let result = diesel::select(json_pretty::<Text, _>(r#"[{"f1":1,"f2":null},2,null,3]"#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"[
+    ///     {
+    ///         "f1": 1,
+    ///         "f2": null
+    ///     },
+    ///     2,
+    ///     null,
+    ///     3
+    /// ]"#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Binary, _>(br#"[{"f1":1,"f2":null},2,null,3]"#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"[
+    ///     {
+    ///         "f1": 1,
+    ///         "f2": null
+    ///     },
+    ///     2,
+    ///     null,
+    ///     3
+    /// ]"#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Text, _>(r#"{"a": 1, "b": "cd"}"#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"{
+    ///     "a": 1,
+    ///     "b": "cd"
+    /// }"#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Text, _>(r#""abc""#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#""abc""#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Text, _>(r#"22"#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"22"#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Text, _>(r#"false"#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"false"#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Text, _>(r#"null"#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"null"#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Text, _>(r#"{}"#))
+    ///     .get_result::<String>(connection)?;
+    ///
+    /// assert_eq!(r#"{}"#, result);
+    ///
+    /// let result = diesel::select(json_pretty::<Nullable<Text>, _>(None::<&str>))
+    ///     .get_result::<Option<String>>(connection)?;
+    ///
+    /// assert!(result.is_none());
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn json_pretty<E: TextOrNullableTextOrBinaryOrNullableBinary + MaybeNullableValue<Text>>(e: E) -> E::Out;
 }

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -123,7 +123,7 @@ define_sql_function! {
     /// #
     /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use diesel::dsl::json_pretty;
+    /// #     use diesel::dsl::{sql, json_pretty};
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Binary, Nullable};
     /// #     let connection = &mut establish_connection();

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -128,6 +128,9 @@ define_sql_function! {
     /// #     use diesel::sql_types::{Text, Binary, Nullable};
     /// #     let connection = &mut establish_connection();
     ///
+    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
+    ///         .get_result::<String>(connection)?;
+    ///
     /// // Querying SQLite version should not fail.
     /// let version_components: Vec<&str> = version.split('.').collect();
     /// let major: u32 = version_components[0].parse().unwrap();

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -128,6 +128,19 @@ define_sql_function! {
     /// #     use diesel::sql_types::{Text, Binary, Nullable};
     /// #     let connection = &mut establish_connection();
     ///
+    /// // Querying SQLite version should not fail.
+    /// let version_components: Vec<&str> = version.split('.').collect();
+    /// let major: u32 = version_components[0].parse().unwrap();
+    /// let minor: u32 = version_components[1].parse().unwrap();
+    /// let patch: u32 = version_components[2].parse().unwrap();
+    ///
+    /// if major > 3 || (major == 3 && minor >= 46) {
+    ///     /* Valid sqlite version, do nothing */
+    /// } else {
+    ///     println!("SQLite version is too old, skipping the test.");
+    ///     return Ok(());
+    /// }
+    ///
     /// let result = diesel::select(json_pretty::<Text, _>(r#"[{"f1":1,"f2":null},2,null,3]"#))
     ///     .get_result::<String>(connection)?;
     ///

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -16,3 +16,8 @@ pub type json<E> = super::functions::json<SqlTypeOf<E>, E>;
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]
 pub type jsonb<E> = super::functions::jsonb<SqlTypeOf<E>, E>;
+
+/// Return type of [`json_pretty(json)`](super::functions::json_pretty())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_pretty<E> = super::functions::json_pretty<SqlTypeOf<E>, E>;

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -21,3 +21,9 @@ pub type jsonb<E> = super::functions::jsonb<SqlTypeOf<E>, E>;
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]
 pub type json_pretty<E> = super::functions::json_pretty<SqlTypeOf<E>, E>;
+
+/// Return type of [`json_pretty(json, indent)`](super::functions::json_pretty_with_indentation())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_pretty_with_indentation<J, I> =
+    super::functions::json_pretty_with_indentation<SqlTypeOf<J>, J, I>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -486,7 +486,12 @@ fn postgres_functions() -> _ {
 #[cfg(feature = "sqlite")]
 #[auto_type]
 fn sqlite_functions() -> _ {
-    (json(sqlite_extras::text), jsonb(sqlite_extras::blob))
+    (
+        json(sqlite_extras::text),
+        jsonb(sqlite_extras::blob),
+        json_pretty(sqlite_extras::text),
+        json_pretty(sqlite_extras::blob),
+    )
 }
 
 #[auto_type]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -489,8 +489,10 @@ fn sqlite_functions() -> _ {
     (
         json(sqlite_extras::text),
         jsonb(sqlite_extras::blob),
-        json_pretty(sqlite_extras::text),
-        json_pretty(sqlite_extras::blob),
+        json_pretty(sqlite_extras::json),
+        json_pretty(sqlite_extras::jsonb),
+        json_pretty_with_indentation(sqlite_extras::json, "  "),
+        json_pretty_with_indentation(sqlite_extras::jsonb, "  "),
     )
 }
 


### PR DESCRIPTION
`TextOrNullableTextOrBinaryOrNullableBinary`. SQLite doc says "the first argument is the JSON or JSONB that is to be pretty-printed" so I added such a trait. I don't know whether it's proper.