### PR TITLE
Add json, Uuid cast operator support

### DIFF
--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -160,11 +160,45 @@ pub trait CastsTo<ST> {}
 impl<ST1, ST2> CastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where ST1: CastsTo<ST2>
 {}
 
-impl CastsTo<sql_types::Int4> for sql_types::Int8 {}
-impl CastsTo<sql_types::Int8> for sql_types::Int4 {}
-#[cfg(feature = "postgres_backend")]
-impl CastsTo<sql_types::Text> for sql_types::Uuid {}
-impl CastsTo<sql_types::Text> for sql_types::Int4 {}
-impl CastsTo<sql_types::Text> for sql_types::Int8 {}
-impl CastsTo<sql_types::Text> for sql_types::Jsonb {}
-impl CastsTo<sql_types::Text> for sql_types::Json {}
+macro_rules! casts_impl {
+    (
+        $(
+            $($feature: literal : )? ($to: tt <- $from: tt),
+        )+
+    ) => {
+        $(
+            $(#[cfg(feature = $feature)])?
+            impl CastsTo<sql_types::$to> for sql_types::$from {}
+        )+
+    };
+}
+
+casts_impl!(
+    (Bool <- Int4),
+    (Bool <- Int8),
+    (Bool <- Float4),
+    (Bool <- Float8),
+    (Float4 <- Float8),
+    (Float4 <- Int4),
+    (Float4 <- Int8),
+    (Float8 <- Float4),
+    (Float8 <- Int4),
+    (Float8 <- Int8),
+    (Int8 <- Bool),
+    (Int8 <- Int4),
+    (Int8 <- Float4),
+    (Int8 <- Float8),
+    (Int4 <- Bool),
+    (Int4 <- Int8),
+    (Int4 <- Float4),
+    (Int4 <- Float8),
+    (Text <- Bool),
+    (Text <- Float4),
+    (Text <- Float8),
+    (Text <- Int4),
+    (Text <- Int8),
+    (Text <- Date),
+    (Text <- Json),
+    (Text <- Jsonb),
+    "postgres_backend": (Text <- Uuid),
+);

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -158,17 +158,17 @@ where
     }
 }
 
-/// Marker trait: this SQL type (`Self`) can be casted to the target SQL type, but some values can be invalid
-pub trait FaillibleCastsTo<ST> {}
+/// Marker trait: this SQL type (`Self`) can be cast to the target SQL type, but some values can be invalid
+pub trait FallibleCastsTo<ST> {}
 
-impl<ST1, ST2> FaillibleCastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where
+impl<ST1, ST2> FallibleCastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where
     ST1: CastsTo<ST2>
 {
 }
 
-/// Marker trait: this SQL type (`Self`) can be casted to the target SQL type
+/// Marker trait: this SQL type (`Self`) can be cast to the target SQL type
 /// (`ST`) using `CAST(expr AS target_sql_type)`
-pub trait CastsTo<ST>: FaillibleCastsTo<ST> {}
+pub trait CastsTo<ST>: FallibleCastsTo<ST> {}
 
 impl<ST1, ST2> CastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where ST1: CastsTo<ST2>
 {}
