### PR TITLE
style: simplify some statements for readability

### DIFF
--- a/diesel_derives/src/deprecated/belongs_to.rs
+++ b/diesel_derives/src/deprecated/belongs_to.rs
@@ -12,8 +12,7 @@ pub fn parse_belongs_to(name: Ident, input: ParseStream) -> Result<BelongsTo> {
             name.span(),
             format!(
                 "unexpected end of input, expected parentheses\n\
-                 help: The correct format looks like `#[diesel({})]`",
-                BELONGS_TO_NOTE
+                 help: The correct format looks like `#[diesel({BELONGS_TO_NOTE})]`"
             ),
         ));
     }

--- a/diesel_derives/src/deprecated/postgres_type.rs
+++ b/diesel_derives/src/deprecated/postgres_type.rs
@@ -43,8 +43,7 @@ pub fn parse_postgres_type(name: Ident, input: ParseStream) -> Result<PostgresTy
             name.span(),
             format!(
                 "unexpected end of input, expected parentheses\n\
-                 help: The correct format looks like `#[diesel({})]`",
-                POSTGRES_TYPE_NOTE
+                 help: The correct format looks like `#[diesel({POSTGRES_TYPE_NOTE})]`"
             ),
         ));
     }

--- a/diesel_derives/src/parsers/mysql_type.rs
+++ b/diesel_derives/src/parsers/mysql_type.rs
@@ -43,8 +43,7 @@ impl Parse for MysqlType {
                 input.span(),
                 format!(
                     "expected attribute `name`\n\
-                     help: The correct format looks like #[diesel({})]",
-                    MYSQL_TYPE_NOTE
+                     help: The correct format looks like #[diesel({MYSQL_TYPE_NOTE})]"
                 ),
             ))
         }

--- a/diesel_derives/src/parsers/sqlite_type.rs
+++ b/diesel_derives/src/parsers/sqlite_type.rs
@@ -43,8 +43,7 @@ impl Parse for SqliteType {
                 input.span(),
                 format!(
                     "expected attribute `name`\n\
-                     help: The correct format looks like #[diesel({})]",
-                    SQLITE_TYPE_NOTE
+                     help: The correct format looks like #[diesel({SQLITE_TYPE_NOTE})]"
                 ),
             ))
         }

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -13,9 +13,7 @@ pub fn expand(path: String) -> proc_macro2::TokenStream {
     };
     let migrations_expr = migration_directory_from_given_path(migrations_path_opt.as_deref())
         .unwrap_or_else(|_| {
-            panic!(
-                "Failed to receive migrations dir from {migrations_path_opt:?}"
-            )
+            panic!("Failed to receive migrations dir from {migrations_path_opt:?}")
         });
     let embedded_migrations =
         migration_literals_from_path(&migrations_expr).expect("Failed to read migration literals");

--- a/diesel_migrations/migrations_macros/src/embed_migrations.rs
+++ b/diesel_migrations/migrations_macros/src/embed_migrations.rs
@@ -14,8 +14,7 @@ pub fn expand(path: String) -> proc_macro2::TokenStream {
     let migrations_expr = migration_directory_from_given_path(migrations_path_opt.as_deref())
         .unwrap_or_else(|_| {
             panic!(
-                "Failed to receive migrations dir from {:?}",
-                migrations_path_opt
+                "Failed to receive migrations dir from {migrations_path_opt:?}"
             )
         });
     let embedded_migrations =
@@ -42,7 +41,7 @@ fn migration_literals_from_path(
 fn migration_literal_from_path(path: &Path) -> proc_macro2::TokenStream {
     let name = path
         .file_name()
-        .unwrap_or_else(|| panic!("Can't get file name from path `{:?}`", path))
+        .unwrap_or_else(|| panic!("Can't get file name from path `{path:?}`"))
         .to_string_lossy();
     if version_from_string(&name).is_none() {
         panic!(


### PR DESCRIPTION
We can improve readability and code maintainability by replacing lines like

```rust
help: The correct format looks like #[diesel({})]",
SQLITE_TYPE_NOTE
```

with

```rust
help: The correct format looks like #[diesel({SQLITE_TYPE_NOTE})]"
```
