### PR TITLE
implement LoadQuery for batch insert statements for sqlite connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,12 +472,12 @@ jobs:
           cargo +stable -Z build-std test --manifest-path diesel/Cargo.toml --no-default-features --features "mysql extras __with_asan_tests" --target x86_64-unknown-linux-gnu
 
   minimal_rust_version:
-    name: Check Minimal supported rust version (1.82.0)
+    name: Check Minimal supported rust version (1.84.0)
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.84.0
       - uses: dtolnay/rust-toolchain@nightly
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
@@ -490,12 +490,12 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install libsqlite3-dev libpq-dev libmysqlclient-dev
       - name: Check diesel_derives
-        run: cargo +1.82.0 minimal-versions check -p diesel_derives --features "postgres sqlite mysql 32-column-tables 64-column-tables 128-column-tables without-deprecated with-deprecated r2d2"
+        run: cargo +1.84.0 minimal-versions check -p diesel_derives --features "postgres sqlite mysql 32-column-tables 64-column-tables 128-column-tables without-deprecated with-deprecated r2d2"
       - name: Check diesel
-        run: cargo +1.82.0 minimal-versions check -p diesel --features "postgres mysql sqlite extras"
+        run: cargo +1.84.0 minimal-versions check -p diesel --features "postgres mysql sqlite extras"
       - name: Check diesel_dynamic_schema
-        run: cargo +1.82.0 minimal-versions check -p diesel-dynamic-schema --all-features
+        run: cargo +1.84.0 minimal-versions check -p diesel-dynamic-schema --all-features
       - name: Check diesel_migrations
-        run: cargo +1.82.0 minimal-versions check -p diesel_migrations --all-features
+        run: cargo +1.84.0 minimal-versions check -p diesel_migrations --all-features
       - name: Check diesel_cli
