### PR TITLE
diesel_cli: Improve error message when migration directory does not exist

### DIFF
--- a/diesel_cli/src/database.rs
+++ b/diesel_cli/src/database.rs
@@ -278,7 +278,7 @@ fn create_schema_table_and_run_migrations_if_needed(
 ) -> Result<(), crate::errors::Error> {
     if !schema_table_exists(database_url)? {
         let migrations = FileBasedMigrations::from_path(migrations_dir)
-            .map_err(|e| crate::errors::Error::MigrationError(Box::new(e)))?;
+            .map_err(|e| crate::errors::Error::from_migration_error(e, Some(migrations_dir)))?;
         let mut conn = InferConnection::from_url(database_url.to_owned())?;
         super::run_migrations_with_output(&mut conn, migrations)
             .map_err(crate::errors::Error::MigrationError)?;

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use diesel_migrations::MigrationError;
+
 use crate::infer_schema_internals::TableName;
 
 #[derive(thiserror::Error, Debug)]
@@ -77,4 +79,13 @@ fn print_path(path: &Path) -> String {
 }
 fn print_optional_path(path: &Option<PathBuf>) -> String {
     path.as_ref().map(|p| print_path(p)).unwrap_or_default()
+}
+
+impl Error {
+    pub fn from_migration_error<T: Into<PathBuf>>(error: MigrationError, path: Option<T>) -> Self {
+        match error {
+            MigrationError::IoError(error) => Self::IoError(error, path.map(Into::into)),
+            _ => Self::MigrationError(Box::new(error)),
+        }
+    }
 }

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -27,16 +27,20 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
         ("run", _) => {
             let mut conn = InferConnection::from_matches(matches)?;
             let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir)
-                .map_err(|e| crate::errors::Error::MigrationError(Box::new(e)))?;
+            let dir = FileBasedMigrations::from_path(dir.clone()).map_err(|err| match err {
+                MigrationError::IoError(err) => crate::errors::Error::IoError(err, Some(dir)),
+                err => crate::errors::Error::MigrationError(Box::new(err)),
+            })?;
             run_migrations_with_output(&mut conn, dir)?;
             regenerate_schema_if_file_specified(matches)?;
         }
         ("revert", args) => {
             let mut conn = InferConnection::from_matches(matches)?;
             let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir)
-                .map_err(|e| crate::errors::Error::MigrationError(Box::new(e)))?;
+            let dir = FileBasedMigrations::from_path(dir.clone()).map_err(|err| match err {
+                MigrationError::IoError(err) => crate::errors::Error::IoError(err, Some(dir)),
+                err => crate::errors::Error::MigrationError(Box::new(err)),
+            })?;
             if args.get_flag("REVERT_ALL") {
                 revert_all_migrations_with_output(&mut conn, dir)?;
             } else {
@@ -64,23 +68,29 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
         ("redo", args) => {
             let mut conn = InferConnection::from_matches(matches)?;
             let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir)
-                .map_err(|e| crate::errors::Error::MigrationError(Box::new(e)))?;
+            let dir = FileBasedMigrations::from_path(dir.clone()).map_err(|err| match err {
+                MigrationError::IoError(err) => crate::errors::Error::IoError(err, Some(dir)),
+                err => crate::errors::Error::MigrationError(Box::new(err)),
+            })?;
             redo_migrations(&mut conn, dir, args)?;
             regenerate_schema_if_file_specified(matches)?;
         }
         ("list", _) => {
             let mut conn = InferConnection::from_matches(matches)?;
             let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir)
-                .map_err(|e| crate::errors::Error::MigrationError(Box::new(e)))?;
+            let dir = FileBasedMigrations::from_path(dir.clone()).map_err(|err| match err {
+                MigrationError::IoError(err) => crate::errors::Error::IoError(err, Some(dir)),
+                err => crate::errors::Error::MigrationError(Box::new(err)),
+            })?;
             list_migrations(&mut conn, dir)?;
         }
         ("pending", _) => {
             let mut conn = InferConnection::from_matches(matches)?;
             let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir)
