### PR TITLE
Better implementation using sqlite-wasm-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,17 @@ jobs:
       - name: Install wasm-pack
         run: cargo install wasm-pack
 
+      - name: Install emscripten toolchains
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install latest
+          ./emsdk activate latest
+
       - name: Test unit and integration tests
-        run: cargo xtask run-tests --wasm sqlite
+        run: |
+          source ./emsdk/emsdk_env.sh
+          cargo xtask run-tests --wasm sqlite
 
   sqlite_bundled:
     name: Check sqlite bundled + Sqlite with asan

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,13 +53,13 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.32.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-# https://github.com/Spxg/sqlite-wasm-rs#why-provide-precompiled-library
-sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", optional = true, default-features = false, features = ["precompiled"] }
+sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", optional = true, default-features = false }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on it, we use feature to override it.
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
+sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", default-features = false, features = ["bundled"] }
 
 [dev-dependencies]
 cfg-if = "1"

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,7 +53,7 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.32.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.1.3, <0.2.0", optional = true }
+sqlite-wasm-rs = { version = ">=0.2.1, <0.3.0", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on it, so we use feature to override it.

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,7 +53,7 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.32.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.2.4, <0.3.0", optional = true }
+sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", optional = true, default-features = false, features = ["precompiled"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on it, we use feature to override it.

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,10 +53,10 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.32.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.2.2, <0.3.0", optional = true }
+sqlite-wasm-rs = { version = ">=0.2.4, <0.3.0", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
-# Something is dependent on it, so we use feature to override it.
+# Something is dependent on it, we use feature to override it.
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,7 +53,7 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.32.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.2.1, <0.3.0", optional = true }
+sqlite-wasm-rs = { version = ">=0.2.2, <0.3.0", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on it, so we use feature to override it.

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,6 +53,7 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.32.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+# https://github.com/Spxg/sqlite-wasm-rs#why-provide-precompiled-library
 sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", optional = true, default-features = false, features = ["precompiled"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -780,12 +780,6 @@ pub mod prelude {
     #[cfg(feature = "sqlite")]
     #[doc(inline)]
     pub use crate::sqlite::SqliteConnection;
-
-    // These exported API from `sqlite-wasm-rs` are stable:
-    #[cfg(feature = "sqlite")]
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-    #[doc(inline)]
-    pub use sqlite_wasm_rs::export::init_sqlite;
 }
 
 #[doc(inline)]

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -987,10 +987,11 @@ mod tests {
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     #[wasm_bindgen_test::wasm_bindgen_test]
     async fn test_sqlite_wasm_vfs_opfs_sahpool() {
-        let util = sqlite_wasm_rs::export::install_opfs_sahpool(None, true)
+        let util = sqlite_wasm_rs::export::install_opfs_sahpool(None, false)
             .await
             .unwrap();
-        SqliteConnection::establish("test_sqlite_wasm_vfs_opfs_sahpool.db").unwrap();
+        SqliteConnection::establish("file:test_sqlite_wasm_vfs_opfs_sahpool.db?vfs=opfs-sahpool")
+            .unwrap();
         assert!(util.get_file_count() > 0);
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -175,7 +175,8 @@ impl Connection for SqliteConnection {
     /// make sure to read the following notes:
     ///
     /// * The database is stored in memory by default.
-    /// * Persistent VFS (Virtual File Systems) is optional, see <https://github.com/Spxg/sqlite-wasm-rs/blob/master/VFS.md>
+    /// * Persistent VFS (Virtual File Systems) is optional,
+    ///     see <https://github.com/Spxg/sqlite-wasm-rs/blob/master/VFS.md> for details
     fn establish(database_url: &str) -> ConnectionResult<Self> {
         let mut instrumentation = DynInstrumentation::default_instrumentation();
         instrumentation.on_connection_event(InstrumentationEvent::StartEstablishConnection {

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -68,15 +68,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -86,9 +86,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "shlex",
 ]
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -481,12 +481,9 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "itoa"
@@ -496,9 +493,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -518,9 +515,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -544,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -556,9 +553,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -618,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "parking_lot"
@@ -671,18 +668,29 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pq-sys"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc05d7ea95200187117196eee9edd0644424911821aeb28a18ce60ea0b8793"
+checksum = "30b51d65ebe1cb1f40641b15abae017fed35ccdda46e3dab1ff8768f625a3222"
 dependencies = [
+ "libc",
  "vcpkg",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.92"
+name = "prettyplease"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -723,10 +731,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustversion"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "ryu"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -753,17 +767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -808,19 +811,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "sqlite-wasm-rs"
-version = "0.1.3"
+name = "sqlite-wasm-macro"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7755091a81ef7605acbfb766d5855d5bb67da5f2763b725c526d0e5a127b305d"
+checksum = "78a45f42b08fbca31e9fa26000eba8d7826f26c20616f44260ff954cb12316c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51dad57724f9febb87e81d3bed0d48ae134693087a4f16a38606c429b30e86f"
 dependencies = [
  "fragile",
  "js-sys",
  "once_cell",
- "serde",
- "serde-wasm-bindgen",
+ "parking_lot",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "sqlite-wasm-macro",
+ "syn",
+ "thiserror",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -837,9 +857,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -870,6 +890,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -915,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -925,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -946,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap",
  "serde",
@@ -959,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcd332a5496c026f1e14b7f3d2b7bd98e509660c04239c58b0ba38a12daded4"
+checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
 dependencies = [
  "glob",
  "serde",
@@ -974,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "url"
@@ -1003,9 +1043,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 
 [[package]]
 name = "vcpkg"
@@ -1015,20 +1055,21 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -1040,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1053,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1063,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1076,15 +1117,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1183,9 +1227,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
 ]

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -677,16 +677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,31 +801,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "sqlite-wasm-macro"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a45f42b08fbca31e9fa26000eba8d7826f26c20616f44260ff954cb12316c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sqlite-wasm-rs"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51dad57724f9febb87e81d3bed0d48ae134693087a4f16a38606c429b30e86f"
+checksum = "84473e8335ed2f167c6f8040970d976990fb66aa62292ae58735de6d61ecfb73"
 dependencies = [
  "fragile",
  "js-sys",
  "once_cell",
  "parking_lot",
- "prettyplease",
- "proc-macro2",
- "quote",
- "sqlite-wasm-macro",
- "syn",
  "thiserror",
  "tokio",
  "wasm-bindgen",

--- a/diesel_test_helper/src/lib.rs
+++ b/diesel_test_helper/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate proc_macro2;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, token::Async, ItemFn};
+use syn::{parse_macro_input, ItemFn};
 
 /// Since sqlite wasm support has been added, #[wasm_bindgen_test] needs
 /// to be used in the wasm environment. This macro is designed to solve platform test differences.
@@ -15,7 +15,6 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
     } = parse_macro_input!(item as ItemFn);
 
     let cfgs = quote! {
-        #[cfg_attr(all(target_family = "wasm", target_os = "unknown", feature = "sqlite"), diesel_test_helper::sqlite_wasm)]
         #[cfg_attr(all(target_family = "wasm", target_os = "unknown"), wasm_bindgen_test::wasm_bindgen_test)]
         #[cfg_attr(not(all(target_family = "wasm", target_os = "unknown")), test)]
     };
@@ -23,33 +22,6 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
         #cfgs
         #(#attrs)*
         #vis #sig {
-            #block
-        }
-    )
-    .into()
-}
-
-/// Sqlite wasm requires asynchronous initialization, so this macro
-/// turns the function into asynchronous and provides an initialization method
-#[proc_macro_attribute]
-pub fn sqlite_wasm(_: TokenStream, item: TokenStream) -> TokenStream {
-    let ItemFn {
-        mut sig,
-        vis,
-        block,
-        attrs,
-    } = parse_macro_input!(item as ItemFn);
-
-    let prepare = quote! {
-        crate::init_sqlite().await.unwrap();
-    };
-
-    sig.asyncness = Some(Async::default());
-
-    quote!(
-        #(#attrs)*
-        #vis #sig {
-            #prepare
             #block
         }
     )

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -32,8 +32,6 @@ diesel_test_helper = { path = "../diesel_test_helper" }
 # Something is dependent on it, so we use feature to override it.
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
-# Wasm can use thread::sleep when atomic target_feature is enabled, but that requires nightly
-wasmtimer = "0.4.1"
 
 [features]
 default = []

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -32,6 +32,7 @@ diesel_test_helper = { path = "../diesel_test_helper" }
 # Something is dependent on it, so we use feature to override it.
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
+sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", default-features = false, features = ["bundled"] }
 
 [features]
 default = []

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -4,6 +4,7 @@ use diesel::*;
 
 #[diesel_test_helper::test]
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 fn managing_updated_at_for_table() {
     use crate::schema_dsl::*;
     use chrono::NaiveDateTime;
@@ -65,12 +66,7 @@ fn managing_updated_at_for_table() {
     assert_eq!(Ok(0), result);
 
     if cfg!(feature = "sqlite") {
-        // wasm can use thread::sleep when atomic target_feature
-        // is enabled, but that requires nightly
-        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
         std::thread::sleep(Duration::from_millis(1000));
-        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-        wasmtimer::tokio::sleep(Duration::from_secs(1)).await;
     }
 
     let query = auto_time.find(2).select(updated_at);

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -2,9 +2,12 @@ use crate::schema::*;
 use diesel::connection::BoxableConnection;
 use diesel::*;
 
+#[cfg_attr(
+    all(target_family = "wasm", target_os = "unknown"),
+    ignore = "can't sleep"
+)]
 #[diesel_test_helper::test]
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 fn managing_updated_at_for_table() {
     use crate::schema_dsl::*;
     use chrono::NaiveDateTime;
@@ -79,10 +82,12 @@ fn managing_updated_at_for_table() {
     assert!(old_time < new_time);
 }
 
-/// wasm does not support `std::env::temp_dir`
+#[cfg_attr(
+    all(target_family = "wasm", target_os = "unknown"),
+    ignore = "no filesystem on this platform"
+)]
 #[diesel_test_helper::test]
 #[cfg(feature = "sqlite")]
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 fn strips_sqlite_url_prefix() {
     let mut path = std::env::temp_dir();
     path.push("diesel_test_sqlite.db");
@@ -99,10 +104,12 @@ fn file_uri_created_in_memory() {
     assert!(!Path::new(":memory:").exists());
 }
 
-/// wasm does not support `std::env::temp_dir`
+#[cfg_attr(
+    all(target_family = "wasm", target_os = "unknown"),
+    ignore = "no filesystem on this platform"
+)]
 #[diesel_test_helper::test]
 #[cfg(feature = "sqlite")]
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 fn sqlite_uri_prefix_interpreted_as_file() {
     let mut path = std::env::temp_dir();
     path.push("diesel_test_sqlite_readonly.db");

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -61,7 +61,3 @@ mod transactions;
 mod types;
 mod types_roundtrip;
 mod update;
-
-/// Re-export it, because the `td::test` macro use `crate::init_sqlite`
-#[cfg(all(target_family = "wasm", target_os = "unknown", feature = "sqlite"))]
-pub use diesel::init_sqlite;

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -13,8 +13,8 @@ wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.2.4, <0.3.0" }
-
+# https://github.com/Spxg/sqlite-wasm-rs#why-provide-precompiled-library
+sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", default-features = false, features = ["precompiled"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -13,8 +13,7 @@ wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-# https://github.com/Spxg/sqlite-wasm-rs#why-provide-precompiled-library
-sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", default-features = false, features = ["precompiled"] }
+sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", default-features = false, features = ["bundled"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -11,7 +11,10 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
-sqlite-wasm-rs = "0.2"
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+sqlite-wasm-rs = { version = ">=0.2.1, <0.3.0" }
+
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -13,7 +13,7 @@ wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.2.1, <0.3.0" }
+sqlite-wasm-rs = { version = ">=0.2.4, <0.3.0" }
 
 
 [lib]

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
+sqlite-wasm-rs = "0.2"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sqlite/wasm/index.html
+++ b/examples/sqlite/wasm/index.html
@@ -10,8 +10,7 @@
     <label for="vfs">choose vfs:</label>
     <select id="vfs">
         <option value="0">memory</option>
-        <option value="1">opfs</option>
-        <option value="2">opfs-sahpool</option>
+        <option value="1">opfs-sahpool</option>
     </select>
     <button id="SwitchVFS">Switch VFS</button>
     <p></p>

--- a/examples/sqlite/wasm/src/lib.rs
+++ b/examples/sqlite/wasm/src/lib.rs
@@ -48,6 +48,7 @@ pub fn establish_connection() -> SqliteConnection {
     conn
 }
 
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 #[wasm_bindgen]
 pub async fn install_opfs_sahpool() {
     sqlite_wasm_rs::export::install_opfs_sahpool(None, false)

--- a/examples/sqlite/wasm/src/lib.rs
+++ b/examples/sqlite/wasm/src/lib.rs
@@ -37,8 +37,7 @@ pub fn establish_connection() -> SqliteConnection {
     let (vfs, once) = &*VFS.lock().unwrap();
     let url = match vfs {
         0 => "post.db",
-        1 => "file:post.db?vfs=opfs",
-        2 => "file:post.db?vfs=opfs-sahpool",
+        1 => "file:post.db?vfs=opfs-sahpool",
         _ => unreachable!(),
     };
     let mut conn =
@@ -49,11 +48,11 @@ pub fn establish_connection() -> SqliteConnection {
     conn
 }
 
-#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 #[wasm_bindgen]
-pub async fn init_sqlite() {
-    let sqlite = diesel::init_sqlite().await.unwrap();
-    sqlite.install_opfs_sahpool(None).await.unwrap();
+pub async fn install_opfs_sahpool() {
+    sqlite_wasm_rs::export::install_opfs_sahpool(None, false)
+        .await
+        .unwrap();
 }
 
 #[wasm_bindgen]

--- a/examples/sqlite/wasm/worker.js
+++ b/examples/sqlite/wasm/worker.js
@@ -1,5 +1,5 @@
 import init, {
-    init_sqlite,
+    install_opfs_sahpool,
     switch_vfs,
     create_post,
     get_post,
@@ -9,7 +9,7 @@ import init, {
 } from "./pkg/sqlite_wasm_example.js";
 
 await init();
-await init_sqlite();
+await install_opfs_sahpool();
 
 async function run_in_worker(event) {
     const payload = event.data;
@@ -65,7 +65,7 @@ async function run_in_worker(event) {
     };
 }
 
-self.onmessage = function (event) {
+self.onmessage = function(event) {
     run_in_worker(event);
 }
 


### PR DESCRIPTION
sqlite-wasm-rs has been updated to a major version, providing a better implementation. For details, see <https://github.com/diesel-rs/diesel/discussions/4473>

There are some breaking changes, such as no longer exporting `init_sqlite()`. But I realized that the last merged commit has not been released yet, and I think it is appropriate to merge it now.