### PR TITLE
feat(sqlite): Add `json_group_object` and `jsonb_group_object` functions

### DIFF
--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1045,14 +1045,10 @@ extern "SQL" {
     /// The json_group_object(NAME,VALUE) function returns a JSON object comprised of all NAME/VALUE pairs in
     /// the aggregation.
     ///
-    /// # Corner cases
-    ///
-    /// This function does not always return a valid JSON. For instance:
-    /// 1. If `names` contains `NULL` entries, the corresponding keys will be omitted, but the values will
-    /// remain: `{"key_1": 0, : 1, "key_3": 2}`.
-    /// 2. If `names` contains duplicate elements, the result will include all of them:
-    /// `{"key": 1, "key": 2, "key": 3}`.
-    ///
+    /// A potential edge case in this function arises when `names` contains duplicate elements. 
+    /// In such case, the result will include all duplicates (e.g., `{"key": 1, "key": 2, "key": 3}`).
+    /// Note that any duplicate entries in the resulting JSON will be removed during deserialization.
+    /// 
     /// # Examples
     ///
     /// ```rust
@@ -1087,10 +1083,6 @@ extern "SQL" {
     /// let result = animals.select(json_group_object(species, name)).get_result::<serde_json::Value>(connection)?;
     /// assert_eq!(json!({"dog":"Jack","spider":null}), result);
     /// #
-    /// # // The first corner case(the second key is missing as it equals NULL).
-    /// # let result = animals.select(json_group_object(name, species)).get_result::<serde_json::Value>(connection);
-    /// # assert!(result.is_err());
-    /// #
     /// # Ok(())
     /// # }
     /// ```
@@ -1100,7 +1092,7 @@ extern "SQL" {
     /// - [`json_group_array`] will return JSON array instead of object.
     #[cfg(feature = "sqlite")]
     #[aggregate]
-    fn json_group_object<N: SqlType + SingleValue, V: SqlType + SingleValue>(
+    fn json_group_object<N: SqlType<IsNull = is_nullable::NotNull> + SingleValue, V: SqlType + SingleValue>(
         names: N,
         values: V,
     ) -> Json;
@@ -1108,13 +1100,9 @@ extern "SQL" {
     /// The jsonb_group_object(NAME,VALUE) function returns a JSONB object comprised of all NAME/VALUE pairs in
     /// the aggregation.
     ///
-    /// # Corner cases
-    ///
-    /// This function does not always return a valid JSONB. For instance:
-    /// 1. If `names` contains `NULL` entries, the corresponding keys will be omitted, but the values will
-    /// remain: `{"key_1": 0, : 1, "key_3": 2}`.
-    /// 2. If `names` contains duplicate elements, the resulting string will include all of them:
-    /// `{"key": 1, "key": 2, "key": 3}`.
+    /// A potential edge case in this function arises when `names` contains duplicate elements. 
+    /// In such case, the result will include all duplicates (e.g., `{"key": 1, "key": 2, "key": 3}`).
+    /// Note that any duplicate entries in the resulting JSONB will be removed during deserialization.
     ///
     /// # Examples
     ///
@@ -1150,10 +1138,6 @@ extern "SQL" {
     /// let result = animals.select(jsonb_group_object(species, name)).get_result::<serde_json::Value>(connection)?;
     /// assert_eq!(json!({"dog":"Jack","spider":null}), result);
     /// #
-    /// # // The first corner case(the second key is missing as it equals NULL).
-    /// # let result = animals.select(jsonb_group_object(name, species)).get_result::<serde_json::Value>(connection);
-    /// # assert!(result.is_err());
-    /// #
     /// # Ok(())
     /// # }
     /// ```
@@ -1163,7 +1147,7 @@ extern "SQL" {
     /// - [`jsonb_group_array`] will return JSONB array instead of object.
     #[cfg(feature = "sqlite")]
     #[aggregate]
-    fn jsonb_group_object<N: SqlType + SingleValue, V: SqlType + SingleValue>(
+    fn jsonb_group_object<N: SqlType<IsNull = is_nullable::NotNull> + SingleValue, V: SqlType + SingleValue>(
         names: N,
         values: V,
     ) -> Jsonb;

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1045,10 +1045,10 @@ extern "SQL" {
     /// The json_group_object(NAME,VALUE) function returns a JSON object comprised of all NAME/VALUE pairs in
     /// the aggregation.
     ///
-    /// A potential edge case in this function arises when `names` contains duplicate elements. 
+    /// A potential edge case in this function arises when `names` contains duplicate elements.
     /// In such case, the result will include all duplicates (e.g., `{"key": 1, "key": 2, "key": 3}`).
     /// Note that any duplicate entries in the resulting JSON will be removed during deserialization.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1092,7 +1092,10 @@ extern "SQL" {
     /// - [`json_group_array`] will return JSON array instead of object.
     #[cfg(feature = "sqlite")]
     #[aggregate]
-    fn json_group_object<N: SqlType<IsNull = is_nullable::NotNull> + SingleValue, V: SqlType + SingleValue>(
+    fn json_group_object<
+        N: SqlType<IsNull = is_nullable::NotNull> + SingleValue,
+        V: SqlType + SingleValue,
+    >(
         names: N,
         values: V,
     ) -> Json;
@@ -1100,7 +1103,7 @@ extern "SQL" {
     /// The jsonb_group_object(NAME,VALUE) function returns a JSONB object comprised of all NAME/VALUE pairs in
     /// the aggregation.
     ///
-    /// A potential edge case in this function arises when `names` contains duplicate elements. 
+    /// A potential edge case in this function arises when `names` contains duplicate elements.
     /// In such case, the result will include all duplicates (e.g., `{"key": 1, "key": 2, "key": 3}`).
     /// Note that any duplicate entries in the resulting JSONB will be removed during deserialization.
     ///
@@ -1147,7 +1150,10 @@ extern "SQL" {
     /// - [`jsonb_group_array`] will return JSONB array instead of object.
     #[cfg(feature = "sqlite")]
     #[aggregate]
-    fn jsonb_group_object<N: SqlType<IsNull = is_nullable::NotNull> + SingleValue, V: SqlType + SingleValue>(
+    fn jsonb_group_object<
+        N: SqlType<IsNull = is_nullable::NotNull> + SingleValue,
+        V: SqlType + SingleValue,
+    >(
         names: N,
         values: V,
     ) -> Jsonb;

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -73,3 +73,15 @@ pub type json_group_array<E> = super::functions::json_group_array<SqlTypeOf<E>, 
 #[allow(non_camel_case_types)]
 #[cfg(feature = "sqlite")]
 pub type jsonb_group_array<E> = super::functions::jsonb_group_array<SqlTypeOf<E>, E>;
+
+/// Return type of [`json_group_object(names, values)`](super::functions::json_group_object())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_group_object<N, V> =
+    super::functions::json_group_object<SqlTypeOf<N>, SqlTypeOf<V>, N, V>;
+
+/// Return type of [`jsonb_group_object(names, values)`](super::functions::jsonb_group_object())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type jsonb_group_object<N, V> =
+    super::functions::jsonb_group_object<SqlTypeOf<N>, SqlTypeOf<V>, N, V>;

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -528,6 +528,8 @@ fn sqlite_aggregate_functions() -> _ {
         json_group_array(users::id),
         jsonb_group_array(users::name),
         jsonb_group_array(users::id),
+        json_group_object(users::name, users::id),
+        jsonb_group_object(users::name, users::id),
     )
 }
 


### PR DESCRIPTION
Part of #4366 

As I discovered during the work on this PR, `sqlite` can return invalid JSON as described in the doc-comments in the `Corner cases` section.

I suppose that implementations of `json` and `jsonb` deserializers are made fail-safe so they will not fail in the second corner case(in this case they'll just omit duplicate elements). This behaviour may be not safe as it silently returns valid json `Value` if the corrupted input is provided. So if it's really the unwanted behaviour I'd propose opening an issue for this.