### PR TITLE
Add fallible `GroupedBy` method

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -352,7 +352,7 @@ use std::hash::Hash;
 
 use crate::query_source::Table;
 
-pub use self::belongs_to::{BelongsTo, GroupedBy};
+pub use self::belongs_to::{BelongsTo, GroupedBy, TryGroupedByError};
 
 #[doc(inline)]
 pub use diesel_derives::Associations;


### PR DESCRIPTION
I am making this pull request to partially address my comments on issue #2298 , by adding a fallible alternative to the `GroupedBy::grouped_by` method, in the form of `GroupedBy::try_grouped_by`.

As suggested, the method features a default implementation that calls `GroupedBy::grouped_by`, to avoid breaking changes, but it does not change any implementations of `GroupedBy::grouped_by`, as I don't think collecting ungrouped items is appropriate in all contexts. If this is the preferred approach, I will add it in a future commit, or separate pull-request.

Additionally, I will submit this pull request as a draft for the time being, as the documentation it provides may be insufficient, and it does not include tests outside of the example used in the documentation for `GroupedBy::try_grouped_by`.