### PR TITLE
Rewite `GroupedBy::grouped_by` method

### DIFF
--- a/diesel/src/associations/belongs_to.rs
+++ b/diesel/src/associations/belongs_to.rs
@@ -44,6 +44,18 @@ pub trait BelongsTo<Parent> {
 /// In the following relationship, User has many Posts,
 /// so User is the parent and Posts are children.
 ///
+/// # Unrelated Rows
+///
+/// When using [`GroupedBy::grouped_by`], if the child rows were not queried
+/// using the provided parent rows, it is not guaranteed a parent row
+/// will be found for a given child row.
+/// This is possible, if the foreign key in the relationship is nullable,
+/// or if a child row's parent was not present in the provided slice,
+/// in which case, unrelated child rows will be discarded.
+///
+/// If discarding these rows is undesirable, it may be preferable to use
+/// [`GroupedBy::try_grouped_by`].
+///
 /// # Example
 ///
 /// ```rust


### PR DESCRIPTION
This PR addresses the initial issue raised in issue #2298, by rewriting `GroupedBy::grouped_by`, having the method drop all child rows where a relationship could not be found, rather than panicking.

As this only applies to child rows where the foreign key was `NULL`, or a parent row wasn't found in the `parents` slice, this shouldn't affect existing usage of this method following its documented usage with `BelongingToDsl::belonging_to` function, as it should not produce rows with these conditions.

As some consumers may not expect this behaviour of dropping child rows, this PR also adds a section to the trait documentation, that highlights this behaviour.