### PR TITLE
feat: Add support for variadic SQL functions

### DIFF
--- a/diesel/src/sqlite/expression/expression_methods.rs
+++ b/diesel/src/sqlite/expression/expression_methods.rs
@@ -159,8 +159,8 @@ pub(in crate::sqlite) mod private {
         `diesel::sql_types::Double`, `diesel::sql_types::Numeric`, `diesel::sql_types::Bool`,
         `diesel::sql_types::Integer`, `diesel::sql_types::SmallInt`, `diesel::sql_types::BigInt`,
         `diesel::sql_types::Date`, `diesel::sql_types::Time`, `diesel::sql_types::Timestamp`,
-        `diesel::sql_types::TimestamptzSqlite`, `diesel::sql_types::Binary`, `diesel::sql_types::Json`,        
-        `diesel::sql_types::Jsonb` nor `diesel::sql_types::Nullable<Any of the above>`",
+        `diesel::sql_types::TimestamptzSqlite`,  `diesel::sql_types::Json` nor 
+        `diesel::sql_types::Nullable<Any of the above>`",
         note = "try to provide an expression that produces one of the expected sql types"
     )]
     pub trait NotBlob: SqlType + SingleValue {}
@@ -178,7 +178,5 @@ pub(in crate::sqlite) mod private {
     impl NotBlob for Time {}
     impl NotBlob for Timestamp {}
     impl NotBlob for TimestamptzSqlite {}
-    impl NotBlob for Binary {}
     impl NotBlob for Json {}
-    impl NotBlob for Jsonb {}
 }

--- a/diesel/src/sqlite/expression/expression_methods.rs
+++ b/diesel/src/sqlite/expression/expression_methods.rs
@@ -155,12 +155,10 @@ pub(in crate::sqlite) mod private {
     }
 
     #[diagnostic::on_unimplemented(
