### PR TITLE
2024 edition compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,12 +472,12 @@ jobs:
           cargo +stable -Z build-std test --manifest-path diesel/Cargo.toml --no-default-features --features "mysql extras __with_asan_tests" --target x86_64-unknown-linux-gnu
 
   minimal_rust_version:
-    name: Check Minimal supported rust version (1.78.0)
+    name: Check Minimal supported rust version (1.82.0)
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.78.0
+      - uses: dtolnay/rust-toolchain@1.82.0
       - uses: dtolnay/rust-toolchain@nightly
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
@@ -490,12 +490,12 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install libsqlite3-dev libpq-dev libmysqlclient-dev
       - name: Check diesel_derives
-        run: cargo +1.78.0 minimal-versions check -p diesel_derives --features "postgres sqlite mysql 32-column-tables 64-column-tables 128-column-tables without-deprecated with-deprecated r2d2"
+        run: cargo +1.82.0 minimal-versions check -p diesel_derives --features "postgres sqlite mysql 32-column-tables 64-column-tables 128-column-tables without-deprecated with-deprecated r2d2"
       - name: Check diesel
-        run: cargo +1.78.0 minimal-versions check -p diesel --features "postgres mysql sqlite extras"
+        run: cargo +1.82.0 minimal-versions check -p diesel --features "postgres mysql sqlite extras"
       - name: Check diesel_dynamic_schema
-        run: cargo +1.78.0 minimal-versions check -p diesel-dynamic-schema --all-features
+        run: cargo +1.82.0 minimal-versions check -p diesel-dynamic-schema --all-features
       - name: Check diesel_migrations
-        run: cargo +1.78.0 minimal-versions check -p diesel_migrations --all-features
+        run: cargo +1.82.0 minimal-versions check -p diesel_migrations --all-features
       - name: Check diesel_cli
