### PR TITLE
Setup cargo-semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,3 +502,17 @@ jobs:
         run: cargo +1.84.0 minimal-versions check -p diesel_migrations --all-features
       - name: Check diesel_cli
         run: cargo +1.84.0 minimal-versions check -p diesel_cli --features "default sqlite-bundled"
+
+  Semver-Checks:
+    name: Run Cargo Semver-Checks
+    runs-on: ubuntu-latest
+    needs: [rustfmt_and_clippy]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+      - name: Run cargo semver-checks
+        run: |
+          cargo xtask semver-checks

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -689,6 +689,9 @@ pub mod sql_types {
     #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
     #[diesel(postgres_type(oid = 3220, array_oid = 3221))]
     pub struct PgLsn;
+
+    #[doc(inline)]
+    pub use crate::sql_types::Jsonb;
 }
 
 mod ops {

--- a/diesel/src/result.rs
+++ b/diesel/src/result.rs
@@ -106,16 +106,16 @@ pub enum Error {
 #[non_exhaustive]
 pub enum DatabaseErrorKind {
     /// A unique constraint was violated.
-    UniqueViolation,
+    UniqueViolation = 0,
 
     /// A foreign key constraint was violated.
-    ForeignKeyViolation,
+    ForeignKeyViolation = 1,
 
     /// The query could not be sent to the database due to a protocol violation.
     ///
     /// An example of a case where this would occur is if you attempted to send
     /// a query with more than 65000 bind parameters using PostgreSQL.
-    UnableToSendCommand,
+    UnableToSendCommand = 2,
 
     /// A serializable transaction failed to commit due to a read/write
     /// dependency on a concurrent transaction.
@@ -124,35 +124,35 @@ pub enum DatabaseErrorKind {
     ///
     /// This error is only detected for PostgreSQL, as we do not yet support
     /// transaction isolation levels for other backends.
-    SerializationFailure,
+    SerializationFailure = 3,
 
     /// The command could not be completed because the transaction was read
     /// only.
     ///
     /// This error will also be returned for `SELECT` statements which attempted
     /// to lock the rows.
-    ReadOnlyTransaction,
+    ReadOnlyTransaction = 4,
 
     /// A restrict constraint was violated.
-    RestrictViolation,
+    RestrictViolation = 9,
 
     /// A not null constraint was violated.
-    NotNullViolation,
+    NotNullViolation = 5,
 
     /// A check constraint was violated.
-    CheckViolation,
+    CheckViolation = 6,
 
     /// An exclusion constraint was violated.
-    ExclusionViolation,
+    ExclusionViolation = 10,
 
     /// The connection to the server was unexpectedly closed.
     ///
     /// This error is only detected for PostgreSQL and is emitted on a best-effort basis
     /// and may be missed.
-    ClosedConnection,
+    ClosedConnection = 7,
 
     #[doc(hidden)]
-    Unknown, // Match against _ instead, more variants may be added in the future
+    Unknown = 8, // Match against _ instead, more variants may be added in the future
 }
 
 /// Information about an error that was returned by the database.

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -219,7 +219,7 @@ error[E0277]: the trait bound `f64: diesel::Expression` is not satisfied
              Exists<T>
            and N others
    = note: required for `f64` to implement `AsExpression<diesel::sql_types::Integer>`
-   = note: required for `(f64, f64)` to implement `AsExpressionList<diesel::sql_types::Integer>`
+   = note: required for `(f64, f64)` to implement `IntoArrayExpression<diesel::sql_types::Integer>`
 note: required by a bound in `diesel::dsl::array`
   --> DIESEL/diesel/diesel/src/pg/expression/array.rs
    |
@@ -233,10 +233,10 @@ error[E0277]: cannot convert `(f64, f64)` into an expression of type `Array<dies
  --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
   |
 LL |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |            ^^^^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(f64, f64)`
+  |            ^^^^^^^^^^^^^^^^^^^ the trait `IntoArrayExpression<diesel::sql_types::Integer>` is not implemented for `(f64, f64)`
   |
   = note: `the trait bound `(f64, f64): IntoArrayExpression<diesel::sql_types::Integer>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
-  = help: the following other types implement trait `AsExpressionList<ST>`:
+  = help: the following other types implement trait `IntoArrayExpression<ST>`:
             (T, T1)
             (T, T1, T2)
             (T, T1, T2, T3)

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -219,7 +219,7 @@ LL |     select(array((1, 3f64)))
              Exists<T>
            and N others
    = note: required for `f64` to implement `AsExpression<diesel::sql_types::Integer>`
-   = note: required for `(i32, f64)` to implement `AsExpressionList<diesel::sql_types::Integer>`
+   = note: required for `(i32, f64)` to implement `IntoArrayExpression<diesel::sql_types::Integer>`
 note: required by a bound in `diesel::dsl::array`
   --> DIESEL/diesel/diesel/src/pg/expression/array.rs
    |
@@ -450,7 +450,7 @@ LL |     select(array((1, 3f64)))
              Exists<T>
            and N others
    = note: required for `{integer}` to implement `AsExpression<diesel::sql_types::Double>`
-   = note: required for `({integer}, f64)` to implement `AsExpressionList<diesel::sql_types::Double>`
+   = note: required for `({integer}, f64)` to implement `IntoArrayExpression<diesel::sql_types::Double>`
 note: required by a bound in `diesel::dsl::array`
   --> DIESEL/diesel/diesel/src/pg/expression/array.rs
    |
@@ -464,10 +464,10 @@ error[E0277]: cannot convert `(i32, f64)` into an expression of type `Array<dies
   --> tests/fail/array_expressions_must_be_same_type.rs:15:12
    |
 LL |     select(array((1, 3f64)))
-   |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(i32, f64)`
+   |            ^^^^^^^^^^^^^^^^ the trait `IntoArrayExpression<diesel::sql_types::Integer>` is not implemented for `(i32, f64)`
    |
    = note: `the trait bound `(i32, f64): IntoArrayExpression<diesel::sql_types::Integer>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
-   = help: the following other types implement trait `AsExpressionList<ST>`:
+   = help: the following other types implement trait `IntoArrayExpression<ST>`:
              (T, T1)
              (T, T1, T2)
              (T, T1, T2, T3)
@@ -482,10 +482,10 @@ error[E0277]: cannot convert `({integer}, f64)` into an expression of type `Arra
   --> tests/fail/array_expressions_must_be_same_type.rs:26:12
    |
 LL |     select(array((1, 3f64)))
-   |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Double>` is not implemented for `({integer}, f64)`
+   |            ^^^^^^^^^^^^^^^^ the trait `IntoArrayExpression<diesel::sql_types::Double>` is not implemented for `({integer}, f64)`
    |
    = note: `the trait bound `({integer}, f64): IntoArrayExpression<diesel::sql_types::Double>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
-   = help: the following other types implement trait `AsExpressionList<ST>`:
+   = help: the following other types implement trait `IntoArrayExpression<ST>`:
              (T, T1)
              (T, T1, T2)
              (T, T1, T2, T3)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use clap::{Parser, ValueEnum};
 
 mod clippy;
+mod semver_checks;
 mod tests;
 mod tidy;
 mod utils;
@@ -22,6 +23,11 @@ enum Commands {
     /// and it will execute `xtask clippy` to verify that the code
     /// compiles without warning
     Tidy(tidy::TidyArgs),
+    /// Check for semver relevant changes
+    ///
+    /// This command will execute `cargo semver-checks` to verify that
+    /// no breaking changes are included
+    SemverChecks(semver_checks::SemverArgs),
 }
 
 impl Commands {
@@ -30,6 +36,7 @@ impl Commands {
             Commands::RunTests(test_args) => test_args.run(),
             Commands::Clippy(clippy) => clippy.run(),
             Commands::Tidy(tidy) => tidy.run(),
+            Commands::SemverChecks(semver) => semver.run(),
         }
     }
 }

--- a/xtask/src/semver_checks.rs
+++ b/xtask/src/semver_checks.rs
@@ -1,0 +1,185 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::process::{Command, Stdio};
+
+use cargo_metadata::MetadataCommand;
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum SemverType {
+    Patch,
+    Minor,
+    Major,
+}
+
+impl Display for SemverType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SemverType::Patch => write!(f, "patch"),
+            SemverType::Minor => write!(f, "minor"),
+            SemverType::Major => write!(f, "major"),
+        }
+    }
+}
+
+#[derive(Debug, clap::Args)]
+pub struct SemverArgs {
+    /// Type of the next release
+    #[clap(long = "type", default_value_t = SemverType::Minor)]
+    tpe: SemverType,
+    /// Baseline version to check against. If that's not
+    /// set the version is inferred from the current package version
+    #[clap(long = "baseline-version")]
+    baseline_version: Option<String>,
+}
+
+impl SemverArgs {
+    pub fn run(&self) {
+        let metadata = MetadataCommand::default().exec().unwrap();
+        let false_positives_for_diesel = HashMap::from([
+            (
+                "inherent_method_missing",
+                // this method was not supposed to be public at all
+                &["SerializedDatabase::new"] as &[_],
+            ),
+            (
+                "trait_added_supertrait",
+                // false positive as cargo semver-checks does not perform trait solving
+                // https://github.com/obi1kenobi/cargo-semver-checks/issues/1265
+                &["trait diesel::connection::Instrumentation gained Downcast"] as &[_],
+            ),
+            (
+                "trait_no_longer_dyn_compatible",
+                // That's technically true, but
+                // noone is able to meaningful use these
+                // traits as trait object as they are only marker
+                // traits, so it's "fine" to break that
+                &[
+                    "trait SqlOrd",
+                    "trait Foldable",
+                    "trait SqlType",
+                    "trait SingleValue",
+                ] as &[_],
+            ),
+        ]);
+        self.run_semver_checks_for(
+            &metadata,
+            "diesel",
+            &["sqlite", "postgres", "mysql", "extras", "with-deprecated"],
+            false_positives_for_diesel,
+        );
+        self.run_semver_checks_for(&metadata, "diesel_migrations", &[], HashMap::new());
+        self.run_semver_checks_for(
+            &metadata,
+            "diesel-dynamic-schema",
+            &["postgres", "mysql", "sqlite"],
+            HashMap::new(),
+        );
+    }
+
+    fn run_semver_checks_for(
+        &self,
+        metadata: &cargo_metadata::Metadata,
+        crate_name: &str,
+        features: &[&str],
+        allow_list: HashMap<&str, &[&str]>,
+    ) {
+        let baseline_diesel_version = if let Some(ref baseline_version) = self.baseline_version {
+            baseline_version.clone()
+        } else {
+            let mut baseline_diesel_version = metadata
+                .packages
+                .iter()
+                .find_map(|c| (c.name == crate_name).then_some(&c.version))
+                .unwrap()
+                .clone();
+            if baseline_diesel_version.major != 0 {
+                baseline_diesel_version.patch = 0;
+            }
+            baseline_diesel_version.to_string()
+        };
+        let mut command = Command::new("cargo");
+        command
+            .args([
+                "semver-checks",
+                "-p",
+                crate_name,
+                "--only-explicit-features",
+                "--baseline-version",
+                &baseline_diesel_version,
+                "--release-type",
+                &self.tpe.to_string(),
+            ])
+            .current_dir(&metadata.workspace_root);
+        for f in features {
+            command.args(["--features", f]);
+        }
+        println!("Run cargo semver-checks via `{command:?}`");
+        let res = command
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .output()
+            .unwrap();
+        let std_out = String::from_utf8(res.stdout).expect("Valid UTF-8");
+        let std_err = String::from_utf8(res.stderr).expect("Valid UTF-8");
+        let mut failed = false;
+        let mut std_out_out = String::new();
+        // That's all here as we want to "patch" the output of cargo-semver-checks
+        // to be able to ignore specific instances of lint violations because:
+        //
+        // * There are a lot of false positives
+        // * Diesel is complex
+        // * Sometimes we want to do things that are technically breaking changes
+        for lint in std_out.split("\n---") {
+            if lint.trim().is_empty() {
+                continue;
+            }
+            let (lint, content) = lint
+                .trim()
+                .strip_prefix("failure")
+                .unwrap_or(lint)
+                .trim()
+                .split_once(':')
+                .expect("Two parts exist");
+            let ignore_list = allow_list.get(lint).copied().unwrap_or_default();
+
+            let failures = content
+                .lines()
+                .skip_while(|l| !l.trim().starts_with("Failed in:"))
+                .skip(1)
+                .filter(|l| ignore_list.iter().all(|e| !l.trim().starts_with(e)))
+                .collect::<Vec<_>>();
+            let content = content
+                .lines()
+                .take_while(|l| !l.trim().starts_with("Failed in:"));
+            if !failures.is_empty() {
+                failed = true;
+                if !std_out_out.is_empty() {
+                    std_out_out += "\n";
+                }
+                std_out_out += "--- failure ";
+                std_out_out += lint;
+                std_out_out += ":";
+                for l in content {
+                    std_out_out += l;
+                    std_out_out += "\n";
+                }
+                std_out_out += "Failed in:";
+                for failure in failures {
+                    std_out_out += "\n";
+                    std_out_out += failure;
+                }
+            }
+        }
+        let (front, back) = std_err.split_once("\n\n").unwrap_or((&std_err, ""));
+        eprintln!("{front}\n");
+        if failed {
+            eprintln!("Cargo semver check failed");
+            println!("{std_out_out}");
+            println!();
+        }
+        eprintln!("{back}");
+        if failed {
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
This commit sets up a xtask for cargo-semver-checks and integrates it in our CI. It also fixes 2 instances of reported breakage. With that there are still 3 more instances reported. I believe two of them are false positives (The `Downcast` super trait and the `IntoArrayExpression` trait message). The third one is a "real" breakage, but I would nevertheless say that this will likely not affect anyone as I do not see any reasonable way to to do something with a trait object there at all.

I'm still not sure what's the correct way to supress such errors only at specific locations.

Marked as draft as the other instances need to be addressed before merging.