### PR TITLE
Add batch upsert support on sqlite

### DIFF
--- a/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs
@@ -8,11 +8,28 @@ table! {
     }
 }
 
+#[derive(Insertable)]
+#[diesel(table_name = users)]
+struct NewUser {
+    id: i32,
+}
+
 fn main() {
     let mut connection = SqliteConnection::establish("").unwrap();
 
+    // it works with plain values
     diesel::insert_into(users::table)
         .values(vec![users::id.eq(42), users::id.eq(43)])
         .on_conflict_do_nothing()
-        .execute(&mut connection);
+        .execute(&mut connection)
+        .unwrap();
+
+    // it's not supported for insertable structs which might require default value
+    // handling
+
+    diesel::insert_into(users::table)
+        .values(Vec::<NewUser>::new())
+        .on_conflict_do_nothing()
+        .execute(&mut connection)
+        .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
@@ -1,16 +1,16 @@
 error[E0271]: type mismatch resolving `<Sqlite as SqlDialect>::InsertWithDefaultKeyword == IsoSqlDefaultKeyword`
-  --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:17:18
+  --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:33:18
    |
-17 |         .execute(&mut connection);
+33 |         .execute(&mut connection)
    |          ------- ^^^^^^^^^^^^^^^ expected `IsoSqlDefaultKeyword`, found `DoesNotSupportDefaultKeyword`
    |          |
    |          required by a bound introduced by this call
    |
-   = note: required for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>` to implement `CanInsertInSingleQuery<Sqlite>`
+   = note: required for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>` to implement `CanInsertInSingleQuery<Sqlite>`
    = note: 1 redundant requirement hidden
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `CanInsertInSingleQuery<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
+   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `CanInsertInSingleQuery<Sqlite>`
+   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Sqlite>`
+   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
   --> $DIESEL/src/query_dsl/mod.rs
    |
@@ -20,24 +20,24 @@ note: required by a bound in `diesel::RunQueryDsl::execute`
    |         Self: methods::ExecuteDsl<Conn>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
 
-error[E0277]: `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:17:18
+error[E0277]: `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>` is no valid SQL fragment for the `Sqlite` backend
+  --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:33:18
    |
-17 |         .execute(&mut connection);
+33 |         .execute(&mut connection)
    |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |          |
    |          required by a bound introduced by this call
    |
-   = help: the trait `QueryFragment<Sqlite, sqlite::backend::SqliteBatchInsert>` is not implemented for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>`
+   = help: the trait `QueryFragment<Sqlite, sqlite::backend::SqliteBatchInsert>` is not implemented for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>`
    = note: this usually means that the `Sqlite` database system does not support
            this SQL syntax
    = help: the following other types implement trait `QueryFragment<DB, SP>`:
              `BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>` implements `QueryFragment<DB>`
              `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<V, Tab>>, Tab, QId, HAS_STATIC_QUERY_ID>` implements `QueryFragment<DB, PostgresLikeBatchInsertSupport>`
-   = note: required for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>` to implement `QueryFragment<Sqlite>`
+   = note: required for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>` to implement `QueryFragment<Sqlite>`
    = note: 3 redundant requirements hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
+   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Sqlite>`
+   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
   --> $DIESEL/src/query_dsl/mod.rs
    |


### PR DESCRIPTION
This commit adds support for batch upsert statements on SQLite if the struct/insert type is marked as `#[diesel(treat_none_as_default_value = false)]`. We don't provide an emulated variant for the other variant yet, as results might differ if we just perform single statements in a loop. Overall this brings the sqlite behaviour a tiny bit closer to the postgres backend.