-        run: cargo +1.82.0 minimal-versions check -p diesel_cli --features "default sqlite-bundled"
+        run: cargo +1.84.0 minimal-versions check -p diesel_cli --features "default sqlite-bundled"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ in a way that makes the pools suitable for use in parallel tests.
 * Add support for the `CAST` operator
 * Support `[print_schema] allow_tables_to_appear_in_same_query_config = "none"` to generate no `allow_tables_to_appear_in_same_query!` calls. (Default: `"all_tables"`.). ([#4333](https://github.com/diesel-rs/diesel/issues/4333))
 * Add `[print_schema] pg_domains_as_custom_types` parameter to generate custom types for [PostgreSQL domains](https://www.postgresql.org/docs/current/domains.html) that matches any of the regexes in the given list. (Default: `[]`.) This option allows an application to selectively give special meaning for the serialization/deserialization of these types, avoiding the default behavior of treating the domain as the underlying type. ([#4592](https://github.com/diesel-rs/diesel/discussions/4592))
+* Add support for batch insert and upsert statements with returning for SQLite
 
 ### Fixed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ in a way that makes the pools suitable for use in parallel tests.
 ### Changed
 
 * Use distinct `DIESEL_LOG` logging filter env variable instead of the default `RUST_LOG` one (#4575)
-* The minimal supported Rust version is now 1.82.0
+* The minimal supported Rust version is now 1.84.0
 
 ## [2.2.2] 2024-07-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.82.0"
+rust-version = "1.84.0"
 include = ["src/**/*.rs", "tests/**/*.rs", "LICENSE-*", "README.md"]
 edition = "2021"
 

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -55,11 +55,7 @@ impl TypeOidLookup for NonZeroU32 {
 impl<'a> PgValue<'a> {
     #[cfg(test)]
     pub(crate) fn for_test(raw_value: &'a [u8]) -> Self {
-        #[allow(unsafe_code)] // that's actual safe
-        static FAKE_OID: NonZeroU32 = unsafe {
-            // 42 != 0, so this is actually safe
-            NonZeroU32::new_unchecked(42)
-        };
+        static FAKE_OID: NonZeroU32 = NonZeroU32::new(42).unwrap();
         Self {
             raw_value,
             type_oid_lookup: &FAKE_OID,

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -292,14 +292,17 @@ where
     }
 }
 
-impl<V, T, QId, Op, const STATIC_QUERY_ID: bool> RunQueryDsl<SqliteConnection>
+impl<V, T, QId, Op, O, const STATIC_QUERY_ID: bool> RunQueryDsl<SqliteConnection>
     for (
-        No,
-        InsertStatement<T, BatchInsert<V, T, QId, STATIC_QUERY_ID>, Op>,
+        O,
+        InsertStatement<T, BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Op>,
     )
 where
     T: QuerySource,
-    InsertStatement<T, BatchInsert<V, T, QId, STATIC_QUERY_ID>, Op>: RunQueryDsl<SqliteConnection>,
+    V: ContainsDefaultableValue<Out = O>,
+    O: Default,
+    InsertStatement<T, BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Op>:
+        RunQueryDsl<SqliteConnection>,
 {
 }
 
@@ -450,6 +453,7 @@ where
         + 'static,
     // Connection bounds
     SqliteConnection: crate::connection::LoadConnection<B>,
+    Self: RunQueryDsl<SqliteConnection>,
 {
     type RowIter<'conn> = Box<dyn Iterator<Item = QueryResult<U>> + 'conn>;
 

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -392,7 +392,14 @@ where
                     .next()
                     .ok_or(crate::result::Error::NotFound)?;
 
-                results.push(result);
+                match &result {
+                    Ok(_) | Err(crate::result::Error::DeserializationError(_)) => {
+                        results.push(result)
+                    }
+                    Err(_) => {
+                        result?;
+                    }
+                };
             }
 
             Ok(results.into_iter())
@@ -451,7 +458,14 @@ where
                     .next()
                     .ok_or(crate::result::Error::NotFound)?;
 
-                results.push(result);
+                match &result {
+                    Ok(_) | Err(crate::result::Error::DeserializationError(_)) => {
+                        results.push(result)
+                    }
+                    Err(_) => {
+                        result?;
+                    }
+                };
             }
 
             Ok(results.into_iter())

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -273,6 +273,50 @@ where
     }
 }
 
+impl<V, T, QId, C, Op, Target, ConflictOpt, const STATIC_QUERY_ID: bool> ExecuteDsl<C, Sqlite>
+    for (
+        Yes,
+        InsertStatement<
+            T,
+            OnConflictValues<
+                BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+                Target,
+                ConflictOpt,
+            >,
+            Op,
+        >,
+    )
+where
+    C: Connection<Backend = Sqlite>,
+    T: Table + Copy + QueryId + 'static,
+    T::FromClause: QueryFragment<Sqlite>,
+    Op: Copy + QueryId + QueryFragment<Sqlite>,
+    V: InsertValues<Sqlite, T> + CanInsertInSingleQuery<Sqlite> + QueryId,
+{
+    fn execute((Yes, query): Self, conn: &mut C) -> QueryResult<usize> {
+        conn.transaction(|conn| {
+            let mut result = 0;
+            for record in &query.records.values.values {
+                let stmt = InsertStatement {
+                    operator: query.operator,
+                    target: query.target,
+                    records: OnConflictValues {
+                        values: record,
+                        target: query.records.target,
+                        action: query.records.action,
+                        where_clause: query.records.where_clause,
+                    },
+                    returning: query.returning,
+                    into_clause: query.into_clause,
+                };
+
+                result += stmt.execute(conn)?;
+            }
+            Ok(result)
+        })
+    }
+}
+
 impl<'query, V, T, QId, Op, O, U, B, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
     for InsertStatement<T, BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Op>

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,4 +1,4 @@
-pub(crate) use self::private::LoadIter;
+use self::private::LoadIter;
 use super::RunQueryDsl;
 use crate::backend::Backend;
 use crate::connection::{Connection, DefaultLoadingMode, LoadConnection};
@@ -109,8 +109,8 @@ mod private {
 
     #[allow(missing_debug_implementations)]
     pub struct LoadIter<U, C, ST, DB> {
-        pub(crate) cursor: C,
-        pub(crate) _marker: std::marker::PhantomData<(ST, U, DB)>,
+        pub(super) cursor: C,
+        pub(super) _marker: std::marker::PhantomData<(ST, U, DB)>,
     }
 
     impl<'a, C, U, ST, DB, R> LoadIter<U, C, ST, DB>

--- a/diesel/src/query_dsl/load_dsl.rs
+++ b/diesel/src/query_dsl/load_dsl.rs
@@ -1,4 +1,4 @@
-use self::private::LoadIter;
+pub(crate) use self::private::LoadIter;
 use super::RunQueryDsl;
 use crate::backend::Backend;
 use crate::connection::{Connection, DefaultLoadingMode, LoadConnection};
@@ -109,8 +109,8 @@ mod private {
 
     #[allow(missing_debug_implementations)]
     pub struct LoadIter<U, C, ST, DB> {
-        pub(super) cursor: C,
-        pub(super) _marker: std::marker::PhantomData<(ST, U, DB)>,
+        pub(crate) cursor: C,
+        pub(crate) _marker: std::marker::PhantomData<(ST, U, DB)>,
     }
 
     impl<'a, C, U, ST, DB, R> LoadIter<U, C, ST, DB>

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -17,9 +17,9 @@ impl FromSql<Any, diesel::pg::Pg> for MyDynamicValue {
         use diesel::pg::Pg;
         use std::num::NonZeroU32;
 
-        const VARCHAR_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1043) };
-        const TEXT_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(25) };
-        const INTEGER_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(23) };
+        const VARCHAR_OID: NonZeroU32 = NonZeroU32::new(1043).unwrap();
+        const TEXT_OID: NonZeroU32 = NonZeroU32::new(25).unwrap();
+        const INTEGER_OID: NonZeroU32 = NonZeroU32::new(23).unwrap();
 
         match value.get_oid() {
             VARCHAR_OID | TEXT_OID => {

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -219,7 +219,7 @@ fn insert_record_attached_database_using_returning_clause() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "sqlite", feature = "mysql")))]
+#[cfg(not(any(not(all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35")), feature = "mysql")))]
 fn insert_records_using_returning_clause() {
     use crate::schema::users::table as users;
     let connection = &mut connection();
@@ -829,6 +829,52 @@ fn batch_insert_is_atomic_on_sqlite() {
     assert_eq!(Ok(0), users.count().get_result(connection));
 }
 
+#[diesel_test_helper::test]
+#[cfg(all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35"))]
+fn batch_insert_with_returning_is_atomic_on_sqlite() {
+    use crate::schema::users::dsl::*;
+    let connection = &mut connection();
+
+    let new_users = vec![(id.eq(1), name.eq("Sean")), (id.eq(1), name.eq("Tess"))];
+    let result = insert_into(users)
+        .values(&new_users)
+        .get_results::<User>(connection);
+    assert!(result.is_err());
+
+    assert_eq!(Ok(0), users.count().get_result(connection));
+}
+
+#[diesel_test_helper::test]
+#[cfg(all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35"))]
+fn batch_insert_with_defaultables_and_returning_is_atomic_on_sqlite() {
+    use crate::schema::users::dsl::*;
+    let connection = &mut connection();
+
+    let new_users = vec![Some(name.eq("Sean")), None];
+    let result = insert_into(users)
+        .values(&new_users)
+        .get_results::<User>(connection);
+    assert!(result.is_err());
+
+    assert_eq!(Ok(0), users.count().get_result(connection));
+}
+
+#[diesel_test_helper::test]
+#[cfg(all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35"))]
+fn batch_upsert_with_defaultables_and_returning_is_atomic_on_sqlite() {
+    use crate::schema::users::dsl::*;
+    let connection = &mut connection();
+
+    let new_users = vec![Some(name.eq("Sean")), None];
+    let result = insert_into(users)
+        .values(&new_users)
+        .on_conflict_do_nothing()
+        .get_results::<User>(connection);
+    assert!(result.is_err());
+
+    assert_eq!(Ok(0), users.count().get_result(connection));
+}
+
 // regression test for https://github.com/diesel-rs/diesel/issues/2898
 #[diesel_test_helper::test]
 fn mixed_defaultable_insert() {
@@ -968,4 +1014,45 @@ fn batch_upsert_non_default_values() {
         (2, Some(String::from("blue"))),
     ];
     assert_eq!(users, expected);
+}
+
+#[diesel_test_helper::test]
+#[cfg(any(feature = "postgres", all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35")))]
+fn batch_upsert_with_returning() {
+    use crate::schema::users;
+    let conn = &mut connection_with_sean_and_tess_in_users_table();
+
+    let inserted_users = diesel::insert_into(users::table)
+        .values([
+            (
+                users::id.eq(1),
+                users::name.eq("Sean"),
+                users::hair_color.eq("black"),
+            ),
+            (
+                users::id.eq(2),
+                users::name.eq("Tess"),
+                users::hair_color.eq("blue"),
+            ),
+        ])
+        .on_conflict(users::id)
+        .do_update()
+        .set(users::hair_color.eq(diesel::upsert::excluded(users::hair_color)))
+        .get_results::<User>(conn)
+        .unwrap();
+
+    let expected_users = vec![
+        User {
+            id: 1,
+            name: "Sean".to_string(),
+            hair_color: Some("black".to_string()),
+        },
+        User {
+            id: 2,
+            name: "Tess".to_string(),
+            hair_color: Some("blue".to_string()),
+        },
+    ];
+
+    assert_eq!(inserted_users, expected_users);
 }

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -219,7 +219,10 @@ fn insert_record_attached_database_using_returning_clause() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(not(all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35")), feature = "mysql")))]
+#[cfg(not(any(
+    not(all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35")),
+    feature = "mysql"
+)))]
 fn insert_records_using_returning_clause() {
     use crate::schema::users::table as users;
     let connection = &mut connection();
@@ -1017,7 +1020,10 @@ fn batch_upsert_non_default_values() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(any(feature = "postgres", all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35")))]
+#[cfg(any(
+    feature = "postgres",
+    all(feature = "sqlite", feature = "returning_clauses_for_sqlite_3_35")
+))]
 fn batch_upsert_with_returning() {
     use crate::schema::users;
     let conn = &mut connection_with_sean_and_tess_in_users_table();

--- a/examples/sqlite/all_about_inserts/Cargo.toml
+++ b/examples/sqlite/all_about_inserts/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-diesel = { version = "2.2.0", path = "../../../diesel", features = ["sqlite", "chrono"] }
+diesel = { version = "2.2.0", path = "../../../diesel", features = ["sqlite", "chrono", "returning_clauses_for_sqlite_3_35"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 chrono = { version = "0.4.20", default-features = false, features = ["clock", "std"] }


### PR DESCRIPTION
This is a draft PR requesting for comments. It allows running insert statements with returning clause for sqlite connection. There are a few remaining tasks, which needs a little bit guidance, to consider this PR as ready:

- [x] Find an appropriate Iterator implementation to return from `internal_load` (instead of currently used boxed iteration).
- [x] Implement `LoadQuery` for `Yes` case which requires running multiple insert statements. I can implement this if `No` case looks good.
- [x] Consider adding tests or examples.
- [x] ~Consider using a generic connection with backend `Sqlite` (similar to `ExecuteDsl` implementation). I tried to do this but it caused conflicting implementation error.~ It looks like trait bounds resolution is being improved with newer version of Rust compiler. In the future, it might be possible to use a generic connection bounded by `Sqlite` backend. For now, we can continue using directly `SqliteConnection`.
- [x] Bump MSRV to 1.84 because of compilation errors caused by `conflicting implementation` error. Check [this](https://github.com/diesel-rs/diesel/pull/4616#issuecomment-2915858331) and [this](https://github.com/diesel-rs/diesel/pull/4616#issuecomment-2915895403) messages for more information

With this PR, following example should compile successfully:

```rust
use diesel::prelude::{ExpressionMethods, Queryable};
use diesel::{Connection, RunQueryDsl, SqliteConnection};

diesel::table! {
    apps (id) {
        id -> Int4,
        #[max_length = 8]
        name -> Varchar,
        #[max_length = 8]
        state -> Varchar,
    }
}

#[derive(Queryable)]
struct App {
    id: i32,
    name: String,
    state: String,
}

fn main() {
    let mut conn = SqliteConnection::establish(":memory:").unwrap();

    let query = diesel::insert_into(apps::table).values(vec![
        (apps::name.eq("Good"), apps::state.eq("Running")),
        (apps::name.eq("Bad"), apps::state.eq("Failed")),
    ]);

    query.get_results::<App>(&mut conn);
}
```