### PR TITLE
Make sqlite value function public

### DIFF
--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -16,8 +16,9 @@ use super::row::PrivateSqliteRow;
 
 /// Raw sqlite value as received from the database
 ///
-/// Use existing `FromSql` implementations to convert this into
-/// rust values
+/// Use the `read_*` functions to access the actual
+/// value or use existing `FromSql` implementations
+/// to convert this into rust values
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct SqliteValue<'row, 'stmt, 'query> {
     // This field exists to ensure that nobody
@@ -90,7 +91,7 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
         }
     }
 
-    pub(crate) fn parse_string<'value, R>(&'value self, f: impl FnOnce(&'value str) -> R) -> R {
+    pub(crate) fn parse_string<'value, R>(&'value mut self, f: impl FnOnce(&'value str) -> R) -> R {
         let s = unsafe {
             let ptr = ffi::sqlite3_value_text(self.value.as_ptr());
             let len = ffi::sqlite3_value_bytes(self.value.as_ptr());
@@ -106,11 +107,29 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
         f(s)
     }
 
-    pub(crate) fn read_text(&self) -> &str {
+    /// Read the underlying value as string
+    ///
+    /// If the underlying value is not a string sqlite will convert it
+    /// into a string and return that value instead.
+    ///
+    /// Use the [`value_type()`] function to determine the actual
+    /// type of the value.
+    ///
+    /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
+    pub fn read_text(&mut self) -> &str {
         self.parse_string(|s| s)
     }
 
-    pub(crate) fn read_blob(&self) -> &[u8] {
+    /// Read the underlying value as blob
+    ///
+    /// If the underlying value is not a blob sqlite will convert it
+    /// into a blob and return that value instead.
+    ///
+    /// Use the [`value_type()`] function to determine the actual
+    /// type of the value.
+    ///
+    /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
+    pub fn read_blob(&mut self) -> &[u8] {
         unsafe {
             let ptr = ffi::sqlite3_value_blob(self.value.as_ptr());
             let len = ffi::sqlite3_value_bytes(self.value.as_ptr());
@@ -128,15 +147,42 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
         }
     }
 
-    pub(crate) fn read_integer(&self) -> i32 {
+    /// Read the underlying value as 32 bit integer
+    ///
+    /// If the underlying value is not an integer sqlite will convert it
+    /// into an integer and return that value instead.
+    ///
+    /// Use the [`value_type()`] function to determine the actual
+    /// type of the value.
+    ///
+    /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
+    pub fn read_integer(&mut self) -> i32 {
         unsafe { ffi::sqlite3_value_int(self.value.as_ptr()) }
     }
 
-    pub(crate) fn read_long(&self) -> i64 {
+    /// Read the underlying value as 64 bit integer
+    ///
+    /// If the underlying value is not a string sqlite will convert it
+    /// into a string and return that value instead.
+    ///
+    /// Use the [`value_type()`] function to determine the actual
+    /// type of the value.
+    ///
+    /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
+    pub fn read_long(&mut self) -> i64 {
         unsafe { ffi::sqlite3_value_int64(self.value.as_ptr()) }
     }
 
-    pub(crate) fn read_double(&self) -> f64 {
+    /// Read the underlying value as 64 bit float
+    ///
+    /// If the underlying value is not a string sqlite will convert it
+    /// into a string and return that value instead.
+    ///
+    /// Use the [`value_type()`] function to determine the actual
+    /// type of the value.
+    ///
+    /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
+    pub fn read_double(&mut self) -> f64 {
         unsafe { ffi::sqlite3_value_double(self.value.as_ptr()) }
     }
 
@@ -180,5 +226,86 @@ impl OwnedSqliteValue {
                  https://github.com/diesel-rs/diesel.",
         );
         OwnedSqliteValue { value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::connection::{LoadConnection, SimpleConnection};
+    use crate::row::Field;
+    use crate::row::Row;
+    use crate::sql_types::{Blob, Double, Int4, Text};
+    use crate::*;
+
+    #[expect(clippy::approx_constant)] // we really want to use 3.14
+    #[diesel_test_helper::test]
+    fn can_convert_all_values() {
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+
+        conn.batch_execute("CREATE TABLE tests(int INTEGER, text TEXT, blob BLOB, float FLOAT)")
+            .unwrap();
+
+        diesel::sql_query("INSERT INTO tests(int, text, blob, float) VALUES(?, ?, ?, ?)")
+            .bind::<Int4, _>(42)
+            .bind::<Text, _>("foo")
+            .bind::<Blob, _>(b"foo")
+            .bind::<Double, _>(3.14)
+            .execute(&mut conn)
+            .unwrap();
+
+        let mut res = conn
+            .load(diesel::sql_query(
+                "SELECT int, text, blob, float FROM tests",
+            ))
+            .unwrap();
+        let row = res.next().unwrap().unwrap();
+        let int_field = row.get(0).unwrap();
+        let text_field = row.get(1).unwrap();
+        let blob_field = row.get(2).unwrap();
+        let float_field = row.get(3).unwrap();
+
+        let mut int_value = int_field.value().unwrap();
+        assert_eq!(int_value.read_integer(), 42);
+        let mut int_value = int_field.value().unwrap();
+        assert_eq!(int_value.read_long(), 42);
+        let mut int_value = int_field.value().unwrap();
+        assert_eq!(int_value.read_double(), 42.0);
+        let mut int_value = int_field.value().unwrap();
+        assert_eq!(int_value.read_text(), "42");
+        let mut int_value = int_field.value().unwrap();
+        assert_eq!(int_value.read_blob(), b"42");
+
+        let mut text_value = text_field.value().unwrap();
+        assert_eq!(text_value.read_integer(), 0);
+        let mut text_value = text_field.value().unwrap();
+        assert_eq!(text_value.read_long(), 0);
+        let mut text_value = text_field.value().unwrap();
+        assert_eq!(text_value.read_double(), 0.0);
+        let mut text_value = text_field.value().unwrap();
+        assert_eq!(text_value.read_text(), "foo");
+        let mut text_value = text_field.value().unwrap();
+        assert_eq!(text_value.read_blob(), b"foo");
+
+        let mut blob_value = blob_field.value().unwrap();
+        assert_eq!(blob_value.read_integer(), 0);
+        let mut blob_value = blob_field.value().unwrap();
+        assert_eq!(blob_value.read_long(), 0);
+        let mut blob_value = blob_field.value().unwrap();
+        assert_eq!(blob_value.read_double(), 0.0);
+        let mut blob_value = blob_field.value().unwrap();
+        assert_eq!(blob_value.read_text(), "foo");
+        let mut blob_value = blob_field.value().unwrap();
+        assert_eq!(blob_value.read_blob(), b"foo");
+
+        let mut float_value = float_field.value().unwrap();
+        assert_eq!(float_value.read_integer(), 3);
+        let mut float_value = float_field.value().unwrap();
+        assert_eq!(float_value.read_long(), 3);
+        let mut float_value = float_field.value().unwrap();
+        assert_eq!(float_value.read_double(), 3.14);
+        let mut float_value = float_field.value().unwrap();
+        assert_eq!(float_value.read_text(), "3.14");
+        let mut float_value = float_field.value().unwrap();
+        assert_eq!(float_value.read_blob(), b"3.14");
     }
 }

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -84,7 +84,7 @@ fn parse_julian(julian_days: f64) -> Option<NaiveDateTime> {
 
 #[cfg(all(feature = "sqlite", feature = "chrono"))]
 impl FromSql<Date, Sqlite> for NaiveDate {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value
             .parse_string(|s| Self::parse_from_str(s, DATE_FORMAT))
             .map_err(Into::into)
@@ -101,7 +101,7 @@ impl ToSql<Date, Sqlite> for NaiveDate {
 
 #[cfg(all(feature = "sqlite", feature = "chrono"))]
 impl FromSql<Time, Sqlite> for NaiveTime {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value.parse_string(|text| {
             for format in TIME_FORMATS {
                 if let Ok(time) = Self::parse_from_str(text, format) {
@@ -124,7 +124,7 @@ impl ToSql<Time, Sqlite> for NaiveTime {
 
 #[cfg(all(feature = "sqlite", feature = "chrono"))]
 impl FromSql<Timestamp, Sqlite> for NaiveDateTime {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value.parse_string(|text| {
             for format in NAIVE_DATETIME_FORMATS {
                 if let Ok(dt) = Self::parse_from_str(text, format) {
@@ -153,7 +153,7 @@ impl ToSql<Timestamp, Sqlite> for NaiveDateTime {
 
 #[cfg(all(feature = "sqlite", feature = "chrono"))]
 impl FromSql<TimestamptzSqlite, Sqlite> for NaiveDateTime {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value.parse_string(|text| {
             for format in NAIVE_DATETIME_FORMATS {
                 if let Ok(dt) = Self::parse_from_str(text, format) {
@@ -182,7 +182,7 @@ impl ToSql<TimestamptzSqlite, Sqlite> for NaiveDateTime {
 
 #[cfg(all(feature = "sqlite", feature = "chrono"))]
 impl FromSql<TimestamptzSqlite, Sqlite> for DateTime<Utc> {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         // First try to parse the timezone
         if let Ok(dt) = value.parse_string(|text| {
             for format in DATETIME_FORMATS {
@@ -205,7 +205,7 @@ impl FromSql<TimestamptzSqlite, Sqlite> for DateTime<Utc> {
 
 #[cfg(all(feature = "sqlite", feature = "chrono"))]
 impl FromSql<TimestamptzSqlite, Sqlite> for DateTime<Local> {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         // First try to parse the timezone
         if let Ok(dt) = value.parse_string(|text| {
             for format in DATETIME_FORMATS {

--- a/diesel/src/sqlite/types/date_and_time/time.rs
+++ b/diesel/src/sqlite/types/date_and_time/time.rs
@@ -137,7 +137,7 @@ fn parse_julian(julian_days: f64) -> Result<PrimitiveDateTime, ComponentRange> {
 
 #[cfg(all(feature = "sqlite", feature = "time"))]
 impl FromSql<Date, Sqlite> for NaiveDate {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value
             .parse_string(|s| Self::parse(s, DATE_FORMAT))
             .map_err(Into::into)
@@ -154,7 +154,7 @@ impl ToSql<Date, Sqlite> for NaiveDate {
 
 #[cfg(all(feature = "sqlite", feature = "time"))]
 impl FromSql<Time, Sqlite> for NaiveTime {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value.parse_string(|text| {
             for format in TIME_FORMATS {
                 if let Ok(time) = Self::parse(text, format) {
@@ -182,7 +182,7 @@ impl ToSql<Time, Sqlite> for NaiveTime {
 
 #[cfg(all(feature = "sqlite", feature = "time"))]
 impl FromSql<Timestamp, Sqlite> for PrimitiveDateTime {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value.parse_string(|text| {
             for format in PRIMITIVE_DATETIME_FORMATS {
                 if let Ok(dt) = Self::parse(text, format) {
@@ -216,7 +216,7 @@ impl ToSql<Timestamp, Sqlite> for PrimitiveDateTime {
 
 #[cfg(all(feature = "sqlite", feature = "time"))]
 impl FromSql<TimestamptzSqlite, Sqlite> for PrimitiveDateTime {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         value.parse_string(|text| {
             for format in PRIMITIVE_DATETIME_FORMATS {
                 if let Ok(dt) = Self::parse(text, format) {
@@ -250,7 +250,7 @@ impl ToSql<TimestamptzSqlite, Sqlite> for PrimitiveDateTime {
 
 #[cfg(all(feature = "sqlite", feature = "time"))]
 impl FromSql<TimestamptzSqlite, Sqlite> for OffsetDateTime {
-    fn from_sql(value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         // First try to parse the timezone
         if let Ok(dt) = value.parse_string(|text| {
             for format in DATETIME_FORMATS {

--- a/diesel/src/sqlite/types/json.rs
+++ b/diesel/src/sqlite/types/json.rs
@@ -7,7 +7,7 @@ use crate::sqlite::{Sqlite, SqliteValue};
 
 #[cfg(all(feature = "sqlite", feature = "serde_json"))]
 impl FromSql<sql_types::Json, Sqlite> for serde_json::Value {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         serde_json::from_str(value.read_text()).map_err(|_| "Invalid Json".into())
     }
 }
@@ -22,7 +22,7 @@ impl ToSql<sql_types::Json, Sqlite> for serde_json::Value {
 
 #[cfg(all(feature = "sqlite", feature = "serde_json"))]
 impl FromSql<sql_types::Jsonb, Sqlite> for serde_json::Value {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         use self::jsonb::*;
 
         let bytes = value.read_blob();

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -18,7 +18,7 @@ use crate::sql_types::SqlType;
 /// `FromSql`
 #[cfg(feature = "sqlite")]
 impl FromSql<sql_types::VarChar, Sqlite> for *const str {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         let text = value.read_text();
         Ok(text as *const _)
     }
@@ -40,7 +40,7 @@ impl Queryable<sql_types::VarChar, Sqlite> for *const str {
 /// `FromSql`
 #[cfg(feature = "sqlite")]
 impl FromSql<sql_types::Binary, Sqlite> for *const [u8] {
-    fn from_sql(bytes: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut bytes: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         let bytes = bytes.read_blob();
         Ok(bytes as *const _)
     }
@@ -58,28 +58,28 @@ impl Queryable<sql_types::Binary, Sqlite> for *const [u8] {
 #[cfg(feature = "sqlite")]
 #[allow(clippy::cast_possible_truncation)] // we want to truncate here
 impl FromSql<sql_types::SmallInt, Sqlite> for i16 {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_integer() as i16)
     }
 }
 
 #[cfg(feature = "sqlite")]
 impl FromSql<sql_types::Integer, Sqlite> for i32 {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_integer())
     }
 }
 
 #[cfg(feature = "sqlite")]
 impl FromSql<sql_types::Bool, Sqlite> for bool {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_integer() != 0)
     }
 }
 
 #[cfg(feature = "sqlite")]
 impl FromSql<sql_types::BigInt, Sqlite> for i64 {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_long())
     }
 }
@@ -87,14 +87,14 @@ impl FromSql<sql_types::BigInt, Sqlite> for i64 {
 #[cfg(feature = "sqlite")]
 #[allow(clippy::cast_possible_truncation)] // we want to truncate here
 impl FromSql<sql_types::Float, Sqlite> for f32 {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_double() as f32)
     }
 }
 
 #[cfg(feature = "sqlite")]
 impl FromSql<sql_types::Double, Sqlite> for f64 {
-    fn from_sql(value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+    fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         Ok(value.read_double())
     }
 }


### PR DESCRIPTION
This commit turns the `read_*` functions of the `SqliteValue` type into public functions, which makes it easier for third party crates to access the underlying sqlite values in a performant way. This enables crates to not clone for example the string, but rather reuse the string slice we got from sqlite instead.

This also turns all these functions into methods that require a mutable reference instead of a shared reference as technically each of those methods might mutate the underlying value according to the sqlite documentation.