### PR TITLE
Added support for multiple having calls (fixes #4649)

### DIFF
--- a/diesel/src/query_builder/having_clause.rs
+++ b/diesel/src/query_builder/having_clause.rs
@@ -1,1 +1,186 @@
-simple_clause!(NoHavingClause, HavingClause, " HAVING ");
+use super::from_clause::AsQuerySource;
+use super::where_clause::{WhereAnd, WhereOr};
+use super::*;
+use crate::backend::DieselReserveSpecialization;
+use crate::expression::grouped::Grouped;
+use crate::expression::operators::{And, Or};
+use crate::expression::*;
+use crate::sql_types::BoolOrNullableBool;
+
+/// Represents that a query has no `HAVING` clause.
+#[derive(Debug, Clone, Copy, QueryId)]
+pub struct NoHavingClause;
+
+impl<DB> QueryFragment<DB> for NoHavingClause
+where
+    DB: Backend + DieselReserveSpecialization,
+{
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        Ok(())
+    }
+}
+
+impl<Predicate> WhereAnd<Predicate> for NoHavingClause
+where
+    Predicate: Expression,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = HavingClause<Predicate>;
+
+    fn and(self, predicate: Predicate) -> Self::Output {
+        HavingClause(predicate)
+    }
+}
+
+impl<Predicate> WhereOr<Predicate> for NoHavingClause
+where
+    Predicate: Expression,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = HavingClause<Predicate>;
+
+    fn or(self, predicate: Predicate) -> Self::Output {
+        HavingClause(predicate)
+    }
+}
+
+impl<DB> From<NoHavingClause> for BoxedHavingClause<'_, DB> {
+    fn from(_: NoHavingClause) -> Self {
+        BoxedHavingClause::None
+    }
+}
+
+/// The `HAVING` clause of a query.
+#[derive(Debug, Clone, Copy, QueryId)]
+pub struct HavingClause<Expr>(Expr);
+
+impl<DB, Expr> QueryFragment<DB> for HavingClause<Expr>
+where
+    DB: Backend + DieselReserveSpecialization,
+    Expr: QueryFragment<DB>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        out.push_sql(" HAVING ");
+        self.0.walk_ast(out.reborrow())?;
+        Ok(())
+    }
+}
+
+impl<Expr, Predicate> WhereAnd<Predicate> for HavingClause<Expr>
+where
+    Expr: Expression,
+    Expr::SqlType: BoolOrNullableBool,
+    Predicate: Expression,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = HavingClause<Grouped<And<Expr, Predicate>>>;
+
+    fn and(self, predicate: Predicate) -> Self::Output {
+        HavingClause(Grouped(And::new(self.0, predicate)))
+    }
+}
+
+impl<Expr, Predicate> WhereOr<Predicate> for HavingClause<Expr>
+where
+    Expr: Expression,
+    Expr::SqlType: BoolOrNullableBool,
+    Predicate: Expression,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = HavingClause<Grouped<Or<Expr, Predicate>>>;
+
+    fn or(self, predicate: Predicate) -> Self::Output {
+        HavingClause(Grouped(Or::new(self.0, predicate)))
+    }
+}
+
+impl<'a, DB, Predicate> From<HavingClause<Predicate>> for BoxedHavingClause<'a, DB>
+where
+    DB: Backend,
+    Predicate: QueryFragment<DB> + Send + 'a,
+{
+    fn from(where_clause: HavingClause<Predicate>) -> Self {
+        BoxedHavingClause::Having(Box::new(where_clause.0))
+    }
+}
+
+/// Marker trait indicating that a `HAVING` clause is valid for a given query
+/// source.
+pub trait ValidHavingClause<QS> {}
+
+impl<QS> ValidHavingClause<QS> for NoHavingClause {}
+
+impl<QS, Expr> ValidHavingClause<QS> for HavingClause<Expr>
+where
+    Expr: AppearsOnTable<QS::QuerySource>,
+    QS: AsQuerySource,
+{
+}
+
+impl<Expr> ValidHavingClause<NoFromClause> for HavingClause<Expr> where
+    Expr: AppearsOnTable<NoFromClause>
+{
+}
+
+#[allow(missing_debug_implementations)] // We can't...
+pub enum BoxedHavingClause<'a, DB> {
+    Having(Box<dyn QueryFragment<DB> + Send + 'a>),
+    None,
+}
+
+impl<DB> QueryFragment<DB> for BoxedHavingClause<'_, DB>
+where
+    DB: Backend + DieselReserveSpecialization,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        match *self {
+            BoxedHavingClause::Having(ref where_clause) => {
+                out.push_sql(" HAVING ");
+                where_clause.walk_ast(out)
+            }
+            BoxedHavingClause::None => Ok(()),
+        }
+    }
+}
+
+impl<DB> QueryId for BoxedHavingClause<'_, DB> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a, DB, Predicate> WhereAnd<Predicate> for BoxedHavingClause<'a, DB>
+where
+    DB: Backend + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
+    Grouped<And<Box<dyn QueryFragment<DB> + Send + 'a>, Predicate>>: QueryFragment<DB>,
+{
+    type Output = Self;
+
+    fn and(self, predicate: Predicate) -> Self::Output {
+        use self::BoxedHavingClause::Having;
+
+        match self {
+            Having(where_clause) => Having(Box::new(Grouped(And::new(where_clause, predicate)))),
+            BoxedHavingClause::None => Having(Box::new(predicate)),
+        }
+    }
+}
+
+impl<'a, DB, Predicate> WhereOr<Predicate> for BoxedHavingClause<'a, DB>
+where
+    DB: Backend + 'a,
+    Predicate: QueryFragment<DB> + Send + 'a,
+    Grouped<Or<Box<dyn QueryFragment<DB> + Send + 'a>, Predicate>>: QueryFragment<DB>,
+{
+    type Output = Self;
+
+    fn or(self, predicate: Predicate) -> Self::Output {
+        use self::BoxedHavingClause::Having;
+
+        match self {
+            Having(where_clause) => Having(Box::new(Grouped(Or::new(where_clause, predicate)))),
+            BoxedHavingClause::None => Having(Box::new(predicate)),
+        }
+    }
+}

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -10,6 +10,7 @@ use crate::query_builder::distinct_clause::*;
 use crate::query_builder::from_clause::AsQuerySource;
 use crate::query_builder::from_clause::FromClause;
 use crate::query_builder::group_by_clause::*;
