### PR TITLE
Better diagnostics for mixed group by

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -715,6 +715,11 @@ impl<T: ValidGrouping<GB> + ?Sized, GB> ValidGrouping<GB> for &T {
 pub use diesel_derives::ValidGrouping;
 
 #[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    note = "if your query contains columns from several tables in your group by or select \
+            clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` \
+            with these columns"
+)]
 pub trait IsContainedInGroupBy<T> {
     type Output;
 }

--- a/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs
+++ b/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs
@@ -1,0 +1,30 @@
+extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> Text,
+        user_id -> Integer,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(users, posts);
+joinable!(posts -> users(user_id));
+
+fn main() {
+    let mut conn = SqliteConnection::establish("").unwrap();
+
+    let q = users::table
+        .inner_join(posts::table)
+        .group_by((users::id, posts::user_id))
+        .select((users::id, posts::user_id, diesel::dsl::count_star()));
+}

--- a/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.stderr
+++ b/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.stderr
@@ -1,0 +1,42 @@
+error[E0277]: the trait bound `posts::columns::user_id: IsContainedInGroupBy<users::columns::id>` is not satisfied
+  --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:29:10
+   |
+29 |         .select((users::id, posts::user_id, diesel::dsl::count_star()));
+   |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `posts::columns::user_id`
+   |
+   = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
+   = help: the following other types implement trait `IsContainedInGroupBy<T>`:
+             `posts::columns::user_id` implements `IsContainedInGroupBy<posts::columns::id>`
+             `posts::columns::user_id` implements `IsContainedInGroupBy<posts::columns::title>`
+             `posts::columns::user_id` implements `IsContainedInGroupBy<posts::columns::user_id>`
+   = note: required for `(posts::columns::user_id,)` to implement `IsContainedInGroupBy<users::columns::id>`
+   = note: 1 redundant requirement hidden
+   = note: required for `(users::columns::id, posts::columns::user_id)` to implement `IsContainedInGroupBy<users::columns::id>`
+note: required for `users::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
+  --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:7:9
+   |
+7  |         id -> Integer,
+   |         ^^
+   = note: 1 redundant requirement hidden
+   = note: required for `(users::columns::id, posts::columns::user_id, CountStar)` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
+   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::id, posts::columns::user_id)>>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`
+
+error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<posts::columns::user_id>` is not satisfied
+  --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:29:10
+   |
+29 |         .select((users::id, posts::user_id, diesel::dsl::count_star()));
+   |          ^^^^^^ the trait `IsContainedInGroupBy<posts::columns::user_id>` is not implemented for `users::columns::id`
+   |
+   = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
+   = help: the following other types implement trait `IsContainedInGroupBy<T>`:
+             `users::columns::id` implements `IsContainedInGroupBy<users::columns::id>`
+             `users::columns::id` implements `IsContainedInGroupBy<users::columns::name>`
+   = note: required for `(users::columns::id, posts::columns::user_id)` to implement `IsContainedInGroupBy<posts::columns::user_id>`
+note: required for `posts::columns::user_id` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
+  --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:16:9
+   |
+16 |         user_id -> Integer,
+   |         ^^^^^^^
+   = note: 2 redundant requirements hidden
+   = note: required for `(users::columns::id, posts::columns::user_id, CountStar)` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
+   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::id, posts::columns::user_id)>>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`

--- a/diesel_compile_tests/tests/fail/invalid_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/invalid_group_by.stderr
@@ -95,6 +95,7 @@ error[E0277]: the trait bound `AliasedField<post1, posts::columns::id>: IsContai
 50 |         .select(users::id)
    |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `AliasedField<post1, posts::columns::id>`
    |
+   = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
    = help: the following other types implement trait `IsContainedInGroupBy<T>`:
              `(T0, T1)` implements `IsContainedInGroupBy<Col>`
              `(T0, T1, T2)` implements `IsContainedInGroupBy<Col>`

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
@@ -88,6 +88,7 @@ error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<comments
 102 |         .select((users::all_columns, posts::all_columns, comments::id));
     |          ^^^^^^ the trait `IsContainedInGroupBy<comments::columns::id>` is not implemented for `users::columns::id`
     |
+    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
     = help: the following other types implement trait `IsContainedInGroupBy<T>`:
               `users::columns::id` implements `IsContainedInGroupBy<posts::columns::id>`
               `users::columns::id` implements `IsContainedInGroupBy<posts::columns::title>`
@@ -111,6 +112,7 @@ error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<comments
 102 |         .select((users::all_columns, posts::all_columns, comments::id));
     |          ^^^^^^ the trait `IsContainedInGroupBy<comments::columns::id>` is not implemented for `posts::columns::id`
     |
+    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
     = help: the following other types implement trait `IsContainedInGroupBy<T>`:
               `posts::columns::id` implements `IsContainedInGroupBy<posts::columns::id>`
               `posts::columns::id` implements `IsContainedInGroupBy<posts::columns::title>`

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -205,6 +205,7 @@ error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::c
 170 |         .select(UserWithEmbeddedPost::as_select())
     |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `posts::columns::id`
     |
+    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
     = help: the following other types implement trait `IsContainedInGroupBy<T>`:
               `posts::columns::id` implements `IsContainedInGroupBy<posts::columns::id>`
               `posts::columns::id` implements `IsContainedInGroupBy<posts::columns::title>`
@@ -224,6 +225,7 @@ error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::c
 170 |         .select(UserWithEmbeddedPost::as_select())
     |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::name>` is not implemented for `posts::columns::id`
     |
+    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
     = help: the following other types implement trait `IsContainedInGroupBy<T>`:
               `posts::columns::id` implements `IsContainedInGroupBy<posts::columns::id>`
               `posts::columns::id` implements `IsContainedInGroupBy<posts::columns::title>`


### PR DESCRIPTION
This commit introduces a `#[diagnostic::on_unimplemented]` attribute to point users to the `allow_columns_to_appear_in_same_group_by_clause!` macro if they are mixing columns from several tables.

See #4612 for a recent case