### PR TITLE
Add pg_lsn postgres data type

### DIFF
--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -62,6 +62,8 @@ pub mod data_types {
     #[doc(inline)]
     pub use super::types::money::PgMoney;
     pub use super::types::money::PgMoney as Cents;
+    #[doc(inline)]
+    pub use super::types::pg_lsn::PgLsn;
 }
 
 #[doc(inline)]

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -688,7 +688,7 @@ pub mod sql_types {
     /// [`pg_lsn`]: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
     #[cfg(feature = "postgres_backend")]
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
-    #[diesel(postgres_type(name = "pg_lsn"))]
+    #[diesel(postgres_type(oid = 3220, array_oid = 3221))]
     pub struct PgLsn;
 }
 

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -19,6 +19,7 @@ mod multirange;
 #[cfg(feature = "network-address")]
 mod network_address;
 mod numeric;
+pub(in crate::pg) mod pg_lsn;
 mod primitives;
 mod ranges;
 mod record;
@@ -670,6 +671,25 @@ pub mod sql_types {
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
     #[diesel(postgres_type(name = "citext"))]
     pub struct Citext;
+
+    /// The [`pg_lsn`] SQL type. This is a PostgreSQL specific type. Encodes a position in the PostgreSQL *Write Ahead Log* (WAL).
+    ///
+    /// ### [`ToSql`] impls
+    ///
+    /// - [`u64`]
+    ///
+    /// ### [`FromSql`] impls
+    ///
+    /// - [`u64`]
+    ///
+    /// [`ToSql`]: crate::serialize::ToSql
+    /// [`FromSql`]: crate::deserialize::FromSql
+    /// [`u64`]: https://doc.rust-lang.org/nightly/std/primitive.u64.html
+    /// [`pg_lsn`]: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+    #[cfg(feature = "postgres_backend")]
+    #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
+    #[diesel(postgres_type(name = "pg_lsn"))]
+    pub struct PgLsn;
 }
 
 mod ops {

--- a/diesel_cli/src/infer_schema_internals/data_structures.rs
+++ b/diesel_cli/src/infer_schema_internals/data_structures.rs
@@ -58,11 +58,7 @@ impl ColumnType {
             if last.ident == "PgLsn" {
                 "pg_lsn".to_string()
             } else {
-                last.ident
-                    .to_string()
-                    .split("_")
-                    .collect::<Vec<_>>()
-                    .join(" ")
+                last.ident.to_string()
             }
         } else if let syn::PathArguments::AngleBracketed(ref args) = last.arguments {
             let arg = args.args.first().expect("There is at least one argument");

--- a/diesel_cli/src/infer_schema_internals/data_structures.rs
+++ b/diesel_cli/src/infer_schema_internals/data_structures.rs
@@ -55,11 +55,15 @@ impl ColumnType {
         };
 
         let sql_name = if !ret.is_nullable && !ret.is_array && !ret.is_unsigned {
-            last.ident
-                .to_string()
-                .split('_')
-                .collect::<Vec<_>>()
-                .join(" ")
+            if last.ident == "PgLsn" {
+                "pg_lsn".to_string()
+            } else {
+                last.ident
+                    .to_string()
+                    .split("_")
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            }
         } else if let syn::PathArguments::AngleBracketed(ref args) = last.arguments {
             let arg = args.args.first().expect("There is at least one argument");
             if let syn::GenericArgument::Type(syn::Type::Path(p)) = arg {

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -107,6 +107,7 @@ fn pg_diesel_types() -> HashSet<&'static str> {
     types.insert("Timestamptz");
     types.insert("Uuid");
     types.insert("Json");
+    types.insert("PgLsn");
     types.insert("Record");
     types.insert("Interval");
 

--- a/diesel_cli/tests/generate_migrations/diff_add_table_all_the_types/postgres/schema.rs
+++ b/diesel_cli/tests/generate_migrations/diff_add_table_all_the_types/postgres/schema.rs
@@ -33,6 +33,7 @@ table! {
         timestamptz_col -> Timestamptz,
         uuid_col -> Uuid,
         json_col -> Json,
+        pg_lsn_col -> PgLsn,
         int4range_col -> Int4range,
         int8range_col -> Int8range,
         daterange_col -> Daterange,

--- a/diesel_cli/tests/generate_migrations/diff_add_table_all_the_types/postgres/schema_out.rs/expected.snap
+++ b/diesel_cli/tests/generate_migrations/diff_add_table_all_the_types/postgres/schema_out.rs/expected.snap
@@ -41,6 +41,7 @@ diesel::table! {
         timestamptz_col -> Timestamptz,
         uuid_col -> Uuid,
         json_col -> Json,
+        pg_lsn_col -> PgLsn,
         int4range_col -> Int4range,
         int8range_col -> Int8range,
         daterange_col -> Daterange,

--- a/diesel_cli/tests/generate_migrations/diff_add_table_all_the_types/postgres/up.sql/expected.snap
+++ b/diesel_cli/tests/generate_migrations/diff_add_table_all_the_types/postgres/up.sql/expected.snap
@@ -37,6 +37,7 @@ CREATE TABLE "all_the_types"(
 	"timestamptz_col" TIMESTAMPTZ NOT NULL,
 	"uuid_col" UUID NOT NULL,
 	"json_col" JSON NOT NULL,
+	"pg_lsn_col" PG_LSN NOT NULL,
 	"int4range_col" INT4RANGE NOT NULL,
 	"int8range_col" INT8RANGE NOT NULL,
 	"daterange_col" DATERANGE NOT NULL,

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1094,6 +1094,25 @@ fn pg_macaddress8_to_sql_macaddress() {
 
 #[diesel_test_helper::test]
 #[cfg(feature = "postgres")]
+fn pg_lsn_from_sql() {
+    let query = "'08002b01/02030405'::pg_lsn";
+    let expected_value = diesel::pg::data_types::PgLsn(0x08002b0102030405);
+    assert_eq!(
+        expected_value,
+        query_single_value::<PgLsn, diesel::pg::data_types::PgLsn>(query)
+    );
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn pg_lsn_to_sql_lsn() {
+    let expected_value = "'08002b01/02030405'::pg_lsn";
+    let value = diesel::pg::data_types::PgLsn(0x08002b0102030405);
+    assert!(query_to_sql_equality::<PgLsn, diesel::pg::data_types::PgLsn>(expected_value, value));
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
 fn pg_v4address_from_sql() {
     extern crate ipnetwork;
     use std::str::FromStr;

--- a/diesel_tests/tests/types_roundtrip.rs
+++ b/diesel_tests/tests/types_roundtrip.rs
@@ -299,6 +299,8 @@ mod pg_types {
 
     test_round_trip!(char_roundtrips, CChar, u8);
 
+    test_round_trip!(pg_lsn_roundtrips, PgLsn, u64, mk_pg_lsn);
+
     #[allow(clippy::type_complexity)]
     fn mk_uuid(data: (u32, u16, u16, (u8, u8, u8, u8, u8, u8, u8, u8))) -> self::uuid::Uuid {
         let a = data.3;
@@ -471,6 +473,10 @@ mod pg_types {
 
     pub fn mk_datetime(data: (i64, u32)) -> DateTime<Utc> {
         Utc.from_utc_datetime(&mk_pg_naive_datetime(data))
+    }
+
+    pub fn mk_pg_lsn(data: u64) -> PgLsn {
+        PgLsn(data)
     }
 }
 


### PR DESCRIPTION
A `pg_lsn` encodes an offset into the Postgres Write Ahead Log (WAL). It is a native type of Postgres.