+use crate::query_builder::having_clause::BoxedHavingClause;
 use crate::query_builder::insert_statement::InsertFromSelect;
 use crate::query_builder::limit_clause::*;
 use crate::query_builder::limit_offset_clause::{BoxedLimitOffsetClause, LimitOffsetClause};
@@ -478,7 +479,7 @@ where
     O: Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>>,
     LOf: IntoBoxedClause<'a, DB, BoxedClause = BoxedLimitOffsetClause<'a, DB>>,
     G: ValidGroupByClause + QueryFragment<DB> + Send + 'a,
-    H: QueryFragment<DB> + Send + 'a,
+    H: Into<BoxedHavingClause<'a, DB>> + Send + 'a,
 {
     type Output =
         BoxedSelectStatement<'a, S::SelectClauseSqlType, FromClause<F>, DB, G::Expressions>;
@@ -492,7 +493,7 @@ where
             self.order.into(),
             self.limit_offset.into_boxed(),
             self.group_by,
-            Box::new(self.having),
+            self.having.into(),
         )
     }
 }
@@ -509,7 +510,7 @@ where
     O: Into<Option<Box<dyn QueryFragment<DB> + Send + 'a>>>,
     LOf: IntoBoxedClause<'a, DB, BoxedClause = BoxedLimitOffsetClause<'a, DB>>,
     G: ValidGroupByClause + QueryFragment<DB> + Send + 'a,
-    H: QueryFragment<DB> + Send + 'a,
+    H: Into<BoxedHavingClause<'a, DB>> + Send + 'a,
 {
     type Output =
         BoxedSelectStatement<'a, S::SelectClauseSqlType, NoFromClause, DB, G::Expressions>;
@@ -523,7 +524,7 @@ where
             self.order.into(),
             self.limit_offset.into_boxed(),
             self.group_by,
-            Box::new(self.having),
+            self.having.into(),
         )
     }
 }
@@ -670,9 +671,9 @@ where
     Predicate: AppearsOnTable<F>,
     Predicate: Expression,
     Predicate::SqlType: BoolOrNullableBool,
+    H: WhereAnd<Predicate>,
 {
-    type Output =
-        SelectStatement<FromClause<F>, S, D, W, O, LOf, GroupByClause<G>, HavingClause<Predicate>>;
+    type Output = SelectStatement<FromClause<F>, S, D, W, O, LOf, GroupByClause<G>, H::Output>;
 
     fn having(self, predicate: Predicate) -> Self::Output {
         SelectStatement::new(
@@ -683,7 +684,7 @@ where
             self.order,
             self.limit_offset,
             self.group_by,
-            HavingClause(predicate),
+            self.having.and(predicate),
             self.locking,
         )
     }


### PR DESCRIPTION
This fixes #4649 by essentially copying the behaviour of where clauses to having clauses. Currently I've just implemented the `and` part, but if this approach is okay I'll add `or_having` too.

The main things to note:

1. This may be somewhat breaking, although only breaking if they were misusing `having` originally. If they have multiple having clauses it'd change the type if not boxed, and behaviour will change to `and`ing them rather than only using the last one. As this use was essentially incorrect, I felt it was acceptable to make this change, rather than the alternate of changing the docs to reflect the non-additive nature.

2. I've reused there `WhereAnd` traits (rather than `HavingAnd`), and it doesn't seems necessary to duplicate what is essentially the same trait and as it's already fairly widely used. Let me know if you disagree.


Will sort clippy issues once `or_having` is done.