### PR TITLE
Disallow mixed aggregates between group by and distinct on clauses

### DIFF
--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -1,9 +1,12 @@
-use crate::expression::SelectableExpression;
+use crate::expression::{SelectableExpression, ValidGrouping};
 use crate::pg::Pg;
+use crate::query_builder::group_by_clause::ValidGroupByClause;
 use crate::query_builder::order_clause::NoOrderClause;
 use crate::query_builder::{
-    AstPass, FromClause, QueryFragment, QueryId, SelectQuery, SelectStatement,
+    AstPass, FromClause, QueryFragment, QueryId, SelectClauseExpression, SelectQuery,
+    SelectStatement,
 };
+use crate::query_dsl::group_by_dsl::ValidDistinctForGroupBy;
 use crate::query_dsl::methods::DistinctOnDsl;
 use crate::query_dsl::order_dsl::ValidOrderingForDistinct;
 use crate::result::QueryResult;
@@ -19,6 +22,8 @@ pub struct DistinctOnClause<T>(pub(crate) T);
 impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for NoOrderClause {}
 impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<(T,)> {}
 impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<T> where T: crate::Expression {}
+
+impl<S, G, D> ValidDistinctForGroupBy<S, G> for DistinctOnClause<D> where (D, S): ValidGrouping<G> {}
 
 impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
     for OrderClause<crate::expression::operators::Asc<T>>
@@ -279,12 +284,15 @@ where
 impl<ST, F, S, D, W, O, LOf, G, H, Selection> DistinctOnDsl<Selection>
     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
 where
+    G: ValidGroupByClause,
     F: QuerySource,
     Selection: SelectableExpression<F>,
     Self: SelectQuery<SqlType = ST>,
     O: ValidOrderingForDistinct<DistinctOnClause<Selection>>,
     SelectStatement<FromClause<F>, S, DistinctOnClause<Selection>, W, O, LOf, G, H>:
         SelectQuery<SqlType = ST>,
+    S: SelectClauseExpression<FromClause<F>>,
+    (Selection, S::Selection): ValidGrouping<G::Expressions>,
 {
     type Output = SelectStatement<FromClause<F>, S, DistinctOnClause<Selection>, W, O, LOf, G, H>;
 

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -1,5 +1,6 @@
 use crate::backend::DieselReserveSpecialization;
 use crate::query_builder::*;
+use crate::query_dsl::group_by_dsl::ValidDistinctForGroupBy;
 use crate::query_dsl::order_dsl::ValidOrderingForDistinct;
 
 #[derive(Debug, Clone, Copy, QueryId)]
@@ -28,6 +29,8 @@ where
 
 impl<O> ValidOrderingForDistinct<NoDistinctClause> for O {}
 impl<O> ValidOrderingForDistinct<DistinctClause> for O {}
+impl<S, G> ValidDistinctForGroupBy<S, G> for NoDistinctClause {}
+impl<S, G> ValidDistinctForGroupBy<S, G> for DistinctClause {}
 
 // This is rexported from another location
 #[allow(unreachable_pub, unused_imports)]

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -18,7 +18,7 @@ mod delete_statement;
 mod distinct_clause;
 pub(crate) mod from_clause;
 pub(crate) mod functions;
-mod group_by_clause;
+pub(crate) mod group_by_clause;
 mod having_clause;
 pub(crate) mod insert_statement;
 pub(crate) mod limit_clause;

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -23,6 +23,7 @@ use crate::query_builder::NoFromClause;
 use crate::query_builder::{
     AsQuery, IntoBoxedClause, Query, QueryFragment, SelectQuery, SelectStatement,
 };
+use crate::query_dsl::group_by_dsl::ValidDistinctForGroupBy;
 use crate::query_dsl::methods::*;
 use crate::query_dsl::order_dsl::ValidOrderingForDistinct;
 use crate::query_dsl::*;
@@ -128,6 +129,7 @@ where
     F: QuerySource,
     Selection: SelectableExpression<F> + ValidGrouping<G::Expressions>,
     SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: SelectQuery,
+    D: ValidDistinctForGroupBy<Selection, G::Expressions>,
 {
     type Output = SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>;
 
@@ -152,6 +154,7 @@ where
     G: ValidGroupByClause,
     Selection: SelectableExpression<NoFromClause> + ValidGrouping<G::Expressions>,
     SelectStatement<NoFromClause, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: SelectQuery,
+    D: ValidDistinctForGroupBy<Selection, G::Expressions>,
 {
     type Output = SelectStatement<NoFromClause, SelectClause<Selection>, D, W, O, LOf, G, H, LC>;
 

--- a/diesel/src/query_dsl/group_by_dsl.rs
+++ b/diesel/src/query_dsl/group_by_dsl.rs
@@ -35,3 +35,5 @@ where
         self.as_query().group_by(expr)
     }
 }
+
+pub trait ValidDistinctForGroupBy<Selection, GroupBy> {}

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -27,7 +27,7 @@ mod combine_dsl;
 mod distinct_dsl;
 #[doc(hidden)]
 pub mod filter_dsl;
-mod group_by_dsl;
+pub(crate) mod group_by_dsl;
 mod having_dsl;
 mod join_dsl;
 #[doc(hidden)]

--- a/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs
+++ b/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs
@@ -1,0 +1,55 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    posts {
+        id -> Integer,
+        user_id -> Integer,
+        hair_color -> Text,
+    }
+}
+
+fn main() {
+    let mut conn = PgConnection::establish("…").unwrap();
+
+    // that one is ok
+    let _ = posts::table
+        .group_by(posts::user_id)
+        .select(posts::user_id)
+        .distinct_on(posts::user_id)
+        .get_result::<i32>(&mut conn);
+
+    // these should fail
+    let _ = posts::table
+        .group_by(posts::user_id)
+        .distinct_on(posts::id) // error
+        .select(posts::user_id)
+        .get_results::<i32>(&mut conn);
+
+    let _ = posts::table
+        .distinct_on(posts::id)
+        .group_by(posts::user_id)
+        .select(posts::user_id) // error
+        .get_results::<i32>(&mut conn);
+
+    let _ = posts::table
+        .distinct_on(posts::user_id)
+        .select(dsl::count(posts::id)) // error
+        .get_result::<i64>(&mut conn);
+
+    let _ = posts::table
+        .select(dsl::count(posts::id))
+        .distinct_on(posts::user_id) // error
+        .get_result::<i64>(&mut conn);
+
+    let _ = posts::table
+        .distinct_on(posts::user_id)
+        .count() // error
+        .get_result::<i64>(&mut conn);
+
+    let _ = posts::table
+        .count()
+        .distinct_on(posts::user_id) // error
+        .get_result::<i64>(&mut conn);
+}

