### PR TITLE
Updated ipnetwork to 0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ in a way that makes the pools suitable for use in parallel tests.
 
 * Use a single space instead of two spaces between `DELETE FROM`.
 * Diesel CLI now ensures that migration versions are always unique. If it fails to generate a unique version, it will return an error. The new version format remains compatible with older Diesel versions.
+* Updated `ipnetwork` to allow version 0.21.
 
 ## [2.2.2] 2024-07-19
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { version = ">=0.8.0, <2.0", optional = true }
 url = { version = "2.1.0", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 uuid = { version = ">=0.7.0, <2.0.0", optional = true }
-ipnetwork = { version = ">=0.12.2, <0.21.0", optional = true }
+ipnetwork = { version = ">=0.12.2, <0.22.0", optional = true }
 ipnet = { version = "2.5.0", optional = true }
 num-bigint = { version = ">=0.2.0, <0.5.0", optional = true }
 num-traits = { version = "0.2.0", optional = true }
@@ -53,7 +53,7 @@ path = "../diesel_derives"
 [dev-dependencies]
 cfg-if = "1"
 dotenvy = "0.15"
-ipnetwork = ">=0.12.2, <0.21.0"
+ipnetwork = ">=0.12.2, <0.22.0"
 quickcheck = "1.0.3"
 tempfile = "3.10.1"
 

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -18,7 +18,7 @@ quickcheck = "1.0.3"
 uuid = { version = "1.0.0" }
 serde_json = { version=">=0.9, <2.0" }
 ipnet = { version = "2.5.0" }
-ipnetwork = ">=0.12.2, <0.21.0"
+ipnetwork = ">=0.12.2, <0.22.0"
 bigdecimal = ">= 0.0.13, < 0.5.0"
 rand = "0.8.4"
 libsqlite3-sys = { workspace = true, optional = true }


### PR DESCRIPTION
This PR updates the ipnetwork dependency to also allow ipnetwork 0.21.