-        message = "`{Self}` is neither `diesel::sql_types::Text`, `diesel::sql_types::Float`, 
-        `diesel::sql_types::Double`, `diesel::sql_types::Numeric`, `diesel::sql_types::Bool`,
-        `diesel::sql_types::Integer`, `diesel::sql_types::SmallInt`, `diesel::sql_types::BigInt`,
-        `diesel::sql_types::Date`, `diesel::sql_types::Time`, `diesel::sql_types::Timestamp`,
-        `diesel::sql_types::TimestamptzSqlite`,  `diesel::sql_types::Json` nor 
-        `diesel::sql_types::Nullable<Any of the above>`",
+        message = "`{Self}` is neither any of `diesel::sql_types::{{
+            Text, Float, Double, Numeric,  Bool, Integer, SmallInt, BigInt, 
+            Date, Time, Timestamp, TimestamptzSqlite, Json
+         }}`  nor `diesel::sql_types::Nullable<Any of the above>`",
         note = "try to provide an expression that produces one of the expected sql types"
     )]
     pub trait NotBlob: SqlType + SingleValue {}

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1158,13 +1158,14 @@ extern "SQL" {
         values: V,
     ) -> Jsonb;
 
-    /// The json_array() SQL function accepts zero or more arguments and returns a well-formed JSON array that
-    /// is composed from those arguments. If any argument to json_array() is a BLOB then an error is thrown.
+    /// The `json_array()` SQL function accepts zero or more arguments and returns a well-formed JSON array
+    /// that is composed from those arguments. If any argument to `json_array()` is a BLOB then an error is
+    /// thrown.
     ///
-    /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the argument
-    /// is the output from another json function, then it is stored as JSON. This allows calls to json_array()
-    /// and json_object() to be nested. The json() function can also be used to force strings to be recognized
-    /// as JSON.
+    /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the
+    /// argument is the output from another json function, then it is stored as JSON. This allows calls to
+    /// `json_array()` and `json_object()` to be nested. The [`json()`] function can also be used to force
+    /// strings to be recognized as JSON.
     ///
     /// # Examples
     ///
@@ -1211,16 +1212,18 @@ extern "SQL" {
     #[variadic(1)]
     fn json_array<V: SqlType + SingleValue>(value: V) -> Json;
 
-    /// The jsonb_array() SQL function accepts zero or more arguments and returns a well-formed JSON array that
-    /// is composed from those arguments. If any argument to jsonb_array() is a BLOB then an error is thrown.
+    /// The `jsonb_array()` SQL function accepts zero or more arguments and returns a well-formed JSON array
+    /// that is composed from those arguments. If any argument to `jsonb_array()` is a BLOB then an error is
+    /// thrown.
     ///
-    /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the argument
-    /// is the output from another json function, then it is stored as JSON. This allows calls to jsonb_array()
-    /// and jsonb_object() to be nested. The json() function can also be used to force strings to be recognized
-    /// as JSON.
+    /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the
+    /// argument is the output from another json function, then it is stored as JSON. This allows calls to
+    /// `jsonb_array()` and `jsonb_object()` to be nested. The [`json()`] function can also be used to force
+    /// strings to be recognized as JSON.
     ///
-    /// This function works just like the json_array() function except that it returns the constructed JSON
-    /// array in the SQLite's private JSONB format rather than in the standard RFC 8259 text format.
+    /// This function works just like the [`json_array()`](json_array_1()) function except that it returns the
+    /// constructed JSON array in the SQLite's private JSONB format rather than in the standard RFC 8259 text
+    /// format.
     ///
     /// # Examples
     ///

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1157,4 +1157,113 @@ extern "SQL" {
         names: N,
         values: V,
     ) -> Jsonb;
+
+    /// The json_array() SQL function accepts zero or more arguments and returns a well-formed JSON array that
+    /// is composed from those arguments. If any argument to json_array() is a BLOB then an error is thrown.
+    ///
+    /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the argument
+    /// is the output from another json function, then it is stored as JSON. This allows calls to json_array()
+    /// and json_object() to be nested. The json() function can also be used to force strings to be recognized
+    /// as JSON.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Text, Double};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
+    /// #         .get_result::<String>(connection)?;
+    /// #
+    /// #     let version_components: Vec<&str> = version.split('.').collect();
+    /// #     let major: u32 = version_components[0].parse().unwrap();
+    /// #     let minor: u32 = version_components[1].parse().unwrap();
+    /// #
+    /// #     if major < 3 || minor < 38 {
+    /// #         println!("SQLite version is too old, skipping the test.");
+    /// #         return Ok(());
+    /// #     }
+    /// #
+    /// let result = diesel::select(json_array_1::<Text, _>("abc"))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!(["abc"]), result);
+    ///
+    /// let result = diesel::select(json_array_2::<Text, Double, _, _>("abc", 3.1415))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!(["abc", 3.1415]), result);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "sqlite")]
+    #[variadic(1)]
+    fn json_array<V: SqlType + SingleValue>(value: V) -> Json;
+
+    /// The jsonb_array() SQL function accepts zero or more arguments and returns a well-formed JSON array that
+    /// is composed from those arguments. If any argument to jsonb_array() is a BLOB then an error is thrown.
+    ///
+    /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the argument
+    /// is the output from another json function, then it is stored as JSON. This allows calls to jsonb_array()
+    /// and jsonb_object() to be nested. The json() function can also be used to force strings to be recognized
+    /// as JSON.
+    ///
+    /// This function works just like the json_array() function except that it returns the constructed JSON
+    /// array in the SQLite's private JSONB format rather than in the standard RFC 8259 text format.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Text, Double};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
+    /// #         .get_result::<String>(connection)?;
+    /// #
+    /// #     let version_components: Vec<&str> = version.split('.').collect();
+    /// #     let major: u32 = version_components[0].parse().unwrap();
+    /// #     let minor: u32 = version_components[1].parse().unwrap();
+    /// #
+    /// #     if major < 3 || minor < 38 {
+    /// #         println!("SQLite version is too old, skipping the test.");
+    /// #         return Ok(());
+    /// #     }
+    /// #
+    /// let result = diesel::select(jsonb_array_1::<Text, _>("abc"))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!(["abc"]), result);
+    ///
+    /// let result = diesel::select(jsonb_array_2::<Text, Double, _, _>("abc", 3.1415))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!(["abc", 3.1415]), result);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "sqlite")]
+    #[variadic(1)]
+    fn jsonb_array<V: SqlType + SingleValue>(value: V) -> Jsonb;
 }

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -5,6 +5,7 @@ use crate::sqlite::expression::expression_methods::BinaryOrNullableBinary;
 use crate::sqlite::expression::expression_methods::JsonOrNullableJson;
 use crate::sqlite::expression::expression_methods::JsonOrNullableJsonOrJsonbOrNullableJsonb;
 use crate::sqlite::expression::expression_methods::MaybeNullableValue;
+use crate::sqlite::expression::expression_methods::NotBlob;
 use crate::sqlite::expression::expression_methods::TextOrNullableText;
 use crate::sqlite::expression::expression_methods::TextOrNullableTextOrBinaryOrNullableBinary;
 
@@ -1159,8 +1160,8 @@ extern "SQL" {
     ) -> Jsonb;
 
     /// The `json_array()` SQL function accepts zero or more arguments and returns a well-formed JSON array
-    /// that is composed from those arguments. If any argument to `json_array()` is a BLOB then an error is
-    /// thrown.
+    /// that is composed from those arguments. Note that arguments of type BLOB will not be accepted by this
+    /// function.
     ///
     /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the
     /// argument is the output from another json function, then it is stored as JSON. This allows calls to
@@ -1210,11 +1211,11 @@ extern "SQL" {
     /// ```
     #[cfg(feature = "sqlite")]
     #[variadic(1)]
-    fn json_array<V: SqlType + SingleValue>(value: V) -> Json;
+    fn json_array<V: NotBlob>(value: V) -> Json;
 
     /// The `jsonb_array()` SQL function accepts zero or more arguments and returns a well-formed JSON array
