### PR TITLE
Bump libsqlite3-sys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Fixed `#[derive(Identifiable)]` ignoring attribute `#[diesel(serialize_as)]` on primary keys
 * Added embedded struct support for `AsChangeset` via `#[diesel(embed)]`
 * Added a `#[diesel(skip_update)]` attribute for the `AsChangeset` derive to skip updating a field present in the struct
-* Support for libsqlite3-sys 0.32.0
+* Support for libsqlite3-sys 0.33.0
 * Add support for built-in PostgreSQL range operators and functions
 * Support for postgres multirange type
 * Added `diesel::r2d2::TestCustomizer`, which allows users to customize their `diesel::r2d2::Pool`s

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ include = ["src/**/*.rs", "tests/**/*.rs", "LICENSE-*", "README.md"]
 edition = "2021"
 
 [workspace.dependencies]
-libsqlite3-sys = ">=0.30.1,<0.33.0"
+libsqlite3-sys = ">=0.30.1,<0.34.0"
 pq-sys = ">=0.6,<0.8"
 openssl-sys = "0.9.100"
 mysqlclient-sys = "0.4"

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -50,7 +50,7 @@ version = "~2.2.0"
 path = "../diesel_derives"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-libsqlite3-sys = { version = ">=0.17.2, <0.33.0", optional = true, features = ["bundled_bindings"] }
+libsqlite3-sys = { version = ">=0.17.2, <0.34.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 sqlite-wasm-rs = { version = ">=0.3.0, <0.4.0", optional = true, default-features = false }

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -515,9 +515,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
 dependencies = [
  "pkg-config",
  "vcpkg",


### PR DESCRIPTION
This commit updates the maximal supported libsqlite3-sys version from 0.32 to 0.33