### PR TITLE
Fix typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -23,6 +23,8 @@ extend-ignore-re = [
     "big_sur",
     # That's Spanish for "type" (used in a unit-test)
     "tipe",
+    # we use this often in place of the reserved type identifier
+    "tpe", 
 ]
 
 [type.md]

--- a/diesel/src/mysql/query_builder/query_fragment_impls.rs
+++ b/diesel/src/mysql/query_builder/query_fragment_impls.rs
@@ -149,7 +149,7 @@ where
 }
 
 /// This is a helper trait
-/// that provideds a fake `DO NOTHING` clause
+/// that provides a fake `DO NOTHING` clause
 /// based on reassigning the possible
 /// composite primary key to itself
 trait DoNothingClauseHelper {


### PR DESCRIPTION
This change fixes new issues found by typos

There is one real issue found by typos. I've desided to ignore `tpe` as that's commonly used in place of `type` in our codebase. We won't change it as it's hard to use `type` in rust code as it's an reserved identifier.