### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,9 @@ jobs:
           echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://root:root@127.0.0.1/diesel_unit_test" >> $GITHUB_ENV
 
       - name: Install postgres (MacOS)
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-15' && matrix.backend == 'postgres'
+        if: (matrix.os == 'macos-13' || matrix.os == 'macos-15') && matrix.backend == 'postgres'
         run: |
+          brew update
           brew install postgresql@14
           brew services start postgresql@14
           sleep 3


### PR DESCRIPTION
This commit fixes our CI setup by making the install postgres script step for MacOS 13 a bit more robust