--- a/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
@@ -1,0 +1,97 @@
+error[E0277]: the trait bound `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>: DistinctOnDsl<_>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:26:10
+   |
+26 |         .distinct_on(posts::id) // error
+   |          ^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>`
+   = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
+
+error[E0277]: the trait bound `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::id>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>: SelectDsl<_>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:33:10
+   |
+33 |         .select(posts::user_id) // error
+   |          ^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `SelectDsl<_>` is not implemented for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::id>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>`
+   = help: the following other types implement trait `SelectDsl<Selection>`:
+             SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
+             SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
+
+error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:38:17
+   |
+38 |         .select(dsl::count(posts::id)) // error
+   |          ------ ^^^^^^^^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `MixedAggregates<Other>`:
+             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
+   = note: required for `(columns::user_id, diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>)` to implement `ValidGrouping<()>`
+   = note: required for `DistinctOnClause<columns::user_id>` to implement `query_dsl::group_by_dsl::ValidDistinctForGroupBy<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>, ()>`
+   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::user_id>>` to implement `SelectDsl<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>>`
+note: required by a bound in `diesel::QueryDsl::select`
+  --> $DIESEL/src/query_dsl/mod.rs
+   |
+   |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+   |        ------ required by a bound in this associated function
+...
+   |         Self: methods::SelectDsl<Selection>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+
+error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:43:22
+   |
+43 |         .distinct_on(posts::user_id) // error
+   |          ----------- ^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `MixedAggregates<Other>`:
+             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
+   = note: required for `(columns::user_id, diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>)` to implement `ValidGrouping<()>`
+   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>>>` to implement `DistinctOnDsl<columns::user_id>`
+note: required by a bound in `diesel::QueryDsl::distinct_on`
+  --> $DIESEL/src/query_dsl/mod.rs
+   |
+   |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+   |        ----------- required by a bound in this associated function
+   |     where
+   |         Self: methods::DistinctOnDsl<Expr>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+
+error[E0277]: the trait bound `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::user_id>>: SelectDsl<CountStar>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:48:10
+   |
+48 |         .count() // error
+   |          ^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `SelectDsl<CountStar>` is not implemented for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::user_id>>`
+   = help: the following other types implement trait `SelectDsl<Selection>`:
+             SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
+             SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
+
+error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:53:22
+   |
+53 |         .distinct_on(posts::user_id) // error
+   |          ----------- ^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `MixedAggregates<Other>`:
+             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
+   = note: required for `(columns::user_id, CountStar)` to implement `ValidGrouping<()>`
+   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<CountStar>>` to implement `DistinctOnDsl<columns::user_id>`
+note: required by a bound in `diesel::QueryDsl::distinct_on`
+  --> $DIESEL/src/query_dsl/mod.rs
+   |
+   |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+   |        ----------- required by a bound in this associated function
+   |     where
+   |         Self: methods::DistinctOnDsl<Expr>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`


### PR DESCRIPTION
This commit fixes an issue where diesel incorrectly allowed code to compile that constructed queries with mixed aggregates in select + distinct on clauses. That's not allowed by postgresql.

This commit rejectes these queries + introduces some compile fail tests for them. That's technically a "breaking" change as we now accept less code. In the past we always handled such cases as bug fixes as they just fix invalid code.

Fix #4606