-                .map_err(|e| crate::errors::Error::MigrationError(Box::new(e)))?;
+            let dir = FileBasedMigrations::from_path(dir.clone()).map_err(|err| match err {
+                MigrationError::IoError(err) => crate::errors::Error::IoError(err, Some(dir)),
+                err => crate::errors::Error::MigrationError(Box::new(err)),
+            })?;
             let result = MigrationHarness::has_pending_migration(&mut conn, dir)
                 .map_err(crate::errors::Error::MigrationError)?;
             println!("{result:?}");

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -25,19 +25,14 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
         .expect("Clap ensures a subcommand is set")
     {
         ("run", _) => {
-            let mut conn = InferConnection::from_matches(matches)?;
-            let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir.clone())
-                .map_err(|e| crate::errors::Error::from_migration_error(e, Some(dir)))?;
+            let (mut conn, dir) = conn_and_migration_dir(matches)?;
+
             run_migrations_with_output(&mut conn, dir)?;
             regenerate_schema_if_file_specified(matches)?;
         }
         ("revert", args) => {
-            let mut conn = InferConnection::from_matches(matches)?;
-            let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir.clone()).map_err(|e| {
-                crate::errors::Error::from_migration_error(e, Some(dir.clone()))
-            })?;
+            let (mut conn, dir) = conn_and_migration_dir(matches)?;
+
             if args.get_flag("REVERT_ALL") {
                 revert_all_migrations_with_output(&mut conn, dir)?;
             } else {
@@ -63,27 +58,21 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
             regenerate_schema_if_file_specified(matches)?;
         }
         ("redo", args) => {
-            let mut conn = InferConnection::from_matches(matches)?;
-            let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir.clone())
-                .map_err(|e| crate::errors::Error::from_migration_error(e, Some(dir)))?;
+            let (mut conn, dir) = conn_and_migration_dir(matches)?;
+
             redo_migrations(&mut conn, dir, args)?;
             regenerate_schema_if_file_specified(matches)?;
         }
 
         ("list", _) => {
-            let mut conn = InferConnection::from_matches(matches)?;
-            let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir.clone())
-                .map_err(|e| crate::errors::Error::from_migration_error(e, Some(dir)))?;
+            let (mut conn, dir) = conn_and_migration_dir(matches)?;
+
             list_migrations(&mut conn, dir)?;
         }
 
         ("pending", _) => {
-            let mut conn = InferConnection::from_matches(matches)?;
-            let dir = migrations_dir(matches)?;
-            let dir = FileBasedMigrations::from_path(dir.clone())
-                .map_err(|e| crate::errors::Error::from_migration_error(e, Some(dir)))?;
+            let (mut conn, dir) = conn_and_migration_dir(matches)?;
+
             let result = MigrationHarness::has_pending_migration(&mut conn, dir)
                 .map_err(crate::errors::Error::MigrationError)?;
             println!("{result:?}");
@@ -172,6 +161,21 @@ pub(super) fn run_migration_command(matches: &ArgMatches) -> Result<(), crate::e
     };
 
     Ok(())
+}
+
+/// Creates a connection to the database and a migration directory
+/// from the command line arguments.
+///
+/// See [migrations_dir] for more information on how the migration directory is found.
+fn conn_and_migration_dir(
+    matches: &ArgMatches,
+) -> Result<(InferConnection, FileBasedMigrations), crate::errors::Error> {
+    let conn = InferConnection::from_matches(matches)?;
+    let dir = migrations_dir(matches)?;
+    let dir = FileBasedMigrations::from_path(dir.clone())
+        .map_err(|e| crate::errors::Error::from_migration_error(e, Some(dir)))?;
+
+    Ok((conn, dir))
 }
 
 /// Opens the .diesel_lock file inside the migrations folder


### PR DESCRIPTION
Implement https://github.com/diesel-rs/diesel/discussions/4550

Now, if the migration directory does not exist, running commands from `diesel migration ...` will show this error message:
``Encountered an IO error: No such file or directory (os error 2)  for `/dir/that/dont/exist/2025-03-21-230906_a_migration` ``