### PR TITLE
Add `#[diagnostic::do_not_recommend]` to the `FromSql` impl for `String`

### DIFF
--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -125,6 +125,7 @@ mod foreign_impls {
     struct BinaryArrayProxy<const N: usize>([u8; N]);
 }
 
+#[diagnostic::do_not_recommend]
 impl<ST, DB> FromSql<ST, DB> for String
 where
     DB: Backend,

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
@@ -15,18 +15,21 @@ error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is 
    = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
    = help: see issue #48214
 
-error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Integer` as `*const str`
+error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
   --> tests/fail/broken_queryable_by_name.rs:16:5
    |
 16 |     id: String,
-   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
+   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
+   = note: `diesel::sql_query` requires the loading target to column names for loading values.
+           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
    = help: the following other types implement trait `FromSql<A, DB>`:
-             `*const str` implements `FromSql<diesel::sql_types::Text, Mysql>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Pg>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Sqlite>`
-   = note: required for `std::string::String` to implement `FromSql<diesel::sql_types::Integer, Pg>`
+             `std::string::String` implements `FromSql<Citext, Pg>`
+             `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
    = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, Pg>`
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214
@@ -48,18 +51,21 @@ error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is 
    = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
    = help: see issue #48214
 
-error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Integer` as `*const str`
+error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
   --> tests/fail/broken_queryable_by_name.rs:24:5
    |
 24 |     id: String,
-   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
+   |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
+   = note: `diesel::sql_query` requires the loading target to column names for loading values.
+           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
    = help: the following other types implement trait `FromSql<A, DB>`:
-             `*const str` implements `FromSql<diesel::sql_types::Text, Mysql>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Pg>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Sqlite>`
-   = note: required for `std::string::String` to implement `FromSql<diesel::sql_types::Integer, Pg>`
+             `std::string::String` implements `FromSql<Citext, Pg>`
+             `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
    = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, Pg>`
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214

--- a/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
+++ b/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
@@ -24,20 +24,19 @@ note: required by a bound in `diesel::RunQueryDsl::load`
    |         Self: LoadQuery<'query, Conn, U>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
-error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Integer` as `*const str`
+error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Integer` as `std::string::String`
   --> tests/fail/select_carries_correct_result_type_info.rs:20:42
    |
 20 |     let names = select_id.load::<String>(&mut connection);
-   |                           ----           ^^^^^^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, _>` is not implemented for `*const str`
-   |                           |
-   |                           required by a bound introduced by this call
+   |                                          ^^^^^^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, _>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
    = help: the following other types implement trait `FromSql<A, DB>`:
-             `*const str` implements `FromSql<diesel::sql_types::Text, Mysql>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Pg>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Sqlite>`
-   = note: required for `std::string::String` to implement `FromSql<diesel::sql_types::Integer, _>`
+             `std::string::String` implements `FromSql<Citext, Pg>`
+             `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
    = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, _>`
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, _>`
    = note: required for `diesel::sql_types::Integer` to implement `load_dsl::private::CompatibleType<std::string::String, _>`

--- a/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
+++ b/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
@@ -1,17 +1,16 @@
-error[E0277]: cannot deserialize a value of the database type `BigInt` as `*const str`
+error[E0277]: cannot deserialize a value of the database type `BigInt` as `std::string::String`
   --> tests/fail/select_sql_still_ensures_result_type.rs:16:51
    |
 16 |     let count = select_count.get_result::<String>(&mut connection).unwrap();
-   |                              ----------           ^^^^^^^^^^^^^^^ the trait `FromSql<BigInt, _>` is not implemented for `*const str`
-   |                              |
-   |                              required by a bound introduced by this call
+   |                                                   ^^^^^^^^^^^^^^^ the trait `FromSql<BigInt, _>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `BigInt`
    = help: the following other types implement trait `FromSql<A, DB>`:
-             `*const str` implements `FromSql<diesel::sql_types::Text, Mysql>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Pg>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Sqlite>`
-   = note: required for `std::string::String` to implement `FromSql<BigInt, _>`
+             `std::string::String` implements `FromSql<Citext, Pg>`
+             `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
    = note: required for `std::string::String` to implement `Queryable<BigInt, _>`
    = note: required for `std::string::String` to implement `FromSqlRow<BigInt, _>`
    = note: required for `BigInt` to implement `load_dsl::private::CompatibleType<std::string::String, _>`

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -15,18 +15,21 @@ error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is 
    = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, Pg>`
    = help: see issue #48214
 
-error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Integer` as `*const str`
+error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
   --> tests/fail/selectable_with_typemisamatch.rs:16:9
    |
 16 |     id: String,
-   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `*const str`
+   |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
+   = note: `diesel::sql_query` requires the loading target to column names for loading values.
+           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
    = help: the following other types implement trait `FromSql<A, DB>`:
-             `*const str` implements `FromSql<diesel::sql_types::Text, Mysql>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Pg>`
-             `*const str` implements `FromSql<diesel::sql_types::Text, Sqlite>`
-   = note: required for `std::string::String` to implement `FromSql<diesel::sql_types::Integer, Pg>`
+             `std::string::String` implements `FromSql<Citext, Pg>`
+             `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
+             `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
    = note: required for `std::string::String` to implement `diesel::Queryable<diesel::sql_types::Integer, Pg>`
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214


### PR DESCRIPTION
This slightly tweaks the error message to not mention `*const str` anymore. All error messages now mention `String` directly instead. I feel that this makes it clearer what's actually wrong there.