### PR TITLE
Make `#[diesel(embed)]` fields be somewhat-checked by `#[check_for_backend]`

### DIFF
--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
@@ -25,6 +25,13 @@ struct UserCorrect {
     name: String,
 }
 
+#[derive(Selectable, Queryable)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+struct SelectableWithEmbed {
+    #[diesel(embed)]
+    embed_user: User,
+}
+
 fn main() {
     let mut conn = PgConnection::establish("...").unwrap();
 

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -31,10 +31,38 @@ error[E0277]: cannot deserialize a value of the database type `diesel::sql_types
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214
 
-error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<User, _>: load_dsl::private::CompatibleType<_, _>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:33:15
+error[E0277]: the trait bound `(std::string::String, i32): FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:32:17
    |
-33 |         .load(&mut conn)
+32 |     embed_user: User,
+   |                 ^^^^ the trait `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not implemented for `(std::string::String, i32)`
+   |
+   = help: the following other types implement trait `FromStaticSqlRow<ST, DB>`:
+             `(T0,)` implements `FromStaticSqlRow<(ST0,), __DB>`
+             `(T1, T0)` implements `FromStaticSqlRow<(ST1, ST0), __DB>`
+             `(T1, T2, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST0), __DB>`
+             `(T1, T2, T3, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST0), __DB>`
+             `(T1, T2, T3, T4, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST4, ST0), __DB>`
+             `(T1, T2, T3, T4, T5, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST4, ST5, ST0), __DB>`
+             `(T1, T2, T3, T4, T5, T6, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST0), __DB>`
+             `(T1, T2, T3, T4, T5, T6, T7, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST0), __DB>`
+           and $N others
+note: required for `User` to implement `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+  --> tests/fail/selectable_with_typemisamatch.rs:12:22
+   |
+12 | #[derive(Selectable, Queryable)]
+   |                      ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+...
+15 | struct User {
+   |        ^^^^
+   = note: required for `User` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+   = help: see issue #48214
+   = note: this error originates in the derive macro `Queryable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<User, _>: load_dsl::private::CompatibleType<_, _>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:40:15
+   |
+40 |         .load(&mut conn)
    |          ---- ^^^^^^^^^ the trait `load_dsl::private::CompatibleType<_, _>` is not implemented for `diesel::expression::select_by::SelectBy<User, _>`
    |          |
    |          required by a bound introduced by this call

--- a/diesel_derives/src/selectable.rs
+++ b/diesel_derives/src/selectable.rs
@@ -1,8 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::spanned::Spanned;
-use syn::DeriveInput;
-use syn::{parse_quote, Result};
+use syn::{parse_quote, DeriveInput, Result};
 
 use crate::field::Field;
 use crate::model::Model;
@@ -48,7 +47,6 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             .fields()
             .iter()
             .zip(&field_columns_ty)
-            .filter(|(f, _)| !f.embed())
             .flat_map(|(f, ty)| {
                 backends.iter().map(move |b| {
                     let span = f.ty.span();

--- a/diesel_derives/src/selectable.rs
+++ b/diesel_derives/src/selectable.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
+use std::borrow::Cow;
 use syn::spanned::Spanned;
 use syn::{parse_quote, DeriveInput, Result};
 
@@ -31,12 +32,16 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let struct_name = &item.ident;
 
     let mut compile_errors: Vec<syn::Error> = Vec::new();
-    let field_columns_ty = model
+    let field_select_expression_type_builders = model
         .fields()
         .iter()
-        .map(|f| field_column_ty(f, &model, &mut compile_errors))
+        .map(|f| field_select_expression_ty_builder(f, &model, &mut compile_errors))
         .collect::<Result<Vec<_>>>()?;
-    let field_columns_inst = model
+    let field_select_expression_types = field_select_expression_type_builders
+        .iter()
+        .map(|f| f.type_with_backend(&parse_quote!(__DB)))
+        .collect::<Vec<_>>();
+    let field_select_expressions = model
         .fields()
         .iter()
         .map(|f| field_column_inst(f, &model))
@@ -46,11 +51,12 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         let field_check_bound = model
             .fields()
             .iter()
-            .zip(&field_columns_ty)
-            .flat_map(|(f, ty)| {
+            .zip(&field_select_expression_type_builders)
+            .flat_map(|(f, ty_builder)| {
                 backends.iter().map(move |b| {
                     let span = f.ty.span();
                     let field_ty = to_field_ty_bound(f.ty_for_deserialize())?;
+                    let ty = ty_builder.type_with_backend(b);
                     Ok(syn::parse_quote_spanned! {span =>
                         #field_ty: diesel::deserialize::FromSqlRow<diesel::dsl::SqlTypeOf<#ty>, #b>
                     })
@@ -83,10 +89,10 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             for #struct_name #ty_generics
         #where_clause
         {
-            type SelectExpression = (#(#field_columns_ty,)*);
+            type SelectExpression = (#(#field_select_expression_types,)*);
 
             fn construct_selection() -> Self::SelectExpression {
-                (#(#field_columns_inst,)*)
+                (#(#field_select_expressions,)*)
             }
         }
 
@@ -122,11 +128,11 @@ fn to_field_ty_bound(field_ty: &syn::Type) -> Result<TokenStream> {
     }
 }
 
-fn field_column_ty(
-    field: &Field,
+fn field_select_expression_ty_builder<'a>(
+    field: &'a Field,
     model: &Model,
     compile_errors: &mut Vec<syn::Error>,
-) -> Result<TokenStream> {
+) -> Result<FieldSelectExpressionTyBuilder<'a>> {
     if let Some(ref select_expression) = field.select_expression {
         use dsl_auto_type::auto_type::expression_type_inference as type_inference;
         let expr = &select_expression.item;
@@ -140,17 +146,38 @@ fn field_column_ty(
                 .build(),
         );
         compile_errors.extend(errors);
-        Ok(quote::quote!(#inferred_type))
+        Ok(FieldSelectExpressionTyBuilder::Always(
+            quote::quote!(#inferred_type),
+        ))
     } else if let Some(ref select_expression_type) = field.select_expression_type {
         let ty = &select_expression_type.item;
-        Ok(quote!(#ty))
+        Ok(FieldSelectExpressionTyBuilder::Always(quote!(#ty)))
     } else if field.embed() {
-        let embed_ty = &field.ty;
-        Ok(quote!(<#embed_ty as Selectable<__DB>>::SelectExpression))
+        Ok(FieldSelectExpressionTyBuilder::EmbedSelectable {
+            embed_ty: &field.ty,
+        })
     } else {
         let table_name = &model.table_names()[0];
         let column_name = field.column_name()?.to_ident()?;
-        Ok(quote!(#table_name::#column_name))
+        Ok(FieldSelectExpressionTyBuilder::Always(
+            quote!(#table_name::#column_name),
+        ))
+    }
+}
+
+enum FieldSelectExpressionTyBuilder<'a> {
+    Always(TokenStream),
+    EmbedSelectable { embed_ty: &'a syn::Type },
+}
+
+impl FieldSelectExpressionTyBuilder<'_> {
+    fn type_with_backend(&self, backend: &syn::TypePath) -> Cow<'_, TokenStream> {
+        match self {
+            FieldSelectExpressionTyBuilder::Always(ty) => Cow::Borrowed(ty),
+            FieldSelectExpressionTyBuilder::EmbedSelectable { embed_ty } => {
+                Cow::Owned(quote!(<#embed_ty as Selectable<#backend>>::SelectExpression))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Currently when a struct has `#[derive(Selectable)]`, `#[check_for_backend(...)]`, and `embed`s another `Selectable` struct that doesn't have `#[check_for_backend]` but whose `FromSqlRow` and `Selectable` impls don't match with regards to `CompatibleType`, the `#[check_for_backend]` does not point us to which of the embed fields is the culprit, because they are ignored.

It seems that this can be avoided by generating the checks even for `embed` fields.

The compatibility check was disabled on `#[embed]` fields in d6d9260e386d2472719c9b7c9babe5dd9644a8bf when the experimented-with approach was "always generating the check on Selectable" with the justification that it was consequently checked by the underlying field's own Selectable checks, before it was decided to instead have the `#[check_for_backend(...)]` attribute, so it seems that this justification was indeed legitimate at the time it was introduced, and doesn't hold anymore now.