### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,9 @@ jobs:
           echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://root:root@127.0.0.1/diesel_unit_test" >> $GITHUB_ENV
 
       - name: Install postgres (MacOS)
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-15' && matrix.backend == 'postgres'
+        if: (matrix.os == 'macos-13' || matrix.os == 'macos-15') && matrix.backend == 'postgres'
         run: |
+          brew update
           brew install postgresql@14
           brew services start postgresql@14
           sleep 3

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -43,7 +43,7 @@ bitflags = { version = "2.0.0", optional = true }
 r2d2 = { version = ">= 0.8.2, < 0.9.0", optional = true }
 itoa = { version = "1.0.0", optional = true }
 time = { version = "0.3.9", optional = true, features = ["macros"] }
-downcast-rs = "1.2.1"
+downcast-rs = "2.0.1"
 
 [dependencies.diesel_derives]
 version = "~2.2.0"

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -552,12 +552,12 @@ pub trait PgSortExpressionMethods: Sized {
     ///
     /// let asc_default_nulls = nullable_numbers.select(nullable_number)
     ///     .order(nullable_number.asc())
-    ///     .load(connection)?;
+    ///     .load::<Option<i32>>(connection)?;
     /// assert_eq!(vec![Some(1), Some(2), None], asc_default_nulls);
     ///
     /// let asc_nulls_first = nullable_numbers.select(nullable_number)
     ///     .order(nullable_number.asc().nulls_first())
-    ///     .load(connection)?;
+    ///     .load::<Option<i32>>(connection)?;
     /// assert_eq!(vec![None, Some(1), Some(2)], asc_nulls_first);
     /// #     Ok(())
     /// # }
@@ -600,12 +600,12 @@ pub trait PgSortExpressionMethods: Sized {
     ///
     /// let desc_default_nulls = nullable_numbers.select(nullable_number)
     ///     .order(nullable_number.desc())
-    ///     .load(connection)?;
+    ///     .load::<Option<i32>>(connection)?;
     /// assert_eq!(vec![None, Some(2), Some(1)], desc_default_nulls);
     ///
     /// let desc_nulls_last = nullable_numbers.select(nullable_number)
     ///     .order(nullable_number.desc().nulls_last())
-    ///     .load(connection)?;
+    ///     .load::<Option<i32>>(connection)?;
     /// assert_eq!(vec![Some(2), Some(1), None], desc_nulls_last);
     /// #     Ok(())
     /// # }

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -21,7 +21,7 @@ ipnet = { version = "2.5.0" }
 ipnetwork = ">=0.12.2, <0.22.0"
 bigdecimal = ">= 0.0.13, < 0.5.0"
 libsqlite3-sys = { workspace = true, optional = true }
-rand = "0.8.4"
+rand = "0.9.0"
 pq-sys = { workspace = true, optional = true }
 pq-src = { version = "0.3", optional = true }
 mysqlclient-sys = { workspace = true, optional = true }
@@ -30,7 +30,8 @@ diesel_test_helper = { path = "../diesel_test_helper" }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 # Something is dependent on it, so we use feature to override it.
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom_02 = { version = "0.2", package = "getrandom", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
 sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", default-features = false, features = ["bundled"] }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,6 @@ edition.workspace = true
 
 [dependencies]
 clap = { version = "4.0", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions", "derive"] }
-cargo_metadata = "0.18"
+cargo_metadata = "0.19"
 dotenvy = "0.15"
 tempfile = "3"

--- a/xtask/src/tests/mod.rs
+++ b/xtask/src/tests/mod.rs
@@ -92,6 +92,7 @@ impl TestArgs {
                 let out = command
                     .args(["test", "--chrome", "--headless", "--features", "sqlite"])
                     .current_dir(metadata.workspace_root.join("diesel"))
+                    .env("RUSTFLAGS", "--cfg getrandom_backend=\"wasm_js\"")
                     .stderr(Stdio::inherit())
                     .stdout(Stdio::inherit())
                     .status()
@@ -104,6 +105,7 @@ impl TestArgs {
                 let out = command
                     .args(["test", "--chrome", "--headless", "--features", "sqlite"])
                     .current_dir(metadata.workspace_root.join("diesel_tests"))
+                    .env("RUSTFLAGS", "--cfg getrandom_backend=\"wasm_js\"")
                     .stderr(Stdio::inherit())
                     .stdout(Stdio::inherit())
                     .status()


### PR DESCRIPTION
This commit performs some major dependency updates 

* getrand to 0.3 for diesel_tests
* cargo_metadata to 0.19 for xtask
* downcast-rs to 2.0 for diesel

We can perform these updates without breaking changes as the first two
are only for our internal crates (tests + xtask) and the later one is
only a dependency on master yet.

(Also temporary includes #4547 to let the CI pass)