### PR TITLE
fix: use PQsendQueryParams for unnamed prepared statements

### DIFF
--- a/diesel/src/pg/connection/stmt/mod.rs
+++ b/diesel/src/pg/connection/stmt/mod.rs
@@ -13,13 +13,8 @@ use crate::result::QueryResult;
 use super::raw::RawConnection;
 
 enum StatementKind {
-    Unnamed {
-        sql: Option<CString>,
-        param_types: Option<Vec<u32>>,
-    },
-    Named {
-        name: CString,
-    },
+    Unnamed { sql: CString, param_types: Vec<u32> },
+    Named { name: CString },
 }
 
 pub(crate) struct Statement {
@@ -52,48 +47,38 @@ impl Statement {
             .try_into()
             .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
 
-        let name = match &self.kind {
-            StatementKind::Named { name } => Some(name),
-            _ => None,
-        };
-
-        if let Some(name) = name {
-            unsafe {
-                // execute the previously prepared statement
-                // in autocommit mode, this will be a new transaction
-                raw_connection.send_query_prepared(
-                    name.as_ptr(),
-                    param_count,
-                    params_pointer.as_ptr(),
-                    param_lengths.as_ptr(),
-                    self.param_formats.as_ptr(),
-                    1,
-                )
-            }?;
-        } else {
-            // execute the unnamed prepared statement using send_query_params
-            // which internally calls PQsendQueryParams, making sure the
-            // prepare and execute happens in a single transaction. This
-            // makes sure these are handled by PgBouncer.
-            // See https://github.com/diesel-rs/diesel/pull/4539
-            if let StatementKind::Unnamed {
-                sql: Some(ref sql),
-                param_types,
-            } = &self.kind
-            {
+        match &self.kind {
+            StatementKind::Named { name } => {
                 unsafe {
-                    raw_connection.send_query_params(
-                        sql.as_ptr(),
+                    // execute the previously prepared statement
+                    // in autocommit mode, this will be a new transaction
+                    raw_connection.send_query_prepared(
+                        name.as_ptr(),
                         param_count,
-                        param_types_to_ptr(param_types.as_ref()),
                         params_pointer.as_ptr(),
                         param_lengths.as_ptr(),
                         self.param_formats.as_ptr(),
                         1,
                     )
-                }?;
+                }?
             }
-        }
+            StatementKind::Unnamed { sql, param_types } => unsafe {
+                // execute the unnamed prepared statement using send_query_params
+                // which internally calls PQsendQueryParams, making sure the
+                // prepare and execute happens in a single transaction. This
+                // makes sure these are handled by PgBouncer.
+                // See https://github.com/diesel-rs/diesel/pull/4539
+                raw_connection.send_query_params(
+                    sql.as_ptr(),
+                    param_count,
+                    param_types.as_ptr(),
+                    params_pointer.as_ptr(),
+                    param_lengths.as_ptr(),
+                    self.param_formats.as_ptr(),
+                    1,
+                )
+            }?,
+        };
 
         if row_by_row {
             raw_connection.enable_row_by_row_mode()?;
@@ -107,12 +92,6 @@ impl Statement {
         is_cached: PrepareForCache,
         param_types: &[PgTypeMetadata],
     ) -> QueryResult<Self> {
-        let query_name = match is_cached {
-            PrepareForCache::Yes { counter } => Some(format!("__diesel_stmt_{counter}")),
-            PrepareForCache::No => None,
-        };
-        let name = query_name.as_deref();
-        let name_cstr = CString::new(name.unwrap_or(""))?;
         let sql_cstr = CString::new(sql)?;
         let param_types_vec = param_types
             .iter()
@@ -120,47 +99,45 @@ impl Statement {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
 
-        // For unnamed statements, we'll return a Statement object without
-        // actually preparing it. This allows us to use send_query_params
-        // later in the execute call. This is needed to better interface
-        // with PgBouncer which cannot handle unnamed prepared statements
-        // when those are prepared and executed in separate transactions.
-        // See https://github.com/diesel-rs/diesel/pull/4539
-        if query_name.is_none() {
-            return Ok(Statement {
-                kind: StatementKind::Unnamed {
-                    sql: Some(sql_cstr),
-                    param_types: Some(param_types_vec),
-                },
-                param_formats: vec![1; param_types.len()],
-            });
+        match is_cached {
+            PrepareForCache::Yes { counter } => {
+                // For named/cached statements, prepare as usual using a prepare phase and then
+                // an execute phase
+                let name_cstr = CString::new(format!("__diesel_stmt_{counter}"))?;
+                let internal_result = unsafe {
+                    let param_count: libc::c_int = param_types
+                        .len()
+                        .try_into()
+                        .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
+                    raw_connection.prepare(
+                        name_cstr.as_ptr(),
+                        sql_cstr.as_ptr(),
+                        param_count,
+                        param_types_vec.as_ptr(),
+                    )
+                };
+                PgResult::new(internal_result?, raw_connection)?;
+
+                Ok(Statement {
+                    kind: StatementKind::Named { name: name_cstr },
+                    param_formats: vec![1; param_types.len()],
+                })
+            }
+            PrepareForCache::No => {
+                // For unnamed statements, we'll return a Statement object without
+                // actually preparing it. This allows us to use send_query_params
+                // later in the execute call. This is needed to better interface
+                // with PgBouncer which cannot handle unnamed prepared statements
+                // when those are prepared and executed in separate transactions.
+                // See https://github.com/diesel-rs/diesel/pull/4539
+                Ok(Statement {
+                    kind: StatementKind::Unnamed {
+                        sql: sql_cstr,
+                        param_types: param_types_vec,
+                    },
+                    param_formats: vec![1; param_types.len()],
+                })
+            }
         }
-
-        // For named/cached statements, prepare as usual using a prepare phase and then
-        // an execute phase
-        let internal_result = unsafe {
-            let param_count: libc::c_int = param_types
-                .len()
-                .try_into()
-                .map_err(|e| crate::result::Error::SerializationError(Box::new(e)))?;
-            raw_connection.prepare(
-                name_cstr.as_ptr(),
-                sql_cstr.as_ptr(),
-                param_count,
-                param_types_to_ptr(Some(&param_types_vec)),
-            )
-        };
-        PgResult::new(internal_result?, raw_connection)?;
-
-        Ok(Statement {
-            kind: StatementKind::Named { name: name_cstr },
-            param_formats: vec![1; param_types.len()],
-        })
     }
-}
-
-fn param_types_to_ptr(param_types: Option<&Vec<u32>>) -> *const pq_sys::Oid {
-    param_types
-        .map(|types| types.as_ptr())
-        .unwrap_or(ptr::null())
 }

--- a/diesel_tests/tests/copy.rs
+++ b/diesel_tests/tests/copy.rs
@@ -262,8 +262,9 @@ fn copy_to_csv() {
 
 #[diesel_test_helper::test]
 fn copy_to_text() {
-    let conn = &mut connection_with_sean_and_tess_in_users_table();
+    // Test with explicit Text format
     {
+        let conn = &mut connection_with_sean_and_tess_in_users_table();
         let mut out = String::new();
         let mut copy = diesel::copy_to(users::table)
             .with_format(CopyFormat::Text)
@@ -272,11 +273,16 @@ fn copy_to_text() {
         copy.read_to_string(&mut out).unwrap();
         assert_eq!(out, "1\tSean\t\\N\n2\tTess\t\\N\n");
     }
-    let mut out = String::new();
-    // default is text
-    let mut copy = diesel::copy_to(users::table).load_raw(conn).unwrap();
-    copy.read_to_string(&mut out).unwrap();
-    assert_eq!(out, "1\tSean\t\\N\n2\tTess\t\\N\n");
+
+    // Test with default format (which is Text)
+    // Use a fresh connection to avoid "another command is already in progress" error
+    {
+        let conn = &mut connection_with_sean_and_tess_in_users_table();
+        let mut out = String::new();
+        let mut copy = diesel::copy_to(users::table).load_raw(conn).unwrap();
+        copy.read_to_string(&mut out).unwrap();
+        assert_eq!(out, "1\tSean\t\\N\n2\tTess\t\\N\n");
+    }
 }
 
 #[diesel_test_helper::test]


### PR DESCRIPTION
In the current implementation, unnamed prepared statements are first prepared and then bound to in different transactions. This breaks pgbouncer's prepared statement tracking in transaction mode leading to "unnamed prepade statement not found" errors.

This PR adds a new wrapper for PQsendQueryParams that prepares and binds unnamed statements in the same transaction, helping pgbouncer track those effectively. This wrapper is called while executing unnamed statements.