### PR TITLE
Adding extended support for `Box`, `Rc`, and `Arc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `json_extract` and `jsonb_extract` SQL function support for the SQLite backend
 * Added `SqliteConnection::get_read_only_blob` method to stream blob's from a SQLite database to Rust via `std::io::Read`
 * Added support for casting to `REAL` in SQLite.
+* Added `ToSql`, `FromSql`, `Queryable`, and `AsExpression` impls for `Rc<T>`, `Arc<T>`, and `Box<T>` (including `Rc/Arc<dyn BoxableExpression>` for cloneable dynamic query fragments and the `<str>` / `<[u8]>` unsized variants).
 
 ### Fixed
 

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -184,6 +184,14 @@ impl<T: Expression + ?Sized> Expression for Box<T> {
     type SqlType = T::SqlType;
 }
 
+impl<T: Expression + ?Sized> Expression for alloc::rc::Rc<T> {
+    type SqlType = T::SqlType;
+}
+
+impl<T: Expression + ?Sized> Expression for alloc::sync::Arc<T> {
+    type SqlType = T::SqlType;
+}
+
 impl<T: Expression + ?Sized> Expression for &T {
     type SqlType = T::SqlType;
 }
@@ -329,6 +337,20 @@ where
 {
 }
 
+impl<T: ?Sized, QS> AppearsOnTable<QS> for alloc::rc::Rc<T>
+where
+    T: AppearsOnTable<QS>,
+    alloc::rc::Rc<T>: Expression,
+{
+}
+
+impl<T: ?Sized, QS> AppearsOnTable<QS> for alloc::sync::Arc<T>
+where
+    T: AppearsOnTable<QS>,
+    alloc::sync::Arc<T>: Expression,
+{
+}
+
 impl<'a, T: ?Sized, QS> AppearsOnTable<QS> for &'a T
 where
     T: AppearsOnTable<QS>,
@@ -355,6 +377,20 @@ impl<T: ?Sized, QS> SelectableExpression<QS> for Box<T>
 where
     T: SelectableExpression<QS>,
     Box<T>: AppearsOnTable<QS>,
+{
+}
+
+impl<T: ?Sized, QS> SelectableExpression<QS> for alloc::rc::Rc<T>
+where
+    T: SelectableExpression<QS>,
+    alloc::rc::Rc<T>: AppearsOnTable<QS>,
+{
+}
+
+impl<T: ?Sized, QS> SelectableExpression<QS> for alloc::sync::Arc<T>
+where
+    T: SelectableExpression<QS>,
+    alloc::sync::Arc<T>: AppearsOnTable<QS>,
 {
 }
 
@@ -738,6 +774,14 @@ pub trait ValidGrouping<GroupByClause> {
 }
 
 impl<T: ValidGrouping<GB> + ?Sized, GB> ValidGrouping<GB> for Box<T> {
+    type IsAggregate = T::IsAggregate;
+}
+
+impl<T: ValidGrouping<GB> + ?Sized, GB> ValidGrouping<GB> for alloc::rc::Rc<T> {
+    type IsAggregate = T::IsAggregate;
+}
+
+impl<T: ValidGrouping<GB> + ?Sized, GB> ValidGrouping<GB> for alloc::sync::Arc<T> {
     type IsAggregate = T::IsAggregate;
 }
 

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -317,6 +317,38 @@ where
     }
 }
 
+impl<T, Tab, const N: usize> Insertable<Tab> for alloc::rc::Rc<[T; N]>
+where
+    T: Insertable<Tab> + core::clone::Clone,
+{
+    // We can reuse the query id for [T; N] here as this compiles down to the
+    // same query. `T: Clone` is required because shared ownership of `Rc`
+    // prevents moving the array elements out; we clone via `<[T]>::to_vec()`.
+    // The `Box<[T; N]>` impl above does not need this bound because it owns
+    // the array exclusively and can move elements out via `Vec::from`.
+    type Values = BatchInsert<Vec<T::Values>, Tab, [T::Values; N], true>;
+
+    fn values(self) -> Self::Values {
+        let v = self.to_vec();
+        let values = v.into_iter().map(Insertable::values).collect::<Vec<_>>();
+        BatchInsert::new(values)
+    }
+}
+
+impl<T, Tab, const N: usize> Insertable<Tab> for alloc::sync::Arc<[T; N]>
+where
+    T: Insertable<Tab> + core::clone::Clone,
+{
+    // See the `Rc<[T; N]>` impl above for the `T: Clone` rationale.
+    type Values = BatchInsert<Vec<T::Values>, Tab, [T::Values; N], true>;
+
+    fn values(self) -> Self::Values {
+        let v = self.to_vec();
+        let values = v.into_iter().map(Insertable::values).collect::<Vec<_>>();
+        BatchInsert::new(values)
+    }
+}
+
 mod private {
     // This helper exists to differentiate between
     // Insertable implementations for tuples and for single values

--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -162,6 +162,42 @@ impl<DB: Backend> Migration<DB> for Box<dyn Migration<DB> + '_> {
     }
 }
 
+impl<DB: Backend> Migration<DB> for alloc::rc::Rc<dyn Migration<DB> + '_> {
+    fn run(&self, conn: &mut dyn BoxableConnection<DB>) -> Result<()> {
+        (**self).run(conn)
+    }
+
+    fn revert(&self, conn: &mut dyn BoxableConnection<DB>) -> Result<()> {
+        (**self).revert(conn)
+    }
+
+    fn metadata(&self) -> &dyn MigrationMetadata {
+        (**self).metadata()
+    }
+
+    fn name(&self) -> &dyn MigrationName {
+        (**self).name()
+    }
+}
+
+impl<DB: Backend> Migration<DB> for alloc::sync::Arc<dyn Migration<DB> + '_> {
+    fn run(&self, conn: &mut dyn BoxableConnection<DB>) -> Result<()> {
+        (**self).run(conn)
+    }
+
+    fn revert(&self, conn: &mut dyn BoxableConnection<DB>) -> Result<()> {
+        (**self).revert(conn)
+    }
+
+    fn metadata(&self) -> &dyn MigrationMetadata {
+        (**self).metadata()
+    }
+
+    fn name(&self) -> &dyn MigrationName {
+        (**self).name()
+    }
+}
+
 impl<DB: Backend> Migration<DB> for &dyn Migration<DB> {
     fn run(&self, conn: &mut dyn BoxableConnection<DB>) -> Result<()> {
         (**self).run(conn)
@@ -223,5 +259,23 @@ impl MigrationConnection for crate::sqlite::SqliteConnection {
     fn setup(&mut self) -> QueryResult<usize> {
         use crate::RunQueryDsl;
         crate::sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Migration;
+    use crate::backend::Backend;
+    use alloc::boxed::Box;
+    use alloc::rc::Rc;
+    use alloc::sync::Arc;
+
+    fn assert_migration<DB: Backend, M: Migration<DB>>() {}
+
+    #[allow(dead_code)]
+    fn migration_for_box_rc_arc_dyn_compiles<DB: Backend>() {
+        assert_migration::<DB, Box<dyn Migration<DB>>>();
+        assert_migration::<DB, Rc<dyn Migration<DB>>>();
+        assert_migration::<DB, Arc<dyn Migration<DB>>>();
     }
 }

--- a/diesel/src/query_builder/insert_statement/batch_insert.rs
+++ b/diesel/src/query_builder/insert_statement/batch_insert.rs
@@ -71,6 +71,24 @@ where
     }
 }
 
+impl<T, DB, const N: usize> CanInsertInSingleQuery<DB> for alloc::rc::Rc<[T; N]>
+where
+    DB: Backend+ SqlDialect<InsertWithDefaultKeyword = sql_dialect::default_keyword_for_insert::IsoSqlDefaultKeyword>
+{
+    fn rows_to_insert(&self) -> Option<usize> {
+        Some(N)
+    }
+}
+
+impl<T, DB, const N: usize> CanInsertInSingleQuery<DB> for alloc::sync::Arc<[T; N]>
+where
+    DB: Backend+ SqlDialect<InsertWithDefaultKeyword = sql_dialect::default_keyword_for_insert::IsoSqlDefaultKeyword>
+{
+    fn rows_to_insert(&self) -> Option<usize> {
+        Some(N)
+    }
+}
+
 impl<T, DB> CanInsertInSingleQuery<DB> for [T]
 where
     DB: Backend+ SqlDialect<InsertWithDefaultKeyword = sql_dialect::default_keyword_for_insert::IsoSqlDefaultKeyword>

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -311,6 +311,26 @@ where
     }
 }
 
+impl<T: ?Sized, DB> QueryFragment<DB> for alloc::rc::Rc<T>
+where
+    DB: Backend,
+    T: QueryFragment<DB>,
+{
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        QueryFragment::walk_ast(&**self, pass)
+    }
+}
+
+impl<T: ?Sized, DB> QueryFragment<DB> for alloc::sync::Arc<T>
+where
+    DB: Backend,
+    T: QueryFragment<DB>,
+{
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        QueryFragment::walk_ast(&**self, pass)
+    }
+}
+
 impl<T: ?Sized, DB> QueryFragment<DB> for &T
 where
     DB: Backend,

--- a/diesel/src/query_builder/query_id.rs
+++ b/diesel/src/query_builder/query_id.rs
@@ -86,6 +86,22 @@ impl<T: QueryId + ?Sized> QueryId for Box<T> {
     const IS_WINDOW_FUNCTION: bool = T::IS_WINDOW_FUNCTION;
 }
 
+impl<T: QueryId + ?Sized> QueryId for alloc::rc::Rc<T> {
+    type QueryId = T::QueryId;
+
+    const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
+
+    const IS_WINDOW_FUNCTION: bool = T::IS_WINDOW_FUNCTION;
+}
+
+impl<T: QueryId + ?Sized> QueryId for alloc::sync::Arc<T> {
+    type QueryId = T::QueryId;
+
+    const HAS_STATIC_QUERY_ID: bool = T::HAS_STATIC_QUERY_ID;
+
+    const IS_WINDOW_FUNCTION: bool = T::IS_WINDOW_FUNCTION;
+}
+
 impl<T: QueryId + ?Sized> QueryId for &T {
     type QueryId = T::QueryId;
 

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -8,6 +8,7 @@ use crate::sql_types::{
 };
 use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
 use alloc::fmt;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -270,5 +271,174 @@ where
 
     fn as_expression(self) -> Self::Expression {
         Bound::new(&**self)
+    }
+}
+
+impl<T: ?Sized, ST, DB> ToSql<ST, DB> for Box<T>
+where
+    T: ToSql<ST, DB>,
+    DB: Backend,
+    Self: fmt::Debug,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> serialize::Result {
+        ToSql::<ST, DB>::to_sql(&**self, out)
+    }
+}
+
+impl<T, ST, DB> FromSql<ST, DB> for Box<T>
+where
+    DB: Backend,
+    T: FromSql<ST, DB>,
+{
+    fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        T::from_sql(bytes).map(Box::from)
+    }
+}
+
+impl<T: ?Sized, ST, DB> Queryable<ST, DB> for Box<T>
+where
+    ST: SingleValue,
+    DB: Backend,
+    Self: FromSql<ST, DB>,
+{
+    type Row = Self;
+
+    fn build(row: Self::Row) -> deserialize::Result<Self> {
+        Ok(row)
+    }
+}
+
+impl<T: ?Sized, ST, DB> ToSql<ST, DB> for alloc::rc::Rc<T>
+where
+    T: ToSql<ST, DB>,
+    DB: Backend,
+    Self: fmt::Debug,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> serialize::Result {
+        ToSql::<ST, DB>::to_sql(&**self, out)
+    }
+}
+
+impl<T, ST, DB> FromSql<ST, DB> for alloc::rc::Rc<T>
+where
+    DB: Backend,
+    T: FromSql<ST, DB>,
+{
+    fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        T::from_sql(bytes).map(alloc::rc::Rc::from)
+    }
+}
+
+impl<T: ?Sized, ST, DB> Queryable<ST, DB> for alloc::rc::Rc<T>
+where
+    ST: SingleValue,
+    DB: Backend,
+    Self: FromSql<ST, DB>,
+{
+    type Row = Self;
+
+    fn build(row: Self::Row) -> deserialize::Result<Self> {
+        Ok(row)
+    }
+}
+
+impl<T: ?Sized, ST, DB> ToSql<ST, DB> for alloc::sync::Arc<T>
+where
+    T: ToSql<ST, DB>,
+    DB: Backend,
+    Self: fmt::Debug,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> serialize::Result {
+        ToSql::<ST, DB>::to_sql(&**self, out)
+    }
+}
+
+impl<T, ST, DB> FromSql<ST, DB> for alloc::sync::Arc<T>
+where
+    DB: Backend,
+    T: FromSql<ST, DB>,
+{
+    fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        T::from_sql(bytes).map(alloc::sync::Arc::from)
+    }
+}
+
+impl<T: ?Sized, ST, DB> Queryable<ST, DB> for alloc::sync::Arc<T>
+where
+    ST: SingleValue,
+    DB: Backend,
+    Self: FromSql<ST, DB>,
+{
+    type Row = Self;
+
+    fn build(row: Self::Row) -> deserialize::Result<Self> {
+        Ok(row)
+    }
+}
+
+// `FromSql` for the unsized-inner-type cases (`Box<str>`, `Rc<str>`, `Arc<str>`,
+// and the `[u8]` equivalents). The generic `FromSql for Box<T> where T: FromSql`
+// blanket above can't cover these because `str`/`[u8]` are `!Sized` and cannot
+// implement `FromSql` themselves. Instead we go through `FromSqlRef` for `&str` /
+// `&[u8]` and then build the smart pointer with `Box::from` / `Rc::from` / `Arc::from`,
+// which all accept `&str` or `&[u8]` and allocate a sized backing buffer.
+
+impl<ST, DB> FromSql<ST, DB> for Box<str>
+where
+    DB: Backend,
+    for<'a> &'a str: FromSqlRef<'a, ST, DB>,
+{
+    fn from_sql(mut bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        <&str as FromSqlRef<'_, ST, DB>>::from_sql(&mut bytes).map(Box::from)
+    }
+}
+
+impl<ST, DB> FromSql<ST, DB> for alloc::rc::Rc<str>
+where
+    DB: Backend,
+    for<'a> &'a str: FromSqlRef<'a, ST, DB>,
+{
+    fn from_sql(mut bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        <&str as FromSqlRef<'_, ST, DB>>::from_sql(&mut bytes).map(alloc::rc::Rc::from)
+    }
+}
+
+impl<ST, DB> FromSql<ST, DB> for alloc::sync::Arc<str>
+where
+    DB: Backend,
+    for<'a> &'a str: FromSqlRef<'a, ST, DB>,
+{
+    fn from_sql(mut bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        <&str as FromSqlRef<'_, ST, DB>>::from_sql(&mut bytes).map(alloc::sync::Arc::from)
+    }
+}
+
+impl<ST, DB> FromSql<ST, DB> for Box<[u8]>
+where
+    DB: Backend,
+    for<'a> &'a [u8]: FromSqlRef<'a, ST, DB>,
+{
+    fn from_sql(mut bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        <&[u8] as FromSqlRef<'_, ST, DB>>::from_sql(&mut bytes).map(Box::from)
+    }
+}
+
+impl<ST, DB> FromSql<ST, DB> for alloc::rc::Rc<[u8]>
+where
+    DB: Backend,
+    for<'a> &'a [u8]: FromSqlRef<'a, ST, DB>,
+{
+    fn from_sql(mut bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        <&[u8] as FromSqlRef<'_, ST, DB>>::from_sql(&mut bytes).map(alloc::rc::Rc::from)
+    }
+}
+
+impl<ST, DB> FromSql<ST, DB> for alloc::sync::Arc<[u8]>
+where
+    DB: Backend,
+    for<'a> &'a [u8]: FromSqlRef<'a, ST, DB>,
+{
+    fn from_sql(mut bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        <&[u8] as FromSqlRef<'_, ST, DB>>::from_sql(&mut bytes).map(alloc::sync::Arc::from)
     }
 }

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
@@ -7,12 +7,12 @@ LL |     int_primary_key::table.find("1");
    = help: the following other types implement trait `Expression`:
              &T
              AliasedField<S, C>
+             Arc<T>
              Box<T>
              CaseWhen<..., ...>
              CaseWhen<CaseWhenConditionsLeaf<W, T>, ...>
              CaseWhen<CaseWhenConditionsLeaf<W, T>, ...>
              Collate<T, C>
-             SqlLiteral<ST, T>
            and N others
    = note: required for `&str` to implement `Expression`
    = note: 1 redundant requirement hidden
@@ -54,12 +54,12 @@ error[E0277]: the trait bound `{integer}: Expression` is not satisfied
     = help: the following other types implement trait `Expression`:
               &T
               AliasedField<S, C>
+              Arc<T>
               Box<T>
               CaseWhen<..., ...>
               CaseWhen<CaseWhenConditionsLeaf<W, T>, ...>
               CaseWhen<CaseWhenConditionsLeaf<W, T>, ...>
               Collate<T, C>
-              SqlLiteral<ST, T>
             and N others
     = note: required for `Eq<id, {integer}>` to implement `Expression`
 note: required for `string_primary_key::columns::id` to implement `diesel::EqAll<{integer}>`

--- a/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
@@ -29,12 +29,12 @@ LL |         .having(users::id.gt(1))
    = help: the following other types implement trait `Expression`:
              &T
              AliasedField<S, C>
+             Arc<T>
              Box<T>
              CaseWhen<..., ...>
              CaseWhen<CaseWhenConditionsLeaf<W, T>, ...>
              CaseWhen<CaseWhenConditionsLeaf<W, T>, ...>
              Collate<T, C>
-             SqlLiteral<ST, T>
            and N others
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), ..., _>` to implement `HavingDsl<_>`
 

