### PR TITLE
fix(ci): Install `libtirpc-dev` in `publish_docs` workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y install libmysqlclient-dev libsqlite3-dev libpq-dev
+        sudo apt-get -y install libmysqlclient-dev libsqlite3-dev libpq-dev libtirpc-dev
     - name: Build documentation
       env:
         RUSTFLAGS: "--cfg docsrs"


### PR DESCRIPTION
Resolve failing `publish_docs` ci workflow by installing `libtirpc-dev`