### PR TITLE
feat: run rustfmt after generating schema.rs file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+          components: rustfmt
 
       - name: Rust version check
         shell: bash

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -62,6 +62,8 @@ pub enum Error {
     ClapMatchesError(#[from] clap::parser::MatchesError),
     #[error("No `[print_schema.{0}]` entries in your diesel.toml")]
     NoSchemaKeyFound(String),
+    #[error("Failed To Run rustfmt")]
+    RustFmtFail(String),
 }
 
 fn print_optional_path(path: &Option<PathBuf>) -> String {

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -297,6 +297,18 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
                 let schema = print_schema::output_schema(&mut connection, config)?;
                 std::fs::write(path, schema.as_bytes())
                     .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
+                match std::process::Command::new("rustfmt").arg(path).status() {
+                    Ok(status) => {
+                        if !status.success() {
+                            eprintln!("rustfmt exited with status code - {}", status)
+                        }
+                    }
+                    Err(err) => eprintln!(
+                        "Couldn't run rustfmt to format {} - {}",
+                        path.display(),
+                        err
+                    ),
+                }
             }
         }
     }

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -276,9 +276,8 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
                     .map_err(|e| crate::errors::Error::IoError(e, Some(parent.to_owned())))?;
             }
 
+            let schema = print_schema::output_schema(&mut connection, config)?;
             if matches.get_flag("LOCKED_SCHEMA") {
-                let schema = print_schema::output_schema(&mut connection, config)?;
-
                 let old_buf = std::fs::read_to_string(path)
                     .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
 
@@ -294,21 +293,8 @@ fn regenerate_schema_if_file_specified(matches: &ArgMatches) -> Result<(), crate
                     ));
                 }
             } else {
-                let schema = print_schema::output_schema(&mut connection, config)?;
                 std::fs::write(path, schema.as_bytes())
                     .map_err(|e| crate::errors::Error::IoError(e, Some(path.to_owned())))?;
-                match std::process::Command::new("rustfmt").arg(path).status() {
-                    Ok(status) => {
-                        if !status.success() {
-                            eprintln!("rustfmt exited with status code - {}", status)
-                        }
-                    }
-                    Err(err) => eprintln!(
-                        "Couldn't run rustfmt to format {} - {}",
-                        path.display(),
-                        err
-                    ),
-                }
             }
         }
     }

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -291,7 +291,14 @@ pub fn output_schema(
         out = diffy::apply(&out, &patch)?;
     }
 