--- a/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
@@ -35,11 +35,11 @@ error[E0277]: `BatchInsert<Vec<...>, ..., (), false>` is no valid SQL fragment f
 help: the following other types implement trait `QueryFragment<DB, SP>`
     --> DIESEL/diesel/diesel/src/query_builder/insert_statement/batch_insert.rs
      |
-  LL | / impl<Tab, DB, V, QId, const HAS_STATIC_QUERY_ID: bool> QueryFragment<DB>
-  LL | |     for BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>
-  LL | | where
-  LL | |     DB: Backend,
-  LL | |     Self: QueryFragment<DB, DB::BatchInsertSupport>,
+ LL | / impl<Tab, DB, V, QId, const HAS_STATIC_QUERY_ID: bool> QueryFragment<DB>
+ LL | |     for BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>
+ LL | | where
+ LL | |     DB: Backend,
+ LL | |     Self: QueryFragment<DB, DB::BatchInsertSupport>,
      | |____________________________________________________^ `BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>` implements `QueryFragment<DB>`
 ...
  LL | / impl<Tab, DB, V, QId, const HAS_STATIC_QUERY_ID: bool>

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -31,6 +31,24 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     generics2.params.push(parse_quote!('__expr2));
     let (impl_generics2, _, where_clause2) = generics2.split_for_impl();
 
+    // Smart-pointer wrapper impls (`Rc<T>`, `Arc<T>`, `Box<T>`) are emitted only for
+    // `#[diesel(foreign_derive)]` types. For user-defined local types they would
+    // run into both coherence (E0119) and orphan (E0117) checks against the wildcard
+    // `impl<T, ST> AsExpression<ST> for T where T: Expression<SqlType=ST>` once
+    // `Expression for Rc/Arc/Box<T>` exists, because Rust treats `MyLocalType:
+    // Expression` as downstream-extensible. Diesel's own `foreign_impls` cover the
+    // standard-library primitives (`String`, `i32`, `bool`, ...) so users get
+    // `Rc<String>`/`Arc<String>` field support automatically.
+    let wrappers: Vec<syn::Path> = if model.foreign_derive {
+        vec![
+            parse_quote!(alloc::rc::Rc),
+            parse_quote!(alloc::sync::Arc),
+            parse_quote!(alloc::boxed::Box),
+        ]
+    } else {
+        Vec::new()
+    };
+
     let tokens = model.sql_types.iter().map(|sql_type| {
 
         let mut to_sql_generics = item.generics.clone();
@@ -38,6 +56,31 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         to_sql_generics.make_where_clause().predicates.push(parse_quote!(__DB: diesel::backend::Backend));
         to_sql_generics.make_where_clause().predicates.push(parse_quote!(Self: diesel::serialize::ToSql<#sql_type, __DB>));
         let (to_sql_impl_generics, _, to_sql_where_clause) = to_sql_generics.split_for_impl();
+
+        let wrapper_borrowed = wrappers.iter().map(|wrapper| quote!(
+            #[diagnostic::do_not_recommend]
+            impl #impl_generics diesel::expression::AsExpression<#sql_type>
+                for &'__expr #wrapper<#struct_ty> #where_clause
+            {
+                type Expression = diesel::internal::derives::as_expression::Bound<#sql_type, &'__expr #struct_ty>;
+
+                fn as_expression(self) -> <Self as diesel::expression::AsExpression<#sql_type>>::Expression {
+                    diesel::internal::derives::as_expression::Bound::new(&**self)
+                }
+            }
+
+            #[diagnostic::do_not_recommend]
+            impl #impl_generics diesel::expression::AsExpression<diesel::sql_types::Nullable<#sql_type>>
+                for &'__expr #wrapper<#struct_ty> #where_clause
+            {
+                type Expression = diesel::internal::derives::as_expression::Bound<diesel::sql_types::Nullable<#sql_type>, &'__expr #struct_ty>;
+
+                fn as_expression(self) -> <Self as diesel::expression::AsExpression<diesel::sql_types::Nullable<#sql_type>>>::Expression {
+                    diesel::internal::derives::as_expression::Bound::new(&**self)
+                }
+            }
+        ));
+        let wrapper_borrowed = quote!( #( #wrapper_borrowed )* );
 
         let tokens = quote!(
             impl #impl_generics diesel::expression::AsExpression<#sql_type>
@@ -91,10 +134,43 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                     diesel::serialize::ToSql::<#sql_type, __DB>::to_sql(self, out)
                 }
             }
+
+            #wrapper_borrowed
         );
 
+        // Owned smart-pointer wrapper impls. Emitted regardless of `model.not_sized`
+        // because `Rc<T>`, `Arc<T>`, and `Box<T>` are always `Sized` even when `T` is
+        // `?Sized` (e.g., `Rc<str>`, `Box<[u8]>`).
+        let wrapper_owned = wrappers.iter().map(|wrapper| quote!(
+            impl #impl_generics_plain diesel::expression::AsExpression<#sql_type>
+                for #wrapper<#struct_ty> #where_clause_plain
+            {
+                type Expression = diesel::internal::derives::as_expression::Bound<#sql_type, Self>;
+
+                fn as_expression(self) -> <Self as diesel::expression::AsExpression<#sql_type>>::Expression {
+                    diesel::internal::derives::as_expression::Bound::new(self)
+                }
+            }
+
+            #[diagnostic::do_not_recommend]
+            impl #impl_generics_plain diesel::expression::AsExpression<diesel::sql_types::Nullable<#sql_type>>
+                for #wrapper<#struct_ty> #where_clause_plain
+            {
+                type Expression = diesel::internal::derives::as_expression::Bound<diesel::sql_types::Nullable<#sql_type>, Self>;
+
+                fn as_expression(self) -> <Self as diesel::expression::AsExpression<diesel::sql_types::Nullable<#sql_type>>>::Expression {
+                    diesel::internal::derives::as_expression::Bound::new(self)
+                }
+            }
+        ));
+        let wrapper_owned = quote!( #( #wrapper_owned )* );
+
         if model.not_sized {
-            tokens
+            quote!(
+                #tokens
+
+                #wrapper_owned
+            )
         } else {
             quote!(
                 #tokens
@@ -116,6 +192,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                         diesel::internal::derives::as_expression::Bound::new(self)
                     }
                 }
+
+                #wrapper_owned
             )
         }
     });

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -155,6 +155,19 @@ fn derive_as_changeset_inner(input: proc_macro2::TokenStream) -> proc_macro2::To
 /// you can specify this by adding the annotation `#[diesel(not_sized)]`
 /// as attribute on the type. This will skip the impls for non-reference types.
 ///
