### PR TITLE
Change BoxableExpression SelectableExpression constraint to AppearsOnTable

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -1015,7 +1015,7 @@ pub trait BoxableExpression<QS, DB, GB = (), IsAggregate = is_aggregate::No>
 where
     DB: Backend,
     Self: Expression,
-    Self: SelectableExpression<QS>,
+    Self: AppearsOnTable<QS>,
     Self: QueryFragment<DB>,
     Self: Send,
 {
@@ -1025,7 +1025,7 @@ impl<QS, T, DB, GB, IsAggregate> BoxableExpression<QS, DB, GB, IsAggregate> for 
 where
     DB: Backend,
     T: Expression,
-    T: SelectableExpression<QS>,
+    T: AppearsOnTable<QS>,
     T: ValidGrouping<GB>,
     T: QueryFragment<DB>,
     T: Send,


### PR DESCRIPTION
I am fairly sure `SelectableExpression` is an unnecessarily strict constraint on `BoxableExpression`. I was unable to use it in a join `.on` as a result. Instead, `AppearsOnTable` is more appropriate I believe.

As I believe this is only intended (and possible to?) use in filters and join conditions (i.e. not selections), it makes sense, as per `AppearsOnTable`.
> [AppearsOnTable] is only used in places where the nullability of a SQL type doesn’t matter (everything except select and returning)