### PR TITLE
Refactor sqlite version check

### DIFF
--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -54,6 +54,8 @@ extern "SQL" {
 
     /// The jsonb(X) function returns the binary JSONB representation of the JSON provided as argument X.
     ///
+    /// This function requires at least SQLite 3.45 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -70,22 +72,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Binary, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 45) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 45, 0);
     ///
     /// let result = diesel::select(jsonb::<Binary, _>(br#"{"a": "b", "c": 1}"#))
     ///     .get_result::<Value>(connection)?;
@@ -111,6 +98,8 @@ extern "SQL" {
     /// or 0 if X is some kind of JSON value other than an array.
     /// Errors are thrown if either X is not well-formed JSON or if P is not a well-formed path.
     ///
+    /// This function requires at least SQLite 3.46 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -127,22 +116,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Json, Jsonb, Text, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 46) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 46, 0);
     ///
     /// let result = diesel::select(json_array_length::<Json, _>(json!([1,2,3,4])))
     ///     .get_result::<i32>(connection)?;
@@ -191,6 +165,8 @@ extern "SQL" {
     /// and NULL if path P does not locate any element of X.
     /// Errors are thrown if either X is not well-formed JSON or if P is not a well-formed path.
     ///
+    /// This function requires at least SQLite 3.46 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -207,22 +183,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Json, Jsonb, Text, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 46) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 46, 0);
     ///
     /// let result = diesel::select(json_array_length_with_path::<Json, _, _>(json!([1,2,3,4]), "$"))
     ///     .get_result::<Option<i32>>(connection)?;
@@ -281,6 +242,8 @@ extern "SQL" {
     /// If the input X is a BLOB, then this routine returns 0 if X is a well-formed JSONB blob. If the return value is positive,
     /// then it represents the approximate 1-based position in the BLOB of the first detected error.
     ///
+    /// This function requires at least SQLite 3.46 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -296,22 +259,7 @@ extern "SQL" {
     /// #     use diesel::dsl::{sql, json_error_position};
     /// #     use diesel::sql_types::{Binary, Text, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 46) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 46, 0);
     ///
     /// let result = diesel::select(json_error_position::<Text, _>(r#"{"a": "b", "c": 1}"#))
     ///     .get_result::<i32>(connection)?;
@@ -383,6 +331,8 @@ extern "SQL" {
 
     /// Converts the given json value to pretty-printed, indented text
     ///
+    /// This function requires at least SQLite 3.46 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -399,22 +349,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 46) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 46, 0);
     ///
     /// let result = diesel::select(json_pretty::<Json, _>(json!([{"f1":1,"f2":null},2,null,3])))
     ///     .get_result::<String>(connection)?;
@@ -526,6 +461,8 @@ extern "SQL" {
 
     /// Converts the given json value to pretty-printed, indented text
     ///
+    /// This function requires at least SQLite 3.46 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -542,22 +479,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 46) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 46, 0);
     ///
     /// let result = diesel::select(json_pretty_with_indentation::<Json, _, _>(json!([{"f1":1,"f2":null},2,null,3]), "  "))
     ///     .get_result::<String>(connection)?;
@@ -700,6 +622,8 @@ extern "SQL" {
 
     /// Returns  `true`  if the argument is well-formed JSON, or returns  `false`  if is not well-formed.
     ///
+    /// This function requires at least SQLite 3.46 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -716,22 +640,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 46) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 46, 0);
     ///
     /// let result = diesel::select(json_valid::<Json, _>(json!({"x":35})))
     ///     .get_result::<bool>(connection)?;
@@ -754,6 +663,8 @@ extern "SQL" {
     /// The "type" returned by json_type() is one of the following SQL text values:
     /// 'null', 'true', 'false', 'integer', 'real', 'text', 'array', or 'object'.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -770,22 +681,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 38) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 38, 0);
     ///
     /// let result = diesel::select(json_type::<Json, _>(json!({"a": [2, 3.5, true, false, null, "x"]})))
     ///     .get_result::<String>(connection)?;
@@ -814,6 +710,8 @@ extern "SQL" {
     /// The json_type(X,P) function returns the "type" of the element in X that is selected by path P.
     /// If the path P in json_type(X,P) selects an element that does not exist in X, then this function returns NULL.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -830,22 +728,7 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Json, Jsonb, Nullable};
     /// #     let connection = &mut establish_connection();
-    ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 38) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
+    /// #     assert_version!(connection, 3, 38, 0);
     ///
     /// let json_value = json!({"a": [2, 3.5, true, false, null, "x"]});
     ///
@@ -897,6 +780,8 @@ extern "SQL" {
     /// The json_quote(X) function converts the SQL value X (a number or a string) into its corresponding JSON
     /// representation. If X is a JSON value returned by another JSON function, then this function is a no-op.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Example
     ///
     /// ```rust
@@ -913,22 +798,8 @@ extern "SQL" {
     /// #     use serde_json::{json, Value};
     /// #     use diesel::sql_types::{Text, Json, Integer, Float, Double, Nullable};
     /// #     let connection = &mut establish_connection();
+    /// #     assert_version!(connection, 3, 38, 0);
     ///
-    /// let version = diesel::select(sql::<Text>("sqlite_version();"))
-    ///         .get_result::<String>(connection)?;
-    ///
-    /// // Querying SQLite version should not fail.
-    /// let version_components: Vec<&str> = version.split('.').collect();
-    /// let major: u32 = version_components[0].parse().unwrap();
-    /// let minor: u32 = version_components[1].parse().unwrap();
-    /// let patch: u32 = version_components[2].parse().unwrap();
-    ///
-    /// if major > 3 || (major == 3 && minor >= 38) {
-    ///     /* Valid sqlite version, do nothing */
-    /// } else {
-    ///     println!("SQLite version is too old, skipping the test.");
-    ///     return Ok(());
-    /// }
     /// let result = diesel::select(json_quote::<Integer, _>(42))
     ///     .get_result::<Value>(connection)?;
     /// assert_eq!(json!(42), result);
@@ -1050,6 +921,8 @@ extern "SQL" {
     /// In such case, the result will include all duplicates (e.g., `{"key": 1, "key": 2, "key": 3}`).
     /// Note that any duplicate entries in the resulting JSON will be removed during deserialization.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1068,18 +941,7 @@ extern "SQL" {
     /// #     use schema::animals::dsl::*;
     /// #
     /// #     let connection = &mut establish_connection();
-    /// #
-    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
-    /// #         .get_result::<String>(connection)?;
-    /// #
-    /// #     let version_components: Vec<&str> = version.split('.').collect();
-    /// #     let major: u32 = version_components[0].parse().unwrap();
-    /// #     let minor: u32 = version_components[1].parse().unwrap();
-    /// #
-    /// #     if major < 3 || minor < 38 {
-    /// #         println!("SQLite version is too old, skipping the test.");
-    /// #         return Ok(());
-    /// #     }
+    /// #     assert_version!(connection, 3, 38, 0);
     /// #
     /// let result = animals.select(json_group_object(species, name)).get_result::<serde_json::Value>(connection)?;
     /// assert_eq!(json!({"dog":"Jack","spider":null}), result);
@@ -1108,6 +970,8 @@ extern "SQL" {
     /// In such case, the result will include all duplicates (e.g., `{"key": 1, "key": 2, "key": 3}`).
     /// Note that any duplicate entries in the resulting JSONB will be removed during deserialization.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1126,18 +990,7 @@ extern "SQL" {
     /// #     use schema::animals::dsl::*;
     /// #
     /// #     let connection = &mut establish_connection();
-    /// #
-    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
-    /// #         .get_result::<String>(connection)?;
-    /// #
-    /// #     let version_components: Vec<&str> = version.split('.').collect();
-    /// #     let major: u32 = version_components[0].parse().unwrap();
-    /// #     let minor: u32 = version_components[1].parse().unwrap();
-    /// #
-    /// #     if major < 3 || minor < 38 {
-    /// #         println!("SQLite version is too old, skipping the test.");
-    /// #         return Ok(());
-    /// #     }
+    /// #     assert_version!(connection, 3, 38, 0);
     /// #
     /// let result = animals.select(jsonb_group_object(species, name)).get_result::<serde_json::Value>(connection)?;
     /// assert_eq!(json!({"dog":"Jack","spider":null}), result);
@@ -1168,6 +1021,8 @@ extern "SQL" {
     /// `json_array()` and `json_object()` to be nested. The [`json()`] function can also be used to force
     /// strings to be recognized as JSON.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1185,18 +1040,7 @@ extern "SQL" {
     /// #     use serde_json::json;
     /// #
     /// #     let connection = &mut establish_connection();
-    /// #
-    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
-    /// #         .get_result::<String>(connection)?;
-    /// #
-    /// #     let version_components: Vec<&str> = version.split('.').collect();
-    /// #     let major: u32 = version_components[0].parse().unwrap();
-    /// #     let minor: u32 = version_components[1].parse().unwrap();
-    /// #
-    /// #     if major < 3 || minor < 38 {
-    /// #         println!("SQLite version is too old, skipping the test.");
-    /// #         return Ok(());
-    /// #     }
+    /// #     assert_version!(connection, 3, 38, 0);
     /// #
     /// let result = diesel::select(json_array_0())
     ///     .get_result::<serde_json::Value>(connection)?;
@@ -1230,6 +1074,8 @@ extern "SQL" {
     /// constructed JSON array in the SQLite's private JSONB format rather than in the standard RFC 8259 text
     /// format.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1247,18 +1093,7 @@ extern "SQL" {
     /// #     use serde_json::json;
     /// #
     /// #     let connection = &mut establish_connection();
-    /// #
-    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
-    /// #         .get_result::<String>(connection)?;
-    /// #
-    /// #     let version_components: Vec<&str> = version.split('.').collect();
-    /// #     let major: u32 = version_components[0].parse().unwrap();
-    /// #     let minor: u32 = version_components[1].parse().unwrap();
-    /// #
-    /// #     if major < 3 || minor < 38 {
-    /// #         println!("SQLite version is too old, skipping the test.");
-    /// #         return Ok(());
-    /// #     }
+    /// #     assert_version!(connection, 3, 38, 0);
     /// #
     /// let result = diesel::select(jsonb_array_0())
     ///     .get_result::<serde_json::Value>(connection)?;
@@ -1292,6 +1127,8 @@ extern "SQL" {
     ///
     /// The `json_remove()` function throws an error if any of the path arguments is not a well-formed path.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1309,18 +1146,7 @@ extern "SQL" {
     /// #     use serde_json::json;
     /// #
     /// #     let connection = &mut establish_connection();
-    /// #
-    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
-    /// #         .get_result::<String>(connection)?;
-    /// #
-    /// #     let version_components: Vec<&str> = version.split('.').collect();
-    /// #     let major: u32 = version_components[0].parse().unwrap();
-    /// #     let minor: u32 = version_components[1].parse().unwrap();
-    /// #
-    /// #     if major < 3 || minor < 38 {
-    /// #         println!("SQLite version is too old, skipping the test.");
-    /// #         return Ok(());
-    /// #     }
+    /// #     assert_version!(connection, 3, 38, 0);
     /// #
     /// let json = json!(['a', 'b', 'c', 'd']);
     /// let result = diesel::select(json_remove_0::<Json, _>(json))
@@ -1375,6 +1201,8 @@ extern "SQL" {
     ///
     /// This function returns value in a binary JSONB format.
     ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1392,18 +1220,7 @@ extern "SQL" {
     /// #     use serde_json::json;
     /// #
     /// #     let connection = &mut establish_connection();
-    /// #
-    /// #     let version = diesel::select(sql::<Text>("sqlite_version();"))
-    /// #         .get_result::<String>(connection)?;
-    /// #
-    /// #     let version_components: Vec<&str> = version.split('.').collect();
-    /// #     let major: u32 = version_components[0].parse().unwrap();
-    /// #     let minor: u32 = version_components[1].parse().unwrap();
-    /// #
-    /// #     if major < 3 || minor < 38 {
-    /// #         println!("SQLite version is too old, skipping the test.");
-    /// #         return Ok(());
-    /// #     }
+    /// #     assert_version!(connection, 3, 38, 0);
     /// #
     /// let json = json!(['a', 'b', 'c', 'd']);
     /// let result = diesel::select(jsonb_remove_0::<Jsonb, _>(json))


### PR DESCRIPTION
This change refactors the way we check for certain SQLite versions in our doc tests. Instead of manually copying the same code over and over again into different doc tests, I've moved the relevant code into the `doc_setup.rs` file and provided a helper function + macro for this check. This makes it much easier to use the same change for different versions in different locations. 

This PR also copies the version used in the doc tests as minimal supported versions for that function into the documentation. I did not check for each version if it's correct. If it turns out to be wrong we can always fix it later.