### PR TITLE
fix(diesel_derives): Dont generate return type helpers in `declare_sql_function` unless attribute is specified

### DIFF
--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
 name = "diesel_derives"
 version = "2.2.0"
 dependencies = [
+ "darling",
  "diesel_table_macro_syntax",
  "dsl_auto_type",
  "proc-macro2",

--- a/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.rs
+++ b/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.rs
@@ -10,12 +10,35 @@ impl<T: SingleValue> TypeWrapper for T {
     type Type = T;
 }
 
-#[declare_sql_function]
-extern "SQL" {
-    fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
+mod with_return_type_helpers {
+    use super::*;
 
-    #[skip_return_type_helper]
-    fn g<A: SingleValue>(a: <A as TypeWrapper>::Type);
+    #[declare_sql_function(generate_return_type_helpers)]
+    extern "SQL" {
+        fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
+
+        #[variadic(1)]
+        fn g<A: SingleValue>(a: <A as TypeWrapper>::Type);
+
+        #[skip_return_type_helper]
+        fn h<A: SingleValue>(a: <A as TypeWrapper>::Type);
+
+        #[skip_return_type_helper]
+        #[variadic(1)]
+        fn i<A: SingleValue>(a: <A as TypeWrapper>::Type);
+    }
+}
+
+mod without_return_type_helpers {
+    use super::*;
+
+    #[declare_sql_function]
+    extern "SQL" {
+        fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
+
+        #[variadic(1)]
+        fn g<A: SingleValue>(a: <A as TypeWrapper>::Type);
+    }
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.stderr
+++ b/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.stderr
@@ -1,5 +1,11 @@
 error: cannot find argument corresponding to the generic
-  --> tests/fail/derive/return_type_helper_errors.rs:15:10
+  --> tests/fail/derive/return_type_helper_errors.rs:18:14
    |
-15 |     fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
-   |          ^
+18 |         fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
+   |              ^
+
+error: cannot find argument corresponding to the generic
+  --> tests/fail/derive/return_type_helper_errors.rs:21:14
+   |
+21 |         fn g<A: SingleValue>(a: <A as TypeWrapper>::Type);
+   |              ^

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -24,7 +24,6 @@ extern crate syn;
 
 use darling::{ast::NestedMeta, FromMeta};
 use proc_macro::TokenStream;
-use quote::TokenStreamExt;
 use sql_function::ExternSqlBlock;
 use syn::{parse_macro_input, parse_quote};
 
@@ -1087,9 +1086,7 @@ pub fn derive_valid_grouping(input: TokenStream) -> TokenStream {
 ///
 #[proc_macro]
 pub fn define_sql_function(input: TokenStream) -> TokenStream {
-    sql_function::expand(vec![parse_macro_input!(input)], false)
-        .tokens
-        .into()
+    sql_function::expand(vec![parse_macro_input!(input)], false, false).into()
 }
 
 /// A legacy version of [`define_sql_function!`].
@@ -1122,9 +1119,7 @@ pub fn define_sql_function(input: TokenStream) -> TokenStream {
 #[proc_macro]
 #[cfg(all(feature = "with-deprecated", not(feature = "without-deprecated")))]
 pub fn sql_function_proc(input: TokenStream) -> TokenStream {
-    sql_function::expand(vec![parse_macro_input!(input)], true)
-        .tokens
-        .into()
+    sql_function::expand(vec![parse_macro_input!(input)], true, false).into()
 }
 
 /// This is an internal diesel macro that
@@ -2183,13 +2178,7 @@ pub fn declare_sql_function(
     };
 
     let result = syn::parse2::<ExternSqlBlock>(input.clone()).map(|res| {
-        let mut expanded = sql_function::expand(res.function_decls, false);
-
-        if attr.generate_return_type_helpers {
-            expanded.tokens.append_all(expanded.return_type_helpers);
-        }
-
-        expanded.tokens
+        sql_function::expand(res.function_decls, false, attr.generate_return_type_helpers)
     });
 
     match result {


### PR DESCRIPTION
Resolves #4634

After #4620 return type helpers were generated for all the functions internally and exposed only if `generate_return_type_helpers` attribute is specified in `#[declare_sql_function]`.  

It introduced a back-compatibility issue as helper types cannot be implemented correctly for every function that's supported by the `#[declare_sql_function]`.

This PR fixes it by completely omitting return type helpers generation when no `generate_return_type_helpers` attribute is specified