### PR TITLE
Add support for postgre jsonb_set_lax

### DIFF
--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -13,7 +13,6 @@ use crate::pg::expression::expression_methods::MultirangeOrRangeMaybeNullable;
 use crate::pg::expression::expression_methods::RangeOrNullableRange;
 use crate::pg::expression::expression_methods::RecordOrNullableRecord;
 use crate::pg::expression::expression_methods::TextArrayOrNullableTextArray;
-use crate::pg::expression::expression_methods::TextOrNullableText;
 use crate::sql_types::*;
 
 define_sql_function! {
@@ -2611,12 +2610,12 @@ define_sql_function! {
     /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::jsonb_set_lax;
-    /// #     use diesel::sql_types::{Jsonb,Array, Json, Nullable, Text};
+    /// #     use diesel::sql_types::{Jsonb,Array,NullValueTreatment, Json, Nullable, Text};
     /// #     use serde_json::{json,Value};
     /// #     let connection = &mut establish_connection();
     ///
-    /// let null_value_treatment : String = "use_json_null".into();
-    /// let result = diesel::select(jsonb_set_lax::<Jsonb, Array<Text>, Text, _, _, _, _, _>(
+    /// let null_value_treatment = NullValueTreatment::UseJsonNull;
+    /// let result = diesel::select(jsonb_set_lax::<Jsonb, Array<Text>, _, _, _, _, _>(
     ///         json!([{"f1":1,"f2":null},2,null,3]),
     ///         vec!["0","f1"],
     ///         json!([2,3,4]),
@@ -2626,8 +2625,8 @@ define_sql_function! {
     /// let expected: Value = json!([{"f1": [2, 3, 4], "f2": null}, 2, null, 3]);
     /// assert_eq!(result, expected);
     ///
-    /// let null_value_treatment : String = "return_target".into();
-    /// let result = diesel::select(jsonb_set_lax::<Nullable<Jsonb>, Array<Nullable<Text>>, Text, _, _, _, _, _>(
+    /// let null_value_treatment = NullValueTreatment::ReturnTarget;
+    /// let result = diesel::select(jsonb_set_lax::<Nullable<Jsonb>, Array<Nullable<Text>>, _, _, _, _, _>(
     ///         json!([{"f1":99,"f2":null},2]),
     ///         vec!["0","f3"],
     ///         None::<Value>,
@@ -2636,9 +2635,9 @@ define_sql_function! {
     ///     )).get_result::<Option<Value>>(connection)?;
     /// assert_eq!(result, Some(json!([{"f1":99,"f2":null},2])));
     ///
-    /// let null_value_treatment : String = "use_json_null".into();
+    /// let null_value_treatment = NullValueTreatment::UseJsonNull;
     /// let empty:Vec<String> = Vec::new();
-    /// let result = diesel::select(jsonb_set_lax::<Jsonb, Array<Nullable<Text>>, Text, _, _, _, _, _>(
+    /// let result = diesel::select(jsonb_set_lax::<Jsonb, Array<Nullable<Text>>, _, _, _, _, _>(
     ///         // cannot be json!(null)
     ///         json!([]),
     ///         empty,
@@ -2649,22 +2648,13 @@ define_sql_function! {
     /// let expected = json!([]);
     /// assert_eq!(result, expected);
     ///
-    /// let null_value_treatment : String = "use_json_null".into();
-    /// let result = diesel::select(jsonb_set_lax::<Jsonb, Nullable<Array<Nullable<Text>>>, Text, _, _, _, _, _,>(
+    /// let null_value_treatment = NullValueTreatment::UseJsonNull;
+    /// let result = diesel::select(jsonb_set_lax::<Jsonb, Nullable<Array<Nullable<Text>>>, _, _, _, _, _,>(
     ///         json!(null),
     ///         None::<Vec<String>>,
     ///         json!({"foo": 42}),
     ///         true,
     ///         null_value_treatment
-    ///     )).get_result::<Option<Value>>(connection)?;
-    /// assert!(result.is_none());
-    ///
-    /// let result = diesel::select(jsonb_set_lax::<Jsonb, Nullable<Array<Nullable<Text>>>, Nullable<Text>, _, _, _, _, _,>(
-    ///         json!(null),
-    ///         None::<Vec<String>>,
-    ///         json!({"foo": 42}),
-    ///         true,
-    ///         None::<String>
     ///     )).get_result::<Option<Value>>(connection)?;
     /// assert!(result.is_none());
     ///
@@ -2674,6 +2664,5 @@ define_sql_function! {
     fn jsonb_set_lax<
         E: JsonbOrNullableJsonb + SingleValue,
         Arr: TextArrayOrNullableTextArray + CombinedNullableValue<E,Jsonb>,
-        T: TextOrNullableText + SingleValue,
-    >(base: E, path: Arr, new_value: E, create_if_missing: Bool, null_value_treatment: T) -> Arr::Out;
+    >(base: E, path: Arr, new_value: E, create_if_missing: Bool, null_value_treatment: NullValueTreatmentEnum) -> Arr::Out;
 }

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -2610,7 +2610,7 @@ define_sql_function! {
     /// #
     /// # #[cfg(feature = "serde_json")]
     /// # fn run_test() -> QueryResult<()> {
-    /// #     use diesel::dsl::jsonb_set;
+    /// #     use diesel::dsl::jsonb_set_lax;
     /// #     use diesel::sql_types::{Jsonb,Array, Json, Nullable, Text};
     /// #     use serde_json::{json,Value};
     /// #     let connection = &mut establish_connection();

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -603,3 +603,9 @@ pub type jsonb_set<B, J, R> = super::functions::jsonb_set<SqlTypeOf<B>, SqlTypeO
 #[cfg(feature = "postgres_backend")]
 pub type jsonb_set_create_if_missing<B, J, R, C> =
     super::functions::jsonb_set_create_if_missing<SqlTypeOf<B>, SqlTypeOf<J>, B, J, R, C>;
+
+/// Return type of [`jsonb_set_lax(base, path, new_value, create_if_missing, null_value_treatment)`](super::functions::jsonb_set_lax())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "postgres_backend")]
+pub type jsonb_set_lax<B, J, R, C, E> =
+    super::functions::jsonb_set_lax<SqlTypeOf<B>, SqlTypeOf<J>, SqlTypeOf<E>, B, J, R, C, E>;

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -608,4 +608,4 @@ pub type jsonb_set_create_if_missing<B, J, R, C> =
 #[allow(non_camel_case_types)]
 #[cfg(feature = "postgres_backend")]
 pub type jsonb_set_lax<B, J, R, C, E> =
-    super::functions::jsonb_set_lax<SqlTypeOf<B>, SqlTypeOf<J>, SqlTypeOf<E>, B, J, R, C, E>;
+    super::functions::jsonb_set_lax<SqlTypeOf<B>, SqlTypeOf<J>, B, J, R, C, E>;

--- a/diesel/src/pg/types/json_function_enum.rs
+++ b/diesel/src/pg/types/json_function_enum.rs
@@ -1,0 +1,21 @@
+use std::error::Error;
+use std::io::Write;
+
+use crate::pg::Pg;
+use crate::serialize::{self, IsNull, Output, ToSql};
+use crate::sql_types::*;
+
+#[cfg(feature = "postgres_backend")]
+impl ToSql<NullValueTreatmentEnum, Pg> for NullValueTreatment {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        let literal = match self {
+            Self::RaiseException => "raise_exxception",
+            Self::UseJsonNull => "use_json_null",
+            Self::DeleteKey => "delete_key",
+            Self::ReturnTarget => "return_target",
+        };
+        out.write_all(literal.as_bytes())
+            .map(|_| IsNull::No)
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    }
+}

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -10,6 +10,7 @@ mod integers;
 mod ipnet_address;
 #[cfg(feature = "serde_json")]
 mod json;
+mod json_function_enum;
 mod mac_addr;
 mod mac_addr_8;
 #[doc(hidden)]
@@ -207,6 +208,31 @@ pub mod sql_types {
     pub type Tsmultirange = Multirange<crate::sql_types::Timestamp>;
     #[doc(hidden)]
     pub type Tstzmultirange = Multirange<crate::sql_types::Timestamptz>;
+
+    /// This is a wrapper for [`NullValueTreatment`] to represent null_value_treatment for jsonb_seet_lax:
+    ///     'raise_exception' 'use_json_null' 'delete_key' 'return_target'
+    /// used in functions jsonb_set_lax
+    #[derive(Debug, Clone, Copy, QueryId, SqlType)]
+    #[cfg(feature = "postgres_backend")]
+    #[diesel(postgres_type(name = "text"))]
+    pub struct NullValueTreatmentEnum;
+
+    /// Represent null_value_treatment for jsonb_seet_lax:
+    ///     'raise_exception' 'use_json_null' 'delete_key' 'return_target'
+    /// used in functions jsonb_seet_lax.
+    #[derive(Debug, Clone, Copy, diesel_derives::AsExpression)]
+    #[diesel(sql_type = NullValueTreatmentEnum)]
+    #[allow(clippy::enum_variant_names)]
+    pub enum NullValueTreatment {
+        /// postgres 'raise_exception'
+        RaiseException,
+        /// postgres 'use_json_null'
+        UseJsonNull,
+        /// postgres 'delete_key'
+        DeleteKey,
+        /// postgres 'return_target'
+        ReturnTarget,
+    }
 
     /// This is a wrapper for [`RangeBound`] to represent range bounds: '[]', '(]', '[)', '()',
     /// used in functions int4range, int8range, numrange, tsrange, tstzrange, daterange.

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -480,6 +480,13 @@ fn postgres_functions() -> _ {
             pg_extras::jsonb,
             pg_extras::boolean,
         ),
+        jsonb_set_lax(
+            pg_extras::jsonb,
+            pg_extras::text_array,
+            pg_extras::jsonb,
+            pg_extras::boolean,
+            pg_extras::name,
+        ),
     )
 }
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -415,6 +415,8 @@ fn test_normal_functions() -> _ {
 fn postgres_functions() -> _ {
     let bound: sql_types::RangeBound =
         sql_types::RangeBound::LowerBoundExclusiveUpperBoundExclusive;
+    let null_value_treatment: sql_types::NullValueTreatment =
+        sql_types::NullValueTreatment::UseJsonNull;
     (
         lower(pg_extras::range),
         upper(pg_extras::range),
@@ -485,7 +487,7 @@ fn postgres_functions() -> _ {
             pg_extras::text_array,
             pg_extras::jsonb,
             pg_extras::boolean,
-            pg_extras::name,
+            null_value_treatment,
         ),
     )
 }


### PR DESCRIPTION
#4216 
Though create_if_missing and null_value_treatment is optional, the case without them is already supported in jsonb_set and jsonb_set_create_if_missing. So I just do not treat them as optional field here. Do you think it's ok?