### PR TITLE
DebugBinds/Query: Reduce monomorphization overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Install sqlite (Linux)
         if: runner.os == 'Linux' && matrix.backend == 'sqlite'
         run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev
           echo "SQLITE_DATABASE_URL=/tmp/test.db" >> $GITHUB_ENV
 
       - name: Install mysql (Linux)


### PR DESCRIPTION
The output of `cargo llvm-lines --package diesel_tests --test integration_tests --profile test --features postgres` showed the `Debug` and `Display` implementations of the `DebugBinds` and `DebugQuery` structs as two of the main code size reasons, slowing down the compilation of applications. This commit significantly reduces the LLVM IR lines of the two structs, which should hopefully improve compile times a little bit (see commit messages for detailed numbers).

/cc @weiznich 

Related:

- https://matklad.github.io/2021/09/04/fast-rust-builds.html#Keeping-an-Eye-on-Instantiations