### PR TITLE
Clear up a bunch of unnecessary clones in diesel_cli config parsing

### DIFF
--- a/diesel_cli/src/migrations/diff_schema.rs
+++ b/diesel_cli/src/migrations/diff_schema.rs
@@ -26,11 +26,11 @@ fn compatible_type_list() -> HashMap<&'static str, Vec<&'static str>> {
 
 #[tracing::instrument]
 pub fn generate_sql_based_on_diff_schema(
-    config: PrintSchema,
+    mut config: PrintSchema,
     matches: &ArgMatches,
     schema_file_path: &Path,
 ) -> Result<(String, String), crate::errors::Error> {
-    let mut config = config.set_filter(matches)?;
+    config.set_filter(matches)?;
 
     let project_root = crate::find_project_root()?;
 


### PR DESCRIPTION
Noticed [upon reviewing #4500](https://github.com/diesel-rs/diesel/pull/4500/commits/df21755a278e317507ad5fec3412b05b0ccb1f0a) that there were similar unnecessary clones all throughout the file.

I went and cleaned them up but it ended up making for enough changes that I felt it deserved to be in a separate PR.

This PR should have no behavioral change.