### PR TITLE
sqlite-json_quote(value)

### DIFF
--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -928,19 +928,25 @@ extern "SQL" {
     ///     println!("SQLite version is too old, skipping the test.");
     ///     return Ok(());
     /// }
-    /// let test_value = 3.14159
-    /// 
-    /// let result = diesel::select(json_quote::<Integer, _>(test_value)
+    /// let test_value = 42;
+    /// let result = diesel::select(json_quote::<Integer, _>(test_value))
     ///     .get_result::<Option<String>>(connection)?;
     ///
-    /// assert_eq!(Some(test_value), result);
+    /// assert_eq!(Some("42".to_string()), result);
     ///
     /// # Ok(())
     /// # }
     /// ```
     #[sql_name = "json_quote"]
     #[cfg(feature = "sqlite")]
-    fn json_quote<J: MaybeNullableValue<Integer> + MaybeNullableValue<Text>>(
-        j: J,
-    ) -> JsonOrNullableJson; 
+    fn json_quote<J: MaybeNullableValue<Integer> + MaybeNullableValue<Text>>( // Have to add Supoprt for Real/Floates, how? Existing Datatype?
+        j: J
+    ) -> Nullable<Text>;
 }
+ // double test case
+ // let test_value = 3.14159;
+ // let result = diesel::select(json_quote::<Integer, _>(test_value))
+ //     .get_result::<Option<String>>(connection)?;
+ //
+ // assert_eq!(Some("3.14159".to_string()), result);
+ 

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -892,4 +892,55 @@ extern "SQL" {
         j: J,
         path: Text,
     ) -> Nullable<Text>;