-    Ok(out)
+    match format_schema(&out) {
+        Ok(schema) => Ok(schema),
+        Err(err) => {
+            eprintln!("Error formatting schema ({})", err);
+            Ok(out)
+        }
+    }
+}
 
 pub fn format_schema(schema: &str) -> Result<String, crate::errors::Error> {
     use crate::errors::Error;

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -294,7 +294,10 @@ pub fn output_schema(
     match format_schema(&out) {
         Ok(schema) => Ok(schema),
         Err(err) => {
-            eprintln!("Error formatting schema ({})", err);
+            tracing::warn!(
+                "Couldn't format schema. Exporting unformatted schema ({:?})",
+                err
+            );
             Ok(out)
         }
     }

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -306,6 +306,7 @@ pub fn format_schema(schema: &str) -> Result<String, crate::errors::Error> {
     let child = process::Command::new("rustfmt")
         .stdin(process::Stdio::piped())
         .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
         .spawn()
         .map_err(|err| Error::RustFmtFail(format!("Failed to launch child process ({})", err)))?;
 

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -5,7 +5,7 @@ use crate::infer_schema_internals::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt::{self, Display, Formatter, Write};
-use std::io::{Read, Write as IoWrite};
+use std::io::Write as IoWrite;
 use std::process;
 
 const SCHEMA_HEADER: &str = "// @generated automatically by Diesel CLI.\n";
@@ -306,7 +306,7 @@ pub fn output_schema(
 pub fn format_schema(schema: &str) -> Result<String, crate::errors::Error> {
     use crate::errors::Error;
     // Inject schema through rustfmt stdin and get the formatted output
-    let child = process::Command::new("rustfmt")
+    let mut child = process::Command::new("rustfmt")
         .stdin(process::Stdio::piped())
         .stdout(process::Stdio::piped())
         .stderr(process::Stdio::piped())
@@ -316,6 +316,7 @@ pub fn format_schema(schema: &str) -> Result<String, crate::errors::Error> {
     {
         let mut stdin = child
             .stdin
+            .take()
             .expect("we can always get the stdin from the child process");
 
         stdin.write_all(schema.as_bytes()).map_err(|err| {

--- a/diesel_cli/tests/generate_migrations/diff_add_table_with_fk/mysql/schema_out.rs/expected.snap
+++ b/diesel_cli/tests/generate_migrations/diff_add_table_with_fk/mysql/schema_out.rs/expected.snap
@@ -23,8 +23,4 @@ diesel::table! {
 
 diesel::joinable!(posts -> users (user_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    posts,
-    users,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(posts, users,);

--- a/diesel_cli/tests/generate_migrations/diff_add_table_with_fk/postgres/schema_out.rs/expected.snap
+++ b/diesel_cli/tests/generate_migrations/diff_add_table_with_fk/postgres/schema_out.rs/expected.snap
@@ -1,7 +1,7 @@
 ---
 source: diesel_cli/tests/migration_generate.rs
-assertion_line: 337
 description: "Test: diff_add_table_with_fk"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -23,8 +23,4 @@ diesel::table! {
 
 diesel::joinable!(posts -> users (user_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    posts,
-    users,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(posts, users,);

--- a/diesel_cli/tests/generate_migrations/diff_add_table_with_fk/sqlite/schema_out.rs/expected.snap
+++ b/diesel_cli/tests/generate_migrations/diff_add_table_with_fk/sqlite/schema_out.rs/expected.snap
@@ -1,7 +1,7 @@
 ---
 source: diesel_cli/tests/migration_generate.rs
-assertion_line: 332
 description: "Test: diff_add_table_with_fk"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -23,8 +23,4 @@ diesel::table! {
 
 diesel::joinable!(posts -> users (user_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    posts,
-    users,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(posts, users,);

--- a/diesel_cli/tests/print_schema/print_schema_custom_types/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types/mysql/expected.snap
@@ -22,8 +22,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_custom_types/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_custom_types"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -23,4 +24,3 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
-

--- a/diesel_cli/tests/print_schema/print_schema_custom_types/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types/postgres/expected.snap
@@ -22,8 +22,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_custom_types/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_custom_types"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -22,5 +23,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_custom_types/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types/sqlite/expected.snap
@@ -23,7 +23,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_custom_types/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_custom_types/sqlite/expected.snap
@@ -22,8 +22,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_patch_file/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_patch_file/mysql/expected.snap
@@ -17,8 +17,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_patch_file/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_patch_file/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_patch_file"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -17,8 +18,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_patch_file/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_patch_file/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_patch_file"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -17,8 +18,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
-description: "Test: print_schema_regression_3446_ignore_compound_foreign_keys"
+description: "Test: print_schema_regression_3446_compound_keys"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -30,5 +31,8 @@ diesel::table! {
 
 diesel::joinable!(payment_card -> person (holder_id));
 
-diesel::allow_tables_to_appear_in_same_query!(payment_card, person, transaction,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    payment_card,
+    person,
+    transaction,
+);

--- a/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
@@ -31,8 +31,4 @@ diesel::table! {
 
 diesel::joinable!(payment_card -> person (holder_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    payment_card,
-    person,
-    transaction,
-);
+diesel::allow_tables_to_appear_in_same_query!(payment_card, person, transaction,);

--- a/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_3446_compound_keys/postgres/expected.snap
@@ -30,9 +30,5 @@ diesel::table! {
 
 diesel::joinable!(payment_card -> person (holder_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    payment_card,
-    person,
-    transaction,
-);
+diesel::allow_tables_to_appear_in_same_query!(payment_card, person, transaction,);
 

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/mysql/expected.snap
@@ -19,8 +19,4 @@ diesel::table! {
 
 diesel::joinable!(tab_problem -> tab_key1 (key1));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    tab_key1,
-    tab_problem,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(tab_key1, tab_problem,);

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_regression_test_for_2623"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -19,5 +20,7 @@ diesel::table! {
 
 diesel::joinable!(tab_problem -> tab1 (key1));
 
-diesel::allow_tables_to_appear_in_same_query!(tab1, tab_problem,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    tab1,
+    tab_problem,
+);

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.snap
@@ -20,7 +20,4 @@ diesel::table! {
 
 diesel::joinable!(tab_problem -> tab1 (key1));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    tab1,
-    tab_problem,
-);
+diesel::allow_tables_to_appear_in_same_query!(tab1, tab_problem,);

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/postgres/expected.snap
@@ -19,8 +19,5 @@ diesel::table! {
 
 diesel::joinable!(tab_problem -> tab1 (key1));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    tab1,
-    tab_problem,
-);
+diesel::allow_tables_to_appear_in_same_query!(tab1, tab_problem,);
 

--- a/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_regression_test_for_2623/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_regression_test_for_2623"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -19,8 +20,4 @@ diesel::table! {
 
 diesel::joinable!(tab_problem -> tab_key1 (key1));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    tab_key1,
-    tab_problem,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(tab_key1, tab_problem,);

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
@@ -31,9 +31,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    payment_card,
-    transaction_one,
-    transaction_two,
-);
+diesel::allow_tables_to_appear_in_same_query!(payment_card, transaction_one, transaction_two,);
 

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
@@ -3,7 +3,6 @@ source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_several_keys_with_compound_key"
 ---
 // @generated automatically by Diesel CLI.
-
 diesel::table! {
     payment_card (id) {
         id -> Integer,
@@ -32,4 +31,3 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(payment_card, transaction_one, transaction_two,);
-

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/mysql/expected.snap
@@ -3,6 +3,7 @@ source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_several_keys_with_compound_key"
 ---
 // @generated automatically by Diesel CLI.
+
 diesel::table! {
     payment_card (id) {
         id -> Integer,

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_several_keys_with_compound_key"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -28,9 +29,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    payment_card,
-    transaction_one,
-    transaction_two,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(payment_card, transaction_one, transaction_two,);

--- a/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_several_keys_with_compound_key/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_several_keys_with_compound_key"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -28,9 +29,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    payment_card,
-    transaction_one,
-    transaction_two,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(payment_card, transaction_one, transaction_two,);

--- a/diesel_cli/tests/print_schema/print_schema_simple/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple/mysql/expected.snap
@@ -32,8 +32,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.snap
@@ -33,7 +33,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.snap
@@ -32,8 +32,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_simple"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -32,5 +33,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.snap
@@ -33,7 +33,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.snap
@@ -32,8 +32,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_simple"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -32,5 +33,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/mysql/expected.snap
@@ -16,8 +16,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_simple_without_docs"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -16,8 +17,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.snap
@@ -17,7 +17,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.snap
@@ -16,8 +16,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_simple_without_docs/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_simple_without_docs"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -16,5 +17,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);

--- a/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.snap
@@ -42,8 +42,5 @@ pub mod custom_schema {
 
     diesel::joinable!(b -> a (parent));
 
-    diesel::allow_tables_to_appear_in_same_query!(
-        a,
-        b,
-    );
+    diesel::allow_tables_to_appear_in_same_query!(a, b,);
 }

--- a/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_specifying_schema_name_with_foreign_keys"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -41,6 +42,8 @@ pub mod custom_schema {
 
     diesel::joinable!(b -> a (parent));
 
-    diesel::allow_tables_to_appear_in_same_query!(a, b,);
+    diesel::allow_tables_to_appear_in_same_query!(
+        a,
+        b,
+    );
 }
-

--- a/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_specifying_schema_name_with_foreign_keys/postgres/expected.snap
@@ -41,9 +41,6 @@ pub mod custom_schema {
 
     diesel::joinable!(b -> a (parent));
 
-    diesel::allow_tables_to_appear_in_same_query!(
-        a,
-        b,
-    );
+    diesel::allow_tables_to_appear_in_same_query!(a, b,);
 }
 

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_implicit_foreign_key_reference/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_implicit_foreign_key_reference/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_sqlite_implicit_foreign_key_reference"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -22,8 +23,4 @@ diesel::table! {
 
 diesel::joinable!(accounts -> data_centers (data_center_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    accounts,
-    data_centers,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(accounts, data_centers,);

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_rowid_column/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_rowid_column/sqlite/expected.snap
@@ -24,8 +24,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-    users3,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2, users3,);

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_rowid_column/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_rowid_column/sqlite/expected.snap
@@ -23,8 +23,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-    users3,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2, users3,);

--- a/diesel_cli/tests/print_schema/print_schema_sqlite_rowid_column/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_sqlite_rowid_column/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_sqlite_rowid_column"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -23,4 +24,8 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(users1, users2, users3,);
+diesel::allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+    users3,
+);

--- a/diesel_cli/tests/print_schema/print_schema_table_order/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_table_order/mysql/expected.snap
@@ -46,9 +46,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    abc,
-    def,
-    ghi,
-);
+diesel::allow_tables_to_appear_in_same_query!(abc, def, ghi,);
 

--- a/diesel_cli/tests/print_schema/print_schema_table_order/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_table_order/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_table_order"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -46,9 +47,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    abc,
-    def,
-    ghi,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(abc, def, ghi,);

--- a/diesel_cli/tests/print_schema/print_schema_table_order/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_table_order/sqlite/expected.snap
@@ -46,9 +46,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    abc,
-    def,
-    ghi,
-);
+diesel::allow_tables_to_appear_in_same_query!(abc, def, ghi,);
 

--- a/diesel_cli/tests/print_schema/print_schema_table_order/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_table_order/sqlite/expected.snap
@@ -47,8 +47,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    abc,
-    def,
-    ghi,
-);
+diesel::allow_tables_to_appear_in_same_query!(abc, def, ghi,);

--- a/diesel_cli/tests/print_schema/print_schema_table_order/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_table_order/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_table_order"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -46,5 +47,8 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(abc, def, ghi,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    abc,
+    def,
+    ghi,
+);

--- a/diesel_cli/tests/print_schema/print_schema_unsigned/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_unsigned/mysql/expected.snap
@@ -38,8 +38,5 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 

--- a/diesel_cli/tests/print_schema/print_schema_with_compound_foreign_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_compound_foreign_keys/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_compound_foreign_keys"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -56,8 +57,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    a,
-    b,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(a, b,);

--- a/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_foreign_keys/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_foreign_keys"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -61,9 +62,4 @@ diesel::table! {
 diesel::joinable!(comments -> posts (post_id));
 diesel::joinable!(posts -> users (user_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    comments,
-    posts,
-    users,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(comments, posts, users,);

--- a/diesel_cli/tests/print_schema/print_schema_with_foreign_keys_reserved_names/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_foreign_keys_reserved_names/postgres/expected.snap
@@ -42,7 +42,4 @@ diesel::table! {
 
 diesel::joinable!(posts -> users (type_));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    posts,
-    users,
-);
+diesel::allow_tables_to_appear_in_same_query!(posts, users,);

--- a/diesel_cli/tests/print_schema/print_schema_with_foreign_keys_reserved_names/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_foreign_keys_reserved_names/postgres/expected.snap
@@ -41,8 +41,5 @@ diesel::table! {
 
 diesel::joinable!(posts -> users (type_));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    posts,
-    users,
-);
+diesel::allow_tables_to_appear_in_same_query!(posts, users,);
 

--- a/diesel_cli/tests/print_schema/print_schema_with_foreign_keys_reserved_names/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_foreign_keys_reserved_names/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_foreign_keys_reserved_names"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -41,5 +42,7 @@ diesel::table! {
 
 diesel::joinable!(posts -> users (type_));
 
-diesel::allow_tables_to_appear_in_same_query!(posts, users,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    posts,
+    users,
+);

--- a/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/mysql/expected.snap
@@ -17,10 +17,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 // @generated automatically by Diesel CLI.
 
 diesel::table! {

--- a/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/postgres/expected.snap
@@ -17,10 +17,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 // @generated automatically by Diesel CLI.
 
 diesel::table! {

--- a/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/postgres/expected.snap
@@ -16,10 +16,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 // @generated automatically by Diesel CLI.
 
 diesel::table! {

--- a/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_multiple_schema"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -16,7 +17,10 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
+diesel::allow_tables_to_appear_in_same_query!(
+    users1,
+    users2,
+);
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
@@ -47,4 +51,3 @@ diesel::table! {
         id -> Int4,
     }
 }
-

--- a/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_multiple_schema/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_multiple_schema"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -16,10 +17,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users1,
-    users2,
-);
+diesel::allow_tables_to_appear_in_same_query!(users1, users2,);
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
@@ -50,4 +48,3 @@ diesel::table! {
         id -> Nullable<Integer>,
     }
 }
-

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/mysql/expected.snap
@@ -62,8 +62,4 @@ diesel::table! {
 
 diesel::joinable!(user_has_complex_role -> self_ (user));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    self_,
-    user_has_complex_role,
-);
-
+diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/postgres/expected.snap
@@ -63,7 +63,4 @@ diesel::table! {
 
 diesel::joinable!(user_has_complex_role -> self_ (user));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    self_,
-    user_has_complex_role,
-);
+diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_unmappable_names"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -62,5 +63,7 @@ diesel::table! {
 
 diesel::joinable!(user_has_complex_role -> self_ (user));
 
-diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    self_,
+    user_has_complex_role,
+);

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/postgres/expected.snap
@@ -62,8 +62,5 @@ diesel::table! {
 
 diesel::joinable!(user_has_complex_role -> self_ (user));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    self_,
-    user_has_complex_role,
-);
+diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);
 

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/sqlite/expected.snap
@@ -63,7 +63,4 @@ diesel::table! {
 
 diesel::joinable!(user_has_complex_role -> self_ (user));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    self_,
-    user_has_complex_role,
-);
+diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/sqlite/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_unmappable_names"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -62,5 +63,7 @@ diesel::table! {
 
 diesel::joinable!(user_has_complex_role -> self_ (user));
 
-diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);
-
+diesel::allow_tables_to_appear_in_same_query!(
+    self_,
+    user_has_complex_role,
+);

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names/sqlite/expected.snap
@@ -62,8 +62,5 @@ diesel::table! {
 
 diesel::joinable!(user_has_complex_role -> self_ (user));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    self_,
-    user_has_complex_role,
-);
+diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);
 

--- a/diesel_cli/tests/print_schema/print_schema_with_unmappable_names_and_schema_name/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_with_unmappable_names_and_schema_name/postgres/expected.snap
@@ -1,6 +1,7 @@
 ---
 source: diesel_cli/tests/print_schema.rs
 description: "Test: print_schema_with_unmappable_names_and_schema_name"
+snapshot_kind: text
 ---
 // @generated automatically by Diesel CLI.
 
@@ -63,9 +64,5 @@ pub mod custom_schema {
 
     diesel::joinable!(user_has_complex_role -> self_ (user));
 
-    diesel::allow_tables_to_appear_in_same_query!(
-        self_,
-        user_has_complex_role,
-    );
+    diesel::allow_tables_to_appear_in_same_query!(self_, user_has_complex_role,);
 }
-

--- a/examples/postgres/advanced-blog-cli/src/schema.rs
+++ b/examples/postgres/advanced-blog-cli/src/schema.rs
@@ -37,8 +37,4 @@ diesel::joinable!(comments -> posts (post_id));
 diesel::joinable!(comments -> users (user_id));
 diesel::joinable!(posts -> users (user_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    comments,
-    posts,
-    users,
-);
+diesel::allow_tables_to_appear_in_same_query!(comments, posts, users,);

--- a/examples/postgres/composite_types/src/schema.rs
+++ b/examples/postgres/composite_types/src/schema.rs
@@ -18,7 +18,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    colors,
-    coordinates,
-);
+diesel::allow_tables_to_appear_in_same_query!(colors, coordinates,);

--- a/examples/postgres/relations/src/schema.rs
+++ b/examples/postgres/relations/src/schema.rs
@@ -34,9 +34,4 @@ diesel::joinable!(books_authors -> authors (author_id));
 diesel::joinable!(books_authors -> books (book_id));
 diesel::joinable!(pages -> books (book_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    authors,
-    books,
-    books_authors,
-    pages,
-);
+diesel::allow_tables_to_appear_in_same_query!(authors, books, books_authors, pages,);

--- a/examples/sqlite/relations/src/schema.rs
+++ b/examples/sqlite/relations/src/schema.rs
@@ -34,9 +34,4 @@ diesel::joinable!(books_authors -> authors (author_id));
 diesel::joinable!(books_authors -> books (book_id));
 diesel::joinable!(pages -> books (book_id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    authors,
-    books,
-    books_authors,
-    pages,
-);
+diesel::allow_tables_to_appear_in_same_query!(authors, books, books_authors, pages,);


### PR DESCRIPTION
Closes #4405 by launching a rustfmt process to format the generated `schema.rs` file

If rustfmt doesn't exist or it throws an error it will simply print a message to the user