### PR TITLE
[Bench] Add new MySQL client

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run Benchmarks (Postgres)
         if: matrix.backend == 'postgres'
-        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "postgres sqlx-bench sqlx/postgres rust_postgres tokio_postgres futures futures-util sea-orm sea-orm/sqlx-postgres criterion/async_tokio serde diesel-async diesel-async/postgres wtx"
+        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "postgres sqlx-bench sqlx/postgres rand_chacha rust_postgres tokio_postgres futures futures-util sea-orm sea-orm/sqlx-postgres criterion/async_tokio serde diesel-async diesel-async/postgres wtx"
 
       - name: Run Benchmarks (Sqlite)
         if: matrix.backend == 'sqlite'
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run Benchmarks (Mysql)
         if: matrix.backend == 'mysql'
-        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "mysql sqlx-bench sqlx/mysql tokio rustorm rustorm/with-mysql rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-mysql criterion/async_tokio serde diesel-async diesel-async/mysql"
+        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "mysql sqlx-bench sqlx/mysql tokio rustorm rustorm/with-mysql rand_chacha rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-mysql criterion/async_tokio serde diesel-async diesel-async/mysql wtx"
 
       - name: Push metrics
         env:

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", optional = true, features = ["rt-multi-thread"] }
 rusqlite = { version = "0.32", optional = true }
 rust_postgres = { version = "0.19.7", optional = true, package = "postgres" }
 tokio_postgres = { version = "0.7.10", optional = true, package = "tokio-postgres" }
+rand_chacha = { features = ["os_rng"], optional = true, version = "0.9" }
 rust_mysql = { version = "25.0", optional = true, package = "mysql" }
 rustorm = { version = "0.20", optional = true }
 rustorm_dao = { version = "0.20", optional = true }
@@ -33,7 +34,7 @@ futures-util = { version = "0.3", optional = true }
 diesel-async = { version = "0.5.0", optional = true, default-features = false }
 criterion-perf-events = { version = "0.4", optional = true }
 perfcnt = { version = "0.8", optional = true }
-wtx = { default-features = false, features = ["optimization", "postgres", "std", "tokio"], optional = true, version = "0.26" }
+wtx = { default-features = false, features = ["mysql", "optimization", "postgres", "rand_chacha", "std", "tokio"], optional = true, version = "0.28" }
 
 [dependencies.diesel]
 path = "../diesel"

--- a/diesel_bench/benches/lib.rs
+++ b/diesel_bench/benches/lib.rs
@@ -15,7 +15,7 @@ mod sea_orm_benches;
 mod sqlx_benches;
 #[cfg(all(feature = "postgres", feature = "tokio_postgres"))]
 mod tokio_postgres_benches;
-#[cfg(feature = "wtx")]
+#[cfg(all(feature = "wtx", not(feature = "sqlite")))]
 mod wtx;
 
 use criterion::{BenchmarkId, Criterion};
@@ -170,7 +170,7 @@ fn bench_trivial_query(c: &mut CriterionType) {
             crate::sea_orm_benches::bench_trivial_query(b, *i);
         });
 
-        #[cfg(all(feature = "postgres", feature = "wtx"))]
+        #[cfg(all(feature = "wtx", not(feature = "sqlite")))]
         group.bench_with_input(BenchmarkId::new("wtx", size), size, |b, i| {
             crate::wtx::bench_trivial_query(b, *i);
         });
@@ -286,7 +286,7 @@ fn bench_medium_complex_query(c: &mut CriterionType) {
             crate::sea_orm_benches::bench_medium_complex_query(b, *i);
         });
 
-        #[cfg(all(feature = "postgres", feature = "wtx"))]
+        #[cfg(all(feature = "wtx", not(feature = "sqlite")))]
         group.bench_with_input(BenchmarkId::new("wtx", size), size, |b, i| {
             crate::wtx::bench_medium_complex_query(b, *i);
         });
@@ -343,7 +343,7 @@ fn bench_loading_associations_sequentially(c: &mut CriterionType) {
         crate::sea_orm_benches::loading_associations_sequentially(b);
     });
 
-    #[cfg(feature = "wtx")]
+    #[cfg(all(feature = "wtx", not(feature = "sqlite")))]
     group.bench_function("wtx", |b| {
         crate::wtx::bench_loading_associations_sequentially(b);
     });
@@ -399,7 +399,7 @@ fn bench_insert(c: &mut CriterionType) {
             crate::sea_orm_benches::bench_insert(b, *i);
         });
 
-        #[cfg(all(feature = "postgres", feature = "wtx"))]
+        #[cfg(all(feature = "wtx", not(feature = "sqlite")))]
         group.bench_with_input(BenchmarkId::new("wtx", size), size, |b, i| {
             crate::wtx::bench_insert(b, *i);
         });


### PR DESCRIPTION
Adds the new `MySQL` client of `wtx` for evaluating purposes

Also reverts #4390. After a couple of runs, it is possible to confirm that such a thing did increase overall performance.