+
+    /// The json_quote(X) function converts the SQL value X (a number or a string) into its corresponding JSON 
+    /// representation. If X is a JSON value returned by another JSON function, then this function is a no-op. 
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::{sql, json_quote};
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Text, Integer, Nullable};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
+    ///         .get_result::<String>(connection)?;
+    ///
+    /// // Querying SQLite version should not fail.
+    /// let version_components: Vec<&str> = version.split('.').collect();
+    /// let major: u32 = version_components[0].parse().unwrap();
+    /// let minor: u32 = version_components[1].parse().unwrap();
+    /// let patch: u32 = version_components[2].parse().unwrap();
+    ///
+    /// if major > 3 || (major == 3 && minor >= 38) {
+    ///     /* Valid sqlite version, do nothing */
+    /// } else {
+    ///     println!("SQLite version is too old, skipping the test.");
+    ///     return Ok(());
+    /// }
+    /// let test_value = 3.14159
+    /// 
+    /// let result = diesel::select(json_quote::<Integer, _>(test_value)
+    ///     .get_result::<Option<String>>(connection)?;
+    ///
+    /// assert_eq!(Some(test_value), result);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[sql_name = "json_quote"]
+    #[cfg(feature = "sqlite")]
+    fn json_quote<J: MaybeNullableValue<Integer> + MaybeNullableValue<Text>>(
+        j: J,
+    ) -> JsonOrNullableJson; 
 }

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -910,7 +910,7 @@ extern "SQL" {
     /// # fn run_test() -> QueryResult<()> {
     /// #     use diesel::dsl::{sql, json_quote};
     /// #     use serde_json::{json, Value};
-    /// #     use diesel::sql_types::{Text, Integer, Nullable};
+    /// #     use diesel::sql_types::{Text, Json, Integer, Nullable};
     /// #     let connection = &mut establish_connection();
     ///
     /// let version = diesel::select(sql::<Text>("sqlite_version();"))
@@ -928,25 +928,41 @@ extern "SQL" {
     ///     println!("SQLite version is too old, skipping the test.");
     ///     return Ok(());
     /// }
-    /// let test_value = 42;
-    /// let result = diesel::select(json_quote::<Integer, _>(test_value))
+    /// let result = diesel::select(json_quote::<Integer, _>(42))
     ///     .get_result::<Option<String>>(connection)?;
-    ///
     /// assert_eq!(Some("42".to_string()), result);
+    ///
+    /// let result = diesel::select(json_quote::<Text, _>("verdant"))
+    ///     .get_result::<Option<String>>(connection)?;
+    /// assert_eq!(Some("\"verdant\"".to_string()), result);
+    ///
+    /// let result = diesel::select(json_quote::<Text, _>("[1]"))
+    ///     .get_result::<Option<String>>(connection)?;
+    /// assert_eq!(Some("\"[1]\"".to_string()), result);
+    ///
+    /// let result = diesel::select(json_quote::<Nullable<Text>, _>(None::<&str>))
+    ///     .get_result::<Option<String>>(connection)?;
+    /// assert_eq!(Some("null".to_string()), result);
+    ///
+    // COMENT----------------------------------------
+    // BELOW NONE WORKING TESTS, JSON and FLOAT TYPES
+    // DATATYPE FOR FLOAT NEEDED & JSON IS TREATED AS TEXT
+    // let result = diesel::select(json_quote::<Json, _>(json!([1])))
+    //     .get_result::<Option<String>>(connection)?;
+    // assert_eq!(Some("[1]".to_string()), result);
+    // 
+    // let result = diesel::select(json_quote::<Integer, _>(3.14159))
+    //     .get_result::<Option<String>>(connection)?;
+    //
+    // assert_eq!(Some("3.14159".to_string()), result);
+    // COMENT----------------------------------------
     ///
     /// # Ok(())
     /// # }
     /// ```
     #[sql_name = "json_quote"]
     #[cfg(feature = "sqlite")]
-    fn json_quote<J: MaybeNullableValue<Integer> + MaybeNullableValue<Text>>( // Have to add Supoprt for Real/Floates, how? Existing Datatype?
+    fn json_quote<J: MaybeNullableValue<Json> + MaybeNullableValue<Integer> + MaybeNullableValue<Text>>(  // Have to add Supoprt for Real/Floates, how? Existing Datatype?
         j: J
     ) -> Nullable<Text>;
 }
- // double test case
- // let test_value = 3.14159;
- // let result = diesel::select(json_quote::<Integer, _>(test_value))
- //     .get_result::<Option<String>>(connection)?;
- //
- // assert_eq!(Some("3.14159".to_string()), result);
- 

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -58,3 +58,9 @@ pub type json_type<E> = super::functions::json_type<SqlTypeOf<E>, E>;
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]
 pub type json_type_with_path<J, P> = super::functions::json_type_with_path<SqlTypeOf<J>, J, P>;
+
+/// Return type of [`json_type(json)`](super::functions::json_type())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_quote<J> = super::functions::json_quote<SqlTypeOf<J>, J>;
+

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -59,8 +59,7 @@ pub type json_type<E> = super::functions::json_type<SqlTypeOf<E>, E>;
 #[cfg(feature = "sqlite")]
 pub type json_type_with_path<J, P> = super::functions::json_type_with_path<SqlTypeOf<J>, J, P>;
 
-/// Return type of [`json_type(json)`](super::functions::json_type())
+/// Return type of [`json_quote(value)`](super::functions::json_quote())
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]
 pub type json_quote<J> = super::functions::json_quote<SqlTypeOf<J>, J>;
-

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -516,6 +516,8 @@ fn sqlite_functions() -> _ {
         json_valid(sqlite_extras::json),
         json_type(sqlite_extras::json),
         json_type_with_path(sqlite_extras::json, sqlite_extras::text),
+        json_quote(sqlite_extras::text),
+        json_quote(sqlite_extras::id),
     )
 }
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -517,6 +517,7 @@ fn sqlite_functions() -> _ {
         json_type(sqlite_extras::json),
         json_type_with_path(sqlite_extras::json, sqlite_extras::text),
         json_quote(sqlite_extras::text),
+        json_quote(sqlite_extras::json),
         json_quote(sqlite_extras::id),
     )
 }


### PR DESCRIPTION
This is not completely done and I'd need some assistance.
Two things are missing, first of all I can't find a value type for Reals/Floats  which I can use with MaybeNullableValue, does this exist?

Secondly, when passing a json as argument a no-op should happen, yet it seems like it gets treated like a normal text and therefore gets quotes around it. I'm not quite sure why this would happen, since I've added the option to call the function with json.

Some help would be appreciated. I've added comments in the code to the last commit, since I wasn't able to add any for this PR.

https://github.com/diesel-rs/diesel/issues/4366#issuecomment-2705003346