+/// `Rc<T>`, `Arc<T>`, and `Box<T>` wrappers around Diesel's built-in primitive
+/// types (`String`, `i32`, `bool`, `Vec<u8>`, etc.) are supported as
+/// `AsExpression` values through Diesel's internal `foreign_derive`
+/// implementations, so fields like `Rc<String>` work transparently with
+/// `#[derive(Insertable)]` and `#[derive(Queryable)]`. The unsized variants
+/// `Rc<str>` / `Arc<str>` / `Box<str>` and the `[u8]` equivalents are supported
+/// as well (one heap allocation instead of two compared to `Rc<String>`).
+/// Wrapping a *user-defined* `AsExpression` type in `Rc`/`Arc`/`Box` is not
+/// currently supported because of coherence and orphan-rule conflicts between
+/// the wildcard
+/// `impl<T, ST> AsExpression<ST> for T where T: Expression<SqlType = ST>` and
+/// the smart-pointer `Expression` impls.
+///
 /// Using this derive requires implementing the `ToSql` trait for your type.
 ///
 /// # Attributes:

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -1,6 +1,8 @@
 use crate::schema::*;
 use diesel::sql_types::VarChar;
 use diesel::*;
+use std::rc::Rc;
+use std::sync::Arc;
 
 macro_rules! assert_sets_eq {
     ($set1:expr, $set2:expr) => {
@@ -37,6 +39,64 @@ fn filter_by_int_equality() {
     assert_eq!(
         Err(NotFound),
         users.filter(id.eq(unused_id)).first::<User>(connection)
+    );
+}
+
+#[diesel_test_helper::test]
+fn filter_rc_by_int_equality() {
+    use crate::schema::users::dsl::*;
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let sean_id = find_user_by_name("Sean", connection).id;
+    let tess_id = find_user_by_name("Tess", connection).id;
+    let unused_id = sean_id + tess_id;
+
+    let sean = UserRcString {
+        id: sean_id,
+        name: Rc::new("Sean".to_string()),
+        hair_color: None,
+    };
+    let tess = UserRcString {
+        id: tess_id,
+        name: Rc::new("Tess".to_string()),
+        hair_color: None,
+    };
+    assert_eq!(Ok(sean), users.filter(id.eq(sean_id)).first(connection));
+    assert_eq!(Ok(tess), users.filter(id.eq(tess_id)).first(connection));
+    assert_eq!(
+        Err(NotFound),
+        users
+            .filter(id.eq(unused_id))
+            .first::<UserRcString>(connection)
+    );
+}
+
+#[diesel_test_helper::test]
+fn filter_arc_by_int_equality() {
+    use crate::schema::users::dsl::*;
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let sean_id = find_user_by_name("Sean", connection).id;
+    let tess_id = find_user_by_name("Tess", connection).id;
+    let unused_id = sean_id + tess_id;
+
+    let sean = UserArcString {
+        id: sean_id,
+        name: Arc::new("Sean".to_string()),
+        hair_color: None,
+    };
+    let tess = UserArcString {
+        id: tess_id,
+        name: Arc::new("Tess".to_string()),
+        hair_color: None,
+    };
+    assert_eq!(Ok(sean), users.filter(id.eq(sean_id)).first(connection));
+    assert_eq!(Ok(tess), users.filter(id.eq(tess_id)).first(connection));
+    assert_eq!(
+        Err(NotFound),
+        users
+            .filter(id.eq(unused_id))
+            .first::<UserArcString>(connection)
     );
 }
 
@@ -423,6 +483,42 @@ fn filter_by_boxed_predicate() {
         name: &str,
     ) -> Box<dyn BoxableExpression<users::table, TestBackend, SqlType = sql_types::Bool>> {
         Box::new(lower(users::name).eq(name.to_string()))
+    }
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let sean = User::new(1, "Sean");
+    let tess = User::new(2, "Tess");
+    let queried_sean = users::table.filter(by_name("sean")).first(connection);
+    let queried_tess = users::table.filter(by_name("tess")).first(connection);
+
+    assert_eq!(Ok(sean), queried_sean);
+    assert_eq!(Ok(tess), queried_tess);
+}
+
+#[diesel_test_helper::test]
+fn filter_by_rc_boxed_predicate() {
+    fn by_name(
+        name: &str,
+    ) -> Rc<dyn BoxableExpression<users::table, TestBackend, SqlType = sql_types::Bool>> {
+        Rc::new(lower(users::name).eq(name.to_string()))
+    }
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let sean = User::new(1, "Sean");
+    let tess = User::new(2, "Tess");
+    let queried_sean = users::table.filter(by_name("sean")).first(connection);
+    let queried_tess = users::table.filter(by_name("tess")).first(connection);
+
+    assert_eq!(Ok(sean), queried_sean);
+    assert_eq!(Ok(tess), queried_tess);
+}
+
+#[diesel_test_helper::test]
+fn filter_by_arc_boxed_predicate() {
+    fn by_name(
+        name: &str,
+    ) -> Arc<dyn BoxableExpression<users::table, TestBackend, SqlType = sql_types::Bool>> {
+        Arc::new(lower(users::name).eq(name.to_string()))
     }
 
     let connection = &mut connection_with_sean_and_tess_in_users_table();

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -1,5 +1,7 @@
 use super::schema::*;
 use diesel::*;
+use std::rc::Rc;
+use std::sync::Arc;
 
 #[diesel_test_helper::test]
 fn insert_records() {
@@ -25,6 +27,150 @@ fn insert_records() {
         User {
             id: actual_users[1].id,
             name: "Tess".to_string(),
+            hair_color: None,
+        },
+    ];
+    assert_eq!(expected_users, actual_users);
+}
+
+#[diesel_test_helper::test]
+fn insert_rc_string_records() {
+    use crate::schema::users::table as users;
+    let connection = &mut connection();
+    let new_users: &[_] = &[
+        NewUserRcString {
+            name: Rc::new("Sean".to_string()),
+            hair_color: Some(Rc::new("Black".to_string())),
+        },
+        NewUserRcString {
+            name: Rc::new("Tess".to_string()),
+            hair_color: None,
+        },
+    ];
+
+    insert_into(users)
+        .values(new_users)
+        .execute(connection)
+        .unwrap();
+    let actual_users = users.load::<UserRcString>(connection).unwrap();
+
+    let expected_users = vec![
+        UserRcString {
+            id: actual_users[0].id,
+            name: Rc::new("Sean".to_string()),
+            hair_color: Some(Rc::new("Black".to_string())),
+        },
+        UserRcString {
+            id: actual_users[1].id,
+            name: Rc::new("Tess".to_string()),
+            hair_color: None,
+        },
+    ];
+    assert_eq!(expected_users, actual_users);
+}
+
+#[diesel_test_helper::test]
+fn insert_rc_str_records() {
+    use crate::schema::users::table as users;
+    let connection = &mut connection();
+    let new_users: &[_] = &[
+        NewUserRcStr {
+            name: Rc::from("Sean"),
+            hair_color: Some(Rc::from("Black")),
+        },
+        NewUserRcStr {
+            name: Rc::from("Tess"),
+            hair_color: None,
+        },
+    ];
+
+    insert_into(users)
+        .values(new_users)
+        .execute(connection)
+        .unwrap();
+    let actual_users = users.load::<UserRcStr>(connection).unwrap();
+
+    let expected_users = vec![
+        UserRcStr {
+            id: actual_users[0].id,
+            name: Rc::from("Sean"),
+            hair_color: Some(Rc::from("Black")),
+        },
+        UserRcStr {
+            id: actual_users[1].id,
+            name: Rc::from("Tess"),
+            hair_color: None,
+        },
+    ];
+    assert_eq!(expected_users, actual_users);
+}
+
+#[diesel_test_helper::test]
+fn insert_arc_str_records() {
+    use crate::schema::users::table as users;
+    let connection = &mut connection();
+    let new_users: &[_] = &[
+        NewUserArcStr {
+            name: Arc::from("Sean"),
+            hair_color: Some(Arc::from("Black")),
+        },
+        NewUserArcStr {
+            name: Arc::from("Tess"),
+            hair_color: None,
+        },
+    ];
+
+    insert_into(users)
+        .values(new_users)
+        .execute(connection)
+        .unwrap();
+    let actual_users = users.load::<UserArcStr>(connection).unwrap();
+
+    let expected_users = vec![
+        UserArcStr {
+            id: actual_users[0].id,
+            name: Arc::from("Sean"),
+            hair_color: Some(Arc::from("Black")),
+        },
+        UserArcStr {
+            id: actual_users[1].id,
+            name: Arc::from("Tess"),
+            hair_color: None,
+        },
+    ];
+    assert_eq!(expected_users, actual_users);
+}
+
+#[diesel_test_helper::test]
+fn insert_arc_string_records() {
+    use crate::schema::users::table as users;
+    let connection = &mut connection();
+    let new_users: &[_] = &[
+        NewUserArcString {
+            name: Arc::new("Sean".to_string()),
+            hair_color: Some(Arc::new("Black".to_string())),
+        },
+        NewUserArcString {
+            name: Arc::new("Tess".to_string()),
+            hair_color: None,
+        },
+    ];
+
+    insert_into(users)
+        .values(new_users)
+        .execute(connection)
+        .unwrap();
+    let actual_users = users.load::<UserArcString>(connection).unwrap();
+
+    let expected_users = vec![
+        UserArcString {
+            id: actual_users[0].id,
+            name: Arc::new("Sean".to_string()),
+            hair_color: Some(Arc::new("Black".to_string())),
+        },
+        UserArcString {
+            id: actual_users[1].id,
+            name: Arc::new("Tess".to_string()),
             hair_color: None,
         },
     ];
@@ -126,6 +272,66 @@ fn insert_records_as_boxed_static_array() {
     use crate::schema::users::{id, table as users};
     let connection = &mut connection();
     let new_users = Box::new([
+        NewUser::new("Sean", Some("Black")),
+        NewUser::new("Tess", None),
+    ]);
+
+    insert_into(users)
+        .values(new_users)
+        .execute(connection)
+        .unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
+
+    let expected_users = vec![
+        User {
+            id: actual_users[0].id,
+            name: "Sean".to_string(),
+            hair_color: Some("Black".to_string()),
+        },
+        User {
+            id: actual_users[1].id,
+            name: "Tess".to_string(),
+            hair_color: None,
+        },
+    ];
+    assert_eq!(expected_users, actual_users);
+}
+
+#[diesel_test_helper::test]
+fn insert_records_as_rc_static_array() {
+    use crate::schema::users::{id, table as users};
+    let connection = &mut connection();
+    let new_users = Rc::new([
+        NewUser::new("Sean", Some("Black")),
+        NewUser::new("Tess", None),
+    ]);
+
+    insert_into(users)
+        .values(new_users)
+        .execute(connection)
+        .unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
+
+    let expected_users = vec![
+        User {
+            id: actual_users[0].id,
+            name: "Sean".to_string(),
+            hair_color: Some("Black".to_string()),
+        },
+        User {
+            id: actual_users[1].id,
+            name: "Tess".to_string(),
+            hair_color: None,
+        },
+    ];
+    assert_eq!(expected_users, actual_users);
+}
+
+#[diesel_test_helper::test]
+fn insert_records_as_arc_static_array() {
+    use crate::schema::users::{id, table as users};
+    let connection = &mut connection();
+    let new_users = Arc::new([
         NewUser::new("Sean", Some("Black")),
         NewUser::new("Tess", None),
     ]);

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -51,6 +51,44 @@ impl User {
     }
 }
 
+#[derive(
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Queryable,
+    Identifiable,
+    Insertable,
+    AsChangeset,
+    QueryableByName,
+    Selectable,
+)]
+#[diesel(table_name = users)]
+pub struct UserRcString {
+    pub id: i32,
+    pub name: std::rc::Rc<String>,
+    pub hair_color: Option<std::rc::Rc<String>>,
+}
+
+#[derive(
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Queryable,
+    Identifiable,
+    Insertable,
+    AsChangeset,
+    QueryableByName,
+    Selectable,
+)]
+#[diesel(table_name = users)]
+pub struct UserArcString {
+    pub id: i32,
+    pub name: std::sync::Arc<String>,
+    pub hair_color: Option<std::sync::Arc<String>>,
+}
+
 #[derive(PartialEq, Eq, Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = users)]
 pub struct UserName(#[diesel(column_name = name)] pub String);
@@ -132,6 +170,72 @@ impl NewUser {
             hair_color: hair_color.map(|s| s.to_string()),
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset, Selectable)]
+#[diesel(table_name = users)]
+pub struct NewUserRcString {
+    pub name: std::rc::Rc<String>,
+    pub hair_color: Option<std::rc::Rc<String>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset, Selectable)]
+#[diesel(table_name = users)]
+pub struct NewUserArcString {
+    pub name: std::sync::Arc<String>,
+    pub hair_color: Option<std::sync::Arc<String>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset, Selectable)]
+#[diesel(table_name = users)]
+pub struct NewUserRcStr {
+    pub name: std::rc::Rc<str>,
+    pub hair_color: Option<std::rc::Rc<str>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Queryable, Clone, Insertable, AsChangeset, Selectable)]
+#[diesel(table_name = users)]
+pub struct NewUserArcStr {
+    pub name: std::sync::Arc<str>,
+    pub hair_color: Option<std::sync::Arc<str>>,
+}
+
+#[derive(
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Queryable,
+    Identifiable,
+    Insertable,
+    AsChangeset,
+    QueryableByName,
+    Selectable,
+)]
+#[diesel(table_name = users)]
+pub struct UserRcStr {
+    pub id: i32,
+    pub name: std::rc::Rc<str>,
+    pub hair_color: Option<std::rc::Rc<str>>,
+}
+
+#[derive(
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Queryable,
+    Identifiable,
+    Insertable,
+    AsChangeset,
+    QueryableByName,
+    Selectable,
+)]
+#[diesel(table_name = users)]
+pub struct UserArcStr {
+    pub id: i32,
+    pub name: std::sync::Arc<str>,
+    pub hair_color: Option<std::sync::Arc<str>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Insertable)]


