### PR TITLE
fix: mark the r2d2 connection check query as safe to cache

### DIFF
--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -447,6 +447,11 @@ where
         pass.push_sql("SELECT 1");
         Ok(())
     }
+
+    // Explicitly mark this query as safe to cache, ensuring it gets a name
+    fn is_safe_to_cache_prepared(&self, _backend: &DB) -> QueryResult<bool> {
+        Ok(true)
+    }
 }
 
 impl Query for CheckConnectionQuery {


### PR DESCRIPTION
Currently diesel runs this query as a unnamed prepared statement sending the parse and bind in different transactions. This breaks when pgbouncer is used in between diesel and postgres. https://github.com/pgbouncer/pgbouncer/issues/1288

Changing this to a named prepared statement does not affect functionality in any way, and makes this work irrespective of poolers.