### PR TITLE
cli: use distinct `DIESEL_LOG` logging filter env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ in a way that makes the pools suitable for use in parallel tests.
 * Diesel CLI now ensures that migration versions are always unique. If it fails to generate a unique version, it will return an error. The new version format remains compatible with older Diesel versions.
 * Updated `ipnetwork` to allow version 0.21.
 
+### Changed
+
+* Use distinct `DIESEL_LOG` logging filter env variable instead of the default `RUST_LOG` one (#4575)
+
 ## [2.2.2] 2024-07-19
 
 ### Fixed

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
 }
 
 fn inner_main() -> Result<(), crate::errors::Error> {
-    let filter = EnvFilter::from_default_env();
+    let filter = EnvFilter::from_env("DIESEL_LOG");
     let fmt = tracing_subscriber::fmt::layer();
 
     tracing_subscriber::Registry::default()


### PR DESCRIPTION
I use diesel on a lot of Rust projects, and I often set the `RUST_LOG` env var, either manually or automatically with tools like direnv.

This means that I end up seeing diesel-cli logs, even if I absolutely don't care about them.

Rust itself switched from `RUST_LOG` over to `RUSTC_LOG` quite a while ago, with a similar motivation.

Since the `diesel` CLI will be used in Rust development environments, it makes sense to :

- Stop respecting the `RUST_LOG` env var
- use a custom `DIESEL_LOG` for logging configuration instead

I don't know how you feel about it from a breaking change point of view. I feel like this is more breaking for developers that are used to `RUST_LOG` when debugging `diesel-cli`.

Maybe you would prefer `DIESEL_CLI_LOG` instead of `DIESEL_LOG` ?

Thanks
