### PR TITLE
feat(cli): generate unique versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ in a way that makes the pools suitable for use in parallel tests.
 ### Fixed
 
 * Use a single space instead of two spaces between `DELETE FROM`.
+* Diesel CLI now ensures that migration versions are always unique. If it fails to generate a unique version, it will return an error. The new version format remains compatible with older Diesel versions.
 
 ## [2.2.2] 2024-07-19
 

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -57,6 +57,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
 thiserror = "2.0.0"
 similar-asserts = "1.6.0"
+fd-lock = "4.0.2"
 
 [dependencies.diesel]
 version = "~2.2.0"

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -64,6 +64,8 @@ pub enum Error {
     NoSchemaKeyFound(String),
     #[error("Failed To Run rustfmt")]
     RustFmtFail(String),
+    #[error("Failed To Acquire Migration Folder Lock")]
+    FailedToAcquireMigrationFolderLock(String),
 }
 
 fn print_optional_path(path: &Option<PathBuf>) -> String {

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::infer_schema_internals::TableName;
 
@@ -72,7 +72,7 @@ pub enum Error {
     DuplicateMigrationVersion(PathBuf, String),
 }
 
-fn print_path(path: &PathBuf) -> String {
+fn print_path(path: &Path) -> String {
     format!("{}", path.display())
 }
 fn print_optional_path(path: &Option<PathBuf>) -> String {

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -66,6 +66,10 @@ pub enum Error {
     RustFmtFail(String),
     #[error("Failed To Acquire Migration Folder Lock")]
     FailedToAcquireMigrationFolderLock(String),
+    #[error("Couldn't Create Migration Folder")]
+    MigrationFolderCreationError,
+    #[error("Duplicate Migration Version Already Exists")]
+    DuplicateMigrationVersion,
 }
 
 fn print_optional_path(path: &Option<PathBuf>) -> String {

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -18,7 +18,7 @@ pub enum Error {
     ProjectRootNotFound(PathBuf),
     #[error("The --database-url argument must be passed, or the DATABASE_URL environment variable must be set.")]
     DatabaseUrlMissing,
-    #[error("Encountered an IO error: {0} {n}", n=print_optional_path(.1))]
+    #[error("Encountered an IO error: {0} for `{n}`", n=print_optional_path(.1))]
     IoError(#[source] std::io::Error, Option<PathBuf>),
     #[error("Failed to execute a database query: {0}")]
     QueryError(#[from] diesel::result::Error),
@@ -64,16 +64,17 @@ pub enum Error {
     NoSchemaKeyFound(String),
     #[error("Failed To Run rustfmt")]
     RustFmtFail(String),
-    #[error("Failed to acquire migration folder lock")]
-    FailedToAcquireMigrationFolderLock(String, PathBuf),
-    #[error("Tried to generate too many migrations with the same version")]
+    #[error("Failed to acquire migration folder lock: {1} for `{n}`", n=print_path(.0))]
+    FailedToAcquireMigrationFolderLock(PathBuf, String),
+    #[error("Tried to generate too many migrations with the same version `{1}` - Migrations folder is `{n}`", n=print_path(.0))]
     TooManyMigrations(PathBuf, String),
-    #[error("Specified migration version already exists")]
+    #[error("Specified migration version `{1}` already exists inside `{n}`", n=print_path(.0))]
     DuplicateMigrationVersion(PathBuf, String),
 }
 
+fn print_path(path: &PathBuf) -> String {
+    format!("{}", path.display())
+}
 fn print_optional_path(path: &Option<PathBuf>) -> String {
-    path.as_ref()
-        .map(|p| format!(" for `{}`", p.display()))
-        .unwrap_or_default()
+    path.as_ref().map(|p| print_path(p)).unwrap_or_default()
 }

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -64,12 +64,12 @@ pub enum Error {
     NoSchemaKeyFound(String),
     #[error("Failed To Run rustfmt")]
     RustFmtFail(String),
-    #[error("Failed To Acquire Migration Folder Lock")]
-    FailedToAcquireMigrationFolderLock(String),
-    #[error("Couldn't Create Migration Folder")]
-    MigrationFolderCreationError,
-    #[error("Duplicate Migration Version Already Exists")]
-    DuplicateMigrationVersion,
+    #[error("Failed to acquire migration folder lock")]
+    FailedToAcquireMigrationFolderLock(String, PathBuf),
+    #[error("Tried to generate too many migrations with the same version")]
+    TooManyMigrations(PathBuf, String),
+    #[error("Specified migration version already exists")]
+    DuplicateMigrationVersion(PathBuf, String),
 }
 
 fn print_optional_path(path: &Option<PathBuf>) -> String {

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -244,8 +244,8 @@ fn create_migration_dir<'a>(
         return create(&migrations_dir, &version, migration_name);
     }
 
-    // else add a subversion so the versions stays unique
-    for subversion in 0..MAX_MIGRATIONS_PER_SEC {
+    // else add a subversion so the versions stay unique
+    for subversion in 0..=MAX_MIGRATIONS_PER_SEC {
         let full_version = format!("{version}-{subversion:04x}");
         if is_duplicate_version(&full_version, &migration_folders) {
             continue;

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -197,7 +197,7 @@ fn create_migration_dir<'a>(
     const MAX_MIGRATIONS_PER_SEC: u16 = 0xFFFF;
     fn is_duplicate_version(full_version: &str, migration_folders: &Vec<PathBuf>) -> bool {
         for folder in migration_folders {
-            if folder.to_string_lossy().starts_with(&full_version) {
+            if folder.to_string_lossy().starts_with(full_version) {
                 return true;
             }
         }

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -86,8 +86,8 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
             println!("{result:?}");
         }
         ("generate", args) => {
-            let dir = migrations_dir(matches)?;
-            let mut lock = RwLock::new(migration_folder_lock(dir)?);
+            let migrations_folder = migrations_dir(matches)?;
+            let mut lock = RwLock::new(migration_folder_lock(migrations_folder.clone())?);
             // This blocks until we can get the lock
             // Will throw an error if we receive a termination signal
             let _ = lock.write().map_err(|err| {
@@ -137,9 +137,8 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
                 (String::new(), String::new())
             };
             let version = migration_version(args);
-            let base_migrations_dir = migrations_dir(matches)?;
             let migration_dir = create_migration_dir(
-                base_migrations_dir,
+                migrations_folder,
                 migration_name,
                 version,
                 args_contains_version(args),

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -193,7 +193,7 @@ fn create_migration_dir<'a>(
     version: Box<dyn Display + 'a>,
     explicit_version: bool,
 ) -> Result<PathBuf, crate::errors::Error> {
-    const MAX_MIGRATIONS_PER_SEC: u16 = 0xFFFF;
+    const MAX_MIGRATIONS_PER_SEC: u16 = u16::MAX;
     fn is_duplicate_version(full_version: &str, migration_folders: &Vec<PathBuf>) -> bool {
         for folder in migration_folders {
             if folder.to_string_lossy().starts_with(full_version) {

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -201,7 +201,7 @@ fn create_migration_dir<'a>(
                 return true;
             }
         }
-        return false;
+        false
     }
 
     fn create(
@@ -226,7 +226,7 @@ fn create_migration_dir<'a>(
                     return Some(e.path().file_name()?.into());
                 }
             }
-            return None;
+            None
         })
         .collect();
 
@@ -297,7 +297,7 @@ fn args_contains_version(matches: &ArgMatches) -> bool {
     if let Ok(exists) = matches.try_contains_id("MIGRATION_VERSION") {
         return exists;
     }
-    return false;
+    false
 }
 
 fn migration_version<'a>(matches: &'a ArgMatches) -> Box<dyn Display + 'a> {

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -92,8 +92,8 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
             // Will throw an error if we receive a termination signal
             let _ = lock.write().map_err(|err| {
                 crate::errors::Error::FailedToAcquireMigrationFolderLock(
-                    err.to_string(),
                     migrations_folder.clone(),
+                    err.to_string(),
                 )
             })?;
 

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -16,8 +16,8 @@ fn migration_generate_creates_a_migration_with_the_proper_name() {
     // check overall output
     let expected_stdout = Regex::new(
         "\
-Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}_hello.up.sql
-Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}_hello.down.sql\
+Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}-0000_hello.up.sql
+Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}-0000_hello.down.sql\
         ",
     )
     .unwrap();
@@ -25,7 +25,7 @@ Creating migrations.\\d{4}-\\d{2}-\\d{2}-\\d{6}_hello.down.sql\
     assert!(expected_stdout.is_match(result.stdout()));
 
     // check timestamps are properly formatted
-    let captured_timestamps = Regex::new(r"(?P<stamp>[\d-]*)_hello").unwrap();
+    let captured_timestamps = Regex::new(r"(?P<stamp>[\d-]*)-0000_hello").unwrap();
     let mut stamps_found = 0;
     for caps in captured_timestamps.captures_iter(result.stdout()) {
         let timestamp = NaiveDateTime::parse_from_str(&caps["stamp"], TIMESTAMP_FORMAT);

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -348,8 +348,12 @@ fn migration_generate_different_versions() {
             assert_ne!(version_i, version_j);
         }
     }
-    // Includes the 00000 migration created on 'setup'
-    assert_eq!(paths.len(), MIGRATIONS_NO + 1);
+    if cfg!(feature = "postgres") {
+        // Includes the 00000 migration created on 'setup'
+        assert_eq!(paths.len(), MIGRATIONS_NO + 1);
+    } else {
+        assert_eq!(paths.len(), MIGRATIONS_NO);
+    }
 }
 
 #[cfg(feature = "sqlite")]

--- a/diesel_cli/tests/migration_generate.rs
+++ b/diesel_cli/tests/migration_generate.rs
@@ -337,7 +337,7 @@ fn migration_generate_different_versions() {
                     return Some(e);
                 }
             }
-            return None;
+            None
         })
         .collect();
 

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -3,8 +3,8 @@ extern crate dotenvy;
 #[cfg(not(feature = "sqlite"))]
 extern crate url;
 
-use std::fs::{self, File};
-use std::io::prelude::*;
+use std::fs::{self, File, ReadDir};
+use std::io::{self, prelude::*};
 use std::path::{Path, PathBuf};
 use tempfile::{Builder, TempDir};
 
@@ -85,8 +85,13 @@ impl Project {
             .join("migrations")
             .read_dir()
             .expect("Error reading directory")
-            .map(|e| Migration {
-                path: e.expect("error reading entry").path(),
+            .filter_map(|e| {
+                if let Ok(e) = e {
+                    if e.path().is_dir() {
+                        return Some(Migration { path: e.path() });
+                    }
+                }
+                return None;
             })
             .collect()
     }
@@ -130,6 +135,10 @@ impl Project {
 
     pub fn has_file<P: AsRef<Path>>(&self, path: P) -> bool {
         self.directory.path().join(path).exists()
+    }
+
+    pub fn directory_entries<P: AsRef<Path>>(&self, path: P) -> Result<ReadDir, io::Error> {
+        fs::read_dir(self.directory.path().join(path))
     }
 
     pub fn file_contents<P: AsRef<Path>>(&self, path: P) -> String {

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -91,7 +91,7 @@ impl Project {
                         return Some(Migration { path: e.path() });
                     }
                 }
-                return None;
+                None
             })
             .collect()
     }


### PR DESCRIPTION
Closes #3698

This PR adds:

1. Migration folder locking mechanism that can easily be added to other migration commands to make sure we don't have multiple diesel cli instances running migration instances
2. Checks to make sure we never generate two migrations with the same version
3.  Adds a "subversion" that gets added to the timestamp so we can generate multiple migrations per second
    - This only happens when the `--version` argument is not specified
    - Adding a subversion allows us to keep the timestamp intact instead of creating a fake timestamp by adding 1 to it