-    /// that is composed from those arguments. If any argument to `jsonb_array()` is a BLOB then an error is
-    /// thrown.
+    /// that is composed from those arguments. Note that arguments of type BLOB will not be accepted by this
+    /// function.
     ///
     /// An argument with SQL type TEXT is normally converted into a quoted JSON string. However, if the
     /// argument is the output from another json function, then it is stored as JSON. This allows calls to
@@ -1268,5 +1269,5 @@ extern "SQL" {
     /// ```
     #[cfg(feature = "sqlite")]
     #[variadic(1)]
-    fn jsonb_array<V: SqlType + SingleValue>(value: V) -> Jsonb;
+    fn jsonb_array<V: NotBlob>(value: V) -> Jsonb;
 }

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -85,3 +85,25 @@ pub type json_group_object<N, V> =
 #[cfg(feature = "sqlite")]
 pub type jsonb_group_object<N, V> =
     super::functions::jsonb_group_object<SqlTypeOf<N>, SqlTypeOf<V>, N, V>;
+
+/// Return type of [`json_array_1(value_1)`](super::functions::json_array_1())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_array_1<V1> = super::functions::json_array_1<SqlTypeOf<V1>, V1>;
+
+/// Return type of [`json_array_2(value_1, value_2)`](super::functions::json_array_2())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type json_array_2<V1, V2> =
+    super::functions::json_array_2<SqlTypeOf<V1>, SqlTypeOf<V2>, V1, V2>;
+
+/// Return type of [`jsonb_array_1(value_1)`](super::functions::jsonb_array_1())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type jsonb_array_1<V1> = super::functions::jsonb_array_1<SqlTypeOf<V1>, V1>;
+
+/// Return type of [`jsonb_array_2(value_1, value_2)`](super::functions::jsonb_array_2())
+#[allow(non_camel_case_types)]
+#[cfg(feature = "sqlite")]
+pub type jsonb_array_2<V1, V2> =
+    super::functions::jsonb_array_2<SqlTypeOf<V1>, SqlTypeOf<V2>, V1, V2>;

--- a/diesel_compile_tests/tests/fail/derive/bad_variadic.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_variadic.rs
@@ -1,0 +1,17 @@
+extern crate diesel;
+
+use diesel::*;
+
+#[declare_sql_function]
+extern "SQL" {
+    #[variadic(non_a_literal_number)]
+    fn f();
+
+    #[variadic(3)]
+    fn g<A: SqlType>(a: A);
+
+    #[variadic(1)]
+    fn h(a: impl SqlType);
+}
+
+fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_variadic.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_variadic.stderr
@@ -1,0 +1,17 @@
+error: expected integer literal
+ --> tests/fail/derive/bad_variadic.rs:7:16
+  |
+7 |     #[variadic(non_a_literal_number)]
+  |                ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid variadic argument count: not enough function arguments
+  --> tests/fail/derive/bad_variadic.rs:10:16
+   |
+10 |     #[variadic(3)]
+   |                ^
+
+error: variadic argument should have path type
+  --> tests/fail/derive/bad_variadic.rs:14:10
+   |
+14 |     fn h(a: impl SqlType);
+   |          ^

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -139,9 +139,10 @@ fn add_variadic_doc_comments(attributes: &mut Vec<Attribute>, fn_name: &str) {
         ///
         #[doc = #fn_family]
         ///
-        /// Here, the postfix indicates repetitions of variadic arguments.
+        /// Here, the postfix number indicates repetitions of variadic arguments.
         /// To use this function, the appropriate version with the correct
         /// argument count must be selected.
+        #[doc(alias = #fn_name)]
     };
 
     for new_attribute in doc_comments {

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -533,6 +533,17 @@ fn sqlite_aggregate_functions() -> _ {
     )
 }
 
+#[cfg(feature = "sqlite")]
+#[auto_type]
+fn sqlite_variadic_functions() -> _ {
+    (
+        json_array_1(sqlite_extras::text),
+        json_array_2(sqlite_extras::id, sqlite_extras::json),
+        jsonb_array_1(sqlite_extras::text),
+        jsonb_array_2(sqlite_extras::id, sqlite_extras::json),
+    )
+}
+
 #[auto_type]
 fn with_lifetime<'a>(name: &'a str) -> _ {
     users::table.filter(users::name.eq(name))


### PR DESCRIPTION
This approach was discussed in https://github.com/diesel-rs/diesel/issues/4366#issuecomment-2828243719

This PR also adds support for `json_array` and `jsonb_array` functions as part of #4366 to showcase usage of newly introduced attribute

Some things are still missing and are to be implemented in the following PRs:
- parse `DIESEL_VARIADIC_FUNCTION_ARGS ` env in `declare_sql_function` and add docs for it
- generate helper types for all the variants, not only for 2
- generate function for 0 argument repetitions
- support not only generic types as arguments to the variadic function (to support functions like `json_remove` from `sqlite`)