### PR TITLE
Add print-schema allow table config option: None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ in a way that makes the pools suitable for use in parallel tests.
 * Support `[print_schema] allow_tables_to_appear_in_same_query_config = "fk_related_tables"` to generate separate `allow_tables_to_appear_in_same_query!` calls containing only tables that are related through foreign keys. (Default: `"all_tables"`.) It is not possible to build queries using two tables that don't appear in the same `allow_tables_to_appear_in_same_query!` call, but that macro generates O(n²) rust code, so this option may be useful to reduce compilation time. ([#4333](https://github.com/diesel-rs/diesel/issues/4333))
 * Added `wasm32-unknown-unknown` target support for sqlite backend.
 * Add support for the `CAST` operator
+* Support `[print_schema] allow_tables_to_appear_in_same_query_config = "none"` to generate no `allow_tables_to_appear_in_same_query!` calls. (Default: `"all_tables"`.). ([#4333](https://github.com/diesel-rs/diesel/issues/4333))
 
 ### Fixed 
 

--- a/diesel_cli/src/cli.rs
+++ b/diesel_cli/src/cli.rs
@@ -286,7 +286,7 @@ pub fn build_cli() -> Command {
                 .help("Group tables in allow_tables_to_appear_in_same_query!().")
                 .num_args(1)
                 .action(ArgAction::Append)
-                .value_parser(PossibleValuesParser::new(["fk_related_tables", "all_tables"])),
+                .value_parser(PossibleValuesParser::new(["fk_related_tables", "all_tables", "none"])),
         )
         .arg(
             Arg::new("column-sorting")

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -40,6 +40,9 @@ pub enum AllowTablesToAppearInSameQueryConfig {
     #[serde(rename = "all_tables")]
     #[default]
     AllTables,
+    /// Don't generate any invocation
+    #[serde(rename = "none")]
+    None,
 }
 
 pub fn run_print_schema<W: IoWrite>(
@@ -585,6 +588,7 @@ impl Display for TableDefinitions<'_> {
             AllowTablesToAppearInSameQueryConfig::AllTables => {
                 vec![self.tables.iter().map(|table| &table.name).collect()]
             }
+            AllowTablesToAppearInSameQueryConfig::None => vec![],
         };
         for (table_group_index, table_group) in table_groups
             .into_iter()
@@ -989,6 +993,7 @@ impl str::FromStr for AllowTablesToAppearInSameQueryConfig {
         Ok(match s {
             "fk_related_tables" => AllowTablesToAppearInSameQueryConfig::FkRelatedTables,
             "all_tables" => AllowTablesToAppearInSameQueryConfig::AllTables,
+            "none" => AllowTablesToAppearInSameQueryConfig::None,
             _ => {
                 return Err(
                     "Unknown variant for `allow_tables_to_appear_in_same_query!` config \

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -360,7 +360,6 @@ fn print_schema_fk_related_tables() {
 }
 
 #[test]
-#[cfg(feature = "postgres")]
 fn print_schema_allows_none() {
     test_print_schema(
         "print_schema_allows_none",

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -360,6 +360,15 @@ fn print_schema_fk_related_tables() {
 }
 
 #[test]
+#[cfg(feature = "postgres")]
+fn print_schema_allows_none() {
+    test_print_schema(
+        "print_schema_allows_none",
+        vec!["--allow-tables-to-appear-in-same-query-config", "none"],
+    )
+}
+
+#[test]
 fn print_schema_reserved_names() {
     test_print_schema("print_schema_reserved_name_mitigation_issue_3404", vec![])
 }

--- a/diesel_cli/tests/print_schema/print_schema_allows_none/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_allows_none/diesel.toml
@@ -1,0 +1,3 @@
+[print_schema]
+file = "src/schema.rs"
+allow_tables_to_appear_in_same_query_config = "none"

--- a/diesel_cli/tests/print_schema/print_schema_allows_none/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_allows_none/mysql/expected.snap
@@ -1,0 +1,52 @@
+---
+source: diesel_cli/tests/print_schema.rs
+assertion_line: 503
+description: "Test: print_schema_allows_none"
+snapshot_kind: text
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    bikes (id) {
+        id -> Unsigned<Bigint>,
+    }
+}
+
+diesel::table! {
+    cars (id) {
+        id -> Unsigned<Bigint>,
+    }
+}
+
+diesel::table! {
+    comments (id) {
+        id -> Unsigned<Bigint>,
+        post_id -> Integer,
+    }
+}
+
+diesel::table! {
+    posts (id) {
+        id -> Unsigned<Bigint>,
+        user_id -> Integer,
+    }
+}
+
+diesel::table! {
+    sessions (id) {
+        id -> Unsigned<Bigint>,
+    }
+}
+
+diesel::table! {
+    transactions (id) {
+        id -> Unsigned<Bigint>,
+        session_id -> Integer,
+    }
+}
+
+diesel::table! {
+    users (id) {
+        id -> Unsigned<Bigint>,
+    }
+}

--- a/diesel_cli/tests/print_schema/print_schema_allows_none/mysql/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_allows_none/mysql/schema.sql
@@ -1,0 +1,12 @@
+-- Three related tables.
+CREATE TABLE users (id SERIAL PRIMARY KEY);
+CREATE TABLE posts (id SERIAL PRIMARY KEY, user_id INTEGER NOT NULL REFERENCES users);
+CREATE TABLE comments (id SERIAL PRIMARY KEY, post_id INTEGER NOT NULL REFERENCES posts);
+
+-- Two related tables.
+CREATE TABLE sessions (id SERIAL PRIMARY KEY);
+CREATE TABLE transactions (id SERIAL PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions);
+
+-- Unrelated tables.
+CREATE TABLE cars (id SERIAL PRIMARY KEY);
+CREATE TABLE bikes (id SERIAL PRIMARY KEY);

--- a/diesel_cli/tests/print_schema/print_schema_allows_none/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_allows_none/postgres/expected.snap
@@ -1,0 +1,56 @@
+---
+source: diesel_cli/tests/print_schema.rs
+assertion_line: 503
+description: "Test: print_schema_allows_none"
+snapshot_kind: text
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    bikes (id) {
+        id -> Int4,
+    }
+}
+
+diesel::table! {
+    cars (id) {
+        id -> Int4,
+    }
+}
+
+diesel::table! {
+    comments (id) {
+        id -> Int4,
+        post_id -> Int4,
+    }
+}
+
+diesel::table! {
+    posts (id) {
+        id -> Int4,
+        user_id -> Int4,
+    }
+}
+
+diesel::table! {
+    sessions (id) {
+        id -> Int4,
+    }
+}
+
+diesel::table! {
+    transactions (id) {
+        id -> Int4,
+        session_id -> Int4,
+    }
+}
+
+diesel::table! {
+    users (id) {
+        id -> Int4,
+    }
+}
+
+diesel::joinable!(comments -> posts (post_id));
+diesel::joinable!(posts -> users (user_id));
+diesel::joinable!(transactions -> sessions (session_id));

--- a/diesel_cli/tests/print_schema/print_schema_allows_none/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_allows_none/postgres/schema.sql
@@ -1,0 +1,12 @@
+-- Three related tables.
+CREATE TABLE users (id SERIAL PRIMARY KEY);
+CREATE TABLE posts (id SERIAL PRIMARY KEY, user_id INTEGER NOT NULL REFERENCES users);
+CREATE TABLE comments (id SERIAL PRIMARY KEY, post_id INTEGER NOT NULL REFERENCES posts);
+
+-- Two related tables.
+CREATE TABLE sessions (id SERIAL PRIMARY KEY);
+CREATE TABLE transactions (id SERIAL PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions);
+
+-- Unrelated tables.
+CREATE TABLE cars (id SERIAL PRIMARY KEY);
+CREATE TABLE bikes (id SERIAL PRIMARY KEY);

--- a/diesel_cli/tests/print_schema/print_schema_allows_none/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_allows_none/sqlite/expected.snap
@@ -1,0 +1,56 @@
+---
+source: diesel_cli/tests/print_schema.rs
+assertion_line: 503
+description: "Test: print_schema_allows_none"
+snapshot_kind: text
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    bikes (id) {
+        id -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
+    cars (id) {
+        id -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
+    comments (id) {
+        id -> Nullable<Integer>,
+        post_id -> Integer,
+    }
+}
+
+diesel::table! {
+    posts (id) {
+        id -> Nullable<Integer>,
+        user_id -> Integer,
+    }
+}
+
+diesel::table! {
+    sessions (id) {
+        id -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
+    transactions (id) {
+        id -> Nullable<Integer>,
+        session_id -> Integer,
+    }
+}
+
+diesel::table! {
+    users (id) {
+        id -> Nullable<Integer>,
+    }
+}
+
+diesel::joinable!(comments -> posts (post_id));
+diesel::joinable!(posts -> users (user_id));
+diesel::joinable!(transactions -> sessions (session_id));

--- a/diesel_cli/tests/print_schema/print_schema_allows_none/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_allows_none/sqlite/schema.sql
@@ -1,0 +1,12 @@
+-- Three related tables.
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL REFERENCES users);
+CREATE TABLE comments (id INTEGER PRIMARY KEY, post_id INTEGER NOT NULL REFERENCES posts);
+
+-- Two related tables.
+CREATE TABLE sessions (id INTEGER PRIMARY KEY);
+CREATE TABLE transactions (id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions);
+
+-- Unrelated tables.
+CREATE TABLE cars (id INTEGER PRIMARY KEY);
+CREATE TABLE bikes (id INTEGER PRIMARY KEY);


### PR DESCRIPTION
Add the `none` option to the `allow_tables_to_appear_in_same_query_config` config. It will generate no allows at the schema file.
Thie pr relates to this [comment](https://github.com/diesel-rs/diesel/issues/4333#issuecomment-2871626144)