-        run: cargo +1.78.0 minimal-versions check -p diesel_cli --features "default sqlite-bundled"
+        run: cargo +1.82.0 minimal-versions check -p diesel_cli --features "default sqlite-bundled"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ in a way that makes the pools suitable for use in parallel tests.
 ### Changed
 
 * Use distinct `DIESEL_LOG` logging filter env variable instead of the default `RUST_LOG` one (#4575)
+* The minimal supported Rust version is now 1.82.0
 
 ## [2.2.2] 2024-07-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.78.0"
+rust-version = "1.82.0"
 include = ["src/**/*.rs", "tests/**/*.rs", "LICENSE-*", "README.md"]
 edition = "2021"
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://diesel.rs"
 repository = "https://github.com/diesel-rs/diesel"
 keywords = ["orm", "database", "sql"]
 categories = ["database"]
-edition = "2021"
+edition.workspace = true
 rust-version.workspace = true
 include = [
     "src/**/*.rs",

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -47,7 +47,7 @@ impl Iterator for StatementIterator<'_> {
         // if that's not the case, we need to copy the output bind buffers
         // to somewhere else
         let res = if let Some(binds) = Rc::get_mut(&mut self.last_row) {
-            if let PrivateMysqlRow::Direct(ref mut binds) = RefCell::get_mut(binds) {
+            if let PrivateMysqlRow::Direct(binds) = RefCell::get_mut(binds) {
                 self.stmt.populate_row_buffers(binds)
             } else {
                 // any other state than `PrivateMysqlRow::Direct` is invalid here

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -101,14 +101,14 @@ impl PgTypeMetadata {
     /// The [OID] of `T`
     ///
     /// [OID]: https://www.postgresql.org/docs/current/static/datatype-oid.html
-    pub fn oid(&self) -> Result<u32, impl std::error::Error + Send + Sync> {
+    pub fn oid(&self) -> Result<u32, impl std::error::Error + Send + Sync + use<>> {
         self.0.as_ref().map(|i| i.oid).map_err(Clone::clone)
     }
 
     /// The [OID] of `T[]`
     ///
     /// [OID]: https://www.postgresql.org/docs/current/static/datatype-oid.html
-    pub fn array_oid(&self) -> Result<u32, impl std::error::Error + Send + Sync> {
+    pub fn array_oid(&self) -> Result<u32, impl std::error::Error + Send + Sync + use<>> {
         self.0.as_ref().map(|i| i.array_oid).map_err(Clone::clone)
     }
 }

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -62,7 +62,8 @@ impl RawConnection {
     }
 
     pub(super) unsafe fn exec(&self, query: *const libc::c_char) -> QueryResult<RawResult> {
-        RawResult::new(PQexec(self.internal_connection.as_ptr(), query), self)
+        let result_ptr = unsafe { PQexec(self.internal_connection.as_ptr(), query) };
+        RawResult::new(result_ptr, self)
     }
 
     /// Sends a query and parameters to the server without using the prepare/bind cycle.
@@ -79,16 +80,18 @@ impl RawConnection {
         param_formats: *const libc::c_int,
         result_format: libc::c_int,
     ) -> QueryResult<()> {
-        let res = PQsendQueryParams(
-            self.internal_connection.as_ptr(),
-            query,
-            param_count,
-            param_types,
-            param_values,
-            param_lengths,
-            param_formats,
-            result_format,
-        );
+        let res = unsafe {
+            PQsendQueryParams(
+                self.internal_connection.as_ptr(),
+                query,
+                param_count,
+                param_types,
+                param_values,
+                param_lengths,
+                param_formats,
+                result_format,
+            )
+        };
         if res == 1 {
             Ok(())
         } else {
@@ -108,15 +111,17 @@ impl RawConnection {
         param_formats: *const libc::c_int,
         result_format: libc::c_int,
     ) -> QueryResult<()> {
-        let res = PQsendQueryPrepared(
-            self.internal_connection.as_ptr(),
-            stmt_name,
-            param_count,
-            param_values,
-            param_lengths,
-            param_formats,
-            result_format,
-        );
+        let res = unsafe {
+            PQsendQueryPrepared(
+                self.internal_connection.as_ptr(),
+                stmt_name,
+                param_count,
+                param_values,
+                param_lengths,
+                param_formats,
+                result_format,
+            )
+        };
         if res == 1 {
             Ok(())
         } else {
@@ -134,13 +139,15 @@ impl RawConnection {
         param_count: libc::c_int,
         param_types: *const Oid,
     ) -> QueryResult<RawResult> {
-        let ptr = PQprepare(
-            self.internal_connection.as_ptr(),
-            stmt_name,
-            query,
-            param_count,
-            param_types,
-        );
+        let ptr = unsafe {
+            PQprepare(
+                self.internal_connection.as_ptr(),
+                stmt_name,
+                query,
+                param_count,
+                param_types,
+            )
+        };
         RawResult::new(ptr, self)
     }
 

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -457,7 +457,7 @@ where
             Some(&mut OptionalAggregator::Some(ref mut agg)) => agg,
             Some(a_ptr @ &mut OptionalAggregator::None) => {
                 ptr::write_unaligned(a_ptr as *mut _, OptionalAggregator::Some(A::default()));
-                if let OptionalAggregator::Some(ref mut agg) = a_ptr {
+                if let OptionalAggregator::Some(agg) = a_ptr {
                     agg
                 } else {
                     return Err(SqliteCallbackError::Abort(NULL_CTX_ERR));
@@ -533,7 +533,9 @@ unsafe fn context_error_str(ctx: *mut ffi::sqlite3_context, error: &str) {
         .len()
         .try_into()
         .expect("Trying to set a error message with more than 2^32 byte is not supported");
-    ffi::sqlite3_result_error(ctx, error.as_ptr() as *const _, len);
+    unsafe {
+        ffi::sqlite3_result_error(ctx, error.as_ptr() as *const _, len);
+    }
 }
 
 struct CollationUserPtr<F> {

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -92,7 +92,7 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
     fn next(&mut self) -> Option<Self::Item> {
         use PrivateStatementIterator::{NotStarted, Started};
         match &mut self.inner {
-            NotStarted(ref mut stmt @ Some(_)) => {
+            NotStarted(stmt @ Some(_)) => {
                 let mut stmt = stmt
                     .take()
                     .expect("It must be there because we checked that above");
@@ -115,7 +115,7 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
                     }
                 }
             }
-            Started(ref mut last_row) => {
+            Started(last_row) => {
                 // There was already at least one iteration step
                 // We check here if the caller already released the row value or not
                 // by checking if our Rc owns the data or not
@@ -125,7 +125,7 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
                     // datastructures for now
                     // We don't need to use the runtime borrowing system of the RefCell here
                     // as we have a mutable reference, so all of this below is checked at compile time
-                    if let PrivateSqliteRow::Direct(ref mut stmt) = last_row_ref.get_mut() {
+                    if let PrivateSqliteRow::Direct(stmt) = last_row_ref.get_mut() {
                         let step = unsafe {
                             // This is actually safe here as we've already
                             // performed one step. For the first step we would have

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -81,21 +81,23 @@ impl Statement {
     ) -> QueryResult<Option<NonNull<[u8]>>> {
         let mut ret_ptr = None;
         let result = match (tpe, value) {
-            (_, InternalSqliteBindValue::Null) => {
+            (_, InternalSqliteBindValue::Null) => unsafe {
                 ffi::sqlite3_bind_null(self.inner_statement.as_ptr(), bind_index)
-            }
+            },
             (SqliteType::Binary, InternalSqliteBindValue::BorrowedBinary(bytes)) => {
                 let n = bytes
                     .len()
                     .try_into()
                     .map_err(|e| Error::SerializationError(Box::new(e)))?;
-                ffi::sqlite3_bind_blob(
-                    self.inner_statement.as_ptr(),
-                    bind_index,
-                    bytes.as_ptr() as *const libc::c_void,
-                    n,
-                    ffi::SQLITE_STATIC(),
-                )
+                unsafe {
+                    ffi::sqlite3_bind_blob(
+                        self.inner_statement.as_ptr(),
+                        bind_index,
+                        bytes.as_ptr() as *const libc::c_void,
+                        n,
+                        ffi::SQLITE_STATIC(),
+                    )
+                }
             }
             (SqliteType::Binary, InternalSqliteBindValue::Binary(mut bytes)) => {
                 let len = bytes
@@ -107,26 +109,30 @@ impl Statement {
                 // and not the pointer to the first element of the slice
                 let ptr = bytes.as_mut_ptr();
                 ret_ptr = NonNull::new(Box::into_raw(bytes));
-                ffi::sqlite3_bind_blob(
-                    self.inner_statement.as_ptr(),
-                    bind_index,
-                    ptr as *const libc::c_void,
-                    len,
-                    ffi::SQLITE_STATIC(),
-                )
+                unsafe {
+                    ffi::sqlite3_bind_blob(
+                        self.inner_statement.as_ptr(),
+                        bind_index,
+                        ptr as *const libc::c_void,
+                        len,
+                        ffi::SQLITE_STATIC(),
+                    )
+                }
             }
             (SqliteType::Text, InternalSqliteBindValue::BorrowedString(bytes)) => {
                 let len = bytes
                     .len()
                     .try_into()
                     .map_err(|e| Error::SerializationError(Box::new(e)))?;
-                ffi::sqlite3_bind_text(
-                    self.inner_statement.as_ptr(),
-                    bind_index,
-                    bytes.as_ptr() as *const libc::c_char,
-                    len,
-                    ffi::SQLITE_STATIC(),
-                )
+                unsafe {
+                    ffi::sqlite3_bind_text(
+                        self.inner_statement.as_ptr(),
+                        bind_index,
+                        bytes.as_ptr() as *const libc::c_char,
+                        len,
+                        ffi::SQLITE_STATIC(),
+                    )
+                }
             }
             (SqliteType::Text, InternalSqliteBindValue::String(bytes)) => {
                 let mut bytes = Box::<[u8]>::from(bytes);
@@ -139,29 +145,31 @@ impl Statement {
                 // and not the pointer to the first element of the slice
                 let ptr = bytes.as_mut_ptr();
                 ret_ptr = NonNull::new(Box::into_raw(bytes));
-                ffi::sqlite3_bind_text(
-                    self.inner_statement.as_ptr(),
-                    bind_index,
-                    ptr as *const libc::c_char,
-                    len,
-                    ffi::SQLITE_STATIC(),
-                )
+                unsafe {
+                    ffi::sqlite3_bind_text(
+                        self.inner_statement.as_ptr(),
+                        bind_index,
+                        ptr as *const libc::c_char,
+                        len,
+                        ffi::SQLITE_STATIC(),
+                    )
+                }
             }
             (SqliteType::Float, InternalSqliteBindValue::F64(value))
-            | (SqliteType::Double, InternalSqliteBindValue::F64(value)) => {
+            | (SqliteType::Double, InternalSqliteBindValue::F64(value)) => unsafe {
                 ffi::sqlite3_bind_double(
                     self.inner_statement.as_ptr(),
                     bind_index,
                     value as libc::c_double,
                 )
-            }
+            },
             (SqliteType::SmallInt, InternalSqliteBindValue::I32(value))
-            | (SqliteType::Integer, InternalSqliteBindValue::I32(value)) => {
+            | (SqliteType::Integer, InternalSqliteBindValue::I32(value)) => unsafe {
                 ffi::sqlite3_bind_int(self.inner_statement.as_ptr(), bind_index, value)
-            }
-            (SqliteType::Long, InternalSqliteBindValue::I64(value)) => {
+            },
+            (SqliteType::Long, InternalSqliteBindValue::I64(value)) => unsafe {
                 ffi::sqlite3_bind_int64(self.inner_statement.as_ptr(), bind_index, value)
-            }
+            },
             (t, b) => {
                 return Err(Error::SerializationError(
                     format!("Type mismatch: Expected {t:?}, got {b}").into(),
@@ -175,7 +183,7 @@ impl Statement {
                     // This is a `NonNul` ptr so it cannot be null
                     // It points to a slice internally as we did not apply
                     // any cast above.
-                    std::mem::drop(Box::from_raw(ptr.as_ptr()))
+                    std::mem::drop(unsafe { Box::from_raw(ptr.as_ptr()) })
                 }
                 Err(e)
             }
@@ -464,7 +472,9 @@ impl<'stmt, 'query> StatementUse<'stmt, 'query> {
     // It's always safe to call this function with `first_step = true` as this removes
     // the cached column names
     pub(super) unsafe fn step(&mut self, first_step: bool) -> QueryResult<bool> {
-        let res = match ffi::sqlite3_step(self.statement.statement.inner_statement.as_ptr()) {
+        let step_result =
+            unsafe { ffi::sqlite3_step(self.statement.statement.inner_statement.as_ptr()) };
+        let res = match step_result {
             ffi::SQLITE_DONE => Ok(false),
             ffi::SQLITE_ROW => Ok(true),
             _ => Err(last_error(self.statement.statement.raw_connection())),
@@ -488,14 +498,15 @@ impl<'stmt, 'query> StatementUse<'stmt, 'query> {
     // it should maximally be called once per column at all.
     unsafe fn column_name(&self, idx: i32) -> *const str {
         let name = {
-            let column_name =
-                ffi::sqlite3_column_name(self.statement.statement.inner_statement.as_ptr(), idx);
+            let column_name = unsafe {
+                ffi::sqlite3_column_name(self.statement.statement.inner_statement.as_ptr(), idx)
+            };
             assert!(
                 !column_name.is_null(),
                 "The Sqlite documentation states that it only returns a \
                  null pointer here if we are in a OOM condition."
             );
-            CStr::from_ptr(column_name)
+            unsafe { CStr::from_ptr(column_name) }
         };
         name.to_str().expect(
             "The Sqlite documentation states that this is UTF8. \

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -112,8 +112,7 @@ fn expand_variadic(
     let variadic_args = args.split_off(nonvariadic_args_count);
     let nonvariadic_args = args;
 
-    let variadic_args: Vec<_> = iter::repeat(variadic_args)
-        .take(variant_no)
+    let variadic_args: Vec<_> = iter::repeat_n(variadic_args, variant_no)
         .enumerate()
         .flat_map(|(arg_group_idx, arg_group)| {
             let mut resulting_args = vec![];
@@ -156,8 +155,7 @@ fn expand_variadic(
             })
             .collect()
     } else {
-        iter::repeat(generics)
-            .take(variant_no)
+        iter::repeat_n(generics, variant_no)
             .enumerate()
             .flat_map(|(generic_group_idx, generic_group)| {
                 let mut resulting_generics = vec![];

--- a/examples/postgres/advanced-blog-cli/src/auth.rs
+++ b/examples/postgres/advanced-blog-cli/src/auth.rs
@@ -130,7 +130,10 @@ mod tests {
     #[test]
     fn current_user_from_env_fails_when_no_username_set() {
         let _guard = this_test_modifies_env();
-        env::remove_var("BLOG_USERNAME");
+        // There doesn't seem to be a better solution
+        unsafe {
+            env::remove_var("BLOG_USERNAME");
+        }
 
         let conn = &mut connection();
 
@@ -140,8 +143,11 @@ mod tests {
     #[test]
     fn current_user_from_env_fails_when_no_password_set() {
         let _guard = this_test_modifies_env();
-        env::remove_var("BLOG_PASSWORD");
-        env::set_var("BLOG_USERNAME", "sgrif");
+        // There doesn't seem to be a better solution
+        unsafe {
+            env::remove_var("BLOG_PASSWORD");
+            env::set_var("BLOG_USERNAME", "sgrif");
+        }
 
         let conn = &mut connection();
 


### PR DESCRIPTION
These changes remove any warnings poping up while trying to compile the crate with 2024 edition set as crate edition. My motivation for fixing all of that is to potentially utilize the merged doc test feature in the future for local runs (which requires compiling with 2024 edition enabled).