### PR DESCRIPTION
This PR addresses discussion #4609

Still have to: 

* [x] Implement also:
    * [x] `impl<T, DB, const N: usize> CanInsertInSingleQuery<DB> for Rc<[T; N]>`
    * [x] `impl<T, DB, const N: usize> CanInsertInSingleQuery<DB> for Arc<[T; N]>`
    * [x] `impl<DB: Backend> Migration<DB> for Rc<dyn Migration<DB> + '_> `
    * [x] `impl<DB: Backend> Migration<DB> for Arc<dyn Migration<DB> + '_> `
    * [x] `impl<T: QueryId + ?Sized> QueryId for Rc<T>`
    * [x] `impl<T: QueryId + ?Sized> QueryId for Arc<T>`
    * [x] `impl<T: ?Sized, DB> QueryFragment<DB> for Rc<T>`
    * [x] `impl<T: ?Sized, DB> QueryFragment<DB> for Arc<T>`
    * [x] `impl<T: Insertable> Insertable for Rc<T>`
    * [x] `impl<T: Insertable> Insertable for Arc<T>`
    * [x] `impl<T: AppearsOnTable> AppearsOnTable for Rc<T>`
    * [x] `impl<T: AppearsOnTable> AppearsOnTable for Arc<T>`
    * [x] `impl<T: SelectableExpression> SelectableExpression for Rc<T>`
    * [x] `impl<T: SelectableExpression> SelectableExpression for Arc<T>`
    * [x] `impl<T: ValidGrouping> ValidGrouping for Rc<T>`
    * [x] `impl<T: ValidGrouping> ValidGrouping for Arc<T>`
    * [x] `impl<T: ?Sized, ST, DB> Queryable<ST, DB> for std::rc::Rc<T>`
    * [x] `impl<T: ?Sized, ST, DB> Queryable<ST, DB> for std::sync::Arc<T>`
    * [x] `impl<T: ?Sized, ST, DB> Queryable<ST, DB> for Box<T>`
    * [x] `impl<impl<T: ?Sized, ST, DB> ToSql<ST, DB> for std::rc::Rc<T>`
    * [x] `impl<impl<T: ?Sized, ST, DB> ToSql<ST, DB> for std::sync::Arc<T>`
    * [x] `impl<impl<T: ?Sized, ST, DB> ToSql<ST, DB> for Box<T>`
    * [x] `impl<T, ST, DB> FromSql<ST, DB> for std::rc::Rc<T>`
    * [x] `impl<T, ST, DB> FromSql<ST, DB> for std::sync::Arc<T>` 
    * [x] `impl<T, ST, DB> FromSql<ST, DB> for Box<T>` 
* [x] Extend test suite for `Rc`
* [x] Extend test suite for `Arc`