@@ -181,7 +181,7 @@ macro_rules! casts_impl {
     ) => {
         $(
             $(#[cfg(feature = $feature)])?
-            impl FaillibleCastsTo<sql_types::$to> for sql_types::$from {}
+            impl FallibleCastsTo<sql_types::$to> for sql_types::$from {}
             $(#[cfg(feature = $feature)])?
             impl CastsTo<sql_types::$to> for sql_types::$from {}
         )+
@@ -215,7 +215,7 @@ casts_impl!(
     "postgres_backend": (Text <- Uuid),
 );
 
-macro_rules! faillible_casts_impl {
+macro_rules! fallible_casts_impl {
     (
         $(
             $($feature: literal : )? ($to: tt <- $from: tt),
@@ -223,12 +223,12 @@ macro_rules! faillible_casts_impl {
     ) => {
         $(
             $(#[cfg(feature = $feature)])?
-            impl FaillibleCastsTo<sql_types::$to> for sql_types::$from {}
+            impl FallibleCastsTo<sql_types::$to> for sql_types::$from {}
         )+
     };
 }
 
-faillible_casts_impl!(
+fallible_casts_impl!(
     (Int4 <- Int8),
     (Int4 <- Float8),
     (Int4 <- Text),

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -107,6 +107,7 @@ macro_rules! type_name {
         )*
     };
 }
+
 type_name! {
     diesel::pg::Pg: "postgres_backend" {
         Bool => "bool",
@@ -129,7 +130,6 @@ type_name! {
         Int4 => "integer",
         Int8 => "integer",
         Text => "char",
-
     }
     diesel::sqlite::Sqlite: "sqlite" {
         Int4 => "integer",

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -161,9 +161,10 @@ where
 /// Marker trait: this SQL type (`Self`) can be casted to the target SQL type, but some values can be invalid
 pub trait FaillibleCastsTo<ST> {}
 
-impl<ST1, ST2> FaillibleCastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where ST1: CastsTo<ST2>
-{}
-
+impl<ST1, ST2> FaillibleCastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where
+    ST1: CastsTo<ST2>
+{
+}
 
 /// Marker trait: this SQL type (`Self`) can be casted to the target SQL type
 /// (`ST`) using `CAST(expr AS target_sql_type)`
@@ -171,8 +172,6 @@ pub trait CastsTo<ST>: FaillibleCastsTo<ST> {}
 
 impl<ST1, ST2> CastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where ST1: CastsTo<ST2>
 {}
-
-
 
 macro_rules! casts_impl {
     (

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -165,11 +165,11 @@ impl CastsTo<sql_types::Int8> for sql_types::Int4 {}
 impl CastsTo<sql_types::Int8> for sql_types::Text {}
 impl CastsTo<sql_types::Int4> for sql_types::Int8 {}
 impl CastsTo<sql_types::Int4> for sql_types::Text {}
-#[cfg(feature = "uuid")]
+#[cfg(all(feature = "uuid", feature = "postgres_backend"))]
 impl CastsTo<sql_types::Uuid> for sql_types::Text {}
 impl CastsTo<sql_types::Text> for sql_types::Int4 {}
 impl CastsTo<sql_types::Text> for sql_types::Int8 {}
-#[cfg(feature = "uuid")]
+#[cfg(all(feature = "uuid", feature = "postgres_backend"))]
 impl CastsTo<sql_types::Text> for sql_types::Uuid {}
 impl CastsTo<sql_types::Text> for sql_types::Jsonb {}
 impl CastsTo<sql_types::Text> for sql_types::Json {}

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -135,6 +135,8 @@ type_name! {
         Int4 => "integer",
         Int8 => "bigint",
         Text => "text",
+        Json => "json",
+        Jsonb => "jsoonb",
     }
 }
 

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -191,6 +191,7 @@ macro_rules! casts_impl {
 casts_impl!(
     (Bool <- Int4),
     (Float4 <- Int4),
+    (Float4 <- Int8),
     (Float8 <- Float4),
     (Float8 <- Int4),
     (Float8 <- Int8),
@@ -232,7 +233,6 @@ faillible_casts_impl!(
     (Int4 <- Float8),
     (Int4 <- Text),
     (Int8 <- Text),
-    (Float4 <- Int8),
     (Float4 <- Float8),
     (Float4 <- Text),
     (Float8 <- Text),

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -121,11 +121,13 @@ type_name! {
         Interval => "interval",
         Time => "time",
         Timestamp => "timestamp",
+        Uuid => "uuid",
     }
     diesel::mysql::Mysql: "mysql_backend" {
         Int4 => "integer",
         Int8 => "integer",
         Text => "char",
+
     }
     diesel::sqlite::Sqlite: "sqlite" {
         Int4 => "integer",
@@ -157,6 +159,14 @@ impl<ST1, ST2> CastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> wh
 {}
 
 impl CastsTo<sql_types::Int8> for sql_types::Int4 {}
+impl CastsTo<sql_types::Int8> for sql_types::Text {}
 impl CastsTo<sql_types::Int4> for sql_types::Int8 {}
+impl CastsTo<sql_types::Int4> for sql_types::Text {}
+impl CastsTo<sql_types::Uuid> for sql_types::Text {}
 impl CastsTo<sql_types::Text> for sql_types::Int4 {}
 impl CastsTo<sql_types::Text> for sql_types::Int8 {}
+impl CastsTo<sql_types::Text> for sql_types::Uuid {}
+impl CastsTo<sql_types::Text> for sql_types::Jsonb {}
+impl CastsTo<sql_types::Text> for sql_types::Json {}
+impl CastsTo<sql_types::Jsonb> for sql_types::Text {}
+impl CastsTo<sql_types::Json> for sql_types::Text {}

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -127,16 +127,19 @@ type_name! {
         Jsonb => "jsonb",
     }
     diesel::mysql::Mysql: "mysql_backend" {
-        Int4 => "integer",
-        Int8 => "integer",
+        Int8 => "signed",
         Text => "char",
+        Date => "date",
+        Datetime => "datetime",
+        Decimal => "decimal",
+        Time => "time",
     }
     diesel::sqlite::Sqlite: "sqlite" {
         Int4 => "integer",
         Int8 => "bigint",
         Text => "text",
         Json => "json",
-        Jsonb => "jsoonb",
+        Jsonb => "jsonb",
     }
 }
 

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -96,11 +96,10 @@ where
 }
 
 macro_rules! type_name {
-    ($($backend: ty: $backend_feature: literal { $($($feature: literal;)? $type: ident => $val: literal,)+ })*) => {
+    ($($backend: ty: $backend_feature: literal { $($type: ident => $val: literal,)+ })*) => {
         $(
             $(
 				#[cfg(feature = $backend_feature)]
-                $(#[cfg(feature = $feature)])?
                 impl KnownCastSqlTypeName<$backend> for sql_types::$type {
                     const SQL_TYPE_NAME: &'static str = $val;
                 }
@@ -122,7 +121,7 @@ type_name! {
         Interval => "interval",
         Time => "time",
         Timestamp => "timestamp",
-        "uuid"; Uuid => "uuid",
+        Uuid => "uuid",
         Json => "json",
         Jsonb => "jsonb",
     }
@@ -161,17 +160,11 @@ pub trait CastsTo<ST> {}
 impl<ST1, ST2> CastsTo<sql_types::Nullable<ST2>> for sql_types::Nullable<ST1> where ST1: CastsTo<ST2>
 {}
 
-impl CastsTo<sql_types::Int8> for sql_types::Int4 {}
-impl CastsTo<sql_types::Int8> for sql_types::Text {}
 impl CastsTo<sql_types::Int4> for sql_types::Int8 {}
-impl CastsTo<sql_types::Int4> for sql_types::Text {}
-#[cfg(all(feature = "uuid", feature = "postgres_backend"))]
-impl CastsTo<sql_types::Uuid> for sql_types::Text {}
+impl CastsTo<sql_types::Int8> for sql_types::Int4 {}
+#[cfg(feature = "postgres_backend")]
+impl CastsTo<sql_types::Text> for sql_types::Uuid {}
 impl CastsTo<sql_types::Text> for sql_types::Int4 {}
 impl CastsTo<sql_types::Text> for sql_types::Int8 {}
-#[cfg(all(feature = "uuid", feature = "postgres_backend"))]
-impl CastsTo<sql_types::Text> for sql_types::Uuid {}
 impl CastsTo<sql_types::Text> for sql_types::Jsonb {}
 impl CastsTo<sql_types::Text> for sql_types::Json {}
-impl CastsTo<sql_types::Jsonb> for sql_types::Text {}
-impl CastsTo<sql_types::Json> for sql_types::Text {}

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -96,10 +96,11 @@ where
 }
 
 macro_rules! type_name {
-    ($($backend: ty: $backend_feature: literal { $($type: ident => $val: literal,)+ })*) => {
+    ($($backend: ty: $backend_feature: literal { $($($feature: literal;)? $type: ident => $val: literal,)+ })*) => {
         $(
             $(
 				#[cfg(feature = $backend_feature)]
+                $(#[cfg(feature = $feature)])?
                 impl KnownCastSqlTypeName<$backend> for sql_types::$type {
                     const SQL_TYPE_NAME: &'static str = $val;
                 }
@@ -121,7 +122,7 @@ type_name! {
         Interval => "interval",
         Time => "time",
         Timestamp => "timestamp",
-        Uuid => "uuid",
+        "uuid"; Uuid => "uuid",
         Json => "json",
         Jsonb => "jsonb",
     }
@@ -164,9 +165,11 @@ impl CastsTo<sql_types::Int8> for sql_types::Int4 {}
 impl CastsTo<sql_types::Int8> for sql_types::Text {}
 impl CastsTo<sql_types::Int4> for sql_types::Int8 {}
 impl CastsTo<sql_types::Int4> for sql_types::Text {}
+#[cfg(feature = "uuid")]
 impl CastsTo<sql_types::Uuid> for sql_types::Text {}
 impl CastsTo<sql_types::Text> for sql_types::Int4 {}
 impl CastsTo<sql_types::Text> for sql_types::Int8 {}
+#[cfg(feature = "uuid")]
 impl CastsTo<sql_types::Text> for sql_types::Uuid {}
 impl CastsTo<sql_types::Text> for sql_types::Jsonb {}
 impl CastsTo<sql_types::Text> for sql_types::Json {}

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -211,6 +211,7 @@ casts_impl!(
     (Text <- Time),
     (Json <- Jsonb),
     (Jsonb <- Json),
+    "mysql_backend": (Text <- Datetime),
     "postgres_backend": (Text <- Uuid),
 );
 

--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -122,6 +122,8 @@ type_name! {
         Time => "time",
         Timestamp => "timestamp",
         Uuid => "uuid",
+        Json => "json",
+        Jsonb => "jsonb",
     }
     diesel::mysql::Mysql: "mysql_backend" {
         Int4 => "integer",

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -97,7 +97,7 @@ pub(crate) mod dsl {
 #[doc(inline)]
 pub use self::case_when::CaseWhen;
 #[doc(inline)]
-pub use self::cast::{CastsTo, KnownCastSqlTypeName};
+pub use self::cast::{CastsTo, KnownCastSqlTypeName, FaillibleCastsTo};
 #[doc(inline)]
 pub use self::sql_literal::{SqlLiteral, UncheckedBind};
 

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -97,7 +97,7 @@ pub(crate) mod dsl {
 #[doc(inline)]
 pub use self::case_when::CaseWhen;
 #[doc(inline)]
-pub use self::cast::{CastsTo, KnownCastSqlTypeName, FaillibleCastsTo};
+pub use self::cast::{CastsTo, FaillibleCastsTo, KnownCastSqlTypeName};
 #[doc(inline)]
 pub use self::sql_literal::{SqlLiteral, UncheckedBind};
 

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -97,7 +97,7 @@ pub(crate) mod dsl {
 #[doc(inline)]
 pub use self::case_when::CaseWhen;
 #[doc(inline)]
-pub use self::cast::{CastsTo, FaillibleCastsTo, KnownCastSqlTypeName};
+pub use self::cast::{CastsTo, FallibleCastsTo, KnownCastSqlTypeName};
 #[doc(inline)]
 pub use self::sql_literal::{SqlLiteral, UncheckedBind};
 

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -503,10 +503,10 @@ pub trait ExpressionMethods: Expression + Sized {
     /// let data = diesel::select(
     ///     "12"
     ///         .into_sql::<sql_types::Text>()
-    ///         .faillible_cast::<sql_types::Int4>(),
+    ///         .faillible_cast::<sql_types::Int8>(),
     /// )
-    /// .first::<i32>(connection)?;
-    /// assert_eq!(12i32, data);
+    /// .first::<i64>(connection)?;
+    /// assert_eq!(12i64, data);
     /// #     Ok(())
     /// # }
     /// ```

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -483,9 +483,7 @@ pub trait ExpressionMethods: Expression + Sized {
         cast::Cast::new(self)
     }
 
-    /// Generates a `CAST(expr AS sql_type)` not compile expression
-    ///
-    /// This doesn't check the castability between the types.
+    /// Generates a `CAST(expr AS sql_type)` expression, it's not type compile time checked.
     ///
     /// # Example
     ///
@@ -503,7 +501,7 @@ pub trait ExpressionMethods: Expression + Sized {
     /// use diesel::sql_types;
     ///
     /// let data = diesel::select(
-    ///     12_i32
+    ///     "12"
     ///         .into_sql::<sql_types::Text>()
     ///         .faillible_cast::<sql_types::Int4>(),
     /// )

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -503,17 +503,17 @@ pub trait ExpressionMethods: Expression + Sized {
     /// let data = diesel::select(
     ///     "12"
     ///         .into_sql::<sql_types::Text>()
-    ///         .faillible_cast::<sql_types::Int8>(),
+    ///         .fallible_cast::<sql_types::Int8>(),
     /// )
     /// .first::<i64>(connection)?;
     /// assert_eq!(12i64, data);
     /// #     Ok(())
     /// # }
     /// ```
-    fn faillible_cast<ST>(self) -> dsl::Cast<Self, ST>
+    fn fallible_cast<ST>(self) -> dsl::Cast<Self, ST>
     where
         ST: SingleValue,
-        Self::SqlType: cast::FaillibleCastsTo<ST>,
+        Self::SqlType: cast::FallibleCastsTo<ST>,
     {
         cast::Cast::new(self)
     }

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -483,6 +483,42 @@ pub trait ExpressionMethods: Expression + Sized {
         cast::Cast::new(self)
     }
 
+    /// Generates a `CAST(expr AS sql_type)` not compile expression
+    ///
+    /// This doesn't check the castability between the types.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// use diesel::sql_types;
+    ///
+    /// let data = diesel::select(
+    ///     12_i32
+    ///         .into_sql::<sql_types::Text>()
+    ///         .faillible_cast::<sql_types::Int4>(),
+    /// )
+    /// .first::<i32>(connection)?;
+    /// assert_eq!("12", data);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn faillible_cast<ST>(self) -> dsl::Cast<Self, ST>
+    where
+        ST: SingleValue,
+    {
+        cast::Cast::new(self)
+    }
+
     /// Creates a SQL `DESC` expression, representing this expression in
     /// descending order.
     ///

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -483,7 +483,7 @@ pub trait ExpressionMethods: Expression + Sized {
         cast::Cast::new(self)
     }
 
-    /// Generates a `CAST(expr AS sql_type)` expression, it's not type compile time checked.
+    /// Generates a `CAST(expr AS sql_type)` expression, this version does not check the castability, like [`cast()`](Self::cast).
     ///
     /// # Example
     ///

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -513,6 +513,7 @@ pub trait ExpressionMethods: Expression + Sized {
     fn faillible_cast<ST>(self) -> dsl::Cast<Self, ST>
     where
         ST: SingleValue,
+        Self::SqlType: cast::FaillibleCastsTo<ST>,
     {
         cast::Cast::new(self)
     }

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -506,7 +506,7 @@ pub trait ExpressionMethods: Expression + Sized {
     ///         .faillible_cast::<sql_types::Int4>(),
     /// )
     /// .first::<i32>(connection)?;
-    /// assert_eq!("12", data);
+    /// assert_eq!(12i32, data);
     /// #     Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
I added JsonB and Uuid cast from text and to text support for the newish cast operator

I don't know, if cast() must compile check types that can be cast without failure (ex: int to text). If it's the case I can add a assume_cast() or faillible_cast() where the cast can fail. 