### PR TITLE
Fix grouped beeing public

### DIFF
--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -5,7 +5,8 @@ use crate::result::QueryResult;
 use crate::sql_types::DieselNumericOps;
 
 #[derive(Debug, Copy, Clone, QueryId, Default, DieselNumericOps, ValidGrouping)]
-pub struct Grouped<T>(pub T);
+#[doc(hidden)]
+pub struct Grouped<T>(pub(crate) T);
 
 impl<T: Expression> Expression for Grouped<T> {
     type SqlType = T::SqlType;


### PR DESCRIPTION
It seems like rustdoc has become to clever. See
https://github.com/rust-lang/rust/issues/142019 for details.

Before this PR: https://docs.diesel.rs/2.2.x/diesel/dsl/type.Eq.html

After this PR: 
![image](https://github.com/user-attachments/assets/585ed1a9-f4ce-45d3-a7d9-743a35c080a9)

