### PR TITLE
Improve CompatibleType not implemented error message

### DIFF
--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -185,7 +185,7 @@ mod private {
     #[diagnostic::on_unimplemented(
         note = "this is a mismatch between what your query returns and what your type expects the query to return",
         note = "the fields in your struct need to match the fields returned by your query in count, order and type",
-        note = "consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend({DB}))]` \n\
+        note = "consider using `#[diesel(check_for_backend({DB}))]` on either `#[derive(Selectable)]` or #[derive(QueryableByName)] \n\
                 on your struct `{U}` and in your query `.select({U}::as_select())` to get a better error message"
     )]
     pub trait CompatibleType<U, DB> {

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -185,7 +185,7 @@ mod private {
     #[diagnostic::on_unimplemented(
         note = "this is a mismatch between what your query returns and what your type expects the query to return",
         note = "the fields in your struct need to match the fields returned by your query in count, order and type",
-        note = "consider using `#[diesel(check_for_backend({DB}))]` on either `#[derive(Selectable)]` or #[derive(QueryableByName)] \n\
+        note = "consider using `#[diesel(check_for_backend({DB}))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` \n\
                 on your struct `{U}` and in your query `.select({U}::as_select())` to get a better error message"
     )]
     pub trait CompatibleType<U, DB> {

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
@@ -74,7 +74,7 @@ error[E0277]: the trait bound `Untyped: load_dsl::private::CompatibleType<User, 
    |
    = note: this is a mismatch between what your query returns and what your type expects the query to return
    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
            on your struct `User` and in your query `.select(User::as_select())` to get a better error message
    = help: the trait `load_dsl::private::CompatibleType<U, DB>` is implemented for `Untyped`
    = note: required for `SqlQuery` to implement `LoadQuery<'_, _, User>`

--- a/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
+++ b/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::T
    = help: the trait `load_dsl::private::CompatibleType<UserWithToFewFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    = note: this is a mismatch between what your query returns and what your type expects the query to return
    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
            on your struct `UserWithToFewFields` and in your query `.select(UserWithToFewFields::as_select())` to get a better error message
    = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
              (ST0, ST1)
@@ -42,7 +42,7 @@ error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::T
    = help: the trait `load_dsl::private::CompatibleType<UserWithToManyFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    = note: this is a mismatch between what your query returns and what your type expects the query to return
    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
            on your struct `UserWithToManyFields` and in your query `.select(UserWithToManyFields::as_select())` to get a better error message
    = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
              (ST0, ST1)
@@ -75,7 +75,7 @@ error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::T
    = help: the trait `load_dsl::private::CompatibleType<UserWrongOrder, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    = note: this is a mismatch between what your query returns and what your type expects the query to return
    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
            on your struct `UserWrongOrder` and in your query `.select(UserWrongOrder::as_select())` to get a better error message
    = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
              (ST0, ST1)
@@ -108,7 +108,7 @@ error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::T
    = help: the trait `load_dsl::private::CompatibleType<UserTypeMismatch, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
    = note: this is a mismatch between what your query returns and what your type expects the query to return
    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
            on your struct `UserTypeMismatch` and in your query `.select(UserTypeMismatch::as_select())` to get a better error message
    = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
              (ST0, ST1)

--- a/diesel_compile_tests/tests/fail/queryable_with_typemismatch.stderr
+++ b/diesel_compile_tests/tests/fail/queryable_with_typemismatch.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::T
    |
    = note: this is a mismatch between what your query returns and what your type expects the query to return
    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
            on your struct `User` and in your query `.select(User::as_select())` to get a better error message
    = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
              (ST0, ST1)

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -943,7 +943,7 @@ error[E0277]: the trait bound `(diesel::expression::select_by::SelectBy<Post, _>
     = help: the trait `load_dsl::private::CompatibleType<((i32, std::string::String), std::string::String), _>` is not implemented for `(diesel::expression::select_by::SelectBy<Post, _>, diesel::sql_types::Text)`
     = note: this is a mismatch between what your query returns and what your type expects the query to return
     = note: the fields in your struct need to match the fields returned by your query in count, order and type
-    = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+    = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
             on your struct `((i32, std::string::String), std::string::String)` and in your query `.select(((i32, std::string::String), std::string::String)::as_select())` to get a better error message
     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
               (ST0, ST1)

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<User, _>:
    |
    = note: this is a mismatch between what your query returns and what your type expects the query to return
    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[derive(Selectable)]` or #[derive(QueryableByName)] + `#[diesel(check_for_backend(_))]`
+   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
            on your struct `_` and in your query `.select(_::as_select())` to get a better error message
    = help: the trait `load_dsl::private::CompatibleType<U, DB>` is implemented for `diesel::expression::select_by::SelectBy<U, DB>`
    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<User, _>>>` to implement `LoadQuery<'_, _, _>`


### PR DESCRIPTION
I was told "OK I see this error message but my struct already implements Selectable so that's not useful".

As it turns out, this message would sometimes be misunderstood as the `check_for_backend` part only relating to the `QueryableByName` usage, but not to the `Selectable` usage, whereas `check_for_backend` is in fact the key point.

Hopefully this new writing will avoid this. :)