### PR TITLE
Sqlite json/jsonb patch

### DIFF
--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -999,6 +999,25 @@ extern "SQL" {
     ///
     /// assert_eq!(json!({"a":1, "b":2, "c":3, "d":4}), result);
     ///
+    /// let result = diesel::select(json_patch::<Json, _, _>(json!({"a":[1,2],"b":2}), json!({"a":9})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":9,"b":2}), result);
+    ///
+    /// let result = diesel::select(json_patch::<Json, _, _>(json!({"a":[1,2],"b":2}), json!({"a":null})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"b":2}), result);
+    ///
+    /// let result = diesel::select(json_patch::<Json, _, _>(json!({"a":1,"b":2}), json!({"a":9,"b":null,"c":8})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":9,"c":8}), result);
+    ///
+    /// let result = diesel::select(json_patch::<Json, _, _>(json!({"a":{"x":1,"y":2},"b":3}), json!({"a":{"y":9},"c":8})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":{"x":1,"y":9},"b":3,"c":8}), result);
     ///
     /// # Ok(())
     /// # }

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1019,6 +1019,16 @@ extern "SQL" {
     ///
     /// assert_eq!(json!({"a":{"x":1,"y":9},"b":3,"c":8}), result);
     ///
+    /// let result = diesel::select(json_patch::<Nullable<Json>, _, _>(None, json!({"a":{"x":1,"y":2},"b":3})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(null), result);
+    ///
+    /// let result = diesel::select(json_patch::<Nullable<Json>, _, _>(json!({"a":{"x":1,"y":2},"b":3}), None))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(null), result);
+    ///
     /// # Ok(())
     /// # }
     /// ```
@@ -1084,7 +1094,18 @@ extern "SQL" {
     ///     .get_result::<Value>(connection)?;
     ///
     /// assert_eq!(json!({"a":{"x":1,"y":9},"b":3,"c":8}), result);
+    /// 
+    /// let result = diesel::select(jsonb_patch::<Nullable<Json>, _, _>(None, json!({"a":{"x":1,"y":2},"b":3})))
+    ///     .get_result::<Value>(connection)?;
     ///
+    /// assert_eq!(json!(null), result);
+    ///
+    /// let result = diesel::select(jsonb_patch::<Nullable<Json>, _, _>(json!({"a":{"x":1,"y":2},"b":3}), None))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!(null), result);
+    /// 
+ 
     /// # Ok(())
     /// # }
     /// ```

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -959,4 +959,51 @@ extern "SQL" {
     #[sql_name = "json_quote"]
     #[cfg(feature = "sqlite")]
     fn json_quote<J: SqlType + SingleValue>(j: J) -> Json;
+
+    /// The json_patch(T,P) SQL function runs the RFC-7396 MergePatch algorithm to apply patch P against input T. The patched copy of T is returned.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::{sql, json_patch};
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Text, Json, Nullable};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
+    ///         .get_result::<String>(connection)?;
+    ///
+    /// // Querying SQLite version should not fail.
+    /// let version_components: Vec<&str> = version.split('.').collect();
+    /// let major: u32 = version_components[0].parse().unwrap();
+    /// let minor: u32 = version_components[1].parse().unwrap();
+    /// let patch: u32 = version_components[2].parse().unwrap();
+    ///
+    /// if major > 3 || (major == 3 && minor >= 38) {
+    ///     /* Valid sqlite version, do nothing */
+    /// } else {
+    ///     println!("SQLite version is too old, skipping the test.");
+    ///     return Ok(());
+    /// }
+    /// let result = diesel::select(json_patch::<Json, _, _>(json!({"a":1,"b":2}), json!({"c":3,"d":4})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":1, "b":2, "c":3, "d":4}), result);
+    ///
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[sql_name = "json_patch"]
+    #[cfg(feature = "sqlite")]
+    fn json_patch<J: JsonOrNullableJson + SingleValue>(j: J, patch: J) -> Json;
 }

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1025,4 +1025,70 @@ extern "SQL" {
     #[sql_name = "json_patch"]
     #[cfg(feature = "sqlite")]
     fn json_patch<J: JsonOrNullableJson + SingleValue>(j: J, patch: J) -> Json;
+
+    /// The jsonb_patch() function works just like the json_patch() function except that the patched JSON is returned in the binary JSONB format.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::{sql, jsonb_patch};
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
+    ///         .get_result::<String>(connection)?;
+    ///
+    /// // Querying SQLite version should not fail.
+    /// let version_components: Vec<&str> = version.split('.').collect();
+    /// let major: u32 = version_components[0].parse().unwrap();
+    /// let minor: u32 = version_components[1].parse().unwrap();
+    /// let patch: u32 = version_components[2].parse().unwrap();
+    ///
+    /// if major > 3 || (major == 3 && minor >= 38) {
+    ///     /* Valid sqlite version, do nothing */
+    /// } else {
+    ///     println!("SQLite version is too old, skipping the test.");
+    ///     return Ok(());
+    /// }
+    /// let result = diesel::select(jsonb_patch::<Json, _, _>(json!({"a":1,"b":2}), json!({"c":3,"d":4})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":1, "b":2, "c":3, "d":4}), result);
+    ///
+    /// let result = diesel::select(jsonb_patch::<Json, _, _>(json!({"a":[1,2],"b":2}), json!({"a":9})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":9,"b":2}), result);
+    ///
+    /// let result = diesel::select(jsonb_patch::<Json, _, _>(json!({"a":[1,2],"b":2}), json!({"a":null})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"b":2}), result);
+    ///
+    /// let result = diesel::select(jsonb_patch::<Json, _, _>(json!({"a":1,"b":2}), json!({"a":9,"b":null,"c":8})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":9,"c":8}), result);
+    ///
+    /// let result = diesel::select(jsonb_patch::<Json, _, _>(json!({"a":{"x":1,"y":2},"b":3}), json!({"a":{"y":9},"c":8})))
+    ///     .get_result::<Value>(connection)?;
+    ///
+    /// assert_eq!(json!({"a":{"x":1,"y":9},"b":3,"c":8}), result);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[sql_name = "jsonb_patch"]
+    #[cfg(feature = "sqlite")]
+    fn jsonb_patch<J: JsonOrNullableJson + SingleValue>(j: J, patch: J) -> Jsonb;
 }

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -63,3 +63,8 @@ pub type json_type_with_path<J, P> = super::functions::json_type_with_path<SqlTy
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]
 pub type json_quote<J> = super::functions::json_quote<SqlTypeOf<J>, J>;
+
+/// Return type of [`json_patch(json, json)`](super::functions::json_patch())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_patch<J, P> = super::functions::json_patch<SqlTypeOf<J>, J, P>;

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -68,3 +68,8 @@ pub type json_quote<J> = super::functions::json_quote<SqlTypeOf<J>, J>;
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]
 pub type json_patch<J, P> = super::functions::json_patch<SqlTypeOf<J>, J, P>;
+
+/// Return type of [`jsonb_patch(json, json)`](super::functions::jsonb_patch())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type jsonb_patch<J, P> = super::functions::jsonb_patch<SqlTypeOf<J>, J, P>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -517,6 +517,7 @@ fn sqlite_functions() -> _ {
         json_type(sqlite_extras::json),
         json_type_with_path(sqlite_extras::json, sqlite_extras::text),
         json_quote(sqlite_extras::json),
+        json_patch(sqlite_extras::json, sqlite_extras::json),
     )
 }
 

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -518,6 +518,7 @@ fn sqlite_functions() -> _ {
         json_type_with_path(sqlite_extras::json, sqlite_extras::text),
         json_quote(sqlite_extras::json),
         json_patch(sqlite_extras::json, sqlite_extras::json),
+        jsonb_patch(sqlite_extras::json, sqlite_extras::json),
     )
 }
 


### PR DESCRIPTION
added json_patch & jsonb_patch with the test cases provided by sqlite.
I'm not completely certain if the jsonb test cases are correct, since jsonb_patch returns a jsonb, yet they pass if I compare it to a json. This was done in the existing jsonb function as well, so I guess it should be correct.

https://github.com/diesel-rs/diesel/issues/4366#issuecomment-2729139146