### PR TITLE
Attempted to implement SupportsOnConflictClauseWhere for sqlite

### DIFF
--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -76,6 +76,7 @@ impl TrustedBackend for Sqlite {}
 pub struct SqliteOnConflictClause;
 
 impl sql_dialect::on_conflict_clause::SupportsOnConflictClause for SqliteOnConflictClause {}
+impl sql_dialect::on_conflict_clause::SupportsOnConflictClauseWhere for SqliteOnConflictClause {}
 impl sql_dialect::on_conflict_clause::PgLikeOnConflictClause for SqliteOnConflictClause {}
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This PR enables the `SupportsOnConflictClauseWhere` marker trait for `SqliteOnConflictClause` [to resolve the issue from this discussiom](https://github.com/diesel-rs/diesel/discussions/4584).