### PR TITLE
feat(sqlite): add json_array_length fn

### DIFF
--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -146,17 +146,7 @@ extern "SQL" {
     ///
     /// assert_eq!(json!(4), result);
     ///
-    /// let result = diesel::select(json_array_length::<Jsonb, _>(json!([1,2,3,4])))
-    ///     .get_result::<Value>(connection)?;
-    ///
-    /// assert_eq!(json!(4), result);
-    ///
     /// let result = diesel::select(json_array_length::<Json, _>(json!({"one":[1,2,3]})))
-    ///     .get_result::<Value>(connection)?;
-    ///
-    /// assert_eq!(json!(0), result);
-    ///
-    /// let result = diesel::select(json_array_length::<Jsonb, _>(json!({"one":[1,2,3]})))
     ///     .get_result::<Value>(connection)?;
     ///
     /// assert_eq!(json!(0), result);
@@ -165,6 +155,16 @@ extern "SQL" {
     ///     .get_result::<Option<Value>>(connection)?;
     ///
     /// assert_eq!(None, result);
+    ///
+    /// let result = diesel::select(json_array_length::<Jsonb, _>(json!([1,2,3,4])))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(4), result);
+    ///
+    /// let result = diesel::select(json_array_length::<Jsonb, _>(json!({"one":[1,2,3]})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(0), result);
     ///
     /// let result = diesel::select(json_array_length::<Nullable<Jsonb>, _>(None::<Value>))
     ///     .get_result::<Option<Value>>(connection)?;
@@ -198,7 +198,7 @@ extern "SQL" {
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::{sql, json_array_length_with_path};
     /// #     use serde_json::{json, Value};
-    /// #     use diesel::sql_types::{Json, Text, Nullable};
+    /// #     use diesel::sql_types::{Json, Jsonb, Text, Nullable};
     /// #     let connection = &mut establish_connection();
     ///
     /// let version = diesel::select(sql::<Text>("sqlite_version();"))
@@ -233,6 +233,26 @@ extern "SQL" {
     /// assert_eq!(json!(3), result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Nullable<Json>, _, _>(json!({"one":[1,2,3]}), "$.two"))
+    ///     .get_result::<Option<Value>>(connection)?;
+    ///
+    /// assert_eq!(None, result);
+    ///
+    /// let result = diesel::select(json_array_length_with_path::<Jsonb, _, _>(json!([1,2,3,4]), "$"))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(4), result);
+    ///
+    /// let result = diesel::select(json_array_length_with_path::<Jsonb, _, _>(json!([1,2,3,4]), "$[2]"))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(0), result);
+    ///
+    /// let result = diesel::select(json_array_length_with_path::<Jsonb, _, _>(json!({"one":[1,2,3]}), "$.one"))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(3), result);
+    ///
+    /// let result = diesel::select(json_array_length_with_path::<Nullable<Jsonb>, _, _>(json!({"one":[1,2,3]}), "$.two"))
     ///     .get_result::<Option<Value>>(connection)?;
     ///
     /// assert_eq!(None, result);

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -142,32 +142,32 @@ extern "SQL" {
     /// }
     ///
     /// let result = diesel::select(json_array_length::<Json, _>(json!([1,2,3,4])))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<i32>(connection)?;
     ///
-    /// assert_eq!(json!(4), result);
+    /// assert_eq!(4, result);
     ///
     /// let result = diesel::select(json_array_length::<Json, _>(json!({"one":[1,2,3]})))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<i32>(connection)?;
     ///
-    /// assert_eq!(json!(0), result);
+    /// assert_eq!(0, result);
     ///
     /// let result = diesel::select(json_array_length::<Nullable<Json>, _>(None::<Value>))
-    ///     .get_result::<Option<Value>>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
     /// assert_eq!(None, result);
     ///
     /// let result = diesel::select(json_array_length::<Jsonb, _>(json!([1,2,3,4])))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<i32>(connection)?;
     ///
-    /// assert_eq!(json!(4), result);
+    /// assert_eq!(4, result);
     ///
     /// let result = diesel::select(json_array_length::<Jsonb, _>(json!({"one":[1,2,3]})))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<i32>(connection)?;
     ///
-    /// assert_eq!(json!(0), result);
+    /// assert_eq!(0, result);
     ///
     /// let result = diesel::select(json_array_length::<Nullable<Jsonb>, _>(None::<Value>))
-    ///     .get_result::<Option<Value>>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
     /// assert_eq!(None, result);
     ///
@@ -175,7 +175,11 @@ extern "SQL" {
     /// # }
     /// ```
     #[cfg(feature = "sqlite")]
-    fn json_array_length<J: JsonOrNullableJsonOrJsonbOrNullableJsonb + MaybeNullableValue<Json>>(j: J) -> J::Out;
+    fn json_array_length<
+        J: JsonOrNullableJsonOrJsonbOrNullableJsonb + MaybeNullableValue<Integer>,
+    >(
+        j: J,
+    ) -> J::Out;
 
     /// The json_array_length(X) function returns the number of elements in the JSON array X,
     /// or 0 if X is some kind of JSON value other than an array.
@@ -218,42 +222,42 @@ extern "SQL" {
     /// }
     ///
     /// let result = diesel::select(json_array_length_with_path::<Json, _, _>(json!([1,2,3,4]), "$"))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
-    /// assert_eq!(json!(4), result);
+    /// assert_eq!(Some(4), result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Json, _, _>(json!([1,2,3,4]), "$[2]"))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
-    /// assert_eq!(json!(0), result);
+    /// assert_eq!(Some(0), result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Json, _, _>(json!({"one":[1,2,3]}), "$.one"))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
-    /// assert_eq!(json!(3), result);
+    /// assert_eq!(Some(3), result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Nullable<Json>, _, _>(json!({"one":[1,2,3]}), "$.two"))
-    ///     .get_result::<Option<Value>>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
     /// assert_eq!(None, result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Jsonb, _, _>(json!([1,2,3,4]), "$"))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
-    /// assert_eq!(json!(4), result);
+    /// assert_eq!(Some(4), result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Jsonb, _, _>(json!([1,2,3,4]), "$[2]"))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
-    /// assert_eq!(json!(0), result);
+    /// assert_eq!(Some(0), result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Jsonb, _, _>(json!({"one":[1,2,3]}), "$.one"))
-    ///     .get_result::<Value>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
-    /// assert_eq!(json!(3), result);
+    /// assert_eq!(Some(3), result);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Nullable<Jsonb>, _, _>(json!({"one":[1,2,3]}), "$.two"))
-    ///     .get_result::<Option<Value>>(connection)?;
+    ///     .get_result::<Option<i32>>(connection)?;
     ///
     /// assert_eq!(None, result);
     ///
@@ -262,7 +266,10 @@ extern "SQL" {
     /// ```
     #[sql_name = "json_array_length"]
     #[cfg(feature = "sqlite")]
-    fn json_array_length_with_path<J: JsonOrNullableJsonOrJsonbOrNullableJsonb + MaybeNullableValue<Json>>(j: J, path: Text) -> J::Out;
+    fn json_array_length_with_path<J: JsonOrNullableJsonOrJsonbOrNullableJsonb + SingleValue>(
+        j: J,
+        path: Text,
+    ) -> Nullable<Integer>;
 
     /// Converts the given json value to pretty-printed, indented text
     ///

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -17,6 +17,17 @@ pub type json<E> = super::functions::json<SqlTypeOf<E>, E>;
 #[cfg(feature = "sqlite")]
 pub type jsonb<E> = super::functions::jsonb<SqlTypeOf<E>, E>;
 
+/// Return type of [`json_array_length(json)`](super::functions::json_array_length())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_array_length<J> = super::functions::json_array_length<SqlTypeOf<J>, J>;
+
+/// Return type of [`json_array_length(json, path)`](super::functions::json_array_length_with_path())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_array_length_with_path<J, P> =
+    super::functions::json_array_length_with_path<SqlTypeOf<J>, J, P>;
+
 /// Return type of [`json_pretty(json)`](super::functions::json_pretty())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -505,6 +505,8 @@ fn sqlite_functions() -> _ {
     (
         json(sqlite_extras::text),
         jsonb(sqlite_extras::blob),
+        json_array_length(sqlite_extras::json),
+        json_array_length_with_path(sqlite_extras::json, sqlite_extras::text),
         json_pretty(sqlite_extras::json),
         json_pretty(sqlite_extras::jsonb),
         json_pretty_with_indentation(sqlite_extras::json, "  "),


### PR DESCRIPTION
# Add json_array_length to sqlite json functions

- related to https://github.com/diesel-rs/diesel/issues/4366

## Notes

- I noticed the doc-tests don't work with outdated versions of sqlite
  - `use diesel::dsl::json_array_length` was the postgres version ?!
  - `use diesel::dsl::json_array_length_with_path` was not found
- this is why I added sqlite version assertion
  - that might break CI
  - that might explain why doctests are skipped for `json_pretty` in the same file below a certain version
- as of now, I am not aware if there some kind official version support
- using the apt package manager in Pop_os, i had to manually install libsqlite3 since the version from apt was outdated

## Install sqlite3 lib

- download `sqlite-autoconf-<VERSION>.tar.gz` from https://www.sqlite.org/download.html
- unpack the file: `tar xvfz ../sqlite-autoconf-<VERSION>.tar.gz`
- get into the created folder
- run `./configure`
- run `make`
- run `sudo make install`
- find where to put `libsqlite3.so`  (`find / -name libsqlite3.so ...` => in my case `/usr/lib/x86_64-linux-gnu`) and copy the file (in my case had to make a symbolic link too)