### PR TITLE
Tighten bignum dependency versions

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -35,10 +35,10 @@ percent-encoding = { version = "2.1.0", optional = true }
 uuid = { version = ">=0.7.0, <2.0.0", optional = true }
 ipnetwork = { version = ">=0.12.2, <0.22.0", optional = true }
 ipnet = { version = "2.5.0", optional = true }
-num-bigint = { version = ">=0.2.0, <0.5.0", optional = true }
+num-bigint = { version = "0.4", optional = true }
 num-traits = { version = "0.2.0", optional = true }
 num-integer = { version = "0.1.39", optional = true }
-bigdecimal = { version = ">=0.0.13, < 0.5.0", optional = true }
+bigdecimal = { version = "0.4", optional = true }
 bitflags = { version = "2.0.0", optional = true }
 r2d2 = { version = ">= 0.8.2, < 0.9.0", optional = true }
 itoa = { version = "1.0.0", optional = true }


### PR DESCRIPTION
Fixes #4477

As `bigdecimal` API exposes implementations of traits defined in a particular version of `num-bigint`, it's fragile to have loosely ranged versions on these dependencies. Lock both down to the currently latest ^0.4, that's consistent with how `bigdecimal` 0.4.x depends on `num-bigint`.