### PR TITLE
Replace trybuild with ui_test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,3 +158,9 @@ Check out [their README](https://github.com/rust-lang/rustfmt) for details.
 `Conn`: Connection
 
 Generally, we prefer to give our types meaningful names. `Lhs` and `Rhs` vs `T` and `U` for a binary expression, for example.
+
+### Compile Tests
+
+Diesel has an extensive suite of compile tests in the `diesel_compile_tests` crate. These test work by having a small test program for each test case and then verifying that the compilation of those tests fail with a specific error message. For that we use the [`ui_test`](https://docs.rs/ui_test/latest/ui_test/) also used by rustc.  
+Running these tests can done by simply running `cargo test` in the `diesel_compile_tests` directory. Adding new tests simply requires adding a new file to `diesel_compile_tests/tests/fail/` containing the source code you want to test.
+You can run these tests with the environment variable `BLESS` set to `1` to update the expected stderr output. You also need to update the inline error annotations in the source code to match on the error message. See the documentation of `ui_test` for how to do that. 

--- a/diesel_compile_tests/Cargo.lock
+++ b/diesel_compile_tests/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "accessory"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3791c4beae5b827e93558ac83a88e63a841aad61759a05d9b577ef16030470"
-dependencies = [
- "macroific",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,25 +18,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
+name = "aho-corasick"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
- "libc",
+ "memchr",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
+name = "annotate-snippets"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "backtrace"
@@ -66,23 +64,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "bigdecimal"
-version = "0.4.7"
+name = "bstr"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
- "autocfg",
- "libm",
- "num-bigint",
- "num-integer",
- "num-traits",
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bumpalo"
@@ -91,18 +81,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "camino"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+dependencies = [
+ "serde",
+]
 
 [[package]]
-name = "cc"
-version = "1.2.12"
+name = "cargo-platform"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
- "shlex",
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -112,230 +119,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.39"
+name = "color-eyre"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "windows-targets",
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors 4.2.1",
+ "tracing-error",
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
+name = "color-spantrace"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "once_cell",
+ "owo-colors 4.2.1",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.20.10"
+name = "colored"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "lazy_static",
+ "windows-sys",
 ]
 
 [[package]]
-name = "darling_macro"
-version = "0.20.10"
+name = "comma"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
-name = "delegate-display"
-version = "3.0.0"
+name = "console"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9926686c832494164c33a36bf65118f4bd6e704000b58c94681bf62e9ad67a74"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
- "impartial-ord",
- "itoa",
- "macroific",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
-name = "diesel"
-version = "2.2.4"
-dependencies = [
- "bigdecimal",
- "bitflags",
- "byteorder",
- "chrono",
- "diesel_derives",
- "downcast-rs",
- "ipnetwork",
- "itoa",
+ "encode_unicode",
  "libc",
- "libsqlite3-sys",
- "mysqlclient-sys",
- "num-bigint",
- "num-integer",
- "num-traits",
- "percent-encoding",
- "pq-sys",
- "r2d2",
- "serde_json",
- "sqlite-wasm-rs",
- "time",
- "url",
- "uuid",
+ "once_cell",
+ "unicode-width 0.2.1",
+ "windows-sys",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "diesel_compile_tests"
 version = "0.1.0"
 dependencies = [
- "diesel",
- "trybuild",
+ "regex",
+ "ui_test",
 ]
 
 [[package]]
-name = "diesel_derives"
-version = "2.2.0"
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
- "darling",
- "diesel_table_macro_syntax",
- "dsl_auto_type",
- "proc-macro2",
- "quote",
- "syn",
+ "indenter",
+ "once_cell",
 ]
-
-[[package]]
-name = "diesel_table_macro_syntax"
-version = "0.2.0"
-dependencies = [
- "syn",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
-
-[[package]]
-name = "dsl_auto_type"
-version = "0.1.0"
-dependencies = [
- "darling",
- "either",
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "fancy_constructor"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac0fd7f4636276b4bd7b3148d0ba2c1c3fbede2b5214e47e7fedb70b02cde44"
-dependencies = [
- "macroific",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "gimli"
@@ -344,251 +220,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.2"
+name = "indenter"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
+name = "indicatif"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.1",
+ "web-time",
 ]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
-name = "impartial-ord"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab604ee7085efba6efc65e4ebca0e9533e3aff6cb501d7d77b211e3a781c6d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "indexed_db_futures"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94eebf0199c01a1560770d964efb1fb09183a3afc0b1c1397fac1bfdbfa7d6cf"
-dependencies = [
- "accessory",
- "cfg-if",
- "delegate-display",
- "derive_more",
- "fancy_constructor",
- "indexed_db_futures_macros_internal",
- "js-sys",
- "sealed",
- "smallvec",
- "thiserror",
- "tokio",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "indexed_db_futures_macros_internal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caeba94923b68f254abef921cea7e7698bf4675fdd89d7c58bf1ed885b49a27d"
-dependencies = [
- "macroific",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "ipnetwork"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "itoa"
@@ -607,96 +255,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
-dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "litemap"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
-name = "macroific"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f276537b4b8f981bf1c13d79470980f71134b7bdcc5e6e911e910e556b0285"
-dependencies = [
- "macroific_attr_parse",
- "macroific_core",
- "macroific_macro",
-]
-
-[[package]]
-name = "macroific_attr_parse"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad4023761b45fcd36abed8fb7ae6a80456b0a38102d55e89a57d9a594a236be9"
-dependencies = [
- "proc-macro2",
- "quote",
- "sealed",
- "syn",
-]
-
-[[package]]
-name = "macroific_core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a7594d3c14916fa55bef7e9d18c5daa9ed410dd37504251e4b75bbdeec33e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "sealed",
- "syn",
-]
-
-[[package]]
-name = "macroific_macro"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da6f2ed796261b0a74e2b52b42c693bb6dee1effba3a482c49592659f824b3b"
-dependencies = [
- "macroific_attr_parse",
- "macroific_core",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "memchr"
@@ -714,48 +294,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mysqlclient-sys"
-version = "0.4.2"
+name = "number_prefix"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbb9b017b98c4cde5802998113e182eecc1ebce8d47e9ea1697b9a623d53870"
-dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -773,33 +315,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
+name = "owo-colors"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.10"
+name = "owo-colors"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.1"
+name = "pad"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -808,25 +342,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.31"
+name = "portable-atomic"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "pq-sys"
+name = "prettydiff"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b51d65ebe1cb1f40641b15abae017fed35ccdda46e3dab1ff8768f625a3222"
+checksum = "abec3fb083c10660b3854367697da94c674e9e82aa7511014dc958beeb7215e9"
 dependencies = [
- "libc",
- "vcpkg",
+ "owo-colors 3.5.0",
+ "pad",
 ]
 
 [[package]]
@@ -848,24 +376,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "r2d2"
-version = "0.8.10"
+name = "regex"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
- "log",
- "parking_lot",
- "scheduled-thread-pool",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.8"
+name = "regex-automata"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
- "bitflags",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
@@ -874,10 +411,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustversion"
-version = "1.0.19"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustfix"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fa69b198d894d84e23afde8e9ab2af4400b2cba20d6bf2b428a8b01c222c5a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
 
 [[package]]
 name = "ryu"
@@ -886,29 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
+name = "semver"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
- "parking_lot",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sealed"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "serde",
 ]
 
 [[package]]
@@ -944,55 +479,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
+name = "sharded-slab"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "serde",
+ "lazy_static",
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
+name = "spanned"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "sqlite-wasm-rs"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20e0d972353ff053376a9c5f5804d2d9a12839831e3487de8947b29df2fe04c"
+checksum = "86af297923fbcfd107c20a189a6e9c872160df71a7190ae4a7a6c5dce4b2feb6"
 dependencies = [
- "fragile",
- "indexed_db_futures",
- "js-sys",
- "once_cell",
- "parking_lot",
- "thiserror",
- "tokio",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
+ "bstr",
+ "color-eyre",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1006,45 +509,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "target-triple"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1052,103 +529,79 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.37"
+name = "thread_local"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
+ "cfg-if",
 ]
 
 [[package]]
-name = "time-core"
-version = "0.1.2"
+name = "tracing"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
-name = "tokio"
-version = "1.44.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
-dependencies = [
- "backtrace",
  "pin-project-lite",
+ "tracing-core",
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.20"
+name = "tracing-core"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "once_cell",
+ "valuable",
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
+name = "tracing-error"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
- "serde",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.23"
+name = "tracing-subscriber"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
-name = "trybuild"
-version = "1.0.103"
+name = "ui_test"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
+checksum = "3c736ed5f29a79ae7168cc85fc591cb18cb4849bf3cde95a664674f59d4892cf"
 dependencies = [
- "glob",
+ "annotate-snippets",
+ "anyhow",
+ "bstr",
+ "cargo-platform",
+ "cargo_metadata",
+ "color-eyre",
+ "colored",
+ "comma",
+ "crossbeam-channel",
+ "indicatif",
+ "levenshtein",
+ "prettydiff",
+ "regex",
+ "rustc_version",
+ "rustfix",
  "serde",
- "serde_derive",
  "serde_json",
- "target-triple",
- "termcolor",
- "toml",
+ "spanned",
 ]
 
 [[package]]
@@ -1158,45 +611,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
+name = "unicode-width"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "url"
-version = "2.5.4"
+name = "unicode-width"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
+name = "valuable"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "uuid"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1206,7 +636,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -1222,19 +651,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1270,31 +686,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]
@@ -1369,91 +767,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/diesel_compile_tests/Cargo.toml
+++ b/diesel_compile_tests/Cargo.toml
@@ -3,9 +3,13 @@ name = "diesel_compile_tests"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-diesel = { version = "2.0.0", default-features = false, features = ["extras", "sqlite", "postgres", "mysql", "with-deprecated"], path = "../diesel" }
-trybuild = "1.0.92"
+[dev-dependencies]
+ui_test = "0.30"
+regex = { version="1.0", default-features = false, features = ["perf", "std", "unicode"] }
+
+[[test]]
+name = "compile_tests"
+path = "tests/trybuild.rs"
+harness = false
 
 [workspace]
-

--- a/diesel_compile_tests/tests/Cargo.toml
+++ b/diesel_compile_tests/tests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "diesel_compile_tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+diesel = { version = "2.0.0", default-features = false, features = ["extras", "sqlite", "postgres", "mysql", "with-deprecated"], path = "../../diesel" }
+
+[workspace]

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.rs
@@ -19,7 +19,15 @@ allow_tables_to_appear_in_same_query!(users, posts);
 fn main() {
     use diesel::dsl::*;
     let source = users::table.select(sum(posts::id));
+    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let source = users::table.select(avg(posts::id));
+    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let source = users::table.select(max(posts::id));
+    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let source = users::table.select(min(posts::id));
+    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
@@ -1,7 +1,7 @@
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
    |
-21 |     let source = users::table.select(sum(posts::id));
+LL |     let source = users::table.select(sum(posts::id));
    |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -13,100 +13,32 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `sum<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
    |
-21 |     let source = users::table.select(sum(posts::id));
+LL |     let source = users::table.select(sum(posts::id));
    |                               ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
    |
-13 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `sum<Integer, id>` to implement `AppearsOnTable<users::table>`
+   = note: required for `sum<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>>`
 
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:22:31
-   |
-22 |     let source = users::table.select(avg(posts::id));
-   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-   |
-   = note: `posts::columns::id` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-             `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-             `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-             `posts::columns::id` implements `SelectableExpression<posts::table>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:22:31
-   |
-22 |     let source = users::table.select(avg(posts::id));
-   |                               ^^^^^^ expected `Once`, found `Never`
-   |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:23:31
-   |
-23 |     let source = users::table.select(max(posts::id));
-   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-   |
-   = note: `posts::columns::id` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-             `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-             `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-             `posts::columns::id` implements `SelectableExpression<posts::table>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
-
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:23:31
-   |
-23 |     let source = users::table.select(max(posts::id));
-   |                               ^^^^^^ expected `Once`, found `Never`
-   |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
-   |
-13 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
-
+   
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:24:31
    |
-24 |     let source = users::table.select(min(posts::id));
+LL |     let source = users::table.select(avg(posts::id));
    |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -118,22 +50,97 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `avg<Integer, id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
+
+   
+error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:24:31
+   |
+LL |     let source = users::table.select(avg(posts::id));
+   |                               ^^^^^^ expected `Once`, found `Never`
+   |
+note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
+   |
+LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 1 redundant requirement hidden
+   = note: required for `avg<Integer, id>` to implement `AppearsOnTable<users::table>`
+   = note: required for `avg<Integer, id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
+
+   
+error[E0277]: Cannot select `posts::columns::id` from `users::table`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:27:31
+   |
+LL |     let source = users::table.select(max(posts::id));
+   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+   |
+   = note: `posts::columns::id` is no valid selection for `users::table`
+   = help: the following other types implement trait `SelectableExpression<QS>`:
+             `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+             `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+             `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+             `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<posts::table>`
+             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+   = note: required for `max<Integer, id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
+
+   
+error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:27:31
+   |
+LL |     let source = users::table.select(max(posts::id));
+   |                               ^^^^^^ expected `Once`, found `Never`
+   |
+note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
+   |
+LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 1 redundant requirement hidden
+   = note: required for `max<Integer, id>` to implement `AppearsOnTable<users::table>`
+   = note: required for `max<Integer, id>` to implement `SelectableExpression<users::table>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
+
+   
+error[E0277]: Cannot select `posts::columns::id` from `users::table`
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:30:31
+   |
+LL |     let source = users::table.select(min(posts::id));
+   |                               ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+   |
+   = note: `posts::columns::id` is no valid selection for `users::table`
+   = help: the following other types implement trait `SelectableExpression<QS>`:
+             `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+             `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+             `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+             `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<posts::table>`
+             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+   = note: required for `min<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:24:31
+  --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:30:31
    |
-24 |     let source = users::table.select(min(posts::id));
+LL |     let source = users::table.select(min(posts::id));
    |                               ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:13:9
    |
-13 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
-   = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>` to implement `SelectableExpression<users::table>`
+   = note: required for `min<Integer, id>` to implement `AppearsOnTable<users::table>`
+   = note: required for `min<Integer, id>` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Integer, posts::columns::id>>`

--- a/diesel_compile_tests/tests/fail/alias_and_group_by.rs
+++ b/diesel_compile_tests/tests/fail/alias_and_group_by.rs
@@ -32,6 +32,7 @@ fn main() {
     user_alias
         .group_by(user_alias.field(users::name))
         .select(user_alias.field(users::id))
+        //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
         .execute(conn)
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/alias_and_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/alias_and_group_by.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
   --> tests/fail/alias_and_group_by.rs:34:10
    |
-34 |         .select(user_alias.field(users::id))
+LL |         .select(user_alias.field(users::id))
    |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
@@ -17,4 +17,6 @@ note: required for `columns::id` to implement `ValidGrouping<columns::name>`
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
    = note: required for `AliasedField<user1, columns::id>` to implement `ValidGrouping<AliasedField<user1, columns::name>>`
-   = note: required for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<Alias<user1>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<AliasedField<user1, columns::name>>>` to implement `SelectDsl<AliasedField<user1, columns::id>>`
+   = note: required for `SelectStatement<FromClause<Alias<...>>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<AliasedField<user1, columns::id>>`
+
+   For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs
+++ b/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs
@@ -13,6 +13,8 @@ fn main() {
     let conn = &mut PgConnection::establish("…").unwrap();
     users::table
         .filter(users::id.eq(1).and(users::id).or(users::id))
+        //~^ ERROR: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
+        //~| ERROR: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
         .select(users::id)
         .execute(conn)
         .unwrap();

--- a/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.stderr
+++ b/diesel_compile_tests/tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
   --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:33
    |
-15 |         .filter(users::id.eq(1).and(users::id).or(users::id))
+LL |         .filter(users::id.eq(1).and(users::id).or(users::id))
    |                                 ^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
    |
    = note: try to provide an expression that produces one of the expected sql types
@@ -9,18 +9,18 @@ error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` 
              Bool
              Nullable<Bool>
 note: required by a bound in `diesel::BoolExpressionMethods::and`
-  --> $DIESEL/src/expression_methods/bool_expression_methods.rs
+  --> DIESEL/diesel/diesel/src/expression_methods/bool_expression_methods.rs
    |
-   |     fn and<T, ST>(self, other: T) -> dsl::And<Self, T, ST>
+LL |     fn and<T, ST>(self, other: T) -> dsl::And<Self, T, ST>
    |        --- required by a bound in this associated function
 ...
-   |         ST: SqlType + TypedExpressionType + BoolOrNullableBool,
+LL |         ST: SqlType + TypedExpressionType + BoolOrNullableBool,
    |                                             ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::and`
 
 error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
   --> tests/fail/and_or_functions_must_take_boolean_expr_as_attributes.rs:15:48
    |
-15 |         .filter(users::id.eq(1).and(users::id).or(users::id))
+LL |         .filter(users::id.eq(1).and(users::id).or(users::id))
    |                                                ^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
    |
    = note: try to provide an expression that produces one of the expected sql types
@@ -28,10 +28,11 @@ error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` 
              Bool
              Nullable<Bool>
 note: required by a bound in `diesel::BoolExpressionMethods::or`
-  --> $DIESEL/src/expression_methods/bool_expression_methods.rs
+  --> DIESEL/diesel/diesel/src/expression_methods/bool_expression_methods.rs
    |
-   |     fn or<T, ST>(self, other: T) -> dsl::Or<Self, T, ST>
+LL |     fn or<T, ST>(self, other: T) -> dsl::Or<Self, T, ST>
    |        -- required by a bound in this associated function
 ...
-   |         ST: SqlType + TypedExpressionType + BoolOrNullableBool,
+LL |         ST: SqlType + TypedExpressionType + BoolOrNullableBool,
    |                                             ^^^^^^^^^^^^^^^^^^ required by this bound in `BoolExpressionMethods::or`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -32,4 +32,6 @@ fn main() {
     let _ = stuff
         .filter(name.eq(any(more_stuff::names)))
         .load(&mut conn);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
+++ b/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
@@ -1,69 +1,70 @@
 warning: use of deprecated function `diesel::dsl::any`: Use `ExpressionMethods::eq_any` instead
   --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:33:25
    |
-33 |         .filter(name.eq(any(more_stuff::names)))
+LL |         .filter(name.eq(any(more_stuff::names)))
    |                         ^^^
    |
    = note: `#[warn(deprecated)]` on by default
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:34:15
-   |
-34 |         .load(&mut conn);
-   |          ---- ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:34:15
+     |
+34   |         .load(&mut conn);
+     |          ---- ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `more_stuff::columns::names` to implement `AppearsOnTable<stuff::table>`
-  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:15:9
-   |
-15 |         names -> Array<VarChar>,
-   |         ^^^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 3 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<stuff::columns::name, diesel::pg::expression::array_comparison::Any<more_stuff::columns::names>>>` to implement `AppearsOnTable<stuff::table>`
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<stuff::columns::name, diesel::pg::expression::array_comparison::Any<more_stuff::columns::names>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<stuff::table>>`
-   = note: required for `SelectStatement<FromClause<stuff::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<stuff::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<stuff::columns::name, diesel::pg::expression::array_comparison::Any<more_stuff::columns::names>>>>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<stuff::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<stuff::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<stuff::columns::name, diesel::pg::expression::array_comparison::Any<more_stuff::columns::names>>>>>` to implement `LoadQuery<'_, _, _>`
+    --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:15:9
+     |
+15   |         names -> Array<VarChar>,
+     |         ^^^^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 3 redundant requirements hidden
+     = note: required for `Grouped<Eq<name, Any<names>>>` to implement `AppearsOnTable<stuff::table>`
+     = note: required for `WhereClause<Grouped<Eq<name, Any<names>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<stuff::table>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, _, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not satisfied
-  --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:34:15
-   |
-34 |         .load(&mut conn);
-   |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-             Interval
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-   = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-   = note: required for `SelectStatement<FromClause<stuff::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<stuff::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<stuff::columns::name, diesel::pg::expression::array_comparison::Any<more_stuff::columns::names>>>>>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
+    --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:34:15
+     |
+34   |         .load(&mut conn);
+     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+               Interval
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.rs
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.rs
@@ -7,5 +7,13 @@ fn main() {
     let mut connection = PgConnection::establish("").unwrap();
     select(array((1, 3))).get_result::<Vec<i32>>(&mut connection);
     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+    //~^ ERROR: Cannot select `f64` from `NoFromClause`
+    //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
+    //~| ERROR: the trait bound `f64: QueryId` is not satisfied
+    //~| ERROR: `f64` is no valid SQL fragment for the `Pg` backend
+    //~| ERROR: the trait bound `f64: diesel::Expression` is not satisfied
+    //~| ERROR: Cannot select `f64` from `NoFromClause`
+    //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
+    //~| ERROR: Cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
     select(array((1f64, 3f64))).get_result::<Vec<f64>>(&mut connection);
 }

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -1,232 +1,238 @@
 error[E0277]: Cannot select `f64` from `NoFromClause`
- --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
-  |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |     ------ ^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
-  |     |
-  |     required by a bound introduced by this call
-  |
-  = note: `f64` is no valid selection for `NoFromClause`
-  = help: the following other types implement trait `SelectableExpression<QS>`:
-            `&'a T` implements `SelectableExpression<QS>`
-            `(T0, T1)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
-          and $N others
-  = note: required for `(f64, f64)` to implement `SelectableExpression<NoFromClause>`
-  = note: 1 redundant requirement hidden
-  = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `SelectableExpression<NoFromClause>`
-  = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `Query`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `AsQuery`
+   --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
+    |
+9   |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+    |     ------ ^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
+    |     |
+    |     required by a bound introduced by this call
+    |
+    = note: `f64` is no valid selection for `NoFromClause`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `&'a T` implements `SelectableExpression<QS>`
+              `(T0, T1)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
+            and N others
+    = note: required for `(f64, f64)` to implement `SelectableExpression<NoFromClause>`
+    = note: 1 redundant requirement hidden
+    = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `SelectableExpression<NoFromClause>`
+    = note: required for `SelectClause<ArrayLiteral<(f64, f64), Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `AsQuery`
 note: required by a bound in `diesel::select`
- --> $DIESEL/src/query_builder/functions.rs
-  |
-  | pub fn select<T>(expression: T) -> crate::dsl::select<T>
-  |        ------ required by a bound in this function
+   --> DIESEL/diesel/diesel/src/query_builder/functions.rs
+    |
+LL | pub fn select<T>(expression: T) -> crate::dsl::select<T>
+    |        ------ required by a bound in this function
 ...
-  |     crate::dsl::select<T>: AsQuery,
-  |                            ^^^^^^^ required by this bound in `select`
-
+LL |     crate::dsl::select<T>: AsQuery,
+    |                            ^^^^^^^ required by this bound in `select`
+ 
+    
 error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
- --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
-  |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |     ------ ^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
-  |     |
-  |     required by a bound introduced by this call
-  |
-  = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-            `&T` implements `ValidGrouping<GB>`
-            `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-          and $N others
-  = note: required for `(f64, f64)` to implement `ValidGrouping<()>`
-  = note: 1 redundant requirement hidden
-  = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `ValidGrouping<()>`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `Query`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `AsQuery`
+   --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
+    |
+9   |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+    |     ------ ^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
+    |     |
+    |     required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `&T` implements `ValidGrouping<GB>`
+              `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
+            and N others
+    = note: required for `(f64, f64)` to implement `ValidGrouping<()>`
+    = note: 1 redundant requirement hidden
+    = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `ValidGrouping<()>`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `AsQuery`
 note: required by a bound in `diesel::select`
- --> $DIESEL/src/query_builder/functions.rs
-  |
-  | pub fn select<T>(expression: T) -> crate::dsl::select<T>
-  |        ------ required by a bound in this function
+   --> DIESEL/diesel/diesel/src/query_builder/functions.rs
+    |
+LL | pub fn select<T>(expression: T) -> crate::dsl::select<T>
+    |        ------ required by a bound in this function
 ...
-  |     crate::dsl::select<T>: AsQuery,
-  |                            ^^^^^^^ required by this bound in `select`
-
+LL |     crate::dsl::select<T>: AsQuery,
+    |                            ^^^^^^^ required by this bound in `select`
+ 
+    
 error[E0277]: Cannot select `f64` from `NoFromClause`
- --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
-  |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |                                 ----------             ^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
-  |                                 |
-  |                                 required by a bound introduced by this call
-  |
-  = note: `f64` is no valid selection for `NoFromClause`
-  = help: the following other types implement trait `SelectableExpression<QS>`:
-            `&'a T` implements `SelectableExpression<QS>`
-            `(T0, T1)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
-            `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
-          and $N others
-  = note: required for `(f64, f64)` to implement `SelectableExpression<NoFromClause>`
-  = note: 1 redundant requirement hidden
-  = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `SelectableExpression<NoFromClause>`
-  = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `Query`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
+     |
+9    |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+     |                                 ----------             ^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
+     |                                 |
+     |                                 required by a bound introduced by this call
+     |
+     = note: `f64` is no valid selection for `NoFromClause`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `&'a T` implements `SelectableExpression<QS>`
+               `(T0, T1)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
+             and N others
+     = note: required for `(f64, f64)` to implement `SelectableExpression<NoFromClause>`
+     = note: 1 redundant requirement hidden
+     = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `SelectableExpression<NoFromClause>`
+     = note: required for `SelectClause<ArrayLiteral<(f64, f64), Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
- --> $DIESEL/src/query_dsl/mod.rs
-  |
-  |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-  |        ---------- required by a bound in this associated function
-  |     where
-  |         Self: LoadQuery<'query, Conn, U>,
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
- --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
-  |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |                                 ----------             ^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
-  |                                 |
-  |                                 required by a bound introduced by this call
-  |
-  = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-            `&T` implements `ValidGrouping<GB>`
-            `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-            `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-          and $N others
-  = note: required for `(f64, f64)` to implement `ValidGrouping<()>`
-  = note: 1 redundant requirement hidden
-  = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `ValidGrouping<()>`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `Query`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
+     |
+9    |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+     |                                 ----------             ^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
+     |                                 |
+     |                                 required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+               `&T` implements `ValidGrouping<GB>`
+               `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
+             and N others
+     = note: required for `(f64, f64)` to implement `ValidGrouping<()>`
+     = note: 1 redundant requirement hidden
+     = note: required for `diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>` to implement `ValidGrouping<()>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
- --> $DIESEL/src/query_dsl/mod.rs
-  |
-  |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-  |        ---------- required by a bound in this associated function
-  |     where
-  |         Self: LoadQuery<'query, Conn, U>,
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `f64: QueryId` is not satisfied
- --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
-  |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |                                 ----------             ^^^^^^^^^^^^^^^ the trait `QueryId` is not implemented for `f64`
-  |                                 |
-  |                                 required by a bound introduced by this call
-  |
-  = help: the following other types implement trait `QueryId`:
-            &T
-            ()
-            (T0, T1)
-            (T0, T1, T2)
-            (T0, T1, T2, T3)
-            (T0, T1, T2, T3, T4)
-            (T0, T1, T2, T3, T4, T5)
-            (T0, T1, T2, T3, T4, T5, T6)
-          and $N others
-  = note: required for `(f64, f64)` to implement `QueryId`
-  = note: 3 redundant requirements hidden
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `QueryId`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
+     |
+9    |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+     |                                 ----------             ^^^^^^^^^^^^^^^ the trait `QueryId` is not implemented for `f64`
+     |                                 |
+     |                                 required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `QueryId`:
+               &T
+               ()
+               (T0, T1)
+               (T0, T1, T2)
+               (T0, T1, T2, T3)
+               (T0, T1, T2, T3, T4)
+               (T0, T1, T2, T3, T4, T5)
+               (T0, T1, T2, T3, T4, T5, T6)
+             and N others
+     = note: required for `(f64, f64)` to implement `QueryId`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `QueryId`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
- --> $DIESEL/src/query_dsl/mod.rs
-  |
-  |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-  |        ---------- required by a bound in this associated function
-  |     where
-  |         Self: LoadQuery<'query, Conn, U>,
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: `f64` is no valid SQL fragment for the `Pg` backend
- --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
-  |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |                                 ----------             ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `f64`
-  |                                 |
-  |                                 required by a bound introduced by this call
-  |
-  = note: this usually means that the `Pg` database system does not support
-          this SQL syntax
-  = help: the following other types implement trait `QueryFragment<DB, SP>`:
-            `&T` implements `QueryFragment<DB>`
-            `()` implements `QueryFragment<DB>`
-            `(T0, T1)` implements `QueryFragment<__DB>`
-            `(T0, T1, T2)` implements `QueryFragment<__DB>`
-            `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
-            `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
-            `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
-            `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
-          and $N others
-  = note: required for `(f64, f64)` to implement `QueryFragment<Pg>`
-  = note: 4 redundant requirements hidden
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `QueryFragment<Pg>`
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(f64, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
+     |
+9    |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+     |                                 ----------             ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `f64`
+     |                                 |
+     |                                 required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `&T` implements `QueryFragment<DB>`
+               `()` implements `QueryFragment<DB>`
+               `(T0, T1)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
+             and N others
+     = note: required for `(f64, f64)` to implement `QueryFragment<Pg>`
+     = note: 4 redundant requirements hidden
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `QueryFragment<Pg>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
- --> $DIESEL/src/query_dsl/mod.rs
-  |
-  |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-  |        ---------- required by a bound in this associated function
-  |     where
-  |         Self: LoadQuery<'query, Conn, U>,
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `f64: diesel::Expression` is not satisfied
- --> tests/fail/array_expressions_must_be_correct_type.rs:9:19
-  |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-  |            -----  ^^^^ the trait `diesel::Expression` is not implemented for `f64`
-  |            |
-  |            required by a bound introduced by this call
-  |
-  = help: the following other types implement trait `diesel::Expression`:
-            &T
-            (T0, T1)
-            (T0, T1, T2)
-            (T0, T1, T2, T3)
-            (T0, T1, T2, T3, T4)
-            (T0, T1, T2, T3, T4, T5)
-            (T0, T1, T2, T3, T4, T5, T6)
-            (T0, T1, T2, T3, T4, T5, T6, T7)
-          and $N others
-  = note: required for `f64` to implement `AsExpression<diesel::sql_types::Integer>`
-  = note: required for `(f64, f64)` to implement `AsExpressionList<diesel::sql_types::Integer>`
+  --> tests/fail/array_expressions_must_be_correct_type.rs:9:19
+   |
+9  |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+   |            -----  ^^^^ the trait `diesel::Expression` is not implemented for `f64`
+   |            |
+   |            required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `diesel::Expression`:
+             &T
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+             (T0, T1, T2, T3, T4, T5, T6)
+             (T0, T1, T2, T3, T4, T5, T6, T7)
+           and N others
+   = note: required for `f64` to implement `AsExpression<diesel::sql_types::Integer>`
+   = note: required for `(f64, f64)` to implement `AsExpressionList<diesel::sql_types::Integer>`
 note: required by a bound in `diesel::dsl::array`
- --> $DIESEL/src/pg/expression/array.rs
-  |
-  | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
-  |        ----- required by a bound in this function
-  | where
-  |     T: IntoArrayExpression<ST>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+  --> DIESEL/diesel/diesel/src/pg/expression/array.rs
+   |
+LL | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
+   |        ----- required by a bound in this function
+LL | where
+LL |     T: IntoArrayExpression<ST>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
 error[E0277]: Cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
  --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
   |
-9 |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
+LL |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
   |            ^^^^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(f64, f64)`
   |
   = note: `the trait bound `(f64, f64): IntoArrayExpression<diesel::sql_types::Integer>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
@@ -239,4 +245,5 @@ error[E0277]: Cannot convert `(f64, f64)` into an expression of type `Array<dies
             (T0, T1, T2, T3, T4, T5, T6)
             (T0, T1, T2, T3, T4, T5, T6, T7)
             (T0, T1, T2, T3, T4, T5, T6, T7, T8)
-          and $N others
+          and N others
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.rs
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.rs
@@ -13,9 +13,25 @@ fn main() {
         .unwrap();
 
     select(array((1, 3f64)))
+        //~^ ERROR: the trait bound `f64: diesel::Expression` is not satisfied
+        //~| ERROR: Cannot select `f64` from `NoFromClause`
+        //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
+        //~| ERROR: Cannot convert `(i32, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
         .get_result::<Vec<i32>>(&mut connection)
+        //~^ ERROR: Cannot select `f64` from `NoFromClause`
+        //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
+        //~| ERROR: the trait bound `f64: QueryId` is not satisfied
+        //~| ERROR: `f64` is no valid SQL fragment for the `Pg` backend
         .unwrap();
     select(array((1, 3f64)))
+        //~^ ERROR: the trait bound `{integer}: diesel::Expression` is not satisfied
+        //~| ERROR: Cannot select `{integer}` from `NoFromClause`
+        //~| ERROR: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
+        //~| ERROR: Cannot convert `({integer}, f64)` into an expression of type `Array<diesel::sql_types::Double>`
         .get_result::<Vec<f64>>(&mut connection)
+        //~^ ERROR: Cannot select `{integer}` from `NoFromClause`
+        //~| ERROR: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
+        //~| ERROR: the trait bound `{integer}: QueryId` is not satisfied
+        //~| ERROR: `{integer}` is no valid SQL fragment for the `Pg` backend
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -1,203 +1,209 @@
 error[E0277]: Cannot select `f64` from `NoFromClause`
-  --> tests/fail/array_expressions_must_be_same_type.rs:15:12
-   |
-15 |     select(array((1, 3f64)))
-   |     ------ ^^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = note: `f64` is no valid selection for `NoFromClause`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `&'a T` implements `SelectableExpression<QS>`
-             `(T0, T1)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
-           and $N others
-   = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `SelectableExpression<NoFromClause>`
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>` to implement `SelectableExpression<NoFromClause>`
-   = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `AsQuery`
+   --> tests/fail/array_expressions_must_be_same_type.rs:15:12
+    |
+15  |     select(array((1, 3f64)))
+    |     ------ ^^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
+    |     |
+    |     required by a bound introduced by this call
+    |
+    = note: `f64` is no valid selection for `NoFromClause`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `&'a T` implements `SelectableExpression<QS>`
+              `(T0, T1)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
+            and N others
+    = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `SelectableExpression<NoFromClause>`
+    = note: 1 redundant requirement hidden
+    = note: required for `ArrayLiteral<(Bound<Integer, i32>, f64), Integer>` to implement `SelectableExpression<NoFromClause>`
+    = note: required for `SelectClause<ArrayLiteral<(Bound<Integer, i32>, f64), Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `AsQuery`
 note: required by a bound in `diesel::select`
-  --> $DIESEL/src/query_builder/functions.rs
-   |
-   | pub fn select<T>(expression: T) -> crate::dsl::select<T>
-   |        ------ required by a bound in this function
+   --> DIESEL/diesel/diesel/src/query_builder/functions.rs
+    |
+LL | pub fn select<T>(expression: T) -> crate::dsl::select<T>
+    |        ------ required by a bound in this function
 ...
-   |     crate::dsl::select<T>: AsQuery,
-   |                            ^^^^^^^ required by this bound in `select`
-
+LL |     crate::dsl::select<T>: AsQuery,
+    |                            ^^^^^^^ required by this bound in `select`
+ 
+    
 error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
-  --> tests/fail/array_expressions_must_be_same_type.rs:15:12
-   |
-15 |     select(array((1, 3f64)))
-   |     ------ ^^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-             `&T` implements `ValidGrouping<GB>`
-             `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-           and $N others
-   = note: required for `(f64,)` to implement `ValidGrouping<()>`
-   = note: 2 redundant requirements hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>` to implement `ValidGrouping<()>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `AsQuery`
+   --> tests/fail/array_expressions_must_be_same_type.rs:15:12
+    |
+15  |     select(array((1, 3f64)))
+    |     ------ ^^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
+    |     |
+    |     required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `&T` implements `ValidGrouping<GB>`
+              `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
+            and N others
+    = note: required for `(f64,)` to implement `ValidGrouping<()>`
+    = note: 2 redundant requirements hidden
+    = note: required for `ArrayLiteral<(Bound<Integer, i32>, f64), Integer>` to implement `ValidGrouping<()>`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `AsQuery`
 note: required by a bound in `diesel::select`
-  --> $DIESEL/src/query_builder/functions.rs
-   |
-   | pub fn select<T>(expression: T) -> crate::dsl::select<T>
-   |        ------ required by a bound in this function
+   --> DIESEL/diesel/diesel/src/query_builder/functions.rs
+    |
+LL | pub fn select<T>(expression: T) -> crate::dsl::select<T>
+    |        ------ required by a bound in this function
 ...
-   |     crate::dsl::select<T>: AsQuery,
-   |                            ^^^^^^^ required by this bound in `select`
-
+LL |     crate::dsl::select<T>: AsQuery,
+    |                            ^^^^^^^ required by this bound in `select`
+ 
+    
 error[E0277]: Cannot select `f64` from `NoFromClause`
-  --> tests/fail/array_expressions_must_be_same_type.rs:16:33
-   |
-16 |         .get_result::<Vec<i32>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `f64` is no valid selection for `NoFromClause`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `&'a T` implements `SelectableExpression<QS>`
-             `(T0, T1)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
-           and $N others
-   = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `SelectableExpression<NoFromClause>`
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>` to implement `SelectableExpression<NoFromClause>`
-   = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:20:33
+     |
+20   |         .get_result::<Vec<i32>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `f64`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `f64` is no valid selection for `NoFromClause`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `&'a T` implements `SelectableExpression<QS>`
+               `(T0, T1)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
+             and N others
+     = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `SelectableExpression<NoFromClause>`
+     = note: 1 redundant requirement hidden
+     = note: required for `ArrayLiteral<(Bound<Integer, i32>, f64), Integer>` to implement `SelectableExpression<NoFromClause>`
+     = note: required for `SelectClause<ArrayLiteral<(Bound<Integer, i32>, f64), Integer>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
-  --> tests/fail/array_expressions_must_be_same_type.rs:16:33
-   |
-16 |         .get_result::<Vec<i32>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-             `&T` implements `ValidGrouping<GB>`
-             `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-           and $N others
-   = note: required for `(f64,)` to implement `ValidGrouping<()>`
-   = note: 2 redundant requirements hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>` to implement `ValidGrouping<()>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:20:33
+     |
+20   |         .get_result::<Vec<i32>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `f64`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+               `&T` implements `ValidGrouping<GB>`
+               `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
+             and N others
+     = note: required for `(f64,)` to implement `ValidGrouping<()>`
+     = note: 2 redundant requirements hidden
+     = note: required for `ArrayLiteral<(Bound<Integer, i32>, f64), Integer>` to implement `ValidGrouping<()>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `f64: QueryId` is not satisfied
-  --> tests/fail/array_expressions_must_be_same_type.rs:16:33
-   |
-16 |         .get_result::<Vec<i32>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryId` is not implemented for `f64`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `QueryId`:
-             &T
-             ()
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-           and $N others
-   = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `QueryId`
-   = note: 3 redundant requirements hidden
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `QueryId`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:20:33
+     |
+20   |         .get_result::<Vec<i32>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryId` is not implemented for `f64`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `QueryId`:
+               &T
+               ()
+               (T0, T1)
+               (T0, T1, T2)
+               (T0, T1, T2, T3)
+               (T0, T1, T2, T3, T4)
+               (T0, T1, T2, T3, T4, T5)
+               (T0, T1, T2, T3, T4, T5, T6)
+             and N others
+     = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `QueryId`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `QueryId`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: `f64` is no valid SQL fragment for the `Pg` backend
-  --> tests/fail/array_expressions_must_be_same_type.rs:16:33
-   |
-16 |         .get_result::<Vec<i32>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `f64`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Pg` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `&T` implements `QueryFragment<DB>`
-             `()` implements `QueryFragment<DB>`
-             `(T0, T1)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
-           and $N others
-   = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `QueryFragment<Pg>`
-   = note: 4 redundant requirements hidden
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `QueryFragment<Pg>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:20:33
+     |
+20   |         .get_result::<Vec<i32>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `f64`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `&T` implements `QueryFragment<DB>`
+               `()` implements `QueryFragment<DB>`
+               `(T0, T1)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
+             and N others
+     = note: required for `(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, f64)` to implement `QueryFragment<Pg>`
+     = note: 4 redundant requirements hidden
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `QueryFragment<Pg>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<i32>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `f64: diesel::Expression` is not satisfied
   --> tests/fail/array_expressions_must_be_same_type.rs:15:22
    |
-15 |     select(array((1, 3f64)))
+LL |     select(array((1, 3f64)))
    |            -----     ^^^^ the trait `diesel::Expression` is not implemented for `f64`
    |            |
    |            required by a bound introduced by this call
@@ -211,218 +217,224 @@ error[E0277]: the trait bound `f64: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `f64` to implement `AsExpression<diesel::sql_types::Integer>`
    = note: required for `(i32, f64)` to implement `AsExpressionList<diesel::sql_types::Integer>`
 note: required by a bound in `diesel::dsl::array`
-  --> $DIESEL/src/pg/expression/array.rs
+  --> DIESEL/diesel/diesel/src/pg/expression/array.rs
    |
-   | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
+LL | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
    |        ----- required by a bound in this function
-   | where
-   |     T: IntoArrayExpression<ST>,
+LL | where
+LL |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
 error[E0277]: Cannot select `{integer}` from `NoFromClause`
-  --> tests/fail/array_expressions_must_be_same_type.rs:18:12
-   |
-18 |     select(array((1, 3f64)))
-   |     ------ ^^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `{integer}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = note: `{integer}` is no valid selection for `NoFromClause`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `&'a T` implements `SelectableExpression<QS>`
-             `(T0, T1)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
-           and $N others
-   = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `SelectableExpression<NoFromClause>`
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>` to implement `SelectableExpression<NoFromClause>`
-   = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `AsQuery`
+   --> tests/fail/array_expressions_must_be_same_type.rs:26:12
+    |
+26  |     select(array((1, 3f64)))
+    |     ------ ^^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `{integer}`
+    |     |
+    |     required by a bound introduced by this call
+    |
+    = note: `{integer}` is no valid selection for `NoFromClause`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `&'a T` implements `SelectableExpression<QS>`
+              `(T0, T1)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
+              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
+            and N others
+    = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `SelectableExpression<NoFromClause>`
+    = note: 1 redundant requirement hidden
+    = note: required for `ArrayLiteral<({integer}, Bound<Double, f64>), Double>` to implement `SelectableExpression<NoFromClause>`
+    = note: required for `SelectClause<ArrayLiteral<({integer}, Bound<Double, f64>), Double>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `AsQuery`
 note: required by a bound in `diesel::select`
-  --> $DIESEL/src/query_builder/functions.rs
-   |
-   | pub fn select<T>(expression: T) -> crate::dsl::select<T>
-   |        ------ required by a bound in this function
+   --> DIESEL/diesel/diesel/src/query_builder/functions.rs
+    |
+LL | pub fn select<T>(expression: T) -> crate::dsl::select<T>
+    |        ------ required by a bound in this function
 ...
-   |     crate::dsl::select<T>: AsQuery,
-   |                            ^^^^^^^ required by this bound in `select`
-
+LL |     crate::dsl::select<T>: AsQuery,
+    |                            ^^^^^^^ required by this bound in `select`
+ 
+    
 error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
-  --> tests/fail/array_expressions_must_be_same_type.rs:18:12
-   |
-18 |     select(array((1, 3f64)))
-   |     ------ ^^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `{integer}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-             `&T` implements `ValidGrouping<GB>`
-             `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-           and $N others
-   = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `ValidGrouping<()>`
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>` to implement `ValidGrouping<()>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `AsQuery`
+   --> tests/fail/array_expressions_must_be_same_type.rs:26:12
+    |
+26  |     select(array((1, 3f64)))
+    |     ------ ^^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `{integer}`
+    |     |
+    |     required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `&T` implements `ValidGrouping<GB>`
+              `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
+            and N others
+    = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `ValidGrouping<()>`
+    = note: 1 redundant requirement hidden
+    = note: required for `ArrayLiteral<({integer}, Bound<Double, f64>), Double>` to implement `ValidGrouping<()>`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+    = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `AsQuery`
 note: required by a bound in `diesel::select`
-  --> $DIESEL/src/query_builder/functions.rs
-   |
-   | pub fn select<T>(expression: T) -> crate::dsl::select<T>
-   |        ------ required by a bound in this function
+   --> DIESEL/diesel/diesel/src/query_builder/functions.rs
+    |
+LL | pub fn select<T>(expression: T) -> crate::dsl::select<T>
+    |        ------ required by a bound in this function
 ...
-   |     crate::dsl::select<T>: AsQuery,
-   |                            ^^^^^^^ required by this bound in `select`
-
+LL |     crate::dsl::select<T>: AsQuery,
+    |                            ^^^^^^^ required by this bound in `select`
+ 
+    
 error[E0277]: Cannot select `{integer}` from `NoFromClause`
-  --> tests/fail/array_expressions_must_be_same_type.rs:19:33
-   |
-19 |         .get_result::<Vec<f64>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `{integer}`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `{integer}` is no valid selection for `NoFromClause`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `&'a T` implements `SelectableExpression<QS>`
-             `(T0, T1)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
-           and $N others
-   = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `SelectableExpression<NoFromClause>`
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>` to implement `SelectableExpression<NoFromClause>`
-   = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:31:33
+     |
+31   |         .get_result::<Vec<f64>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `SelectableExpression<NoFromClause>` is not implemented for `{integer}`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `{integer}` is no valid selection for `NoFromClause`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `&'a T` implements `SelectableExpression<QS>`
+               `(T0, T1)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `SelectableExpression<QS>`
+               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `SelectableExpression<QS>`
+             and N others
+     = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `SelectableExpression<NoFromClause>`
+     = note: 1 redundant requirement hidden
+     = note: required for `ArrayLiteral<({integer}, Bound<Double, f64>), Double>` to implement `SelectableExpression<NoFromClause>`
+     = note: required for `SelectClause<ArrayLiteral<({integer}, Bound<Double, f64>), Double>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<NoFromClause>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
-  --> tests/fail/array_expressions_must_be_same_type.rs:19:33
-   |
-19 |         .get_result::<Vec<f64>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `{integer}`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-             `&T` implements `ValidGrouping<GB>`
-             `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-           and $N others
-   = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `ValidGrouping<()>`
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>` to implement `ValidGrouping<()>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `Query`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:31:33
+     |
+31   |         .get_result::<Vec<f64>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `{integer}`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+               `&T` implements `ValidGrouping<GB>`
+               `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
+             and N others
+     = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `ValidGrouping<()>`
+     = note: 1 redundant requirement hidden
+     = note: required for `ArrayLiteral<({integer}, Bound<Double, f64>), Double>` to implement `ValidGrouping<()>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `Query`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `{integer}: QueryId` is not satisfied
-  --> tests/fail/array_expressions_must_be_same_type.rs:19:33
-   |
-19 |         .get_result::<Vec<f64>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryId` is not implemented for `{integer}`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `QueryId`:
-             &T
-             ()
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-           and $N others
-   = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `QueryId`
-   = note: 3 redundant requirements hidden
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `QueryId`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:31:33
+     |
+31   |         .get_result::<Vec<f64>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryId` is not implemented for `{integer}`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `QueryId`:
+               &T
+               ()
+               (T0, T1)
+               (T0, T1, T2)
+               (T0, T1, T2, T3)
+               (T0, T1, T2, T3, T4)
+               (T0, T1, T2, T3, T4, T5)
+               (T0, T1, T2, T3, T4, T5, T6)
+             and N others
+     = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `QueryId`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `QueryId`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: `{integer}` is no valid SQL fragment for the `Pg` backend
-  --> tests/fail/array_expressions_must_be_same_type.rs:19:33
-   |
-19 |         .get_result::<Vec<f64>>(&mut connection)
-   |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `{integer}`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Pg` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `&T` implements `QueryFragment<DB>`
-             `()` implements `QueryFragment<DB>`
-             `(T0, T1)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
-           and $N others
-   = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `QueryFragment<Pg>`
-   = note: 4 redundant requirements hidden
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `QueryFragment<Pg>`
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>), diesel::sql_types::Double>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
+    --> tests/fail/array_expressions_must_be_same_type.rs:31:33
+     |
+31   |         .get_result::<Vec<f64>>(&mut connection)
+     |          ----------             ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `{integer}`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `&T` implements `QueryFragment<DB>`
+               `()` implements `QueryFragment<DB>`
+               `(T0, T1)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
+             and N others
+     = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `QueryFragment<Pg>`
+     = note: 4 redundant requirements hidden
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `QueryFragment<Pg>`
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<..., ...>>>` to implement `LoadQuery<'_, _, Vec<f64>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
-  --> tests/fail/array_expressions_must_be_same_type.rs:18:19
+  --> tests/fail/array_expressions_must_be_same_type.rs:26:19
    |
-18 |     select(array((1, 3f64)))
+LL |     select(array((1, 3f64)))
    |            -----  ^ the trait `diesel::Expression` is not implemented for `{integer}`
    |            |
    |            required by a bound introduced by this call
@@ -436,22 +448,22 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `{integer}` to implement `AsExpression<diesel::sql_types::Double>`
    = note: required for `({integer}, f64)` to implement `AsExpressionList<diesel::sql_types::Double>`
 note: required by a bound in `diesel::dsl::array`
-  --> $DIESEL/src/pg/expression/array.rs
+  --> DIESEL/diesel/diesel/src/pg/expression/array.rs
    |
-   | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
+LL | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
    |        ----- required by a bound in this function
-   | where
-   |     T: IntoArrayExpression<ST>,
+LL | where
+LL |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
 error[E0277]: Cannot convert `(i32, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
   --> tests/fail/array_expressions_must_be_same_type.rs:15:12
    |
-15 |     select(array((1, 3f64)))
+LL |     select(array((1, 3f64)))
    |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Integer>` is not implemented for `(i32, f64)`
    |
    = note: `the trait bound `(i32, f64): IntoArrayExpression<diesel::sql_types::Integer>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
@@ -464,12 +476,12 @@ error[E0277]: Cannot convert `(i32, f64)` into an expression of type `Array<dies
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
              (T0, T1, T2, T3, T4, T5, T6, T7, T8)
-           and $N others
+           and N others
 
 error[E0277]: Cannot convert `({integer}, f64)` into an expression of type `Array<diesel::sql_types::Double>`
-  --> tests/fail/array_expressions_must_be_same_type.rs:18:12
+  --> tests/fail/array_expressions_must_be_same_type.rs:26:12
    |
-18 |     select(array((1, 3f64)))
+LL |     select(array((1, 3f64)))
    |            ^^^^^^^^^^^^^^^^ the trait `AsExpressionList<diesel::sql_types::Double>` is not implemented for `({integer}, f64)`
    |
    = note: `the trait bound `({integer}, f64): IntoArrayExpression<diesel::sql_types::Double>` is not satisfied. (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)
@@ -482,4 +494,5 @@ error[E0277]: Cannot convert `({integer}, f64)` into an expression of type `Arra
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
              (T0, T1, T2, T3, T4, T5, T6, T7, T8)
-           and $N others
+           and N others
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/array_only_usable_with_pg.rs
+++ b/diesel_compile_tests/tests/fail/array_only_usable_with_pg.rs
@@ -6,7 +6,9 @@ use diesel::*;
 fn main() {
     let mut connection = SqliteConnection::establish("").unwrap();
     select(array((1,))).get_result::<Vec<i32>>(&mut connection);
+    //~^ ERROR: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
 
     let mut connection = MysqlConnection::establish("").unwrap();
     select(array((1,))).get_result::<Vec<i32>>(&mut connection);
+    //~^ ERROR: type mismatch resolving `<MysqlConnection as Connection>::Backend == Pg`
 }

--- a/diesel_compile_tests/tests/fail/array_only_usable_with_pg.stderr
+++ b/diesel_compile_tests/tests/fail/array_only_usable_with_pg.stderr
@@ -1,35 +1,38 @@
 error[E0271]: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
- --> tests/fail/array_only_usable_with_pg.rs:8:48
-  |
-8 |     select(array((1,))).get_result::<Vec<i32>>(&mut connection);
-  |                         ----------             ^^^^^^^^^^^^^^^ expected `Pg`, found `Sqlite`
-  |                         |
-  |                         required by a bound introduced by this call
-  |
-  = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>,), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, Vec<i32>>`
+    --> tests/fail/array_only_usable_with_pg.rs:8:48
+     |
+8    |     select(array((1,))).get_result::<Vec<i32>>(&mut connection);
+     |                         ----------             ^^^^^^^^^^^^^^^ expected `Pg`, found `Sqlite`
+     |                         |
+     |                         required by a bound introduced by this call
+     |
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<(...,), ...>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, Vec<i32>>`
 note: required by a bound in `get_result`
- --> $DIESEL/src/query_dsl/mod.rs
-  |
-  |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-  |        ---------- required by a bound in this associated function
-  |     where
-  |         Self: LoadQuery<'query, Conn, U>,
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0271]: type mismatch resolving `<MysqlConnection as Connection>::Backend == Pg`
-  --> tests/fail/array_only_usable_with_pg.rs:11:48
-   |
-11 |     select(array((1,))).get_result::<Vec<i32>>(&mut connection);
-   |                         ----------             ^^^^^^^^^^^^^^^ expected `Pg`, found `Mysql`
-   |                         |
-   |                         required by a bound introduced by this call
-   |
-   = note: required for `SelectStatement<NoFromClause, diesel::query_builder::select_clause::SelectClause<diesel::pg::expression::array::ArrayLiteral<(diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>,), diesel::sql_types::Integer>>>` to implement `LoadQuery<'_, diesel::MysqlConnection, Vec<i32>>`
+    --> tests/fail/array_only_usable_with_pg.rs:12:48
+     |
+12   |     select(array((1,))).get_result::<Vec<i32>>(&mut connection);
+     |                         ----------             ^^^^^^^^^^^^^^^ expected `Pg`, found `Mysql`
+     |                         |
+     |                         required by a bound introduced by this call
+     |
+     = note: required for `SelectStatement<NoFromClause, SelectClause<ArrayLiteral<(...,), ...>>>` to implement `LoadQuery<'_, diesel::MysqlConnection, Vec<i32>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/auto_type.rs
+++ b/diesel_compile_tests/tests/fail/auto_type.rs
@@ -34,6 +34,7 @@ fn users_with_posts_with_id_greater_than(id_greater_than: i32) -> _ {
     // `user_has_post_with_id_greater_than<i32>`
     users::table
         .filter(user_has_post_with_id_greater_than(id_greater_than))
+        //~^ ERROR: type alias takes 0 generic arguments but 1 generic argument was supplied
         .select(users::name)
 }
 
@@ -43,6 +44,8 @@ fn user_has_post_with_id_greater_than_2() -> _ {
     // (Literals must have type suffix for auto_type, e.g. 2i64), and that it's properly spanned
     // (on the `2`)
     let n = 2;
+    //~^ ERROR: Literals must have type suffix for auto_type, e.g. 2i64
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for type aliases
     let m = 3;
     dsl::exists(
         posts::table
@@ -54,6 +57,9 @@ fn user_has_post_with_id_greater_than_2() -> _ {
 #[dsl::auto_type]
 fn less_arguments_than_generics() -> _ {
     posts::user_id.eq::<_>()
+    //~^ ERROR: auto_type: Can't infer generic argument because there is no function argument to infer from (less function arguments than generic arguments)
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for type aliases
+    //~| ERROR: this method takes 1 argument but 0 arguments were supplied
 }
 
 #[derive(Queryable, Selectable)]
@@ -64,6 +70,8 @@ struct User {
         posts::table
             .filter(posts::user_id.eq(users::id))
             .filter(posts::id.gt(2)),
+        //~^ ERROR: Literals must have type suffix for auto_type, e.g. 2i64
+        //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated types
     ))]
     user_has_post_with_id_greater_than_2: bool,
 }

--- a/diesel_compile_tests/tests/fail/auto_type.stderr
+++ b/diesel_compile_tests/tests/fail/auto_type.stderr
@@ -1,30 +1,30 @@
 error: Literals must have type suffix for auto_type, e.g. 2i64
-  --> tests/fail/auto_type.rs:45:13
+  --> tests/fail/auto_type.rs:46:13
    |
-45 |     let n = 2;
+LL |     let n = 2;
    |             ^
 
 error: auto_type: Can't infer generic argument because there is no function argument to infer from (less function arguments than generic arguments)
-  --> tests/fail/auto_type.rs:56:25
+  --> tests/fail/auto_type.rs:59:25
    |
-56 |     posts::user_id.eq::<_>()
+LL |     posts::user_id.eq::<_>()
    |                         ^
 
 error: Literals must have type suffix for auto_type, e.g. 2i64
-  --> tests/fail/auto_type.rs:66:34
+  --> tests/fail/auto_type.rs:72:34
    |
-66 |             .filter(posts::id.gt(2)),
+LL |             .filter(posts::id.gt(2)),
    |                                  ^
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> tests/fail/auto_type.rs:36:17
    |
-30 |   #[dsl::auto_type]
+LL |   #[dsl::auto_type]
    |  __________________-
-31 | | fn users_with_posts_with_id_greater_than(id_greater_than: i32) -> _ {
+LL | | fn users_with_posts_with_id_greater_than(id_greater_than: i32) -> _ {
 ...  |
-35 | |     users::table
-36 | |         .filter(user_has_post_with_id_greater_than(id_greater_than))
+LL | |     users::table
+LL | |         .filter(user_has_post_with_id_greater_than(id_greater_than))
    | |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |_________________|________________________________|
    |                   |                                help: remove the unnecessary generics
@@ -33,42 +33,42 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
 note: type alias defined here, with 0 generic parameters
   --> tests/fail/auto_type.rs:22:4
    |
-22 | fn user_has_post_with_id_greater_than(id_greater_than: i32) -> _ {
+LL | fn user_has_post_with_id_greater_than(id_greater_than: i32) -> _ {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> tests/fail/auto_type.rs:45:13
+  --> tests/fail/auto_type.rs:46:13
    |
-45 |     let n = 2;
+LL |     let n = 2;
    |             ^
    |             |
    |             not allowed in type signatures
    |             not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> tests/fail/auto_type.rs:56:25
+  --> tests/fail/auto_type.rs:59:25
    |
-56 |     posts::user_id.eq::<_>()
+LL |     posts::user_id.eq::<_>()
    |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> tests/fail/auto_type.rs:66:34
+  --> tests/fail/auto_type.rs:72:34
    |
-66 |             .filter(posts::id.gt(2)),
+LL |             .filter(posts::id.gt(2)),
    |                                  ^ not allowed in type signatures
 
 error[E0061]: this method takes 1 argument but 0 arguments were supplied
-  --> tests/fail/auto_type.rs:56:20
+  --> tests/fail/auto_type.rs:59:20
    |
-56 |     posts::user_id.eq::<_>()
+LL |     posts::user_id.eq::<_>()
    |                    ^^^^^^^-- argument #1 is missing
    |
 note: method defined here
-  --> $DIESEL/src/expression_methods/global_expression_methods.rs
+  --> DIESEL/diesel/diesel/src/expression_methods/global_expression_methods.rs
    |
-   |     fn eq<T>(self, other: T) -> dsl::Eq<Self, T>
+LL |     fn eq<T>(self, other: T) -> dsl::Eq<Self, T>
    |        ^^
 help: provide the argument
    |
-56 |     posts::user_id.eq::<_>(/* other */)
+LL |     posts::user_id.eq::<_>(/* other */)
    |                            +++++++++++

--- a/diesel_compile_tests/tests/fail/auto_type_life_times.rs
+++ b/diesel_compile_tests/tests/fail/auto_type_life_times.rs
@@ -10,11 +10,15 @@ diesel::table! {
 
 #[auto_type]
 fn with_lifetime(name: &'_ str) -> _ {
+    //~^ ERROR: `#[auto_type]` requires named lifetimes
+    //~| ERROR: missing lifetime specifier
     users::table.filter(users::name.eq(name))
 }
 
 #[auto_type]
 fn with_lifetime2(name: &str) -> _ {
+    //~^ ERROR: `#[auto_type]` requires named lifetimes
+    //~| ERROR: missing lifetime specifier
     users::table.filter(users::name.eq(name))
 }
 

--- a/diesel_compile_tests/tests/fail/auto_type_life_times.stderr
+++ b/diesel_compile_tests/tests/fail/auto_type_life_times.stderr
@@ -1,19 +1,19 @@
 error: `#[auto_type]` requires named lifetimes
   --> tests/fail/auto_type_life_times.rs:12:25
    |
-12 | fn with_lifetime(name: &'_ str) -> _ {
+LL | fn with_lifetime(name: &'_ str) -> _ {
    |                         ^^
 
 error: `#[auto_type]` requires named lifetimes
-  --> tests/fail/auto_type_life_times.rs:17:25
+  --> tests/fail/auto_type_life_times.rs:19:25
    |
-17 | fn with_lifetime2(name: &str) -> _ {
+LL | fn with_lifetime2(name: &str) -> _ {
    |                         ^^^^
 
 error[E0106]: missing lifetime specifier
   --> tests/fail/auto_type_life_times.rs:12:25
    |
-12 | fn with_lifetime(name: &'_ str) -> _ {
+LL | fn with_lifetime(name: &'_ str) -> _ {
    |                         ^^ expected named lifetime parameter
    |
 help: consider introducing a named lifetime parameter
@@ -23,12 +23,13 @@ help: consider introducing a named lifetime parameter
    |
 
 error[E0106]: missing lifetime specifier
-  --> tests/fail/auto_type_life_times.rs:17:25
+  --> tests/fail/auto_type_life_times.rs:19:25
    |
-17 | fn with_lifetime2(name: &str) -> _ {
+LL | fn with_lifetime2(name: &str) -> _ {
    |                         ^ expected named lifetime parameter
    |
 help: consider introducing a named lifetime parameter
    |
-17 | fn with_lifetime2<'a>(name: &'a str) -> _ {
+LL | fn with_lifetime2<'a>(name: &'a str) -> _ {
    |                  ++++        ++
+For more information about this error, try `rustc --explain E0106`.

--- a/diesel_compile_tests/tests/fail/boxed_queries_and_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_and_group_by.stderr
@@ -1,48 +1,18 @@
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::name>>: BoxedDsl<'_, _>` is not satisfied
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: BoxedDsl<'_, _>` is not satisfied
   --> tests/fail/boxed_queries_and_group_by.rs:55:40
    |
-55 |     users::table.group_by(users::name).into_boxed();
-   |                                        ^^^^^^^^^^ unsatisfied trait bound
+LL |     users::table.group_by(users::name).into_boxed();
+   |                                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::name>>`
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
 
+   
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/boxed_queries_and_group_by.rs:59:10
-   |
-59 |         .select(users::id)
-   |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   |
-note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
-  --> tests/fail/boxed_queries_and_group_by.rs:8:9
-   |
-8  |         name -> Text,
-   |         ^^^^
-note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
-  --> tests/fail/boxed_queries_and_group_by.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::name>>` to implement `SelectDsl<users::columns::id>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::name>>: BoxedDsl<'_, _>` is not satisfied
   --> tests/fail/boxed_queries_and_group_by.rs:60:10
    |
-60 |         .into_boxed();
-   |          ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::name>>`
-   = help: the following other types implement trait `BoxedDsl<'a, DB>`:
-             SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
-             SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
-
-error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/boxed_queries_and_group_by.rs:66:10
-   |
-66 |         .select(users::id)
+LL |         .select(users::id)
    |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
@@ -56,15 +26,46 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
 7  |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `BoxedSelectStatement<'_, diesel::sql_types::Text, FromClause<users::table>, _, users::columns::name>` to implement `SelectDsl<users::columns::id>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
-error[E0277]: the trait bound `BoxedSelectStatement<'_, diesel::sql_types::Text, FromClause<users::table>, _, users::columns::name>: Table` is not satisfied
-  --> tests/fail/boxed_queries_and_group_by.rs:73:10
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: BoxedDsl<'_, _>` is not satisfied
+  --> tests/fail/boxed_queries_and_group_by.rs:62:10
    |
-73 |         .inner_join(posts::table)
-   |          ^^^^^^^^^^ unsatisfied trait bound
+LL |         .into_boxed();
+   |          ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `Table` is not implemented for `BoxedSelectStatement<'_, diesel::sql_types::Text, FromClause<users::table>, _, users::columns::name>`
+   = help: the following other types implement trait `BoxedDsl<'a, DB>`:
+             SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
+             SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
+
+   
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+  --> tests/fail/boxed_queries_and_group_by.rs:69:10
+   |
+LL |         .select(users::id)
+   |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/boxed_queries_and_group_by.rs:8:9
+   |
+8  |         name -> Text,
+   |         ^^^^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/boxed_queries_and_group_by.rs:7:9
+   |
+7  |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: required for `BoxedSelectStatement<'_, Text, FromClause<table>, _, name>` to implement `SelectDsl<users::columns::id>`
+
+   
+error[E0277]: the trait bound `BoxedSelectStatement<'_, Text, FromClause<table>, _, name>: Table` is not satisfied
+  --> tests/fail/boxed_queries_and_group_by.rs:77:10
+   |
+LL |         .inner_join(posts::table)
+   |          ^^^^^^^^^^ the trait `Table` is not implemented for `BoxedSelectStatement<'_, Text, FromClause<table>, _, name>`
+   |
    = help: the following other types implement trait `Table`:
              Only<S>
              Tablesample<S, TSM>
@@ -72,65 +73,66 @@ error[E0277]: the trait bound `BoxedSelectStatement<'_, diesel::sql_types::Text,
              pg::metadata_lookup::pg_type::table
              posts::table
              users::table
-   = note: required for `BoxedSelectStatement<'_, diesel::sql_types::Text, FromClause<users::table>, _, users::columns::name>` to implement `JoinTo<query_source::joins::OnClauseWrapper<_, _>>`
-   = note: required for `BoxedSelectStatement<'_, diesel::sql_types::Text, FromClause<users::table>, _, users::columns::name>` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<_, _>, Inner>`
+   = note: required for `BoxedSelectStatement<'_, Text, FromClause<table>, _, name>` to implement `JoinTo<query_source::joins::OnClauseWrapper<_, _>>`
+   = note: required for `BoxedSelectStatement<'_, Text, FromClause<table>, _, name>` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<_, _>, Inner>`
 
+   
 error[E0308]: mismatched types
-  --> tests/fail/boxed_queries_and_group_by.rs:73:21
-   |
-73 |         .inner_join(posts::table)
-   |          ---------- ^^^^^^^^^^^^ expected `OnClauseWrapper<_, _>`, found `table`
-   |          |
-   |          arguments to this method are incorrect
-   |
-   = note: expected struct `query_source::joins::OnClauseWrapper<_, _>`
-              found struct `posts::table`
+   --> tests/fail/boxed_queries_and_group_by.rs:77:21
+    |
+77  |         .inner_join(posts::table)
+    |          ---------- ^^^^^^^^^^^^ expected `OnClauseWrapper<_, _>`, found `table`
+    |          |
+    |          arguments to this method are incorrect
+    |
+    = note: expected struct `query_source::joins::OnClauseWrapper<_, _>`
+               found struct `posts::table`
 help: the return type of this call is `posts::table` due to the type of the argument passed
-  --> tests/fail/boxed_queries_and_group_by.rs:69:5
-   |
-69 | /     users::table
-70 | |         .group_by(users::name)
-71 | |         .select(users::name)
-72 | |         .into_boxed()
-73 | |         .inner_join(posts::table)
-   | |_____________________------------^
-   |                       |
-   |                       this argument influences the return type of `inner_join`
+   --> tests/fail/boxed_queries_and_group_by.rs:73:5
+    |
+73  | /     users::table
+74  | |         .group_by(users::name)
+75  | |         .select(users::name)
+76  | |         .into_boxed()
+77  | |         .inner_join(posts::table)
+    | |_____________________------------^
+    |                       |
+    |                       this argument influences the return type of `inner_join`
 note: method defined here
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ^^^^^^^^^^
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> tests/fail/boxed_queries_and_group_by.rs:79:9
+  --> tests/fail/boxed_queries_and_group_by.rs:85:9
    |
-76 |     let mut a = users::table.into_boxed();
+LL |     let mut a = users::table.into_boxed();
    |                 ------------------------- expected due to this value
 ...
-79 |     a = users::table.group_by(users::id).into_boxed();
+LL |     a = users::table.group_by(users::id).into_boxed();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `BoxedSelectStatement<'_, ..., ..., _>`, found `BoxedSelectStatement<'_, ..., ..., _, ...>`
    |
-   = note: expected struct `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _, ()>`
-              found struct `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _, users::columns::id>`
+   = note: expected struct `BoxedSelectStatement<'_, _, _, _, ()>`
+              found struct `BoxedSelectStatement<'_, _, _, _, users::columns::id>`
 
-error[E0271]: type mismatch resolving `<BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _> as AsQuery>::Query == SelectStatement<FromClause<BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>>>`
-  --> tests/fail/boxed_queries_and_group_by.rs:84:10
+error[E0271]: type mismatch resolving `<BoxedSelectStatement<'_, ..., ..., _> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/boxed_queries_and_group_by.rs:91:10
    |
-84 |         .group_by(users::id)
+LL |         .group_by(users::id)
    |          ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `BoxedSelectStatement<'_, ..., ..., _>`
    |
    = note: expected struct `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>>>`
               found struct `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>` to implement `GroupByDsl<_>`
+   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>` to implement `GroupByDsl<_>`
 
-error[E0277]: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>: Table` is not satisfied
-  --> tests/fail/boxed_queries_and_group_by.rs:84:10
+   
+error[E0277]: the trait bound `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>: Table` is not satisfied
+  --> tests/fail/boxed_queries_and_group_by.rs:91:10
    |
-84 |         .group_by(users::id)
-   |          ^^^^^^^^ unsatisfied trait bound
+LL |         .group_by(users::id)
+   |          ^^^^^^^^ the trait `Table` is not implemented for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>`
    |
-   = help: the trait `Table` is not implemented for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>`
    = help: the following other types implement trait `Table`:
              Only<S>
              Tablesample<S, TSM>
@@ -138,13 +140,13 @@ error[E0277]: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Inte
              pg::metadata_lookup::pg_type::table
              posts::table
              users::table
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>` to implement `GroupByDsl<_>`
+   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>` to implement `GroupByDsl<_>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>>>: GroupByDsl<_>` is not satisfied
-  --> tests/fail/boxed_queries_and_group_by.rs:84:10
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
+  --> tests/fail/boxed_queries_and_group_by.rs:91:10
    |
-84 |         .group_by(users::id)
-   |          ^^^^^^^^ unsatisfied trait bound
+LL |         .group_by(users::id)
+   |          ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<BoxedSelectStatement<'_, ..., ..., _>>>`
    |
-   = help: the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>>>`
    = help: the trait `GroupByDsl<Expr>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`

--- a/diesel_compile_tests/tests/fail/boxed_queries_must_be_used_with_proper_connection.rs
+++ b/diesel_compile_tests/tests/fail/boxed_queries_must_be_used_with_proper_connection.rs
@@ -11,5 +11,8 @@ table! {
 
 fn main() {
     let mut connection = SqliteConnection::establish("").unwrap();
-    users::table.into_boxed::<Pg>().load::<(i32,)>(&mut connection);
+    users::table
+        .into_boxed::<Pg>()
+        .load::<(i32,)>(&mut connection);
+    //~^ ERROR: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
 }

--- a/diesel_compile_tests/tests/fail/boxed_queries_must_be_used_with_proper_connection.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_must_be_used_with_proper_connection.stderr
@@ -1,17 +1,18 @@
 error[E0271]: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
-  --> tests/fail/boxed_queries_must_be_used_with_proper_connection.rs:14:52
-   |
-14 |     users::table.into_boxed::<Pg>().load::<(i32,)>(&mut connection);
-   |                                     ----           ^^^^^^^^^^^^^^^ expected `Pg`, found `Sqlite`
-   |                                     |
-   |                                     required by a bound introduced by this call
-   |
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, Pg>` to implement `LoadQuery<'_, diesel::SqliteConnection, (i32,)>`
+    --> tests/fail/boxed_queries_must_be_used_with_proper_connection.rs:16:25
+     |
+16   |         .load::<(i32,)>(&mut connection);
+     |          ----           ^^^^^^^^^^^^^^^ expected `Pg`, found `Sqlite`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, Pg>` to implement `LoadQuery<'_, diesel::SqliteConnection, (i32,)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.rs
@@ -23,4 +23,5 @@ fn main() {
     users::table
         .into_boxed::<Pg>()
         .filter(posts::title.eq("Hello"));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_filter.stderr
@@ -1,15 +1,17 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/boxed_queries_require_selectable_expression_for_filter.rs:25:10
    |
-25 |         .filter(posts::title.eq("Hello"));
+LL |         .filter(posts::title.eq("Hello"));
    |          ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
   --> tests/fail/boxed_queries_require_selectable_expression_for_filter.rs:16:9
    |
-16 |         title -> VarChar,
+LL |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>`
+   = note: required for `Grouped<Eq<title, Bound<Text, &str>>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>`
+
+   For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.rs
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.rs
@@ -21,4 +21,5 @@ allow_tables_to_appear_in_same_query!(users, posts);
 
 fn main() {
     users::table.into_boxed::<Pg>().order(posts::title.desc());
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_require_selectable_expression_for_order.stderr
@@ -1,15 +1,17 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/boxed_queries_require_selectable_expression_for_order.rs:23:37
    |
-23 |     users::table.into_boxed::<Pg>().order(posts::title.desc());
+LL |     users::table.into_boxed::<Pg>().order(posts::title.desc());
    |                                     ^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
   --> tests/fail/boxed_queries_require_selectable_expression_for_order.rs:16:9
    |
-16 |         title -> VarChar,
+LL |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
    = note: required for `diesel::expression::operators::Desc<posts::columns::title>` to implement `AppearsOnTable<users::table>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `OrderDsl<diesel::expression::operators::Desc<posts::columns::title>>`
+   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `OrderDsl<diesel::expression::operators::Desc<posts::columns::title>>`
+
+   For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.rs
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.rs
@@ -14,7 +14,9 @@ table! {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 struct User {
     id: String,
+    //~^ ERROR: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
     name: i32,
+    //~^ ERROR: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
 }
 
 #[derive(QueryableByName)]
@@ -22,12 +24,16 @@ struct User {
 struct User2 {
     #[diesel(sql_type = diesel::sql_types::Integer)]
     id: String,
+    //~^ ERROR: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
     #[diesel(sql_type = diesel::sql_types::Text)]
     name: i32,
+    //~^ ERROR: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
 }
 
 fn main() {
     let conn = &mut PgConnection::establish("…").unwrap();
 
     let s = diesel::sql_query("…").load::<User>(conn);
+    //~^ ERROR: the trait bound `Untyped: load_dsl::private::CompatibleType<User, _>` is not satisfied
+    //~| ERROR: the trait bound `User: FromSqlRow<_, _>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:17:5
+  --> tests/fail/broken_queryable_by_name.rs:18:5
    |
-17 |     name: i32,
+LL |     name: i32,
    |     ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Text`
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
   --> tests/fail/broken_queryable_by_name.rs:16:5
    |
-16 |     id: String,
+LL |     id: String,
    |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
@@ -35,9 +35,9 @@ error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types
    = help: see issue #48214
 
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:26:5
+  --> tests/fail/broken_queryable_by_name.rs:29:5
    |
-26 |     name: i32,
+LL |     name: i32,
    |     ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Text`
@@ -52,9 +52,9 @@ error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is 
    = help: see issue #48214
 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:24:5
+  --> tests/fail/broken_queryable_by_name.rs:26:5
    |
-24 |     id: String,
+LL |     id: String,
    |     ^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
@@ -71,55 +71,56 @@ error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types
    = help: see issue #48214
 
 error[E0277]: the trait bound `Untyped: load_dsl::private::CompatibleType<User, _>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:32:49
-   |
-32 |     let s = diesel::sql_query("…").load::<User>(conn);
-   |                                    ----         ^^^^ the trait `load_dsl::private::CompatibleType<User, _>` is not implemented for `Untyped`
-   |                                    |
-   |                                    required by a bound introduced by this call
-   |
-   = note: this is a mismatch between what your query returns and what your type expects the query to return
-   = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-           on your struct `User` and in your query `.select(User::as_select())` to get a better error message
-   = help: the trait `load_dsl::private::CompatibleType<U, DB>` is implemented for `Untyped`
-   = note: required for `SqlQuery` to implement `LoadQuery<'_, _, User>`
+    --> tests/fail/broken_queryable_by_name.rs:36:49
+     |
+36   |     let s = diesel::sql_query("…").load::<User>(conn);
+     |                                    ----         ^^^^ the trait `load_dsl::private::CompatibleType<User, _>` is not implemented for `Untyped`
+     |                                    |
+     |                                    required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `User` and in your query `.select(User::as_select())` to get a better error message
+     = help: the trait `load_dsl::private::CompatibleType<U, DB>` is implemented for `Untyped`
+     = note: required for `SqlQuery` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
 error[E0277]: the trait bound `User: FromSqlRow<_, _>` is not satisfied
-  --> tests/fail/broken_queryable_by_name.rs:32:49
-   |
-32 |     let s = diesel::sql_query("…").load::<User>(conn);
-   |                                    ----         ^^^^ the trait `FromSqlRow<_, _>` is not implemented for `User`
-   |                                    |
-   |                                    required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `_`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `FromSqlRow<ST, DB>`:
-             `(T1, T0)` implements `FromSqlRow<(ST1, Untyped), __DB>`
-             `(T1, T2, T0)` implements `FromSqlRow<(ST1, ST2, Untyped), __DB>`
-             `(T1, T2, T3, T0)` implements `FromSqlRow<(ST1, ST2, ST3, Untyped), __DB>`
-             `(T1, T2, T3, T4, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, Untyped), __DB>`
-             `(T1, T2, T3, T4, T5, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, Untyped), __DB>`
-             `(T1, T2, T3, T4, T5, T6, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, Untyped), __DB>`
-             `(T1, T2, T3, T4, T5, T6, T7, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, Untyped), __DB>`
-             `(T1, T2, T3, T4, T5, T6, T7, T8, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8, Untyped), __DB>`
-           and $N others
-   = note: required for `SqlQuery` to implement `LoadQuery<'_, _, User>`
+    --> tests/fail/broken_queryable_by_name.rs:36:49
+     |
+36   |     let s = diesel::sql_query("…").load::<User>(conn);
+     |                                    ----         ^^^^ the trait `FromSqlRow<_, _>` is not implemented for `User`
+     |                                    |
+     |                                    required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `_`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `FromSqlRow<ST, DB>`:
+               `(T1, T0)` implements `FromSqlRow<(ST1, Untyped), __DB>`
+               `(T1, T2, T0)` implements `FromSqlRow<(ST1, ST2, Untyped), __DB>`
+               `(T1, T2, T3, T0)` implements `FromSqlRow<(ST1, ST2, ST3, Untyped), __DB>`
+               `(T1, T2, T3, T4, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, Untyped), __DB>`
+               `(T1, T2, T3, T4, T5, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, Untyped), __DB>`
+               `(T1, T2, T3, T4, T5, T6, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, Untyped), __DB>`
+               `(T1, T2, T3, T4, T5, T6, T7, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, Untyped), __DB>`
+               `(T1, T2, T3, T4, T5, T6, T7, T8, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8, Untyped), __DB>`
+             and N others
+     = note: required for `SqlQuery` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.rs
+++ b/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.rs
@@ -28,10 +28,13 @@ allow_tables_to_appear_in_same_query!(comments, posts, users);
 
 fn main() {
     let _ = users::table.inner_join(posts::table);
+    //~^ ERROR: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
     let _ = users::table.left_outer_join(posts::table);
+    //~^ ERROR: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
 
     // Sanity check to make sure the error is when users
     // become involved
     let join = posts::table.inner_join(comments::table);
     let _ = users::table.inner_join(join);
+    //~^ ERROR: the trait bound `posts::table: JoinTo<users::table>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
@@ -1,59 +1,59 @@
 error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
-  --> tests/fail/cannot_join_to_non_joinable_table.rs:30:37
-   |
-30 |     let _ = users::table.inner_join(posts::table);
-   |                          ---------- ^^^^^^^^^^^^ the trait `JoinTo<posts::table>` is not implemented for `users::table`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `JoinTo<T>`:
-             `users::table` implements `JoinTo<Alias<S>>`
-             `users::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`
-             `users::table` implements `JoinTo<JoinOn<Join, On>>`
-             `users::table` implements `JoinTo<Only<S>>`
-             `users::table` implements `JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>`
-             `users::table` implements `JoinTo<Tablesample<S, TSM>>`
-             `users::table` implements `JoinTo<query_source::joins::Join<Left, Right, Kind>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<posts::table, Inner>`
+   --> tests/fail/cannot_join_to_non_joinable_table.rs:30:37
+    |
+30  |     let _ = users::table.inner_join(posts::table);
+    |                          ---------- ^^^^^^^^^^^^ the trait `JoinTo<posts::table>` is not implemented for `users::table`
+    |                          |
+    |                          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `JoinTo<T>`:
+              `users::table` implements `JoinTo<Alias<S>>`
+              `users::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`
+              `users::table` implements `JoinTo<JoinOn<Join, On>>`
+              `users::table` implements `JoinTo<Only<S>>`
+              `users::table` implements `JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>`
+              `users::table` implements `JoinTo<Tablesample<S, TSM>>`
+              `users::table` implements `JoinTo<query_source::joins::Join<Left, Right, Kind>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<posts::table, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
 
 error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
-  --> tests/fail/cannot_join_to_non_joinable_table.rs:31:42
-   |
-31 |     let _ = users::table.left_outer_join(posts::table);
-   |                          --------------- ^^^^^^^^^^^^ the trait `JoinTo<posts::table>` is not implemented for `users::table`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `JoinTo<T>`:
-             `users::table` implements `JoinTo<Alias<S>>`
-             `users::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`
-             `users::table` implements `JoinTo<JoinOn<Join, On>>`
-             `users::table` implements `JoinTo<Only<S>>`
-             `users::table` implements `JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>`
-             `users::table` implements `JoinTo<Tablesample<S, TSM>>`
-             `users::table` implements `JoinTo<query_source::joins::Join<Left, Right, Kind>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<posts::table, LeftOuter>`
+   --> tests/fail/cannot_join_to_non_joinable_table.rs:32:42
+    |
+32  |     let _ = users::table.left_outer_join(posts::table);
+    |                          --------------- ^^^^^^^^^^^^ the trait `JoinTo<posts::table>` is not implemented for `users::table`
+    |                          |
+    |                          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `JoinTo<T>`:
+              `users::table` implements `JoinTo<Alias<S>>`
+              `users::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`
+              `users::table` implements `JoinTo<JoinOn<Join, On>>`
+              `users::table` implements `JoinTo<Only<S>>`
+              `users::table` implements `JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>`
+              `users::table` implements `JoinTo<Tablesample<S, TSM>>`
+              `users::table` implements `JoinTo<query_source::joins::Join<Left, Right, Kind>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<posts::table, LeftOuter>`
 note: required by a bound in `left_outer_join`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn left_outer_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
-   |        --------------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_outer_join`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn left_outer_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
+    |        --------------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_outer_join`
 
 error[E0277]: the trait bound `posts::table: JoinTo<users::table>` is not satisfied
-  --> tests/fail/cannot_join_to_non_joinable_table.rs:36:26
+  --> tests/fail/cannot_join_to_non_joinable_table.rs:38:26
    |
-36 |     let _ = users::table.inner_join(join);
+LL |     let _ = users::table.inner_join(join);
    |                          ^^^^^^^^^^ the trait `JoinTo<users::table>` is not implemented for `posts::table`
    |
    = help: the following other types implement trait `JoinTo<T>`:
@@ -67,3 +67,4 @@ error[E0277]: the trait bound `posts::table: JoinTo<users::table>` is not satisf
              `posts::table` implements `JoinTo<query_source::joins::Join<Left, Right, Kind>>`
    = note: required for `query_source::joins::Join<posts::table, comments::table, Inner>` to implement `JoinTo<users::table>`
    = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_load_default_select_with_group_by.rs
+++ b/diesel_compile_tests/tests/fail/cannot_load_default_select_with_group_by.rs
@@ -14,4 +14,5 @@ fn main() {
     let _ = users::table
         .group_by(users::name)
         .load::<(i32, String)>(&mut conn);
+    //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
 }

--- a/diesel_compile_tests/tests/fail/cannot_load_default_select_with_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_load_default_select_with_group_by.stderr
@@ -1,31 +1,33 @@
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/cannot_load_default_select_with_group_by.rs:16:32
-   |
-16 |         .load::<(i32, String)>(&mut conn);
-   |          ----                  ^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/cannot_load_default_select_with_group_by.rs:16:32
+     |
+16   |         .load::<(i32, String)>(&mut conn);
+     |          ----                  ^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
-  --> tests/fail/cannot_load_default_select_with_group_by.rs:8:9
-   |
-8  |         name -> Text,
-   |         ^^^^
+    --> tests/fail/cannot_load_default_select_with_group_by.rs:8:9
+     |
+8    |         name -> Text,
+     |         ^^^^
 note: required for `columns::id` to implement `ValidGrouping<columns::name>`
-  --> tests/fail/cannot_load_default_select_with_group_by.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `(columns::id, columns::name)` to implement `ValidGrouping<columns::name>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::name>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::name>>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
+    --> tests/fail/cannot_load_default_select_with_group_by.rs:7:9
+     |
+7    |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 1 redundant requirement hidden
+     = note: required for `(columns::id, columns::name)` to implement `ValidGrouping<columns::name>`
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
@@ -21,8 +21,11 @@ fn main() {
     use diesel::dsl::max;
 
     let source = users.select((id, count_star()));
+    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
 
     let source = users.select(nullable_int_col + max(nullable_int_col));
+    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
 
     let source = users.select(f(nullable_int_col, max(nullable_int_col)));
+    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:23:24
    |
-23 |     let source = users.select((id, count_star()));
+LL |     let source = users.select((id, count_star()));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
    |
    = help: the following other types implement trait `MixedAggregates<Other>`:
@@ -11,32 +11,35 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggreg
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(columns::id, CountStar)>`
 
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
-  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:25:24
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:26:24
    |
-25 |     let source = users.select(nullable_int_col + max(nullable_int_col));
+LL |     let source = users.select(nullable_int_col + max(nullable_int_col));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
    |
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
-   = note: required for `diesel::expression::ops::numeric::Add<columns::nullable_int_col, diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Nullable<diesel::sql_types::Integer>, columns::nullable_int_col>>` to implement `ValidGrouping<()>`
+   = note: required for `Add<nullable_int_col, max<Nullable<Integer>, nullable_int_col>>` to implement `ValidGrouping<()>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::ops::numeric::Add<columns::nullable_int_col, diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Nullable<diesel::sql_types::Integer>, columns::nullable_int_col>>>`
 
+   
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
-  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:27:24
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:29:24
    |
-27 |     let source = users.select(f(nullable_int_col, max(nullable_int_col)));
+LL |     let source = users.select(f(nullable_int_col, max(nullable_int_col)));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
    |
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
-note: required for `__Derived<columns::nullable_int_col, diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Nullable<diesel::sql_types::Integer>, columns::nullable_int_col>>` to implement `ValidGrouping<()>`
+note: required for `__Derived<nullable_int_col, max<Nullable<Integer>, nullable_int_col>>` to implement `ValidGrouping<()>`
   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:14:1
    |
-14 | #[declare_sql_function]
+LL | #[declare_sql_function]
    | ^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
    = note: 1 redundant requirement hidden
-   = note: required for `f_utils::f<columns::nullable_int_col, diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Nullable<diesel::sql_types::Integer>, columns::nullable_int_col>>` to implement `ValidGrouping<()>`
+   = note: required for `f<nullable_int_col, max<Nullable<Integer>, nullable_int_col>>` to implement `ValidGrouping<()>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<f_utils::f<columns::nullable_int_col, diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Nullable<diesel::sql_types::Integer>, columns::nullable_int_col>>>`
-   = note: this error originates in the derive macro `ValidGrouping` which comes from the expansion of the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+      = note: this error originates in the derive macro `ValidGrouping` which comes from the expansion of the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.rs
+++ b/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.rs
@@ -13,4 +13,5 @@ fn main() {
     use self::users::dsl::*;
 
     let source = users.filter(count(id).gt(3));
+    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.stderr
@@ -1,11 +1,13 @@
 error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
   --> tests/fail/cannot_pass_aggregate_to_where.rs:15:24
    |
-15 |     let source = users.filter(count(id).gt(3));
+LL |     let source = users.filter(count(id).gt(3));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
    |
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>, diesel::expression::bound::Bound<BigInt, i64>>>` to implement `NonAggregate`
+   = note: required for `Grouped<Gt<count<Integer, id>, Bound<BigInt, i64>>>` to implement `NonAggregate`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>, diesel::expression::bound::Bound<BigInt, i64>>>>`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs
+++ b/diesel_compile_tests/tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs
@@ -13,5 +13,9 @@ fn main() {
     use self::users::dsl::*;
 
     let command = update(users.select(id)).set(id.eq(1));
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, SelectClause<id>>: IntoUpdateTarget` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, SelectClause<id>>: Identifiable` is not satisfied
     let command = update(users.order(id)).set(id.eq(1));
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<...>, ..., ..., ..., ...>: IntoUpdateTarget` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ..., ...>: Identifiable` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/cannot_update_target_with_methods_other_than_filter_called.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_update_target_with_methods_other_than_filter_called.stderr
@@ -1,53 +1,54 @@
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: IntoUpdateTarget` is not satisfied
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, SelectClause<id>>: IntoUpdateTarget` is not satisfied
   --> tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs:15:26
    |
-15 |     let command = update(users.select(id)).set(id.eq(1));
-   |                   ------ ^^^^^^^^^^^^^^^^ unsatisfied trait bound
+LL |     let command = update(users.select(id)).set(id.eq(1));
+   |                   ------ ^^^^^^^^^^^^^^^^ the trait `Identifiable` is not implemented for `SelectStatement<FromClause<table>, SelectClause<id>>`
    |                   |
    |                   required by a bound introduced by this call
    |
-   = help: the trait `Identifiable` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>`
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>` to implement `IntoUpdateTarget`
+   = note: required for `SelectStatement<FromClause<table>, SelectClause<id>>` to implement `IntoUpdateTarget`
 note: required by a bound in `diesel::update`
-  --> $DIESEL/src/query_builder/functions.rs
+  --> DIESEL/diesel/diesel/src/query_builder/functions.rs
    |
-   | pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {
+LL | pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {
    |                  ^^^^^^^^^^^^^^^^ required by this bound in `update`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>: IntoUpdateTarget` is not satisfied
-  --> tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs:16:26
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>, ..., ..., ..., ...>: IntoUpdateTarget` is not satisfied
+  --> tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs:18:26
    |
-16 |     let command = update(users.order(id)).set(id.eq(1));
-   |                   ------ ^^^^^^^^^^^^^^^ unsatisfied trait bound
+LL |     let command = update(users.order(id)).set(id.eq(1));
+   |                   ------ ^^^^^^^^^^^^^^^ the trait `Identifiable` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ...>`
    |                   |
    |                   required by a bound introduced by this call
    |
-   = help: the trait `Identifiable` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>`
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>` to implement `IntoUpdateTarget`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `IntoUpdateTarget`
 note: required by a bound in `diesel::update`
-  --> $DIESEL/src/query_builder/functions.rs
+  --> DIESEL/diesel/diesel/src/query_builder/functions.rs
    |
-   | pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {
+LL | pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {
    |                  ^^^^^^^^^^^^^^^^ required by this bound in `update`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: Identifiable` is not satisfied
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, SelectClause<id>>: Identifiable` is not satisfied
   --> tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs:15:19
    |
-15 |     let command = update(users.select(id)).set(id.eq(1));
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+LL |     let command = update(users.select(id)).set(id.eq(1));
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Identifiable` is not implemented for `SelectStatement<FromClause<table>, SelectClause<id>>`
    |
-   = help: the trait `Identifiable` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>`
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>` to implement `IntoUpdateTarget`
+   = note: required for `SelectStatement<FromClause<table>, SelectClause<id>>` to implement `IntoUpdateTarget`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>: Identifiable` is not satisfied
-  --> tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs:16:19
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ..., ...>: Identifiable` is not satisfied
+  --> tests/fail/cannot_update_target_with_methods_other_than_filter_called.rs:18:19
    |
-16 |     let command = update(users.order(id)).set(id.eq(1));
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+LL |     let command = update(users.order(id)).set(id.eq(1));
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Identifiable` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ...>`
    |
-   = help: the trait `Identifiable` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>`
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>` to implement `IntoUpdateTarget`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `IntoUpdateTarget`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_use_expression_methods_on_tuples.rs
+++ b/diesel_compile_tests/tests/fail/cannot_use_expression_methods_on_tuples.rs
@@ -16,5 +16,7 @@ fn main() {
     users.filter(id.eq_any(users.select(id)));
 
     users.filter((id, name).is_not_null());
+    //~^ ERROR: the method `is_not_null` exists for tuple `(id, name)`, but its trait bounds were not satisfied
     users.filter((id, name).eq_any(users.find(1)));
+    //~^ ERROR: the method `eq_any` exists for tuple `(id, name)`, but its trait bounds were not satisfied
 }

--- a/diesel_compile_tests/tests/fail/cannot_use_expression_methods_on_tuples.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_use_expression_methods_on_tuples.stderr
@@ -1,7 +1,7 @@
 error[E0599]: the method `is_not_null` exists for tuple `(id, name)`, but its trait bounds were not satisfied
   --> tests/fail/cannot_use_expression_methods_on_tuples.rs:18:29
    |
-18 |     users.filter((id, name).is_not_null());
+LL |     users.filter((id, name).is_not_null());
    |                             ^^^^^^^^^^^
    |
    = note: the following trait bounds were not satisfied:
@@ -13,9 +13,9 @@ error[E0599]: the method `is_not_null` exists for tuple `(id, name)`, but its tr
            which is required by `&mut (columns::id, columns::name): diesel::ExpressionMethods`
 
 error[E0599]: the method `eq_any` exists for tuple `(id, name)`, but its trait bounds were not satisfied
-  --> tests/fail/cannot_use_expression_methods_on_tuples.rs:19:29
+  --> tests/fail/cannot_use_expression_methods_on_tuples.rs:20:29
    |
-19 |     users.filter((id, name).eq_any(users.find(1)));
+LL |     users.filter((id, name).eq_any(users.find(1)));
    |                             ^^^^^^
    |
    = note: the following trait bounds were not satisfied:
@@ -25,3 +25,4 @@ error[E0599]: the method `eq_any` exists for tuple `(id, name)`, but its trait b
            which is required by `&(columns::id, columns::name): diesel::ExpressionMethods`
            `&mut (columns::id, columns::name): diesel::Expression`
            which is required by `&mut (columns::id, columns::name): diesel::ExpressionMethods`
+For more information about this error, try `rustc --explain E0599`.

--- a/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.rs
+++ b/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.rs
@@ -21,5 +21,6 @@ table! {
         column_18 -> Integer,
     }
 }
+//~^^^^^^^^^^^^^^^^^^^^^ ERROR: Table contains more than 16 columns. Consider enabling the `32-column-tables` feature to enable diesels support for tables with more than 16 columns.
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.stderr
+++ b/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.stderr
@@ -6,7 +6,7 @@ error: Table contains more than 16 columns. Consider enabling the `32-column-tab
 5  | |         column_1 -> Integer,
 6  | |         column_2 -> Integer,
 ...  |
-23 | | }
+LL | | }
    | |_^
    |
    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs
@@ -24,4 +24,5 @@ fn main() {
         hair_color: "black".to_string(),
     };
     user.save_changes(&mut connection);
+    //~^ ERROR: the method `save_changes` exists for struct `User`, but its trait bounds were not satisfied
 }

--- a/diesel_compile_tests/tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.stderr
@@ -1,45 +1,46 @@
 error[E0599]: the method `save_changes` exists for struct `User`, but its trait bounds were not satisfied
-  --> tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs:26:10
-   |
-15 | pub struct User {
-   | --------------- method `save_changes` not found for this struct because it doesn't satisfy `User: Copy`, `User: HasTable`, `User: IntoUpdateTarget` or `User: diesel::SaveChangesDsl<_>`
+   --> tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.rs:26:10
+    |
+15  | pub struct User {
+    | --------------- method `save_changes` not found for this struct because it doesn't satisfy `User: Copy`, `User: HasTable`, `User: IntoUpdateTarget` or `User: diesel::SaveChangesDsl<_>`
 ...
-26 |     user.save_changes(&mut connection);
-   |          ^^^^^^^^^^^^ method cannot be called on `User` due to unsatisfied trait bounds
-   |
-   = note: the following trait bounds were not satisfied:
-           `User: HasTable`
-           which is required by `User: diesel::SaveChangesDsl<_>`
-           `User: Copy`
-           which is required by `User: diesel::SaveChangesDsl<_>`
-           `User: IntoUpdateTarget`
-           which is required by `User: diesel::SaveChangesDsl<_>`
-           `User: HasTable`
-           which is required by `&User: diesel::SaveChangesDsl<_>`
-           `&User: IntoUpdateTarget`
-           which is required by `&User: diesel::SaveChangesDsl<_>`
-           `&mut User: HasTable`
-           which is required by `&mut User: diesel::SaveChangesDsl<_>`
-           `<&mut User as diesel::AsChangeset>::Target = _`
-           which is required by `&mut User: diesel::SaveChangesDsl<_>`
-           `&mut User: Copy`
-           which is required by `&mut User: diesel::SaveChangesDsl<_>`
-           `&mut User: diesel::AsChangeset`
-           which is required by `&mut User: diesel::SaveChangesDsl<_>`
-           `&mut User: IntoUpdateTarget`
-           which is required by `&mut User: diesel::SaveChangesDsl<_>`
+26  |     user.save_changes(&mut connection);
+    |          ^^^^^^^^^^^^ method cannot be called on `User` due to unsatisfied trait bounds
+    |
+    = note: the following trait bounds were not satisfied:
+            `User: HasTable`
+            which is required by `User: diesel::SaveChangesDsl<_>`
+            `User: Copy`
+            which is required by `User: diesel::SaveChangesDsl<_>`
+            `User: IntoUpdateTarget`
+            which is required by `User: diesel::SaveChangesDsl<_>`
+            `User: HasTable`
+            which is required by `&User: diesel::SaveChangesDsl<_>`
+            `&User: IntoUpdateTarget`
+            which is required by `&User: diesel::SaveChangesDsl<_>`
+            `&mut User: HasTable`
+            which is required by `&mut User: diesel::SaveChangesDsl<_>`
+            `<&mut User as diesel::AsChangeset>::Target = _`
+            which is required by `&mut User: diesel::SaveChangesDsl<_>`
+            `&mut User: Copy`
+            which is required by `&mut User: diesel::SaveChangesDsl<_>`
+            `&mut User: diesel::AsChangeset`
+            which is required by `&mut User: diesel::SaveChangesDsl<_>`
+            `&mut User: IntoUpdateTarget`
+            which is required by `&mut User: diesel::SaveChangesDsl<_>`
 note: the traits `HasTable` and `IntoUpdateTarget` must be implemented
-  --> $DIESEL/src/associations/mod.rs
-   |
-   | pub trait HasTable {
-   | ^^^^^^^^^^^^^^^^^^
-   |
-  ::: $DIESEL/src/query_builder/update_statement/target.rs
-   |
-   | pub trait IntoUpdateTarget: HasTable {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   --> DIESEL/diesel/diesel/src/associations/mod.rs
+    |
+LL | pub trait HasTable {
+    | ^^^^^^^^^^^^^^^^^^
+    |
+   ::: DIESEL/diesel/diesel/src/query_builder/update_statement/target.rs
+    |
+28  | pub trait IntoUpdateTarget: HasTable {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider annotating `User` with `#[derive(Clone, Copy)]`
     |
 15  + #[derive(Clone, Copy)]
 16  | pub struct User {
     |
+For more information about this error, try `rustc --explain E0599`.

--- a/diesel_compile_tests/tests/fail/columns_cannot_be_rhs_of_insert.rs
+++ b/diesel_compile_tests/tests/fail/columns_cannot_be_rhs_of_insert.rs
@@ -18,5 +18,6 @@ fn main() {
     insert_into(users)
         .values(&name.eq(hair_color))
         .execute(&mut conn)
+        //~^ ERROR: type mismatch resolving `<NoFromClause as AppearsInFromClause<table>>::Count == Once`
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/columns_cannot_be_rhs_of_insert.stderr
+++ b/diesel_compile_tests/tests/fail/columns_cannot_be_rhs_of_insert.stderr
@@ -1,29 +1,31 @@
 error[E0271]: type mismatch resolving `<NoFromClause as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/columns_cannot_be_rhs_of_insert.rs:20:18
-   |
-20 |         .execute(&mut conn)
-   |          ------- ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/columns_cannot_be_rhs_of_insert.rs:20:18
+     |
+20   |         .execute(&mut conn)
+     |          ------- ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `columns::hair_color` to implement `AppearsOnTable<NoFromClause>`
-  --> tests/fail/columns_cannot_be_rhs_of_insert.rs:10:9
-   |
-10 |         hair_color -> Text,
-   |         ^^^^^^^^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `&columns::hair_color` to implement `AppearsOnTable<NoFromClause>`
-   = note: required for `ColumnInsertValue<columns::name, &columns::hair_color>` to implement `InsertValues<_, users::table>`
-   = note: required for `diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::name, &columns::hair_color>, users::table>` to implement `QueryFragment<_>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::name, &columns::hair_color>, users::table>>` to implement `QueryFragment<_>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::name, &columns::hair_color>, users::table>>` to implement `ExecuteDsl<_, _>`
+    --> tests/fail/columns_cannot_be_rhs_of_insert.rs:10:9
+     |
+10   |         hair_color -> Text,
+     |         ^^^^^^^^^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 1 redundant requirement hidden
+     = note: required for `&columns::hair_color` to implement `AppearsOnTable<NoFromClause>`
+     = note: required for `ColumnInsertValue<columns::name, &columns::hair_color>` to implement `InsertValues<_, users::table>`
+     = note: required for `ValuesClause<ColumnInsertValue<name, &hair_color>, table>` to implement `QueryFragment<_>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, ValuesClause<ColumnInsertValue<..., ...>, ...>>` to implement `QueryFragment<_>`
+     = note: required for `InsertStatement<table, ValuesClause<ColumnInsertValue<..., ...>, ...>>` to implement `ExecuteDsl<_, _>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/combinations_require_same_sql_types.rs
+++ b/diesel_compile_tests/tests/fail/combinations_require_same_sql_types.rs
@@ -28,9 +28,11 @@ allow_tables_to_appear_in_same_query!(comments, posts, users);
 
 fn main() {
     let _ = users::table.union(comments::table);
+    //~^ ERROR: type mismatch resolving `<table as AsQuery>::SqlType == (Integer, Text)`
 
     // Sanity check to make sure the error is when comments
     // become involved
     let union = users::table.union(posts::table);
     let _ = union.union(comments::table);
+    //~^ ERROR: type mismatch resolving `<table as AsQuery>::SqlType == (Integer, Text)`
 }

--- a/diesel_compile_tests/tests/fail/combinations_require_same_sql_types.stderr
+++ b/diesel_compile_tests/tests/fail/combinations_require_same_sql_types.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<table as AsQuery>::SqlType == (Integer, Text)`
   --> tests/fail/combinations_require_same_sql_types.rs:30:32
    |
-30 |     let _ = users::table.union(comments::table);
+LL |     let _ = users::table.union(comments::table);
    |                          ----- ^^^^^^^^^^^^^^^ expected `(Integer, Text)`, found `(Integer, Integer)`
    |                          |
    |                          required by a bound introduced by this call
@@ -9,18 +9,18 @@ error[E0271]: type mismatch resolving `<table as AsQuery>::SqlType == (Integer, 
    = note: expected tuple `(diesel::sql_types::Integer, diesel::sql_types::Text)`
               found tuple `(diesel::sql_types::Integer, diesel::sql_types::Integer)`
 note: required by a bound in `union`
-  --> $DIESEL/src/query_dsl/combine_dsl.rs
+  --> DIESEL/diesel/diesel/src/query_dsl/combine_dsl.rs
    |
-   |     fn union<Rhs>(self, rhs: Rhs) -> dsl::Union<Self, Rhs>
+LL |     fn union<Rhs>(self, rhs: Rhs) -> dsl::Union<Self, Rhs>
    |        ----- required by a bound in this associated function
-   |     where
-   |         Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>;
+LL |     where
+LL |         Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CombineDsl::union`
 
 error[E0271]: type mismatch resolving `<table as AsQuery>::SqlType == (Integer, Text)`
-  --> tests/fail/combinations_require_same_sql_types.rs:35:25
+  --> tests/fail/combinations_require_same_sql_types.rs:36:25
    |
-35 |     let _ = union.union(comments::table);
+LL |     let _ = union.union(comments::table);
    |                   ----- ^^^^^^^^^^^^^^^ expected `(Integer, Text)`, found `(Integer, Integer)`
    |                   |
    |                   required by a bound introduced by this call
@@ -28,10 +28,11 @@ error[E0271]: type mismatch resolving `<table as AsQuery>::SqlType == (Integer, 
    = note: expected tuple `(diesel::sql_types::Integer, diesel::sql_types::Text)`
               found tuple `(diesel::sql_types::Integer, diesel::sql_types::Integer)`
 note: required by a bound in `union`
-  --> $DIESEL/src/query_dsl/combine_dsl.rs
+  --> DIESEL/diesel/diesel/src/query_dsl/combine_dsl.rs
    |
-   |     fn union<Rhs>(self, rhs: Rhs) -> dsl::Union<Self, Rhs>
+LL |     fn union<Rhs>(self, rhs: Rhs) -> dsl::Union<Self, Rhs>
    |        ----- required by a bound in this associated function
-   |     where
-   |         Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>;
+LL |     where
+LL |         Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CombineDsl::union`
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/copy_can_only_be_used_with_postgres_connections.rs
+++ b/diesel_compile_tests/tests/fail/copy_can_only_be_used_with_postgres_connections.rs
@@ -50,8 +50,12 @@ fn main() {
     diesel::copy_from(users::table)
         .from_insertable(vec![NewUser { name: "John" }])
         .execute(conn)
+        //~^ ERROR: type mismatch resolving `<MysqlConnection as Connection>::Backend == Pg`
+        //~| ERROR: the trait bound `CopyFromQuery<table, InsertableWrapper<...>>: ExecuteCopyFromDsl<...>` is not satisfied
         .unwrap();
     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
+    //~^ ERROR: the trait bound `diesel::MysqlConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
+    //~| ERROR: the trait bound `diesel::MysqlConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
 
     let conn = &mut SqliteConnection::establish("_").unwrap();
 
@@ -59,6 +63,10 @@ fn main() {
     diesel::copy_from(users::table)
         .from_insertable(vec![NewUser { name: "John" }])
         .execute(conn)
+        //~^ ERROR: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
+        //~| ERROR: the trait bound `CopyFromQuery<table, InsertableWrapper<...>>: ExecuteCopyFromDsl<...>` is not satisfied
         .unwrap();
     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
+    //~^ ERROR: the trait bound `diesel::SqliteConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
+    //~| ERROR: the trait bound `diesel::SqliteConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/copy_can_only_be_used_with_postgres_connections.stderr
+++ b/diesel_compile_tests/tests/fail/copy_can_only_be_used_with_postgres_connections.stderr
@@ -1,135 +1,137 @@
 error[E0271]: type mismatch resolving `<MysqlConnection as Connection>::Backend == Pg`
-  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:52:18
-   |
-52 |         .execute(conn)
-   |          ------- ^^^^ expected `Pg`, found `Mysql`
-   |          |
-   |          required by a bound introduced by this call
-   |
+   --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:52:18
+    |
+52  |         .execute(conn)
+    |          ------- ^^^^ expected `Pg`, found `Mysql`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: required by a bound in `diesel::ExecuteCopyFromDsl::execute`
-  --> $DIESEL/src/pg/query_builder/copy/copy_from.rs
-   |
-   |     C: Connection<Backend = Pg>,
-   |                   ^^^^^^^^^^^^ required by this bound in `ExecuteCopyFromDsl::execute`
+   --> DIESEL/diesel/diesel/src/pg/query_builder/copy/copy_from.rs
+    |
+LL |     C: Connection<Backend = Pg>,
+    |                   ^^^^^^^^^^^^ required by this bound in `ExecuteCopyFromDsl::execute`
 ...
-   |     fn execute(self, conn: &mut C) -> Result<usize, Self::Error>;
-   |        ------- required by a bound in this associated function
+LL |     fn execute(self, conn: &mut C) -> Result<usize, Self::Error>;
+    |        ------- required by a bound in this associated function
 
-error[E0277]: the trait bound `CopyFromQuery<users::table, pg::query_builder::copy::copy_from::InsertableWrapper<Vec<NewUser>>>: diesel::ExecuteCopyFromDsl<diesel::MysqlConnection>` is not satisfied
+error[E0277]: the trait bound `CopyFromQuery<table, InsertableWrapper<...>>: ExecuteCopyFromDsl<...>` is not satisfied
   --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:52:18
    |
-52 |         .execute(conn)
+LL |         .execute(conn)
    |          ------- ^^^^ unsatisfied trait bound
    |          |
    |          required by a bound introduced by this call
    |
-   = help: the trait `diesel::ExecuteCopyFromDsl<diesel::MysqlConnection>` is not implemented for `CopyFromQuery<users::table, pg::query_builder::copy::copy_from::InsertableWrapper<Vec<NewUser>>>`
+   = help: the trait `diesel::ExecuteCopyFromDsl<diesel::MysqlConnection>` is not implemented for `CopyFromQuery<table, InsertableWrapper<Vec<NewUser>>>`
    = help: the following other types implement trait `diesel::ExecuteCopyFromDsl<C>`:
              `CopyFromQuery<T, A>` implements `diesel::ExecuteCopyFromDsl<PooledConnection<diesel::r2d2::ConnectionManager<C>>>`
              `CopyFromQuery<T, A>` implements `diesel::ExecuteCopyFromDsl<diesel::PgConnection>`
 
+   
 error[E0277]: the trait bound `diesel::MysqlConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
-  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:54:48
-   |
-54 |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
-   |                                   ----         ^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::MysqlConnection`
-   |                                   |
-   |                                   required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
-             PooledConnection<diesel::r2d2::ConnectionManager<C>>
-             diesel::PgConnection
+   --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:56:48
+    |
+56  |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
+    |                                   ----         ^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::MysqlConnection`
+    |                                   |
+    |                                   required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
+              PooledConnection<diesel::r2d2::ConnectionManager<C>>
+              diesel::PgConnection
 note: required by a bound in `CopyToQuery::<T, pg::query_builder::copy::copy_to::NotSet>::load`
-  --> $DIESEL/src/pg/query_builder/copy/copy_to.rs
-   |
-   |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
-   |            ---- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/pg/query_builder/copy/copy_to.rs
+    |
+LL |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
+    |            ---- required by a bound in this associated function
 ...
-   |         C: ExecuteCopyToConnection,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`
+LL |         C: ExecuteCopyToConnection,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`
 
 error[E0277]: the trait bound `diesel::MysqlConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
-  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:54:5
-   |
-54 |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::MysqlConnection`
-   |
-   = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
-             PooledConnection<diesel::r2d2::ConnectionManager<C>>
-             diesel::PgConnection
+   --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:56:5
+    |
+56  |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::MysqlConnection`
+    |
+    = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
+              PooledConnection<diesel::r2d2::ConnectionManager<C>>
+              diesel::PgConnection
 note: required by a bound in `CopyToQuery::<T, pg::query_builder::copy::copy_to::NotSet>::load`
-  --> $DIESEL/src/pg/query_builder/copy/copy_to.rs
-   |
-   |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
-   |            ---- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/pg/query_builder/copy/copy_to.rs
+    |
+LL |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
+    |            ---- required by a bound in this associated function
 ...
-   |         C: ExecuteCopyToConnection,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`
+LL |         C: ExecuteCopyToConnection,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`
 
 error[E0271]: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
-  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:61:18
-   |
-61 |         .execute(conn)
-   |          ------- ^^^^ expected `Pg`, found `Sqlite`
-   |          |
-   |          required by a bound introduced by this call
-   |
+   --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:65:18
+    |
+65  |         .execute(conn)
+    |          ------- ^^^^ expected `Pg`, found `Sqlite`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: required by a bound in `diesel::ExecuteCopyFromDsl::execute`
-  --> $DIESEL/src/pg/query_builder/copy/copy_from.rs
-   |
-   |     C: Connection<Backend = Pg>,
-   |                   ^^^^^^^^^^^^ required by this bound in `ExecuteCopyFromDsl::execute`
+   --> DIESEL/diesel/diesel/src/pg/query_builder/copy/copy_from.rs
+    |
+LL |     C: Connection<Backend = Pg>,
+    |                   ^^^^^^^^^^^^ required by this bound in `ExecuteCopyFromDsl::execute`
 ...
-   |     fn execute(self, conn: &mut C) -> Result<usize, Self::Error>;
-   |        ------- required by a bound in this associated function
+LL |     fn execute(self, conn: &mut C) -> Result<usize, Self::Error>;
+    |        ------- required by a bound in this associated function
 
-error[E0277]: the trait bound `CopyFromQuery<users::table, pg::query_builder::copy::copy_from::InsertableWrapper<Vec<NewUser>>>: diesel::ExecuteCopyFromDsl<diesel::SqliteConnection>` is not satisfied
-  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:61:18
+error[E0277]: the trait bound `CopyFromQuery<table, InsertableWrapper<...>>: ExecuteCopyFromDsl<...>` is not satisfied
+  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:65:18
    |
-61 |         .execute(conn)
+LL |         .execute(conn)
    |          ------- ^^^^ unsatisfied trait bound
    |          |
    |          required by a bound introduced by this call
    |
-   = help: the trait `diesel::ExecuteCopyFromDsl<diesel::SqliteConnection>` is not implemented for `CopyFromQuery<users::table, pg::query_builder::copy::copy_from::InsertableWrapper<Vec<NewUser>>>`
+   = help: the trait `diesel::ExecuteCopyFromDsl<diesel::SqliteConnection>` is not implemented for `CopyFromQuery<table, InsertableWrapper<Vec<NewUser>>>`
    = help: the following other types implement trait `diesel::ExecuteCopyFromDsl<C>`:
              `CopyFromQuery<T, A>` implements `diesel::ExecuteCopyFromDsl<PooledConnection<diesel::r2d2::ConnectionManager<C>>>`
              `CopyFromQuery<T, A>` implements `diesel::ExecuteCopyFromDsl<diesel::PgConnection>`
 
+   
 error[E0277]: the trait bound `diesel::SqliteConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
-  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:63:48
-   |
-63 |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
-   |                                   ----         ^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::SqliteConnection`
-   |                                   |
-   |                                   required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
-             PooledConnection<diesel::r2d2::ConnectionManager<C>>
-             diesel::PgConnection
+   --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:69:48
+    |
+69  |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
+    |                                   ----         ^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::SqliteConnection`
+    |                                   |
+    |                                   required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
+              PooledConnection<diesel::r2d2::ConnectionManager<C>>
+              diesel::PgConnection
 note: required by a bound in `CopyToQuery::<T, pg::query_builder::copy::copy_to::NotSet>::load`
-  --> $DIESEL/src/pg/query_builder/copy/copy_to.rs
-   |
-   |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
-   |            ---- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/pg/query_builder/copy/copy_to.rs
+    |
+LL |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
+    |            ---- required by a bound in this associated function
 ...
-   |         C: ExecuteCopyToConnection,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`
+LL |         C: ExecuteCopyToConnection,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`
 
 error[E0277]: the trait bound `diesel::SqliteConnection: pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not satisfied
-  --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:63:5
-   |
-63 |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::SqliteConnection`
-   |
-   = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
-             PooledConnection<diesel::r2d2::ConnectionManager<C>>
-             diesel::PgConnection
+   --> tests/fail/copy_can_only_be_used_with_postgres_connections.rs:69:5
+    |
+69  |     diesel::copy_to(users::table).load::<User, _>(conn).unwrap();
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection` is not implemented for `diesel::SqliteConnection`
+    |
+    = help: the following other types implement trait `pg::query_builder::copy::copy_to::ExecuteCopyToConnection`:
+              PooledConnection<diesel::r2d2::ConnectionManager<C>>
+              diesel::PgConnection
 note: required by a bound in `CopyToQuery::<T, pg::query_builder::copy::copy_to::NotSet>::load`
-  --> $DIESEL/src/pg/query_builder/copy/copy_to.rs
-   |
-   |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
-   |            ---- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/pg/query_builder/copy/copy_to.rs
+    |
+LL |     pub fn load<U, C>(self, conn: &mut C) -> QueryResult<impl Iterator<Item = QueryResult<U>> + '_>
+    |            ---- required by a bound in this associated function
 ...
-   |         C: ExecuteCopyToConnection,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`
+LL |         C: ExecuteCopyToConnection,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CopyToQuery::<T, NotSet>::load`

--- a/diesel_compile_tests/tests/fail/copy_can_only_use_options_with_raw_variant.rs
+++ b/diesel_compile_tests/tests/fail/copy_can_only_use_options_with_raw_variant.rs
@@ -47,11 +47,13 @@ fn main() {
     diesel::copy_from(users::table)
         .from_insertable(vec![NewUser { name: "John" }])
         .with_format(CopyFormat::Csv)
+        //~^ ERROR: no method named `with_format` found for struct `CopyFromQuery<table, InsertableWrapper<Vec<NewUser>>>` in the current scope
         .execute(conn)
         .unwrap();
 
     diesel::copy_to(users::table)
         .with_format(CopyFormat::Csv)
         .load::<User, _>(conn)
+        //~^ ERROR: the method `load` exists for struct `CopyToQuery<table, CopyToOptions>`, but its trait bounds were not satisfied
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/copy_can_only_use_options_with_raw_variant.stderr
+++ b/diesel_compile_tests/tests/fail/copy_can_only_use_options_with_raw_variant.stderr
@@ -1,9 +1,9 @@
-error[E0599]: no method named `with_format` found for struct `CopyFromQuery<users::table, pg::query_builder::copy::copy_from::InsertableWrapper<Vec<NewUser>>>` in the current scope
+error[E0599]: no method named `with_format` found for struct `CopyFromQuery<table, InsertableWrapper<Vec<NewUser>>>` in the current scope
   --> tests/fail/copy_can_only_use_options_with_raw_variant.rs:49:10
    |
-47 | /     diesel::copy_from(users::table)
-48 | |         .from_insertable(vec![NewUser { name: "John" }])
-49 | |         .with_format(CopyFormat::Csv)
+LL | /     diesel::copy_from(users::table)
+LL | |         .from_insertable(vec![NewUser { name: "John" }])
+LL | |         .with_format(CopyFormat::Csv)
    | |         -^^^^^^^^^^^ method not found in `CopyFromQuery<table, InsertableWrapper<Vec<NewUser>>>`
    | |_________|
    |
@@ -12,22 +12,23 @@ error[E0599]: no method named `with_format` found for struct `CopyFromQuery<user
            - `CopyFromQuery<T, pg::query_builder::copy::copy_from::CopyFrom<C, F>>`
 
 error[E0599]: the method `load` exists for struct `CopyToQuery<table, CopyToOptions>`, but its trait bounds were not satisfied
-  --> tests/fail/copy_can_only_use_options_with_raw_variant.rs:55:10
-   |
-53 | /     diesel::copy_to(users::table)
-54 | |         .with_format(CopyFormat::Csv)
-55 | |         .load::<User, _>(conn)
-   | |_________-^^^^
-   |
-  ::: $DIESEL/src/pg/query_builder/copy/copy_to.rs
-   |
-   |   pub struct CopyToQuery<T, O> {
-   |   ---------------------------- doesn't satisfy `_: RunQueryDsl<_>` or `_: Table`
-   |
-   = note: the following trait bounds were not satisfied:
-           `CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: Table`
-           which is required by `CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: diesel::RunQueryDsl<_>`
-           `&CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: Table`
-           which is required by `&CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: diesel::RunQueryDsl<_>`
-           `&mut CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: Table`
-           which is required by `&mut CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: diesel::RunQueryDsl<_>`
+   --> tests/fail/copy_can_only_use_options_with_raw_variant.rs:56:10
+    |
+54  | /     diesel::copy_to(users::table)
+55  | |         .with_format(CopyFormat::Csv)
+56  | |         .load::<User, _>(conn)
+    | |_________-^^^^
+    |
+   ::: DIESEL/diesel/diesel/src/pg/query_builder/copy/copy_to.rs
+    |
+LL |   pub struct CopyToQuery<T, O> {
+    |   ---------------------------- doesn't satisfy `_: RunQueryDsl<_>` or `_: Table`
+    |
+    = note: the following trait bounds were not satisfied:
+            `CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: Table`
+            which is required by `CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: diesel::RunQueryDsl<_>`
+            `&CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: Table`
+            which is required by `&CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: diesel::RunQueryDsl<_>`
+            `&mut CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: Table`
+            which is required by `&mut CopyToQuery<users::table, pg::query_builder::copy::copy_to::CopyToOptions>: diesel::RunQueryDsl<_>`
+For more information about this error, try `rustc --explain E0599`.

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.rs
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.rs
@@ -19,10 +19,16 @@ pub struct NewUser {
 fn main() {
     use self::users::dsl::*;
 
-    let stmt = update(users.filter(id.eq(1))).set(name.eq("Bill")).returning(count(id));
+    let stmt = update(users.filter(id.eq(1)))
+        .set(name.eq("Bill"))
+        .returning(count(id));
+    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
 
     let new_user = NewUser {
         name: "Foobar".to_string(),
     };
-    let stmt = insert_into(users).values(&new_user).returning((name, count(name)));
+    let stmt = insert_into(users)
+        .values(&new_user)
+        .returning((name, count(name)));
+    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.stderr
@@ -1,43 +1,46 @@
 error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
-  --> tests/fail/custom_returning_requires_nonaggregate.rs:22:78
-   |
-22 |     let stmt = update(users.filter(id.eq(1))).set(name.eq("Bill")).returning(count(id));
-   |                                                                    --------- ^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
-   |                                                                    |
-   |                                                                    required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `MixedAggregates<Other>`:
-             `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
-             `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>>>` to implement `Query`
+   --> tests/fail/custom_returning_requires_nonaggregate.rs:24:20
+    |
+24  |         .returning(count(id));
+    |          --------- ^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `MixedAggregates<Other>`:
+              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
+    = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ..., ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
-  --> $DIESEL/src/query_builder/update_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
 ...
-   |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
-   |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
-
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+    |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
+ 
+    
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
-  --> tests/fail/custom_returning_requires_nonaggregate.rs:27:63
-   |
-27 |     let stmt = insert_into(users).values(&new_user).returning((name, count(name)));
-   |                                                     --------- ^^^^^^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
-   |                                                     |
-   |                                                     required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `MixedAggregates<Other>`:
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
-   = note: required for `(columns::name, diesel::expression::count::count_utils::count<diesel::sql_types::Text, columns::name>)` to implement `ValidGrouping<()>`
-   = note: required for `(columns::name, diesel::expression::count::count_utils::count<diesel::sql_types::Text, columns::name>)` to implement `NonAggregate`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<(columns::name, diesel::expression::count::count_utils::count<diesel::sql_types::Text, columns::name>)>>` to implement `Query`
+   --> tests/fail/custom_returning_requires_nonaggregate.rs:32:20
+    |
+32  |         .returning((name, count(name)));
+    |          --------- ^^^^^^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `MixedAggregates<Other>`:
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
+    = note: required for `(name, count<Text, name>)` to implement `ValidGrouping<()>`
+    = note: required for `(name, count<Text, name>)` to implement `NonAggregate`
+    = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
-   |     where
-   |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
-   |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+    For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
@@ -30,6 +30,7 @@ fn main() {
     let stmt = update(users.filter(id.eq(1)))
         .set(name.eq("Bill"))
         .returning(bad::age);
+    //~^ ERROR: Cannot select `bad::columns::age` from `users::table`
 
     let new_user = NewUser {
         name: "Foobar".to_string(),
@@ -37,4 +38,6 @@ fn main() {
     let stmt = insert_into(users)
         .values(&new_user)
         .returning((name, bad::age));
+    //~^ ERROR: Cannot select `bad::columns::age` from `users::table`
+    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
@@ -1,81 +1,83 @@
 error[E0277]: Cannot select `bad::columns::age` from `users::table`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:32:20
-   |
-32 |         .returning(bad::age);
-   |          --------- ^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `bad::columns::age` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `bad::columns::age` implements `SelectableExpression<JoinOn<Join, On>>`
-             `bad::columns::age` implements `SelectableExpression<Only<bad::table>>`
-             `bad::columns::age` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `bad::columns::age` implements `SelectableExpression<Tablesample<bad::table, TSM>>`
-             `bad::columns::age` implements `SelectableExpression<bad::table>`
-             `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<bad::columns::age>>` to implement `Query`
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:32:20
+    |
+32  |         .returning(bad::age);
+    |          --------- ^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `bad::columns::age` is no valid selection for `users::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `bad::columns::age` implements `SelectableExpression<JoinOn<Join, On>>`
+              `bad::columns::age` implements `SelectableExpression<Only<bad::table>>`
+              `bad::columns::age` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `bad::columns::age` implements `SelectableExpression<Tablesample<bad::table, TSM>>`
+              `bad::columns::age` implements `SelectableExpression<bad::table>`
+              `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ..., ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
-  --> $DIESEL/src/query_builder/update_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
 ...
-   |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
-   |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
-
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+    |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
+ 
+    
 error[E0277]: Cannot select `bad::columns::age` from `users::table`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:39:20
-   |
-39 |         .returning((name, bad::age));
-   |          --------- ^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `bad::columns::age` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `bad::columns::age` implements `SelectableExpression<JoinOn<Join, On>>`
-             `bad::columns::age` implements `SelectableExpression<Only<bad::table>>`
-             `bad::columns::age` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `bad::columns::age` implements `SelectableExpression<Tablesample<bad::table, TSM>>`
-             `bad::columns::age` implements `SelectableExpression<bad::table>`
-             `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<(users::columns::name, bad::columns::age)>>` to implement `Query`
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:40:20
+    |
+40  |         .returning((name, bad::age));
+    |          --------- ^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `bad::columns::age` is no valid selection for `users::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `bad::columns::age` implements `SelectableExpression<JoinOn<Join, On>>`
+              `bad::columns::age` implements `SelectableExpression<Only<bad::table>>`
+              `bad::columns::age` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `bad::columns::age` implements `SelectableExpression<Tablesample<bad::table, TSM>>`
+              `bad::columns::age` implements `SelectableExpression<bad::table>`
+              `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `bad::columns::age` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`
+    = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
-   |     where
-   |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
-   |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
-
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+    
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:39:20
-   |
-39 |         .returning((name, bad::age));
-   |          --------- ^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:40:20
+    |
+40  |         .returning((name, bad::age));
+    |          --------- ^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: required for `bad::columns::age` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
-   |
-15 |       age -> Integer,
-   |       ^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<users::table>`
-   = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<(users::columns::name, bad::columns::age)>>` to implement `Query`
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
+    |
+15  |       age -> Integer,
+    |       ^^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 1 redundant requirement hidden
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<users::table>`
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`
+    = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
-   |     where
-   |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
-   |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`

--- a/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -13,10 +13,12 @@ fn main() {
     use self::users::dsl::*;
     let mut connection = SqliteConnection::establish(":memory:").unwrap();
 
-    delete(users.filter(name.eq("Bill")))
-        .get_result(&mut connection);
+    delete(users.filter(name.eq("Bill"))).get_result(&mut connection);
+    //~^ ERROR: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
+    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
 
     delete(users.filter(name.eq("Bill")))
         .returning(name)
         .get_result(&mut connection);
+    //~^ ERROR: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
 }

--- a/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -1,87 +1,91 @@
 error[E0277]: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:17:21
-   |
-17 |         .get_result(&mut connection);
-   |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<(columns::id, columns::name)>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB>`
-   = note: required for `ReturningClause<(columns::id, columns::name)>` to implement `QueryFragment<Sqlite>`
-   = note: 1 redundant requirement hidden
-   = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>, ReturningClause<(columns::id, columns::name)>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
+    --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:16:54
+     |
+16   |     delete(users.filter(name.eq("Bill"))).get_result(&mut connection);
+     |                                           ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<(columns::id, columns::name)>`
+     |                                           |
+     |                                           required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB>`
+     = note: required for `ReturningClause<(columns::id, columns::name)>` to implement `QueryFragment<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>, ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:21:21
-   |
-21 |         .get_result(&mut connection);
-   |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB>`
-   = note: required for `ReturningClause<columns::name>` to implement `QueryFragment<Sqlite>`
-   = note: 1 redundant requirement hidden
-   = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>, ReturningClause<columns::name>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>, ReturningClause<columns::name>>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
+    --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:22:21
+     |
+22   |         .get_result(&mut connection);
+     |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB>`
+     = note: required for `ReturningClause<columns::name>` to implement `QueryFragment<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>, ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
-  --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:17:21
-   |
-17 |         .get_result(&mut connection);
-   |          ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-   = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-   = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
+    --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:16:54
+     |
+16   |     delete(users.filter(name.eq("Bill"))).get_result(&mut connection);
+     |                                           ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     |                                           |
+     |                                           required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
+     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
+     = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/derive/aliases.rs
+++ b/diesel_compile_tests/tests/fail/derive/aliases.rs
@@ -34,24 +34,31 @@ pub fn check(conn: &mut PgConnection) {
     // wrong fields
 
     user_alias.field(posts::id);
+    //~^ ERROR: type mismatch resolving `<id as Column>::Table == table`
 
     // joining the same alias twice
 
     users::table
         .inner_join(post_alias)
         .inner_join(post_alias)
+        //~^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
+        //~| ERROR: type mismatch resolving `<Join<..., ..., ...> as AppearsInFromClause<...>>::Count == Once`
         .select(users::id)
+        //~^ ERROR: the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>`, but its trait bounds were not satisfied
         .load::<i32>(conn)
         .unwrap();
 
     // Selecting the raw field on the aliased table
     user_alias.select(users::id).load::<i32>(conn).unwrap();
+    //~^ ERROR: Cannot select `users::columns::id` from `Alias<users2>`
+    //~| ERROR: Cannot select `users::columns::id` from `Alias<users2>`
 
     let user2_alias = alias!(users as user3);
 
     // don't allow joins to not joinable tables
     pets::table
         .inner_join(user_alias)
+        //~^ ERROR: the trait bound `users::table: JoinTo<pets::table>` is not satisfied
         .select(pets::id)
         .load::<i32>(conn)
         .unwrap();
@@ -60,11 +67,15 @@ pub fn check(conn: &mut PgConnection) {
     let post_alias_2 = alias!(posts as posts3);
     let posts = post_alias
         .inner_join(
+            //~^ ERROR: the trait bound `Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<...>` is not satisfied
+            //~| ERROR: the trait bound `Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<...>` is not satisfied
             post_alias_2.on(post_alias
                 .field(posts::author)
                 .eq(post_alias_2.field(posts::author))),
+            //~^^^ ERROR: the trait bound `Alias<posts3>: AppearsInFromClause<Alias<posts2>>` is not satisfied
         )
         .select((post_alias.field(posts::id), post_alias_2.field(posts::id)))
+        //~^ ERROR:  the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<Alias<...>, ..., ...>, ...>>>`, but its trait bounds were not satisfied
         .load::<(i32, i32)>(conn)
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/derive/aliases.stderr
+++ b/diesel_compile_tests/tests/fail/derive/aliases.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<id as Column>::Table == table`
   --> tests/fail/derive/aliases.rs:36:22
    |
-36 |     user_alias.field(posts::id);
+LL |     user_alias.field(posts::id);
    |                ----- ^^^^^^^^^ type mismatch resolving `<id as Column>::Table == table`
    |                |
    |                required by a bound introduced by this call
@@ -9,18 +9,18 @@ error[E0271]: type mismatch resolving `<id as Column>::Table == table`
 note: expected this to be `users::table`
   --> tests/fail/derive/aliases.rs:15:9
    |
-15 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
   --> tests/fail/derive/aliases.rs:13:1
    |
-13 | / table! {
-14 | |     posts {
-15 | |         id -> Integer,
-16 | |         author -> Integer,
+LL | / table! {
+LL | |     posts {
+LL | |         id -> Integer,
+LL | |         author -> Integer,
 ...  |
-19 | | }
+LL | | }
    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
   --> tests/fail/derive/aliases.rs:6:1
@@ -29,65 +29,68 @@ note: `users::table` is defined in module `crate::users` of the current crate
 7  | |     users {
 8  | |         id -> Integer,
 9  | |         name -> Text,
-10 | |     }
-11 | | }
+LL | |     }
+LL | | }
    | |_^
 note: required by a bound in `Alias::<S>::field`
-  --> $DIESEL/src/query_source/aliasing/alias.rs
+  --> DIESEL/diesel/diesel/src/query_source/aliasing/alias.rs
    |
-   |     pub fn field<F>(&self, field: F) -> AliasedField<S, F>
+LL |     pub fn field<F>(&self, field: F) -> AliasedField<S, F>
    |            ----- required by a bound in this associated function
-   |     where
-   |         F: Column<Table = S::Target>,
+LL |     where
+LL |         F: Column<Table = S::Target>,
    |                   ^^^^^^^^^^^^^^^^^ required by this bound in `Alias::<S>::field`
    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/derive/aliases.rs:42:21
-   |
-42 |         .inner_join(post_alias)
-   |          ---------- ^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: required for `AliasedField<posts2, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>>`
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), (AliasedField<posts2, posts::columns::id>, AliasedField<posts2, posts::columns::author>, AliasedField<posts2, posts::columns::title>), (AliasedField<posts2, posts::columns::id>, AliasedField<posts2, posts::columns::author>, AliasedField<posts2, posts::columns::title>))` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>>`
-   = note: required for `query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>>>` to implement `InternalJoinDsl<Alias<posts2>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>>>` to implement `JoinWithImplicitOnClause<Alias<posts2>, Inner>`
+   --> tests/fail/derive/aliases.rs:43:21
+    |
+43  |         .inner_join(post_alias)
+    |          ---------- ^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: required for `AliasedField<posts2, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), (AliasedField<posts2, id>, ..., ...), ...)` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>>`
+    = note: required for `Join<JoinOn<Join<table, Alias<posts2>, Inner>, ...>, ..., ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<JoinOn<Join<table, Alias<...>, ...>, ...>, ..., ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, Alias<...>, ...>, ...>>>` to implement `InternalJoinDsl<Alias<posts2>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, Alias<...>, ...>, ...>>>` to implement `JoinWithImplicitOnClause<Alias<posts2>, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+ 
+    
+error[E0271]: type mismatch resolving `<Join<..., ..., ...> as AppearsInFromClause<...>>::Count == Once`
+  --> tests/fail/derive/aliases.rs:43:10
    |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
-
-error[E0271]: type mismatch resolving `<Join<JoinOn<Join<table, Alias<posts2>, Inner>, Grouped<Eq<Nullable<AliasedField<posts2, author>>, Nullable<id>>>>, Alias<posts2>, Inner> as AppearsInFromClause<Alias<posts2>>>::Count == Once`
-  --> tests/fail/derive/aliases.rs:42:10
-   |
-42 |         .inner_join(post_alias)
+LL |         .inner_join(post_alias)
    |          ^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
    |
    = note: required for `AliasedField<posts2, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>>`
    = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), (AliasedField<posts2, posts::columns::id>, AliasedField<posts2, posts::columns::author>, AliasedField<posts2, posts::columns::title>), (AliasedField<posts2, posts::columns::id>, AliasedField<posts2, posts::columns::author>, AliasedField<posts2, posts::columns::title>))` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>>`
-   = note: required for `query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>` to implement `QuerySource`
+   = note: required for `((id, name), (AliasedField<posts2, id>, ..., ...), ...)` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>>`
+   = note: required for `Join<JoinOn<Join<table, Alias<posts2>, Inner>, ...>, ..., ...>` to implement `QuerySource`
    = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>>>` to implement `InternalJoinDsl<Alias<posts2>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>`
+   = note: required for `JoinOn<Join<JoinOn<Join<table, Alias<...>, ...>, ...>, ..., ...>, ...>` to implement `QuerySource`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<table, Alias<...>, ...>, ...>>>` to implement `InternalJoinDsl<Alias<posts2>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>`
 
-error[E0599]: the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<JoinOn<Join<table, Alias<posts2>, Inner>, Grouped<Eq<Nullable<AliasedField<posts2, author>>, Nullable<id>>>>, Alias<posts2>, Inner>, Grouped<Eq<Nullable<AliasedField<posts2, author>>, Nullable<id>>>>>>`, but its trait bounds were not satisfied
-  --> tests/fail/derive/aliases.rs:43:10
+   
+error[E0599]: the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>`, but its trait bounds were not satisfied
+  --> tests/fail/derive/aliases.rs:46:10
    |
-40 | /     users::table
-41 | |         .inner_join(post_alias)
-42 | |         .inner_join(post_alias)
-43 | |         .select(users::id)
+LL | /     users::table
+LL | |         .inner_join(post_alias)
+LL | |         .inner_join(post_alias)
+...  |
+LL | |         .select(users::id)
    | |         -^^^^^^ private field, not a method
    | |_________|
    |
@@ -99,67 +102,68 @@ error[E0599]: the method `select` exists for struct `SelectStatement<FromClause<
            which is required by `&mut SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>>>: diesel::QueryDsl`
 
 error[E0277]: Cannot select `users::columns::id` from `Alias<users2>`
-  --> tests/fail/derive/aliases.rs:48:23
-   |
-48 |     user_alias.select(users::id).load::<i32>(conn).unwrap();
-   |                ------ ^^^^^^^^^ the trait `SelectableExpression<Alias<users2>>` is not implemented for `users::columns::id`
-   |                |
-   |                required by a bound introduced by this call
-   |
-   = note: `users::columns::id` is no valid selection for `Alias<users2>`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `users::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-             `users::columns::id` implements `SelectableExpression<Only<users::table>>`
-             `users::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `users::columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
-             `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-             `users::columns::id` implements `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<Alias<users2>>>` to implement `SelectDsl<users::columns::id>`
-   = note: 1 redundant requirement hidden
-   = note: required for `Alias<users2>` to implement `SelectDsl<users::columns::id>`
+   --> tests/fail/derive/aliases.rs:52:23
+    |
+52  |     user_alias.select(users::id).load::<i32>(conn).unwrap();
+    |                ------ ^^^^^^^^^ the trait `SelectableExpression<Alias<users2>>` is not implemented for `users::columns::id`
+    |                |
+    |                required by a bound introduced by this call
+    |
+    = note: `users::columns::id` is no valid selection for `Alias<users2>`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `users::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+              `users::columns::id` implements `SelectableExpression<Only<users::table>>`
+              `users::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `users::columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
+              `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+              `users::columns::id` implements `SelectableExpression<users::table>`
+    = note: required for `SelectStatement<FromClause<Alias<users2>>>` to implement `SelectDsl<users::columns::id>`
+    = note: 1 redundant requirement hidden
+    = note: required for `Alias<users2>` to implement `SelectDsl<users::columns::id>`
 note: required by a bound in `diesel::QueryDsl::select`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
-   |        ------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
 ...
-   |         Self: methods::SelectDsl<Selection>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
 
 error[E0277]: Cannot select `users::columns::id` from `Alias<users2>`
-  --> tests/fail/derive/aliases.rs:48:46
-   |
-48 |     user_alias.select(users::id).load::<i32>(conn).unwrap();
-   |                                  ----        ^^^^ the trait `SelectableExpression<Alias<users2>>` is not implemented for `users::columns::id`
-   |                                  |
-   |                                  required by a bound introduced by this call
-   |
-   = note: `users::columns::id` is no valid selection for `Alias<users2>`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `users::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-             `users::columns::id` implements `SelectableExpression<Only<users::table>>`
-             `users::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `users::columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
-             `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-             `users::columns::id` implements `SelectableExpression<users::table>`
-   = note: required for `diesel::query_builder::select_clause::SelectClause<users::columns::id>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<Alias<users2>>>`
-   = note: required for `SelectStatement<FromClause<Alias<users2>>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<Alias<users2>>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>` to implement `LoadQuery<'_, _, i32>`
+    --> tests/fail/derive/aliases.rs:52:46
+     |
+52   |     user_alias.select(users::id).load::<i32>(conn).unwrap();
+     |                                  ----        ^^^^ the trait `SelectableExpression<Alias<users2>>` is not implemented for `users::columns::id`
+     |                                  |
+     |                                  required by a bound introduced by this call
+     |
+     = note: `users::columns::id` is no valid selection for `Alias<users2>`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `users::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+               `users::columns::id` implements `SelectableExpression<Only<users::table>>`
+               `users::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `users::columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
+               `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `users::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+               `users::columns::id` implements `SelectableExpression<users::table>`
+     = note: required for `diesel::query_builder::select_clause::SelectClause<users::columns::id>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<Alias<users2>>>`
+     = note: required for `SelectStatement<FromClause<Alias<users2>>, SelectClause<id>>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<Alias<users2>>, SelectClause<id>>` to implement `LoadQuery<'_, _, i32>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `users::table: JoinTo<pets::table>` is not satisfied
-  --> tests/fail/derive/aliases.rs:54:10
+  --> tests/fail/derive/aliases.rs:60:10
    |
-54 |         .inner_join(user_alias)
+LL |         .inner_join(user_alias)
    |          ^^^^^^^^^^ the trait `JoinTo<pets::table>` is not implemented for `users::table`
    |
    = help: the following other types implement trait `JoinTo<T>`:
@@ -175,83 +179,85 @@ error[E0277]: the trait bound `users::table: JoinTo<pets::table>` is not satisfi
    = note: required for `pets::table` to implement `JoinWithImplicitOnClause<Alias<users2>, Inner>`
 
 error[E0277]: the trait bound `Alias<posts3>: AppearsInFromClause<Alias<posts2>>` is not satisfied
-  --> tests/fail/derive/aliases.rs:63:13
-   |
-62 |           .inner_join(
-   |            ---------- required by a bound introduced by this call
-63 | /             post_alias_2.on(post_alias
-64 | |                 .field(posts::author)
-65 | |                 .eq(post_alias_2.field(posts::author))),
-   | |_______________________________________________________^ the trait `AppearsInFromClause<Alias<posts2>>` is not implemented for `Alias<posts3>`
-   |
-   = note: double check that `Alias<posts2>` and `Alias<posts3>` appear in the same `allow_tables_to_appear_in_same_query!`
-           call if both are tables
-   = note: double check that any two aliases to the same table in `Alias<posts2>` and `Alias<posts3>` appear in the same `alias!` call
-   = help: the trait `AppearsInFromClause<QS>` is implemented for `Alias<S>`
-   = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `AppearsInFromClause<Alias<posts2>>`
-   = note: required for `AliasedField<posts2, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
-   = note: 2 redundant requirements hidden
-   = note: required for `((AliasedField<posts2, posts::columns::id>, AliasedField<posts2, posts::columns::author>, AliasedField<posts2, posts::columns::title>), (AliasedField<posts3, posts::columns::id>, AliasedField<posts3, posts::columns::author>, AliasedField<posts3, posts::columns::title>))` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
-   = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<Alias<posts2>>>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `Alias<posts2>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
-   = note: required for `Alias<posts2>` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<Alias<posts3>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>, Inner>`
+   --> tests/fail/derive/aliases.rs:72:13
+    |
+69  |           .inner_join(
+    |            ---------- required by a bound introduced by this call
+...
+72  | /             post_alias_2.on(post_alias
+73  | |                 .field(posts::author)
+74  | |                 .eq(post_alias_2.field(posts::author))),
+    | |_______________________________________________________^ the trait `AppearsInFromClause<Alias<posts2>>` is not implemented for `Alias<posts3>`
+    |
+    = note: double check that `Alias<posts2>` and `Alias<posts3>` appear in the same `allow_tables_to_appear_in_same_query!` 
+            call if both are tables
+    = note: double check that any two aliases to the same table in `Alias<posts2>` and `Alias<posts3>` appear in the same `alias!` call
+    = help: the trait `AppearsInFromClause<QS>` is implemented for `Alias<S>`
+    = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `AppearsInFromClause<Alias<posts2>>`
+    = note: required for `AliasedField<posts2, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `((AliasedField<posts2, id>, AliasedField<posts2, author>, ...), ...)` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+    = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<...>>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<Alias<posts2>>>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `Alias<posts2>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
+    = note: required for `Alias<posts2>` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<Alias<posts3>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+ 
+    
+error[E0277]: the trait bound `Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<...>` is not satisfied
+  --> tests/fail/derive/aliases.rs:69:10
    |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
-
-error[E0277]: the trait bound `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<Alias<posts3>>` is not satisfied
-  --> tests/fail/derive/aliases.rs:62:10
-   |
-62 |         .inner_join(
+LL |         .inner_join(
    |          ^^^^^^^^^^ the trait `AppearsInFromClause<Alias<posts3>>` is not implemented for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>`
    |
-   = note: double check that `Alias<posts3>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `allow_tables_to_appear_in_same_query!`
+   = note: double check that `Alias<posts3>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `allow_tables_to_appear_in_same_query!` 
            call if both are tables
    = note: double check that any two aliases to the same table in `Alias<posts3>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `alias!` call
    = help: the trait `AppearsInFromClause<T>` is implemented for `query_source::joins::Join<Left, Right, Kind>`
    = note: required for `AliasedField<posts3, posts::columns::id>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
    = note: 2 redundant requirements hidden
-   = note: required for `((AliasedField<posts2, posts::columns::id>, AliasedField<posts2, posts::columns::author>, AliasedField<posts2, posts::columns::title>), (AliasedField<posts3, posts::columns::id>, AliasedField<posts3, posts::columns::author>, AliasedField<posts3, posts::columns::title>))` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: required for `((AliasedField<posts2, id>, AliasedField<posts2, author>, ...), ...)` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
    = note: required for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` to implement `QuerySource`
    = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>` to implement `QuerySource`
+   = note: required for `JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<...>>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<Alias<posts2>>>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
 
-error[E0277]: the trait bound `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<Alias<posts2>>` is not satisfied
-  --> tests/fail/derive/aliases.rs:62:10
+   
+error[E0277]: the trait bound `Join<Alias<posts2>, Alias<posts3>, Inner>: AppearsInFromClause<...>` is not satisfied
+  --> tests/fail/derive/aliases.rs:69:10
    |
-62 |         .inner_join(
+LL |         .inner_join(
    |          ^^^^^^^^^^ the trait `AppearsInFromClause<Alias<posts2>>` is not implemented for `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>`
    |
-   = note: double check that `Alias<posts2>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `allow_tables_to_appear_in_same_query!`
+   = note: double check that `Alias<posts2>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `allow_tables_to_appear_in_same_query!` 
            call if both are tables
    = note: double check that any two aliases to the same table in `Alias<posts2>` and `query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>` appear in the same `alias!` call
    = help: the trait `AppearsInFromClause<T>` is implemented for `query_source::joins::Join<Left, Right, Kind>`
    = note: required for `AliasedField<posts2, posts::columns::author>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
-   = note: required for `JoinOn<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<AliasedField<posts2, author>, AliasedField<posts3, ...>>>` to implement `AppearsOnTable<query_source::joins::Join<Alias<posts2>, Alias<posts3>, Inner>>`
+   = note: required for `JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<...>>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<Alias<posts2>>>` to implement `InternalJoinDsl<Alias<posts3>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<AliasedField<posts2, posts::columns::author>, AliasedField<posts3, posts::columns::author>>>>`
 
-error[E0599]: the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<Alias<posts2>, Alias<posts3>, Inner>, Grouped<Eq<AliasedField<posts2, author>, AliasedField<posts3, author>>>>>>`, but its trait bounds were not satisfied
-  --> tests/fail/derive/aliases.rs:67:10
+   
+error[E0599]: the method `select` exists for struct `SelectStatement<FromClause<JoinOn<Join<Alias<...>, ..., ...>, ...>>>`, but its trait bounds were not satisfied
+  --> tests/fail/derive/aliases.rs:77:10
    |
-61 |       let posts = post_alias
+LL |       let posts = post_alias
    |  _________________-
-62 | |         .inner_join(
-63 | |             post_alias_2.on(post_alias
-64 | |                 .field(posts::author)
+LL | |         .inner_join(
 ...  |
-67 | |         .select((post_alias.field(posts::id), post_alias_2.field(posts::id)))
+LL | |         .select((post_alias.field(posts::id), post_alias_2.field(posts::id)))
    | |         -^^^^^^ private field, not a method
    | |_________|
    |

--- a/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.rs
@@ -16,12 +16,14 @@ struct Foo1 {
 }
 
 #[derive(AsChangeset)]
+//~^ ERROR: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
 #[diesel(table_name = foo)]
 struct Foo2 {
     id: i32,
 }
 
 #[derive(AsChangeset)]
+//~^ ERROR: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
 #[diesel(table_name = foo, primary_key(id, bar))]
 struct Foo3 {
     id: i32,

--- a/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.stderr
@@ -3,7 +3,7 @@ error: Deriving `AsChangeset` on a structure that only contains primary keys isn
        note: `#[derive(AsChangeset)]` never changes the primary key of a row.
   --> tests/fail/derive/as_changeset_struct_with_only_primary_key.rs:18:10
    |
-18 | #[derive(AsChangeset)]
+LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -11,9 +11,9 @@ error: Deriving `AsChangeset` on a structure that only contains primary keys isn
 error: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
        help: If you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
        note: `#[derive(AsChangeset)]` never changes the primary key of a row.
-  --> tests/fail/derive/as_changeset_struct_with_only_primary_key.rs:24:10
+  --> tests/fail/derive/as_changeset_struct_with_only_primary_key.rs:25:10
    |
-24 | #[derive(AsChangeset)]
+LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.rs
+++ b/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.rs
@@ -2,6 +2,7 @@ extern crate diesel;
 use diesel::expression::AsExpression;
 
 #[derive(AsExpression)]
+//~^ ERROR: At least one `sql_type` is needed for deriving `AsExpression` on a structure.
 struct Lol;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.stderr
@@ -1,7 +1,7 @@
 error: At least one `sql_type` is needed for deriving `AsExpression` on a structure.
  --> tests/fail/derive/as_expression_without_sql_type.rs:4:10
   |
-4 | #[derive(AsExpression)]
+LL | #[derive(AsExpression)]
   |          ^^^^^^^^^^^^
   |
   = note: this error originates in the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.rs
+++ b/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.rs
@@ -2,6 +2,7 @@
 extern crate diesel;
 
 #[derive(Associations)]
+//~^ ERROR: At least one `belongs_to` is needed for deriving `Associations` on a structure.
 struct User {
     id: i32,
 }

--- a/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.stderr
+++ b/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.stderr
@@ -1,7 +1,7 @@
 error: At least one `belongs_to` is needed for deriving `Associations` on a structure.
  --> tests/fail/derive/associations_without_belongs_to.rs:4:10
   |
-4 | #[derive(Associations)]
+LL | #[derive(Associations)]
   |          ^^^^^^^^^^^^
   |
   = note: this error originates in the derive macro `Associations` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/bad_aggregate.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_aggregate.rs
@@ -4,6 +4,7 @@ use diesel::expression::ValidGrouping;
 
 #[derive(ValidGrouping)]
 #[diesel(aggregate = true)]
+//~^ ERROR: expected `,`
 struct User;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_aggregate.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_aggregate.stderr
@@ -1,5 +1,5 @@
 error: expected `,`
  --> tests/fail/derive/bad_aggregate.rs:6:20
   |
-6 | #[diesel(aggregate = true)]
+LL | #[diesel(aggregate = true)]
   |                    ^

--- a/diesel_compile_tests/tests/fail/derive/bad_belongs_to.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_belongs_to.rs
@@ -27,6 +27,7 @@ struct Baz {
 
 #[derive(Associations)]
 #[diesel(belongs_to)]
+//~^ ERROR: unexpected end of input, expected parentheses
 #[diesel(table_name = foo)]
 struct Foo1 {
     bar_id: i32,
@@ -34,6 +35,7 @@ struct Foo1 {
 
 #[derive(Associations)]
 #[diesel(belongs_to = "Bar")]
+//~^ ERROR: expected parentheses
 #[diesel(table_name = foo)]
 struct Foo2 {
     bar_id: i32,
@@ -41,6 +43,7 @@ struct Foo2 {
 
 #[derive(Associations)]
 #[diesel(belongs_to())]
+//~^ ERROR: unexpected end of input, expected identifier
 #[diesel(table_name = foo)]
 struct Foo3 {
     bar_id: i32,
@@ -48,6 +51,7 @@ struct Foo3 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(foreign_key = bar_id))]
+//~^ ERROR: expected `,`
 #[diesel(table_name = foo)]
 struct Foo4 {
     bar_id: i32,
@@ -55,6 +59,7 @@ struct Foo4 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar = "bar_id"))]
+//~^ ERROR: expected `,`
 #[diesel(table_name = foo)]
 struct Foo5 {
     bar_id: i32,
@@ -62,6 +67,7 @@ struct Foo5 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key))]
+//~^ ERROR:  unexpected end of input, expected `=`
 #[diesel(table_name = foo)]
 struct Foo6 {
     bar_id: i32,
@@ -69,6 +75,7 @@ struct Foo6 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key(bar_id)))]
+//~^ ERROR: expected `=`
 #[diesel(table_name = foo)]
 struct Foo7 {
     bar_id: i32,
@@ -76,6 +83,7 @@ struct Foo7 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, what))]
+//~^ ERROR: unknown attribute, expected `foreign_key`
 #[diesel(table_name = foo)]
 struct Foo8 {
     bar_id: i32,

--- a/diesel_compile_tests/tests/fail/derive/bad_belongs_to.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_belongs_to.stderr
@@ -2,48 +2,48 @@ error: unexpected end of input, expected parentheses
        help: The correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
   --> tests/fail/derive/bad_belongs_to.rs:29:20
    |
-29 | #[diesel(belongs_to)]
+LL | #[diesel(belongs_to)]
    |                    ^
 
 error: expected parentheses
-  --> tests/fail/derive/bad_belongs_to.rs:36:21
+  --> tests/fail/derive/bad_belongs_to.rs:37:21
    |
-36 | #[diesel(belongs_to = "Bar")]
+LL | #[diesel(belongs_to = "Bar")]
    |                     ^
 
 error: unexpected end of input, expected identifier
-  --> tests/fail/derive/bad_belongs_to.rs:43:21
+  --> tests/fail/derive/bad_belongs_to.rs:45:21
    |
-43 | #[diesel(belongs_to())]
+LL | #[diesel(belongs_to())]
    |                     ^
 
 error: expected `,`
-  --> tests/fail/derive/bad_belongs_to.rs:50:33
+  --> tests/fail/derive/bad_belongs_to.rs:53:33
    |
-50 | #[diesel(belongs_to(foreign_key = bar_id))]
+LL | #[diesel(belongs_to(foreign_key = bar_id))]
    |                                 ^
 
 error: expected `,`
-  --> tests/fail/derive/bad_belongs_to.rs:57:25
+  --> tests/fail/derive/bad_belongs_to.rs:61:25
    |
-57 | #[diesel(belongs_to(Bar = "bar_id"))]
+LL | #[diesel(belongs_to(Bar = "bar_id"))]
    |                         ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
-  --> tests/fail/derive/bad_belongs_to.rs:64:37
+  --> tests/fail/derive/bad_belongs_to.rs:69:37
    |
-64 | #[diesel(belongs_to(Bar, foreign_key))]
+LL | #[diesel(belongs_to(Bar, foreign_key))]
    |                                     ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_belongs_to.rs:71:37
+  --> tests/fail/derive/bad_belongs_to.rs:77:37
    |
-71 | #[diesel(belongs_to(Bar, foreign_key(bar_id)))]
+LL | #[diesel(belongs_to(Bar, foreign_key(bar_id)))]
    |                                     ^
 
 error: unknown attribute, expected `foreign_key`
-  --> tests/fail/derive/bad_belongs_to.rs:78:26
+  --> tests/fail/derive/bad_belongs_to.rs:85:26
    |
-78 | #[diesel(belongs_to(Bar, what))]
+LL | #[diesel(belongs_to(Bar, what))]
    |                          ^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_column_name.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_column_name.rs
@@ -14,6 +14,7 @@ table! {
 #[diesel(table_name = users)]
 struct User1 {
     #[diesel(column_name)]
+    //~^ ERROR: unexpected end of input, expected `=`
     name: String,
 }
 
@@ -21,6 +22,7 @@ struct User1 {
 #[diesel(table_name = users)]
 struct User2 {
     #[diesel(column_name(another))]
+    //~^ ERROR: expected `=`
     name: String,
 }
 
@@ -28,22 +30,23 @@ struct User2 {
 #[diesel(table_name = users)]
 struct User3 {
     #[diesel(column_name = true)]
+    //~^ ERROR: expected string literal
     name: String,
 }
-
 
 #[derive(Insertable)]
 #[diesel(table_name = users)]
 struct User4 {
     #[diesel(column_name = "spa ce")]
+    //~^ ERROR:  Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
     space: String,
 }
-
 
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 struct User5 {
     #[diesel(column_name = "spa ce")]
+    //~^ ERROR:  Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
     space: String,
 }
 

--- a/diesel_compile_tests/tests/fail/derive/bad_column_name.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_column_name.stderr
@@ -2,29 +2,29 @@ error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(column_name = foo)]`
   --> tests/fail/derive/bad_column_name.rs:16:25
    |
-16 |     #[diesel(column_name)]
+LL |     #[diesel(column_name)]
    |                         ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_column_name.rs:23:25
+  --> tests/fail/derive/bad_column_name.rs:24:25
    |
-23 |     #[diesel(column_name(another))]
+LL |     #[diesel(column_name(another))]
    |                         ^
 
 error: expected string literal
-  --> tests/fail/derive/bad_column_name.rs:30:28
+  --> tests/fail/derive/bad_column_name.rs:32:28
    |
-30 |     #[diesel(column_name = true)]
+LL |     #[diesel(column_name = true)]
    |                            ^^^^
 
 error: Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
-  --> tests/fail/derive/bad_column_name.rs:38:28
+  --> tests/fail/derive/bad_column_name.rs:40:28
    |
-38 |     #[diesel(column_name = "spa ce")]
+LL |     #[diesel(column_name = "spa ce")]
    |                            ^^^^^^^^
 
 error: Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
-  --> tests/fail/derive/bad_column_name.rs:46:28
+  --> tests/fail/derive/bad_column_name.rs:48:28
    |
-46 |     #[diesel(column_name = "spa ce")]
+LL |     #[diesel(column_name = "spa ce")]
    |                            ^^^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_derive_input.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_derive_input.rs
@@ -10,10 +10,12 @@ table! {
 }
 
 #[derive(AsChangeset)]
+//~^ ERROR: This derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 enum UserEnum {}
 
 #[derive(AsChangeset)]
+//~^ ERROR: This derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct UserStruct;
 

--- a/diesel_compile_tests/tests/fail/derive/bad_derive_input.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_derive_input.stderr
@@ -1,15 +1,15 @@
 error: This derive can only be used on non-unit structs
   --> tests/fail/derive/bad_derive_input.rs:12:10
    |
-12 | #[derive(AsChangeset)]
+LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: This derive can only be used on non-unit structs
-  --> tests/fail/derive/bad_derive_input.rs:16:10
+  --> tests/fail/derive/bad_derive_input.rs:17:10
    |
-16 | #[derive(AsChangeset)]
+LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/bad_deserialize_as.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_deserialize_as.rs
@@ -5,6 +5,7 @@ extern crate diesel;
 struct User1 {
     id: i32,
     #[diesel(deserialize_as)]
+    //~^ ERROR: unexpected end of input, expected `=`
     name: String,
 }
 
@@ -12,6 +13,7 @@ struct User1 {
 struct User2 {
     id: i32,
     #[diesel(deserialize_as(Foo))]
+    //~^ ERROR: expected `=`
     name: String,
 }
 
@@ -19,6 +21,7 @@ struct User2 {
 struct User3 {
     id: i32,
     #[diesel(deserialize_as = "foo")]
+    //~^ ERROR: expected identifier
     name: String,
 }
 
@@ -26,6 +29,7 @@ struct User3 {
 struct User4 {
     id: i32,
     #[diesel(deserialize_as = 1omg)]
+    //~^ ERROR: expected identifier
     name: String,
 }
 

--- a/diesel_compile_tests/tests/fail/derive/bad_deserialize_as.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_deserialize_as.stderr
@@ -2,23 +2,23 @@ error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(deserialize_as = Foo)]`
  --> tests/fail/derive/bad_deserialize_as.rs:7:28
   |
-7 |     #[diesel(deserialize_as)]
+LL |     #[diesel(deserialize_as)]
   |                            ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_deserialize_as.rs:14:28
+  --> tests/fail/derive/bad_deserialize_as.rs:15:28
    |
-14 |     #[diesel(deserialize_as(Foo))]
+LL |     #[diesel(deserialize_as(Foo))]
    |                            ^
 
 error: expected identifier
-  --> tests/fail/derive/bad_deserialize_as.rs:21:31
+  --> tests/fail/derive/bad_deserialize_as.rs:23:31
    |
-21 |     #[diesel(deserialize_as = "foo")]
+LL |     #[diesel(deserialize_as = "foo")]
    |                               ^^^^^
 
 error: expected identifier
-  --> tests/fail/derive/bad_deserialize_as.rs:28:31
+  --> tests/fail/derive/bad_deserialize_as.rs:31:31
    |
-28 |     #[diesel(deserialize_as = 1omg)]
+LL |     #[diesel(deserialize_as = 1omg)]
    |                               ^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_embed.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_embed.rs
@@ -12,6 +12,7 @@ table! {
 struct User {
     id: i32,
     #[diesel(embed = true)]
+    //~^ ERROR: expected `,`
     name: String,
 }
 

--- a/diesel_compile_tests/tests/fail/derive/bad_embed.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_embed.stderr
@@ -1,5 +1,5 @@
 error: expected `,`
   --> tests/fail/derive/bad_embed.rs:14:20
    |
-14 |     #[diesel(embed = true)]
+LL |     #[diesel(embed = true)]
    |                    ^

--- a/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.rs
@@ -11,6 +11,7 @@ table! {
 struct User {
     id: String,
     #[diesel(embed, treat_none_as_default_value = true)]
+    //~^ ERROR: `embed` and `treat_none_as_default_value` are mutually exclusive
     name: Option<i32>,
 }
 

--- a/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_embed_treat_none_as_default_value.stderr
@@ -1,5 +1,5 @@
 error: `embed` and `treat_none_as_default_value` are mutually exclusive
   --> tests/fail/derive/bad_embed_treat_none_as_default_value.rs:13:7
    |
-13 |     #[diesel(embed, treat_none_as_default_value = true)]
+LL |     #[diesel(embed, treat_none_as_default_value = true)]
    |       ^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_foreign_derive.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_foreign_derive.rs
@@ -5,18 +5,22 @@ use diesel::expression::{AsExpression, ValidGrouping};
 
 #[derive(ValidGrouping)]
 #[diesel(foreign_derive = true)]
+//~^ ERROR: expected `,`
 struct User1;
 
 #[derive(ValidGrouping)]
+//~^ ERROR: foreign_derive requires at least one field
 #[diesel(foreign_derive)]
 struct User2;
 
 #[derive(AsExpression)]
+//~^ ERROR: foreign_derive requires at least one field
 #[diesel(sql_type = bool)]
 #[diesel(foreign_derive)]
 struct User3;
 
 #[derive(FromSqlRow)]
+//~^ ERROR: foreign_derive requires at least one field
 #[diesel(foreign_derive)]
 struct User4;
 

--- a/diesel_compile_tests/tests/fail/derive/bad_foreign_derive.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_foreign_derive.stderr
@@ -1,29 +1,29 @@
 error: expected `,`
  --> tests/fail/derive/bad_foreign_derive.rs:7:25
   |
-7 | #[diesel(foreign_derive = true)]
+LL | #[diesel(foreign_derive = true)]
   |                         ^
 
 error: foreign_derive requires at least one field
-  --> tests/fail/derive/bad_foreign_derive.rs:10:10
+  --> tests/fail/derive/bad_foreign_derive.rs:11:10
    |
-10 | #[derive(ValidGrouping)]
+LL | #[derive(ValidGrouping)]
    |          ^^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `ValidGrouping` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: foreign_derive requires at least one field
-  --> tests/fail/derive/bad_foreign_derive.rs:14:10
+  --> tests/fail/derive/bad_foreign_derive.rs:16:10
    |
-14 | #[derive(AsExpression)]
+LL | #[derive(AsExpression)]
    |          ^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: foreign_derive requires at least one field
-  --> tests/fail/derive/bad_foreign_derive.rs:19:10
+  --> tests/fail/derive/bad_foreign_derive.rs:22:10
    |
-19 | #[derive(FromSqlRow)]
+LL | #[derive(FromSqlRow)]
    |          ^^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromSqlRow` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.rs
@@ -8,9 +8,17 @@ table! {
 }
 
 #[derive(Insertable)]
+//~^ ERROR: the trait bound `std::string::String: diesel::Expression` is not satisfied
+//~| ERROR: the trait bound `i32: diesel::Expression` is not satisfied
+//~| ERROR: the trait bound `std::string::String: diesel::Expression` is not satisfied
+//~| ERROR: the trait bound `i32: diesel::Expression` is not satisfied
 struct User {
     id: String,
+    //~^ ERROR: the trait bound `std::string::String: diesel::Expression` is not satisfied
+    //~| ERROR: the trait bound `std::string::String: diesel::Expression` is not satisfied
     name: i32,
+    //~^ ERROR: the trait bound `i32: diesel::Expression` is not satisfied
+    //~| ERROR: the trait bound `i32: diesel::Expression` is not satisfied
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:10:10
    |
-10 | #[derive(Insertable)]
+LL | #[derive(Insertable)]
    |          ^^^^^^^^^^ the trait `diesel::Expression` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -13,14 +13,14 @@ error[E0277]: the trait bound `std::string::String: diesel::Expression` is not s
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:10:10
    |
-10 | #[derive(Insertable)]
+LL | #[derive(Insertable)]
    |          ^^^^^^^^^^ the trait `diesel::Expression` is not implemented for `i32`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -32,14 +32,14 @@ error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `i32` to implement `AsExpression<diesel::sql_types::Text>`
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:10:10
    |
-10 | #[derive(Insertable)]
+LL | #[derive(Insertable)]
    |          ^^^^^^^^^^ the trait `diesel::Expression` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -51,7 +51,7 @@ error[E0277]: the trait bound `std::string::String: diesel::Expression` is not s
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `&'insert std::string::String` to implement `diesel::Expression`
    = note: required for `&'insert std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -59,7 +59,7 @@ error[E0277]: the trait bound `std::string::String: diesel::Expression` is not s
 error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:10:10
    |
-10 | #[derive(Insertable)]
+LL | #[derive(Insertable)]
    |          ^^^^^^^^^^ the trait `diesel::Expression` is not implemented for `i32`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -71,15 +71,15 @@ error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `&'insert i32` to implement `diesel::Expression`
    = note: required for `&'insert i32` to implement `AsExpression<diesel::sql_types::Text>`
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
-  --> tests/fail/derive/bad_insertable.rs:12:5
+  --> tests/fail/derive/bad_insertable.rs:16:5
    |
-12 |     id: String,
+LL |     id: String,
    |     ^^ the trait `diesel::Expression` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -91,13 +91,13 @@ error[E0277]: the trait bound `std::string::String: diesel::Expression` is not s
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
 
 error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
-  --> tests/fail/derive/bad_insertable.rs:13:5
+  --> tests/fail/derive/bad_insertable.rs:19:5
    |
-13 |     name: i32,
+LL |     name: i32,
    |     ^^^^ the trait `diesel::Expression` is not implemented for `i32`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -109,13 +109,13 @@ error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `i32` to implement `AsExpression<diesel::sql_types::Text>`
 
 error[E0277]: the trait bound `std::string::String: diesel::Expression` is not satisfied
-  --> tests/fail/derive/bad_insertable.rs:12:5
+  --> tests/fail/derive/bad_insertable.rs:16:5
    |
-12 |     id: String,
+LL |     id: String,
    |     ^^ the trait `diesel::Expression` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -127,14 +127,14 @@ error[E0277]: the trait bound `std::string::String: diesel::Expression` is not s
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `&'insert std::string::String` to implement `diesel::Expression`
    = note: required for `&'insert std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
 
 error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
-  --> tests/fail/derive/bad_insertable.rs:13:5
+  --> tests/fail/derive/bad_insertable.rs:19:5
    |
-13 |     name: i32,
+LL |     name: i32,
    |     ^^^^ the trait `diesel::Expression` is not implemented for `i32`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -146,6 +146,7 @@ error[E0277]: the trait bound `i32: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `&'insert i32` to implement `diesel::Expression`
    = note: required for `&'insert i32` to implement `AsExpression<diesel::sql_types::Text>`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/derive/bad_mysql_type.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_mysql_type.rs
@@ -4,30 +4,37 @@ use diesel::sql_types::SqlType;
 
 #[derive(SqlType)]
 #[diesel(mysql_type)]
+//~^ ERROR: unexpected end of input, expected parentheses
 struct Type1;
 
 #[derive(SqlType)]
 #[diesel(mysql_type())]
+//~^ ERROR: expected attribute `name`
 struct Type2;
 
 #[derive(SqlType)]
 #[diesel(mysql_type = "foo")]
+//~^ ERROR: expected parentheses
 struct Type3;
 
 #[derive(SqlType)]
 #[diesel(mysql_type(name))]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type4;
 
 #[derive(SqlType)]
 #[diesel(mysql_type(name()))]
+//~^ ERROR: expected `=`
 struct Type5;
 
 #[derive(SqlType)]
 #[diesel(mysql_type(name = Foo))]
+//~^ ERROR: expected string literal
 struct Type6;
 
 #[derive(SqlType)]
 #[diesel(mysql_type(what))]
+//~^ ERROR: unknown attribute, expected `name`
 struct Type7;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_mysql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_mysql_type.stderr
@@ -2,43 +2,43 @@ error: unexpected end of input, expected parentheses
        help: The correct format looks like `#[diesel(mysql_type(name = "foo"))]`
  --> tests/fail/derive/bad_mysql_type.rs:6:20
   |
-6 | #[diesel(mysql_type)]
+LL | #[diesel(mysql_type)]
   |                    ^
 
 error: expected attribute `name`
        help: The correct format looks like #[diesel(mysql_type(name = "foo"))]
-  --> tests/fail/derive/bad_mysql_type.rs:10:21
+  --> tests/fail/derive/bad_mysql_type.rs:11:21
    |
-10 | #[diesel(mysql_type())]
+LL | #[diesel(mysql_type())]
    |                     ^
 
 error: expected parentheses
-  --> tests/fail/derive/bad_mysql_type.rs:14:21
+  --> tests/fail/derive/bad_mysql_type.rs:16:21
    |
-14 | #[diesel(mysql_type = "foo")]
+LL | #[diesel(mysql_type = "foo")]
    |                     ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(mysql_type(name = "foo"))]`
-  --> tests/fail/derive/bad_mysql_type.rs:18:25
+  --> tests/fail/derive/bad_mysql_type.rs:21:25
    |
-18 | #[diesel(mysql_type(name))]
+LL | #[diesel(mysql_type(name))]
    |                         ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_mysql_type.rs:22:25
+  --> tests/fail/derive/bad_mysql_type.rs:26:25
    |
-22 | #[diesel(mysql_type(name()))]
+LL | #[diesel(mysql_type(name()))]
    |                         ^
 
 error: expected string literal
-  --> tests/fail/derive/bad_mysql_type.rs:26:28
+  --> tests/fail/derive/bad_mysql_type.rs:31:28
    |
-26 | #[diesel(mysql_type(name = Foo))]
+LL | #[diesel(mysql_type(name = Foo))]
    |                            ^^^
 
 error: unknown attribute, expected `name`
-  --> tests/fail/derive/bad_mysql_type.rs:30:21
+  --> tests/fail/derive/bad_mysql_type.rs:36:21
    |
-30 | #[diesel(mysql_type(what))]
+LL | #[diesel(mysql_type(what))]
    |                     ^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_not_sized.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_not_sized.rs
@@ -3,6 +3,7 @@ use diesel::expression::AsExpression;
 
 #[derive(AsExpression)]
 #[diesel(not_sized = true)]
+//~^ ERROR: expected `,`
 struct Lol;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_not_sized.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_not_sized.stderr
@@ -1,5 +1,5 @@
 error: expected `,`
  --> tests/fail/derive/bad_not_sized.rs:5:20
   |
-5 | #[diesel(not_sized = true)]
+LL | #[diesel(not_sized = true)]
   |                    ^

--- a/diesel_compile_tests/tests/fail/derive/bad_postgres_type.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_postgres_type.rs
@@ -4,66 +4,82 @@ use diesel::sql_types::SqlType;
 
 #[derive(SqlType)]
 #[diesel(postgres_type)]
+//~^ ERROR: unexpected end of input, expected parentheses
 struct Type1;
 
 #[derive(SqlType)]
 #[diesel(postgres_type())]
+//~^ ERROR: expected `oid` and `array_oid` attribute or `name` attribute
 struct Type2;
 
 #[derive(SqlType)]
 #[diesel(postgres_type = "foo")]
+//~^ ERROR: expected parentheses
 struct Type3;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(name))]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type4;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(name()))]
+//~^ ERROR: expected `=`
 struct Type5;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(name = Foo))]
+//~^ ERROR: expected string literal
 struct Type6;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(name = "foo", oid = 2, array_oid = 3))]
+//~^ ERROR: unexpected `oid` when `name` is present
 struct Type7;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(name = "foo", array_oid = 3))]
+//~^ ERROR: unexpected `array_oid` when `name` is present
 struct Type8;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(oid = 2))]
+//~^ ERROR: expected `oid` and `array_oid` attribute or `name` attribute
 struct Type9;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(oid = 1, array_oid = "1"))]
+//~^ ERROR: expected integer literal
 struct Type10;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(oid = "1", array_oid = 1))]
+//~^ ERROR: expected integer literal
 struct Type11;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(schema = "foo"))]
+//~^ ERROR: expected `name` to be also present
 struct Type12;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(what))]
+//~^ ERROR: unknown attribute, expected one of `oid`, `array_oid`, `name`, `schema`
 struct Type13;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(schema))]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type14;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(oid))]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type15;
 
 #[derive(SqlType)]
 #[diesel(postgres_type(array_oid))]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type16;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_postgres_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_postgres_type.stderr
@@ -2,104 +2,104 @@ error: unexpected end of input, expected parentheses
        help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
  --> tests/fail/derive/bad_postgres_type.rs:6:23
   |
-6 | #[diesel(postgres_type)]
+LL | #[diesel(postgres_type)]
   |                       ^
 
 error: expected `oid` and `array_oid` attribute or `name` attribute
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive/bad_postgres_type.rs:10:24
+  --> tests/fail/derive/bad_postgres_type.rs:11:24
    |
-10 | #[diesel(postgres_type())]
+LL | #[diesel(postgres_type())]
    |                        ^
 
 error: expected parentheses
-  --> tests/fail/derive/bad_postgres_type.rs:14:24
+  --> tests/fail/derive/bad_postgres_type.rs:16:24
    |
-14 | #[diesel(postgres_type = "foo")]
+LL | #[diesel(postgres_type = "foo")]
    |                        ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
-  --> tests/fail/derive/bad_postgres_type.rs:18:28
+  --> tests/fail/derive/bad_postgres_type.rs:21:28
    |
-18 | #[diesel(postgres_type(name))]
+LL | #[diesel(postgres_type(name))]
    |                            ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_postgres_type.rs:22:28
+  --> tests/fail/derive/bad_postgres_type.rs:26:28
    |
-22 | #[diesel(postgres_type(name()))]
+LL | #[diesel(postgres_type(name()))]
    |                            ^
 
 error: expected string literal
-  --> tests/fail/derive/bad_postgres_type.rs:26:31
+  --> tests/fail/derive/bad_postgres_type.rs:31:31
    |
-26 | #[diesel(postgres_type(name = Foo))]
+LL | #[diesel(postgres_type(name = Foo))]
    |                               ^^^
 
 error: unexpected `oid` when `name` is present
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive/bad_postgres_type.rs:30:38
+  --> tests/fail/derive/bad_postgres_type.rs:36:38
    |
-30 | #[diesel(postgres_type(name = "foo", oid = 2, array_oid = 3))]
+LL | #[diesel(postgres_type(name = "foo", oid = 2, array_oid = 3))]
    |                                      ^^^
 
 error: unexpected `array_oid` when `name` is present
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive/bad_postgres_type.rs:34:38
+  --> tests/fail/derive/bad_postgres_type.rs:41:38
    |
-34 | #[diesel(postgres_type(name = "foo", array_oid = 3))]
+LL | #[diesel(postgres_type(name = "foo", array_oid = 3))]
    |                                      ^^^^^^^^^
 
 error: expected `oid` and `array_oid` attribute or `name` attribute
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive/bad_postgres_type.rs:38:31
+  --> tests/fail/derive/bad_postgres_type.rs:46:31
    |
-38 | #[diesel(postgres_type(oid = 2))]
+LL | #[diesel(postgres_type(oid = 2))]
    |                               ^
 
 error: expected integer literal
-  --> tests/fail/derive/bad_postgres_type.rs:42:45
+  --> tests/fail/derive/bad_postgres_type.rs:51:45
    |
-42 | #[diesel(postgres_type(oid = 1, array_oid = "1"))]
+LL | #[diesel(postgres_type(oid = 1, array_oid = "1"))]
    |                                             ^^^
 
 error: expected integer literal
-  --> tests/fail/derive/bad_postgres_type.rs:46:30
+  --> tests/fail/derive/bad_postgres_type.rs:56:30
    |
-46 | #[diesel(postgres_type(oid = "1", array_oid = 1))]
+LL | #[diesel(postgres_type(oid = "1", array_oid = 1))]
    |                              ^^^
 
 error: expected `name` to be also present
        help: make sure `name` is present, `#[diesel(postgres_type(name = "...", schema = "foo"))]`
-  --> tests/fail/derive/bad_postgres_type.rs:50:24
+  --> tests/fail/derive/bad_postgres_type.rs:61:24
    |
-50 | #[diesel(postgres_type(schema = "foo"))]
+LL | #[diesel(postgres_type(schema = "foo"))]
    |                        ^^^^^^
 
 error: unknown attribute, expected one of `oid`, `array_oid`, `name`, `schema`
-  --> tests/fail/derive/bad_postgres_type.rs:54:24
+  --> tests/fail/derive/bad_postgres_type.rs:66:24
    |
-54 | #[diesel(postgres_type(what))]
+LL | #[diesel(postgres_type(what))]
    |                        ^^^^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
-  --> tests/fail/derive/bad_postgres_type.rs:58:30
+  --> tests/fail/derive/bad_postgres_type.rs:71:30
    |
-58 | #[diesel(postgres_type(schema))]
+LL | #[diesel(postgres_type(schema))]
    |                              ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive/bad_postgres_type.rs:62:27
+  --> tests/fail/derive/bad_postgres_type.rs:76:27
    |
-62 | #[diesel(postgres_type(oid))]
+LL | #[diesel(postgres_type(oid))]
    |                           ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive/bad_postgres_type.rs:66:33
+  --> tests/fail/derive/bad_postgres_type.rs:81:33
    |
-66 | #[diesel(postgres_type(array_oid))]
+LL | #[diesel(postgres_type(array_oid))]
    |                                 ^

--- a/diesel_compile_tests/tests/fail/derive/bad_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_primary_key.rs
@@ -10,6 +10,7 @@ table! {
 
 #[derive(AsChangeset)]
 #[diesel(primary_key(id, bar = "baz"))]
+//~^ ERROR: expected `,`
 struct UserForm1 {
     id: i32,
     name: String,
@@ -17,6 +18,7 @@ struct UserForm1 {
 
 #[derive(AsChangeset)]
 #[diesel(primary_key(id, qux(id)))]
+//~^ ERROR: expected `,`
 struct UserForm2 {
     id: i32,
     name: String,
@@ -24,6 +26,7 @@ struct UserForm2 {
 
 #[derive(AsChangeset)]
 #[diesel(primary_key)]
+//~^ ERROR:  unexpected end of input, expected parentheses
 struct UserForm3 {
     id: i32,
     name: String,
@@ -31,6 +34,7 @@ struct UserForm3 {
 
 #[derive(AsChangeset)]
 #[diesel(primary_key = id)]
+//~^ ERROR: expected parentheses
 struct UserForm4 {
     id: i32,
     name: String,

--- a/diesel_compile_tests/tests/fail/derive/bad_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_primary_key.stderr
@@ -1,24 +1,24 @@
 error: expected `,`
   --> tests/fail/derive/bad_primary_key.rs:12:30
    |
-12 | #[diesel(primary_key(id, bar = "baz"))]
+LL | #[diesel(primary_key(id, bar = "baz"))]
    |                              ^
 
 error: expected `,`
-  --> tests/fail/derive/bad_primary_key.rs:19:29
+  --> tests/fail/derive/bad_primary_key.rs:20:29
    |
-19 | #[diesel(primary_key(id, qux(id)))]
+LL | #[diesel(primary_key(id, qux(id)))]
    |                             ^
 
 error: unexpected end of input, expected parentheses
        help: The correct format looks like `#[diesel(key1, key2)]`
-  --> tests/fail/derive/bad_primary_key.rs:26:21
+  --> tests/fail/derive/bad_primary_key.rs:28:21
    |
-26 | #[diesel(primary_key)]
+LL | #[diesel(primary_key)]
    |                     ^
 
 error: expected parentheses
-  --> tests/fail/derive/bad_primary_key.rs:33:22
+  --> tests/fail/derive/bad_primary_key.rs:36:22
    |
-33 | #[diesel(primary_key = id)]
+LL | #[diesel(primary_key = id)]
    |                      ^

--- a/diesel_compile_tests/tests/fail/derive/bad_serialize_as.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_serialize_as.rs
@@ -13,6 +13,7 @@ table! {
 struct User1 {
     id: i32,
     #[diesel(serialize_as)]
+    //~^ ERROR: unexpected end of input, expected `=`
     name: String,
 }
 
@@ -21,6 +22,7 @@ struct User1 {
 struct User2 {
     id: i32,
     #[diesel(serialize_as(Foo))]
+    //~^ ERROR:  expected `=`
     name: String,
 }
 
@@ -29,6 +31,7 @@ struct User2 {
 struct User3 {
     id: i32,
     #[diesel(serialize_as = "foo")]
+    //~^ ERROR: expected identifier
     name: String,
 }
 
@@ -37,6 +40,7 @@ struct User3 {
 struct User4 {
     id: i32,
     #[diesel(serialize_as = 1omg)]
+    //~^ ERROR: expected identifier
     name: String,
 }
 

--- a/diesel_compile_tests/tests/fail/derive/bad_serialize_as.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_serialize_as.stderr
@@ -2,23 +2,23 @@ error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(serialize_as = Foo)]`
   --> tests/fail/derive/bad_serialize_as.rs:15:26
    |
-15 |     #[diesel(serialize_as)]
+LL |     #[diesel(serialize_as)]
    |                          ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_serialize_as.rs:23:26
+  --> tests/fail/derive/bad_serialize_as.rs:24:26
    |
-23 |     #[diesel(serialize_as(Foo))]
+LL |     #[diesel(serialize_as(Foo))]
    |                          ^
 
 error: expected identifier
-  --> tests/fail/derive/bad_serialize_as.rs:31:29
+  --> tests/fail/derive/bad_serialize_as.rs:33:29
    |
-31 |     #[diesel(serialize_as = "foo")]
+LL |     #[diesel(serialize_as = "foo")]
    |                             ^^^^^
 
 error: expected identifier
-  --> tests/fail/derive/bad_serialize_as.rs:39:29
+  --> tests/fail/derive/bad_serialize_as.rs:42:29
    |
-39 |     #[diesel(serialize_as = 1omg)]
+LL |     #[diesel(serialize_as = 1omg)]
    |                             ^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_sql_type.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_sql_type.rs
@@ -3,18 +3,22 @@ use diesel::expression::AsExpression;
 
 #[derive(AsExpression)]
 #[diesel(sql_type)]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Lol;
 
 #[derive(AsExpression)]
 #[diesel(sql_type(Foo))]
+//~^ ERROR: expected `=`
 struct Lol2;
 
 #[derive(AsExpression)]
 #[diesel(sql_type = "foo")]
+//~^ ERROR: expected identifier
 struct Lol3;
 
 #[derive(AsExpression)]
 #[diesel(sql_type = 1omg)]
+//~^ ERROR: expected identifier
 struct Lol4;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_sql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_sql_type.stderr
@@ -2,23 +2,23 @@ error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(sql_type = Foo)]`
  --> tests/fail/derive/bad_sql_type.rs:5:18
   |
-5 | #[diesel(sql_type)]
+LL | #[diesel(sql_type)]
   |                  ^
 
 error: expected `=`
- --> tests/fail/derive/bad_sql_type.rs:9:18
-  |
-9 | #[diesel(sql_type(Foo))]
-  |                  ^
+  --> tests/fail/derive/bad_sql_type.rs:10:18
+   |
+LL | #[diesel(sql_type(Foo))]
+   |                  ^
 
 error: expected identifier
-  --> tests/fail/derive/bad_sql_type.rs:13:21
+  --> tests/fail/derive/bad_sql_type.rs:15:21
    |
-13 | #[diesel(sql_type = "foo")]
+LL | #[diesel(sql_type = "foo")]
    |                     ^^^^^
 
 error: expected identifier
-  --> tests/fail/derive/bad_sql_type.rs:17:21
+  --> tests/fail/derive/bad_sql_type.rs:20:21
    |
-17 | #[diesel(sql_type = 1omg)]
+LL | #[diesel(sql_type = 1omg)]
    |                     ^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_sqlite_type.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_sqlite_type.rs
@@ -4,30 +4,37 @@ use diesel::sql_types::SqlType;
 
 #[derive(SqlType)]
 #[diesel(sqlite_type)]
+//~^ ERROR: unexpected end of input, expected parentheses
 struct Type1;
 
 #[derive(SqlType)]
 #[diesel(sqlite_type())]
+//~^ ERROR: expected attribute `name`
 struct Type2;
 
 #[derive(SqlType)]
 #[diesel(sqlite_type = "foo")]
+//~^ ERROR: expected parentheses
 struct Type3;
 
 #[derive(SqlType)]
 #[diesel(sqlite_type(name))]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type4;
 
 #[derive(SqlType)]
 #[diesel(sqlite_type(name()))]
+//~^ ERROR: expected `=`
 struct Type5;
 
 #[derive(SqlType)]
 #[diesel(sqlite_type(name = Foo))]
+//~^ ERROR: expected string literal
 struct Type6;
 
 #[derive(SqlType)]
 #[diesel(sqlite_type(what))]
+//~^ ERROR: unknown attribute, expected `name`
 struct Type7;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_sqlite_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_sqlite_type.stderr
@@ -2,43 +2,43 @@ error: unexpected end of input, expected parentheses
        help: The correct format looks like `#[diesel(sqlite_type(name = "foo"))]`
  --> tests/fail/derive/bad_sqlite_type.rs:6:21
   |
-6 | #[diesel(sqlite_type)]
+LL | #[diesel(sqlite_type)]
   |                     ^
 
 error: expected attribute `name`
        help: The correct format looks like #[diesel(sqlite_type(name = "foo"))]
-  --> tests/fail/derive/bad_sqlite_type.rs:10:22
+  --> tests/fail/derive/bad_sqlite_type.rs:11:22
    |
-10 | #[diesel(sqlite_type())]
+LL | #[diesel(sqlite_type())]
    |                      ^
 
 error: expected parentheses
-  --> tests/fail/derive/bad_sqlite_type.rs:14:22
+  --> tests/fail/derive/bad_sqlite_type.rs:16:22
    |
-14 | #[diesel(sqlite_type = "foo")]
+LL | #[diesel(sqlite_type = "foo")]
    |                      ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(sqlite_type(name = "foo"))]`
-  --> tests/fail/derive/bad_sqlite_type.rs:18:26
+  --> tests/fail/derive/bad_sqlite_type.rs:21:26
    |
-18 | #[diesel(sqlite_type(name))]
+LL | #[diesel(sqlite_type(name))]
    |                          ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_sqlite_type.rs:22:26
+  --> tests/fail/derive/bad_sqlite_type.rs:26:26
    |
-22 | #[diesel(sqlite_type(name()))]
+LL | #[diesel(sqlite_type(name()))]
    |                          ^
 
 error: expected string literal
-  --> tests/fail/derive/bad_sqlite_type.rs:26:29
+  --> tests/fail/derive/bad_sqlite_type.rs:31:29
    |
-26 | #[diesel(sqlite_type(name = Foo))]
+LL | #[diesel(sqlite_type(name = Foo))]
    |                             ^^^
 
 error: unknown attribute, expected `name`
-  --> tests/fail/derive/bad_sqlite_type.rs:30:22
+  --> tests/fail/derive/bad_sqlite_type.rs:36:22
    |
-30 | #[diesel(sqlite_type(what))]
+LL | #[diesel(sqlite_type(what))]
    |                      ^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_table_name.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_table_name.rs
@@ -10,30 +10,35 @@ table! {
 
 #[derive(Queryable)]
 #[diesel(table_name)]
+//~^ ERROR: unexpected end of input, expected `=`
 struct User1 {
     name: String,
 }
 
 #[derive(Queryable)]
 #[diesel(table_name(users))]
+//~^ ERROR: expected `=`
 struct User2 {
     name: String,
 }
 
 #[derive(Insertable)]
 #[diesel(table_name = true)]
+//~^ ERROR: expected identifier, found keyword `true`
 struct User3 {
     id: i32,
 }
 
 #[derive(Insertable)]
 #[diesel(table_name = "not a path")]
+//~^ ERROR:  expected identifier
 struct User4 {
     id: i32,
 }
 
 #[derive(Insertable)]
 #[diesel(table_name = does::not::exist)]
+//~^ ERROR: failed to resolve: use of unresolved module or unlinked crate `does`
 struct User5 {
     id: i32,
 }

--- a/diesel_compile_tests/tests/fail/derive/bad_table_name.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_table_name.stderr
@@ -2,31 +2,32 @@ error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(table_name = foo)]`
   --> tests/fail/derive/bad_table_name.rs:12:20
    |
-12 | #[diesel(table_name)]
+LL | #[diesel(table_name)]
    |                    ^
 
 error: expected `=`
-  --> tests/fail/derive/bad_table_name.rs:18:20
+  --> tests/fail/derive/bad_table_name.rs:19:20
    |
-18 | #[diesel(table_name(users))]
+LL | #[diesel(table_name(users))]
    |                    ^
 
 error: expected identifier, found keyword `true`
-  --> tests/fail/derive/bad_table_name.rs:24:23
+  --> tests/fail/derive/bad_table_name.rs:26:23
    |
-24 | #[diesel(table_name = true)]
+LL | #[diesel(table_name = true)]
    |                       ^^^^
 
 error: expected identifier
-  --> tests/fail/derive/bad_table_name.rs:30:23
+  --> tests/fail/derive/bad_table_name.rs:33:23
    |
-30 | #[diesel(table_name = "not a path")]
+LL | #[diesel(table_name = "not a path")]
    |                       ^^^^^^^^^^^^
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `does`
-  --> tests/fail/derive/bad_table_name.rs:36:23
+  --> tests/fail/derive/bad_table_name.rs:40:23
    |
-36 | #[diesel(table_name = does::not::exist)]
+LL | #[diesel(table_name = does::not::exist)]
    |                       ^^^^ use of unresolved module or unlinked crate `does`
    |
-   = help: if you wanted to use a crate named `does`, use `cargo add does` to add it to your `Cargo.toml`
+   = help: you might be missing a crate named `does`
+For more information about this error, try `rustc --explain E0433`.

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.rs
@@ -11,6 +11,7 @@ table! {
 #[derive(Insertable)]
 #[diesel(table_name = users)]
 #[diesel(treat_none_as_default_value())]
+//~^ ERROR: expected `=`
 struct UserForm1 {
     id: i32,
     name: String,
@@ -19,6 +20,7 @@ struct UserForm1 {
 #[derive(Insertable)]
 #[diesel(table_name = users)]
 #[diesel(treat_none_as_default_value)]
+//~^ ERROR: unexpected end of input, expected `=`
 struct UserForm2 {
     id: i32,
     name: String,
@@ -27,6 +29,7 @@ struct UserForm2 {
 #[derive(Insertable)]
 #[diesel(table_name = users)]
 #[diesel(treat_none_as_default_value = "foo")]
+//~^ ERROR: expected boolean literal
 struct UserForm3 {
     id: i32,
     name: String,
@@ -38,6 +41,7 @@ struct UserForm4 {
     id: i32,
     #[diesel(treat_none_as_default_value = false)]
     name: String,
+    //~^ ERROR:  expected `treat_none_as_default_value` field to be of type `Option<_>`
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.stderr
@@ -1,24 +1,24 @@
 error: expected `=`
   --> tests/fail/derive/bad_treat_none_as_default_value.rs:13:37
    |
-13 | #[diesel(treat_none_as_default_value())]
+LL | #[diesel(treat_none_as_default_value())]
    |                                     ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(treat_none_as_default_value = true)]`
-  --> tests/fail/derive/bad_treat_none_as_default_value.rs:21:37
+  --> tests/fail/derive/bad_treat_none_as_default_value.rs:22:37
    |
-21 | #[diesel(treat_none_as_default_value)]
+LL | #[diesel(treat_none_as_default_value)]
    |                                     ^
 
 error: expected boolean literal
-  --> tests/fail/derive/bad_treat_none_as_default_value.rs:29:40
+  --> tests/fail/derive/bad_treat_none_as_default_value.rs:31:40
    |
-29 | #[diesel(treat_none_as_default_value = "foo")]
+LL | #[diesel(treat_none_as_default_value = "foo")]
    |                                        ^^^^^
 
 error: expected `treat_none_as_default_value` field to be of type `Option<_>`
-  --> tests/fail/derive/bad_treat_none_as_default_value.rs:40:11
+  --> tests/fail/derive/bad_treat_none_as_default_value.rs:43:11
    |
-40 |     name: String,
+LL |     name: String,
    |           ^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.rs
@@ -11,6 +11,7 @@ table! {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[diesel(treat_none_as_null("true"))]
+//~^ ERROR: expected `=`
 struct UserForm1 {
     id: i32,
     name: String,
@@ -19,6 +20,7 @@ struct UserForm1 {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[diesel(treat_none_as_null)]
+//~^ ERROR: unexpected end of input, expected `=`
 struct UserForm2 {
     id: i32,
     name: String,
@@ -27,6 +29,7 @@ struct UserForm2 {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[diesel(treat_none_as_null = "foo")]
+//~^ ERROR: expected boolean literal
 struct UserForm3 {
     id: i32,
     name: String,
@@ -38,6 +41,7 @@ struct UserForm4 {
     id: i32,
     #[diesel(treat_none_as_null = true)]
     name: String,
+    //~^ ERROR: expected `treat_none_as_null` field to be of type `Option<_>`
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.stderr
@@ -1,24 +1,24 @@
 error: expected `=`
   --> tests/fail/derive/bad_treat_none_as_null.rs:13:28
    |
-13 | #[diesel(treat_none_as_null("true"))]
+LL | #[diesel(treat_none_as_null("true"))]
    |                            ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(treat_none_as_null = true)]`
-  --> tests/fail/derive/bad_treat_none_as_null.rs:21:28
+  --> tests/fail/derive/bad_treat_none_as_null.rs:22:28
    |
-21 | #[diesel(treat_none_as_null)]
+LL | #[diesel(treat_none_as_null)]
    |                            ^
 
 error: expected boolean literal
-  --> tests/fail/derive/bad_treat_none_as_null.rs:29:31
+  --> tests/fail/derive/bad_treat_none_as_null.rs:31:31
    |
-29 | #[diesel(treat_none_as_null = "foo")]
+LL | #[diesel(treat_none_as_null = "foo")]
    |                               ^^^^^
 
 error: expected `treat_none_as_null` field to be of type `Option<_>`
-  --> tests/fail/derive/bad_treat_none_as_null.rs:40:11
+  --> tests/fail/derive/bad_treat_none_as_null.rs:43:11
    |
-40 |     name: String,
+LL |     name: String,
    |           ^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/bad_variadic.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_variadic.rs
@@ -5,9 +5,11 @@ use diesel::*;
 #[declare_sql_function]
 extern "SQL" {
     #[variadic(not_a_literal_number)]
+    //~^ ERROR: expected integer literal
     fn f();
 
     #[variadic(3)]
+    //~^ ERROR: invalid variadic argument count: not enough function arguments
     fn g<A: SqlType>(a: A);
 }
 

--- a/diesel_compile_tests/tests/fail/derive/bad_variadic.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_variadic.stderr
@@ -1,11 +1,11 @@
 error: expected integer literal
  --> tests/fail/derive/bad_variadic.rs:7:16
   |
-7 |     #[variadic(not_a_literal_number)]
+LL |     #[variadic(not_a_literal_number)]
   |                ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid variadic argument count: not enough function arguments
-  --> tests/fail/derive/bad_variadic.rs:10:16
+  --> tests/fail/derive/bad_variadic.rs:11:16
    |
-10 |     #[variadic(3)]
+LL |     #[variadic(3)]
    |                ^

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_incorrect_lifetime_syntax.rs
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_incorrect_lifetime_syntax.rs
@@ -23,6 +23,8 @@ struct Foo<'a> {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Foo<'a>))]
+//~^ ERROR: use of undeclared lifetime name `'a`
+//~| ERROR: use of undeclared lifetime name `'a`
 struct Bar {
     foo_id: i32,
 }

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_incorrect_lifetime_syntax.stderr
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_incorrect_lifetime_syntax.stderr
@@ -1,17 +1,18 @@
 error[E0261]: use of undeclared lifetime name `'a`
   --> tests/fail/derive/belongs_to_incorrect_lifetime_syntax.rs:25:25
    |
-24 | #[derive(Associations)]
+LL | #[derive(Associations)]
    |          ------------ lifetime `'a` is missing in item created through this procedural macro
-25 | #[diesel(belongs_to(Foo<'a>))]
+LL | #[diesel(belongs_to(Foo<'a>))]
    |                         ^^ undeclared lifetime
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> tests/fail/derive/belongs_to_incorrect_lifetime_syntax.rs:25:25
    |
-24 | #[derive(Associations)]
+LL | #[derive(Associations)]
    |          ------------ lifetime `'a` is missing in item created through this procedural macro
-25 | #[diesel(belongs_to(Foo<'a>))]
+LL | #[diesel(belongs_to(Foo<'a>))]
    |                         ^^ undeclared lifetime
    |
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+For more information about this error, try `rustc --explain E0261`.

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_column.rs
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_column.rs
@@ -11,6 +11,8 @@ table! {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar))]
+//~^ ERROR: cannot find type `bar_id` in module `foo`
+//~| ERROR: cannot find value `bar_id` in module `foo`
 #[diesel(table_name = foo)]
 struct Foo1 {
     bar_id: i32,
@@ -18,6 +20,8 @@ struct Foo1 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+//~^ ERROR: cannot find type `bar_id` in module `foo`
+//~| ERROR: cannot find value `bar_id` in module `foo`
 #[diesel(table_name = foo)]
 struct Foo2 {
     bar_id: i32,
@@ -25,6 +29,8 @@ struct Foo2 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar))]
+//~^ ERROR: cannot find type `bar_id` in module `foo`
+//~| ERROR: cannot find value `bar_id` in module `foo`
 #[diesel(table_name = foo)]
 struct Foo3 {
     #[diesel(column_name = bar_id)]
@@ -33,6 +39,8 @@ struct Foo3 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+//~^ ERROR: cannot find type `bar_id` in module `foo`
+//~| ERROR: cannot find value `bar_id` in module `foo`
 #[diesel(table_name = foo)]
 struct Foo4 {
     #[diesel(column_name = bar_id)]

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_column.stderr
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_column.stderr
@@ -1,47 +1,47 @@
 error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:13:21
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:13:21
    |
-13 | #[diesel(belongs_to(Bar))]
+LL | #[diesel(belongs_to(Bar))]
    |                     ^^^ not found in `foo`
 
 error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:13:21
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:13:21
    |
-13 | #[diesel(belongs_to(Bar))]
-   |                     ^^^ not found in `foo`
-
-error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:20:40
-   |
-20 | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
-   |                                        ^^^^^^ not found in `foo`
-
-error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:20:40
-   |
-20 | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
-   |                                        ^^^^^^ not found in `foo`
-
-error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:27:21
-   |
-27 | #[diesel(belongs_to(Bar))]
-   |                     ^^^ not found in `foo`
-
-error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:27:21
-   |
-27 | #[diesel(belongs_to(Bar))]
+LL | #[diesel(belongs_to(Bar))]
    |                     ^^^ not found in `foo`
 
 error[E0412]: cannot find type `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:35:40
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:22:40
    |
-35 | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
    |                                        ^^^^^^ not found in `foo`
 
 error[E0425]: cannot find value `bar_id` in module `foo`
-  --> $DIR/belongs_to_missing_foreign_key_column.rs:35:40
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:22:40
    |
-35 | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+   |                                        ^^^^^^ not found in `foo`
+
+error[E0412]: cannot find type `bar_id` in module `foo`
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:31:21
+   |
+LL | #[diesel(belongs_to(Bar))]
+   |                     ^^^ not found in `foo`
+
+error[E0425]: cannot find value `bar_id` in module `foo`
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:31:21
+   |
+LL | #[diesel(belongs_to(Bar))]
+   |                     ^^^ not found in `foo`
+
+error[E0412]: cannot find type `bar_id` in module `foo`
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:41:40
+   |
+LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+   |                                        ^^^^^^ not found in `foo`
+
+error[E0425]: cannot find value `bar_id` in module `foo`
+  --> tests/fail/derive/belongs_to_missing_foreign_key_column.rs:41:40
+   |
+LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
    |                                        ^^^^^^ not found in `foo`

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.rs
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.rs
@@ -5,14 +5,17 @@ struct Bar;
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar))]
+//~^ ERROR: No field with column name bar_id
 struct Foo1 {}
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+//~^ ERROR: No field with column name bar_id
 struct Foo2 {}
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar))]
+//~^ ERROR: No field with column name bar_id
 struct Baz1 {
     #[diesel(column_name = baz_id)]
     bar_id: i32,
@@ -20,6 +23,7 @@ struct Baz1 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+//~^ ERROR: No field with column name bar_id
 struct Baz2 {
     #[diesel(column_name = baz_id)]
     bar_id: i32,

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.stderr
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.stderr
@@ -1,23 +1,23 @@
 error: No field with column name bar_id
  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:7:21
   |
-7 | #[diesel(belongs_to(Bar))]
+LL | #[diesel(belongs_to(Bar))]
   |                     ^^^
 
 error: No field with column name bar_id
-  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:11:40
+  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:12:40
    |
-11 | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
    |                                        ^^^^^^
 
 error: No field with column name bar_id
-  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:15:21
+  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:17:21
    |
-15 | #[diesel(belongs_to(Bar))]
+LL | #[diesel(belongs_to(Bar))]
    |                     ^^^
 
 error: No field with column name bar_id
-  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:22:40
+  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:25:40
    |
-22 | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
+LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
    |                                        ^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_parent_import.rs
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_parent_import.rs
@@ -10,6 +10,7 @@ table! {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar))]
+//~^ ERROR: cannot find type `Bar` in this scope
 struct Foo {
     bar_id: i32,
 }

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_parent_import.stderr
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_parent_import.stderr
@@ -1,5 +1,6 @@
 error[E0412]: cannot find type `Bar` in this scope
-  --> $DIR/belongs_to_missing_parent_import.rs:12:21
+  --> tests/fail/derive/belongs_to_missing_parent_import.rs:12:21
    |
-12 | #[diesel(belongs_to(Bar))]
+LL | #[diesel(belongs_to(Bar))]
    |                     ^^^ not found in this scope
+For more information about this error, try `rustc --explain E0412`.

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_second_parent.rs
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_second_parent.rs
@@ -27,6 +27,7 @@ struct Baz {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, Baz))]
+//~^ ERROR: unknown attribute, expected `foreign_key`
 #[diesel(table_name = foo)]
 struct Foo {
     bar_id: i32,

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_second_parent.stderr
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_second_parent.stderr
@@ -1,5 +1,5 @@
 error: unknown attribute, expected `foreign_key`
   --> tests/fail/derive/belongs_to_second_parent.rs:29:26
    |
-29 | #[diesel(belongs_to(Bar, Baz))]
+LL | #[diesel(belongs_to(Bar, Baz))]
    |                          ^^^

--- a/diesel_compile_tests/tests/fail/derive/embed_and_serialize_as_cannot_be_mixed.rs
+++ b/diesel_compile_tests/tests/fail/derive/embed_and_serialize_as_cannot_be_mixed.rs
@@ -20,6 +20,7 @@ struct NameAndHairColor<'a> {
 struct User<'a> {
     id: i32,
     #[diesel(embed, serialize_as = SomeType)]
+    //~^ ERROR: `#[diesel(embed)]` cannot be combined with `#[diesel(serialize_as)]`
     // to test the compile error, this type doesn't need to exist
     name_and_hair_color: NameAndHairColor<'a>,
 }
@@ -29,6 +30,7 @@ struct User<'a> {
 struct UserChangeSet<'a> {
     id: i32,
     #[diesel(embed, serialize_as = SomeType)]
+    //~^ ERROR: `#[diesel(embed)]` cannot be combined with `#[diesel(serialize_as)]`
     // to test the compile error, this type doesn't need to exist
     name_and_hair_color: NameAndHairColor<'a>,
 }

--- a/diesel_compile_tests/tests/fail/derive/embed_and_serialize_as_cannot_be_mixed.stderr
+++ b/diesel_compile_tests/tests/fail/derive/embed_and_serialize_as_cannot_be_mixed.stderr
@@ -1,11 +1,11 @@
 error: `#[diesel(embed)]` cannot be combined with `#[diesel(serialize_as)]`
   --> tests/fail/derive/embed_and_serialize_as_cannot_be_mixed.rs:22:7
    |
-22 |     #[diesel(embed, serialize_as = SomeType)]
+LL |     #[diesel(embed, serialize_as = SomeType)]
    |       ^^^^^^
 
 error: `#[diesel(embed)]` cannot be combined with `#[diesel(serialize_as)]`
-  --> tests/fail/derive/embed_and_serialize_as_cannot_be_mixed.rs:31:7
+  --> tests/fail/derive/embed_and_serialize_as_cannot_be_mixed.rs:32:7
    |
-31 |     #[diesel(embed, serialize_as = SomeType)]
+LL |     #[diesel(embed, serialize_as = SomeType)]
    |       ^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/empty_struct.rs
+++ b/diesel_compile_tests/tests/fail/derive/empty_struct.rs
@@ -8,27 +8,34 @@ table! {
 }
 
 #[derive(AsChangeset)]
+//~^ ERROR: This derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User1;
 
 #[derive(Identifiable)]
+//~^ ERROR: This derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User2;
 
 #[derive(Insertable)]
+//~^ ERROR: This derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User3;
 
 #[derive(Queryable)]
+//~^ ERROR: This derive can only be used on non-unit structs
 struct User4;
 
 #[derive(QueryableByName)]
+//~^ ERROR: This derive can only be used on non-unit structs
 struct User5;
 
 #[derive(Selectable)]
+//~^ ERROR: This derive can only be used on non-unit structs
 struct User6;
 
 #[derive(Associations)]
+//~^ ERROR: This derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User7;
 

--- a/diesel_compile_tests/tests/fail/derive/empty_struct.stderr
+++ b/diesel_compile_tests/tests/fail/derive/empty_struct.stderr
@@ -1,55 +1,55 @@
 error: This derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:10:10
    |
-10 | #[derive(AsChangeset)]
+LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: This derive can only be used on non-unit structs
-  --> tests/fail/derive/empty_struct.rs:14:10
+  --> tests/fail/derive/empty_struct.rs:15:10
    |
-14 | #[derive(Identifiable)]
+LL | #[derive(Identifiable)]
    |          ^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `Identifiable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: This derive can only be used on non-unit structs
-  --> tests/fail/derive/empty_struct.rs:18:10
+  --> tests/fail/derive/empty_struct.rs:20:10
    |
-18 | #[derive(Insertable)]
+LL | #[derive(Insertable)]
    |          ^^^^^^^^^^
    |
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: This derive can only be used on non-unit structs
-  --> tests/fail/derive/empty_struct.rs:22:10
+  --> tests/fail/derive/empty_struct.rs:25:10
    |
-22 | #[derive(Queryable)]
+LL | #[derive(Queryable)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `Queryable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: This derive can only be used on non-unit structs
-  --> tests/fail/derive/empty_struct.rs:25:10
+  --> tests/fail/derive/empty_struct.rs:29:10
    |
-25 | #[derive(QueryableByName)]
+LL | #[derive(QueryableByName)]
    |          ^^^^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `QueryableByName` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: This derive can only be used on non-unit structs
-  --> tests/fail/derive/empty_struct.rs:28:10
+  --> tests/fail/derive/empty_struct.rs:33:10
    |
-28 | #[derive(Selectable)]
+LL | #[derive(Selectable)]
    |          ^^^^^^^^^^
    |
    = note: this error originates in the derive macro `Selectable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: This derive can only be used on non-unit structs
-  --> tests/fail/derive/empty_struct.rs:31:10
+  --> tests/fail/derive/empty_struct.rs:37:10
    |
-31 | #[derive(Associations)]
+LL | #[derive(Associations)]
    |          ^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `Associations` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.rs
+++ b/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.rs
@@ -8,10 +8,12 @@ table! {
 }
 
 #[derive(Identifiable)]
+//~^ ERROR: No field with column name id
 #[diesel(table_name = foo)]
 struct Foo1 {}
 
 #[derive(Identifiable)]
+//~^ ERROR: No field with column name id
 #[diesel(table_name = foo)]
 struct Foo2 {
     #[diesel(column_name = foo)]
@@ -20,11 +22,13 @@ struct Foo2 {
 
 #[derive(Identifiable)]
 #[diesel(primary_key(bar))]
+//~^ ERROR: No field with column name bar
 #[diesel(table_name = foo)]
 struct Foo3 {}
 
 #[derive(Identifiable)]
 #[diesel(primary_key(baz))]
+//~^ ERROR: No field with column name baz
 #[diesel(table_name = foo)]
 struct Foo4 {
     #[diesel(column_name = bar)]
@@ -33,6 +37,7 @@ struct Foo4 {
 
 #[derive(Identifiable)]
 #[diesel(primary_key(foo, bar))]
+//~^ ERROR: No field with column name bar
 #[diesel(table_name = foo)]
 struct Foo5 {
     foo: i32,
@@ -40,6 +45,7 @@ struct Foo5 {
 
 #[derive(Identifiable)]
 #[diesel(primary_key(foo, bar))]
+//~^ ERROR: No field with column name bar
 #[diesel(table_name = foo)]
 struct Foo6 {
     foo: i32,

--- a/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.stderr
+++ b/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.stderr
@@ -1,39 +1,39 @@
 error: No field with column name id
   --> tests/fail/derive/identifiable_missing_pk_field.rs:10:10
    |
-10 | #[derive(Identifiable)]
+LL | #[derive(Identifiable)]
    |          ^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `Identifiable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: No field with column name id
-  --> tests/fail/derive/identifiable_missing_pk_field.rs:14:10
+  --> tests/fail/derive/identifiable_missing_pk_field.rs:15:10
    |
-14 | #[derive(Identifiable)]
+LL | #[derive(Identifiable)]
    |          ^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `Identifiable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: No field with column name bar
-  --> tests/fail/derive/identifiable_missing_pk_field.rs:22:22
+  --> tests/fail/derive/identifiable_missing_pk_field.rs:24:22
    |
-22 | #[diesel(primary_key(bar))]
+LL | #[diesel(primary_key(bar))]
    |                      ^^^
 
 error: No field with column name baz
-  --> tests/fail/derive/identifiable_missing_pk_field.rs:27:22
+  --> tests/fail/derive/identifiable_missing_pk_field.rs:30:22
    |
-27 | #[diesel(primary_key(baz))]
+LL | #[diesel(primary_key(baz))]
    |                      ^^^
 
 error: No field with column name bar
-  --> tests/fail/derive/identifiable_missing_pk_field.rs:35:27
+  --> tests/fail/derive/identifiable_missing_pk_field.rs:39:27
    |
-35 | #[diesel(primary_key(foo, bar))]
+LL | #[diesel(primary_key(foo, bar))]
    |                           ^^^
 
 error: No field with column name bar
-  --> tests/fail/derive/identifiable_missing_pk_field.rs:42:27
+  --> tests/fail/derive/identifiable_missing_pk_field.rs:47:27
    |
-42 | #[diesel(primary_key(foo, bar))]
+LL | #[diesel(primary_key(foo, bar))]
    |                           ^^^

--- a/diesel_compile_tests/tests/fail/derive/multiple_table_names.rs
+++ b/diesel_compile_tests/tests/fail/derive/multiple_table_names.rs
@@ -27,6 +27,7 @@ struct Group {
 
 #[derive(AsChangeset)]
 #[diesel(table_name = users, table_name = users_)]
+//~^ ERROR: expected a single table name attribute
 struct User1 {
     id: i32,
     group_id: i32,
@@ -35,6 +36,7 @@ struct User1 {
 #[derive(Associations)]
 #[diesel(belongs_to(Group))]
 #[diesel(table_name = users, table_name = users_)]
+//~^ ERROR: expected a single table name attribute
 struct User2 {
     id: i32,
     group_id: i32,
@@ -42,6 +44,7 @@ struct User2 {
 
 #[derive(Identifiable)]
 #[diesel(table_name = users, table_name = users_)]
+//~^ ERROR: expected a single table name attribute
 struct User3 {
     id: i32,
     group_id: i32,
@@ -50,6 +53,7 @@ struct User3 {
 #[derive(Selectable)]
 #[diesel(table_name = users)]
 #[diesel(table_name = users_)]
+//~^ ERROR: expected a single table name attribute
 struct User4 {
     id: i32,
     group_id: i32,

--- a/diesel_compile_tests/tests/fail/derive/multiple_table_names.stderr
+++ b/diesel_compile_tests/tests/fail/derive/multiple_table_names.stderr
@@ -2,26 +2,26 @@ error: expected a single table name attribute
        note: remove this attribute
   --> tests/fail/derive/multiple_table_names.rs:29:30
    |
-29 | #[diesel(table_name = users, table_name = users_)]
+LL | #[diesel(table_name = users, table_name = users_)]
    |                              ^^^^^^^^^^
 
 error: expected a single table name attribute
        note: remove this attribute
-  --> tests/fail/derive/multiple_table_names.rs:37:30
+  --> tests/fail/derive/multiple_table_names.rs:38:30
    |
-37 | #[diesel(table_name = users, table_name = users_)]
+LL | #[diesel(table_name = users, table_name = users_)]
    |                              ^^^^^^^^^^
 
 error: expected a single table name attribute
        note: remove this attribute
-  --> tests/fail/derive/multiple_table_names.rs:44:30
+  --> tests/fail/derive/multiple_table_names.rs:46:30
    |
-44 | #[diesel(table_name = users, table_name = users_)]
+LL | #[diesel(table_name = users, table_name = users_)]
    |                              ^^^^^^^^^^
 
 error: expected a single table name attribute
        note: remove this attribute
-  --> tests/fail/derive/multiple_table_names.rs:52:10
+  --> tests/fail/derive/multiple_table_names.rs:55:10
    |
-52 | #[diesel(table_name = users_)]
+LL | #[diesel(table_name = users_)]
    |          ^^^^^^^^^^

--- a/diesel_compile_tests/tests/fail/derive/no_column.rs
+++ b/diesel_compile_tests/tests/fail/derive/no_column.rs
@@ -11,17 +11,23 @@ table! {
 #[diesel(table_name = users)]
 struct UserStruct1 {
     name: String,
+    //~^ ERROR: cannot find type `name` in module `users`
+    //~| ERROR: cannot find value `name` in module `users`
 }
 
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 struct UserStruct2 {
     #[diesel(column_name = name)]
+    //~^ ERROR: cannot find type `name` in module `users`
+    //~| ERROR: cannot find value `name` in module `users`
     full_name: String,
 }
 
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 struct UserTuple(#[diesel(column_name = name)] String);
+//~^ ERROR: cannot find type `name` in module `users`
+//~| ERROR: cannot find value `name` in module `users`
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/no_column.stderr
+++ b/diesel_compile_tests/tests/fail/derive/no_column.stderr
@@ -1,35 +1,35 @@
 error[E0412]: cannot find type `name` in module `users`
-  --> $DIR/no_column.rs:13:5
+  --> tests/fail/derive/no_column.rs:13:5
    |
-13 |     name: String,
+LL |     name: String,
    |     ^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
-  --> $DIR/no_column.rs:13:5
+  --> tests/fail/derive/no_column.rs:13:5
    |
-13 |     name: String,
+LL |     name: String,
    |     ^^^^ not found in `users`
 
 error[E0412]: cannot find type `name` in module `users`
-  --> $DIR/no_column.rs:19:28
+  --> tests/fail/derive/no_column.rs:21:28
    |
-19 |     #[diesel(column_name = name)]
+LL |     #[diesel(column_name = name)]
    |                            ^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
-  --> $DIR/no_column.rs:19:28
+  --> tests/fail/derive/no_column.rs:21:28
    |
-19 |     #[diesel(column_name = name)]
+LL |     #[diesel(column_name = name)]
    |                            ^^^^ not found in `users`
 
 error[E0412]: cannot find type `name` in module `users`
-  --> $DIR/no_column.rs:25:41
+  --> tests/fail/derive/no_column.rs:29:41
    |
-25 | struct UserTuple(#[diesel(column_name = name)] String);
+LL | struct UserTuple(#[diesel(column_name = name)] String);
    |                                         ^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
-  --> $DIR/no_column.rs:25:41
+  --> tests/fail/derive/no_column.rs:29:41
    |
-25 | struct UserTuple(#[diesel(column_name = name)] String);
+LL | struct UserTuple(#[diesel(column_name = name)] String);
    |                                         ^^^^ not found in `users`

--- a/diesel_compile_tests/tests/fail/derive/no_table.rs
+++ b/diesel_compile_tests/tests/fail/derive/no_table.rs
@@ -3,12 +3,14 @@ extern crate diesel;
 
 #[derive(AsChangeset)]
 struct User {
+    //~^ ERROR: failed to resolve: use of unresolved module or unlinked crate `users`
     id: i32,
     name: String,
 }
 
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
+//~^ ERROR: failed to resolve: use of unresolved module or unlinked crate `users`
 struct UserForm {
     id: i32,
     name: String,

--- a/diesel_compile_tests/tests/fail/derive/no_table.stderr
+++ b/diesel_compile_tests/tests/fail/derive/no_table.stderr
@@ -1,15 +1,16 @@
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `users`
  --> tests/fail/derive/no_table.rs:5:8
   |
-5 | struct User {
+LL | struct User {
   |        ^^^^ use of unresolved module or unlinked crate `users`
   |
-  = help: if you wanted to use a crate named `users`, use `cargo add users` to add it to your `Cargo.toml`
+  = help: you might be missing a crate named `users`
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `users`
-  --> tests/fail/derive/no_table.rs:11:23
+  --> tests/fail/derive/no_table.rs:12:23
    |
-11 | #[diesel(table_name = users)]
+LL | #[diesel(table_name = users)]
    |                       ^^^^^ use of unresolved module or unlinked crate `users`
    |
-   = help: if you wanted to use a crate named `users`, use `cargo add users` to add it to your `Cargo.toml`
+   = help: you might be missing a crate named `users`
+For more information about this error, try `rustc --explain E0433`.

--- a/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
+++ b/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
@@ -3,11 +3,13 @@ extern crate diesel;
 
 #[derive(QueryableByName)]
 struct Foo {
+    //~^ ERROR: failed to resolve: use of unresolved module or unlinked crate `foos`
     foo: i32,
     bar: String,
 }
 
 #[derive(QueryableByName)]
+//~^ ERROR: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
 struct Bar(i32, String);
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
+++ b/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
@@ -1,7 +1,7 @@
 error: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
-  --> tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:10:10
+  --> tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:11:10
    |
-10 | #[derive(QueryableByName)]
+LL | #[derive(QueryableByName)]
    |          ^^^^^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `QueryableByName` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -9,7 +9,8 @@ error: All fields of tuple structs must be annotated with `#[diesel(column_name)
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foos`
  --> tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:5:8
   |
-5 | struct Foo {
+LL | struct Foo {
   |        ^^^ use of unresolved module or unlinked crate `foos`
   |
-  = help: if you wanted to use a crate named `foos`, use `cargo add foos` to add it to your `Cargo.toml`
+  = help: you might be missing a crate named `foos`
+For more information about this error, try `rustc --explain E0433`.

--- a/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.rs
+++ b/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.rs
@@ -48,23 +48,27 @@ struct UserTypeMismatch {
 #[derive(Queryable)]
 struct UserNullableTypeMismatch {
     id: i32,
-    name: String,
-    bio: Option<String>,
+    name: Option<String>,
+    bio: String,
 }
 
 fn test(conn: &mut PgConnection) {
     // check that this works fine
     let _ = users::table.load::<User>(conn);
-
     let _ = users::table.load::<UserWithToFewFields>(conn);
+    //~^ ERROR: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<..., _>` is not satisfied
 
     let _ = users::table.load::<UserWithToManyFields>(conn);
+    //~^ ERROR: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<..., _>` is not satisfied
 
     let _ = users::table.load::<UserWrongOrder>(conn);
+    //~^ ERROR: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<UserWrongOrder, _>` is not satisfied
 
     let _ = users::table.load::<UserTypeMismatch>(conn);
+    //~^ ERROR: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<UserTypeMismatch, _>` is not satisfied
 
     let _ = users::table.load::<UserNullableTypeMismatch>(conn);
+    //~^ ERROR: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<..., _>` is not satisfied
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
+++ b/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
@@ -1,131 +1,165 @@
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserWithToFewFields, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_mismatch.rs:59:54
-   |
-59 |     let _ = users::table.load::<UserWithToFewFields>(conn);
-   |                          ----                        ^^^^ unsatisfied trait bound
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = help: the trait `load_dsl::private::CompatibleType<UserWithToFewFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
-   = note: this is a mismatch between what your query returns and what your type expects the query to return
-   = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-           on your struct `UserWithToFewFields` and in your query `.select(UserWithToFewFields::as_select())` to get a better error message
-   = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-             (ST0, ST1)
-             (ST0, ST1, ST2)
-             (ST0, ST1, ST2, ST3)
-             (ST0, ST1, ST2, ST3, ST4)
-             (ST0, ST1, ST2, ST3, ST4, ST5)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
-           and $N others
-   = note: required for `users::table` to implement `LoadQuery<'_, _, UserWithToFewFields>`
+error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<..., _>` is not satisfied
+    --> tests/fail/derive/queryable_type_mismatch.rs:58:54
+     |
+58   |     let _ = users::table.load::<UserWithToFewFields>(conn);
+     |                          ----                        ^^^^ the trait `load_dsl::private::CompatibleType<UserWithToFewFields, _>` is not implemented for `(Integer, Text, Nullable<Text>)`
+     |                          |
+     |                          required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `UserWithToFewFields` and in your query `.select(UserWithToFewFields::as_select())` to get a better error message
+     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
+               (ST0, ST1)
+               (ST0, ST1, ST2)
+               (ST0, ST1, ST2, ST3)
+               (ST0, ST1, ST2, ST3, ST4)
+               (ST0, ST1, ST2, ST3, ST4, ST5)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+             and N others
+     = note: required for `users::table` to implement `LoadQuery<'_, _, UserWithToFewFields>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserWithToManyFields, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_mismatch.rs:61:55
-   |
-61 |     let _ = users::table.load::<UserWithToManyFields>(conn);
-   |                          ----                         ^^^^ unsatisfied trait bound
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = help: the trait `load_dsl::private::CompatibleType<UserWithToManyFields, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
-   = note: this is a mismatch between what your query returns and what your type expects the query to return
-   = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-           on your struct `UserWithToManyFields` and in your query `.select(UserWithToManyFields::as_select())` to get a better error message
-   = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-             (ST0, ST1)
-             (ST0, ST1, ST2)
-             (ST0, ST1, ST2, ST3)
-             (ST0, ST1, ST2, ST3, ST4)
-             (ST0, ST1, ST2, ST3, ST4, ST5)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
-           and $N others
-   = note: required for `users::table` to implement `LoadQuery<'_, _, UserWithToManyFields>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<..., _>` is not satisfied
+    --> tests/fail/derive/queryable_type_mismatch.rs:61:55
+     |
+61   |     let _ = users::table.load::<UserWithToManyFields>(conn);
+     |                          ----                         ^^^^ the trait `load_dsl::private::CompatibleType<UserWithToManyFields, _>` is not implemented for `(Integer, Text, Nullable<Text>)`
+     |                          |
+     |                          required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `UserWithToManyFields` and in your query `.select(UserWithToManyFields::as_select())` to get a better error message
+     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
+               (ST0, ST1)
+               (ST0, ST1, ST2)
+               (ST0, ST1, ST2, ST3)
+               (ST0, ST1, ST2, ST3, ST4)
+               (ST0, ST1, ST2, ST3, ST4, ST5)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+             and N others
+     = note: required for `users::table` to implement `LoadQuery<'_, _, UserWithToManyFields>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserWrongOrder, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_mismatch.rs:63:49
-   |
-63 |     let _ = users::table.load::<UserWrongOrder>(conn);
-   |                          ----                   ^^^^ unsatisfied trait bound
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = help: the trait `load_dsl::private::CompatibleType<UserWrongOrder, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
-   = note: this is a mismatch between what your query returns and what your type expects the query to return
-   = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-           on your struct `UserWrongOrder` and in your query `.select(UserWrongOrder::as_select())` to get a better error message
-   = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-             (ST0, ST1)
-             (ST0, ST1, ST2)
-             (ST0, ST1, ST2, ST3)
-             (ST0, ST1, ST2, ST3, ST4)
-             (ST0, ST1, ST2, ST3, ST4, ST5)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
-           and $N others
-   = note: required for `users::table` to implement `LoadQuery<'_, _, UserWrongOrder>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<UserWrongOrder, _>` is not satisfied
+    --> tests/fail/derive/queryable_type_mismatch.rs:64:49
+     |
+64   |     let _ = users::table.load::<UserWrongOrder>(conn);
+     |                          ----                   ^^^^ the trait `load_dsl::private::CompatibleType<UserWrongOrder, _>` is not implemented for `(Integer, Text, Nullable<Text>)`
+     |                          |
+     |                          required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `UserWrongOrder` and in your query `.select(UserWrongOrder::as_select())` to get a better error message
+     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
+               (ST0, ST1)
+               (ST0, ST1, ST2)
+               (ST0, ST1, ST2, ST3)
+               (ST0, ST1, ST2, ST3, ST4)
+               (ST0, ST1, ST2, ST3, ST4, ST5)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+             and N others
+     = note: required for `users::table` to implement `LoadQuery<'_, _, UserWrongOrder>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>): load_dsl::private::CompatibleType<UserTypeMismatch, _>` is not satisfied
-  --> tests/fail/derive/queryable_type_mismatch.rs:65:51
-   |
-65 |     let _ = users::table.load::<UserTypeMismatch>(conn);
-   |                          ----                     ^^^^ unsatisfied trait bound
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = help: the trait `load_dsl::private::CompatibleType<UserTypeMismatch, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
-   = note: this is a mismatch between what your query returns and what your type expects the query to return
-   = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-           on your struct `UserTypeMismatch` and in your query `.select(UserTypeMismatch::as_select())` to get a better error message
-   = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-             (ST0, ST1)
-             (ST0, ST1, ST2)
-             (ST0, ST1, ST2, ST3)
-             (ST0, ST1, ST2, ST3, ST4)
-             (ST0, ST1, ST2, ST3, ST4, ST5)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
-           and $N others
-   = note: required for `users::table` to implement `LoadQuery<'_, _, UserTypeMismatch>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<UserTypeMismatch, _>` is not satisfied
+    --> tests/fail/derive/queryable_type_mismatch.rs:67:51
+     |
+67   |     let _ = users::table.load::<UserTypeMismatch>(conn);
+     |                          ----                     ^^^^ the trait `load_dsl::private::CompatibleType<UserTypeMismatch, _>` is not implemented for `(Integer, Text, Nullable<Text>)`
+     |                          |
+     |                          required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `UserTypeMismatch` and in your query `.select(UserTypeMismatch::as_select())` to get a better error message
+     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
+               (ST0, ST1)
+               (ST0, ST1, ST2)
+               (ST0, ST1, ST2, ST3)
+               (ST0, ST1, ST2, ST3, ST4)
+               (ST0, ST1, ST2, ST3, ST4, ST5)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+             and N others
+     = note: required for `users::table` to implement `LoadQuery<'_, _, UserTypeMismatch>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<..., _>` is not satisfied
+    --> tests/fail/derive/queryable_type_mismatch.rs:70:59
+     |
+70   |     let _ = users::table.load::<UserNullableTypeMismatch>(conn);
+     |                          ----                             ^^^^ the trait `load_dsl::private::CompatibleType<UserNullableTypeMismatch, _>` is not implemented for `(Integer, Text, Nullable<Text>)`
+     |                          |
+     |                          required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `UserNullableTypeMismatch` and in your query `.select(UserNullableTypeMismatch::as_select())` to get a better error message
+     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
+               (ST0, ST1)
+               (ST0, ST1, ST2)
+               (ST0, ST1, ST2, ST3)
+               (ST0, ST1, ST2, ST3, ST4)
+               (ST0, ST1, ST2, ST3, ST4, ST5)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+             and N others
+     = note: required for `users::table` to implement `LoadQuery<'_, _, UserNullableTypeMismatch>`
+note: required by a bound in `diesel::RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.rs
+++ b/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.rs
@@ -16,9 +16,11 @@ mod with_return_type_helpers {
     #[declare_sql_function(generate_return_type_helpers)]
     extern "SQL" {
         fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
+        //~^ ERROR: cannot find argument corresponding to the generic
 
         #[variadic(1)]
         fn g<A: SingleValue>(a: <A as TypeWrapper>::Type);
+        //~^ ERROR: cannot find argument corresponding to the generic
 
         #[skip_return_type_helper]
         fn h<A: SingleValue>(a: <A as TypeWrapper>::Type);

--- a/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.stderr
+++ b/diesel_compile_tests/tests/fail/derive/return_type_helper_errors.stderr
@@ -1,11 +1,11 @@
 error: cannot find argument corresponding to the generic
   --> tests/fail/derive/return_type_helper_errors.rs:18:14
    |
-18 |         fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
+LL |         fn f<A: SingleValue>(a: <A as TypeWrapper>::Type);
    |              ^
 
 error: cannot find argument corresponding to the generic
-  --> tests/fail/derive/return_type_helper_errors.rs:21:14
+  --> tests/fail/derive/return_type_helper_errors.rs:22:14
    |
-21 |         fn g<A: SingleValue>(a: <A as TypeWrapper>::Type);
+LL |         fn g<A: SingleValue>(a: <A as TypeWrapper>::Type);
    |              ^

--- a/diesel_compile_tests/tests/fail/derive/selectable.rs
+++ b/diesel_compile_tests/tests/fail/derive/selectable.rs
@@ -24,18 +24,25 @@ struct User {
     )]
     name_and_id: (Option<String>, i32),
     non_existing: String,
+    //~^ ERROR: cannot find type `non_existing` in module `users`
+    //~| ERROR: cannot find value `non_existing` in module `users`
     #[diesel(
         select_expression = users::non_existing,
+        //~^ ERROR: cannot find value `non_existing` in module `users`
         select_expression_type = users::non_existing
+        //~^ ERROR: cannot find type `non_existing` in module `users`
     )]
     non_existing_with_annotation: String,
     #[diesel(
         select_expression = (users::id, users::non_existing),
+        //~^ ERROR: cannot find value `non_existing` in module `users`
         select_expression_type = (users::id, users::non_existing)
+        //~^ ERROR: cannot find type `non_existing` in module `users`
     )]
     non_existing_in_tuple: (i32, String),
     #[diesel(
         select_expression = (users::id + 45),
+        //~^ ERROR: mismatched types
         select_expression_type = users::id,
     )]
     no_tuple: i32,
@@ -46,6 +53,7 @@ struct User {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 struct User1<'a> {
     name: &'a str,
+    //~^ ERROR: References are not supported in `Queryable` types
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/selectable.stderr
@@ -1,50 +1,50 @@
 error: References are not supported in `Queryable` types
        Consider using `std::borrow::Cow<'a, str>` instead
-  --> tests/fail/derive/selectable.rs:48:11
+  --> tests/fail/derive/selectable.rs:55:11
    |
-48 |     name: &'a str,
+LL |     name: &'a str,
    |           ^
 
 error[E0412]: cannot find type `non_existing` in module `users`
   --> tests/fail/derive/selectable.rs:26:5
    |
-26 |     non_existing: String,
+LL |     non_existing: String,
    |     ^^^^^^^^^^^^ not found in `users`
 
 error[E0412]: cannot find type `non_existing` in module `users`
-  --> tests/fail/derive/selectable.rs:29:41
+  --> tests/fail/derive/selectable.rs:32:41
    |
-29 |         select_expression_type = users::non_existing
+LL |         select_expression_type = users::non_existing
    |                                         ^^^^^^^^^^^^ not found in `users`
 
 error[E0412]: cannot find type `non_existing` in module `users`
-  --> tests/fail/derive/selectable.rs:34:53
+  --> tests/fail/derive/selectable.rs:39:53
    |
-34 |         select_expression_type = (users::id, users::non_existing)
+LL |         select_expression_type = (users::id, users::non_existing)
    |                                                     ^^^^^^^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `non_existing` in module `users`
   --> tests/fail/derive/selectable.rs:26:5
    |
-26 |     non_existing: String,
+LL |     non_existing: String,
    |     ^^^^^^^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `non_existing` in module `users`
-  --> tests/fail/derive/selectable.rs:28:36
+  --> tests/fail/derive/selectable.rs:30:36
    |
-28 |         select_expression = users::non_existing,
+LL |         select_expression = users::non_existing,
    |                                    ^^^^^^^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `non_existing` in module `users`
-  --> tests/fail/derive/selectable.rs:33:48
+  --> tests/fail/derive/selectable.rs:37:48
    |
-33 |         select_expression = (users::id, users::non_existing),
+LL |         select_expression = (users::id, users::non_existing),
    |                                                ^^^^^^^^^^^^ not found in `users`
 
 error[E0308]: mismatched types
-  --> tests/fail/derive/selectable.rs:38:29
+  --> tests/fail/derive/selectable.rs:44:29
    |
-38 |         select_expression = (users::id + 45),
+LL |         select_expression = (users::id + 45),
    |                             ^^^^^^^^^^^^^^^^ expected `id`, found `Add<id, Bound<Integer, i32>>`
    |
    = note: expected struct `columns::id`

--- a/diesel_compile_tests/tests/fail/derive/tuple_struct.rs
+++ b/diesel_compile_tests/tests/fail/derive/tuple_struct.rs
@@ -10,6 +10,7 @@ table! {
 }
 
 #[derive(AsChangeset)]
+//~^ ERROR: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
 #[diesel(table_name = users)]
 struct User(i32, #[diesel(column_name = name)] String, String);
 

--- a/diesel_compile_tests/tests/fail/derive/tuple_struct.stderr
+++ b/diesel_compile_tests/tests/fail/derive/tuple_struct.stderr
@@ -1,7 +1,7 @@
 error: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
   --> tests/fail/derive/tuple_struct.rs:12:10
    |
-12 | #[derive(AsChangeset)]
+LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/unknown_attribute.rs
+++ b/diesel_compile_tests/tests/fail/derive/unknown_attribute.rs
@@ -3,6 +3,7 @@ extern crate diesel;
 
 #[derive(Queryable)]
 #[diesel(what = true)]
+//~^ ERROR: unknown attribute, expected one of `aggregate`, `not_sized`, `foreign_derive`, `table_name`, `sql_type`, `treat_none_as_default_value`, `treat_none_as_null`, `belongs_to`, `mysql_type`, `sqlite_type`, `postgres_type`, `primary_key`, `check_for_backend`
 struct User1 {
     id: i32,
 }
@@ -10,6 +11,7 @@ struct User1 {
 #[derive(Queryable)]
 struct User2 {
     #[diesel(what = true)]
+    //~^ ERROR: unknown attribute, expected one of `embed`, `skip_insertion`, `column_name`, `sql_type`, `treat_none_as_default_value`, `treat_none_as_null`, `serialize_as`, `deserialize_as`, `select_expression`, `select_expression_type`
     id: i32,
 }
 

--- a/diesel_compile_tests/tests/fail/derive/unknown_attribute.stderr
+++ b/diesel_compile_tests/tests/fail/derive/unknown_attribute.stderr
@@ -1,11 +1,11 @@
 error: unknown attribute, expected one of `aggregate`, `not_sized`, `foreign_derive`, `table_name`, `sql_type`, `treat_none_as_default_value`, `treat_none_as_null`, `belongs_to`, `mysql_type`, `sqlite_type`, `postgres_type`, `primary_key`, `check_for_backend`
  --> tests/fail/derive/unknown_attribute.rs:5:10
   |
-5 | #[diesel(what = true)]
+LL | #[diesel(what = true)]
   |          ^^^^
 
 error: unknown attribute, expected one of `embed`, `skip_insertion`, `column_name`, `sql_type`, `treat_none_as_default_value`, `treat_none_as_null`, `serialize_as`, `deserialize_as`, `select_expression`, `select_expression_type`
-  --> tests/fail/derive/unknown_attribute.rs:12:14
+  --> tests/fail/derive/unknown_attribute.rs:13:14
    |
-12 |     #[diesel(what = true)]
+LL |     #[diesel(what = true)]
    |              ^^^^

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_belongs_to.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_belongs_to.rs
@@ -27,6 +27,7 @@ struct Baz {
 
 #[derive(Associations)]
 #[belongs_to]
+//~^ ERROR: unexpected end of input, expected parentheses
 #[diesel(table_name = foo)]
 struct Foo1 {
     bar_id: i32,
@@ -34,6 +35,8 @@ struct Foo1 {
 
 #[derive(Associations)]
 #[belongs_to = Bar]
+//~^ ERROR: attribute value must be a literal
+//~| ERROR: expected parentheses
 #[diesel(table_name = foo)]
 struct Foo2 {
     bar_id: i32,
@@ -41,6 +44,7 @@ struct Foo2 {
 
 #[derive(Associations)]
 #[belongs_to()]
+//~^ ERROR: unexpected end of input, expected identifier
 #[diesel(table_name = foo)]
 struct Foo3 {
     bar_id: i32,
@@ -48,6 +52,7 @@ struct Foo3 {
 
 #[derive(Associations)]
 #[belongs_to("what")]
+//~^ ERROR: expected identifier
 #[diesel(table_name = foo)]
 struct Foo4 {
     bar_id: i32,
@@ -55,6 +60,7 @@ struct Foo4 {
 
 #[derive(Associations)]
 #[belongs_to(parent)]
+//~^ ERROR: unexpected end of input, expected `=`
 #[diesel(table_name = foo)]
 struct Foo5 {
     bar_id: i32,
@@ -62,6 +68,7 @@ struct Foo5 {
 
 #[derive(Associations)]
 #[belongs_to(parent())]
+//~^ ERROR: expected `=`
 #[diesel(table_name = foo)]
 struct Foo6 {
     bar_id: i32,
@@ -69,6 +76,7 @@ struct Foo6 {
 
 #[derive(Associations)]
 #[belongs_to(parent = 1)]
+//~^ ERROR: expected string literal
 #[diesel(table_name = foo)]
 struct Foo7 {
     bar_id: i32,
@@ -76,6 +84,7 @@ struct Foo7 {
 
 #[derive(Associations)]
 #[belongs_to(parent = "1")]
+//~^ ERROR: expected identifier
 #[diesel(table_name = foo)]
 struct Foo8 {
     bar_id: i32,
@@ -90,6 +99,7 @@ struct Foo9 {
 
 #[derive(Associations)]
 #[belongs_to(Bar, what)]
+//~^ ERROR: expected `foreign_key`
 #[diesel(table_name = foo)]
 struct Foo10 {
     bar_id: i32,
@@ -97,6 +107,7 @@ struct Foo10 {
 
 #[derive(Associations)]
 #[belongs_to(Bar, foreign_key)]
+//~^ ERROR: unexpected end of input, expected `=`
 #[diesel(table_name = foo)]
 struct Foo11 {
     bar_id: i32,
@@ -104,6 +115,7 @@ struct Foo11 {
 
 #[derive(Associations)]
 #[belongs_to(Bar, foreign_key = 1)]
+//~^ ERROR: expected string literal
 #[diesel(table_name = foo)]
 struct Foo12 {
     bar_id: i32,
@@ -111,6 +123,7 @@ struct Foo12 {
 
 #[derive(Associations)]
 #[belongs_to(Bar, foreign_key = "1")]
+//~^ ERROR: expected identifier
 #[diesel(table_name = foo)]
 struct Foo13 {
     bar_id: i32,

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_belongs_to.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_belongs_to.stderr
@@ -2,79 +2,85 @@ error: unexpected end of input, expected parentheses
        help: The correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
   --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:29:3
    |
-29 | #[belongs_to]
+LL | #[belongs_to]
    |   ^^^^^^^^^^
 
 error: expected parentheses
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:36:14
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:37:14
    |
-36 | #[belongs_to = Bar]
+LL | #[belongs_to = Bar]
    |              ^
 
 error: unexpected end of input, expected identifier
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:43:13
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:46:13
    |
-43 | #[belongs_to()]
+LL | #[belongs_to()]
    |             ^^
 
 error: expected identifier
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:50:14
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:54:14
    |
-50 | #[belongs_to("what")]
+LL | #[belongs_to("what")]
    |              ^^^^^^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:57:14
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:62:14
    |
-57 | #[belongs_to(parent)]
+LL | #[belongs_to(parent)]
    |              ^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:64:20
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:70:20
    |
-64 | #[belongs_to(parent())]
+LL | #[belongs_to(parent())]
    |                    ^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:71:23
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:78:23
    |
-71 | #[belongs_to(parent = 1)]
+LL | #[belongs_to(parent = 1)]
    |                       ^
 
 error: expected identifier
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:78:23
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:86:23
    |
-78 | #[belongs_to(parent = "1")]
+LL | #[belongs_to(parent = "1")]
    |                       ^^^
 
+warning: #[belongs_to] attribute form is deprecated
+  = help: use `#[diesel(belongs_to(Bar))]` instead
+
 error: expected `foreign_key`
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:92:19
-   |
-92 | #[belongs_to(Bar, what)]
-   |                   ^^^^
+   --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:101:19
+    |
+LL | #[belongs_to(Bar, what)]
+    |                   ^^^^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:99:19
-   |
-99 | #[belongs_to(Bar, foreign_key)]
-   |                   ^^^^^^^^^^^
+   --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:109:19
+    |
+LL | #[belongs_to(Bar, foreign_key)]
+    |                   ^^^^^^^^^^^
 
 error: expected string literal
-   --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:106:33
+   --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:117:33
     |
-106 | #[belongs_to(Bar, foreign_key = 1)]
+LL | #[belongs_to(Bar, foreign_key = 1)]
     |                                 ^
 
 error: expected identifier
-   --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:113:33
+   --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:125:33
     |
-113 | #[belongs_to(Bar, foreign_key = "1")]
+LL | #[belongs_to(Bar, foreign_key = "1")]
     |                                 ^^^
 
+warning: #[belongs_to] attribute form is deprecated
+  = help: use `#[diesel(belongs_to(Baz, foreign_key = bar_id))]` instead
+
 error: attribute value must be a literal
-  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:36:16
+  --> tests/fail/derive_deprecated/deprecated_belongs_to.rs:37:16
    |
-36 | #[belongs_to = Bar]
+LL | #[belongs_to = Bar]
    |                ^^^

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_changeset_options.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_changeset_options.rs
@@ -19,6 +19,7 @@ struct UserForm1 {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[changeset_options]
+//~^ ERROR: unexpected end of input, expected parentheses
 struct UserForm2 {
     id: i32,
     name: String,
@@ -27,6 +28,7 @@ struct UserForm2 {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[changeset_options()]
+//~^ ERROR: unexpected end of input, expected identifier
 struct UserForm3 {
     id: i32,
     name: String,
@@ -35,6 +37,7 @@ struct UserForm3 {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[changeset_options(what)]
+//~^ ERROR: expected `treat_none_as_null`
 struct UserForm4 {
     id: i32,
     name: String,
@@ -43,6 +46,7 @@ struct UserForm4 {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[changeset_options(treat_none_as_null)]
+//~^ ERROR: unexpected end of input, expected `=`
 struct UserForm5 {
     id: i32,
     name: String,
@@ -51,6 +55,7 @@ struct UserForm5 {
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 #[changeset_options(treat_none_as_null = "what")]
+//~^ ERROR: expected boolean literal
 struct UserForm6 {
     id: i32,
     name: String,

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_changeset_options.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_changeset_options.stderr
@@ -1,30 +1,33 @@
+warning: #[changeset_options] attribute form is deprecated
+  = help: use `#[diesel(treat_none_as_null = true)]` instead
+
 error: unexpected end of input, expected parentheses
   --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:21:3
    |
-21 | #[changeset_options]
+LL | #[changeset_options]
    |   ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected identifier
-  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:29:20
+  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:30:20
    |
-29 | #[changeset_options()]
+LL | #[changeset_options()]
    |                    ^^
 
 error: expected `treat_none_as_null`
-  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:37:21
+  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:39:21
    |
-37 | #[changeset_options(what)]
+LL | #[changeset_options(what)]
    |                     ^^^^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(treat_none_as_null = true)]`
-  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:45:21
+  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:48:21
    |
-45 | #[changeset_options(treat_none_as_null)]
+LL | #[changeset_options(treat_none_as_null)]
    |                     ^^^^^^^^^^^^^^^^^^
 
 error: expected boolean literal
-  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:53:42
+  --> tests/fail/derive_deprecated/deprecated_changeset_options.rs:57:42
    |
-53 | #[changeset_options(treat_none_as_null = "what")]
+LL | #[changeset_options(treat_none_as_null = "what")]
    |                                          ^^^^^^

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_column_name.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_column_name.rs
@@ -11,17 +11,22 @@ table! {
 #[diesel(table_name = users)]
 struct UserStruct1 {
     #[column_name = "name"]
+    //~^ ERROR: cannot find type `name` in module `users`
+    //~| ERROR: cannot find value `name` in module `users`
     full_name: String,
 }
 
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 struct UserTuple(#[column_name = "name"] String);
+//~^ ERROR: cannot find type `name` in module `users`
+//~| ERROR: cannot find value `name` in module `users`
 
 #[derive(AsChangeset)]
 #[diesel(table_name = users)]
 struct UserStruct2 {
     #[column_name]
+    //~^ ERROR: unexpected end of input, expected `=`
     id: i32,
 }
 
@@ -29,6 +34,7 @@ struct UserStruct2 {
 #[diesel(table_name = users)]
 struct UserStruct3 {
     #[column_name()]
+    //~^ ERROR: expected `=`
     id: i32,
 }
 
@@ -36,6 +42,7 @@ struct UserStruct3 {
 #[diesel(table_name = users)]
 struct UserStruct4 {
     #[column_name = 1]
+    //~^ ERROR: expected string literal
     id: i32,
 }
 
@@ -43,6 +50,7 @@ struct UserStruct4 {
 #[diesel(table_name = users)]
 struct UserStruct5 {
     #[column_name = "1"]
+    //~^ ERROR: expected string literal
     id: i32,
 }
 

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_column_name.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_column_name.stderr
@@ -1,48 +1,57 @@
+warning: #[column_name] attribute form is deprecated
+  = help: use `#[diesel(column_name = name)]` instead
+
+warning: #[column_name] attribute form is deprecated
+  = help: use `#[diesel(column_name = name)]` instead
+
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(column_name = foo)]`
-  --> tests/fail/derive_deprecated/deprecated_column_name.rs:24:7
+  --> tests/fail/derive_deprecated/deprecated_column_name.rs:28:7
    |
-24 |     #[column_name]
+LL |     #[column_name]
    |       ^^^^^^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_column_name.rs:31:18
+  --> tests/fail/derive_deprecated/deprecated_column_name.rs:36:18
    |
-31 |     #[column_name()]
+LL |     #[column_name()]
    |                  ^^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_column_name.rs:38:21
+  --> tests/fail/derive_deprecated/deprecated_column_name.rs:44:21
    |
-38 |     #[column_name = 1]
+LL |     #[column_name = 1]
    |                     ^
 
+warning: #[column_name] attribute form is deprecated
+  = help: use `#[diesel(column_name = 1)]` instead
+
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_column_name.rs:45:21
+  --> tests/fail/derive_deprecated/deprecated_column_name.rs:52:21
    |
-45 |     #[column_name = "1"]
+LL |     #[column_name = "1"]
    |                     ^^^
 
 error[E0412]: cannot find type `name` in module `users`
   --> tests/fail/derive_deprecated/deprecated_column_name.rs:13:21
    |
-13 |     #[column_name = "name"]
+LL |     #[column_name = "name"]
    |                     ^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
   --> tests/fail/derive_deprecated/deprecated_column_name.rs:13:21
    |
-13 |     #[column_name = "name"]
+LL |     #[column_name = "name"]
    |                     ^^^^^^ not found in `users`
 
 error[E0412]: cannot find type `name` in module `users`
-  --> tests/fail/derive_deprecated/deprecated_column_name.rs:19:34
+  --> tests/fail/derive_deprecated/deprecated_column_name.rs:21:34
    |
-19 | struct UserTuple(#[column_name = "name"] String);
+LL | struct UserTuple(#[column_name = "name"] String);
    |                                  ^^^^^^ not found in `users`
 
 error[E0425]: cannot find value `name` in module `users`
-  --> tests/fail/derive_deprecated/deprecated_column_name.rs:19:34
+  --> tests/fail/derive_deprecated/deprecated_column_name.rs:21:34
    |
-19 | struct UserTuple(#[column_name = "name"] String);
+LL | struct UserTuple(#[column_name = "name"] String);
    |                                  ^^^^^^ not found in `users`

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_mysql_type.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_mysql_type.rs
@@ -4,17 +4,21 @@ use diesel::sql_types::SqlType;
 
 #[derive(SqlType)]
 #[mysql_type]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type1;
 
 #[derive(SqlType)]
 #[mysql_type()]
+//~^ ERROR: expected `=
 struct Type2;
 
 #[derive(SqlType)]
 #[mysql_type = 1]
+//~^ ERROR: expected string literal
 struct Type3;
 
 #[derive(SqlType)]
+//~^ ERROR: no variant or associated item named `foo` found for enum `MysqlType` in the current scope
 #[mysql_type = "foo"]
 struct Type4;
 

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_mysql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_mysql_type.stderr
@@ -2,25 +2,29 @@ error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(mysql_type(name = "foo"))]`
  --> tests/fail/derive_deprecated/deprecated_mysql_type.rs:6:3
   |
-6 | #[mysql_type]
+LL | #[mysql_type]
   |   ^^^^^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_mysql_type.rs:10:13
+  --> tests/fail/derive_deprecated/deprecated_mysql_type.rs:11:13
    |
-10 | #[mysql_type()]
+LL | #[mysql_type()]
    |             ^^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_mysql_type.rs:14:16
+  --> tests/fail/derive_deprecated/deprecated_mysql_type.rs:16:16
    |
-14 | #[mysql_type = 1]
+LL | #[mysql_type = 1]
    |                ^
 
+warning: #[mysql_type] attribute form is deprecated
+  = help: use `#[diesel(mysql_type(name = "foo"))]` instead
+
 error[E0599]: no variant or associated item named `foo` found for enum `MysqlType` in the current scope
-  --> tests/fail/derive_deprecated/deprecated_mysql_type.rs:17:10
+  --> tests/fail/derive_deprecated/deprecated_mysql_type.rs:20:10
    |
-17 | #[derive(SqlType)]
+LL | #[derive(SqlType)]
    |          ^^^^^^^ variant or associated item not found in `MysqlType`
    |
    = note: this error originates in the derive macro `SqlType` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0599`.

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_postgres_type.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_postgres_type.rs
@@ -4,46 +4,57 @@ use diesel::sql_types::SqlType;
 
 #[derive(SqlType)]
 #[postgres]
+//~^ ERROR: unexpected end of input, expected parentheses
 struct Type1;
 
 #[derive(SqlType)]
 #[postgres()]
+//~^ ERROR: expected `oid` and `array_oid` attribute or `name` attribute
 struct Type2;
 
 #[derive(SqlType)]
 #[postgres = "foo"]
+//~^ ERROR: expected parentheses
 struct Type3;
 
 #[derive(SqlType)]
 #[postgres(type_name)]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type4;
 
 #[derive(SqlType)]
 #[postgres(type_name())]
+//~^ ERROR: expected `=`
 struct Type5;
 
 #[derive(SqlType)]
 #[postgres(type_name = 1)]
+//~^ ERROR: expected string literal
 struct Type6;
 
 #[derive(SqlType)]
 #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
+//~^ ERROR: unexpected `oid` when `name` is present
 struct Type7;
 
 #[derive(SqlType)]
 #[postgres(type_name = "foo", array_oid = "3")]
+//~^ ERROR: unexpected `array_oid` when `name` is present
 struct Type8;
 
 #[derive(SqlType)]
 #[postgres(oid = "2")]
+//~^ ERROR: expected `oid` and `array_oid` attribute or `name` attribute
 struct Type9;
 
 #[derive(SqlType)]
 #[postgres(oid = 1, array_oid = "1")]
+//~^ ERROR: expected string literal
 struct Type10;
 
 #[derive(SqlType)]
 #[postgres(oid = "1", array_oid = 1)]
+//~^ ERROR: expected string literal
 struct Type11;
 
 #[derive(SqlType)]
@@ -52,6 +63,7 @@ struct Type12;
 
 #[derive(SqlType)]
 #[postgres(what)]
+//~^ ERROR: unknown attribute, expected one of `oid`, `array_oid`, `type_name`
 struct Type13;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_postgres_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_postgres_type.stderr
@@ -2,76 +2,79 @@ error: unexpected end of input, expected parentheses
        help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:6:3
   |
-6 | #[postgres]
+LL | #[postgres]
   |   ^^^^^^^^
 
 error: expected `oid` and `array_oid` attribute or `name` attribute
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:10:11
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:11:11
    |
-10 | #[postgres()]
+LL | #[postgres()]
    |           ^^
 
 error: expected parentheses
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:14:12
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:16:12
    |
-14 | #[postgres = "foo"]
+LL | #[postgres = "foo"]
    |            ^
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:18:12
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:21:12
    |
-18 | #[postgres(type_name)]
+LL | #[postgres(type_name)]
    |            ^^^^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:22:21
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:26:21
    |
-22 | #[postgres(type_name())]
+LL | #[postgres(type_name())]
    |                     ^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:26:24
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:31:24
    |
-26 | #[postgres(type_name = 1)]
+LL | #[postgres(type_name = 1)]
    |                        ^
 
 error: unexpected `oid` when `name` is present
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:30:31
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:36:31
    |
-30 | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
+LL | #[postgres(type_name = "foo", oid = "2", array_oid = "3")]
    |                               ^^^
 
 error: unexpected `array_oid` when `name` is present
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:34:31
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:41:31
    |
-34 | #[postgres(type_name = "foo", array_oid = "3")]
+LL | #[postgres(type_name = "foo", array_oid = "3")]
    |                               ^^^^^^^^^
 
 error: expected `oid` and `array_oid` attribute or `name` attribute
        help: The correct format looks like either `#[diesel(postgres_type(name = "foo", schema = "public"))]` or `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:38:11
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:46:11
    |
-38 | #[postgres(oid = "2")]
+LL | #[postgres(oid = "2")]
    |           ^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:42:18
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:51:18
    |
-42 | #[postgres(oid = 1, array_oid = "1")]
+LL | #[postgres(oid = 1, array_oid = "1")]
    |                  ^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:46:35
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:56:35
    |
-46 | #[postgres(oid = "1", array_oid = 1)]
+LL | #[postgres(oid = "1", array_oid = 1)]
    |                                   ^
 
+warning: #[postgres] attribute form is deprecated
+  = help: use `#[diesel(postgres_type(oid = 1, array_oid = 1))]` instead
+
 error: unknown attribute, expected one of `oid`, `array_oid`, `type_name`
-  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:54:12
+  --> tests/fail/derive_deprecated/deprecated_postgres_type.rs:65:12
    |
-54 | #[postgres(what)]
+LL | #[postgres(what)]
    |            ^^^^

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.rs
@@ -10,6 +10,7 @@ table! {
 
 #[derive(AsChangeset)]
 #[primary_key(id, bar = "baz")]
+//~^ ERROR: expected `,`
 struct UserForm1 {
     id: i32,
     name: String,
@@ -17,6 +18,7 @@ struct UserForm1 {
 
 #[derive(AsChangeset)]
 #[primary_key(id, qux(id))]
+//~^ ERROR: expected `,`
 struct UserForm2 {
     id: i32,
     name: String,
@@ -24,6 +26,7 @@ struct UserForm2 {
 
 #[derive(AsChangeset)]
 #[primary_key]
+//~^ ERROR: unexpected end of input, expected parentheses
 struct UserForm3 {
     id: i32,
     name: String,
@@ -31,12 +34,15 @@ struct UserForm3 {
 
 #[derive(AsChangeset)]
 #[primary_key = id]
+//~^ ERROR: attribute value must be a literal
+//~| ERROR: expected parentheses
 struct UserForm4 {
     id: i32,
     name: String,
 }
 
 #[derive(AsChangeset)]
+//~^ ERROR: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
 #[diesel(table_name = users)]
 #[primary_key(id, name)]
 struct UserForm5 {

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.stderr
@@ -1,39 +1,42 @@
 error: expected `,`
   --> tests/fail/derive_deprecated/deprecated_primary_key.rs:12:23
    |
-12 | #[primary_key(id, bar = "baz")]
+LL | #[primary_key(id, bar = "baz")]
    |                       ^
 
 error: expected `,`
-  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:19:22
+  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:20:22
    |
-19 | #[primary_key(id, qux(id))]
+LL | #[primary_key(id, qux(id))]
    |                      ^
 
 error: unexpected end of input, expected parentheses
-  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:26:3
+  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:28:3
    |
-26 | #[primary_key]
+LL | #[primary_key]
    |   ^^^^^^^^^^^
 
 error: expected parentheses
-  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:33:15
+  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:36:15
    |
-33 | #[primary_key = id]
+LL | #[primary_key = id]
    |               ^
+
+warning: #[primary_key] attribute form is deprecated
+  = help: use `#[diesel(primary_key(id, name))]` instead
 
 error: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
        help: If you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
        note: `#[derive(AsChangeset)]` never changes the primary key of a row.
-  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:39:10
+  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:44:10
    |
-39 | #[derive(AsChangeset)]
+LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: attribute value must be a literal
-  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:33:17
+  --> tests/fail/derive_deprecated/deprecated_primary_key.rs:36:17
    |
-33 | #[primary_key = id]
+LL | #[primary_key = id]
    |                 ^^

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sql_type.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sql_type.rs
@@ -4,51 +4,61 @@ use diesel::expression::AsExpression;
 
 #[derive(Debug, AsExpression)]
 #[sql_type = "foo"]
+//~^ ERROR: cannot find type `foo` in this scope
 struct Lol1;
 
 #[derive(AsExpression)]
 #[sql_type]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Lol2;
 
 #[derive(AsExpression)]
 #[sql_type()]
+//~^ ERROR: expected `=`
 struct Lol3;
 
 #[derive(AsExpression)]
 #[sql_type = 1]
+//~^ ERROR: expected string literal
 struct Lol4;
 
 #[derive(AsExpression)]
 #[sql_type = "1"]
+//~^ ERROR: expected identifier
 struct Lol5;
 
 #[derive(QueryableByName)]
 struct Lul1 {
     #[sql_type = "foo"]
+    //~^ ERROR: cannot find type `foo` in this scope
     foo: i32,
 }
 
 #[derive(QueryableByName)]
 struct Lul2 {
     #[sql_type]
+    //~^ ERROR: unexpected end of input, expected `=`
     foo: i32,
 }
 
 #[derive(QueryableByName)]
 struct Lul3 {
     #[sql_type()]
+    //~^ ERROR: expected `=
     foo: i32,
 }
 
 #[derive(QueryableByName)]
 struct Lul4 {
     #[sql_type = 1]
+    //~^ ERROR: expected string literal
     foo: i32,
 }
 
 #[derive(QueryableByName)]
 struct Lul5 {
     #[sql_type = "1"]
+    //~^ ERROR: expected identifier
     foo: i32,
 }
 

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sql_type.stderr
@@ -1,61 +1,74 @@
+warning: #[sql_type] attribute form is deprecated
+  = help: use `#[diesel(sql_type = foo)]` instead
+
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(sql_type = Foo)]`
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:10:3
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:11:3
    |
-10 | #[sql_type]
+LL | #[sql_type]
    |   ^^^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:14:11
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:16:11
    |
-14 | #[sql_type()]
+LL | #[sql_type()]
    |           ^^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:18:14
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:21:14
    |
-18 | #[sql_type = 1]
+LL | #[sql_type = 1]
    |              ^
 
+warning: #[sql_type] attribute form is deprecated
+  = help: use `#[diesel(sql_type = 1)]` instead
+
 error: expected identifier
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:22:14
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:26:14
    |
-22 | #[sql_type = "1"]
+LL | #[sql_type = "1"]
    |              ^^^
+
+warning: #[sql_type] attribute form is deprecated
+  = help: use `#[diesel(sql_type = foo)]` instead
 
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(sql_type = Foo)]`
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:33:7
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:39:7
    |
-33 |     #[sql_type]
+LL |     #[sql_type]
    |       ^^^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:39:15
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:46:15
    |
-39 |     #[sql_type()]
+LL |     #[sql_type()]
    |               ^^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:45:18
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:53:18
    |
-45 |     #[sql_type = 1]
+LL |     #[sql_type = 1]
    |                  ^
 
+warning: #[sql_type] attribute form is deprecated
+  = help: use `#[diesel(sql_type = 1)]` instead
+
 error: expected identifier
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:51:18
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:60:18
    |
-51 |     #[sql_type = "1"]
+LL |     #[sql_type = "1"]
    |                  ^^^
 
 error[E0412]: cannot find type `foo` in this scope
  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:6:14
   |
-6 | #[sql_type = "foo"]
+LL | #[sql_type = "foo"]
   |              ^^^^^ not found in this scope
 
 error[E0412]: cannot find type `foo` in this scope
-  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:27:18
+  --> tests/fail/derive_deprecated/deprecated_sql_type.rs:32:18
    |
-27 |     #[sql_type = "foo"]
+LL |     #[sql_type = "foo"]
    |                  ^^^^^ not found in this scope
+For more information about this error, try `rustc --explain E0412`.

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sqlite_type.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sqlite_type.rs
@@ -4,17 +4,21 @@ use diesel::sql_types::SqlType;
 
 #[derive(SqlType)]
 #[sqlite_type]
+//~^ ERROR: unexpected end of input, expected `=`
 struct Type1;
 
 #[derive(SqlType)]
 #[sqlite_type()]
+//~^ ERROR: expected `=`
 struct Type2;
 
 #[derive(SqlType)]
 #[sqlite_type = 1]
+//~^ ERROR: expected string literal
 struct Type3;
 
 #[derive(SqlType)]
+//~^ ERROR: no variant or associated item named `foo` found for enum `SqliteType` in the current scope
 #[sqlite_type = "foo"]
 struct Type4;
 

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sqlite_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_sqlite_type.stderr
@@ -2,25 +2,29 @@ error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(sqlite_type(name = "foo"))]`
  --> tests/fail/derive_deprecated/deprecated_sqlite_type.rs:6:3
   |
-6 | #[sqlite_type]
+LL | #[sqlite_type]
   |   ^^^^^^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_sqlite_type.rs:10:14
+  --> tests/fail/derive_deprecated/deprecated_sqlite_type.rs:11:14
    |
-10 | #[sqlite_type()]
+LL | #[sqlite_type()]
    |              ^^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_sqlite_type.rs:14:17
+  --> tests/fail/derive_deprecated/deprecated_sqlite_type.rs:16:17
    |
-14 | #[sqlite_type = 1]
+LL | #[sqlite_type = 1]
    |                 ^
 
+warning: #[sqlite_type] attribute form is deprecated
+  = help: use `#[diesel(sqlite_type(name = "foo"))]` instead
+
 error[E0599]: no variant or associated item named `foo` found for enum `SqliteType` in the current scope
-  --> tests/fail/derive_deprecated/deprecated_sqlite_type.rs:17:10
+  --> tests/fail/derive_deprecated/deprecated_sqlite_type.rs:20:10
    |
-17 | #[derive(SqlType)]
+LL | #[derive(SqlType)]
    |          ^^^^^^^ variant or associated item not found in `SqliteType`
    |
    = note: this error originates in the derive macro `SqlType` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0599`.

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_table_name.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_table_name.rs
@@ -3,6 +3,7 @@ extern crate diesel;
 
 #[derive(AsChangeset)]
 #[table_name = "users"]
+//~^ ERROR: failed to resolve: use of unresolved module or unlinked crate `users`
 struct UserForm1 {
     id: i32,
     name: String,
@@ -10,6 +11,7 @@ struct UserForm1 {
 
 #[derive(AsChangeset)]
 #[table_name]
+//~^ ERROR: unexpected end of input, expected `=`
 struct UserForm2 {
     id: i32,
     name: String,
@@ -17,12 +19,14 @@ struct UserForm2 {
 
 #[derive(AsChangeset)]
 #[table_name()]
+//~^ ERROR: expected `=`
 struct UserForm3 {
     name: String,
 }
 
 #[derive(AsChangeset)]
 #[table_name = 1]
+//~^ ERROR: expected string literal
 struct UserForm4 {
     id: i32,
     name: String,
@@ -30,6 +34,7 @@ struct UserForm4 {
 
 #[derive(AsChangeset)]
 #[table_name = "1"]
+//~^ ERROR: expected identifier
 struct UserForm5 {
     id: i32,
     name: String,

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_table_name.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_table_name.stderr
@@ -1,32 +1,39 @@
+warning: #[table_name] attribute form is deprecated
+  = help: use `#[diesel(table_name = users)]` instead
+
 error: unexpected end of input, expected `=`
        help: The correct format looks like `#[diesel(table_name = foo)]`
-  --> tests/fail/derive_deprecated/deprecated_table_name.rs:12:3
+  --> tests/fail/derive_deprecated/deprecated_table_name.rs:13:3
    |
-12 | #[table_name]
+LL | #[table_name]
    |   ^^^^^^^^^^
 
 error: expected `=`
-  --> tests/fail/derive_deprecated/deprecated_table_name.rs:19:13
+  --> tests/fail/derive_deprecated/deprecated_table_name.rs:21:13
    |
-19 | #[table_name()]
+LL | #[table_name()]
    |             ^^
 
 error: expected string literal
-  --> tests/fail/derive_deprecated/deprecated_table_name.rs:25:16
+  --> tests/fail/derive_deprecated/deprecated_table_name.rs:28:16
    |
-25 | #[table_name = 1]
+LL | #[table_name = 1]
    |                ^
 
+warning: #[table_name] attribute form is deprecated
+  = help: use `#[diesel(table_name = 1)]` instead
+
 error: expected identifier
-  --> tests/fail/derive_deprecated/deprecated_table_name.rs:32:16
+  --> tests/fail/derive_deprecated/deprecated_table_name.rs:36:16
    |
-32 | #[table_name = "1"]
+LL | #[table_name = "1"]
    |                ^^^
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `users`
  --> tests/fail/derive_deprecated/deprecated_table_name.rs:5:16
   |
-5 | #[table_name = "users"]
+LL | #[table_name = "users"]
   |                ^^^^^^^ use of unresolved module or unlinked crate `users`
   |
-  = help: if you wanted to use a crate named `users`, use `cargo add users` to add it to your `Cargo.toml`
+  = help: you might be missing a crate named `users`
+For more information about this error, try `rustc --explain E0433`.

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
@@ -24,9 +24,14 @@ fn main() {
 
     users::table
         .distinct_on(posts::id)
+        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
         .get_results(&mut connection);
+    //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
 
     posts::table
         .distinct_on((posts::name, users::name))
+        //~^ ERROR: Cannot select `users::columns::name` from `posts::table`
+        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .get_result(&mut connection);
+    //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text): SingleValue` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
@@ -1,34 +1,34 @@
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:26:22
-   |
-26 |         .distinct_on(posts::id)
-   |          ----------- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `posts::columns::id` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-             `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-             `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-             `posts::columns::id` implements `SelectableExpression<posts::table>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `users::table` to implement `DistinctOnDsl<posts::columns::id>`
+   --> tests/fail/distinct_on_allows_only_fields_of_table.rs:26:22
+    |
+26  |         .distinct_on(posts::id)
+    |          ----------- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `posts::columns::id` is no valid selection for `users::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+              `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::id` implements `SelectableExpression<posts::table>`
+              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    = note: required for `users::table` to implement `DistinctOnDsl<posts::columns::id>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: methods::DistinctOnDsl<Expr>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+    |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
 
 error[E0277]: Cannot select `users::columns::name` from `posts::table`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:30:10
+  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:32:10
    |
-30 |         .distinct_on((posts::name, users::name))
+LL |         .distinct_on((posts::name, users::name))
    |          ^^^^^^^^^^^ the trait `SelectableExpression<posts::table>` is not implemented for `users::columns::name`
    |
    = note: `users::columns::name` is no valid selection for `posts::table`
@@ -44,9 +44,9 @@ error[E0277]: Cannot select `users::columns::name` from `posts::table`
    = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:30:10
+  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:32:10
    |
-30 |         .distinct_on((posts::name, users::name))
+LL |         .distinct_on((posts::name, users::name))
    |          ^^^^^^^^^^^ expected `Once`, found `Never`
    |
 note: required for `users::columns::name` to implement `AppearsOnTable<posts::table>`
@@ -61,63 +61,64 @@ note: required for `users::columns::name` to implement `AppearsOnTable<posts::ta
    = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
 
 error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:27:22
-   |
-27 |         .get_results(&mut connection);
-   |          ----------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-   = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<posts::columns::id>>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
+    --> tests/fail/distinct_on_allows_only_fields_of_table.rs:28:22
+     |
+28   |         .get_results(&mut connection);
+     |          ----------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
 note: required by a bound in `get_results`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
+  
+     
 error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text): SingleValue` is not satisfied
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:31:21
-   |
-31 |         .get_result(&mut connection);
-   |          ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text), Pg>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text), Pg>`
-   = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<(posts::columns::name, users::columns::name)>>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
+    --> tests/fail/distinct_on_allows_only_fields_of_table.rs:35:21
+     |
+35   |         .get_result(&mut connection);
+     |          ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text), Pg>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text), Pg>`
+     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`

--- a/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.rs
@@ -14,8 +14,11 @@ fn main() {
     let mut sqlite_connection = SqliteConnection::establish(":memory:").unwrap();
 
     users.distinct_on(name).get_results(&mut sqlite_connection);
+    //~^ ERROR: `DistinctOnClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
+    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
 
     let mut mysql_connection = MysqlConnection::establish("mysql://foo").unwrap();
 
     users.distinct_on(name).get_results(&mut mysql_connection);
+    //~^ ERROR: `DistinctOnClause<columns::name>` is no valid SQL fragment for the `Mysql` backend
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.stderr
@@ -1,85 +1,89 @@
 error[E0277]: `DistinctOnClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:16:41
-   |
-16 |     users.distinct_on(name).get_results(&mut sqlite_connection);
-   |                             ----------- ^^^^^^^^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `DistinctOnClause<columns::name>`
-   |                             |
-   |                             required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `DistinctOnClause<columns::name>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Sqlite`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `QueryFragment<Sqlite, AnsiSqlSelectStatement>`
-   = note: 1 redundant requirement hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
+    --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:16:41
+     |
+16   |     users.distinct_on(name).get_results(&mut sqlite_connection);
+     |                             ----------- ^^^^^^^^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `DistinctOnClause<columns::name>`
+     |                             |
+     |                             required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `DistinctOnClause<columns::name>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `QueryFragment<Sqlite, AnsiSqlSelectStatement>`
+     = note: 1 redundant requirement hidden
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
 note: required by a bound in `get_results`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
+  
+     
 error[E0277]: `DistinctOnClause<columns::name>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:20:41
-   |
-20 |     users.distinct_on(name).get_results(&mut mysql_connection);
-   |                             ----------- ^^^^^^^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `DistinctOnClause<columns::name>`
-   |                             |
-   |                             required by a bound introduced by this call
-   |
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `DistinctOnClause<columns::name>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Mysql`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `QueryFragment<Mysql, AnsiSqlSelectStatement>`
-   = note: 1 redundant requirement hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `QueryFragment<Mysql>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `LoadQuery<'_, diesel::MysqlConnection, _>`
+    --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:22:41
+     |
+22   |     users.distinct_on(name).get_results(&mut mysql_connection);
+     |                             ----------- ^^^^^^^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `DistinctOnClause<columns::name>`
+     |                             |
+     |                             required by a bound introduced by this call
+     |
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `DistinctOnClause<columns::name>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Mysql`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `QueryFragment<Mysql, AnsiSqlSelectStatement>`
+     = note: 1 redundant requirement hidden
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::MysqlConnection, _>`
 note: required by a bound in `get_results`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
+  
+     
 error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
-  --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:16:41
-   |
-16 |     users.distinct_on(name).get_results(&mut sqlite_connection);
-   |                             ----------- ^^^^^^^^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   |                             |
-   |                             required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-   = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
+    --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:16:41
+     |
+16   |     users.distinct_on(name).get_results(&mut sqlite_connection);
+     |                             ----------- ^^^^^^^^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     |                             |
+     |                             required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
+     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `get_results`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
@@ -11,7 +11,6 @@ table! {
 }
 
 fn main() {
-
     // verify that we could use distinct on without order clause
     let _ = users::table.distinct_on(users::name);
 
@@ -19,16 +18,24 @@ fn main() {
     let _ = users::table.order_by(users::name).distinct_on(users::name);
 
     // verify that we could use distinct on with an order clause that contains also a different column
-    let _ = users::table.order_by((users::name, users::id)).distinct_on(users::name);
+    let _ = users::table
+        .order_by((users::name, users::id))
+        .distinct_on(users::name);
 
     // verify that we could use multiple columns for both order by and distinct on
-    let _ = users::table.order_by((users::name, users::id)).distinct_on((users::name, users::id));
+    let _ = users::table
+        .order_by((users::name, users::id))
+        .distinct_on((users::name, users::id));
 
     // verify that we could use multiple columns for both order by and distinct on and distinct on has more columns than order by
-    let _ = users::table.order_by((users::name, users::id)).distinct_on((users::name, users::id, users::hair_color));
+    let _ = users::table
+        .order_by((users::name, users::id))
+        .distinct_on((users::name, users::id, users::hair_color));
 
     // verify that we could use multiple columns for both order by and distinct on and distinct on has less columns than order by
-    let _ = users::table.order_by((users::name, users::id, users::hair_color)).distinct_on((users::name, users::id));
+    let _ = users::table
+        .order_by((users::name, users::id, users::hair_color))
+        .distinct_on((users::name, users::id));
 
     // verify that we could use distinct on with a select expression and an order clause that contains a different column
     let _ = users::table
@@ -111,29 +118,40 @@ fn main() {
     //
     // we do not allow queries with order clauses that does not contain the distinct value
     let _ = users::table.order_by(users::id).distinct_on(users::name);
+    //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
 
     // we do not allow queries where the distinct on expression is not the first expression
     // in our order clause
-    let _ = users::table.order_by((users::id, users::name)).distinct_on(users::name);
+    let _ = users::table
+        .order_by((users::id, users::name))
+        .distinct_on(users::name);
+    //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
 
     // we cannot workaround that with `then_order_by`
     let _ = users::table
         .order_by(users::id)
         .then_order_by(users::name)
         .distinct_on(users::name);
+    //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
 
     // it's not possible to set an invalid order clause after we set
     // the distinct on clause
     let _ = users::table.distinct_on(users::name).order_by(users::id);
+    //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
 
     // we cannot box invalid queries
-    let _ = users::table.order_by(users::id).distinct_on(users::name).into_boxed();
+    let _ = users::table
+        .order_by(users::id)
+        .distinct_on(users::name)
+        //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+        .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
     // for multiple order by and one distinct on
     let _ = users::table
         .order_by((users::id, users::name))
         .distinct_on(users::name)
+        //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
         .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
@@ -141,6 +159,7 @@ fn main() {
     let _ = users::table
         .order_by((users::id, users::name))
         .distinct_on((users::name, users::id))
+        //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
         .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
@@ -148,6 +167,7 @@ fn main() {
     let _ = users::table
         .order_by(users::id)
         .distinct_on((users::name, users::id))
+        //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<...>>` is not satisfied
         .into_boxed();
 
     // we cannot workaround that with `then_order_by`
@@ -155,6 +175,7 @@ fn main() {
         .order_by(users::id)
         .then_order_by(users::name)
         .distinct_on(users::name)
+        //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
         .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
@@ -162,5 +183,6 @@ fn main() {
     let _ = users::table
         .distinct_on(users::name)
         .order_by(users::id)
+        //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
         .into_boxed();
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -1,7 +1,7 @@
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<columns::id>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:113:58
+error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:120:58
     |
-113 |     let _ = users::table.order_by(users::id).distinct_on(users::name);
+LL |     let _ = users::table.order_by(users::id).distinct_on(users::name);
     |                                              ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |                                              |
     |                                              required by a bound introduced by this call
@@ -16,50 +16,22 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>` to implement `DistinctOnDsl<columns::name>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:117:73
+ 
+    
+error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:127:22
     |
-117 |     let _ = users::table.order_by((users::id, users::name)).distinct_on(users::name);
-    |                                                             ----------- ^^^^^^^^^^^ unsatisfied trait bound
-    |                                                             |
-    |                                                             required by a bound introduced by this call
-    |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
-    = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>>` to implement `DistinctOnDsl<columns::name>`
-note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
-    |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:123:22
-    |
-123 |         .distinct_on(users::name);
+LL |         .distinct_on(users::name);
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
@@ -74,21 +46,52 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>>` to implement `DistinctOnDsl<columns::name>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<columns::id>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:127:60
+ 
+    
+error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:134:22
     |
-127 |     let _ = users::table.distinct_on(users::name).order_by(users::id);
+LL |         .distinct_on(users::name);
+    |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
+    = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
+              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
+              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
+              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
+              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
+              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
+              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
+              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
+              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
+note: required by a bound in `diesel::QueryDsl::distinct_on`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+    |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+ 
+    
+error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:139:60
+    |
+LL |     let _ = users::table.distinct_on(users::name).order_by(users::id);
     |                                                   -------- ^^^^^^^^^ unsatisfied trait bound
     |                                                   |
     |                                                   required by a bound introduced by this call
@@ -103,24 +106,25 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `OrderDsl<columns::id>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `OrderDsl<columns::id>`
 note: required by a bound in `order_by`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
+LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
     |        -------- required by a bound in this associated function
 ...
-    |         Self: methods::OrderDsl<Expr>,
+LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<columns::id>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:130:58
+ 
+    
+error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:145:22
     |
-130 |     let _ = users::table.order_by(users::id).distinct_on(users::name).into_boxed();
-    |                                              ----------- ^^^^^^^^^^^ unsatisfied trait bound
-    |                                              |
-    |                                              required by a bound introduced by this call
+LL |         .distinct_on(users::name)
+    |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
@@ -132,21 +136,22 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>` to implement `DistinctOnDsl<columns::name>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:136:22
+ 
+    
+error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:153:22
     |
-136 |         .distinct_on(users::name)
+LL |         .distinct_on(users::name)
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
@@ -161,21 +166,22 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>>` to implement `DistinctOnDsl<columns::name>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:143:22
+ 
+    
+error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:161:22
     |
-143 |         .distinct_on((users::name, users::id))
+LL |         .distinct_on((users::name, users::id))
     |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
@@ -190,21 +196,22 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<columns::id>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:150:22
+ 
+    
+error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<...>>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:169:22
     |
-150 |         .distinct_on((users::name, users::id))
+LL |         .distinct_on((users::name, users::id))
     |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
@@ -219,21 +226,22 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<columns::id>>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:157:22
+ 
+    
+error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:177:22
     |
-157 |         .distinct_on(users::name)
+LL |         .distinct_on(users::name)
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
@@ -248,21 +256,22 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>>` to implement `DistinctOnDsl<columns::name>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
     |        ----------- required by a bound in this associated function
-    |     where
-    |         Self: methods::DistinctOnDsl<Expr>,
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<columns::id>: query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not satisfied
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:164:19
+ 
+    
+error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:185:19
     |
-164 |         .order_by(users::id)
+LL |         .order_by(users::id)
     |          -------- ^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
@@ -277,13 +286,15 @@ error[E0277]: the trait bound `diesel::query_builder::order_clause::OrderClause<
               `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
               `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and $N others
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::name>>` to implement `OrderDsl<columns::id>`
+            and N others
+    = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `OrderDsl<columns::id>`
 note: required by a bound in `order_by`
-   --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
-    |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
+LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
     |        -------- required by a bound in this associated function
 ...
-    |         Self: methods::OrderDsl<Expr>,
+LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
+ 
+    For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/ensure_sqlite_cannot_access_memory_of_dropped_bind.rs
+++ b/diesel_compile_tests/tests/fail/ensure_sqlite_cannot_access_memory_of_dropped_bind.rs
@@ -1,5 +1,6 @@
+//@no-rustfix
+use diesel::connection::{DefaultLoadingMode, LoadConnection};
 use diesel::prelude::*;
-use diesel::connection::{LoadConnection, DefaultLoadingMode};
 use diesel::sql_types;
 
 fn main() {
@@ -15,6 +16,7 @@ fn main() {
         // Sqlite borrows the buffer internally, so dropping it here is not allowed
         // while the statement is still alive.
         std::mem::drop(buf);
+        //~^ ERROR: cannot move out of `buf` because it is borrowed
 
         assert_eq!(iter.next().is_some(), true);
         assert_eq!(iter.next().is_none(), true);
@@ -66,5 +68,4 @@ fn main() {
         std::mem::drop(iter);
         std::mem::drop(buf);
     }
-
 }

--- a/diesel_compile_tests/tests/fail/ensure_sqlite_cannot_access_memory_of_dropped_bind.stderr
+++ b/diesel_compile_tests/tests/fail/ensure_sqlite_cannot_access_memory_of_dropped_bind.stderr
@@ -1,19 +1,20 @@
 error[E0505]: cannot move out of `buf` because it is borrowed
-  --> tests/fail/ensure_sqlite_cannot_access_memory_of_dropped_bind.rs:17:24
+  --> tests/fail/ensure_sqlite_cannot_access_memory_of_dropped_bind.rs:18:24
    |
-9  |         let buf: Vec<u8> = vec![0, 1, 2];
+LL |         let buf: Vec<u8> = vec![0, 1, 2];
    |             --- binding `buf` declared here
-10 |
-11 |         let query = diesel::select((&buf as &[u8]).into_sql::<sql_types::Binary>());
+LL |
+LL |         let query = diesel::select((&buf as &[u8]).into_sql::<sql_types::Binary>());
    |                                     ---- borrow of `buf` occurs here
 ...
-17 |         std::mem::drop(buf);
+LL |         std::mem::drop(buf);
    |                        ^^^ move out of `buf` occurs here
-18 |
-19 |         assert_eq!(iter.next().is_some(), true);
+...
+LL |         assert_eq!(iter.next().is_some(), true);
    |                    ---- borrow later used here
    |
 help: consider cloning the value if the performance cost is acceptable
    |
-11 |         let query = diesel::select((&buf.clone() as &[u8]).into_sql::<sql_types::Binary>());
+LL |         let query = diesel::select((&buf.clone() as &[u8]).into_sql::<sql_types::Binary>());
    |                                         ++++++++
+For more information about this error, try `rustc --explain E0505`.

--- a/diesel_compile_tests/tests/fail/eq_any_is_nullable.rs
+++ b/diesel_compile_tests/tests/fail/eq_any_is_nullable.rs
@@ -16,5 +16,6 @@ fn main() {
     let _: Vec<bool> = users::table
         .select(users::name.eq_any(["foo", "bar"]))
         .load(&mut conn)
+        //~^ ERROR: cannot deserialize a value of the database type `diesel::sql_types::Nullable<Bool>` as `bool`
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/eq_any_is_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/eq_any_is_nullable.stderr
@@ -1,25 +1,27 @@
 error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Nullable<Bool>` as `bool`
-  --> tests/fail/eq_any_is_nullable.rs:18:15
-   |
-18 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Nullable<Bool>, Pg>` is not implemented for `bool`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `diesel::sql_types::Nullable<Bool>`
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             `bool` implements `FromSql<Bool, Mysql>`
-             `bool` implements `FromSql<Bool, Pg>`
-             `bool` implements `FromSql<Bool, Sqlite>`
-   = note: required for `bool` to implement `Queryable<diesel::sql_types::Nullable<Bool>, Pg>`
-   = note: required for `bool` to implement `FromSqlRow<diesel::sql_types::Nullable<Bool>, Pg>`
-   = note: required for `diesel::sql_types::Nullable<Bool>` to implement `load_dsl::private::CompatibleType<bool, Pg>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::grouped::Grouped<In<columns::name, Many<diesel::sql_types::Nullable<diesel::sql_types::Text>, &str>>>>>` to implement `LoadQuery<'_, diesel::PgConnection, bool>`
+    --> tests/fail/eq_any_is_nullable.rs:18:15
+     |
+18   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `FromSql<diesel::sql_types::Nullable<Bool>, Pg>` is not implemented for `bool`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `diesel::sql_types::Nullable<Bool>`
+     = help: the following other types implement trait `FromSql<A, DB>`:
+               `bool` implements `FromSql<Bool, Mysql>`
+               `bool` implements `FromSql<Bool, Pg>`
+               `bool` implements `FromSql<Bool, Sqlite>`
+     = note: required for `bool` to implement `Queryable<diesel::sql_types::Nullable<Bool>, Pg>`
+     = note: required for `bool` to implement `FromSqlRow<diesel::sql_types::Nullable<Bool>, Pg>`
+     = note: required for `diesel::sql_types::Nullable<Bool>` to implement `load_dsl::private::CompatibleType<bool, Pg>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<Grouped<...>>>` to implement `LoadQuery<'_, diesel::PgConnection, bool>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/exists_can_only_take_subselects.rs
+++ b/diesel_compile_tests/tests/fail/exists_can_only_take_subselects.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::dsl::exists;
+use diesel::*;
 
 table! {
     users {
@@ -18,8 +18,13 @@ table! {
 fn main() {
     let mut conn = SqliteConnection::establish(":memory:").unwrap();
     // Sanity check, no error
-    users::table.filter(exists(posts::table.select(posts::id))).execute(&mut conn).unwrap();
+    users::table
+        .filter(exists(posts::table.select(posts::id)))
+        .execute(&mut conn)
+        .unwrap();
 
     users::table.filter(exists(true));
+    //~^ ERROR: the trait bound `bool: SelectQuery` is not satisfied
     users::table.filter(exists(users::id));
+    //~^ ERROR: the trait bound `users::columns::id: SelectQuery` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/exists_can_only_take_subselects.stderr
+++ b/diesel_compile_tests/tests/fail/exists_can_only_take_subselects.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `bool: SelectQuery` is not satisfied
-  --> tests/fail/exists_can_only_take_subselects.rs:23:18
+  --> tests/fail/exists_can_only_take_subselects.rs:26:18
    |
-23 |     users::table.filter(exists(true));
+LL |     users::table.filter(exists(true));
    |                  ^^^^^^ the trait `SelectQuery` is not implemented for `bool`
    |
    = help: the following other types implement trait `SelectQuery`:
@@ -14,9 +14,9 @@ error[E0277]: the trait bound `bool: SelectQuery` is not satisfied
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `FilterDsl<Exists<bool>>`
 
 error[E0277]: the trait bound `users::columns::id: SelectQuery` is not satisfied
-  --> tests/fail/exists_can_only_take_subselects.rs:24:18
+  --> tests/fail/exists_can_only_take_subselects.rs:28:18
    |
-24 |     users::table.filter(exists(users::id));
+LL |     users::table.filter(exists(users::id));
    |                  ^^^^^^ the trait `SelectQuery` is not implemented for `users::columns::id`
    |
    = help: the following other types implement trait `SelectQuery`:
@@ -27,3 +27,4 @@ error[E0277]: the trait bound `users::columns::id: SelectQuery` is not satisfied
    = note: 1 redundant requirement hidden
    = note: required for `Exists<users::columns::id>` to implement `diesel::Expression`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `FilterDsl<Exists<users::columns::id>>`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.rs
+++ b/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.rs
@@ -13,5 +13,7 @@ fn main() {
     use self::users::dsl::*;
 
     let pred = id.eq("string");
+    //~^ ERROR: the trait bound `str: diesel::Expression` is not satisfied
     let pred = id.eq(name);
+    //~^ ERROR: type mismatch resolving `<name as Expression>::SqlType == Integer`
 }

--- a/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `str: diesel::Expression` is not satisfied
   --> tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.rs:15:19
    |
-15 |     let pred = id.eq("string");
+LL |     let pred = id.eq("string");
    |                   ^^ the trait `diesel::Expression` is not implemented for `str`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -13,14 +13,14 @@ error[E0277]: the trait bound `str: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `&str` to implement `diesel::Expression`
    = note: required for `&str` to implement `AsExpression<diesel::sql_types::Integer>`
 
 error[E0271]: type mismatch resolving `<name as Expression>::SqlType == Integer`
-  --> tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.rs:16:19
+  --> tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.rs:17:19
    |
-16 |     let pred = id.eq(name);
+LL |     let pred = id.eq(name);
    |                   ^^ type mismatch resolving `<name as Expression>::SqlType == Integer`
    |
 note: expected this to be `diesel::sql_types::Integer`

--- a/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::pg::Pg;
+use diesel::*;
 
 table! {
     users {
@@ -28,26 +28,29 @@ struct User {
 fn main() {
     let mut conn = PgConnection::establish("").unwrap();
 
-    let _ = users::table.filter(posts::id.eq(1))
+    let _ = users::table.filter(posts::id.eq(1)).load::<User>(&mut conn);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+
+    let _ = users::table.into_boxed::<Pg>().filter(posts::id.eq(1));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+
+    let _ = users::table.filter(posts::id.eq(1)).into_boxed::<Pg>();
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+    // FIXME: It'd be great if this mentioned `AppearsInFromClause` instead...
+
+    let _ = users::table
+        .filter(users::name.eq(posts::title))
         .load::<User>(&mut conn);
+    //~^ ERROR: AppearsInFromClause
 
     let _ = users::table
         .into_boxed::<Pg>()
-        .filter(posts::id.eq(1));
-
-    let _ = users::table.filter(posts::id.eq(1))
-        .into_boxed::<Pg>();
-        // FIXME: It'd be great if this mentioned `AppearsInFromClause` instead...
-
-    let _ = users::table.filter(users::name.eq(posts::title))
-        .load::<User>(&mut conn);
-        //~^ ERROR AppearsInFromClause
-
-    let _ = users::table.into_boxed::<Pg>()
         .filter(users::name.eq(posts::title));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 
     let _ = users::table
         .filter(users::name.eq(posts::title))
         .into_boxed::<Pg>();
-        // FIXME: It'd be great if this mentioned `AppearsInFromClause` instead...
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+    // FIXME: It'd be great if this mentioned `AppearsInFromClause` instead...
 }

--- a/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.stderr
+++ b/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.stderr
@@ -1,109 +1,112 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:32:23
-   |
-32 |         .load::<User>(&mut conn);
-   |          ----         ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:31:63
+     |
+31   |     let _ = users::table.filter(posts::id.eq(1)).load::<User>(&mut conn);
+     |                                                  ----         ^^^^^^^^^ expected `Once`, found `Never`
+     |                                                  |
+     |                                                  required by a bound introduced by this call
+     |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:15:9
-   |
-15 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>` to implement `LoadQuery<'_, _, User>`
+    --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:15:9
+     |
+15   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 2 redundant requirements hidden
+     = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
+     = note: required for `WhereClause<Grouped<Eq<id, Bound<Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:36:10
+  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:34:45
    |
-36 |         .filter(posts::id.eq(1));
-   |          ^^^^^^ expected `Once`, found `Never`
+LL |     let _ = users::table.into_boxed::<Pg>().filter(posts::id.eq(1));
+   |                                             ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:15:9
    |
-15 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
+   = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: BoxedDsl<'_, Pg>` is not satisfied
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:39:10
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:37:50
    |
-39 |         .into_boxed::<Pg>();
-   |          ^^^^^^^^^^ unsatisfied trait bound
+LL |     let _ = users::table.filter(posts::id.eq(1)).into_boxed::<Pg>();
+   |                                                  ^^^^^^^^^^ the trait `BoxedDsl<'_, Pg>` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
    |
-   = help: the trait `BoxedDsl<'_, Pg>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:43:23
-   |
-43 |         .load::<User>(&mut conn);
-   |          ----         ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:43:23
+     |
+43   |         .load::<User>(&mut conn);
+     |          ----         ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:16:9
-   |
-16 |         title -> VarChar,
-   |         ^^^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>>` to implement `LoadQuery<'_, _, User>`
+    --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:16:9
+     |
+16   |         title -> VarChar,
+     |         ^^^^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 2 redundant requirements hidden
+     = note: required for `Grouped<Eq<name, title>>` to implement `AppearsOnTable<users::table>`
+     = note: required for `WhereClause<Grouped<Eq<name, title>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:47:10
+  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:48:10
    |
-47 |         .filter(users::name.eq(posts::title));
+LL |         .filter(users::name.eq(posts::title));
    |          ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:16:9
    |
-16 |         title -> VarChar,
+LL |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>`
+   = note: required for `Grouped<Eq<name, title>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>>: BoxedDsl<'_, Pg>` is not satisfied
-  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:51:10
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+  --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:53:10
    |
-51 |         .into_boxed::<Pg>();
-   |          ^^^^^^^^^^ unsatisfied trait bound
+LL |         .into_boxed::<Pg>();
+   |          ^^^^^^^^^^ the trait `BoxedDsl<'_, Pg>` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
    |
-   = help: the trait `BoxedDsl<'_, Pg>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>>`
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>

--- a/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.rs
+++ b/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.rs
@@ -13,5 +13,7 @@ fn main() {
     use diesel::dsl::sum;
 
     let _ = users::table.filter(users::name);
+    //~^ ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
     let _ = users::table.filter(sum(users::id).eq(1));
+    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.stderr
+++ b/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.stderr
@@ -1,35 +1,37 @@
 error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
-  --> tests/fail/filter_requires_bool_nonaggregate_expression.rs:15:33
-   |
-15 |     let _ = users::table.filter(users::name);
-   |                          ------ ^^^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Text`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = note: try to provide an expression that produces one of the expected sql types
-   = help: the following other types implement trait `BoolOrNullableBool`:
-             Bool
-             Nullable<Bool>
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `FilterDsl<columns::name>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `FilterDsl<columns::name>`
+   --> tests/fail/filter_requires_bool_nonaggregate_expression.rs:15:33
+    |
+15  |     let _ = users::table.filter(users::name);
+    |                          ------ ^^^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Text`
+    |                          |
+    |                          required by a bound introduced by this call
+    |
+    = note: try to provide an expression that produces one of the expected sql types
+    = help: the following other types implement trait `BoolOrNullableBool`:
+              Bool
+              Nullable<Bool>
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `FilterDsl<columns::name>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `FilterDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::filter`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn filter<Predicate>(self, predicate: Predicate) -> Filter<Self, Predicate>
-   |        ------ required by a bound in this associated function
-   |     where
-   |         Self: methods::FilterDsl<Predicate>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::filter`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn filter<Predicate>(self, predicate: Predicate) -> Filter<Self, Predicate>
+    |        ------ required by a bound in this associated function
+LL |     where
+LL |         Self: methods::FilterDsl<Predicate>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::filter`
 
 error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
-  --> tests/fail/filter_requires_bool_nonaggregate_expression.rs:16:26
+  --> tests/fail/filter_requires_bool_nonaggregate_expression.rs:17:26
    |
-16 |     let _ = users::table.filter(sum(users::id).eq(1));
+LL |     let _ = users::table.filter(sum(users::id).eq(1));
    |                          ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
    |
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, columns::id>, diesel::expression::bound::Bound<Nullable<BigInt>, i64>>>` to implement `NonAggregate`
+   = note: required for `Grouped<Eq<sum<Integer, id>, Bound<Nullable<BigInt>, i64>>>` to implement `NonAggregate`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, columns::id>, diesel::expression::bound::Bound<Nullable<BigInt>, i64>>>>`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.rs
@@ -18,6 +18,10 @@ fn main() {
     let mut connection = PgConnection::establish("").unwrap();
     // FIXME: It'd be nice if this mentioned `AsExpression`
     int_primary_key::table.find("1");
+    //~^ ERROR: the trait bound `str: diesel::Expression` is not satisfied
+    //~| ERROR: the trait bound `str: ValidGrouping<()>` is not satisfied
     // FIXME: It'd be nice if this mentioned `AsExpression`
     string_primary_key::table.find(1);
+    //~^ ERROR: the trait bound `{integer}: diesel::Expression` is not satisfied
+    //~| ERROR: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `str: diesel::Expression` is not satisfied
   --> tests/fail/find_requires_correct_type.rs:20:28
    |
-20 |     int_primary_key::table.find("1");
+LL |     int_primary_key::table.find("1");
    |                            ^^^^ the trait `diesel::Expression` is not implemented for `str`
    |
    = help: the following other types implement trait `diesel::Expression`:
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `str: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `&str` to implement `diesel::Expression`
    = note: 1 redundant requirement hidden
    = note: required for `diesel::expression::operators::Eq<int_primary_key::columns::id, &str>` to implement `diesel::Expression`
@@ -22,7 +22,7 @@ error[E0277]: the trait bound `str: diesel::Expression` is not satisfied
 error[E0277]: the trait bound `str: ValidGrouping<()>` is not satisfied
   --> tests/fail/find_requires_correct_type.rs:20:28
    |
-20 |     int_primary_key::table.find("1");
+LL |     int_primary_key::table.find("1");
    |                            ^^^^ the trait `ValidGrouping<()>` is not implemented for `str`
    |
    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
@@ -34,76 +34,79 @@ error[E0277]: the trait bound `str: ValidGrouping<()>` is not satisfied
              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-           and $N others
+           and N others
    = note: required for `&str` to implement `ValidGrouping<()>`
    = note: 1 redundant requirement hidden
    = note: required for `diesel::expression::operators::Eq<int_primary_key::columns::id, &str>` to implement `ValidGrouping<()>`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<int_primary_key::columns::id, &str>>` to implement `NonAggregate`
+   = note: required for `Grouped<Eq<id, &str>>` to implement `NonAggregate`
    = note: required for `SelectStatement<FromClause<int_primary_key::table>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<int_primary_key::columns::id, &str>>>`
 
+   
 error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
-  --> tests/fail/find_requires_correct_type.rs:22:36
-   |
-22 |     string_primary_key::table.find(1);
-   |                               ---- ^ the trait `diesel::Expression` is not implemented for `{integer}`
-   |                               |
-   |                               required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `diesel::Expression`:
-             &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
-   = note: required for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>` to implement `diesel::Expression`
+   --> tests/fail/find_requires_correct_type.rs:24:36
+    |
+24  |     string_primary_key::table.find(1);
+    |                               ---- ^ the trait `diesel::Expression` is not implemented for `{integer}`
+    |                               |
+    |                               required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `diesel::Expression`:
+              &T
+              (T0, T1)
+              (T0, T1, T2)
+              (T0, T1, T2, T3)
+              (T0, T1, T2, T3, T4)
+              (T0, T1, T2, T3, T4, T5)
+              (T0, T1, T2, T3, T4, T5, T6)
+              (T0, T1, T2, T3, T4, T5, T6, T7)
+            and N others
+    = note: required for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>` to implement `diesel::Expression`
 note: required for `string_primary_key::columns::id` to implement `EqAll<{integer}>`
-  --> tests/fail/find_requires_correct_type.rs:13:9
-   |
-13 |         id -> VarChar,
-   |         ^^
-   = note: required for `string_primary_key::table` to implement `FindDsl<{integer}>`
+   --> tests/fail/find_requires_correct_type.rs:13:9
+    |
+13  |         id -> VarChar,
+    |         ^^
+    = note: required for `string_primary_key::table` to implement `FindDsl<{integer}>`
 note: required by a bound in `diesel::QueryDsl::find`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn find<PK>(self, id: PK) -> Find<Self, PK>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: methods::FindDsl<PK>,
-   |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::find`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn find<PK>(self, id: PK) -> Find<Self, PK>
+    |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::FindDsl<PK>,
+    |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::find`
 
 error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
-  --> tests/fail/find_requires_correct_type.rs:22:36
-   |
-22 |     string_primary_key::table.find(1);
-   |                               ---- ^ the trait `ValidGrouping<()>` is not implemented for `{integer}`
-   |                               |
-   |                               required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-             `&T` implements `ValidGrouping<GB>`
-             `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
-           and $N others
-   = note: required for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>` to implement `ValidGrouping<()>`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>` to implement `NonAggregate`
-   = note: required for `SelectStatement<FromClause<string_primary_key::table>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `string_primary_key::table` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>`
-   = note: required for `string_primary_key::table` to implement `FindDsl<{integer}>`
+   --> tests/fail/find_requires_correct_type.rs:24:36
+    |
+24  |     string_primary_key::table.find(1);
+    |                               ---- ^ the trait `ValidGrouping<()>` is not implemented for `{integer}`
+    |                               |
+    |                               required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `&T` implements `ValidGrouping<GB>`
+              `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
+            and N others
+    = note: required for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>` to implement `ValidGrouping<()>`
+    = note: required for `Grouped<Eq<id, {integer}>>` to implement `NonAggregate`
+    = note: required for `SelectStatement<FromClause<string_primary_key::table>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `string_primary_key::table` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>>>`
+    = note: required for `string_primary_key::table` to implement `FindDsl<{integer}>`
 note: required by a bound in `diesel::QueryDsl::find`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn find<PK>(self, id: PK) -> Find<Self, PK>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: methods::FindDsl<PK>,
-   |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::find`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn find<PK>(self, id: PK) -> Find<Self, PK>
+    |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::FindDsl<PK>,
+    |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::find`
+ 
+    For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs
+++ b/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs
@@ -27,4 +27,6 @@ fn main() {
         .inner_join(posts::table)
         .group_by((users::id, posts::user_id))
         .select((users::id, posts::user_id, diesel::dsl::count_star()));
+    //~^ ERROR: the trait bound `posts::columns::user_id: IsContainedInGroupBy<users::columns::id>` is not satisfied
+    //~| ERROR: he trait bound `users::columns::id: IsContainedInGroupBy<posts::columns::user_id>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.stderr
+++ b/diesel_compile_tests/tests/fail/group_by_with_multiple_tables_gives_good_error_message.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `posts::columns::user_id: IsContainedInGroupBy<users::columns::id>` is not satisfied
   --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:29:10
    |
-29 |         .select((users::id, posts::user_id, diesel::dsl::count_star()));
+LL |         .select((users::id, posts::user_id, diesel::dsl::count_star()));
    |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `posts::columns::user_id`
    |
    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
@@ -19,12 +19,13 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
    |         ^^
    = note: 1 redundant requirement hidden
    = note: required for `(users::columns::id, posts::columns::user_id, CountStar)` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::id, posts::columns::user_id)>>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`
+   = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`
 
+   
 error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<posts::columns::user_id>` is not satisfied
   --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:29:10
    |
-29 |         .select((users::id, posts::user_id, diesel::dsl::count_star()));
+LL |         .select((users::id, posts::user_id, diesel::dsl::count_star()));
    |          ^^^^^^ the trait `IsContainedInGroupBy<posts::columns::user_id>` is not implemented for `users::columns::id`
    |
    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
@@ -35,8 +36,10 @@ error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<posts::c
 note: required for `posts::columns::user_id` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
   --> tests/fail/group_by_with_multiple_tables_gives_good_error_message.rs:16:9
    |
-16 |         user_id -> Integer,
+LL |         user_id -> Integer,
    |         ^^^^^^^
    = note: 2 redundant requirements hidden
    = note: required for `(users::columns::id, posts::columns::user_id, CountStar)` to implement `ValidGrouping<(users::columns::id, posts::columns::user_id)>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::id, posts::columns::user_id)>>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`
+   = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<(users::columns::id, posts::columns::user_id, CountStar)>`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.rs
+++ b/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.rs
@@ -23,11 +23,31 @@ allow_tables_to_appear_in_same_query!(users, posts);
 fn main() {
     let mut conn = PgConnection::establish("").unwrap();
 
-    users::table.select(users::name).having(users::id.gt(1)).load(&mut conn);
+    users::table
+        .select(users::name)
+        .having(users::id.gt(1))
+        //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, SelectClause<name>>: HavingDsl<_>` is not satisfied
+        .load(&mut conn);
 
-    users::table.into_boxed().having(users::id.gt(1)).load(&mut conn);
+    users::table
+        .into_boxed()
+        .having(users::id.gt(1))
+        //~^ ERROR: the trait bound `(): diesel::Expression` is not satisfied
+        .load(&mut conn);
+    //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
 
-    users::table.select(users::name).group_by(users::id).having(posts::id.eq(42)).load(&mut conn);
+    users::table
+        .select(users::name)
+        .group_by(users::id)
+        .having(posts::id.eq(42))
+        //~^ ERROR: ype mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        .load(&mut conn);
 
-    users::table.select(users::name).group_by(users::id).into_boxed().having(posts::id.eq(42)).load(&mut conn);
+    users::table
+        .select(users::name)
+        .group_by(users::id)
+        .into_boxed()
+        .having(posts::id.eq(42))
+        //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once
+        .load(&mut conn);
 }

--- a/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
@@ -1,18 +1,19 @@
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::name>>: HavingDsl<_>` is not satisfied
-  --> tests/fail/having_cant_be_used_without_group_by.rs:26:38
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, SelectClause<name>>: HavingDsl<_>` is not satisfied
+  --> tests/fail/having_cant_be_used_without_group_by.rs:28:10
    |
-26 |     users::table.select(users::name).having(users::id.gt(1)).load(&mut conn);
-   |                                      ^^^^^^ unsatisfied trait bound
+LL |         .having(users::id.gt(1))
+   |          ^^^^^^ the trait `HavingDsl<_>` is not implemented for `SelectStatement<FromClause<table>, SelectClause<name>>`
    |
-   = help: the trait `HavingDsl<_>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::name>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::NoLockingClause>`
-           but it is implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::name>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<_>, _, diesel::query_builder::locking_clause::NoLockingClause>`
+   = help: the trait `HavingDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, _>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::GroupByClause<_>, _, _>`
    = help: for that trait implementation, expected `diesel::query_builder::group_by_clause::GroupByClause<_>`, found `diesel::query_builder::group_by_clause::NoGroupByClause`
 
+   
 error[E0277]: the trait bound `(): diesel::Expression` is not satisfied
-  --> tests/fail/having_cant_be_used_without_group_by.rs:28:31
+  --> tests/fail/having_cant_be_used_without_group_by.rs:34:10
    |
-28 |     users::table.into_boxed().having(users::id.gt(1)).load(&mut conn);
-   |                               ^^^^^^ the trait `diesel::Expression` is not implemented for `()`
+LL |         .having(users::id.gt(1))
+   |          ^^^^^^ the trait `diesel::Expression` is not implemented for `()`
    |
    = help: the following other types implement trait `diesel::Expression`:
              (T0, T1)
@@ -23,68 +24,71 @@ error[E0277]: the trait bound `(): diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
              (T0, T1, T2, T3, T4, T5, T6, T7, T8)
-           and $N others
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>` to implement `HavingDsl<_>`
+           and N others
+   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>` to implement `HavingDsl<_>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/having_cant_be_used_without_group_by.rs:30:58
+  --> tests/fail/having_cant_be_used_without_group_by.rs:42:10
    |
-30 |     users::table.select(users::name).group_by(users::id).having(posts::id.eq(42)).load(&mut conn);
-   |                                                          ^^^^^^ expected `Once`, found `Never`
+LL |         .having(posts::id.eq(42))
+   |          ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/having_cant_be_used_without_group_by.rs:14:9
    |
-14 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::name>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::id>>` to implement `HavingDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
+   = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `HavingDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/having_cant_be_used_without_group_by.rs:32:71
+  --> tests/fail/having_cant_be_used_without_group_by.rs:50:10
    |
-32 |     users::table.select(users::name).group_by(users::id).into_boxed().having(posts::id.eq(42)).load(&mut conn);
-   |                                                                       ^^^^^^ expected `Once`, found `Never`
+LL |         .having(posts::id.eq(42))
+   |          ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/having_cant_be_used_without_group_by.rs:14:9
    |
-14 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `BoxedSelectStatement<'_, diesel::sql_types::Text, FromClause<users::table>, _, users::columns::id>` to implement `HavingDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
+   = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `BoxedSelectStatement<'_, Text, FromClause<table>, _, id>` to implement `HavingDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
+   
 error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
-  --> tests/fail/having_cant_be_used_without_group_by.rs:28:60
-   |
-28 |     users::table.into_boxed().having(users::id.gt(1)).load(&mut conn);
-   |                                                       ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   |                                                       |
-   |                                                       required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-   = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, Pg>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
+    --> tests/fail/having_cant_be_used_without_group_by.rs:36:15
+     |
+36   |         .load(&mut conn);
+     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
+     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
+     = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/ilike_only_compiles_for_pg.rs
+++ b/diesel_compile_tests/tests/fail/ilike_only_compiles_for_pg.rs
@@ -18,8 +18,14 @@ struct User {
 
 fn main() {
     let mut connection = SqliteConnection::establish("").unwrap();
-    users::table.filter(users::name.ilike("%hey%")).execute(&mut connection);
+    users::table
+        .filter(users::name.ilike("%hey%"))
+        .execute(&mut connection);
+    //~^ ERROR: `ILike<name, Bound<Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
 
     let mut connection = MysqlConnection::establish("").unwrap();
-    users::table.filter(users::name.ilike("%hey%")).execute(&mut connection);
+    users::table
+        .filter(users::name.ilike("%hey%"))
+        .execute(&mut connection);
+    //~^ ERROR: `ILike<name, Bound<Text, &str>>` is no valid SQL fragment for the `Mysql` backend
 }

--- a/diesel_compile_tests/tests/fail/ilike_only_compiles_for_pg.stderr
+++ b/diesel_compile_tests/tests/fail/ilike_only_compiles_for_pg.stderr
@@ -1,51 +1,54 @@
-error[E0277]: `diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/ilike_only_compiles_for_pg.rs:21:61
-   |
-21 |     users::table.filter(users::name.ilike("%hey%")).execute(&mut connection);
-   |                                                     ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |                                                     |
-   |                                                     required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Sqlite`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>` to implement `QueryFragment<Sqlite>`
-   = note: 3 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
+error[E0277]: `ILike<name, Bound<Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/ilike_only_compiles_for_pg.rs:23:18
+     |
+23   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `ILike<name, Bound<Text, &str>>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `ILike<name, Bound<Text, &str>>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `Grouped<ILike<name, Bound<Text, &str>>>` to implement `QueryFragment<Sqlite>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: `diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/ilike_only_compiles_for_pg.rs:24:61
-   |
-24 |     users::table.filter(users::name.ilike("%hey%")).execute(&mut connection);
-   |                                                     ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |                                                     |
-   |                                                     required by a bound introduced by this call
-   |
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Mysql`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>` to implement `QueryFragment<Mysql>`
-   = note: 3 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::pg::expression::operators::ILike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: `ILike<name, Bound<Text, &str>>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/ilike_only_compiles_for_pg.rs:29:18
+     |
+29   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `ILike<name, Bound<Text, &str>>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `ILike<name, Bound<Text, &str>>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Mysql`
+     = note: required for `Grouped<ILike<name, Bound<Text, &str>>>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/insert_cannot_reference_columns_from_other_table.rs
+++ b/diesel_compile_tests/tests/fail/insert_cannot_reference_columns_from_other_table.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::pg::PgConnection;
+use diesel::*;
 
 table! {
     users {
@@ -18,10 +18,12 @@ table! {
 fn main() {
     let mut conn = PgConnection::establish("").unwrap();
 
-    insert_into(users::table)
-        .values(&posts::id.eq(1));
+    insert_into(users::table).values(&posts::id.eq(1));
+    //~^ ERROR: type mismatch resolving `<id as Column>::Table == table`
 
-    insert_into(users::table)
-        .values(&(posts::id.eq(1), users::id.eq(2)));
-        //FIXME: Bad error on the second one
+    insert_into(users::table).values(&(posts::id.eq(1), users::id.eq(2)));
+    //~^ ERROR: type mismatch resolving `<&... as Insertable<...>>::Values == ValuesClause<..., ...>`
+    //~| ERROR: type mismatch resolving `<id as Column>::Table == table`
+    //~| ERROR: type mismatch resolving `<&... as Insertable<...>>::Values == ValuesClause<..., ...>`
+    //FIXME: Bad error on the second one
 }

--- a/diesel_compile_tests/tests/fail/insert_cannot_reference_columns_from_other_table.stderr
+++ b/diesel_compile_tests/tests/fail/insert_cannot_reference_columns_from_other_table.stderr
@@ -1,63 +1,64 @@
 error[E0271]: type mismatch resolving `<id as Column>::Table == table`
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:22:18
-   |
-22 |         .values(&posts::id.eq(1));
-   |          ------  ^^^^^^^^^^^^^^^ type mismatch resolving `<id as Column>::Table == table`
-   |          |
-   |          required by a bound introduced by this call
-   |
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:21:39
+    |
+21  |     insert_into(users::table).values(&posts::id.eq(1));
+    |                               ------  ^^^^^^^^^^^^^^^ type mismatch resolving `<id as Column>::Table == table`
+    |                               |
+    |                               required by a bound introduced by this call
+    |
 note: expected this to be `users::table`
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:14:9
-   |
-14 |         id -> Integer,
-   |         ^^
-   = note: `posts::table` and `users::table` have similar names, but are actually distinct types
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:14:9
+    |
+14  |         id -> Integer,
+    |         ^^
+    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:12:1
-   |
-12 | / table! {
-13 | |     posts {
-14 | |         id -> Integer,
-15 | |     }
-16 | | }
-   | |_^
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:12:1
+    |
+12  | / table! {
+13  | |     posts {
+14  | |         id -> Integer,
+15  | |     }
+16  | | }
+    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:6:1
-   |
-6  | / table! {
-7  | |     users {
-8  | |         id -> Integer,
-9  | |     }
-10 | | }
-   | |_^
-   = note: required for `&diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>` to implement `diesel::Insertable<users::table>`
-   = note: 1 redundant requirement hidden
-   = note: required for `&diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `diesel::Insertable<users::table>`
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:6:1
+    |
+6   | / table! {
+7   | |     users {
+8   | |         id -> Integer,
+9   | |     }
+10  | | }
+    | |_^
+    = note: required for `&Eq<id, Bound<Integer, i32>>` to implement `diesel::Insertable<users::table>`
+    = note: 1 redundant requirement hidden
+    = note: required for `&Grouped<Eq<id, Bound<Integer, i32>>>` to implement `diesel::Insertable<users::table>`
 note: required by a bound in `IncompleteInsertStatement::<T, Op>::values`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
-   |            ------ required by a bound in this associated function
-   |     where
-   |         U: Insertable<T>,
-   |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
+    |            ------ required by a bound in this associated function
+LL |     where
+LL |         U: Insertable<T>,
+    |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<&Grouped<Eq<id, Bound<Integer, i32>>> as Insertable<table>>::Values == ValuesClause<ColumnInsertValue<id, &Bound<Integer, i32>>, table>`
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:25:10
+error[E0271]: type mismatch resolving `<&... as Insertable<...>>::Values == ValuesClause<..., ...>`
+  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:24:31
    |
-25 |         .values(&(posts::id.eq(1), users::id.eq(2)));
-   |          ^^^^^^ expected `users::table`, found `posts::table`
+LL |     insert_into(users::table).values(&(posts::id.eq(1), users::id.eq(2)));
+   |                               ^^^^^^ expected `users::table`, found `posts::table`
    |
    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:12:1
    |
-12 | / table! {
-13 | |     posts {
-14 | |         id -> Integer,
-15 | |     }
-16 | | }
+LL | / table! {
+LL | |     posts {
+LL | |         id -> Integer,
+LL | |     }
+LL | | }
    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:6:1
@@ -66,92 +67,96 @@ note: `users::table` is defined in module `crate::users` of the current crate
 7  | |     users {
 8  | |         id -> Integer,
 9  | |     }
-10 | | }
+LL | | }
    | |_^
-   = note: required for `(&diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>, &diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>)` to implement `diesel::Insertable<users::table>`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: required for `(&Grouped<Eq<id, Bound<Integer, i32>>>, &Grouped<Eq<id, ...>>)` to implement `diesel::Insertable<users::table>`
 
-error[E0271]: type mismatch resolving `<&Grouped<Eq<id, Bound<Integer, i32>>> as Insertable<table>>::Values == ValuesClause<ColumnInsertValue<id, &Bound<Integer, i32>>, table>`
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:25:18
-   |
-25 |         .values(&(posts::id.eq(1), users::id.eq(2)));
-   |          ------  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `users::table`, found `posts::table`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `posts::table` and `users::table` have similar names, but are actually distinct types
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<&... as Insertable<...>>::Values == ValuesClause<..., ...>`
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:24:39
+    |
+24  |     insert_into(users::table).values(&(posts::id.eq(1), users::id.eq(2)));
+    |                               ------  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `users::table`, found `posts::table`
+    |                               |
+    |                               required by a bound introduced by this call
+    |
+    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:12:1
-   |
-12 | / table! {
-13 | |     posts {
-14 | |         id -> Integer,
-15 | |     }
-16 | | }
-   | |_^
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:12:1
+    |
+12  | / table! {
+13  | |     posts {
+14  | |         id -> Integer,
+15  | |     }
+16  | | }
+    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:6:1
-   |
-6  | / table! {
-7  | |     users {
-8  | |         id -> Integer,
-9  | |     }
-10 | | }
-   | |_^
-   = note: required for `(&diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>, &diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>)` to implement `diesel::Insertable<users::table>`
-   = note: 1 redundant requirement hidden
-   = note: required for `&(diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>)` to implement `diesel::Insertable<users::table>`
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:6:1
+    |
+6   | / table! {
+7   | |     users {
+8   | |         id -> Integer,
+9   | |     }
+10  | | }
+    | |_^
+    = note: required for `(&Grouped<Eq<id, Bound<Integer, i32>>>, &Grouped<Eq<id, ...>>)` to implement `diesel::Insertable<users::table>`
+    = note: 1 redundant requirement hidden
+    = note: required for `&(Grouped<Eq<id, Bound<Integer, i32>>>, Grouped<Eq<id, ...>>)` to implement `diesel::Insertable<users::table>`
 note: required by a bound in `IncompleteInsertStatement::<T, Op>::values`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
-   |            ------ required by a bound in this associated function
-   |     where
-   |         U: Insertable<T>,
-   |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
+    |            ------ required by a bound in this associated function
+LL |     where
+LL |         U: Insertable<T>,
+    |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<id as Column>::Table == table`
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:25:18
-   |
-25 |         .values(&(posts::id.eq(1), users::id.eq(2)));
-   |          ------  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<id as Column>::Table == table`
-   |          |
-   |          required by a bound introduced by this call
-   |
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:24:39
+    |
+24  |     insert_into(users::table).values(&(posts::id.eq(1), users::id.eq(2)));
+    |                               ------  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<id as Column>::Table == table`
+    |                               |
+    |                               required by a bound introduced by this call
+    |
 note: expected this to be `users::table`
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:14:9
-   |
-14 |         id -> Integer,
-   |         ^^
-   = note: `posts::table` and `users::table` have similar names, but are actually distinct types
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:14:9
+    |
+14  |         id -> Integer,
+    |         ^^
+    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:12:1
-   |
-12 | / table! {
-13 | |     posts {
-14 | |         id -> Integer,
-15 | |     }
-16 | | }
-   | |_^
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:12:1
+    |
+12  | / table! {
+13  | |     posts {
+14  | |         id -> Integer,
+15  | |     }
+16  | | }
+    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
-  --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:6:1
-   |
-6  | / table! {
-7  | |     users {
-8  | |         id -> Integer,
-9  | |     }
-10 | | }
-   | |_^
-   = note: required for `&diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>` to implement `diesel::Insertable<users::table>`
-   = note: 3 redundant requirements hidden
-   = note: required for `&(diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>)` to implement `diesel::Insertable<users::table>`
+   --> tests/fail/insert_cannot_reference_columns_from_other_table.rs:6:1
+    |
+6   | / table! {
+7   | |     users {
+8   | |         id -> Integer,
+9   | |     }
+10  | | }
+    | |_^
+    = note: required for `&Eq<id, Bound<Integer, i32>>` to implement `diesel::Insertable<users::table>`
+    = note: 3 redundant requirements hidden
+    = note: required for `&(Grouped<Eq<id, Bound<Integer, i32>>>, Grouped<Eq<id, ...>>)` to implement `diesel::Insertable<users::table>`
 note: required by a bound in `IncompleteInsertStatement::<T, Op>::values`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
-   |            ------ required by a bound in this associated function
-   |     where
-   |         U: Insertable<T>,
-   |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
+    |            ------ required by a bound in this associated function
+LL |     where
+LL |         U: Insertable<T>,
+    |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs
+++ b/diesel_compile_tests/tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::pg::PgConnection;
+use diesel::*;
 
 table! {
     users {
@@ -20,19 +20,17 @@ table! {
 }
 
 fn main() {
-    use self::users::dsl::*;
     use self::posts::dsl::*;
+    use self::users::dsl::*;
     let mut conn = PgConnection::establish("").unwrap();
 
     // Sanity check, valid query
-    insert_into(posts)
-        .values(users)
-        .execute(&mut conn)
-        .unwrap();
+    insert_into(posts).values(users).execute(&mut conn).unwrap();
 
-    insert_into(posts)
-        .values(vec![users, users]);
+    insert_into(posts).values(vec![users, users]);
+    //~^ ERROR: the trait bound `users::table: UndecoratedInsertRecord<posts::table>` is not satisfied
 
-    insert_into(posts)
-        .values((users, users));
+    insert_into(posts).values((users, users));
+    //~^ ERROR: type mismatch resolving `<table as Insertable<table>>::Values == ValuesClause<_, table>`
+    //~| ERROR: type mismatch resolving `<table as Insertable<table>>::Values == ValuesClause<_, table>`
 }

--- a/diesel_compile_tests/tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.stderr
+++ b/diesel_compile_tests/tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `users::table: UndecoratedInsertRecord<posts::table>` is not satisfied
-  --> tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs:34:10
+  --> tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs:30:24
    |
-34 |         .values(vec![users, users]);
-   |          ^^^^^^ the trait `UndecoratedInsertRecord<posts::table>` is not implemented for `users::table`
+LL |     insert_into(posts).values(vec![users, users]);
+   |                        ^^^^^^ the trait `UndecoratedInsertRecord<posts::table>` is not implemented for `users::table`
    |
    = help: the following other types implement trait `UndecoratedInsertRecord<Table>`:
              `&T` implements `UndecoratedInsertRecord<Tab>`
@@ -13,35 +13,36 @@ error[E0277]: the trait bound `users::table: UndecoratedInsertRecord<posts::tabl
              `(T0, T1, T2, T3, T4, T5)` implements `UndecoratedInsertRecord<Tab>`
              `(T0, T1, T2, T3, T4, T5, T6)` implements `UndecoratedInsertRecord<Tab>`
              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `UndecoratedInsertRecord<Tab>`
-           and $N others
+           and N others
    = note: required for `Vec<users::table>` to implement `diesel::Insertable<posts::table>`
 
 error[E0271]: type mismatch resolving `<table as Insertable<table>>::Values == ValuesClause<_, table>`
-  --> tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs:37:10
+  --> tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs:33:24
    |
-37 |         .values((users, users));
-   |          ^^^^^^ expected `ValuesClause<_, table>`, found `InsertFromSelect<..., ...>`
+LL |     insert_into(posts).values((users, users));
+   |                        ^^^^^^ expected `ValuesClause<_, table>`, found `InsertFromSelect<..., ...>`
    |
    = note: expected struct `diesel::query_builder::insert_statement::ValuesClause<_, posts::table>`
-              found struct `diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<SelectStatement<FromClause<users::table>>, (posts::columns::user_id, posts::columns::title, posts::columns::body)>`
+              found struct `InsertFromSelect<SelectStatement<FromClause<table>>, (..., ..., ...)>`
    = note: required for `(users::table, users::table)` to implement `diesel::Insertable<posts::table>`
 
+   
 error[E0271]: type mismatch resolving `<table as Insertable<table>>::Values == ValuesClause<_, table>`
-  --> tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs:37:17
-   |
-37 |         .values((users, users));
-   |          ------ ^^^^^^^^^^^^^^ expected `ValuesClause<_, table>`, found `InsertFromSelect<..., ...>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: expected struct `diesel::query_builder::insert_statement::ValuesClause<_, posts::table>`
-              found struct `diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<SelectStatement<FromClause<users::table>>, (posts::columns::user_id, posts::columns::title, posts::columns::body)>`
-   = note: required for `(users::table, users::table)` to implement `diesel::Insertable<posts::table>`
+   --> tests/fail/insert_from_select_cant_be_used_with_tuples_or_arrays.rs:33:31
+    |
+33  |     insert_into(posts).values((users, users));
+    |                        ------ ^^^^^^^^^^^^^^ expected `ValuesClause<_, table>`, found `InsertFromSelect<..., ...>`
+    |                        |
+    |                        required by a bound introduced by this call
+    |
+    = note: expected struct `diesel::query_builder::insert_statement::ValuesClause<_, posts::table>`
+               found struct `InsertFromSelect<SelectStatement<FromClause<table>>, (..., ..., ...)>`
+    = note: required for `(users::table, users::table)` to implement `diesel::Insertable<posts::table>`
 note: required by a bound in `IncompleteInsertStatement::<T, Op>::values`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
-   |            ------ required by a bound in this associated function
-   |     where
-   |         U: Insertable<T>,
-   |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn values<U>(self, records: U) -> InsertStatement<T, U::Values, Op>
+    |            ------ required by a bound in this associated function
+LL |     where
+LL |         U: Insertable<T>,
+    |            ^^^^^^^^^^^^^ required by this bound in `IncompleteInsertStatement::<T, Op>::values`

--- a/diesel_compile_tests/tests/fail/insert_from_select_requires_valid_column_list.rs
+++ b/diesel_compile_tests/tests/fail/insert_from_select_requires_valid_column_list.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::pg::PgConnection;
+use diesel::*;
 
 table! {
     users {
@@ -27,63 +27,74 @@ table! {
 }
 
 fn main() {
-    use self::users::dsl::*;
     use self::posts::dsl::*;
+    use self::users::dsl::*;
     let mut conn = PgConnection::establish("").unwrap();
 
     // Sanity check, valid query with no column list
-    users
-        .insert_into(posts)
-        .execute(&mut conn)
-        .unwrap();
+    users.insert_into(posts).execute(&mut conn).unwrap();
 
     // Sanity check, valid query with single column
-    users.select(id)
+    users
+        .select(id)
         .insert_into(posts)
         .into_columns(user_id)
         .execute(&mut conn)
         .unwrap();
 
     // Sanity check, valid query with column list
-    users.select((name, hair_color))
+    users
+        .select((name, hair_color))
         .insert_into(posts)
         .into_columns((title, body))
         .execute(&mut conn)
         .unwrap();
 
     // No column list, mismatched types
-    users.select((name, hair_color))
+    users
+        .select((name, hair_color))
         .insert_into(posts)
         .execute(&mut conn)
+        //~^ ERROR: type mismatch resolving `<SelectStatement<..., ...> as Query>::SqlType == (..., ..., ...)`
         .unwrap();
 
     // Single column, wrong table
-    users.select(id)
+    users
+        .select(id)
         .insert_into(posts)
         .into_columns(comments::post_id);
+    //~^ ERROR: type mismatch resolving `<post_id as ColumnList>::Table == table`
 
     // Single column, wrong type
-    users.select(id)
-        .insert_into(posts)
-        .into_columns(title);
+    users.select(id).insert_into(posts).into_columns(title);
+    //~^ ERROR: type mismatch resolving `<title as Expression>::SqlType == Integer`
 
     // Multiple columns, one from wrong table
-    users.select((id, name))
+    users
+        .select((id, name))
         .insert_into(posts)
         .into_columns((comments::post_id, title));
+    //~^ ERROR: the trait bound `(post_id, title): ColumnList` is not satisfied
 
     // Multiple columns, both from wrong table
-    users.select((id, hair_color))
+    users
+        .select((id, hair_color))
         .insert_into(posts)
         .into_columns((comments::post_id, comments::body));
+    //~^ ERROR: type mismatch resolving `<post_id as ColumnList>::Table == table`
+    //~| ERROR: type mismatch resolving `<body as ColumnList>::Table == table`
 
     // Multiple columns, one wrong type
-    users.select((id, name))
+    users
+        .select((id, name))
         .insert_into(posts)
         .into_columns((user_id, body));
+    //~^ ERROR: type mismatch resolving `<(user_id, body) as Expression>::SqlType == (Integer, Text)`
 
     // Multiple columns, both wrong types
-    users.select((id, name))
+    users
+        .select((id, name))
         .insert_into(posts)
         .into_columns((title, body));
+    //~^ ERROR: type mismatch resolving `<(title, body) as Expression>::SqlType == (Integer, Text)`
 }

--- a/diesel_compile_tests/tests/fail/insert_from_select_requires_valid_column_list.stderr
+++ b/diesel_compile_tests/tests/fail/insert_from_select_requires_valid_column_list.stderr
@@ -1,198 +1,200 @@
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, SelectClause<(name, hair_color)>> as Query>::SqlType == (Integer, Text, Nullable<Text>)`
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:57:18
-   |
-57 |         .execute(&mut conn)
-   |          ------- ^^^^^^^^^ expected a tuple with 3 elements, found one with 2 elements
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: expected tuple `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
-              found tuple `(diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
-   = note: required for `diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<(users::columns::name, users::columns::hair_color)>>, (posts::columns::user_id, posts::columns::title, posts::columns::body)>` to implement `QueryFragment<_>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<posts::table, diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<(users::columns::name, users::columns::hair_color)>>, (posts::columns::user_id, posts::columns::title, posts::columns::body)>>` to implement `QueryFragment<_>`
-   = note: required for `InsertStatement<posts::table, diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<(users::columns::name, users::columns::hair_color)>>, (posts::columns::user_id, posts::columns::title, posts::columns::body)>>` to implement `ExecuteDsl<_, _>`
+error[E0271]: type mismatch resolving `<SelectStatement<..., ...> as Query>::SqlType == (..., ..., ...)`
+    --> tests/fail/insert_from_select_requires_valid_column_list.rs:57:18
+     |
+57   |         .execute(&mut conn)
+     |          ------- ^^^^^^^^^ expected a tuple with 3 elements, found one with 2 elements
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: expected tuple `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
+                found tuple `(diesel::sql_types::Text, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
+     = note: required for `InsertFromSelect<SelectStatement<FromClause<table>, ...>, ...>` to implement `QueryFragment<_>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, InsertFromSelect<..., ...>>` to implement `QueryFragment<_>`
+     = note: required for `InsertStatement<table, InsertFromSelect<..., ...>>` to implement `ExecuteDsl<_, _>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
 error[E0271]: type mismatch resolving `<post_id as ColumnList>::Table == table`
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:63:23
-   |
-63 |         .into_columns(comments::post_id);
-   |          ------------ ^^^^^^^^^^^^^^^^^ expected `posts::table`, found `comments::table`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `comments::table` and `posts::table` have similar names, but are actually distinct types
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:65:23
+    |
+65  |         .into_columns(comments::post_id);
+    |          ------------ ^^^^^^^^^^^^^^^^^ expected `posts::table`, found `comments::table`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `comments::table` and `posts::table` have similar names, but are actually distinct types
 note: `comments::table` is defined in module `crate::comments` of the current crate
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:22:1
-   |
-22 | / table! {
-23 | |     comments (post_id) {
-24 | |         post_id -> Integer,
-25 | |         body -> Nullable<Text>,
-26 | |     }
-27 | | }
-   | |_^
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:22:1
+    |
+22  | / table! {
+23  | |     comments (post_id) {
+24  | |         post_id -> Integer,
+25  | |         body -> Nullable<Text>,
+26  | |     }
+27  | | }
+    | |_^
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:14:1
-   |
-14 | / table! {
-15 | |     posts (user_id) {
-16 | |         user_id -> Integer,
-17 | |         title -> Text,
-...  |
-20 | | }
-   | |_^
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:14:1
+    |
+14  | / table! {
+15  | |     posts (user_id) {
+16  | |         user_id -> Integer,
+17  | |         title -> Text,
+...   |
+20  | | }
+    | |_^
 note: required by a bound in `InsertStatement::<T, diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<U, C>, Op, Ret>::into_columns`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn into_columns<C2>(
-   |            ------------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn into_columns<C2>(
+    |            ------------ required by a bound in this associated function
 ...
-   |         C2: ColumnList<Table = T> + Expression,
-   |                        ^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |         C2: ColumnList<Table = T> + Expression,
+    |                        ^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
+    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<title as Expression>::SqlType == Integer`
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:68:10
+  --> tests/fail/insert_from_select_requires_valid_column_list.rs:69:41
    |
-68 |         .into_columns(title);
-   |          ^^^^^^^^^^^^ type mismatch resolving `<title as Expression>::SqlType == Integer`
+LL |     users.select(id).insert_into(posts).into_columns(title);
+   |                                         ^^^^^^^^^^^^ type mismatch resolving `<title as Expression>::SqlType == Integer`
    |
 note: expected this to be `diesel::sql_types::Integer`
   --> tests/fail/insert_from_select_requires_valid_column_list.rs:17:18
    |
-17 |         title -> Text,
+LL |         title -> Text,
    |                  ^^^^
 
-error[E0277]: the trait bound `(comments::columns::post_id, posts::columns::title): diesel::query_builder::insert_statement::column_list::ColumnList` is not satisfied
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:73:23
-   |
-73 |         .into_columns((comments::post_id, title));
-   |          ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `diesel::query_builder::insert_statement::column_list::ColumnList` is not implemented for `(comments::columns::post_id, posts::columns::title)`
-   = help: the following other types implement trait `diesel::query_builder::insert_statement::column_list::ColumnList`:
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
-             (T0, T1, T2, T3, T4, T5, T6, T7, T8)
-           and $N others
+error[E0277]: the trait bound `(post_id, title): ColumnList` is not satisfied
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:76:23
+    |
+76  |         .into_columns((comments::post_id, title));
+    |          ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `diesel::query_builder::insert_statement::column_list::ColumnList` is not implemented for `(comments::columns::post_id, posts::columns::title)`
+    = help: the following other types implement trait `diesel::query_builder::insert_statement::column_list::ColumnList`:
+              (T0, T1)
+              (T0, T1, T2)
+              (T0, T1, T2, T3)
+              (T0, T1, T2, T3, T4)
+              (T0, T1, T2, T3, T4, T5)
+              (T0, T1, T2, T3, T4, T5, T6)
+              (T0, T1, T2, T3, T4, T5, T6, T7)
+              (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+            and N others
 note: required by a bound in `InsertStatement::<T, diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<U, C>, Op, Ret>::into_columns`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn into_columns<C2>(
-   |            ------------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn into_columns<C2>(
+    |            ------------ required by a bound in this associated function
 ...
-   |         C2: ColumnList<Table = T> + Expression,
-   |             ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
-
+LL |         C2: ColumnList<Table = T> + Expression,
+    |             ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
+ 
+    
 error[E0271]: type mismatch resolving `<post_id as ColumnList>::Table == table`
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:78:23
-   |
-78 |         .into_columns((comments::post_id, comments::body));
-   |          ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `posts::table`, found `comments::table`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `comments::table` and `posts::table` have similar names, but are actually distinct types
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:83:23
+    |
+83  |         .into_columns((comments::post_id, comments::body));
+    |          ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `posts::table`, found `comments::table`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `comments::table` and `posts::table` have similar names, but are actually distinct types
 note: `comments::table` is defined in module `crate::comments` of the current crate
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:22:1
-   |
-22 | / table! {
-23 | |     comments (post_id) {
-24 | |         post_id -> Integer,
-25 | |         body -> Nullable<Text>,
-26 | |     }
-27 | | }
-   | |_^
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:22:1
+    |
+22  | / table! {
+23  | |     comments (post_id) {
+24  | |         post_id -> Integer,
+25  | |         body -> Nullable<Text>,
+26  | |     }
+27  | | }
+    | |_^
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:14:1
-   |
-14 | / table! {
-15 | |     posts (user_id) {
-16 | |         user_id -> Integer,
-17 | |         title -> Text,
-...  |
-20 | | }
-   | |_^
-   = note: required for `(comments::columns::post_id, comments::columns::body)` to implement `diesel::query_builder::insert_statement::column_list::ColumnList`
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:14:1
+    |
+14  | / table! {
+15  | |     posts (user_id) {
+16  | |         user_id -> Integer,
+17  | |         title -> Text,
+...   |
+20  | | }
+    | |_^
+    = note: required for `(comments::columns::post_id, comments::columns::body)` to implement `diesel::query_builder::insert_statement::column_list::ColumnList`
 note: required by a bound in `InsertStatement::<T, diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<U, C>, Op, Ret>::into_columns`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn into_columns<C2>(
-   |            ------------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn into_columns<C2>(
+    |            ------------ required by a bound in this associated function
 ...
-   |         C2: ColumnList<Table = T> + Expression,
-   |                        ^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |         C2: ColumnList<Table = T> + Expression,
+    |                        ^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
+    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<body as ColumnList>::Table == table`
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:78:23
-   |
-78 |         .into_columns((comments::post_id, comments::body));
-   |          ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `posts::table`, found `comments::table`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `comments::table` and `posts::table` have similar names, but are actually distinct types
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:83:23
+    |
+83  |         .into_columns((comments::post_id, comments::body));
+    |          ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `posts::table`, found `comments::table`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `comments::table` and `posts::table` have similar names, but are actually distinct types
 note: `comments::table` is defined in module `crate::comments` of the current crate
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:22:1
-   |
-22 | / table! {
-23 | |     comments (post_id) {
-24 | |         post_id -> Integer,
-25 | |         body -> Nullable<Text>,
-26 | |     }
-27 | | }
-   | |_^
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:22:1
+    |
+22  | / table! {
+23  | |     comments (post_id) {
+24  | |         post_id -> Integer,
+25  | |         body -> Nullable<Text>,
+26  | |     }
+27  | | }
+    | |_^
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:14:1
-   |
-14 | / table! {
-15 | |     posts (user_id) {
-16 | |         user_id -> Integer,
-17 | |         title -> Text,
-...  |
-20 | | }
-   | |_^
-   = note: required for `(comments::columns::post_id, comments::columns::body)` to implement `diesel::query_builder::insert_statement::column_list::ColumnList`
+   --> tests/fail/insert_from_select_requires_valid_column_list.rs:14:1
+    |
+14  | / table! {
+15  | |     posts (user_id) {
+16  | |         user_id -> Integer,
+17  | |         title -> Text,
+...   |
+20  | | }
+    | |_^
+    = note: required for `(comments::columns::post_id, comments::columns::body)` to implement `diesel::query_builder::insert_statement::column_list::ColumnList`
 note: required by a bound in `InsertStatement::<T, diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<U, C>, Op, Ret>::into_columns`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn into_columns<C2>(
-   |            ------------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn into_columns<C2>(
+    |            ------------ required by a bound in this associated function
 ...
-   |         C2: ColumnList<Table = T> + Expression,
-   |                        ^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |         C2: ColumnList<Table = T> + Expression,
+    |                        ^^^^^^^^^ required by this bound in `InsertStatement::<T, InsertFromSelect<U, C>, Op, Ret>::into_columns`
+    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<(user_id, body) as Expression>::SqlType == (Integer, Text)`
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:83:10
+  --> tests/fail/insert_from_select_requires_valid_column_list.rs:91:10
    |
-83 |         .into_columns((user_id, body));
+LL |         .into_columns((user_id, body));
    |          ^^^^^^^^^^^^ expected `(Integer, Text)`, found `(Integer, Nullable<Text>)`
    |
    = note: expected tuple `(diesel::sql_types::Integer, diesel::sql_types::Text)`
               found tuple `(diesel::sql_types::Integer, diesel::sql_types::Nullable<diesel::sql_types::Text>)`
 
 error[E0271]: type mismatch resolving `<(title, body) as Expression>::SqlType == (Integer, Text)`
-  --> tests/fail/insert_from_select_requires_valid_column_list.rs:88:10
+  --> tests/fail/insert_from_select_requires_valid_column_list.rs:98:10
    |
-88 |         .into_columns((title, body));
+LL |         .into_columns((title, body));
    |          ^^^^^^^^^^^^ expected `(Integer, Text)`, found `(Text, Nullable<Text>)`
    |
    = note: expected tuple `(diesel::sql_types::Integer, diesel::sql_types::Text)`

--- a/diesel_compile_tests/tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.rs
@@ -11,12 +11,13 @@ table! {
 fn main() {
     let mut connection = SqliteConnection::establish("").unwrap();
 
-    users::table.select(users::id)
+    users::table
+        .select(users::id)
         .insert_into(users::table)
         .into_columns(users::id)
         .on_conflict(users::id)
         .do_nothing()
         .execute(&mut connection)
+        //~^ ERROR: `OnConflictSelectWrapper<SelectStatement<FromClause<table>, ...>>` is no valid SQL fragment for the `Sqlite` backend
         .unwrap();
-
 }

--- a/diesel_compile_tests/tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.stderr
@@ -1,28 +1,29 @@
-error[E0277]: `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.rs:19:18
-   |
-19 |         .execute(&mut connection)
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>>`
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<BoxedSelectStatement<'_, ST, QS, Sqlite, GB>>` implements `QueryFragment<Sqlite>`
-             `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<S>` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<S>` implements `QueryFragment<Pg>`
-             `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<SelectStatement<F, S, D, diesel::query_builder::where_clause::WhereClause<W>, O, LOf, G, H, LC>>` implements `QueryFragment<Sqlite>`
-   = note: required for `diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>>, columns::id>` to implement `QueryFragment<Sqlite>`
-   = note: 3 redundant requirements hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>>, columns::id>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<columns::id>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::insert_from_select::InsertFromSelect<diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>>, columns::id>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<columns::id>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
+error[E0277]: `OnConflictSelectWrapper<SelectStatement<FromClause<table>, ...>>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.rs:20:18
+     |
+20   |         .execute(&mut connection)
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `OnConflictSelectWrapper<SelectStatement<FromClause<table>, ...>>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<BoxedSelectStatement<'_, ST, QS, Sqlite, GB>>` implements `QueryFragment<Sqlite>`
+               `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<S>` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<S>` implements `QueryFragment<Pg>`
+               `diesel::query_builder::upsert::into_conflict_clause::OnConflictSelectWrapper<SelectStatement<F, S, D, diesel::query_builder::where_clause::WhereClause<W>, O, LOf, G, H, LC>>` implements `QueryFragment<Sqlite>`
+     = note: required for `InsertFromSelect<OnConflictSelectWrapper<...>, ...>` to implement `QueryFragment<Sqlite>`
+     = note: 3 redundant requirements hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Sqlite>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.rs
+++ b/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::pg::PgConnection;
+use diesel::*;
 
 table! {
     users {
@@ -15,6 +15,6 @@ fn main() {
     use self::users::dsl::*;
     let mut conn = PgConnection::establish("").unwrap();
 
-    insert_into(users)
-        .values(&name.eq(1));
+    insert_into(users).values(&name.eq(1));
+    //~^ ERROR: the trait bound `{integer}: diesel::Expression` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
+++ b/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
-  --> tests/fail/insert_requires_value_of_same_type_as_column.rs:19:23
+  --> tests/fail/insert_requires_value_of_same_type_as_column.rs:18:37
    |
-19 |         .values(&name.eq(1));
-   |                       ^^ the trait `diesel::Expression` is not implemented for `{integer}`
+LL |     insert_into(users).values(&name.eq(1));
+   |                                     ^^ the trait `diesel::Expression` is not implemented for `{integer}`
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
@@ -13,5 +13,6 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
              (T0, T1, T2, T3, T4, T5)
              (T0, T1, T2, T3, T4, T5, T6)
              (T0, T1, T2, T3, T4, T5, T6, T7)
-           and $N others
+           and N others
    = note: required for `{integer}` to implement `AsExpression<diesel::sql_types::Text>`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -27,9 +27,11 @@ fn main() {
     insert_into(users::table)
         .values(&NewUser("Hello".into()))
         .get_result::<User>(&mut connection);
+    //~^ ERROR: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
 
     insert_into(users::table)
         .values(&NewUser("Hello".into()))
         .returning(users::name)
         .get_result::<String>(&mut connection);
+    //~^ ERROR: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
 }

--- a/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -1,53 +1,56 @@
 error[E0277]: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs:29:29
-   |
-29 |         .get_result::<User>(&mut connection);
-   |          ----------         ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<(columns::id, columns::name)>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB>`
-   = note: required for `ReturningClause<(columns::id, columns::name)>` to implement `QueryFragment<Sqlite>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<(columns::id, columns::name)>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>>` to implement `LoadQuery<'_, SqliteConnection, User>`
+    --> tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs:29:29
+     |
+29   |         .get_result::<User>(&mut connection);
+     |          ----------         ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<(columns::id, columns::name)>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB>`
+     = note: required for `ReturningClause<(columns::id, columns::name)>` to implement `QueryFragment<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `InsertStatement<table, ValuesClause<(...,), ...>>` to implement `LoadQuery<'_, SqliteConnection, User>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs:34:31
-   |
-34 |         .get_result::<String>(&mut connection);
-   |          ----------           ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB>`
-   = note: required for `ReturningClause<columns::name>` to implement `QueryFragment<Sqlite>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<columns::name>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<columns::name>>` to implement `LoadQuery<'_, SqliteConnection, std::string::String>`
+    --> tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.rs:35:31
+     |
+35   |         .get_result::<String>(&mut connection);
+     |          ----------           ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB>`
+     = note: required for `ReturningClause<columns::name>` to implement `QueryFragment<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` to implement `LoadQuery<'_, SqliteConnection, std::string::String>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/invalid_group_by.rs
+++ b/diesel_compile_tests/tests/fail/invalid_group_by.rs
@@ -25,7 +25,9 @@ fn main() {
     // this fails because `posts` is not part of the from clause
     users::table
         .group_by(posts::id)
+        //~^ ERROR: type mismatch resolving `<FromClause<table> as AppearsInFromClause<table>>::Count == Once`
         .select(users::id)
+        //~^ ERROR: type mismatch resolving `<id as IsContainedInGroupBy<id>>::Output == Yes`
         .execute(conn)
         .unwrap();
 
@@ -33,6 +35,7 @@ fn main() {
     users::table
         .select(users::id)
         .group_by(posts::id)
+        //~^ ERROR: type mismatch resolving `<FromClause<table> as AppearsInFromClause<table>>::Count == Once`
         .execute(conn)
         .unwrap();
 
@@ -41,37 +44,46 @@ fn main() {
     // this also fails if we use aliases
     user_alias
         .group_by(posts::id)
+        //~^ ERROR: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<table>>::Count == Once`
         .select(user_alias.field(users::id))
+        //~^ ERROR: the trait bound `AliasedField<user1, users::columns::id>: ValidGrouping<posts::columns::id>` is not satisfied
         .execute(conn)
         .unwrap();
 
     users::table
         .group_by(post_alias.field(posts::id))
+        //~^ ERROR: type mismatch resolving `<FromClause<table> as AppearsInFromClause<Alias<post1>>>::Count == Once`
         .select(users::id)
+        //~^ ERROR: the trait bound `AliasedField<post1, posts::columns::id>: IsContainedInGroupBy<users::columns::id>` is not satisfied
         .execute(conn)
         .unwrap();
 
     user_alias
         .group_by(post_alias.field(posts::id))
+        //~^ ERROR: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<Alias<post1>>>::Count == Once`
         .select(user_alias.field(users::id))
+        //~^ ERROR: the trait bound `AliasedField<user1, id>: ValidGrouping<AliasedField<post1, id>>` is not satisfied
         .execute(conn)
         .unwrap();
 
     user_alias
         .select(user_alias.field(users::id))
         .group_by(posts::id)
+        //~^ ERROR: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<table>>::Count == Once`
         .execute(conn)
         .unwrap();
 
     users::table
         .select(users::id)
         .group_by(post_alias.field(posts::id))
+        //~^ ERROR: type mismatch resolving `<FromClause<table> as AppearsInFromClause<Alias<post1>>>::Count == Once`
         .execute(conn)
         .unwrap();
 
     user_alias
         .select(user_alias.field(users::id))
         .group_by(post_alias.field(posts::id))
+        //~^ ERROR: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<Alias<post1>>>::Count == Once`
         .execute(conn)
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/invalid_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/invalid_group_by.stderr
@@ -1,27 +1,27 @@
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/invalid_group_by.rs:27:10
    |
-27 |         .group_by(posts::id)
+LL |         .group_by(posts::id)
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<users::table>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
-15 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `GroupByDsl<posts::columns::id>`
 
 error[E0271]: type mismatch resolving `<id as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/invalid_group_by.rs:28:10
+  --> tests/fail/invalid_group_by.rs:29:10
    |
-28 |         .select(users::id)
+LL |         .select(users::id)
    |          ^^^^^^ type mismatch resolving `<id as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
   --> tests/fail/invalid_group_by.rs:15:9
    |
-15 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
 note: required for `users::columns::id` to implement `ValidGrouping<posts::columns::id>`
   --> tests/fail/invalid_group_by.rs:8:9
@@ -29,70 +29,73 @@ note: required for `users::columns::id` to implement `ValidGrouping<posts::colum
 8  |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>` to implement `SelectDsl<users::columns::id>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
+   
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:35:10
+  --> tests/fail/invalid_group_by.rs:37:10
    |
-35 |         .group_by(posts::id)
+LL |         .group_by(posts::id)
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<users::table>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
-15 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>` to implement `GroupByDsl<posts::columns::id>`
+   = note: required for `SelectStatement<FromClause<table>, SelectClause<id>>` to implement `GroupByDsl<posts::columns::id>`
 
+   
 error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:43:10
+  --> tests/fail/invalid_group_by.rs:46:10
    |
-43 |         .group_by(posts::id)
+LL |         .group_by(posts::id)
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
-15 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<Alias<user1>>>` to implement `GroupByDsl<posts::columns::id>`
 
 error[E0277]: the trait bound `AliasedField<user1, users::columns::id>: ValidGrouping<posts::columns::id>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:44:17
-   |
-44 |         .select(user_alias.field(users::id))
-   |          ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<posts::columns::id>` is not implemented for `AliasedField<user1, users::columns::id>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-             `AliasedField<S, C2>` implements `ValidGrouping<AliasedField<S, C1>>`
-             `AliasedField<S, C>` implements `ValidGrouping<()>`
-   = note: required for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<Alias<user1>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>` to implement `SelectDsl<AliasedField<user1, users::columns::id>>`
+   --> tests/fail/invalid_group_by.rs:48:17
+    |
+48  |         .select(user_alias.field(users::id))
+    |          ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<posts::columns::id>` is not implemented for `AliasedField<user1, users::columns::id>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `AliasedField<S, C2>` implements `ValidGrouping<AliasedField<S, C1>>`
+              `AliasedField<S, C>` implements `ValidGrouping<()>`
+    = note: required for `SelectStatement<FromClause<Alias<...>>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<AliasedField<user1, users::columns::id>>`
 note: required by a bound in `diesel::QueryDsl::select`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
-   |        ------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
 ...
-   |         Self: methods::SelectDsl<Selection>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
-
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+ 
+    
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<Alias<post1>>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:49:10
+  --> tests/fail/invalid_group_by.rs:54:10
    |
-49 |         .group_by(post_alias.field(posts::id))
+LL |         .group_by(post_alias.field(posts::id))
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<users::table>>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
 
 error[E0277]: the trait bound `AliasedField<post1, posts::columns::id>: IsContainedInGroupBy<users::columns::id>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:50:10
+  --> tests/fail/invalid_group_by.rs:56:10
    |
-50 |         .select(users::id)
+LL |         .select(users::id)
    |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `AliasedField<post1, posts::columns::id>`
    |
    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
@@ -105,72 +108,76 @@ error[E0277]: the trait bound `AliasedField<post1, posts::columns::id>: IsContai
              `(T0, T1, T2, T3, T4, T5, T6)` implements `IsContainedInGroupBy<Col>`
              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `IsContainedInGroupBy<Col>`
              `(T0, T1, T2, T3, T4, T5, T6, T7, T8)` implements `IsContainedInGroupBy<Col>`
-           and $N others
+           and N others
 note: required for `users::columns::id` to implement `ValidGrouping<AliasedField<post1, posts::columns::id>>`
   --> tests/fail/invalid_group_by.rs:8:9
    |
 8  |         id -> Integer,
    |         ^^
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<AliasedField<post1, posts::columns::id>>>` to implement `SelectDsl<users::columns::id>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
+   
 error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<Alias<post1>>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:55:10
+  --> tests/fail/invalid_group_by.rs:62:10
    |
-55 |         .group_by(post_alias.field(posts::id))
+LL |         .group_by(post_alias.field(posts::id))
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
    = note: required for `SelectStatement<FromClause<Alias<user1>>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
 
-error[E0277]: the trait bound `AliasedField<user1, users::columns::id>: ValidGrouping<AliasedField<post1, posts::columns::id>>` is not satisfied
-  --> tests/fail/invalid_group_by.rs:56:17
-   |
-56 |         .select(user_alias.field(users::id))
-   |          ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<AliasedField<post1, posts::columns::id>>` is not implemented for `AliasedField<user1, users::columns::id>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
-             `AliasedField<S, C2>` implements `ValidGrouping<AliasedField<S, C1>>`
-             `AliasedField<S, C>` implements `ValidGrouping<()>`
-   = note: required for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<Alias<user1>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<AliasedField<post1, posts::columns::id>>>` to implement `SelectDsl<AliasedField<user1, users::columns::id>>`
+error[E0277]: the trait bound `AliasedField<user1, id>: ValidGrouping<AliasedField<post1, id>>` is not satisfied
+   --> tests/fail/invalid_group_by.rs:64:17
+    |
+64  |         .select(user_alias.field(users::id))
+    |          ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ValidGrouping<AliasedField<post1, posts::columns::id>>` is not implemented for `AliasedField<user1, users::columns::id>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `AliasedField<S, C2>` implements `ValidGrouping<AliasedField<S, C1>>`
+              `AliasedField<S, C>` implements `ValidGrouping<()>`
+    = note: required for `SelectStatement<FromClause<Alias<...>>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<AliasedField<user1, users::columns::id>>`
 note: required by a bound in `diesel::QueryDsl::select`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
-   |        ------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
 ...
-   |         Self: methods::SelectDsl<Selection>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
-
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+ 
+    
 error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:62:10
+  --> tests/fail/invalid_group_by.rs:71:10
    |
-62 |         .group_by(posts::id)
+LL |         .group_by(posts::id)
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
   --> tests/fail/invalid_group_by.rs:15:9
    |
-15 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::SelectClause<AliasedField<user1, users::columns::id>>>` to implement `GroupByDsl<posts::columns::id>`
+   = note: required for `SelectStatement<FromClause<Alias<user1>>, SelectClause<...>>` to implement `GroupByDsl<posts::columns::id>`
 
+   
 error[E0271]: type mismatch resolving `<FromClause<table> as AppearsInFromClause<Alias<post1>>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:68:10
+  --> tests/fail/invalid_group_by.rs:78:10
    |
-68 |         .group_by(post_alias.field(posts::id))
+LL |         .group_by(post_alias.field(posts::id))
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<users::columns::id>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
+   = note: required for `SelectStatement<FromClause<table>, SelectClause<id>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
 
+   
 error[E0271]: type mismatch resolving `<FromClause<Alias<user1>> as AppearsInFromClause<Alias<post1>>>::Count == Once`
-  --> tests/fail/invalid_group_by.rs:74:10
+  --> tests/fail/invalid_group_by.rs:85:10
    |
-74 |         .group_by(post_alias.field(posts::id))
+LL |         .group_by(post_alias.field(posts::id))
    |          ^^^^^^^^ expected `Once`, found `Never`
    |
    = note: required for `AliasedField<post1, posts::columns::id>` to implement `AppearsOnTable<FromClause<Alias<user1>>>`
-   = note: required for `SelectStatement<FromClause<Alias<user1>>, diesel::query_builder::select_clause::SelectClause<AliasedField<user1, users::columns::id>>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`
+   = note: required for `SelectStatement<FromClause<Alias<user1>>, SelectClause<...>>` to implement `GroupByDsl<AliasedField<post1, posts::columns::id>>`

--- a/diesel_compile_tests/tests/fail/invalid_joins.rs
+++ b/diesel_compile_tests/tests/fail/invalid_joins.rs
@@ -39,15 +39,29 @@ fn invalid_inner_joins() {
 
     // This fails, because we join the same table more than once
     let _ = users::table.inner_join(posts::table.inner_join(users::table));
+    //~^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
+    //~| ERROR: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
 
     // It also fails if we use an explicit on clause
-    let _ = users::table.inner_join(posts::table.inner_join(users::table.on(posts::user_id.eq(users::id))));
+    let _ = users::table
+        .inner_join(posts::table.inner_join(users::table.on(posts::user_id.eq(users::id))));
+    //~^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
+    //~| ERROR: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
 
     // Also if we put the on clause on the first join
-    let _ = users::table.inner_join(posts::table.on(users::id.eq(posts::user_id)).inner_join(users::table));
+    let _ = users::table.inner_join(
+        //~^ ERROR: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
+        posts::table
+            .on(users::id.eq(posts::user_id))
+            .inner_join(users::table),
+        //~^^^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
+    );
 
     // it also fails if we join to another subjoin
-    let _ = users::table.inner_join(comments::table).inner_join(posts::table.inner_join(comments::table));
+    let _ = users::table
+        .inner_join(comments::table)
+        .inner_join(posts::table.inner_join(comments::table));
+    //~^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
 }
 
 fn invalid_left_joins() {
@@ -56,13 +70,27 @@ fn invalid_left_joins() {
 
     // This fails, because we join the same table more than once
     let _ = users::table.left_join(posts::table.left_join(users::table));
+    //~^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
+    //~| ERROR: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
 
     // It also fails if we use an explicit on clause
-    let _ = users::table.left_join(posts::table.left_join(users::table.on(posts::user_id.eq(users::id))));
+    let _ = users::table
+        .left_join(posts::table.left_join(users::table.on(posts::user_id.eq(users::id))));
+    //~^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
+    //~| ERROR: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
 
     // Also if we put the on clause on the first join
-    let _ = users::table.left_join(posts::table.on(users::id.eq(posts::user_id)).left_join(users::table));
+    let _ = users::table.left_join(
+        //~^ ERROR: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
+        posts::table
+            .on(users::id.eq(posts::user_id))
+            .left_join(users::table),
+        //~^^^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
+    );
 
     // it also fails if we join to another subjoin
-    let _ = users::table.left_join(comments::table).left_join(posts::table.left_join(comments::table));
+    let _ = users::table
+        .left_join(comments::table)
+        .left_join(posts::table.left_join(comments::table));
+    //~^ ERROR: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
 }

--- a/diesel_compile_tests/tests/fail/invalid_joins.stderr
+++ b/diesel_compile_tests/tests/fail/invalid_joins.stderr
@@ -1,39 +1,40 @@
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:41:37
-   |
-41 |     let _ = users::table.inner_join(posts::table.inner_join(users::table));
-   |                          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:41:37
+    |
+41  |     let _ = users::table.inner_join(posts::table.inner_join(users::table));
+    |                          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+    |                          |
+    |                          required by a bound introduced by this call
+    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
-  --> tests/fail/invalid_joins.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), (users::columns::id, users::columns::name))>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
-   = note: required for `query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>`
+   --> tests/fail/invalid_joins.rs:7:9
+    |
+7   |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), SkipSelectableExpressionBoundCheckWrapper<(..., ...)>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
+    = note: required for `Join<table, SelectStatement<FromClause<JoinOn<..., ...>>>, ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
-
-error[E0271]: type mismatch resolving `<Join<table, SelectStatement<FromClause<JoinOn<Join<table, table, Inner>, Grouped<Eq<Nullable<user_id>, Nullable<id>>>>>>, Inner> as AppearsInFromClause<table>>::Count == Once`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+ 
+    
+error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
   --> tests/fail/invalid_joins.rs:41:26
    |
-41 |     let _ = users::table.inner_join(posts::table.inner_join(users::table));
+LL |     let _ = users::table.inner_join(posts::table.inner_join(users::table));
    |                          ^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
@@ -43,47 +44,49 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 3 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<Nullable<user_id>, Nullable<id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
+   = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
+   
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:44:37
-   |
-44 |     let _ = users::table.inner_join(posts::table.inner_join(users::table.on(posts::user_id.eq(users::id))));
-   |                          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:47:21
+    |
+47  |         .inner_join(posts::table.inner_join(users::table.on(posts::user_id.eq(users::id))));
+    |          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>>`
-  --> tests/fail/invalid_joins.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), (users::columns::id, users::columns::name))>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>>`
-   = note: required for `query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>`
+   --> tests/fail/invalid_joins.rs:7:9
+    |
+7   |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), SkipSelectableExpressionBoundCheckWrapper<(..., ...)>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>>`
+    = note: required for `Join<table, SelectStatement<FromClause<JoinOn<..., ...>>>, ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+ 
+    
+error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
+  --> tests/fail/invalid_joins.rs:47:10
    |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
-
-error[E0271]: type mismatch resolving `<Join<table, SelectStatement<FromClause<JoinOn<Join<table, table, Inner>, Grouped<Eq<user_id, id>>>>>, Inner> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_joins.rs:44:26
-   |
-44 |     let _ = users::table.inner_join(posts::table.inner_join(users::table.on(posts::user_id.eq(users::id))));
-   |                          ^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+LL |         .inner_join(posts::table.inner_join(users::table.on(posts::user_id.eq(users::id))));
+   |          ^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>>`
   --> tests/fail/invalid_joins.rs:7:9
@@ -92,46 +95,51 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 3 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>>`
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<Nullable<user_id>, Nullable<id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner>>`
+   = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
+   
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:47:37
-   |
-47 |     let _ = users::table.inner_join(posts::table.on(users::id.eq(posts::user_id)).inner_join(users::table));
-   |                          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:54:9
+    |
+52  |       let _ = users::table.inner_join(
+    |                            ---------- required by a bound introduced by this call
+53  |
+54  | /         posts::table
+55  | |             .on(users::id.eq(posts::user_id))
+56  | |             .inner_join(users::table),
+    | |_____________________________________^ expected `Once`, found `MoreThanOnce`
+    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
-  --> tests/fail/invalid_joins.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), (users::columns::id, users::columns::name))>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
-   = note: required for `query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>, Inner>`
+   --> tests/fail/invalid_joins.rs:7:9
+    |
+7   |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), SkipSelectableExpressionBoundCheckWrapper<(..., ...)>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
+    = note: required for `Join<table, SelectStatement<FromClause<JoinOn<..., ...>>>, ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+ 
+    
+error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
+  --> tests/fail/invalid_joins.rs:52:26
    |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
-
-error[E0271]: type mismatch resolving `<Join<table, SelectStatement<FromClause<JoinOn<Join<table, table, Inner>, Grouped<Eq<Nullable<user_id>, Nullable<id>>>>>>, Inner> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_joins.rs:47:26
-   |
-47 |     let _ = users::table.inner_join(posts::table.on(users::id.eq(posts::user_id)).inner_join(users::table));
+LL |     let _ = users::table.inner_join(
    |                          ^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
@@ -141,76 +149,79 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<id, user_id>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>>`
+   = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
 
+   
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:50:65
-   |
-50 |     let _ = users::table.inner_join(comments::table).inner_join(posts::table.inner_join(comments::table));
-   |                                                      ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                                                      |
-   |                                                      required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:63:21
+    |
+63  |         .inner_join(posts::table.inner_join(comments::table));
+    |          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: required for `comments::columns::id` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>>`
-  --> tests/fail/invalid_joins.rs:22:9
-   |
-22 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), (comments::columns::id, comments::columns::user_id, comments::columns::post_id, comments::columns::name), query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), (comments::columns::id, comments::columns::user_id, comments::columns::post_id, comments::columns::name))>)` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>>`
-   = note: required for `query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>`
+   --> tests/fail/invalid_joins.rs:22:9
+    |
+22  |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), (id, user_id, post_id, name), ...)` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>>`
+    = note: required for `Join<JoinOn<Join<table, table, Inner>, Grouped<...>>, ..., ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<JoinOn<Join<table, table, Inner>, ...>, ..., ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, Inner>, ...>>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, Inner>, ...>>>` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
-
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+ 
+    
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:58:36
-   |
-58 |     let _ = users::table.left_join(posts::table.left_join(users::table));
-   |                          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:72:36
+    |
+72  |     let _ = users::table.left_join(posts::table.left_join(users::table));
+    |                          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+    |                          |
+    |                          required by a bound introduced by this call
+    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-  --> tests/fail/invalid_joins.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), NullableExpression<query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), NullableExpression<(users::columns::id, users::columns::name)>)>>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-   = note: required for `query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>`
+   --> tests/fail/invalid_joins.rs:7:9
+    |
+7   |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), Nullable<SkipSelectableExpressionBoundCheckWrapper<...>>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+    = note: required for `Join<table, SelectStatement<FromClause<JoinOn<..., ...>>>, ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>`
 note: required by a bound in `left_join`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
+    |        --------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
+ 
+    
+error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
+  --> tests/fail/invalid_joins.rs:72:26
    |
-   |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
-   |        --------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
-
-error[E0271]: type mismatch resolving `<Join<table, SelectStatement<FromClause<JoinOn<Join<table, table, LeftOuter>, Grouped<Eq<Nullable<user_id>, Nullable<id>>>>>>, LeftOuter> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_joins.rs:58:26
-   |
-58 |     let _ = users::table.left_join(posts::table.left_join(users::table));
+LL |     let _ = users::table.left_join(posts::table.left_join(users::table));
    |                          ^^^^^^^^^ expected `Once`, found `MoreThanOnce`
    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
@@ -220,47 +231,49 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 3 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<Nullable<user_id>, Nullable<id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+   = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
+   
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:61:36
-   |
-61 |     let _ = users::table.left_join(posts::table.left_join(users::table.on(posts::user_id.eq(users::id))));
-   |                          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:78:20
+    |
+78  |         .left_join(posts::table.left_join(users::table.on(posts::user_id.eq(users::id))));
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>>`
-  --> tests/fail/invalid_joins.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), NullableExpression<query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), NullableExpression<(users::columns::id, users::columns::name)>)>>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>>`
-   = note: required for `query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>`
+   --> tests/fail/invalid_joins.rs:7:9
+    |
+7   |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), Nullable<SkipSelectableExpressionBoundCheckWrapper<...>>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>>`
+    = note: required for `Join<table, SelectStatement<FromClause<JoinOn<..., ...>>>, ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>`
 note: required by a bound in `left_join`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
+    |        --------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
+ 
+    
+error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
+  --> tests/fail/invalid_joins.rs:78:10
    |
-   |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
-   |        --------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
-
-error[E0271]: type mismatch resolving `<Join<table, SelectStatement<FromClause<JoinOn<Join<table, table, LeftOuter>, Grouped<Eq<user_id, id>>>>>, LeftOuter> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_joins.rs:61:26
-   |
-61 |     let _ = users::table.left_join(posts::table.left_join(users::table.on(posts::user_id.eq(users::id))));
-   |                          ^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+LL |         .left_join(posts::table.left_join(users::table.on(posts::user_id.eq(users::id))));
+   |          ^^^^^^^^^ expected `Once`, found `MoreThanOnce`
    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>>`
   --> tests/fail/invalid_joins.rs:7:9
@@ -269,46 +282,51 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 3 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>>`
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<Nullable<user_id>, Nullable<id>>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter>>`
+   = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::user_id, users::columns::id>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
 
+   
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:64:36
-   |
-64 |     let _ = users::table.left_join(posts::table.on(users::id.eq(posts::user_id)).left_join(users::table));
-   |                          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:85:9
+    |
+83  |       let _ = users::table.left_join(
+    |                            --------- required by a bound introduced by this call
+84  |
+85  | /         posts::table
+86  | |             .on(users::id.eq(posts::user_id))
+87  | |             .left_join(users::table),
+    | |____________________________________^ expected `Once`, found `MoreThanOnce`
+    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-  --> tests/fail/invalid_joins.rs:7:9
-   |
-7  |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), NullableExpression<query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), NullableExpression<(users::columns::id, users::columns::name)>)>>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-   = note: required for `query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>, LeftOuter>`
+   --> tests/fail/invalid_joins.rs:7:9
+    |
+7   |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `((id, name), Nullable<SkipSelectableExpressionBoundCheckWrapper<...>>)` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+    = note: required for `Join<table, SelectStatement<FromClause<JoinOn<..., ...>>>, ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>, LeftOuter>`
 note: required by a bound in `left_join`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
+    |        --------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
+ 
+    
+error[E0271]: type mismatch resolving `<Join<table, ..., ...> as AppearsInFromClause<...>>::Count == Once`
+  --> tests/fail/invalid_joins.rs:83:26
    |
-   |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
-   |        --------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
-
-error[E0271]: type mismatch resolving `<Join<table, SelectStatement<FromClause<JoinOn<Join<table, table, LeftOuter>, Grouped<Eq<Nullable<user_id>, Nullable<id>>>>>>, LeftOuter> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/invalid_joins.rs:64:26
-   |
-64 |     let _ = users::table.left_join(posts::table.on(users::id.eq(posts::user_id)).left_join(users::table));
+LL |     let _ = users::table.left_join(
    |                          ^^^^^^^^^ expected `Once`, found `MoreThanOnce`
    |
 note: required for `users::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
@@ -318,36 +336,39 @@ note: required for `users::columns::id` to implement `AppearsOnTable<query_sourc
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-   = note: required for `JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<id, user_id>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+   = note: required for `JoinOn<Join<table, SelectStatement<FromClause<...>>, ...>, ...>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, users::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, posts::columns::user_id>>>`
 
+   
 error[E0271]: type mismatch resolving `<Once as Plus<Once>>::Output == Once`
-  --> tests/fail/invalid_joins.rs:67:63
-   |
-67 |     let _ = users::table.left_join(comments::table).left_join(posts::table.left_join(comments::table));
-   |                                                     --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
-   |                                                     |
-   |                                                     required by a bound introduced by this call
-   |
+   --> tests/fail/invalid_joins.rs:94:20
+    |
+94  |         .left_join(posts::table.left_join(comments::table));
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `MoreThanOnce`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: required for `comments::columns::id` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter>>`
-  --> tests/fail/invalid_joins.rs:22:9
-   |
-22 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 3 redundant requirements hidden
-   = note: required for `((users::columns::id, users::columns::name), NullableExpression<(comments::columns::id, comments::columns::user_id, comments::columns::post_id, comments::columns::name)>, NullableExpression<query_source::joins::private::SkipSelectableExpressionBoundCheckWrapper<((posts::columns::id, posts::columns::title, posts::columns::user_id), NullableExpression<(comments::columns::id, comments::columns::user_id, comments::columns::post_id, comments::columns::name)>)>>)` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter>>`
-   = note: required for `query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter>` to implement `QuerySource`
-   = note: 1 redundant requirement hidden
-   = note: required for `JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter>`
+   --> tests/fail/invalid_joins.rs:22:9
+    |
+22  |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 3 redundant requirements hidden
+    = note: required for `((id, name), Nullable<(id, user_id, post_id, name)>, Nullable<...>)` to implement `AppearsOnTable<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::user_id>, NullableExpression<users::columns::id>>>>, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter>>`
+    = note: required for `Join<JoinOn<Join<table, table, LeftOuter>, Grouped<...>>, ..., ...>` to implement `QuerySource`
+    = note: 1 redundant requirement hidden
+    = note: required for `JoinOn<Join<JoinOn<Join<table, table, ...>, ...>, ..., ...>, ...>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `InternalJoinDsl<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `JoinWithImplicitOnClause<SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, LeftOuter>`
 note: required by a bound in `left_join`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
-   |        --------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn left_join<Rhs>(self, rhs: Rhs) -> LeftJoin<Self, Rhs>
+    |        --------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_join`
+ 
+    For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/join_with_explicit_on_requires_valid_boolean_expression.rs
+++ b/diesel_compile_tests/tests/fail/join_with_explicit_on_requires_valid_boolean_expression.rs
@@ -29,6 +29,8 @@ fn main() {
     let _ = users::table.inner_join(posts::table.on(users::id.eq(posts::id)));
     // Invalid, references column that isn't being queried
     let _ = users::table.inner_join(posts::table.on(users::id.eq(comments::id)));
+    //~^ ERROR: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
     // Invalid, type is not boolean
     let _ = users::table.inner_join(posts::table.on(users::id));
+    //~^ ERROR: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
 }

--- a/diesel_compile_tests/tests/fail/join_with_explicit_on_requires_valid_boolean_expression.stderr
+++ b/diesel_compile_tests/tests/fail/join_with_explicit_on_requires_valid_boolean_expression.stderr
@@ -1,42 +1,43 @@
 error[E0271]: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/join_with_explicit_on_requires_valid_boolean_expression.rs:31:26
    |
-31 |     let _ = users::table.inner_join(posts::table.on(users::id.eq(comments::id)));
+LL |     let _ = users::table.inner_join(posts::table.on(users::id.eq(comments::id)));
    |                          ^^^^^^^^^^ expected `Once`, found `Never`
    |
 note: required for `comments::columns::id` to implement `AppearsOnTable<query_source::joins::Join<users::table, posts::table, Inner>>`
   --> tests/fail/join_with_explicit_on_requires_valid_boolean_expression.rs:19:9
    |
-19 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, comments::columns::id>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, posts::table, Inner>>`
-   = note: required for `JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, comments::columns::id>>>` to implement `QuerySource`
+   = note: required for `Grouped<Eq<id, id>>` to implement `AppearsOnTable<query_source::joins::Join<users::table, posts::table, Inner>>`
+   = note: required for `JoinOn<Join<table, table, Inner>, Grouped<Eq<id, id>>>` to implement `QuerySource`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<posts::table, Inner, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, comments::columns::id>>>`
 
+   
 error[E0277]: `diesel::sql_types::Integer` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
-  --> tests/fail/join_with_explicit_on_requires_valid_boolean_expression.rs:33:37
-   |
-33 |     let _ = users::table.inner_join(posts::table.on(users::id));
-   |                          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
-   |                          |
-   |                          required by a bound introduced by this call
-   |
-   = note: try to provide an expression that produces one of the expected sql types
-   = help: the following other types implement trait `BoolOrNullableBool`:
-             Bool
-             Nullable<Bool>
-   = note: required for `JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, users::columns::id>` to implement `QuerySource`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<posts::table, Inner, users::columns::id>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `InternalJoinDsl<posts::table, Inner, users::columns::id>`
-   = note: required for `users::table` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<posts::table, users::columns::id>, Inner>`
+   --> tests/fail/join_with_explicit_on_requires_valid_boolean_expression.rs:34:37
+    |
+34  |     let _ = users::table.inner_join(posts::table.on(users::id));
+    |                          ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `BoolOrNullableBool` is not implemented for `diesel::sql_types::Integer`
+    |                          |
+    |                          required by a bound introduced by this call
+    |
+    = note: try to provide an expression that produces one of the expected sql types
+    = help: the following other types implement trait `BoolOrNullableBool`:
+              Bool
+              Nullable<Bool>
+    = note: required for `JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, users::columns::id>` to implement `QuerySource`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `InternalJoinDsl<posts::table, Inner, users::columns::id>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `InternalJoinDsl<posts::table, Inner, users::columns::id>`
+    = note: required for `users::table` to implement `JoinWithImplicitOnClause<query_source::joins::OnClauseWrapper<posts::table, users::columns::id>, Inner>`
 note: required by a bound in `inner_join`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`

--- a/diesel_compile_tests/tests/fail/must_use_query_methods.rs
+++ b/diesel_compile_tests/tests/fail/must_use_query_methods.rs
@@ -15,21 +15,33 @@ fn main() {
     use stuff::table as st;
 
     st.select(b);
+    //~^ ERROR: unused `SelectStatement` that must be used
     st.select(b).distinct();
+    //~^ ERROR: unused `SelectStatement` that must be used
     st.count();
+    //~^ ERROR: unused `SelectStatement` that must be used
     st.order(b);
+    //~^ ERROR: unused `SelectStatement` that must be used
     st.limit(1);
+    //~^ ERROR: unused `SelectStatement` that must be used
     st.offset(1);
+    //~^ ERROR: unused `SelectStatement` that must be used
 
     st.filter(b.eq(true));
+    //~^ ERROR: unused `SelectStatement` that must be used
     st.filter(b.eq(true)).limit(1);
+    //~^ ERROR: unused `SelectStatement` that must be used
 
     insert_into(st);
+    //~^ ERROR: unused `IncompleteInsertStatement` that must be used
     insert_into(st).values(&vec![b.eq(true), b.eq(false)]);
+    //~^ ERROR: unused `InsertStatement` that must be used
 
     update(st).set(b.eq(true));
+    //~^ ERROR: unused `UpdateStatement` that must be used
 
     delete(st);
+    //~^ ERROR: unused `DeleteStatement` that must be used
 
     let _thingies = st.filter(b.eq(true)); // No ERROR
 }

--- a/diesel_compile_tests/tests/fail/must_use_query_methods.stderr
+++ b/diesel_compile_tests/tests/fail/must_use_query_methods.stderr
@@ -1,7 +1,7 @@
 error: unused `SelectStatement` that must be used
   --> tests/fail/must_use_query_methods.rs:17:5
    |
-17 |     st.select(b);
+LL |     st.select(b);
    |     ^^^^^^^^^^^^
    |
    = note: Queries are only executed when calling `load`, `get_result` or similar.
@@ -12,137 +12,137 @@ note: the lint level is defined here
    |         ^^^^^^^^^^^^^^^
 help: use `let _ = ...` to ignore the resulting value
    |
-17 |     let _ = st.select(b);
-   |     +++++++
-
-error: unused `SelectStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:18:5
-   |
-18 |     st.select(b).distinct();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-18 |     let _ = st.select(b).distinct();
+LL |     let _ = st.select(b);
    |     +++++++
 
 error: unused `SelectStatement` that must be used
   --> tests/fail/must_use_query_methods.rs:19:5
    |
-19 |     st.count();
-   |     ^^^^^^^^^^
+LL |     st.select(b).distinct();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Queries are only executed when calling `load`, `get_result` or similar.
 help: use `let _ = ...` to ignore the resulting value
    |
-19 |     let _ = st.count();
-   |     +++++++
-
-error: unused `SelectStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:20:5
-   |
-20 |     st.order(b);
-   |     ^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-20 |     let _ = st.order(b);
+LL |     let _ = st.select(b).distinct();
    |     +++++++
 
 error: unused `SelectStatement` that must be used
   --> tests/fail/must_use_query_methods.rs:21:5
    |
-21 |     st.limit(1);
-   |     ^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-21 |     let _ = st.limit(1);
-   |     +++++++
-
-error: unused `SelectStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:22:5
-   |
-22 |     st.offset(1);
-   |     ^^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-22 |     let _ = st.offset(1);
-   |     +++++++
-
-error: unused `SelectStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:24:5
-   |
-24 |     st.filter(b.eq(true));
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-24 |     let _ = st.filter(b.eq(true));
-   |     +++++++
-
-error: unused `SelectStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:25:5
-   |
-25 |     st.filter(b.eq(true)).limit(1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-25 |     let _ = st.filter(b.eq(true)).limit(1);
-   |     +++++++
-
-error: unused `IncompleteInsertStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:27:5
-   |
-27 |     insert_into(st);
-   |     ^^^^^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-27 |     let _ = insert_into(st);
-   |     +++++++
-
-error: unused `InsertStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:28:5
-   |
-28 |     insert_into(st).values(&vec![b.eq(true), b.eq(false)]);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-28 |     let _ = insert_into(st).values(&vec![b.eq(true), b.eq(false)]);
-   |     +++++++
-
-error: unused `UpdateStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:30:5
-   |
-30 |     update(st).set(b.eq(true));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: Queries are only executed when calling `load`, `get_result` or similar.
-help: use `let _ = ...` to ignore the resulting value
-   |
-30 |     let _ = update(st).set(b.eq(true));
-   |     +++++++
-
-error: unused `DeleteStatement` that must be used
-  --> tests/fail/must_use_query_methods.rs:32:5
-   |
-32 |     delete(st);
+LL |     st.count();
    |     ^^^^^^^^^^
    |
    = note: Queries are only executed when calling `load`, `get_result` or similar.
 help: use `let _ = ...` to ignore the resulting value
    |
-32 |     let _ = delete(st);
+LL |     let _ = st.count();
+   |     +++++++
+
+error: unused `SelectStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:23:5
+   |
+LL |     st.order(b);
+   |     ^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = st.order(b);
+   |     +++++++
+
+error: unused `SelectStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:25:5
+   |
+LL |     st.limit(1);
+   |     ^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = st.limit(1);
+   |     +++++++
+
+error: unused `SelectStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:27:5
+   |
+LL |     st.offset(1);
+   |     ^^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = st.offset(1);
+   |     +++++++
+
+error: unused `SelectStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:30:5
+   |
+LL |     st.filter(b.eq(true));
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = st.filter(b.eq(true));
+   |     +++++++
+
+error: unused `SelectStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:32:5
+   |
+LL |     st.filter(b.eq(true)).limit(1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = st.filter(b.eq(true)).limit(1);
+   |     +++++++
+
+error: unused `IncompleteInsertStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:35:5
+   |
+LL |     insert_into(st);
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = insert_into(st);
+   |     +++++++
+
+error: unused `InsertStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:37:5
+   |
+LL |     insert_into(st).values(&vec![b.eq(true), b.eq(false)]);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = insert_into(st).values(&vec![b.eq(true), b.eq(false)]);
+   |     +++++++
+
+error: unused `UpdateStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:40:5
+   |
+LL |     update(st).set(b.eq(true));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = update(st).set(b.eq(true));
+   |     +++++++
+
+error: unused `DeleteStatement` that must be used
+  --> tests/fail/must_use_query_methods.rs:43:5
+   |
+LL |     delete(st);
+   |     ^^^^^^^^^^
+   |
+   = note: Queries are only executed when calling `load`, `get_result` or similar.
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = delete(st);
    |     +++++++

--- a/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.rs
+++ b/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.rs
@@ -9,11 +9,17 @@ table! {
     }
 }
 
-
-
 fn main() {
     let mut connection = MysqlConnection::establish("").unwrap();
-    users::table.offset(42).get_result::<(i32, String)>(&mut connection);
+    users::table
+        .offset(42)
+        .get_result::<(i32, String)>(&mut connection);
+    //~^ ERROR: LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>` is no valid SQL fragment for the `Mysql` backend
 
-    users::table.offset(42).into_boxed().get_result::<(i32, String)>(&mut connection);
+    users::table
+        .offset(42)
+        .into_boxed()
+        //~^ ERROR: the trait bound `LimitOffsetClause<NoLimitClause, ...>: IntoBoxedClause<'_, ...>` is not satisfied
+        //~| ERROR: the trait bound `LimitOffsetClause<NoLimitClause, ...>: IntoBoxedClause<'_, ...>` is not satisfied
+        .get_result::<(i32, String)>(&mut connection);
 }

--- a/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.stderr
+++ b/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.stderr
@@ -1,59 +1,42 @@
 error[E0277]: `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/mysql_does_not_support_offset_without_limit.rs:16:57
-   |
-16 |     users::table.offset(42).get_result::<(i32, String)>(&mut connection);
-   |                             ----------                  ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |                             |
-   |                             required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql>` is not implemented for `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>`
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `LimitOffsetClause<L, O>` implements `QueryFragment<Pg>`
-             `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `QueryFragment<Mysql>`
-             `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `QueryFragment<Sqlite>`
-             `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `QueryFragment<Mysql>`
-             `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `QueryFragment<Sqlite>`
-             `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `QueryFragment<Mysql>`
-             `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `QueryFragment<Sqlite>`
-             `LimitOffsetClause<NoLimitClause, OffsetClause<O>>` implements `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>>` to implement `QueryFragment<Mysql, AnsiSqlSelectStatement>`
-   = note: 1 redundant requirement hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>>` to implement `LoadQuery<'_, diesel::MysqlConnection, (i32, std::string::String)>`
+    --> tests/fail/mysql_does_not_support_offset_without_limit.rs:16:38
+     |
+16   |         .get_result::<(i32, String)>(&mut connection);
+     |          ----------                  ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql>` is not implemented for `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>`
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `LimitOffsetClause<L, O>` implements `QueryFragment<Pg>`
+               `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `QueryFragment<Mysql>`
+               `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `QueryFragment<Sqlite>`
+               `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `QueryFragment<Mysql>`
+               `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `QueryFragment<Sqlite>`
+               `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `QueryFragment<Mysql>`
+               `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `QueryFragment<Sqlite>`
+               `LimitOffsetClause<NoLimitClause, OffsetClause<O>>` implements `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql, AnsiSqlSelectStatement>`
+     = note: 1 redundant requirement hidden
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, diesel::MysqlConnection, (i32, std::string::String)>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
+error[E0277]: the trait bound `LimitOffsetClause<NoLimitClause, ...>: IntoBoxedClause<'_, ...>` is not satisfied
+  --> tests/fail/mysql_does_not_support_offset_without_limit.rs:21:10
    |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
-error[E0277]: the trait bound `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>: IntoBoxedClause<'_, Mysql>` is not satisfied
-  --> tests/fail/mysql_does_not_support_offset_without_limit.rs:18:29
-   |
-18 |     users::table.offset(42).into_boxed().get_result::<(i32, String)>(&mut connection);
-   |                             ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `IntoBoxedClause<'_, Mysql>` is not implemented for `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>`
-   = help: the following other types implement trait `IntoBoxedClause<'a, DB>`:
-             `LimitOffsetClause<L, O>` implements `IntoBoxedClause<'_, Pg>`
-             `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `IntoBoxedClause<'_, Mysql>`
-             `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `IntoBoxedClause<'_, Sqlite>`
-             `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `IntoBoxedClause<'_, Mysql>`
-             `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `IntoBoxedClause<'_, Sqlite>`
-             `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `IntoBoxedClause<'_, Mysql>`
-             `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `IntoBoxedClause<'_, Sqlite>`
-             `LimitOffsetClause<NoLimitClause, OffsetClause<O>>` implements `IntoBoxedClause<'_, Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>>` to implement `BoxedDsl<'_, Mysql>`
-
-error[E0277]: the trait bound `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>: IntoBoxedClause<'_, Mysql>` is not satisfied
-  --> tests/fail/mysql_does_not_support_offset_without_limit.rs:18:29
-   |
-18 |     users::table.offset(42).into_boxed().get_result::<(i32, String)>(&mut connection);
-   |                             ^^^^^^^^^^ unsatisfied trait bound
+LL |         .into_boxed()
+   |          ^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `IntoBoxedClause<'_, Mysql>` is not implemented for `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>`
    = help: the following other types implement trait `IntoBoxedClause<'a, DB>`:
@@ -65,12 +48,33 @@ error[E0277]: the trait bound `LimitOffsetClause<NoLimitClause, OffsetClause<die
              `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `IntoBoxedClause<'_, Mysql>`
              `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `IntoBoxedClause<'_, Sqlite>`
              `LimitOffsetClause<NoLimitClause, OffsetClause<O>>` implements `IntoBoxedClause<'_, Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>>` to implement `BoxedDsl<'_, Mysql>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, Mysql>`
+
+   
+error[E0277]: the trait bound `LimitOffsetClause<NoLimitClause, ...>: IntoBoxedClause<'_, ...>` is not satisfied
+    --> tests/fail/mysql_does_not_support_offset_without_limit.rs:21:10
+     |
+21   |         .into_boxed()
+     |          ^^^^^^^^^^ unsatisfied trait bound
+     |
+     = help: the trait `IntoBoxedClause<'_, Mysql>` is not implemented for `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>`
+     = help: the following other types implement trait `IntoBoxedClause<'a, DB>`:
+               `LimitOffsetClause<L, O>` implements `IntoBoxedClause<'_, Pg>`
+               `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `IntoBoxedClause<'_, Mysql>`
+               `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `IntoBoxedClause<'_, Sqlite>`
+               `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `IntoBoxedClause<'_, Mysql>`
+               `LimitOffsetClause<LimitClause<L>, OffsetClause<O>>` implements `IntoBoxedClause<'_, Sqlite>`
+               `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `IntoBoxedClause<'_, Mysql>`
+               `LimitOffsetClause<NoLimitClause, NoOffsetClause>` implements `IntoBoxedClause<'_, Sqlite>`
+               `LimitOffsetClause<NoLimitClause, OffsetClause<O>>` implements `IntoBoxedClause<'_, Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, Mysql>`
 note: required by a bound in `diesel::QueryDsl::into_boxed`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn into_boxed<'a, DB>(self) -> IntoBoxed<'a, Self, DB>
-   |        ---------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn into_boxed<'a, DB>(self) -> IntoBoxed<'a, Self, DB>
+     |        ---------- required by a bound in this associated function
 ...
-   |         Self: methods::BoxedDsl<'a, DB>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::into_boxed`
+LL |         Self: methods::BoxedDsl<'a, DB>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::into_boxed`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/mysql_on_conflict_tests.rs
+++ b/diesel_compile_tests/tests/fail/mysql_on_conflict_tests.rs
@@ -9,7 +9,6 @@ table! {
     }
 }
 
-
 fn main() {
     use self::users::dsl::*;
 
@@ -41,18 +40,22 @@ fn main() {
         .on_conflict(name)
         .do_nothing()
         .execute(&mut connection);
+    //~^ ERROR: OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
 
     insert_into(users)
         .values((id.eq(42), name.eq("John")))
         .on_conflict((id, name))
         .do_nothing()
         .execute(&mut connection);
+    //~^ ERROR: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
 
     insert_into(users)
         .values((id.eq(42), name.eq("John")))
         .on_conflict((dsl::DuplicatedKeys, name))
+        //~^ ERROR: the trait bound `ConflictTarget<(DuplicatedKeys, name)>: OnConflictTarget<table>` is not satisfied
         .do_nothing()
         .execute(&mut connection);
+    //~^ ERROR: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
 
     // do not allow raw sql fragments as on_conflict target
     insert_into(users)
@@ -60,6 +63,7 @@ fn main() {
         .on_conflict(dsl::sql("foo"))
         .do_nothing()
         .execute(&mut connection);
+    //~^ ERROR: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
 
     // do not allow excluded
     insert_into(users)
@@ -68,6 +72,7 @@ fn main() {
         .do_update()
         .set(name.eq(upsert::excluded(name)))
         .execute(&mut connection);
+    //~^ ERROR: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
 
     let mut connection = PgConnection::establish("postgres://localhost").unwrap();
 
@@ -77,17 +82,21 @@ fn main() {
         .on_conflict(dsl::DuplicatedKeys)
         .do_nothing()
         .execute(&mut connection);
+    //~^ ERROR: `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>` is no valid SQL fragment for the `Pg` backend
 
     insert_into(users)
         .values((id.eq(42), name.eq("John")))
         .on_conflict((name, dsl::DuplicatedKeys))
+        //~^ ERROR: the trait bound `ConflictTarget<(name, DuplicatedKeys)>: OnConflictTarget<table>` is not satisfied
         .do_nothing()
         .execute(&mut connection);
+    //~^ ERROR: `ConflictTarget<(name, DuplicatedKeys)>` is no valid SQL fragment for the `Pg` backend
 
     insert_into(users)
         .values((id.eq(42), name.eq("John")))
         .on_conflict((dsl::DuplicatedKeys, name))
+        //~^ ERROR: the trait bound `ConflictTarget<(DuplicatedKeys, name)>: OnConflictTarget<table>` is not satisfied
         .do_nothing()
         .execute(&mut connection);
-
+    //~^ ERROR: `ConflictTarget<(DuplicatedKeys, name)>` is no valid SQL fragment for the `Pg` backend
 }

--- a/diesel_compile_tests/tests/fail/mysql_on_conflict_tests.stderr
+++ b/diesel_compile_tests/tests/fail/mysql_on_conflict_tests.stderr
@@ -1,321 +1,331 @@
-error[E0277]: `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<columns::name>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:43:18
-   |
-43 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<columns::name>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>`
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<columns::name>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `QueryFragment<Mysql>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<columns::name>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<columns::name>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+error[E0277]: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/mysql_on_conflict_tests.rs:42:18
+     |
+42   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>`
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::id, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:49:18
-   |
-49 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::id, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>`
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::id, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `QueryFragment<Mysql>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::id, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::id, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/mysql_on_conflict_tests.rs:49:18
+     |
+49   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>`
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: the trait bound `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>: diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not satisfied
-  --> tests/fail/mysql_on_conflict_tests.rs:53:22
-   |
-53 |         .on_conflict((dsl::DuplicatedKeys, name))
-   |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>`
-   = help: the following other types implement trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<Table>`:
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-           and $N others
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `ConflictTarget<(DuplicatedKeys, name)>: OnConflictTarget<table>` is not satisfied
+   --> tests/fail/mysql_on_conflict_tests.rs:54:22
+    |
+54  |         .on_conflict((dsl::DuplicatedKeys, name))
+    |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not implemented for `ConflictTarget<(DuplicatedKeys, name)>`
+    = help: the following other types implement trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<Table>`:
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+            and N others
 note: required by a bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-  --> $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |     pub fn on_conflict<Target>(
-   |            ----------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |     pub fn on_conflict<Target>(
+    |            ----------- required by a bound in this associated function
 ...
-   |         ConflictTarget<Target>: OnConflictTarget<T>,
-   |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-
-error[E0277]: `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:55:18
-   |
-55 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>`
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `QueryFragment<Mysql>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+LL |         ConflictTarget<Target>: OnConflictTarget<T>,
+    |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
+ 
+    
+error[E0277]: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/mysql_on_conflict_tests.rs:57:18
+     |
+57   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>`
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<SqlLiteral<_>>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:62:18
-   |
-62 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<SqlLiteral<_>>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>`
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<SqlLiteral<_>>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `QueryFragment<Mysql>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<SqlLiteral<_>>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<SqlLiteral<_>>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/mysql_on_conflict_tests.rs:65:18
+     |
+65   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>`
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoUpdate<diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::query_builder::upsert::on_conflict_actions::Excluded<columns::name>>, users::table>>` is no valid SQL fragment for the `Mysql` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:70:18
-   |
-70 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoUpdate<diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::query_builder::upsert::on_conflict_actions::Excluded<columns::name>>, users::table>>`
-   = note: this usually means that the `Mysql` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
-             `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoUpdate<diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::query_builder::upsert::on_conflict_actions::Excluded<columns::name>>, users::table>>` to implement `QueryFragment<Mysql>`
-   = note: 1 redundant requirement hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoUpdate<diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::query_builder::upsert::on_conflict_actions::Excluded<columns::name>>, users::table>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoUpdate<diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::query_builder::upsert::on_conflict_actions::Excluded<columns::name>>, users::table>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/mysql_on_conflict_tests.rs:74:18
+     |
+74   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is not implemented for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>`
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action, diesel::query_builder::where_clause::WhereClause<Expr>>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB, SD>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<DB>`
+               `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<Values, Target, Action>` implements `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>`
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 1 redundant requirement hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
 error[E0277]: `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>` is no valid SQL fragment for the `Pg` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:79:18
-   |
-79 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Pg` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>`
-           but trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is implemented for it
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `QueryFragment<Pg, pg::backend::PgOnConflictClause>`
-   = note: 2 redundant requirements hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Pg>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
+    --> tests/fail/mysql_on_conflict_tests.rs:84:18
+     |
+84   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<DuplicatedKeys>`
+             but trait `QueryFragment<Mysql, mysql::backend::MysqlOnConflictClause>` is implemented for it
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Pg, pg::backend::PgOnConflictClause>`
+     = note: 2 redundant requirements hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Pg>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: the trait bound `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::name, DuplicatedKeys)>: diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not satisfied
-  --> tests/fail/mysql_on_conflict_tests.rs:83:22
-   |
-83 |         .on_conflict((name, dsl::DuplicatedKeys))
-   |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::name, DuplicatedKeys)>`
-   = help: the following other types implement trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<Table>`:
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-           and $N others
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `ConflictTarget<(name, DuplicatedKeys)>: OnConflictTarget<table>` is not satisfied
+   --> tests/fail/mysql_on_conflict_tests.rs:89:22
+    |
+89  |         .on_conflict((name, dsl::DuplicatedKeys))
+    |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not implemented for `ConflictTarget<(name, DuplicatedKeys)>`
+    = help: the following other types implement trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<Table>`:
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+            and N others
 note: required by a bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-  --> $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |     pub fn on_conflict<Target>(
-   |            ----------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |     pub fn on_conflict<Target>(
+    |            ----------- required by a bound in this associated function
 ...
-   |         ConflictTarget<Target>: OnConflictTarget<T>,
-   |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-
-error[E0277]: `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::name, DuplicatedKeys)>` is no valid SQL fragment for the `Pg` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:85:18
-   |
-85 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::name, DuplicatedKeys)>`
-   = note: this usually means that the `Pg` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `QueryFragment<DB, SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `QueryFragment<_DB, _SP>`
-           and $N others
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::name, DuplicatedKeys)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `QueryFragment<Pg, pg::backend::PgOnConflictClause>`
-   = note: 2 redundant requirements hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::name, DuplicatedKeys)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Pg>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(columns::name, DuplicatedKeys)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
+LL |         ConflictTarget<Target>: OnConflictTarget<T>,
+    |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
+ 
+    
+error[E0277]: `ConflictTarget<(name, DuplicatedKeys)>` is no valid SQL fragment for the `Pg` backend
+    --> tests/fail/mysql_on_conflict_tests.rs:92:18
+     |
+92   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `ConflictTarget<(name, DuplicatedKeys)>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `QueryFragment<DB, SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `QueryFragment<_DB, _SP>`
+             and N others
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Pg, pg::backend::PgOnConflictClause>`
+     = note: 2 redundant requirements hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Pg>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: the trait bound `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>: diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not satisfied
-  --> tests/fail/mysql_on_conflict_tests.rs:89:22
-   |
-89 |         .on_conflict((dsl::DuplicatedKeys, name))
-   |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>`
-   = help: the following other types implement trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<Table>`:
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
-           and $N others
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `ConflictTarget<(DuplicatedKeys, name)>: OnConflictTarget<table>` is not satisfied
+   --> tests/fail/mysql_on_conflict_tests.rs:97:22
+    |
+97  |         .on_conflict((dsl::DuplicatedKeys, name))
+    |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>` is not implemented for `ConflictTarget<(DuplicatedKeys, name)>`
+    = help: the following other types implement trait `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<Table>`:
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+              `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<<_T as Column>::Table>`
+            and N others
 note: required by a bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-  --> $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |     pub fn on_conflict<Target>(
-   |            ----------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |     pub fn on_conflict<Target>(
+    |            ----------- required by a bound in this associated function
 ...
-   |         ConflictTarget<Target>: OnConflictTarget<T>,
-   |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-
-error[E0277]: `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>` is no valid SQL fragment for the `Pg` backend
-  --> tests/fail/mysql_on_conflict_tests.rs:91:18
-   |
-91 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>`
-   = note: this usually means that the `Pg` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `QueryFragment<DB, SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `QueryFragment<_DB, _SP>`
-             `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `QueryFragment<_DB, _SP>`
-           and $N others
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `QueryFragment<Pg, pg::backend::PgOnConflictClause>`
-   = note: 2 redundant requirements hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Pg>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<diesel::query_builder::insert_statement::ValuesClause<(ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>), users::table>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(DuplicatedKeys, columns::name)>, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
+LL |         ConflictTarget<Target>: OnConflictTarget<T>,
+    |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `diesel::upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
+ 
+    
+error[E0277]: `ConflictTarget<(DuplicatedKeys, name)>` is no valid SQL fragment for the `Pg` backend
+    --> tests/fail/mysql_on_conflict_tests.rs:100:18
+     |
+100  |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `ConflictTarget<(DuplicatedKeys, name)>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(T,)>` implements `QueryFragment<DB, SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5)>` implements `QueryFragment<_DB, _SP>`
+               `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<(_T, T0, T1, T2, T3, T4, T5, T6)>` implements `QueryFragment<_DB, _SP>`
+             and N others
+     = note: required for `OnConflictValues<ValuesClause<(..., ...), ...>, ..., ...>` to implement `QueryFragment<Pg, pg::backend::PgOnConflictClause>`
+     = note: 2 redundant requirements hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Pg>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.rs
+++ b/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.rs
@@ -13,4 +13,5 @@ fn main() {
     use self::users::dsl::*;
 
     let _ = users.select(name + name);
+    //~^ ERROR: cannot add `columns::name` to `columns::name`
 }

--- a/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
+++ b/diesel_compile_tests/tests/fail/numeric_ops_require_numeric_column.stderr
@@ -1,7 +1,7 @@
 error[E0369]: cannot add `columns::name` to `columns::name`
   --> tests/fail/numeric_ops_require_numeric_column.rs:15:31
    |
-15 |     let _ = users.select(name + name);
+LL |     let _ = users.select(name + name);
    |                          ---- ^ ---- columns::name
    |                          |
    |                          columns::name
@@ -12,4 +12,5 @@ note: an implementation of `std::ops::Add` might be missing for `columns::name`
 8  |         name -> VarChar,
    |         ^^^^ must implement `std::ops::Add`
 note: the trait `std::ops::Add` must be implemented
-  --> $RUST/core/src/ops/arith.rs
+  --> /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/ops/arith.rs:78:1
+For more information about this error, try `rustc --explain E0369`.

--- a/diesel_compile_tests/tests/fail/only_only_on_table.rs
+++ b/diesel_compile_tests/tests/fail/only_only_on_table.rs
@@ -11,14 +11,20 @@ table! {
 
 fn main() {
     foo::table.select(foo::id).only();
+    //~^ ERROR: the method `only` exists for struct `SelectStatement<FromClause<table>, SelectClause<id>>`, but its trait bounds were not satisfied
     foo::table.select(foo::id).filter(foo::id.eq(1)).only();
+    //~^ ERROR: the method `only` exists for struct `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>`, but its trait bounds were not satisfied
     foo::table.select(foo::id.only());
+    //~^ ERROR: the method `only` exists for struct `id`, but its trait bounds were not satisfied
 
     // .only() is not supported for SQLite
     let mut conn = SqliteConnection::establish("").unwrap();
     foo::table.only().load(&mut conn).unwrap();
+    //~^ ERROR: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::SqliteConnection, _>` is not satisfied
+    //~| ERROR: the trait bound `{type error}: FromSqlRow<(BigInt,), Sqlite>` is not satisfied
 
     // .only() is not supported for MySql
     let mut conn = MysqlConnection::establish("").unwrap();
     foo::table.only().load(&mut conn).unwrap();
+    //~^ ERROR: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::MysqlConnection, _>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/only_only_on_table.stderr
+++ b/diesel_compile_tests/tests/fail/only_only_on_table.stderr
@@ -1,17 +1,17 @@
 error[E0599]: the method `only` exists for struct `SelectStatement<FromClause<table>, SelectClause<id>>`, but its trait bounds were not satisfied
   --> tests/fail/only_only_on_table.rs:13:32
    |
-13 |       foo::table.select(foo::id).only();
+LL |       foo::table.select(foo::id).only();
    |                                  ^^^^ method cannot be called due to unsatisfied trait bounds
    |
-  ::: $DIESEL/src/query_builder/select_statement/mod.rs
+  ::: DIESEL/diesel/diesel/src/query_builder/select_statement/mod.rs
    |
-   | / #[diesel_derives::__diesel_public_if(
-   | |     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-   | |     public_fields(
-   | |         select,
+LL | / #[diesel_derives::__diesel_public_if(
+LL | |     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+LL | |     public_fields(
+LL | |         select,
 ...  |
-   | | )]
+LL | | )]
    | |__- doesn't satisfy `_: OnlyDsl` or `_: Table`
    |
    = note: the following trait bounds were not satisfied:
@@ -22,20 +22,20 @@ error[E0599]: the method `only` exists for struct `SelectStatement<FromClause<ta
            `&mut SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: Table`
            which is required by `&mut SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>: diesel::dsl::OnlyDsl`
 
-error[E0599]: the method `only` exists for struct `SelectStatement<FromClause<table>, SelectClause<id>, NoDistinctClause, WhereClause<Grouped<Eq<id, Bound<BigInt, i64>>>>>`, but its trait bounds were not satisfied
-  --> tests/fail/only_only_on_table.rs:14:54
+error[E0599]: the method `only` exists for struct `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>`, but its trait bounds were not satisfied
+  --> tests/fail/only_only_on_table.rs:15:54
    |
-14 |       foo::table.select(foo::id).filter(foo::id.eq(1)).only();
+LL |       foo::table.select(foo::id).filter(foo::id.eq(1)).only();
    |                                                        ^^^^ method cannot be called due to unsatisfied trait bounds
    |
-  ::: $DIESEL/src/query_builder/select_statement/mod.rs
+  ::: DIESEL/diesel/diesel/src/query_builder/select_statement/mod.rs
    |
-   | / #[diesel_derives::__diesel_public_if(
-   | |     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-   | |     public_fields(
-   | |         select,
+LL | / #[diesel_derives::__diesel_public_if(
+LL | |     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+LL | |     public_fields(
+LL | |         select,
 ...  |
-   | | )]
+LL | | )]
    | |__- doesn't satisfy `_: OnlyDsl` or `_: Table`
    |
    = note: the following trait bounds were not satisfied:
@@ -47,12 +47,12 @@ error[E0599]: the method `only` exists for struct `SelectStatement<FromClause<ta
            which is required by `&mut SelectStatement<FromClause<foo::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<BigInt, i64>>>>>: diesel::dsl::OnlyDsl`
 
 error[E0599]: the method `only` exists for struct `id`, but its trait bounds were not satisfied
-  --> tests/fail/only_only_on_table.rs:15:31
+  --> tests/fail/only_only_on_table.rs:17:31
    |
 8  |         id -> Int8,
    |         -- method `only` not found for this struct because it doesn't satisfy `columns::id: Table` or `columns::id: diesel::dsl::OnlyDsl`
 ...
-15 |     foo::table.select(foo::id.only());
+LL |     foo::table.select(foo::id.only());
    |                               ^^^^ method cannot be called on `id` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
@@ -63,92 +63,92 @@ error[E0599]: the method `only` exists for struct `id`, but its trait bounds wer
            `&mut columns::id: Table`
            which is required by `&mut columns::id: diesel::dsl::OnlyDsl`
 note: the trait `Table` must be implemented
-  --> $DIESEL/src/query_source/mod.rs
+  --> DIESEL/diesel/diesel/src/query_source/mod.rs
    |
-   | pub trait Table: QuerySource + AsQuery + Sized {
+LL | pub trait Table: QuerySource + AsQuery + Sized {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `only`, perhaps you need to implement it:
            candidate #1: `diesel::dsl::OnlyDsl`
 
 error[E0277]: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::SqliteConnection, _>` is not satisfied
-  --> tests/fail/only_only_on_table.rs:19:28
-   |
-19 |     foo::table.only().load(&mut conn).unwrap();
-   |                       ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `Only<foo::table>`
-   |                       |
-   |                       required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `Only<foo::table>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Sqlite`
-   = note: required for `FromClause<Only<foo::table>>` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<Only<foo::table>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
+    --> tests/fail/only_only_on_table.rs:22:28
+     |
+22   |     foo::table.only().load(&mut conn).unwrap();
+     |                       ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `Only<foo::table>`
+     |                       |
+     |                       required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `Only<foo::table>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `FromClause<Only<foo::table>>` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<Only<foo::table>>>` to implement `QueryFragment<Sqlite>`
+     = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
 error[E0277]: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::MysqlConnection, _>` is not satisfied
-  --> tests/fail/only_only_on_table.rs:23:28
-   |
-23 |     foo::table.only().load(&mut conn).unwrap();
-   |                       ---- ^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `Only<foo::table>`
-   |                       |
-   |                       required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `Only<foo::table>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Mysql`
-   = note: required for `FromClause<Only<foo::table>>` to implement `QueryFragment<Mysql>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<Only<foo::table>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::MysqlConnection, _>`
+    --> tests/fail/only_only_on_table.rs:28:28
+     |
+28   |     foo::table.only().load(&mut conn).unwrap();
+     |                       ---- ^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `Only<foo::table>`
+     |                       |
+     |                       required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `Only<foo::table>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Mysql`
+     = note: required for `FromClause<Only<foo::table>>` to implement `QueryFragment<Mysql>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<Only<foo::table>>>` to implement `QueryFragment<Mysql>`
+     = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::MysqlConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
 error[E0277]: the trait bound `{type error}: FromSqlRow<(BigInt,), Sqlite>` is not satisfied
-  --> tests/fail/only_only_on_table.rs:19:28
-   |
-19 |     foo::table.only().load(&mut conn).unwrap();
-   |                       ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(BigInt,)`
-   |                       |
-   |                       required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(BigInt,)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(BigInt,), Sqlite>`
-   = note: required for `{type error}` to implement `FromSqlRow<(BigInt,), Sqlite>`
-   = note: required for `(BigInt,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-   = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
+    --> tests/fail/only_only_on_table.rs:22:28
+     |
+22   |     foo::table.only().load(&mut conn).unwrap();
+     |                       ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(BigInt,)`
+     |                       |
+     |                       required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(BigInt,)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(BigInt,), Sqlite>`
+     = note: required for `{type error}` to implement `FromSqlRow<(BigInt,), Sqlite>`
+     = note: required for `(BigInt,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
+     = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.rs
@@ -18,4 +18,5 @@ allow_tables_to_appear_in_same_query!(users, posts);
 
 fn main() {
     let source = users::table.order(posts::id);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/order_requires_column_from_same_table.stderr
@@ -1,13 +1,14 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/order_requires_column_from_same_table.rs:20:31
    |
-20 |     let source = users::table.order(posts::id);
+LL |     let source = users::table.order(posts::id);
    |                               ^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/order_requires_column_from_same_table.rs:13:9
    |
-13 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `OrderDsl<posts::columns::id>`
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/ordering_functions_require_ord.rs
+++ b/diesel_compile_tests/tests/fail/ordering_functions_require_ord.rs
@@ -11,5 +11,9 @@ table! {
 
 fn main() {
     let source = stuff::table.select(max(stuff::b));
+    //~^ ERROR: the trait bound `Bool: SqlOrdAggregate` is not satisfied
+    //~| ERROR: expressions of the type `diesel::sql_types::Bool` cannot be ordered by the database
     let source = stuff::table.select(min(stuff::b));
+    //~^ ERROR: the trait bound `Bool: SqlOrdAggregate` is not satisfied
+    //~| ERROR: expressions of the type `diesel::sql_types::Bool` cannot be ordered by the database
 }

--- a/diesel_compile_tests/tests/fail/ordering_functions_require_ord.stderr
+++ b/diesel_compile_tests/tests/fail/ordering_functions_require_ord.stderr
@@ -1,7 +1,7 @@
-error[E0277]: the trait bound `diesel::sql_types::Bool: diesel::expression::functions::aggregate_ordering::private::SqlOrdAggregate` is not satisfied
+error[E0277]: the trait bound `Bool: SqlOrdAggregate` is not satisfied
   --> tests/fail/ordering_functions_require_ord.rs:13:38
    |
-13 |     let source = stuff::table.select(max(stuff::b));
+LL |     let source = stuff::table.select(max(stuff::b));
    |                                      ^^^^^^^^^^^^^ the trait `SqlOrd` is not implemented for `diesel::sql_types::Bool`
    |
    = help: the following other types implement trait `SqlOrd`:
@@ -13,18 +13,19 @@ error[E0277]: the trait bound `diesel::sql_types::Bool: diesel::expression::func
              Nullable<T>
              Unsigned<BigInt>
              Unsigned<diesel::sql_types::Integer>
-           and $N others
+           and N others
    = note: required for `diesel::sql_types::Bool` to implement `diesel::expression::functions::aggregate_ordering::private::SqlOrdAggregate`
 note: required by a bound in `diesel::dsl::max`
-  --> $DIESEL/src/expression/functions/aggregate_ordering.rs
+  --> DIESEL/diesel/diesel/src/expression/functions/aggregate_ordering.rs
    |
-   |     fn max<ST: SqlOrdAggregate>(expr: ST) -> ST::Ret;
+LL |     fn max<ST: SqlOrdAggregate>(expr: ST) -> ST::Ret;
    |                ^^^^^^^^^^^^^^^ required by this bound in `max`
 
+   
 error[E0277]: expressions of the type `diesel::sql_types::Bool` cannot be ordered by the database
   --> tests/fail/ordering_functions_require_ord.rs:13:31
    |
-13 |     let source = stuff::table.select(max(stuff::b));
+LL |     let source = stuff::table.select(max(stuff::b));
    |                               ^^^^^^ the trait `SqlOrd` is not implemented for `diesel::sql_types::Bool`
    |
    = help: the following other types implement trait `SqlOrd`:
@@ -36,15 +37,16 @@ error[E0277]: expressions of the type `diesel::sql_types::Bool` cannot be ordere
              Nullable<T>
              Unsigned<BigInt>
              Unsigned<diesel::sql_types::Integer>
-           and $N others
+           and N others
    = note: required for `diesel::sql_types::Bool` to implement `diesel::expression::functions::aggregate_ordering::private::SqlOrdAggregate`
-   = note: required for `diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Bool, columns::b>` to implement `diesel::Expression`
+   = note: required for `max<Bool, b>` to implement `diesel::Expression`
    = note: required for `stuff::table` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Bool, columns::b>>`
 
-error[E0277]: the trait bound `diesel::sql_types::Bool: diesel::expression::functions::aggregate_ordering::private::SqlOrdAggregate` is not satisfied
-  --> tests/fail/ordering_functions_require_ord.rs:14:38
+   
+error[E0277]: the trait bound `Bool: SqlOrdAggregate` is not satisfied
+  --> tests/fail/ordering_functions_require_ord.rs:16:38
    |
-14 |     let source = stuff::table.select(min(stuff::b));
+LL |     let source = stuff::table.select(min(stuff::b));
    |                                      ^^^^^^^^^^^^^ the trait `SqlOrd` is not implemented for `diesel::sql_types::Bool`
    |
    = help: the following other types implement trait `SqlOrd`:
@@ -56,18 +58,19 @@ error[E0277]: the trait bound `diesel::sql_types::Bool: diesel::expression::func
              Nullable<T>
              Unsigned<BigInt>
              Unsigned<diesel::sql_types::Integer>
-           and $N others
+           and N others
    = note: required for `diesel::sql_types::Bool` to implement `diesel::expression::functions::aggregate_ordering::private::SqlOrdAggregate`
 note: required by a bound in `diesel::dsl::min`
-  --> $DIESEL/src/expression/functions/aggregate_ordering.rs
+  --> DIESEL/diesel/diesel/src/expression/functions/aggregate_ordering.rs
    |
-   |     fn min<ST: SqlOrdAggregate>(expr: ST) -> ST::Ret;
+LL |     fn min<ST: SqlOrdAggregate>(expr: ST) -> ST::Ret;
    |                ^^^^^^^^^^^^^^^ required by this bound in `min`
 
+   
 error[E0277]: expressions of the type `diesel::sql_types::Bool` cannot be ordered by the database
-  --> tests/fail/ordering_functions_require_ord.rs:14:31
+  --> tests/fail/ordering_functions_require_ord.rs:16:31
    |
-14 |     let source = stuff::table.select(min(stuff::b));
+LL |     let source = stuff::table.select(min(stuff::b));
    |                               ^^^^^^ the trait `SqlOrd` is not implemented for `diesel::sql_types::Bool`
    |
    = help: the following other types implement trait `SqlOrd`:
@@ -79,7 +82,9 @@ error[E0277]: expressions of the type `diesel::sql_types::Bool` cannot be ordere
              Nullable<T>
              Unsigned<BigInt>
              Unsigned<diesel::sql_types::Integer>
-           and $N others
+           and N others
    = note: required for `diesel::sql_types::Bool` to implement `diesel::expression::functions::aggregate_ordering::private::SqlOrdAggregate`
-   = note: required for `diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Bool, columns::b>` to implement `diesel::Expression`
+   = note: required for `min<Bool, b>` to implement `diesel::Expression`
    = note: required for `stuff::table` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::min_utils::min<diesel::sql_types::Bool, columns::b>>`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/pg_on_conflict_requires_valid_conflict_target.rs
+++ b/diesel_compile_tests/tests/fail/pg_on_conflict_requires_valid_conflict_target.rs
@@ -39,12 +39,15 @@ fn main() {
     let column_from_other_table = insert_into(users)
         .values(&NewUser("Sean"))
         .on_conflict(posts::id);
+    //~^ ERROR: type mismatch resolving `<id as Column>::Table == table`
 
     let expression_using_column_from_other_table = insert_into(users)
         .values(&NewUser("Sean"))
         .on_conflict(lower(posts::title));
+    //~^ ERROR: the trait bound `lower_utils::lower<posts::columns::title>: Column` is not satisfied
 
     let random_non_expression = insert_into(users)
         .values(&NewUser("Sean"))
         .on_conflict("id");
+    //~^ ERROR: the trait bound `&str: Column` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/pg_on_conflict_requires_valid_conflict_target.stderr
+++ b/diesel_compile_tests/tests/fail/pg_on_conflict_requires_valid_conflict_target.stderr
@@ -1,99 +1,100 @@
 error[E0271]: type mismatch resolving `<id as Column>::Table == table`
-  --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:41:22
-   |
-41 |         .on_conflict(posts::id);
-   |          ----------- ^^^^^^^^^ type mismatch resolving `<id as Column>::Table == table`
-   |          |
-   |          required by a bound introduced by this call
-   |
+   --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:41:22
+    |
+41  |         .on_conflict(posts::id);
+    |          ----------- ^^^^^^^^^ type mismatch resolving `<id as Column>::Table == table`
+    |          |
+    |          required by a bound introduced by this call
+    |
 note: expected this to be `users::table`
-  --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:14:9
-   |
-14 |         id -> Integer,
-   |         ^^
-   = note: `posts::table` and `users::table` have similar names, but are actually distinct types
+   --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:14:9
+    |
+14  |         id -> Integer,
+    |         ^^
+    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:12:1
-   |
-12 | / table! {
-13 | |     posts {
-14 | |         id -> Integer,
-15 | |         title -> VarChar,
-16 | |     }
-17 | | }
-   | |_^
+   --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:12:1
+    |
+12  | / table! {
+13  | |     posts {
+14  | |         id -> Integer,
+15  | |         title -> VarChar,
+16  | |     }
+17  | | }
+    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
-  --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:5:1
-   |
-5  | / table! {
-6  | |     users {
-7  | |         id -> Integer,
-8  | |         name -> VarChar,
-9  | |     }
-10 | | }
-   | |_^
+   --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:5:1
+    |
+5   | / table! {
+6   | |     users {
+7   | |         id -> Integer,
+8   | |         name -> VarChar,
+9   | |     }
+10  | | }
+    | |_^
 note: required by a bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-  --> $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |     pub fn on_conflict<Target>(
-   |            ----------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |     pub fn on_conflict<Target>(
+    |            ----------- required by a bound in this associated function
 ...
-   |         ConflictTarget<Target>: OnConflictTarget<T>,
-   |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |         ConflictTarget<Target>: OnConflictTarget<T>,
+    |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
+    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `lower_utils::lower<posts::columns::title>: Column` is not satisfied
-  --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:45:22
-   |
-45 |         .on_conflict(lower(posts::title));
-   |          ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Column` is not implemented for `lower_utils::lower<posts::columns::title>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `Column`:
-             pg::metadata_lookup::pg_namespace::columns::nspname
-             pg::metadata_lookup::pg_namespace::columns::oid
-             pg::metadata_lookup::pg_type::columns::oid
-             pg::metadata_lookup::pg_type::columns::typarray
-             pg::metadata_lookup::pg_type::columns::typname
-             pg::metadata_lookup::pg_type::columns::typnamespace
-             posts::columns::id
-             posts::columns::title
-           and $N others
-   = note: required for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<lower_utils::lower<posts::columns::title>>` to implement `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>`
+   --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:46:22
+    |
+46  |         .on_conflict(lower(posts::title));
+    |          ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Column` is not implemented for `lower_utils::lower<posts::columns::title>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `Column`:
+              pg::metadata_lookup::pg_namespace::columns::nspname
+              pg::metadata_lookup::pg_namespace::columns::oid
+              pg::metadata_lookup::pg_type::columns::oid
+              pg::metadata_lookup::pg_type::columns::typarray
+              pg::metadata_lookup::pg_type::columns::typname
+              pg::metadata_lookup::pg_type::columns::typnamespace
+              posts::columns::id
+              posts::columns::title
+            and N others
+    = note: required for `ConflictTarget<lower<title>>` to implement `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>`
 note: required by a bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-  --> $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |     pub fn on_conflict<Target>(
-   |            ----------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |     pub fn on_conflict<Target>(
+    |            ----------- required by a bound in this associated function
 ...
-   |         ConflictTarget<Target>: OnConflictTarget<T>,
-   |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-
+LL |         ConflictTarget<Target>: OnConflictTarget<T>,
+    |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
+ 
+    
 error[E0277]: the trait bound `&str: Column` is not satisfied
-  --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:49:22
-   |
-49 |         .on_conflict("id");
-   |          ----------- ^^^^ the trait `Column` is not implemented for `&str`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `Column`:
-             pg::metadata_lookup::pg_namespace::columns::nspname
-             pg::metadata_lookup::pg_namespace::columns::oid
-             pg::metadata_lookup::pg_type::columns::oid
-             pg::metadata_lookup::pg_type::columns::typarray
-             pg::metadata_lookup::pg_type::columns::typname
-             pg::metadata_lookup::pg_type::columns::typnamespace
-             posts::columns::id
-             posts::columns::title
-           and $N others
-   = note: required for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<&str>` to implement `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>`
+   --> tests/fail/pg_on_conflict_requires_valid_conflict_target.rs:51:22
+    |
+51  |         .on_conflict("id");
+    |          ----------- ^^^^ the trait `Column` is not implemented for `&str`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `Column`:
+              pg::metadata_lookup::pg_namespace::columns::nspname
+              pg::metadata_lookup::pg_namespace::columns::oid
+              pg::metadata_lookup::pg_type::columns::oid
+              pg::metadata_lookup::pg_type::columns::typarray
+              pg::metadata_lookup::pg_type::columns::typname
+              pg::metadata_lookup::pg_type::columns::typnamespace
+              posts::columns::id
+              posts::columns::title
+            and N others
+    = note: required for `diesel::query_builder::upsert::on_conflict_target::ConflictTarget<&str>` to implement `diesel::query_builder::upsert::on_conflict_target::OnConflictTarget<users::table>`
 note: required by a bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
-  --> $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |     pub fn on_conflict<Target>(
-   |            ----------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |     pub fn on_conflict<Target>(
+    |            ----------- required by a bound in this associated function
 ...
-   |         ConflictTarget<Target>: OnConflictTarget<T>,
-   |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`
+LL |         ConflictTarget<Target>: OnConflictTarget<T>,
+    |                                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `upsert::on_conflict_extension::<impl InsertStatement<T, U, Op, Ret>>::on_conflict`

--- a/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs
+++ b/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs
@@ -18,7 +18,9 @@ fn main() {
         .select(name.concat(b"foo".to_vec()))
         .filter(name.like(b"bar".to_vec()))
         .filter(name.not_like(b"baz".to_vec()))
-        .get_result::<Vec<u8>>(&mut connection).unwrap();
+        .get_result::<Vec<u8>>(&mut connection)
+        //~^ ERROR: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Sqlite`
+        .unwrap();
 
     let mut connection = MysqlConnection::establish("").unwrap();
 
@@ -26,5 +28,7 @@ fn main() {
         .select(name.concat(b"foo".to_vec()))
         .filter(name.like(b"bar".to_vec()))
         .filter(name.not_like(b"baz".to_vec()))
-        .get_result::<Vec<u8>>(&mut connection).unwrap();
+        .get_result::<Vec<u8>>(&mut connection)
+        //~^ ERROR: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Mysql`
+        .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.stderr
+++ b/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.stderr
@@ -1,55 +1,58 @@
 error[E0277]: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Sqlite`
-  --> tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs:21:32
-   |
-21 |         .get_result::<Vec<u8>>(&mut connection).unwrap();
-   |          ----------            ^^^^^^^^^^^^^^^ the trait `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>` is not implemented for `Sqlite`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: Expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are
-           allowed for all backends
-   = note: Expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are
-           allowed for the PostgreSQL backend
-   = help: the following other types implement trait `diesel::expression::operators::LikeIsAllowedForType<ST>`:
-             `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<Citext>`
-             `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>`
-   = note: required for `diesel::expression::operators::Like<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>` to implement `QueryFragment<Sqlite>`
-   = note: 6 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Concat<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::And<diesel::expression::grouped::Grouped<diesel::expression::operators::Like<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::NotLike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Concat<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::And<diesel::expression::grouped::Grouped<diesel::expression::operators::Like<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::NotLike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, Vec<u8>>`
+    --> tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs:21:32
+     |
+21   |         .get_result::<Vec<u8>>(&mut connection)
+     |          ----------            ^^^^^^^^^^^^^^^ the trait `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>` is not implemented for `Sqlite`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: Expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are 
+             allowed for all backends
+     = note: Expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are 
+             allowed for the PostgreSQL backend
+     = help: the following other types implement trait `diesel::expression::operators::LikeIsAllowedForType<ST>`:
+               `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<Citext>`
+               `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>`
+     = note: required for `Like<name, Bound<Binary, Vec<u8>>>` to implement `QueryFragment<Sqlite>`
+     = note: 6 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>, ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, Vec<u8>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Mysql`
-  --> tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs:29:32
-   |
-29 |         .get_result::<Vec<u8>>(&mut connection).unwrap();
-   |          ----------            ^^^^^^^^^^^^^^^ the trait `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>` is not implemented for `Mysql`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: Expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are
-           allowed for all backends
-   = note: Expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are
-           allowed for the PostgreSQL backend
-   = help: the following other types implement trait `diesel::expression::operators::LikeIsAllowedForType<ST>`:
-             `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<Citext>`
-             `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>`
-   = note: required for `diesel::expression::operators::Like<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>` to implement `QueryFragment<Mysql>`
-   = note: 6 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Concat<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::And<diesel::expression::grouped::Grouped<diesel::expression::operators::Like<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::NotLike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Concat<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::And<diesel::expression::grouped::Grouped<diesel::expression::operators::Like<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>, diesel::expression::grouped::Grouped<diesel::expression::operators::NotLike<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Binary, Vec<u8>>>>>>>>` to implement `LoadQuery<'_, diesel::MysqlConnection, Vec<u8>>`
+    --> tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs:31:32
+     |
+31   |         .get_result::<Vec<u8>>(&mut connection)
+     |          ----------            ^^^^^^^^^^^^^^^ the trait `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>` is not implemented for `Mysql`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: Expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are 
+             allowed for all backends
+     = note: Expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are 
+             allowed for the PostgreSQL backend
+     = help: the following other types implement trait `diesel::expression::operators::LikeIsAllowedForType<ST>`:
+               `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<Citext>`
+               `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<diesel::sql_types::Binary>`
+     = note: required for `Like<name, Bound<Binary, Vec<u8>>>` to implement `QueryFragment<Mysql>`
+     = note: 6 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>, ..., ...>` to implement `LoadQuery<'_, diesel::MysqlConnection, Vec<u8>>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
+++ b/diesel_compile_tests/tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs
@@ -30,16 +30,20 @@ fn main() {
         .select(id)
         .filter(name.eq(any(Vec::<String>::new())))
         .load::<i32>(&mut connection);
+    //~^ ERROR: `Any<Bound<Array<Text>, Vec<String>>>` is no valid SQL fragment for the `Sqlite` backend
     users
         .select(id)
         .filter(name.is_not_distinct_from("Sean"))
         .load::<i32>(&mut connection);
+    //~^ ERROR: `IsNotDistinctFrom<name, Bound<Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
     users
         .select(id)
         .filter(now.eq(now.at_time_zone("UTC")))
         .load::<i32>(&mut connection);
+    //~^ ERROR: `AtTimeZone<now, Bound<Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
     insert_into(users)
         .values(&NewUser("Sean"))
         .on_conflict(on_constraint("name"))
         .execute(&mut connection);
+    //~^ ERROR: the method `execute` exists for struct `IncompleteOnConflict<InsertStatement<table, ...>, ...>`, but its trait bounds were not satisfied
 }

--- a/diesel_compile_tests/tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.stderr
+++ b/diesel_compile_tests/tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.stderr
@@ -1,109 +1,112 @@
 warning: use of deprecated function `diesel::dsl::any`: Use `ExpressionMethods::eq_any` instead
   --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:31:25
    |
-31 |         .filter(name.eq(any(Vec::<String>::new())))
+LL |         .filter(name.eq(any(Vec::<String>::new())))
    |                         ^^^
    |
    = note: `#[warn(deprecated)]` on by default
 
-error[E0277]: `diesel::pg::expression::array_comparison::Any<diesel::expression::bound::Bound<Array<diesel::sql_types::Text>, Vec<std::string::String>>>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:32:22
-   |
-32 |         .load::<i32>(&mut connection);
-   |          ----        ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `diesel::pg::expression::array_comparison::Any<diesel::expression::bound::Bound<Array<diesel::sql_types::Text>, Vec<std::string::String>>>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Sqlite`
-   = note: required for `diesel::expression::operators::Eq<columns::name, diesel::pg::expression::array_comparison::Any<diesel::expression::bound::Bound<Array<diesel::sql_types::Text>, Vec<std::string::String>>>>` to implement `QueryFragment<Sqlite>`
-   = note: 4 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::pg::expression::array_comparison::Any<diesel::expression::bound::Bound<Array<diesel::sql_types::Text>, Vec<std::string::String>>>>>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::pg::expression::array_comparison::Any<diesel::expression::bound::Bound<Array<diesel::sql_types::Text>, Vec<std::string::String>>>>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, i32>`
+error[E0277]: `Any<Bound<Array<Text>, Vec<String>>>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:32:22
+     |
+32   |         .load::<i32>(&mut connection);
+     |          ----        ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `Any<Bound<Array<Text>, Vec<String>>>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `Any<Bound<Array<Text>, Vec<String>>>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `Eq<name, Any<Bound<Array<Text>, Vec<String>>>>` to implement `QueryFragment<Sqlite>`
+     = note: 4 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, i32>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: `diesel::pg::expression::operators::IsNotDistinctFrom<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:36:22
-   |
-36 |         .load::<i32>(&mut connection);
-   |          ----        ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `diesel::pg::expression::operators::IsNotDistinctFrom<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Sqlite`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::pg::expression::operators::IsNotDistinctFrom<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>` to implement `QueryFragment<Sqlite>`
-   = note: 3 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::pg::expression::operators::IsNotDistinctFrom<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::pg::expression::operators::IsNotDistinctFrom<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, i32>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: `IsNotDistinctFrom<name, Bound<Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:37:22
+     |
+37   |         .load::<i32>(&mut connection);
+     |          ----        ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `IsNotDistinctFrom<name, Bound<Text, &str>>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `IsNotDistinctFrom<name, Bound<Text, &str>>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `Grouped<IsNotDistinctFrom<name, Bound<Text, &str>>>` to implement `QueryFragment<Sqlite>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, i32>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: `diesel::pg::expression::date_and_time::AtTimeZone<diesel::dsl::now, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:40:22
-   |
-40 |         .load::<i32>(&mut connection);
-   |          ----        ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `diesel::pg::expression::date_and_time::AtTimeZone<diesel::dsl::now, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Sqlite`
-   = note: required for `diesel::expression::grouped::Grouped<diesel::pg::expression::date_and_time::AtTimeZone<diesel::dsl::now, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>` to implement `QueryFragment<Sqlite>`
-   = note: 5 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<diesel::dsl::now, diesel::expression::grouped::Grouped<diesel::pg::expression::date_and_time::AtTimeZone<diesel::dsl::now, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<diesel::dsl::now, diesel::expression::grouped::Grouped<diesel::pg::expression::date_and_time::AtTimeZone<diesel::dsl::now, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, i32>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: `AtTimeZone<now, Bound<Text, &str>>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:42:22
+     |
+42   |         .load::<i32>(&mut connection);
+     |          ----        ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `AtTimeZone<now, Bound<Text, &str>>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `AtTimeZone<now, Bound<Text, &str>>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `Grouped<AtTimeZone<now, Bound<Text, &str>>>` to implement `QueryFragment<Sqlite>`
+     = note: 5 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, i32>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0599]: the method `execute` exists for struct `IncompleteOnConflict<InsertStatement<table, ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<name, Bound<Text, &&str>>>,), table>>, ConflictTarget<OnConstraint<'_>>>`, but its trait bounds were not satisfied
-  --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:44:10
-   |
-41 | /     insert_into(users)
-42 | |         .values(&NewUser("Sean"))
-43 | |         .on_conflict(on_constraint("name"))
-44 | |         .execute(&mut connection);
-   | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
-   | |_________|
-   |
-   |
-  ::: $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |   pub struct IncompleteOnConflict<Stmt, Target> {
-   |   --------------------------------------------- doesn't satisfy `_: RunQueryDsl<_>` or `_: Table`
-   |
-   = note: the following trait bounds were not satisfied:
-           `IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: Table`
-           which is required by `IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: diesel::RunQueryDsl<_>`
-           `&IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: Table`
-           which is required by `&IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: diesel::RunQueryDsl<_>`
-           `&mut IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: Table`
-           which is required by `&mut IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: diesel::RunQueryDsl<_>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0599]: the method `execute` exists for struct `IncompleteOnConflict<InsertStatement<table, ...>, ...>`, but its trait bounds were not satisfied
+   --> tests/fail/pg_specific_expressions_cant_be_used_in_a_sqlite_query.rs:47:10
+    |
+44  | /     insert_into(users)
+45  | |         .values(&NewUser("Sean"))
+46  | |         .on_conflict(on_constraint("name"))
+47  | |         .execute(&mut connection);
+    | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
+    | |_________|
+    |
+    |
+   ::: DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |   pub struct IncompleteOnConflict<Stmt, Target> {
+    |   --------------------------------------------- doesn't satisfy `_: RunQueryDsl<_>` or `_: Table`
+    |
+    = note: the following trait bounds were not satisfied:
+            `IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: Table`
+            which is required by `IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: diesel::RunQueryDsl<_>`
+            `&IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: Table`
+            which is required by `&IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: diesel::RunQueryDsl<_>`
+            `&mut IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: Table`
+            which is required by `&mut IncompleteOnConflict<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<OnConstraint<'_>>>: diesel::RunQueryDsl<_>`

--- a/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_mysql.rs
+++ b/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_mysql.rs
@@ -18,4 +18,5 @@ fn main() {
         .tablesample_system(10)
         .with_seed(42.0)
         .load::<(i32, String)>(&mut connection);
+    //~^ ERROR: the trait bound `Tablesample<table, SystemMethod>: LoadQuery<'_, MysqlConnection, ...>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_mysql.stderr
+++ b/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_mysql.stderr
@@ -1,23 +1,25 @@
-error[E0277]: the trait bound `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>: LoadQuery<'_, diesel::MysqlConnection, (i32, std::string::String)>` is not satisfied
-  --> tests/fail/pg_specific_tablesample_cannot_be_used_on_mysql.rs:20:32
-   |
-20 |         .load::<(i32, String)>(&mut connection);
-   |          ----                  ^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Mysql`
-   = note: required for `FromClause<Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>>` to implement `QueryFragment<Mysql>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>>>` to implement `QueryFragment<Mysql>`
-   = note: required for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>` to implement `LoadQuery<'_, diesel::MysqlConnection, (i32, std::string::String)>`
+error[E0277]: the trait bound `Tablesample<table, SystemMethod>: LoadQuery<'_, MysqlConnection, ...>` is not satisfied
+    --> tests/fail/pg_specific_tablesample_cannot_be_used_on_mysql.rs:20:32
+     |
+20   |         .load::<(i32, String)>(&mut connection);
+     |          ----                  ^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Mysql`
+     = note: required for `FromClause<Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>>` to implement `QueryFragment<Mysql>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<Tablesample<table, SystemMethod>>>` to implement `QueryFragment<Mysql>`
+     = note: required for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>` to implement `LoadQuery<'_, diesel::MysqlConnection, (i32, std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_sqlite.rs
@@ -18,4 +18,5 @@ fn main() {
         .tablesample_system(10)
         .with_seed(42.0)
         .load::<(i32, String)>(&mut connection);
+    //~^ ERROR: the trait bound `Tablesample<table, SystemMethod>: LoadQuery<'_, SqliteConnection, ...>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/pg_specific_tablesample_cannot_be_used_on_sqlite.stderr
@@ -1,23 +1,25 @@
-error[E0277]: the trait bound `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>: LoadQuery<'_, diesel::SqliteConnection, (i32, std::string::String)>` is not satisfied
-  --> tests/fail/pg_specific_tablesample_cannot_be_used_on_sqlite.rs:20:32
-   |
-20 |         .load::<(i32, String)>(&mut connection);
-   |          ----                  ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
-           but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
-   = help: for that trait implementation, expected `Pg`, found `Sqlite`
-   = note: required for `FromClause<Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>>` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>` to implement `LoadQuery<'_, diesel::SqliteConnection, (i32, std::string::String)>`
+error[E0277]: the trait bound `Tablesample<table, SystemMethod>: LoadQuery<'_, SqliteConnection, ...>` is not satisfied
+    --> tests/fail/pg_specific_tablesample_cannot_be_used_on_sqlite.rs:20:32
+     |
+20   |         .load::<(i32, String)>(&mut connection);
+     |          ----                  ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `FromClause<Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>>` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<Tablesample<table, SystemMethod>>>` to implement `QueryFragment<Sqlite>`
+     = note: required for `Tablesample<users::table, pg::query_builder::tablesample::SystemMethod>` to implement `LoadQuery<'_, diesel::SqliteConnection, (i32, std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.rs
+++ b/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.rs
@@ -42,6 +42,7 @@ fn main() {
         .on_conflict(id)
         .do_update()
         .execute(&mut connection);
+    //~^ ERROR: the method `execute` exists for struct `IncompleteDoUpdate<InsertStatement<table, ...>, ...>`, but its trait bounds were not satisfied
 
     // Update column from other table
     insert_into(users)
@@ -49,6 +50,7 @@ fn main() {
         .on_conflict(id)
         .do_update()
         .set(posts::title.eq("Sean"));
+    //~^ ERROR: type mismatch resolving `<Grouped<Eq<title, Bound<Text, &str>>> as AsChangeset>::Target == table`
 
     // Update column with value that is not selectable
     insert_into(users)
@@ -56,6 +58,7 @@ fn main() {
         .on_conflict(id)
         .do_update()
         .set(name.eq(posts::title));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 
     // Update column with excluded value that is not selectable
     insert_into(users)
@@ -63,6 +66,7 @@ fn main() {
         .on_conflict(id)
         .do_update()
         .set(name.eq(excluded(posts::title)));
+    //~^ ERROR: type mismatch resolving `<title as Column>::Table == table`
 
     // Update column with excluded value of wrong type
     insert_into(users)
@@ -70,6 +74,7 @@ fn main() {
         .on_conflict(id)
         .do_update()
         .set(name.eq(excluded(id)));
+    //~^ ERROR: type mismatch resolving `<Excluded<id> as Expression>::SqlType == Text`
 
     // Excluded is only valid in upsert
     // FIXME: This should not compile

--- a/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
+++ b/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
@@ -1,109 +1,109 @@
-error[E0599]: the method `execute` exists for struct `IncompleteDoUpdate<InsertStatement<table, ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<name, Bound<Text, &&str>>>,), table>>, ConflictTarget<id>>`, but its trait bounds were not satisfied
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:44:10
-   |
-40 | /     insert_into(users)
-41 | |         .values(&NewUser("Sean"))
-42 | |         .on_conflict(id)
-43 | |         .do_update()
-44 | |         .execute(&mut connection);
-   | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
-   | |_________|
-   |
-   |
-  ::: $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |   pub struct IncompleteDoUpdate<Stmt, Target> {
-   |   ------------------------------------------- doesn't satisfy `_: RunQueryDsl<_>` or `_: Table`
-   |
-   = note: the following trait bounds were not satisfied:
-           `IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: Table`
-           which is required by `IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: diesel::RunQueryDsl<_>`
-           `&IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: Table`
-           which is required by `&IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: diesel::RunQueryDsl<_>`
-           `&mut IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: Table`
-           which is required by `&mut IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: diesel::RunQueryDsl<_>`
+error[E0599]: the method `execute` exists for struct `IncompleteDoUpdate<InsertStatement<table, ...>, ...>`, but its trait bounds were not satisfied
+   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:44:10
+    |
+40  | /     insert_into(users)
+41  | |         .values(&NewUser("Sean"))
+42  | |         .on_conflict(id)
+43  | |         .do_update()
+44  | |         .execute(&mut connection);
+    | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
+    | |_________|
+    |
+    |
+   ::: DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |   pub struct IncompleteDoUpdate<Stmt, Target> {
+    |   ------------------------------------------- doesn't satisfy `_: RunQueryDsl<_>` or `_: Table`
+    |
+    = note: the following trait bounds were not satisfied:
+            `IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: Table`
+            which is required by `IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: diesel::RunQueryDsl<_>`
+            `&IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: Table`
+            which is required by `&IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: diesel::RunQueryDsl<_>`
+            `&mut IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: Table`
+            which is required by `&mut IncompleteDoUpdate<InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &&str>>>,), users::table>>, diesel::query_builder::upsert::on_conflict_target::ConflictTarget<users::columns::id>>: diesel::RunQueryDsl<_>`
 
 error[E0271]: type mismatch resolving `<Grouped<Eq<title, Bound<Text, &str>>> as AsChangeset>::Target == table`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:51:14
-   |
-51 |         .set(posts::title.eq("Sean"));
-   |          --- ^^^^^^^^^^^^^^^^^^^^^^^ expected `users::table`, found `posts::table`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `posts::table` and `users::table` have similar names, but are actually distinct types
+   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:52:14
+    |
+52  |         .set(posts::title.eq("Sean"));
+    |          --- ^^^^^^^^^^^^^^^^^^^^^^^ expected `users::table`, found `posts::table`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:13:1
-   |
-13 | / table! {
-14 | |     posts {
-15 | |         id -> Integer,
-16 | |         title -> VarChar,
-17 | |     }
-18 | | }
-   | |_^
+   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:13:1
+    |
+13  | / table! {
+14  | |     posts {
+15  | |         id -> Integer,
+16  | |         title -> VarChar,
+17  | |     }
+18  | | }
+    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:6:1
-   |
-6  | / table! {
-7  | |     users {
-8  | |         id -> Integer,
-9  | |         name -> VarChar,
-10 | |     }
-11 | | }
-   | |_^
+   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:6:1
+    |
+6   | / table! {
+7   | |     users {
+8   | |         id -> Integer,
+9   | |         name -> VarChar,
+10  | |     }
+11  | | }
+    | |_^
 note: the method call chain might not have had the expected associated types
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:51:27
-   |
-51 |         .set(posts::title.eq("Sean"));
-   |              ------------ ^^^^^^^^^^ `AsChangeset::Target` is `table` here
-   |              |
-   |              this expression has type `title`
+   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:52:27
+    |
+52  |         .set(posts::title.eq("Sean"));
+    |              ------------ ^^^^^^^^^^ `AsChangeset::Target` is `table` here
+    |              |
+    |              this expression has type `title`
 note: required by a bound in `IncompleteDoUpdate::<InsertStatement<T, U, Op, Ret>, Target>::set`
-  --> $DIESEL/src/upsert/on_conflict_extension.rs
-   |
-   |     pub fn set<Changes>(
-   |            --- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/upsert/on_conflict_extension.rs
+    |
+LL |     pub fn set<Changes>(
+    |            --- required by a bound in this associated function
 ...
-   |         Changes: AsChangeset<Target = T>,
-   |                              ^^^^^^^^^^ required by this bound in `IncompleteDoUpdate::<InsertStatement<T, U, Op, Ret>, Target>::set`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |         Changes: AsChangeset<Target = T>,
+    |                              ^^^^^^^^^^ required by this bound in `IncompleteDoUpdate::<InsertStatement<T, U, Op, Ret>, Target>::set`
+    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:58:10
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:60:10
    |
-58 |         .set(name.eq(posts::title));
+LL |         .set(name.eq(posts::title));
    |          ^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:16:9
    |
-16 |         title -> VarChar,
+LL |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`
 
 error[E0271]: type mismatch resolving `<title as Column>::Table == table`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:65:10
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:68:10
    |
-65 |         .set(name.eq(excluded(posts::title)));
+LL |         .set(name.eq(excluded(posts::title)));
    |          ^^^ type mismatch resolving `<title as Column>::Table == table`
    |
 note: expected this to be `users::table`
   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:16:9
    |
-16 |         title -> VarChar,
+LL |         title -> VarChar,
    |         ^^^^^
    = note: `posts::table` and `users::table` have similar names, but are actually distinct types
 note: `posts::table` is defined in module `crate::posts` of the current crate
   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:13:1
    |
-13 | / table! {
-14 | |     posts {
-15 | |         id -> Integer,
-16 | |         title -> VarChar,
-17 | |     }
-18 | | }
+LL | / table! {
+LL | |     posts {
+LL | |         id -> Integer,
+LL | |         title -> VarChar,
+LL | |     }
+LL | | }
    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
   --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:6:1
@@ -112,16 +112,17 @@ note: `users::table` is defined in module `crate::users` of the current crate
 7  | |     users {
 8  | |         id -> Integer,
 9  | |         name -> VarChar,
-10 | |     }
-11 | | }
+LL | |     }
+LL | | }
    | |_^
-   = note: required for `diesel::expression::operators::Eq<users::columns::name, diesel::query_builder::upsert::on_conflict_actions::Excluded<posts::columns::title>>` to implement `AsChangeset`
-   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: required for `Eq<name, Excluded<title>>` to implement `AsChangeset`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Excluded<id> as Expression>::SqlType == Text`
-  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:72:19
+  --> tests/fail/pg_upsert_do_update_requires_valid_update.rs:76:19
    |
-72 |         .set(name.eq(excluded(id)));
+LL |         .set(name.eq(excluded(id)));
    |                   ^^ expected `Text`, found `Integer`
    |
    = note: required for `diesel::query_builder::upsert::on_conflict_actions::Excluded<users::columns::id>` to implement `AsExpression<diesel::sql_types::Text>`

--- a/diesel_compile_tests/tests/fail/queryable_with_typemismatch.rs
+++ b/diesel_compile_tests/tests/fail/queryable_with_typemismatch.rs
@@ -19,4 +19,5 @@ fn main() {
     let mut conn = PgConnection::establish("...").unwrap();
 
     users::table.load::<User>(&mut conn).unwrap();
+    //~^ ERROR: the trait bound `(Integer, Text): CompatibleType<User, _>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/queryable_with_typemismatch.stderr
+++ b/diesel_compile_tests/tests/fail/queryable_with_typemismatch.stderr
@@ -1,31 +1,33 @@
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): load_dsl::private::CompatibleType<User, _>` is not satisfied
-  --> tests/fail/queryable_with_typemismatch.rs:21:31
-   |
-21 |     users::table.load::<User>(&mut conn).unwrap();
-   |                  ----         ^^^^^^^^^ the trait `load_dsl::private::CompatibleType<User, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   |                  |
-   |                  required by a bound introduced by this call
-   |
-   = note: this is a mismatch between what your query returns and what your type expects the query to return
-   = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-           on your struct `User` and in your query `.select(User::as_select())` to get a better error message
-   = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-             (ST0, ST1)
-             (ST0, ST1, ST2)
-             (ST0, ST1, ST2, ST3)
-             (ST0, ST1, ST2, ST3, ST4)
-             (ST0, ST1, ST2, ST3, ST4, ST5)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-             (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
-           and $N others
-   = note: required for `users::table` to implement `LoadQuery<'_, _, User>`
+error[E0277]: the trait bound `(Integer, Text): CompatibleType<User, _>` is not satisfied
+    --> tests/fail/queryable_with_typemismatch.rs:21:31
+     |
+21   |     users::table.load::<User>(&mut conn).unwrap();
+     |                  ----         ^^^^^^^^^ the trait `load_dsl::private::CompatibleType<User, _>` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     |                  |
+     |                  required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `User` and in your query `.select(User::as_select())` to get a better error message
+     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
+               (ST0, ST1)
+               (ST0, ST1, ST2)
+               (ST0, ST1, ST2, ST3)
+               (ST0, ST1, ST2, ST3, ST4)
+               (ST0, ST1, ST2, ST3, ST4, ST5)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+             and N others
+     = note: required for `users::table` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs
+++ b/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs
@@ -23,33 +23,39 @@ fn main() {
     // these should fail
     let _ = posts::table
         .group_by(posts::user_id)
-        .distinct_on(posts::id) // error
+        .distinct_on(posts::id)
+        //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<_>` is not satisfied
         .select(posts::user_id)
         .get_results::<i32>(&mut conn);
 
     let _ = posts::table
         .distinct_on(posts::id)
         .group_by(posts::user_id)
-        .select(posts::user_id) // error
+        .select(posts::user_id)
+        //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: SelectDsl<_>` is not satisfied
         .get_results::<i32>(&mut conn);
 
     let _ = posts::table
         .distinct_on(posts::user_id)
-        .select(dsl::count(posts::id)) // error
+        .select(dsl::count(posts::id))
+        //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
         .get_result::<i64>(&mut conn);
 
     let _ = posts::table
         .select(dsl::count(posts::id))
-        .distinct_on(posts::user_id) // error
+        .distinct_on(posts::user_id)
+        //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
         .get_result::<i64>(&mut conn);
 
     let _ = posts::table
         .distinct_on(posts::user_id)
-        .count() // error
+        .count()
+        //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: SelectDsl<...>` is not satisfied
         .get_result::<i64>(&mut conn);
 
     let _ = posts::table
         .count()
-        .distinct_on(posts::user_id) // error
+        .distinct_on(posts::user_id)
+        //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
         .get_result::<i64>(&mut conn);
 }

--- a/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
@@ -1,97 +1,101 @@
-error[E0277]: the trait bound `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>: DistinctOnDsl<_>` is not satisfied
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<_>` is not satisfied
   --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:26:10
    |
-26 |         .distinct_on(posts::id) // error
-   |          ^^^^^^^^^^^ unsatisfied trait bound
+LL |         .distinct_on(posts::id)
+   |          ^^^^^^^^^^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>`
    = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::id>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>: SelectDsl<_>` is not satisfied
-  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:33:10
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: SelectDsl<_>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:34:10
    |
-33 |         .select(posts::user_id) // error
-   |          ^^^^^^ unsatisfied trait bound
+LL |         .select(posts::user_id)
+   |          ^^^^^^ the trait `SelectDsl<_>` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `SelectDsl<_>` is not implemented for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::id>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::user_id>>`
    = help: the following other types implement trait `SelectDsl<Selection>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
 
+   
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
-  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:38:17
-   |
-38 |         .select(dsl::count(posts::id)) // error
-   |          ------ ^^^^^^^^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `MixedAggregates<Other>`:
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
-   = note: required for `(columns::user_id, diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>)` to implement `ValidGrouping<()>`
-   = note: required for `DistinctOnClause<columns::user_id>` to implement `query_dsl::group_by_dsl::ValidDistinctForGroupBy<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>, ()>`
-   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::user_id>>` to implement `SelectDsl<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>>`
+   --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:40:17
+    |
+40  |         .select(dsl::count(posts::id))
+    |          ------ ^^^^^^^^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `MixedAggregates<Other>`:
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
+    = note: required for `(user_id, count<Integer, id>)` to implement `ValidGrouping<()>`
+    = note: required for `DistinctOnClause<columns::user_id>` to implement `query_dsl::group_by_dsl::ValidDistinctForGroupBy<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>, ()>`
+    = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `SelectDsl<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>>`
 note: required by a bound in `diesel::QueryDsl::select`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
-   |        ------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
 ...
-   |         Self: methods::SelectDsl<Selection>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
-
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+ 
+    
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
-  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:43:22
-   |
-43 |         .distinct_on(posts::user_id) // error
-   |          ----------- ^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `MixedAggregates<Other>`:
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
-   = note: required for `(columns::user_id, diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>)` to implement `ValidGrouping<()>`
-   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>>>` to implement `DistinctOnDsl<columns::user_id>`
+   --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:46:22
+    |
+46  |         .distinct_on(posts::user_id)
+    |          ----------- ^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `MixedAggregates<Other>`:
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
+    = note: required for `(user_id, count<Integer, id>)` to implement `ValidGrouping<()>`
+    = note: required for `SelectStatement<FromClause<table>, SelectClause<count<Integer, id>>>` to implement `DistinctOnDsl<columns::user_id>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-  --> $DIESEL/src/query_dsl/mod.rs
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+    |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+ 
+    
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ...>: SelectDsl<...>` is not satisfied
+  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:52:10
    |
-   |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: methods::DistinctOnDsl<Expr>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::user_id>>: SelectDsl<CountStar>` is not satisfied
-  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:48:10
+LL |         .count()
+   |          ^^^^^ the trait `SelectDsl<CountStar>` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>`
    |
-48 |         .count() // error
-   |          ^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `SelectDsl<CountStar>` is not implemented for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, DistinctOnClause<columns::user_id>>`
    = help: the following other types implement trait `SelectDsl<Selection>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
 
+   
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
-  --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:53:22
-   |
-53 |         .distinct_on(posts::user_id) // error
-   |          ----------- ^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the following other types implement trait `MixedAggregates<Other>`:
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
-             `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
-   = note: required for `(columns::user_id, CountStar)` to implement `ValidGrouping<()>`
-   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<CountStar>>` to implement `DistinctOnDsl<columns::user_id>`
+   --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:58:22
+    |
+58  |         .distinct_on(posts::user_id)
+    |          ----------- ^^^^^^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `MixedAggregates<Other>`:
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
+    = note: required for `(columns::user_id, CountStar)` to implement `ValidGrouping<()>`
+    = note: required for `SelectStatement<FromClause<table>, SelectClause<CountStar>>` to implement `DistinctOnDsl<columns::user_id>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: methods::DistinctOnDsl<Expr>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+    |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+ 
+    For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/returning_cannot_be_called_twice.rs
+++ b/diesel_compile_tests/tests/fail/returning_cannot_be_called_twice.rs
@@ -20,12 +20,15 @@ fn main() {
 
     let query = delete(users.filter(name.eq("Bill"))).returning(id);
     query.returning(name);
+    //~^ ERROR: no method named `returning` found for struct `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>, ...>` in the current scope
 
     let query = insert_into(users)
         .values(&NewUser("Hello".into()))
         .returning(id);
     query.returning(name);
+    //~^ ERROR: no method named `returning` found for struct `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` in the current scope
 
     let query = update(users).set(name.eq("Bill")).returning(id);
     query.returning(name);
+    //~^ ERROR: no method named `returning` found for struct `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` in the current scope
 }

--- a/diesel_compile_tests/tests/fail/returning_cannot_be_called_twice.stderr
+++ b/diesel_compile_tests/tests/fail/returning_cannot_be_called_twice.stderr
@@ -1,17 +1,18 @@
-error[E0599]: no method named `returning` found for struct `DeleteStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>>, ReturningClause<columns::id>>` in the current scope
+error[E0599]: no method named `returning` found for struct `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>, ...>` in the current scope
   --> tests/fail/returning_cannot_be_called_twice.rs:22:11
    |
-22 |     query.returning(name);
+LL |     query.returning(name);
    |           ^^^^^^^^^ private field, not a method
 
-error[E0599]: no method named `returning` found for struct `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<columns::id>>` in the current scope
-  --> tests/fail/returning_cannot_be_called_twice.rs:27:11
+error[E0599]: no method named `returning` found for struct `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` in the current scope
+  --> tests/fail/returning_cannot_be_called_twice.rs:28:11
    |
-27 |     query.returning(name);
+LL |     query.returning(name);
    |           ^^^^^^^^^ private field, not a method
 
-error[E0599]: no method named `returning` found for struct `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<columns::id>>` in the current scope
-  --> tests/fail/returning_cannot_be_called_twice.rs:30:11
+error[E0599]: no method named `returning` found for struct `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` in the current scope
+  --> tests/fail/returning_cannot_be_called_twice.rs:32:11
    |
-30 |     query.returning(name);
+LL |     query.returning(name);
    |           ^^^^^^^^^ private field, not a method
+For more information about this error, try `rustc --explain E0599`.

--- a/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.rs
@@ -25,12 +25,15 @@ fn main() {
 
     delete(users::table.filter(users::columns::name.eq("Bill")))
         .returning(non_users::columns::noname);
+    //~^ ERROR: Cannot select `non_users::columns::noname` from `users::table`
 
     insert_into(users::table)
         .values(&NewUser("Hello".into()))
         .returning(non_users::columns::noname);
+    //~^ ERROR: Cannot select `non_users::columns::noname` from `users::table`
 
     update(users::table)
         .set(users::columns::name.eq("Bill"))
         .returning(non_users::columns::noname);
+    //~^ ERROR: Cannot select `non_users::columns::noname` from `users::table`
 }

--- a/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
@@ -1,79 +1,82 @@
 error[E0277]: Cannot select `non_users::columns::noname` from `users::table`
-  --> tests/fail/returning_clause_requires_selectable_expression.rs:27:20
-   |
-27 |         .returning(non_users::columns::noname);
-   |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `non_users::columns::noname` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `non_users::columns::noname` implements `SelectableExpression<JoinOn<Join, On>>`
-             `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
-             `non_users::columns::noname` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
-             `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
-             `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+   --> tests/fail/returning_clause_requires_selectable_expression.rs:27:20
+    |
+27  |         .returning(non_users::columns::noname);
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `non_users::columns::noname` is no valid selection for `users::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `non_users::columns::noname` implements `SelectableExpression<JoinOn<Join, On>>`
+              `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
+              `non_users::columns::noname` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
+              `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
+              `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
 note: required by a bound in `DeleteStatement::<T, U>::returning`
-  --> $DIESEL/src/query_builder/delete_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
-   |     where
-   |         E: SelectableExpression<T>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         E: SelectableExpression<T>,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
 
 error[E0277]: Cannot select `non_users::columns::noname` from `users::table`
-  --> tests/fail/returning_clause_requires_selectable_expression.rs:31:20
-   |
-31 |         .returning(non_users::columns::noname);
-   |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `non_users::columns::noname` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `non_users::columns::noname` implements `SelectableExpression<JoinOn<Join, On>>`
-             `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
-             `non_users::columns::noname` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
-             `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
-             `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &std::string::String>>>,), users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<non_users::columns::noname>>` to implement `Query`
+   --> tests/fail/returning_clause_requires_selectable_expression.rs:32:20
+    |
+32  |         .returning(non_users::columns::noname);
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `non_users::columns::noname` is no valid selection for `users::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `non_users::columns::noname` implements `SelectableExpression<JoinOn<Join, On>>`
+              `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
+              `non_users::columns::noname` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
+              `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
+              `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-  --> $DIESEL/src/query_builder/insert_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
-   |     where
-   |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
-   |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
-
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+    
 error[E0277]: Cannot select `non_users::columns::noname` from `users::table`
-  --> tests/fail/returning_clause_requires_selectable_expression.rs:35:20
-   |
-35 |         .returning(non_users::columns::noname);
-   |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: `non_users::columns::noname` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `non_users::columns::noname` implements `SelectableExpression<JoinOn<Join, On>>`
-             `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
-             `non_users::columns::noname` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
-             `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
-             `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<non_users::columns::noname>>` to implement `Query`
+   --> tests/fail/returning_clause_requires_selectable_expression.rs:37:20
+    |
+37  |         .returning(non_users::columns::noname);
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `non_users::columns::noname` is no valid selection for `users::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `non_users::columns::noname` implements `SelectableExpression<JoinOn<Join, On>>`
+              `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
+              `non_users::columns::noname` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
+              `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
+              `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `non_users::columns::noname` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
-  --> $DIESEL/src/query_builder/update_statement/mod.rs
-   |
-   |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
-   |            --------- required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
 ...
-   |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
-   |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+    |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
+ 
+    For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.rs
@@ -42,14 +42,20 @@ fn direct_joins() {
 
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: annot select `posts::columns::title` from `users::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
     let _ = join.select(lower(posts::title).nullable());
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: annot select `posts::columns::title` from `users::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
+    //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
+    //~| ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
 }
 
 fn nested_outer_joins_left_associative() {
@@ -59,14 +65,20 @@ fn nested_outer_joins_left_associative() {
 
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
     let _ = join.select(lower(posts::title).nullable());
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
+    //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
+    //~| ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
 }
 
 fn nested_mixed_joins_left_associative() {
@@ -76,14 +88,20 @@ fn nested_mixed_joins_left_associative() {
 
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
     let _ = join.select(lower(posts::title).nullable());
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
+    //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
+    //~| ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
 }
 
 fn nested_outer_joins_right_associative() {
@@ -91,14 +109,20 @@ fn nested_outer_joins_right_associative() {
 
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
+    //~^ ERROR: type mismatch resolving `<SelectStatement<...> as AppearsInFromClause<...>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `pets::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
     let _ = join.select(lower(posts::title).nullable());
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
+    //~^ ERROR: type mismatch resolving `<SelectStatement<...> as AppearsInFromClause<...>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `pets::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
+    //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
+    //~| ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
 }
 
 fn nested_mixed_joins_right_associative() {
@@ -106,12 +130,18 @@ fn nested_mixed_joins_right_associative() {
 
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
     let _ = join.select(lower(posts::title).nullable());
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
+    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
+    //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
+    //~| ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
 }

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
@@ -1,13 +1,13 @@
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:44:18
    |
-44 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
    |                  ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
@@ -16,12 +16,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
+   
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:44:18
    |
-44 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
    |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
    |
    = note: `posts::columns::title` is no valid selection for `users::table`
@@ -36,22 +37,23 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: 1 redundant requirement hidden
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:50:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:52:18
    |
-50 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
    |                  ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
@@ -60,12 +62,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
+   
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:50:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:52:18
    |
-50 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
    |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
    |
    = note: `posts::columns::title` is no valid selection for `users::table`
@@ -80,16 +83,17 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: 2 redundant requirements hidden
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
+   
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:52:31
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:56:31
    |
-52 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
    |                         ----- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
    |                         |
    |                         required by a bound introduced by this call
@@ -100,17 +104,17 @@ error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType 
 note: required by a bound in `lower`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
    |
-33 | #[declare_sql_function]
+LL | #[declare_sql_function]
    | ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
-34 | extern "SQL" {
-35 |     fn lower(x: Text) -> Text;
+LL | extern "SQL" {
+LL |     fn lower(x: Text) -> Text;
    |        ----- required by a bound in this function
    = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:52:25
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:56:25
    |
-52 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
    |
    = note: expected struct `diesel::sql_types::Text`
@@ -118,15 +122,15 @@ error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType 
    = note: required for `NullableExpression<posts::columns::title>` to implement `AsExpression<diesel::sql_types::Text>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:61:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:67:18
    |
-61 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
    |                  ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
@@ -135,12 +139,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 3 redundant requirements hidden
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
+   
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:61:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:67:18
    |
-61 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
    |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
    |
    = note: `posts::columns::title` is no valid selection for `users::table`
@@ -155,22 +160,23 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: 3 redundant requirements hidden
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:67:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:75:18
    |
-67 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
    |                  ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
@@ -179,12 +185,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 4 redundant requirements hidden
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
+   
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:67:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:75:18
    |
-67 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
    |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
    |
    = note: `posts::columns::title` is no valid selection for `users::table`
@@ -199,16 +206,17 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: 4 redundant requirements hidden
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
+   
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:69:31
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:79:31
    |
-69 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
    |                         ----- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
    |                         |
    |                         required by a bound introduced by this call
@@ -219,17 +227,17 @@ error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType 
 note: required by a bound in `lower`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
    |
-33 | #[declare_sql_function]
+LL | #[declare_sql_function]
    | ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
-34 | extern "SQL" {
-35 |     fn lower(x: Text) -> Text;
+LL | extern "SQL" {
+LL |     fn lower(x: Text) -> Text;
    |        ----- required by a bound in this function
    = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:69:25
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:79:25
    |
-69 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
    |
    = note: expected struct `diesel::sql_types::Text`
@@ -237,15 +245,15 @@ error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType 
    = note: required for `NullableExpression<posts::columns::title>` to implement `AsExpression<diesel::sql_types::Text>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:78:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:90:18
    |
-78 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
    |                  ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
@@ -254,12 +262,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 3 redundant requirements hidden
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
+   
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:78:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:90:18
    |
-78 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
    |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
    |
    = note: `posts::columns::title` is no valid selection for `users::table`
@@ -274,22 +283,23 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: 3 redundant requirements hidden
    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:84:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:98:18
    |
-84 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
    |                  ^^^^^^ expected `Never`, found `Once`
    |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
@@ -298,12 +308,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 4 redundant requirements hidden
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
+   
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:84:18
+  --> tests/fail/right_side_of_left_join_requires_nullable.rs:98:18
    |
-84 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
    |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
    |
    = note: `posts::columns::title` is no valid selection for `users::table`
@@ -318,135 +329,17 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
    |
-16 |         title -> Text,
+LL |         title -> Text,
    |         ^^^^^
    = note: 4 redundant requirements hidden
    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>, pets::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+   = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
+   
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:86:31
-   |
-86 |     let _ = join.select(lower(posts::title.nullable()));
-   |                         ----- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
-   |                         |
-   |                         required by a bound introduced by this call
-   |
-   = note: expected struct `diesel::sql_types::Text`
-              found struct `Nullable<diesel::sql_types::Text>`
-   = note: required for `NullableExpression<posts::columns::title>` to implement `AsExpression<diesel::sql_types::Text>`
-note: required by a bound in `lower`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
-   |
-33 | #[declare_sql_function]
-   | ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
-34 | extern "SQL" {
-35 |     fn lower(x: Text) -> Text;
-   |        ----- required by a bound in this function
-   = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:86:25
-   |
-86 |     let _ = join.select(lower(posts::title.nullable()));
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
-   |
-   = note: expected struct `diesel::sql_types::Text`
-              found struct `Nullable<diesel::sql_types::Text>`
-   = note: required for `NullableExpression<posts::columns::title>` to implement `AsExpression<diesel::sql_types::Text>`
-
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<JoinOn<Join<table, table, LeftOuter>, Grouped<Eq<Nullable<user_id>, Nullable<id>>>>>> as AppearsInFromClause<table>>::Count == Never`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:93:18
-   |
-93 |     let _ = join.select(posts::title);
-   |                  ^^^^^^ expected `Never`, found `Once`
-   |
-note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
-   |
-16 |         title -> Text,
-   |         ^^^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
-
-error[E0277]: Cannot select `posts::columns::title` from `pets::table`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:93:18
-   |
-93 |     let _ = join.select(posts::title);
-   |                  ^^^^^^ the trait `SelectableExpression<pets::table>` is not implemented for `posts::columns::title`
-   |
-   = note: `posts::columns::title` is no valid selection for `pets::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
-             `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
-             `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-             `posts::columns::title` implements `SelectableExpression<posts::table>`
-             `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
-   |
-16 |         title -> Text,
-   |         ^^^^^
-   = note: 1 redundant requirement hidden
-   = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
-
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<JoinOn<Join<table, table, LeftOuter>, Grouped<Eq<Nullable<user_id>, Nullable<id>>>>>> as AppearsInFromClause<table>>::Count == Never`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:99:18
-   |
-99 |     let _ = join.select(lower(posts::title));
-   |                  ^^^^^^ expected `Never`, found `Once`
-   |
-note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
-   |
-16 |         title -> Text,
-   |         ^^^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
-
-error[E0277]: Cannot select `posts::columns::title` from `pets::table`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:99:18
-   |
-99 |     let _ = join.select(lower(posts::title));
-   |                  ^^^^^^ the trait `SelectableExpression<pets::table>` is not implemented for `posts::columns::title`
-   |
-   = note: `posts::columns::title` is no valid selection for `pets::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
-             `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
-             `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-             `posts::columns::title` implements `SelectableExpression<posts::table>`
-             `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
-  --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
-   |
-16 |         title -> Text,
-   |         ^^^^^
-   = note: 2 redundant requirements hidden
-   = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
-
-error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:101:31
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:102:31
     |
-101 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
     |                         ----- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
     |                         |
     |                         required by a bound introduced by this call
@@ -465,9 +358,132 @@ note: required by a bound in `lower`
     = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:101:25
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:102:25
     |
-101 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
+    |
+    = note: expected struct `diesel::sql_types::Text`
+               found struct `Nullable<diesel::sql_types::Text>`
+    = note: required for `NullableExpression<posts::columns::title>` to implement `AsExpression<diesel::sql_types::Text>`
+
+error[E0271]: type mismatch resolving `<SelectStatement<...> as AppearsInFromClause<...>>::Count == Never`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:111:18
+    |
+LL |     let _ = join.select(posts::title);
+    |                  ^^^^^^ expected `Never`, found `Once`
+    |
+note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
+    |
+16  |         title -> Text,
+    |         ^^^^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 1 redundant requirement hidden
+    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
+ 
+    
+error[E0277]: Cannot select `posts::columns::title` from `pets::table`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:111:18
+    |
+LL |     let _ = join.select(posts::title);
+    |                  ^^^^^^ the trait `SelectableExpression<pets::table>` is not implemented for `posts::columns::title`
+    |
+    = note: `posts::columns::title` is no valid selection for `pets::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
+              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
+              `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<posts::table>`
+              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
+    |
+16  |         title -> Text,
+    |         ^^^^^
+    = note: 1 redundant requirement hidden
+    = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
+ 
+    
+error[E0271]: type mismatch resolving `<SelectStatement<...> as AppearsInFromClause<...>>::Count == Never`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:119:18
+    |
+LL |     let _ = join.select(lower(posts::title));
+    |                  ^^^^^^ expected `Never`, found `Once`
+    |
+note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
+    |
+16  |         title -> Text,
+    |         ^^^^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+ 
+    
+error[E0277]: Cannot select `posts::columns::title` from `pets::table`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:119:18
+    |
+LL |     let _ = join.select(lower(posts::title));
+    |                  ^^^^^^ the trait `SelectableExpression<pets::table>` is not implemented for `posts::columns::title`
+    |
+    = note: `posts::columns::title` is no valid selection for `pets::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
+              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
+              `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<posts::table>`
+              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>>`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:16:9
+    |
+16  |         title -> Text,
+    |         ^^^^^
+    = note: 2 redundant requirements hidden
+    = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+ 
+    
+error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:123:31
+    |
+LL |     let _ = join.select(lower(posts::title.nullable()));
+    |                         ----- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
+    |                         |
+    |                         required by a bound introduced by this call
+    |
+    = note: expected struct `diesel::sql_types::Text`
+               found struct `Nullable<diesel::sql_types::Text>`
+    = note: required for `NullableExpression<posts::columns::title>` to implement `AsExpression<diesel::sql_types::Text>`
+note: required by a bound in `lower`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
+    |
+33  | #[declare_sql_function]
+    | ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
+34  | extern "SQL" {
+35  |     fn lower(x: Text) -> Text;
+    |        ----- required by a bound in this function
+    = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:123:25
+    |
+LL |     let _ = join.select(lower(posts::title.nullable()));
     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
     |
     = note: expected struct `diesel::sql_types::Text`
@@ -475,9 +491,9 @@ error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType 
     = note: required for `NullableExpression<posts::columns::title>` to implement `AsExpression<diesel::sql_types::Text>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:108:18
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:132:18
     |
-108 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
     |                  ^^^^^^ expected `Never`, found `Once`
     |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
@@ -492,12 +508,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
     = note: 4 redundant requirements hidden
     = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
+ 
+    
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:108:18
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:132:18
     |
-108 |     let _ = join.select(posts::title);
+LL |     let _ = join.select(posts::title);
     |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
     |
     = note: `posts::columns::title` is no valid selection for `users::table`
@@ -516,12 +533,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     |         ^^^^^
     = note: 4 redundant requirements hidden
     = note: required for `posts::columns::title` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<posts::columns::title>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
+ 
+    
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:114:18
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:140:18
     |
-114 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
     |                  ^^^^^^ expected `Never`, found `Once`
     |
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
@@ -536,12 +554,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
     = note: 5 redundant requirements hidden
     = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+ 
+    
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:114:18
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:140:18
     |
-114 |     let _ = join.select(lower(posts::title));
+LL |     let _ = join.select(lower(posts::title));
     |                  ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
     |
     = note: `posts::columns::title` is no valid selection for `users::table`
@@ -560,12 +579,13 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     |         ^^^^^
     = note: 5 redundant requirements hidden
     = note: required for `lower_utils::lower<posts::columns::title>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<pets::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<pets::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
+ 
+    
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:116:31
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:144:31
     |
-116 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
     |                         ----- ^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
     |                         |
     |                         required by a bound introduced by this call
@@ -584,9 +604,9 @@ note: required by a bound in `lower`
     = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
-   --> tests/fail/right_side_of_left_join_requires_nullable.rs:116:25
+   --> tests/fail/right_side_of_left_join_requires_nullable.rs:144:25
     |
-116 |     let _ = join.select(lower(posts::title.nullable()));
+LL |     let _ = join.select(lower(posts::title.nullable()));
     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Text`, found `Nullable<Text>`
     |
     = note: expected struct `diesel::sql_types::Text`

--- a/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.rs
+++ b/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.rs
@@ -17,5 +17,7 @@ fn main() {
     let select_name = users.select(name);
 
     let ids = select_name.load::<i32>(&mut connection);
+    //~^ ERROR: cannot deserialize a value of the database type `diesel::sql_types::Text` as `i32`
     let names = select_id.load::<String>(&mut connection);
+    //~^ ERROR: cannot deserialize a value of the database type `diesel::sql_types::Integer` as `std::string::String`
 }

--- a/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
+++ b/diesel_compile_tests/tests/fail/select_carries_correct_result_type_info.stderr
@@ -1,51 +1,54 @@
 error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Text` as `i32`
-  --> tests/fail/select_carries_correct_result_type_info.rs:19:39
-   |
-19 |     let ids = select_name.load::<i32>(&mut connection);
-   |                           ----        ^^^^^^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, _>` is not implemented for `i32`
-   |                           |
-   |                           required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `diesel::sql_types::Text`
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             `i32` implements `FromSql<diesel::sql_types::Integer, Mysql>`
-             `i32` implements `FromSql<diesel::sql_types::Integer, Pg>`
-             `i32` implements `FromSql<diesel::sql_types::Integer, Sqlite>`
-   = note: required for `i32` to implement `Queryable<diesel::sql_types::Text, _>`
-   = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, _>`
-   = note: required for `diesel::sql_types::Text` to implement `load_dsl::private::CompatibleType<i32, _>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::name>>` to implement `LoadQuery<'_, _, i32>`
+    --> tests/fail/select_carries_correct_result_type_info.rs:19:39
+     |
+19   |     let ids = select_name.load::<i32>(&mut connection);
+     |                           ----        ^^^^^^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Text, _>` is not implemented for `i32`
+     |                           |
+     |                           required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `diesel::sql_types::Text`
+     = help: the following other types implement trait `FromSql<A, DB>`:
+               `i32` implements `FromSql<diesel::sql_types::Integer, Mysql>`
+               `i32` implements `FromSql<diesel::sql_types::Integer, Pg>`
+               `i32` implements `FromSql<diesel::sql_types::Integer, Sqlite>`
+     = note: required for `i32` to implement `Queryable<diesel::sql_types::Text, _>`
+     = note: required for `i32` to implement `FromSqlRow<diesel::sql_types::Text, _>`
+     = note: required for `diesel::sql_types::Text` to implement `load_dsl::private::CompatibleType<i32, _>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<name>>` to implement `LoadQuery<'_, _, i32>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: cannot deserialize a value of the database type `diesel::sql_types::Integer` as `std::string::String`
-  --> tests/fail/select_carries_correct_result_type_info.rs:20:42
-   |
-20 |     let names = select_id.load::<String>(&mut connection);
-   |                                          ^^^^^^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, _>` is not implemented for `std::string::String`
-   |
-   = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             `std::string::String` implements `FromSql<Citext, Pg>`
-             `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
-             `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
-             `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
-             `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
-   = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, _>`
-   = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, _>`
-   = note: required for `diesel::sql_types::Integer` to implement `load_dsl::private::CompatibleType<std::string::String, _>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<columns::id>>` to implement `LoadQuery<'_, _, std::string::String>`
+    --> tests/fail/select_carries_correct_result_type_info.rs:21:42
+     |
+21   |     let names = select_id.load::<String>(&mut connection);
+     |                                          ^^^^^^^^^^^^^^^ the trait `FromSql<diesel::sql_types::Integer, _>` is not implemented for `std::string::String`
+     |
+     = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
+     = help: the following other types implement trait `FromSql<A, DB>`:
+               `std::string::String` implements `FromSql<Citext, Pg>`
+               `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
+               `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
+               `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
+               `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
+     = note: required for `std::string::String` to implement `Queryable<diesel::sql_types::Integer, _>`
+     = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, _>`
+     = note: required for `diesel::sql_types::Integer` to implement `load_dsl::private::CompatibleType<std::string::String, _>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>>` to implement `LoadQuery<'_, _, std::string::String>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
@@ -12,16 +12,49 @@ fn main() {
     use self::users::dsl::*;
 
     users.for_update().distinct();
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctDsl` is not satisfied
     users.distinct().for_update();
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
     users.for_update().distinct_on(id);
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
+    //~| ERROR: Cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+    //~| ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
     users.distinct_on(id).for_update();
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
 
     users.for_update().group_by(id);
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
     users.group_by(id).for_update();
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
 
     users.into_boxed().for_update();
+    //~^ ERROR: type mismatch resolving `<BoxedSelectStatement<'_, ..., ..., _> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
     users.for_update().into_boxed();
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
 
     users.for_update().group_by(id).having(id.gt(1));
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
     users.group_by(id).having(id.gt(1)).for_update();
+    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
@@ -1,270 +1,280 @@
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause>>>`
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:14:24
    |
-14 |     users.for_update().distinct();
+LL |     users.for_update().distinct();
    |                        ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `DistinctDsl`
+   = note: expected struct `SelectStatement<FromClause<...>>`
+              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctDsl`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>: Table` is not satisfied
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:14:24
    |
-14 |     users.for_update().distinct();
-   |                        ^^^^^^^^ unsatisfied trait bound
+LL |     users.for_update().distinct();
+   |                        ^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
    = help: the following other types implement trait `Table`:
              Only<S>
              Tablesample<S, TSM>
              pg::metadata_lookup::pg_namespace::table
              pg::metadata_lookup::pg_type::table
              users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `DistinctDsl`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctDsl`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>: DistinctDsl` is not satisfied
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: DistinctDsl` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:14:24
    |
-14 |     users.for_update().distinct();
-   |                        ^^^^^^^^ unsatisfied trait bound
+LL |     users.for_update().distinct();
+   |                        ^^^^^^^^ the trait `DistinctDsl` is not implemented for `SelectStatement<FromClause<...>>`
    |
-   = help: the trait `DistinctDsl` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
    = help: the trait `DistinctDsl` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
 
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, DistinctClause> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, DistinctClause>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:15:22
+   
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:18:22
    |
-15 |     users.distinct().for_update();
+LL |     users.distinct().for_update();
    |                      ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = note: expected struct `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
+              found struct `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>`
+   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:15:22
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:18:22
    |
-15 |     users.distinct().for_update();
+LL |     users.distinct().for_update();
+   |                      ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>`
+   |
+   = help: the following other types implement trait `Table`:
+             Only<S>
+             Tablesample<S, TSM>
+             pg::metadata_lookup::pg_namespace::table
+             pg::metadata_lookup::pg_type::table
+             users::table
+   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:18:22
+   |
+LL |     users.distinct().for_update();
    |                      ^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>`
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>>>: LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:15:22
-   |
-15 |     users.distinct().for_update();
-   |                      ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::DistinctClause>>>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
 
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:16:24
-   |
-16 |     users.for_update().distinct_on(id);
-   |                        ^^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `DistinctOnDsl<_>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:16:24
-   |
-16 |     users.for_update().distinct_on(id);
-   |                        ^^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `DistinctOnDsl<_>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>: DistinctOnDsl<_>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:16:24
-   |
-16 |     users.for_update().distinct_on(id);
-   |                        ^^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-   = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `DistinctOnDsl<_>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>: DistinctOnDsl<_>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:16:36
-   |
-16 |     users.for_update().distinct_on(id);
-   |                        ----------- ^^ unsatisfied trait bound
-   |                        |
-   |                        required by a bound introduced by this call
-   |
-   = help: the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-   = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `DistinctOnDsl<_>`
-note: required by a bound in `diesel::QueryDsl::distinct_on`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: methods::DistinctOnDsl<Expr>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0277]: Cannot select `columns::id` from `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:16:36
-   |
-16 |     users.for_update().distinct_on(id);
-   |                        ----------- ^^ unsatisfied trait bound
-   |                        |
-   |                        required by a bound introduced by this call
-   |
-   = help: the trait `SelectableExpression<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>` is not implemented for `columns::id`
-   = note: `columns::id` is no valid selection for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-             `columns::id` implements `SelectableExpression<Only<users::table>>`
-             `columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
-             `columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-             `columns::id` implements `SelectableExpression<users::table>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `DistinctOnDsl<columns::id>`
-note: required by a bound in `diesel::QueryDsl::distinct_on`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
-   |        ----------- required by a bound in this associated function
-   |     where
-   |         Self: methods::DistinctOnDsl<Expr>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
-
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, DistinctOnClause<id>> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, DistinctOnClause<id>>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:17:27
-   |
-17 |     users.distinct_on(id).for_update();
-   |                           ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ...>`
-   |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:17:27
-   |
-17 |     users.distinct_on(id).for_update();
-   |                           ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>`
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>>>: LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:17:27
-   |
-17 |     users.distinct_on(id).for_update();
-   |                           ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>>>>`
-   = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
-
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:19:24
-   |
-19 |     users.for_update().group_by(id);
-   |                        ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `GroupByDsl<_>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:19:24
-   |
-19 |     users.for_update().group_by(id);
-   |                        ^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `GroupByDsl<_>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>: GroupByDsl<_>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:19:24
-   |
-19 |     users.for_update().group_by(id);
-   |                        ^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-   = help: the trait `GroupByDsl<Expr>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
-
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, GroupByClause<id>> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, GroupByClause<id>>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:20:24
-   |
-20 |     users.group_by(id).for_update();
-   |                        ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
-   |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:20:24
-   |
-20 |     users.group_by(id).for_update();
-   |                        ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>`
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
-
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>>>: LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:20:24
-   |
-20 |     users.group_by(id).for_update();
-   |                        ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>>>`
-   = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
-
-error[E0271]: type mismatch resolving `<BoxedSelectStatement<'_, (Integer,), FromClause<table>, _> as AsQuery>::Query == SelectStatement<FromClause<BoxedSelectStatement<'_, (Integer,), FromClause<table>, _>>>`
+   
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
    |
-22 |     users.into_boxed().for_update();
+LL |     users.for_update().distinct_on(id);
+   |                        ^^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |
+   = note: expected struct `SelectStatement<FromClause<...>>`
+              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
+
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
+   |
+LL |     users.for_update().distinct_on(id);
+   |                        ^^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |
+   = help: the following other types implement trait `Table`:
+             Only<S>
+             Tablesample<S, TSM>
+             pg::metadata_lookup::pg_namespace::table
+             pg::metadata_lookup::pg_type::table
+             users::table
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
+   |
+LL |     users.for_update().distinct_on(id);
+   |                        ^^^^^^^^^^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
+   |
+   = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
+   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:36
+    |
+22  |     users.for_update().distinct_on(id);
+    |                        ----------- ^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
+    |                        |
+    |                        required by a bound introduced by this call
+    |
+    = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
+note: required by a bound in `diesel::QueryDsl::distinct_on`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+    |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+ 
+    
+error[E0277]: Cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:36
+    |
+22  |     users.for_update().distinct_on(id);
+    |                        ----------- ^^ unsatisfied trait bound
+    |                        |
+    |                        required by a bound introduced by this call
+    |
+    = help: the trait `SelectableExpression<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>` is not implemented for `columns::id`
+    = note: `columns::id` is no valid selection for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+              `columns::id` implements `SelectableExpression<Only<users::table>>`
+              `columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
+              `columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+              `columns::id` implements `SelectableExpression<users::table>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::id>`
+note: required by a bound in `diesel::QueryDsl::distinct_on`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn distinct_on<Expr>(self, expr: Expr) -> DistinctOn<Self, Expr>
+    |        ----------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::DistinctOnDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
+ 
+    
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:28:27
+   |
+LL |     users.distinct_on(id).for_update();
+   |                           ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ...>`
+   |
+   = note: expected struct `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
+              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>, _, _, _, _, _, _>`
+   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:28:27
+   |
+LL |     users.distinct_on(id).for_update();
+   |                           ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>`
+   |
+   = help: the following other types implement trait `Table`:
+             Only<S>
+             Tablesample<S, TSM>
+             pg::metadata_lookup::pg_namespace::table
+             pg::metadata_lookup::pg_type::table
+             users::table
+   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:28:27
+   |
+LL |     users.distinct_on(id).for_update();
+   |                           ^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
+   = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
+
+   
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:33:24
+   |
+LL |     users.for_update().group_by(id);
+   |                        ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |
+   = note: expected struct `SelectStatement<FromClause<...>>`
+              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
+
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:33:24
+   |
+LL |     users.for_update().group_by(id);
+   |                        ^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |
+   = help: the following other types implement trait `Table`:
+             Only<S>
+             Tablesample<S, TSM>
+             pg::metadata_lookup::pg_namespace::table
+             pg::metadata_lookup::pg_type::table
+             users::table
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:33:24
+   |
+LL |     users.for_update().group_by(id);
+   |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
+   |
+   = help: the trait `GroupByDsl<Expr>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
+
+   
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:37:24
+   |
+LL |     users.group_by(id).for_update();
+   |                        ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
+   |
+   = note: expected struct `SelectStatement<FromClause<...>>`
+              found struct `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:37:24
+   |
+LL |     users.group_by(id).for_update();
+   |                        ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
+   |
+   = help: the following other types implement trait `Table`:
+             Only<S>
+             Tablesample<S, TSM>
+             pg::metadata_lookup::pg_namespace::table
+             pg::metadata_lookup::pg_type::table
+             users::table
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:37:24
+   |
+LL |     users.group_by(id).for_update();
+   |                        ^^^^^^^^^^ the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<...>>`
+   |
+   = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
+
+   
+error[E0271]: type mismatch resolving `<BoxedSelectStatement<'_, ..., ..., _> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:42:24
+   |
+LL |     users.into_boxed().for_update();
    |                        ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `BoxedSelectStatement<'_, (...,), ..., _>`
    |
    = note: expected struct `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>>>`
               found struct `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>`
    = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
 
+   
 error[E0277]: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:42:24
    |
-22 |     users.into_boxed().for_update();
+LL |     users.into_boxed().for_update();
    |                        ^^^^^^^^^^ the trait `Table` is not implemented for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>`
    |
    = help: the following other types implement trait `Table`:
@@ -275,136 +285,139 @@ error[E0277]: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Inte
              users::table
    = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>>>: LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:42:24
    |
-22 |     users.into_boxed().for_update();
+LL |     users.into_boxed().for_update();
    |                        ^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>>>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<BoxedSelectStatement<'_, (...,), ..., _>>>`
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
 
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:23:24
+   
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
    |
-23 |     users.for_update().into_boxed();
+LL |     users.for_update().into_boxed();
    |                        ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `BoxedDsl<'_, _>`
+   = note: expected struct `SelectStatement<FromClause<...>>`
+              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:23:24
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
    |
-23 |     users.for_update().into_boxed();
-   |                        ^^^^^^^^^^ unsatisfied trait bound
+LL |     users.for_update().into_boxed();
+   |                        ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
    = help: the following other types implement trait `Table`:
              Only<S>
              Tablesample<S, TSM>
              pg::metadata_lookup::pg_namespace::table
              pg::metadata_lookup::pg_type::table
              users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `BoxedDsl<'_, _>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>: BoxedDsl<'_, _>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:23:24
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
    |
-23 |     users.for_update().into_boxed();
-   |                        ^^^^^^^^^^ unsatisfied trait bound
+LL |     users.for_update().into_boxed();
+   |                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<...>>`
    |
-   = help: the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `BoxedDsl<'_, _>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>: BoxedDsl<'_, _>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:23:24
-   |
-23 |     users.for_update().into_boxed();
-   |                        ^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-   = help: the following other types implement trait `BoxedDsl<'a, DB>`:
-             SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
-             SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `BoxedDsl<'_, _>`
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
+    --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
+     |
+46   |     users.for_update().into_boxed();
+     |                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<...>>`
+     |
+     = help: the following other types implement trait `BoxedDsl<'a, DB>`:
+               SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
+               SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
 note: required by a bound in `diesel::QueryDsl::into_boxed`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn into_boxed<'a, DB>(self) -> IntoBoxed<'a, Self, DB>
-   |        ---------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn into_boxed<'a, DB>(self) -> IntoBoxed<'a, Self, DB>
+     |        ---------- required by a bound in this associated function
 ...
-   |         Self: methods::BoxedDsl<'a, DB>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::into_boxed`
-
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, NoGroupByClause, NoHavingClause, LockingClause>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:25:24
+LL |         Self: methods::BoxedDsl<'a, DB>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::into_boxed`
+  
+     
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:52:24
    |
-25 |     users.for_update().group_by(id).having(id.gt(1));
+LL |     users.for_update().group_by(id).having(id.gt(1));
    |                        ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `GroupByDsl<_>`
+   = note: expected struct `SelectStatement<FromClause<...>>`
+              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:25:24
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:52:24
    |
-25 |     users.for_update().group_by(id).having(id.gt(1));
-   |                        ^^^^^^^^ unsatisfied trait bound
+LL |     users.for_update().group_by(id).having(id.gt(1));
+   |                        ^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>`
    = help: the following other types implement trait `Table`:
              Only<S>
              Tablesample<S, TSM>
              pg::metadata_lookup::pg_namespace::table
              pg::metadata_lookup::pg_type::table
              users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `GroupByDsl<_>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>: GroupByDsl<_>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:25:24
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:52:24
    |
-25 |     users.for_update().group_by(id).having(id.gt(1));
-   |                        ^^^^^^^^ unsatisfied trait bound
+LL |     users.for_update().group_by(id).having(id.gt(1));
+   |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
    |
-   = help: the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>>`
    = help: the trait `GroupByDsl<Expr>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
 
-error[E0271]: type mismatch resolving `<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, GroupByClause<id>, HavingClause<Grouped<Gt<id, Bound<Integer, i32>>>>> as AsQuery>::Query == SelectStatement<FromClause<SelectStatement<FromClause<table>, DefaultSelectClause<FromClause<table>>, NoDistinctClause, NoWhereClause, NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, GroupByClause<id>, HavingClause<Grouped<Gt<id, Bound<Integer, i32>>>>>>>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:26:41
+   
+error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:56:41
    |
-26 |     users.group_by(id).having(id.gt(1)).for_update();
+LL |     users.group_by(id).having(id.gt(1)).for_update();
    |                                         ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = note: expected struct `SelectStatement<FromClause<...>>`
+              found struct `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:26:41
+   
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:56:41
    |
-26 |     users.group_by(id).having(id.gt(1)).for_update();
-   |                                         ^^^^^^^^^^ unsatisfied trait bound
+LL |     users.group_by(id).having(id.gt(1)).for_update();
+   |                                         ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the trait `Table` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
    = help: the following other types implement trait `Table`:
              Only<S>
              Tablesample<S, TSM>
              pg::metadata_lookup::pg_namespace::table
              pg::metadata_lookup::pg_type::table
              users::table
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>>>: LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:26:41
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:56:41
    |
-26 |     users.group_by(id).having(id.gt(1)).for_update();
-   |                                         ^^^^^^^^^^ unsatisfied trait bound
+LL |     users.group_by(id).having(id.gt(1)).for_update();
+   |                                         ^^^^^^^^^^ the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<...>>`
    |
-   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>>>`
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::sqlite::SqliteConnection;
+use diesel::*;
 
 table! {
     users {
@@ -14,5 +14,8 @@ fn main() {
     users::table
         .for_update()
         .load(&mut conn)
+        //~^ ERROR: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
+        //~| ERROR: `diesel::query_builder::locking_clause::NoModifier` is no valid SQL fragment for the `Sqlite` backend
+        //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.stderr
@@ -1,85 +1,89 @@
 error[E0277]: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/select_for_update_cannot_be_used_on_sqlite.rs:16:15
-   |
-16 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::ForUpdate`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Pg>`
-   = note: required for `diesel::query_builder::locking_clause::LockingClause` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `LoadQuery<'_, SqliteConnection, _>`
+    --> tests/fail/select_for_update_cannot_be_used_on_sqlite.rs:16:15
+     |
+16   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::ForUpdate`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Pg>`
+     = note: required for `diesel::query_builder::locking_clause::LockingClause` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: `diesel::query_builder::locking_clause::NoModifier` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/select_for_update_cannot_be_used_on_sqlite.rs:16:15
-   |
-16 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::NoModifier`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::locking_clause::NoModifier` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::locking_clause::NoModifier` implements `QueryFragment<Pg>`
-   = note: required for `diesel::query_builder::locking_clause::LockingClause` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `LoadQuery<'_, SqliteConnection, _>`
+    --> tests/fail/select_for_update_cannot_be_used_on_sqlite.rs:16:15
+     |
+16   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::NoModifier`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::locking_clause::NoModifier` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::locking_clause::NoModifier` implements `QueryFragment<Pg>`
+     = note: required for `diesel::query_builder::locking_clause::LockingClause` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_used_on_sqlite.rs:16:15
-   |
-16 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-   = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
+    --> tests/fail/select_for_update_cannot_be_used_on_sqlite.rs:16:15
+     |
+16   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
+     = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::sqlite::SqliteConnection;
+use diesel::*;
 
 table! {
     users {
@@ -15,5 +15,8 @@ fn main() {
         .for_update()
         .no_wait()
         .load(&mut conn)
+        //~^ ERROR: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
+        //~| ERROR: `diesel::query_builder::locking_clause::NoWait` is no valid SQL fragment for the `Sqlite` backend
+        //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.stderr
@@ -1,85 +1,89 @@
 error[E0277]: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs:17:15
-   |
-17 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::ForUpdate`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Pg>`
-   = note: required for `diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::NoWait>` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::NoWait>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::NoWait>>` to implement `LoadQuery<'_, SqliteConnection, _>`
+    --> tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs:17:15
+     |
+17   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::ForUpdate`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Pg>`
+     = note: required for `LockingClause<ForUpdate, NoWait>` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: `diesel::query_builder::locking_clause::NoWait` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs:17:15
-   |
-17 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::NoWait`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::locking_clause::NoWait` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::locking_clause::NoWait` implements `QueryFragment<Pg>`
-   = note: required for `diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::NoWait>` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::NoWait>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::NoWait>>` to implement `LoadQuery<'_, SqliteConnection, _>`
+    --> tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs:17:15
+     |
+17   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::NoWait`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::locking_clause::NoWait` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::locking_clause::NoWait` implements `QueryFragment<Pg>`
+     = note: required for `LockingClause<ForUpdate, NoWait>` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
-  --> tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs:17:15
-   |
-17 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-   = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::NoWait>>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
+    --> tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs:17:15
+     |
+17   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
+     = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs
@@ -1,7 +1,7 @@
 extern crate diesel;
 
-use diesel::*;
 use diesel::sqlite::SqliteConnection;
+use diesel::*;
 
 table! {
     users {
@@ -15,5 +15,8 @@ fn main() {
         .for_update()
         .skip_locked()
         .load(&mut conn)
+        //~^ ERROR: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
+        //~| ERROR: `diesel::query_builder::locking_clause::SkipLocked` is no valid SQL fragment for the `Sqlite` backend
+        //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.stderr
@@ -1,85 +1,89 @@
 error[E0277]: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs:17:15
-   |
-17 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::ForUpdate`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Pg>`
-   = note: required for `diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::SkipLocked>` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::SkipLocked>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::SkipLocked>>` to implement `LoadQuery<'_, SqliteConnection, _>`
+    --> tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs:17:15
+     |
+17   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::ForUpdate`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::locking_clause::ForUpdate` implements `QueryFragment<Pg>`
+     = note: required for `LockingClause<ForUpdate, SkipLocked>` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: `diesel::query_builder::locking_clause::SkipLocked` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs:17:15
-   |
-17 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::SkipLocked`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::locking_clause::SkipLocked` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::locking_clause::SkipLocked` implements `QueryFragment<Pg>`
-   = note: required for `diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::SkipLocked>` to implement `QueryFragment<Sqlite>`
-   = note: 2 redundant requirements hidden
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::SkipLocked>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::SkipLocked>>` to implement `LoadQuery<'_, SqliteConnection, _>`
+    --> tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs:17:15
+     |
+17   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `diesel::query_builder::locking_clause::SkipLocked`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::locking_clause::SkipLocked` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::locking_clause::SkipLocked` implements `QueryFragment<Pg>`
+     = note: required for `LockingClause<ForUpdate, SkipLocked>` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
-  --> tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs:17:15
-   |
-17 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-   = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause<diesel::query_builder::locking_clause::ForUpdate, diesel::query_builder::locking_clause::SkipLocked>>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
+    --> tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs:17:15
+     |
+17   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
+     = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.rs
@@ -18,4 +18,5 @@ table! {
 
 fn main() {
     let select_id = users::table.select(posts::id);
+    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
 }

--- a/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
@@ -1,28 +1,29 @@
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/select_requires_column_from_same_table.rs:20:41
-   |
-20 |     let select_id = users::table.select(posts::id);
-   |                                  ------ ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-   |                                  |
-   |                                  required by a bound introduced by this call
-   |
-   = note: `posts::columns::id` is no valid selection for `users::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-             `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-             `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-             `posts::columns::id` implements `SelectableExpression<posts::table>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<posts::columns::id>`
-   = note: 1 redundant requirement hidden
-   = note: required for `users::table` to implement `SelectDsl<posts::columns::id>`
+   --> tests/fail/select_requires_column_from_same_table.rs:20:41
+    |
+20  |     let select_id = users::table.select(posts::id);
+    |                                  ------ ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+    |                                  |
+    |                                  required by a bound introduced by this call
+    |
+    = note: `posts::columns::id` is no valid selection for `users::table`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+              `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::id` implements `SelectableExpression<posts::table>`
+              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<posts::columns::id>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `SelectDsl<posts::columns::id>`
 note: required by a bound in `diesel::QueryDsl::select`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
-   |        ------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
 ...
-   |         Self: methods::SelectDsl<Selection>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping.rs
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping.rs
@@ -83,21 +83,28 @@ fn main() {
 
     // cases that should fail to compile
     let source = users::table.group_by(users::name).select(users::id);
+    //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
     let source = users::table
         .group_by((users::name, users::hair_color))
         .select(users::id);
+    //~^ ERROR: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
     let source = users::table
         .group_by(users::name)
         .select((users::name, users::id));
+    //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
     let source = users::table
         .group_by((users::name, users::hair_color))
         .select(users::id);
+    //~^ ERROR: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
     let source = users::table
         .inner_join(posts::table)
         .group_by((users::id, posts::title))
         .select((users::all_columns, posts::id));
+    //~^ ERROR: type mismatch resolving `<(id, title) as IsContainedInGroupBy<id>>::Output == Yes`
     let source = users::table
         .inner_join(posts::table.inner_join(comments::table))
         .group_by((users::id, posts::id))
         .select((users::all_columns, posts::all_columns, comments::id));
+    //~^ ERROR: the trait bound `users::columns::id: IsContainedInGroupBy<comments::columns::id>` is not satisfied
+    //~| ERROR: the trait bound `posts::columns::id: IsContainedInGroupBy<comments::columns::id>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
   --> tests/fail/select_requires_valid_grouping.rs:85:53
    |
-85 |     let source = users::table.group_by(users::name).select(users::id);
+LL |     let source = users::table.group_by(users::name).select(users::id);
    |                                                     ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
@@ -15,12 +15,13 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
 7  |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::name>>` to implement `SelectDsl<users::columns::id>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
+   
 error[E0271]: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/select_requires_valid_grouping.rs:88:10
+  --> tests/fail/select_requires_valid_grouping.rs:89:10
    |
-88 |         .select(users::id);
+LL |         .select(users::id);
    |          ^^^^^^ expected `Yes`, found `No`
    |
 note: required for `users::columns::id` to implement `ValidGrouping<(users::columns::name, users::columns::hair_color)>`
@@ -29,12 +30,13 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
 7  |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::name, users::columns::hair_color)>>` to implement `SelectDsl<users::columns::id>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
+   
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/select_requires_valid_grouping.rs:91:10
+  --> tests/fail/select_requires_valid_grouping.rs:93:10
    |
-91 |         .select((users::name, users::id));
+LL |         .select((users::name, users::id));
    |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
@@ -50,12 +52,13 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
    = note: required for `(users::columns::name, users::columns::id)` to implement `ValidGrouping<users::columns::name>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::name>>` to implement `SelectDsl<(users::columns::name, users::columns::id)>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<(users::columns::name, users::columns::id)>`
 
+   
 error[E0271]: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/select_requires_valid_grouping.rs:94:10
+  --> tests/fail/select_requires_valid_grouping.rs:97:10
    |
-94 |         .select(users::id);
+LL |         .select(users::id);
    |          ^^^^^^ expected `Yes`, found `No`
    |
 note: required for `users::columns::id` to implement `ValidGrouping<(users::columns::name, users::columns::hair_color)>`
@@ -64,28 +67,30 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
 7  |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::name, users::columns::hair_color)>>` to implement `SelectDsl<users::columns::id>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
+   
 error[E0271]: type mismatch resolving `<(id, title) as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/select_requires_valid_grouping.rs:98:10
-   |
-98 |         .select((users::all_columns, posts::id));
-   |          ^^^^^^ expected `Yes`, found `No`
-   |
-note: required for `posts::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
-  --> tests/fail/select_requires_valid_grouping.rs:15:9
-   |
-15 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `((users::columns::id, users::columns::name, users::columns::hair_color), posts::columns::id)` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
-   = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::id, posts::columns::title)>>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), posts::columns::id)>`
-
-error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<comments::columns::id>` is not satisfied
    --> tests/fail/select_requires_valid_grouping.rs:102:10
     |
-102 |         .select((users::all_columns, posts::all_columns, comments::id));
+LL |         .select((users::all_columns, posts::id));
+    |          ^^^^^^ expected `Yes`, found `No`
+    |
+note: required for `posts::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
+   --> tests/fail/select_requires_valid_grouping.rs:15:9
+    |
+15  |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 1 redundant requirement hidden
+    = note: required for `((users::columns::id, users::columns::name, users::columns::hair_color), posts::columns::id)` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
+    = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), posts::columns::id)>`
+ 
+    
+error[E0277]: the trait bound `users::columns::id: IsContainedInGroupBy<comments::columns::id>` is not satisfied
+   --> tests/fail/select_requires_valid_grouping.rs:107:10
+    |
+LL |         .select((users::all_columns, posts::all_columns, comments::id));
     |          ^^^^^^ the trait `IsContainedInGroupBy<comments::columns::id>` is not implemented for `users::columns::id`
     |
     = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
@@ -103,13 +108,14 @@ note: required for `comments::columns::id` to implement `ValidGrouping<(users::c
 23  |         id -> Integer,
     |         ^^
     = note: 2 redundant requirements hidden
-    = note: required for `((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::id, posts::columns::id)>>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)>`
-
+    = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
+    = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)>`
+ 
+    
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<comments::columns::id>` is not satisfied
-   --> tests/fail/select_requires_valid_grouping.rs:102:10
+   --> tests/fail/select_requires_valid_grouping.rs:107:10
     |
-102 |         .select((users::all_columns, posts::all_columns, comments::id));
+LL |         .select((users::all_columns, posts::all_columns, comments::id));
     |          ^^^^^^ the trait `IsContainedInGroupBy<comments::columns::id>` is not implemented for `posts::columns::id`
     |
     = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
@@ -129,5 +135,5 @@ note: required for `comments::columns::id` to implement `ValidGrouping<(users::c
 23  |         id -> Integer,
     |         ^^
     = note: 2 redundant requirements hidden
-    = note: required for `((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, SelectStatement<FromClause<JoinOn<query_source::joins::Join<posts::table, comments::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<comments::columns::post_id>, NullableExpression<posts::columns::id>>>>>>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<(users::columns::id, posts::columns::id)>>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)>`
+    = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
+    = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((users::columns::id, users::columns::name, users::columns::hair_color), (posts::columns::id, posts::columns::title, posts::columns::user_id), comments::columns::id)>`

--- a/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.rs
+++ b/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.rs
@@ -14,4 +14,5 @@ fn main() {
     let mut connection = PgConnection::establish("").unwrap();
     let select_count = users::table.select(sql::<sql_types::BigInt>("COUNT(*)"));
     let count = select_count.get_result::<String>(&mut connection).unwrap();
+    //~^ ERROR: cannot deserialize a value of the database type `BigInt` as `std::string::String`
 }

--- a/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
+++ b/diesel_compile_tests/tests/fail/select_sql_still_ensures_result_type.stderr
@@ -1,25 +1,27 @@
 error[E0277]: cannot deserialize a value of the database type `BigInt` as `std::string::String`
-  --> tests/fail/select_sql_still_ensures_result_type.rs:16:51
-   |
-16 |     let count = select_count.get_result::<String>(&mut connection).unwrap();
-   |                                                   ^^^^^^^^^^^^^^^ the trait `FromSql<BigInt, _>` is not implemented for `std::string::String`
-   |
-   = note: double check your type mappings via the documentation of `BigInt`
-   = help: the following other types implement trait `FromSql<A, DB>`:
-             `std::string::String` implements `FromSql<Citext, Pg>`
-             `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
-             `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
-             `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
-             `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
-   = note: required for `std::string::String` to implement `Queryable<BigInt, _>`
-   = note: required for `std::string::String` to implement `FromSqlRow<BigInt, _>`
-   = note: required for `BigInt` to implement `load_dsl::private::CompatibleType<std::string::String, _>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<SqlLiteral<BigInt>>>` to implement `LoadQuery<'_, _, std::string::String>`
+    --> tests/fail/select_sql_still_ensures_result_type.rs:16:51
+     |
+16   |     let count = select_count.get_result::<String>(&mut connection).unwrap();
+     |                                                   ^^^^^^^^^^^^^^^ the trait `FromSql<BigInt, _>` is not implemented for `std::string::String`
+     |
+     = note: double check your type mappings via the documentation of `BigInt`
+     = help: the following other types implement trait `FromSql<A, DB>`:
+               `std::string::String` implements `FromSql<Citext, Pg>`
+               `std::string::String` implements `FromSql<TimestamptzSqlite, Sqlite>`
+               `std::string::String` implements `FromSql<diesel::sql_types::Date, Sqlite>`
+               `std::string::String` implements `FromSql<diesel::sql_types::Time, Sqlite>`
+               `std::string::String` implements `FromSql<diesel::sql_types::Timestamp, Sqlite>`
+     = note: required for `std::string::String` to implement `Queryable<BigInt, _>`
+     = note: required for `std::string::String` to implement `FromSqlRow<BigInt, _>`
+     = note: required for `BigInt` to implement `load_dsl::private::CompatibleType<std::string::String, _>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<SqlLiteral<BigInt>>>` to implement `LoadQuery<'_, _, std::string::String>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -1,36 +1,36 @@
 error[E0412]: cannot find type `titel` in module `posts`
   --> tests/fail/selectable.rs:53:5
    |
-15 |         title -> Text,
+LL |         title -> Text,
    |         ----- similarly named struct `title` defined here
 ...
-53 |     titel: String,
+LL |     titel: String,
    |     ^^^^^ help: a struct with a similar name exists: `title`
 
 error[E0425]: cannot find value `titel` in module `posts`
   --> tests/fail/selectable.rs:53:5
    |
-15 |         title -> Text,
+LL |         title -> Text,
    |         ----- similarly named unit struct `title` defined here
 ...
-53 |     titel: String,
+LL |     titel: String,
    |     ^^^^^ help: a unit struct with a similar name exists: `title`
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `post`
-  --> tests/fail/selectable.rs:58:23
+  --> tests/fail/selectable.rs:60:23
    |
-58 | #[diesel(table_name = post)]
+LL | #[diesel(table_name = post)]
    |                       ^^^^
    |                       |
    |                       use of unresolved module or unlinked crate `post`
    |                       help: a struct with a similar name exists: `Post`
    |
-   = help: if you wanted to use a crate named `post`, use `cargo add post` to add it to your `Cargo.toml`
+   = help: you might be missing a crate named `post`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-   --> tests/fail/selectable.rs:162:10
+   --> tests/fail/selectable.rs:165:10
     |
-162 |         .select(UserWithEmbeddedPost::as_select())
+LL |         .select(UserWithEmbeddedPost::as_select())
     |          ^^^^^^ expected `Never`, found `Once`
     |
 note: required for `posts::columns::id` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
@@ -45,12 +45,13 @@ note: required for `posts::columns::id` to implement `SelectableExpression<query
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
     = note: 4 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
+ 
+    
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:162:10
+   --> tests/fail/selectable.rs:165:10
     |
-162 |         .select(UserWithEmbeddedPost::as_select())
+LL |         .select(UserWithEmbeddedPost::as_select())
     |          ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
     |
     = note: `posts::columns::id` is no valid selection for `users::table`
@@ -69,12 +70,13 @@ note: required for `posts::columns::id` to implement `SelectableExpression<query
     |         ^^
     = note: 4 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
+ 
+    
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:162:10
+   --> tests/fail/selectable.rs:165:10
     |
-162 |         .select(UserWithEmbeddedPost::as_select())
+LL |         .select(UserWithEmbeddedPost::as_select())
     |          ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
     |
     = note: `posts::columns::title` is no valid selection for `users::table`
@@ -93,116 +95,120 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     |         ^^^^^
     = note: 4 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
+ 
+    
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-   --> tests/fail/selectable.rs:163:15
-    |
-163 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ expected `Never`, found `Once`
-    |          |
-    |          required by a bound introduced by this call
-    |
+    --> tests/fail/selectable.rs:169:15
+     |
+169  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ expected `Never`, found `Once`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `posts::columns::id` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
-   --> tests/fail/selectable.rs:14:9
-    |
-14  |         id -> Integer,
-    |         ^^
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: 4 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:14:9
+     |
+14   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 4 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
+     = note: required for `SelectClause<SelectBy<UserWithEmbeddedPost, _>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>`
+     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>, ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:163:15
-    |
-163 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::id` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::id` implements `SelectableExpression<posts::table>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    --> tests/fail/selectable.rs:169:15
+     |
+169  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::id` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<posts::table>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
 note: required for `posts::columns::id` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
-   --> tests/fail/selectable.rs:14:9
-    |
-14  |         id -> Integer,
-    |         ^^
-    = note: 4 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:14:9
+     |
+14   |         id -> Integer,
+     |         ^^
+     = note: 4 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
+     = note: required for `SelectClause<SelectBy<UserWithEmbeddedPost, _>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>`
+     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>, ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:163:15
-    |
-163 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::title` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::title` implements `SelectableExpression<posts::table>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+    --> tests/fail/selectable.rs:169:15
+     |
+169  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::title` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<posts::table>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
 note: required for `posts::columns::title` to implement `SelectableExpression<query_source::joins::Join<users::table, posts::table, LeftOuter>>`
-   --> tests/fail/selectable.rs:15:9
-    |
-15  |         title -> Text,
-    |         ^^^^^
-    = note: 4 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
-    = note: required for `diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:15:9
+     |
+15   |         title -> Text,
+     |         ^^^^^
+     = note: 4 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>`
+     = note: required for `SelectClause<SelectBy<UserWithEmbeddedPost, _>>` to implement `diesel::query_builder::select_clause::SelectClauseExpression<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, LeftOuter>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>`
+     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>, ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::id>` is not satisfied
-   --> tests/fail/selectable.rs:170:10
+   --> tests/fail/selectable.rs:179:10
     |
-170 |         .select(UserWithEmbeddedPost::as_select())
+LL |         .select(UserWithEmbeddedPost::as_select())
     |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::id>` is not implemented for `posts::columns::id`
     |
     = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
@@ -217,12 +223,13 @@ note: required for `users::columns::id` to implement `ValidGrouping<posts::colum
     |         ^^
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `ValidGrouping<posts::columns::id>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
-
+    = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
+ 
+    
 error[E0277]: the trait bound `posts::columns::id: IsContainedInGroupBy<users::columns::name>` is not satisfied
-   --> tests/fail/selectable.rs:170:10
+   --> tests/fail/selectable.rs:179:10
     |
-170 |         .select(UserWithEmbeddedPost::as_select())
+LL |         .select(UserWithEmbeddedPost::as_select())
     |          ^^^^^^ the trait `IsContainedInGroupBy<users::columns::name>` is not implemented for `posts::columns::id`
     |
     = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
@@ -237,26 +244,28 @@ note: required for `users::columns::name` to implement `ValidGrouping<posts::col
     |         ^^^^
     = note: 3 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `ValidGrouping<posts::columns::id>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<posts::columns::id>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
-
+    = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
+ 
+    
 error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
-   --> tests/fail/selectable.rs:177:10
+   --> tests/fail/selectable.rs:188:10
     |
-177 |         .select(UserWithPostCount::as_select())
+LL |         .select(UserWithPostCount::as_select())
     |          ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
     |
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
-    = note: required for `(users::columns::name, diesel::expression::count::count_utils::count<diesel::sql_types::Integer, posts::columns::id>)` to implement `ValidGrouping<()>`
+    = note: required for `(name, count<Integer, id>)` to implement `ValidGrouping<()>`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithPostCount, Pg>` to implement `ValidGrouping<()>`
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithPostCount, Pg>>`
-
+    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, Inner>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithPostCount, Pg>>`
+ 
+    
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:185:20
+   --> tests/fail/selectable.rs:197:20
     |
-185 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
     |          |
     |          required by a bound introduced by this call
@@ -273,20 +282,21 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
+    = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-   --> $DIESEL/src/query_builder/insert_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
     |            --------- required by a bound in this associated function
-    |     where
-    |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
-
+ 
+    
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:185:20
+   --> tests/fail/selectable.rs:197:20
     |
-185 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
     |          |
     |          required by a bound introduced by this call
@@ -303,20 +313,21 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
+    = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-   --> $DIESEL/src/query_builder/insert_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
     |            --------- required by a bound in this associated function
-    |     where
-    |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
-
+ 
+    
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:185:20
+   --> tests/fail/selectable.rs:197:20
     |
-185 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
     |          |
     |          required by a bound introduced by this call
@@ -332,112 +343,116 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
+    = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
-   --> $DIESEL/src/query_builder/insert_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
     |            --------- required by a bound in this associated function
-    |     where
-    |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
-
+ 
+    
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:186:15
-    |
-186 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::id` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::id` implements `SelectableExpression<posts::table>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:201:15
+     |
+201  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::id` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<posts::table>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:186:15
-    |
-186 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::title` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::title` implements `SelectableExpression<posts::table>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:201:15
+     |
+201  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::title` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<posts::table>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:186:15
-    |
-186 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ expected `Once`, found `Never`
-    |          |
-    |          required by a bound introduced by this call
-    |
+    --> tests/fail/selectable.rs:201:15
+     |
+201  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-   --> tests/fail/selectable.rs:14:9
-    |
-14  |         id -> Integer,
-    |         ^^
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: 1 redundant requirement hidden
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<users::columns::name, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, users::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:14:9
+     |
+14   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:193:20
+   --> tests/fail/selectable.rs:211:20
     |
-193 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
     |          |
     |          required by a bound introduced by this call
@@ -454,20 +469,21 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
+    = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
-   --> $DIESEL/src/query_builder/update_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
     |            --------- required by a bound in this associated function
 ...
-    |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
-
+ 
+    
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:193:20
+   --> tests/fail/selectable.rs:211:20
     |
-193 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
     |          |
     |          required by a bound introduced by this call
@@ -484,20 +500,21 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
+    = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
-   --> $DIESEL/src/query_builder/update_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
     |            --------- required by a bound in this associated function
 ...
-    |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
-
+ 
+    
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:193:20
+   --> tests/fail/selectable.rs:211:20
     |
-193 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
     |          |
     |          required by a bound introduced by this call
@@ -513,112 +530,116 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
+    = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
-   --> $DIESEL/src/query_builder/update_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
     |            --------- required by a bound in this associated function
 ...
-    |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
-
+ 
+    
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:194:15
-    |
-194 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::id` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::id` implements `SelectableExpression<posts::table>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:215:15
+     |
+215  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::id` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<posts::table>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `Query`
+     = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:194:15
-    |
-194 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::title` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::title` implements `SelectableExpression<posts::table>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:215:15
+     |
+215  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::title` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<posts::table>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `Query`
+     = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:194:15
-    |
-194 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ expected `Once`, found `Never`
-    |          |
-    |          required by a bound introduced by this call
-    |
+    --> tests/fail/selectable.rs:215:15
+     |
+215  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-   --> tests/fail/selectable.rs:14:9
-    |
-14  |         id -> Integer,
-    |         ^^
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: 1 redundant requirement hidden
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:14:9
+     |
+14   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `Query`
+     = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:200:20
+   --> tests/fail/selectable.rs:224:20
     |
-200 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
     |          |
     |          required by a bound introduced by this call
@@ -636,18 +657,18 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
 note: required by a bound in `DeleteStatement::<T, U>::returning`
-   --> $DIESEL/src/query_builder/delete_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
     |            --------- required by a bound in this associated function
-    |     where
-    |         E: SelectableExpression<T>,
+LL |     where
+LL |         E: SelectableExpression<T>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
 
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:200:20
+   --> tests/fail/selectable.rs:224:20
     |
-200 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
     |          |
     |          required by a bound introduced by this call
@@ -665,18 +686,18 @@ error[E0277]: Cannot select `posts::columns::title` from `users::table`
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
 note: required by a bound in `DeleteStatement::<T, U>::returning`
-   --> $DIESEL/src/query_builder/delete_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
     |            --------- required by a bound in this associated function
-    |     where
-    |         E: SelectableExpression<T>,
+LL |     where
+LL |         E: SelectableExpression<T>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:200:20
+   --> tests/fail/selectable.rs:224:20
     |
-200 |         .returning(UserWithEmbeddedPost::as_select())
+LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
     |          |
     |          required by a bound introduced by this call
@@ -693,113 +714,116 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
     = note: 2 redundant requirements hidden
     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
 note: required by a bound in `DeleteStatement::<T, U>::returning`
-   --> $DIESEL/src/query_builder/delete_statement/mod.rs
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
     |
-    |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
     |            --------- required by a bound in this associated function
-    |     where
-    |         E: SelectableExpression<T>,
+LL |     where
+LL |         E: SelectableExpression<T>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
 
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:201:15
-    |
-201 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::id` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::id` implements `SelectableExpression<posts::table>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:228:15
+     |
+228  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::id` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<posts::table>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `DeleteStatement<table, NoWhereClause, ReturningClause<...>>` to implement `Query`
+     = note: required for `DeleteStatement<table, NoWhereClause, ReturningClause<...>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: Cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:201:15
-    |
-201 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: `posts::columns::title` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::title` implements `SelectableExpression<posts::table>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:228:15
+     |
+228  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `posts::columns::title` is no valid selection for `users::table`
+     = help: the following other types implement trait `SelectableExpression<QS>`:
+               `posts::columns::title` implements `SelectableExpression<JoinOn<Join, On>>`
+               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
+               `posts::columns::title` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
+               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<posts::table>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
+               `posts::columns::title` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `DeleteStatement<table, NoWhereClause, ReturningClause<...>>` to implement `Query`
+     = note: required for `DeleteStatement<table, NoWhereClause, ReturningClause<...>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:201:15
-    |
-201 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ expected `Once`, found `Never`
-    |          |
-    |          required by a bound introduced by this call
-    |
+    --> tests/fail/selectable.rs:228:15
+     |
+228  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-   --> tests/fail/selectable.rs:14:9
-    |
-14  |         id -> Integer,
-    |         ^^
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: 1 redundant requirement hidden
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-    = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `Query`
-    = note: required for `DeleteStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, ReturningClause<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+    --> tests/fail/selectable.rs:14:9
+     |
+14   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `DeleteStatement<table, NoWhereClause, ReturningClause<...>>` to implement `Query`
+     = note: required for `DeleteStatement<table, NoWhereClause, ReturningClause<...>>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0599]: the function or associated item `as_select` exists for struct `UserWithoutSelectable`, but its trait bounds were not satisfied
-   --> tests/fail/selectable.rs:206:40
+   --> tests/fail/selectable.rs:236:40
     |
-80  | struct UserWithoutSelectable {
+83  | struct UserWithoutSelectable {
     | ---------------------------- function or associated item `as_select` not found for this struct because it doesn't satisfy `UserWithoutSelectable: diesel::Selectable<_>` or `UserWithoutSelectable: diesel::SelectableHelper<_>`
 ...
-206 |         .select(UserWithoutSelectable::as_select())
+LL |         .select(UserWithoutSelectable::as_select())
     |                                        ^^^^^^^^^ function or associated item cannot be called on `UserWithoutSelectable` due to unsatisfied trait bounds
     |
     = note: the following trait bounds were not satisfied:
@@ -810,238 +834,245 @@ error[E0599]: the function or associated item `as_select` exists for struct `Use
             `&mut UserWithoutSelectable: diesel::Selectable<_>`
             which is required by `&mut UserWithoutSelectable: diesel::SelectableHelper<_>`
 note: the trait `diesel::Selectable` must be implemented
-   --> $DIESEL/src/expression/mod.rs
+   --> DIESEL/diesel/diesel/src/expression/mod.rs
     |
-    | pub trait Selectable<DB: Backend> {
+LL | pub trait Selectable<DB: Backend> {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: items from traits can only be used if the trait is implemented and in scope
     = note: the following trait defines an item `as_select`, perhaps you need to implement it:
             candidate #1: `diesel::SelectableHelper`
 
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<Post, _>: SingleValue` is not satisfied
-   --> tests/fail/selectable.rs:213:32
-    |
-213 |         .load::<(i32, String)>(&mut conn)
-    |          ----                  ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `SingleValue`:
-              Array<ST>
-              BigInt
-              Bool
-              CChar
-              Cidr
-              Citext
-              Datetime
-              Inet
-            and $N others
-    = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
-    = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<Post, _>>>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
+    --> tests/fail/selectable.rs:244:32
+     |
+244  |         .load::<(i32, String)>(&mut conn)
+     |          ----                  ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<SelectBy<Post, _>>>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `(i32, std::string::String): diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not satisfied
-   --> tests/fail/selectable.rs:213:32
-    |
-213 |         .load::<(i32, String)>(&mut conn)
-    |          ----                  ^^^^^^^^^ the trait `diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String)`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `diesel::Queryable<ST, DB>`:
-              `(T0, T1)` implements `diesel::Queryable<(ST0, ST1), __DB>`
-              `(T0, T1)` implements `diesel::Queryable<Record<(ST0, ST1)>, Pg>`
-              `(T0, T1, T2)` implements `diesel::Queryable<(ST0, ST1, ST2), __DB>`
-              `(T0, T1, T2)` implements `diesel::Queryable<Record<(ST0, ST1, ST2)>, Pg>`
-              `(T0, T1, T2, T3)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3), __DB>`
-              `(T0, T1, T2, T3)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3)>, Pg>`
-              `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3, ST4), __DB>`
-              `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3, ST4)>, Pg>`
-            and $N others
-    = note: required for `(i32, std::string::String)` to implement `FromSqlRow<diesel::expression::select_by::SelectBy<Post, _>, _>`
-    = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
-    = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<Post, _>>>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(i32, String): Queryable<SelectBy<Post, _>, _>` is not satisfied
+    --> tests/fail/selectable.rs:244:32
+     |
+244  |         .load::<(i32, String)>(&mut conn)
+     |          ----                  ^^^^^^^^^ the trait `diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `diesel::Queryable<ST, DB>`:
+               `(T0, T1)` implements `diesel::Queryable<(ST0, ST1), __DB>`
+               `(T0, T1)` implements `diesel::Queryable<Record<(ST0, ST1)>, Pg>`
+               `(T0, T1, T2)` implements `diesel::Queryable<(ST0, ST1, ST2), __DB>`
+               `(T0, T1, T2)` implements `diesel::Queryable<Record<(ST0, ST1, ST2)>, Pg>`
+               `(T0, T1, T2, T3)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3), __DB>`
+               `(T0, T1, T2, T3)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3)>, Pg>`
+               `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3, ST4), __DB>`
+               `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3, ST4)>, Pg>`
+             and N others
+     = note: required for `(i32, std::string::String)` to implement `FromSqlRow<diesel::expression::select_by::SelectBy<Post, _>, _>`
+     = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<SelectBy<Post, _>>>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<Post, _>: SingleValue` is not satisfied
-   --> tests/fail/selectable.rs:218:32
-    |
-218 |         .load::<(i32, String)>(&mut conn)
-    |          ----                  ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `SingleValue`:
-              Array<ST>
-              BigInt
-              Bool
-              CChar
-              Cidr
-              Citext
-              Datetime
-              Inet
-            and $N others
-    = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
-    = note: required for `BoxedSelectStatement<'_, diesel::expression::select_by::SelectBy<Post, _>, FromClause<posts::table>, _>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
+    --> tests/fail/selectable.rs:251:32
+     |
+251  |         .load::<(i32, String)>(&mut conn)
+     |          ----                  ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
+     = note: required for `BoxedSelectStatement<'_, SelectBy<Post, _>, FromClause<table>, _>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `(i32, std::string::String): diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not satisfied
-   --> tests/fail/selectable.rs:218:32
-    |
-218 |         .load::<(i32, String)>(&mut conn)
-    |          ----                  ^^^^^^^^^ the trait `diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String)`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `diesel::Queryable<ST, DB>`:
-              `(T0, T1)` implements `diesel::Queryable<(ST0, ST1), __DB>`
-              `(T0, T1)` implements `diesel::Queryable<Record<(ST0, ST1)>, Pg>`
-              `(T0, T1, T2)` implements `diesel::Queryable<(ST0, ST1, ST2), __DB>`
-              `(T0, T1, T2)` implements `diesel::Queryable<Record<(ST0, ST1, ST2)>, Pg>`
-              `(T0, T1, T2, T3)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3), __DB>`
-              `(T0, T1, T2, T3)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3)>, Pg>`
-              `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3, ST4), __DB>`
-              `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3, ST4)>, Pg>`
-            and $N others
-    = note: required for `(i32, std::string::String)` to implement `FromSqlRow<diesel::expression::select_by::SelectBy<Post, _>, _>`
-    = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
-    = note: required for `BoxedSelectStatement<'_, diesel::expression::select_by::SelectBy<Post, _>, FromClause<posts::table>, _>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(i32, String): Queryable<SelectBy<Post, _>, _>` is not satisfied
+    --> tests/fail/selectable.rs:251:32
+     |
+251  |         .load::<(i32, String)>(&mut conn)
+     |          ----                  ^^^^^^^^^ the trait `diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `diesel::Queryable<ST, DB>`:
+               `(T0, T1)` implements `diesel::Queryable<(ST0, ST1), __DB>`
+               `(T0, T1)` implements `diesel::Queryable<Record<(ST0, ST1)>, Pg>`
+               `(T0, T1, T2)` implements `diesel::Queryable<(ST0, ST1, ST2), __DB>`
+               `(T0, T1, T2)` implements `diesel::Queryable<Record<(ST0, ST1, ST2)>, Pg>`
+               `(T0, T1, T2, T3)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3), __DB>`
+               `(T0, T1, T2, T3)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3)>, Pg>`
+               `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3, ST4), __DB>`
+               `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3, ST4)>, Pg>`
+             and N others
+     = note: required for `(i32, std::string::String)` to implement `FromSqlRow<diesel::expression::select_by::SelectBy<Post, _>, _>`
+     = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String), _>`
+     = note: required for `BoxedSelectStatement<'_, SelectBy<Post, _>, FromClause<table>, _>` to implement `LoadQuery<'_, _, (i32, std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `(diesel::expression::select_by::SelectBy<Post, _>, diesel::sql_types::Text): load_dsl::private::CompatibleType<((i32, std::string::String), std::string::String), _>` is not satisfied
-   --> tests/fail/selectable.rs:222:42
-    |
-222 |         .load::<((i32, String), String)>(&mut conn)
-    |          ----                            ^^^^^^^^^ unsatisfied trait bound
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the trait `load_dsl::private::CompatibleType<((i32, std::string::String), std::string::String), _>` is not implemented for `(diesel::expression::select_by::SelectBy<Post, _>, diesel::sql_types::Text)`
-    = note: this is a mismatch between what your query returns and what your type expects the query to return
-    = note: the fields in your struct need to match the fields returned by your query in count, order and type
-    = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-            on your struct `((i32, std::string::String), std::string::String)` and in your query `.select(((i32, std::string::String), std::string::String)::as_select())` to get a better error message
-    = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-              (ST0, ST1)
-              (ST0, ST1, ST2)
-              (ST0, ST1, ST2, ST3)
-              (ST0, ST1, ST2, ST3, ST4)
-              (ST0, ST1, ST2, ST3, ST4, ST5)
-              (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-              (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-              (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
-            and $N others
-    = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<(diesel::expression::select_by::SelectBy<Post, _>, posts::columns::title)>>` to implement `LoadQuery<'_, _, ((i32, std::string::String), std::string::String)>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(SelectBy<Post, _>, Text): CompatibleType<((i32, String), String), _>` is not satisfied
+    --> tests/fail/selectable.rs:257:42
+     |
+257  |         .load::<((i32, String), String)>(&mut conn)
+     |          ----                            ^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `load_dsl::private::CompatibleType<((i32, std::string::String), std::string::String), _>` is not implemented for `(diesel::expression::select_by::SelectBy<Post, _>, diesel::sql_types::Text)`
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `((i32, std::string::String), std::string::String)` and in your query `.select(((i32, std::string::String), std::string::String)::as_select())` to get a better error message
+     = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
+               (ST0, ST1)
+               (ST0, ST1, ST2)
+               (ST0, ST1, ST2, ST3)
+               (ST0, ST1, ST2, ST3, ST4)
+               (ST0, ST1, ST2, ST3, ST4, ST5)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
+               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+             and N others
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<(..., ...)>>` to implement `LoadQuery<'_, _, ((i32, std::string::String), std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<Post, _>: SingleValue` is not satisfied
-   --> tests/fail/selectable.rs:227:37
-    |
-227 |         .load::<(i32, String, i32)>(&mut conn)
-    |          ----                       ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `SingleValue`:
-              Array<ST>
-              BigInt
-              Bool
-              CChar
-              Cidr
-              Citext
-              Datetime
-              Inet
-            and $N others
-    = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String, i32), _>`
-    = note: required for `InsertStatement<posts::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<Post, _>>>` to implement `LoadQuery<'_, _, (i32, std::string::String, i32)>`
+    --> tests/fail/selectable.rs:263:37
+     |
+263  |         .load::<(i32, String, i32)>(&mut conn)
+     |          ----                       ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String, i32), _>`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `LoadQuery<'_, _, (i32, std::string::String, i32)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `(i32, std::string::String, i32): diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not satisfied
-   --> tests/fail/selectable.rs:227:37
-    |
-227 |         .load::<(i32, String, i32)>(&mut conn)
-    |          ----                       ^^^^^^^^^ the trait `diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String, i32)`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `diesel::Queryable<ST, DB>`:
-              `(T0, T1)` implements `diesel::Queryable<(ST0, ST1), __DB>`
-              `(T0, T1)` implements `diesel::Queryable<Record<(ST0, ST1)>, Pg>`
-              `(T0, T1, T2)` implements `diesel::Queryable<(ST0, ST1, ST2), __DB>`
-              `(T0, T1, T2)` implements `diesel::Queryable<Record<(ST0, ST1, ST2)>, Pg>`
-              `(T0, T1, T2, T3)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3), __DB>`
-              `(T0, T1, T2, T3)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3)>, Pg>`
-              `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3, ST4), __DB>`
-              `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3, ST4)>, Pg>`
-            and $N others
-    = note: required for `(i32, std::string::String, i32)` to implement `FromSqlRow<diesel::expression::select_by::SelectBy<Post, _>, _>`
-    = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String, i32), _>`
-    = note: required for `InsertStatement<posts::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<posts::columns::title, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, posts::table>, diesel::query_builder::insert_statement::private::Insert, ReturningClause<diesel::expression::select_by::SelectBy<Post, _>>>` to implement `LoadQuery<'_, _, (i32, std::string::String, i32)>`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
+error[E0277]: the trait bound `(i32, String, i32): Queryable<SelectBy<Post, _>, _>` is not satisfied
+    --> tests/fail/selectable.rs:263:37
+     |
+263  |         .load::<(i32, String, i32)>(&mut conn)
+     |          ----                       ^^^^^^^^^ the trait `diesel::Queryable<diesel::expression::select_by::SelectBy<Post, _>, _>` is not implemented for `(i32, std::string::String, i32)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `diesel::Queryable<ST, DB>`:
+               `(T0, T1)` implements `diesel::Queryable<(ST0, ST1), __DB>`
+               `(T0, T1)` implements `diesel::Queryable<Record<(ST0, ST1)>, Pg>`
+               `(T0, T1, T2)` implements `diesel::Queryable<(ST0, ST1, ST2), __DB>`
+               `(T0, T1, T2)` implements `diesel::Queryable<Record<(ST0, ST1, ST2)>, Pg>`
+               `(T0, T1, T2, T3)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3), __DB>`
+               `(T0, T1, T2, T3)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3)>, Pg>`
+               `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<(ST0, ST1, ST2, ST3, ST4), __DB>`
+               `(T0, T1, T2, T3, T4)` implements `diesel::Queryable<Record<(ST0, ST1, ST2, ST3, ST4)>, Pg>`
+             and N others
+     = note: required for `(i32, std::string::String, i32)` to implement `FromSqlRow<diesel::expression::select_by::SelectBy<Post, _>, _>`
+     = note: required for `diesel::expression::select_by::SelectBy<Post, _>` to implement `load_dsl::private::CompatibleType<(i32, std::string::String, i32), _>`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ..., ...>` to implement `LoadQuery<'_, _, (i32, std::string::String, i32)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
-   --> tests/fail/selectable.rs:236:15
-    |
-236 |         .load(&mut conn)
-    |          ---- ^^^^^^^^^ expected `Pg`, found `Sqlite`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = note: required for `SelectStatement<FromClause<JoinOn<query_source::joins::Join<users::table, posts::table, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<posts::columns::user_id>, NullableExpression<users::columns::id>>>>>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<UserWithPostCount, Pg>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<users::columns::id>>` to implement `LoadQuery<'_, diesel::SqliteConnection, UserWithPostCount>`
+    --> tests/fail/selectable.rs:274:15
+     |
+274  |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ expected `Pg`, found `Sqlite`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, UserWithPostCount>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.rs
@@ -14,7 +14,9 @@ table! {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 struct User {
     id: String,
+    //~^ ERROR: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
     name: i32,
+    //~^ ERROR: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
 }
 
 #[derive(Selectable, Queryable)]
@@ -30,6 +32,7 @@ struct UserCorrect {
 struct SelectableWithEmbed {
     #[diesel(embed)]
     embed_user: User,
+    //~^ ERROR: the trait bound `(String, i32): FromStaticSqlRow<(Integer, Text), Pg>` is not satisfied
 }
 
 fn main() {
@@ -38,6 +41,7 @@ fn main() {
     users::table
         .select(User::as_select())
         .load(&mut conn)
+        //~^ ERROR: the trait bound `diesel::expression::select_by::SelectBy<User, _>: load_dsl::private::CompatibleType<_, _>` is not satisfied
         .unwrap();
     users::table
         .select(UserCorrect::as_select())

--- a/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
+++ b/diesel_compile_tests/tests/fail/selectable_with_typemisamatch.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:17:11
+  --> tests/fail/selectable_with_typemisamatch.rs:18:11
    |
-17 |     name: i32,
+LL |     name: i32,
    |           ^^^ the trait `FromSql<diesel::sql_types::Text, Pg>` is not implemented for `i32`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Text`
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
   --> tests/fail/selectable_with_typemisamatch.rs:16:9
    |
-16 |     id: String,
+LL |     id: String,
    |         ^^^^^^ the trait `FromSql<diesel::sql_types::Integer, Pg>` is not implemented for `std::string::String`
    |
    = note: double check your type mappings via the documentation of `diesel::sql_types::Integer`
@@ -34,10 +34,10 @@ error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types
    = note: required for `std::string::String` to implement `FromSqlRow<diesel::sql_types::Integer, Pg>`
    = help: see issue #48214
 
-error[E0277]: the trait bound `(std::string::String, i32): FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:32:17
+error[E0277]: the trait bound `(String, i32): FromStaticSqlRow<(Integer, Text), Pg>` is not satisfied
+  --> tests/fail/selectable_with_typemisamatch.rs:34:17
    |
-32 |     embed_user: User,
+LL |     embed_user: User,
    |                 ^^^^ the trait `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not implemented for `(std::string::String, i32)`
    |
    = help: the following other types implement trait `FromStaticSqlRow<ST, DB>`:
@@ -49,38 +49,41 @@ error[E0277]: the trait bound `(std::string::String, i32): FromStaticSqlRow<(die
              `(T1, T2, T3, T4, T5, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST4, ST5, ST0), __DB>`
              `(T1, T2, T3, T4, T5, T6, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST0), __DB>`
              `(T1, T2, T3, T4, T5, T6, T7, T0)` implements `FromStaticSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST0), __DB>`
-           and $N others
+           and N others
 note: required for `User` to implement `diesel::Queryable<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
   --> tests/fail/selectable_with_typemisamatch.rs:12:22
    |
-12 | #[derive(Selectable, Queryable)]
+LL | #[derive(Selectable, Queryable)]
    |                      ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 ...
-15 | struct User {
+LL | struct User {
    |        ^^^^
    = note: required for `User` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
    = help: see issue #48214
-   = note: this error originates in the derive macro `Queryable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+      = note: this error originates in the derive macro `Queryable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<User, _>: load_dsl::private::CompatibleType<_, _>` is not satisfied
-  --> tests/fail/selectable_with_typemisamatch.rs:40:15
-   |
-40 |         .load(&mut conn)
-   |          ---- ^^^^^^^^^ the trait `load_dsl::private::CompatibleType<_, _>` is not implemented for `diesel::expression::select_by::SelectBy<User, _>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this is a mismatch between what your query returns and what your type expects the query to return
-   = note: the fields in your struct need to match the fields returned by your query in count, order and type
-   = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]`
-           on your struct `_` and in your query `.select(_::as_select())` to get a better error message
-   = help: the trait `load_dsl::private::CompatibleType<U, DB>` is implemented for `diesel::expression::select_by::SelectBy<U, DB>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<diesel::expression::select_by::SelectBy<User, _>>>` to implement `LoadQuery<'_, _, _>`
+    --> tests/fail/selectable_with_typemisamatch.rs:43:15
+     |
+43   |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `load_dsl::private::CompatibleType<_, _>` is not implemented for `diesel::expression::select_by::SelectBy<User, _>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this is a mismatch between what your query returns and what your type expects the query to return
+     = note: the fields in your struct need to match the fields returned by your query in count, order and type
+     = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
+             on your struct `_` and in your query `.select(_::as_select())` to get a better error message
+     = help: the trait `load_dsl::private::CompatibleType<U, DB>` is implemented for `diesel::expression::select_by::SelectBy<U, DB>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<SelectBy<User, _>>>` to implement `LoadQuery<'_, _, _>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -21,5 +21,10 @@ allow_tables_to_appear_in_same_query!(users, posts);
 
 fn main() {
     let stuff = users::table.select((posts::id, posts::user_id));
+    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~| ERROR: Cannot select `posts::columns::user_id` from `users::table`
+    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let stuff = users::table.select((posts::id, users::name));
+    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
@@ -1,7 +1,7 @@
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
-23 |     let stuff = users::table.select((posts::id, posts::user_id));
+LL |     let stuff = users::table.select((posts::id, posts::user_id));
    |                              ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -19,7 +19,7 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
 error[E0277]: Cannot select `posts::columns::user_id` from `users::table`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
-23 |     let stuff = users::table.select((posts::id, posts::user_id));
+LL |     let stuff = users::table.select((posts::id, posts::user_id));
    |                              ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::user_id`
    |
    = note: `posts::columns::user_id` is no valid selection for `users::table`
@@ -37,13 +37,13 @@ error[E0277]: Cannot select `posts::columns::user_id` from `users::table`
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
-23 |     let stuff = users::table.select((posts::id, posts::user_id));
+LL |     let stuff = users::table.select((posts::id, posts::user_id));
    |                              ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:14:9
    |
-14 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden
@@ -52,9 +52,9 @@ note: required for `posts::columns::id` to implement `AppearsOnTable<users::tabl
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
 
 error[E0277]: Cannot select `posts::columns::id` from `users::table`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:24:30
+  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:27:30
    |
-24 |     let stuff = users::table.select((posts::id, users::name));
+LL |     let stuff = users::table.select((posts::id, users::name));
    |                              ^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
    |
    = note: `posts::columns::id` is no valid selection for `users::table`
@@ -70,15 +70,15 @@ error[E0277]: Cannot select `posts::columns::id` from `users::table`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, users::columns::name)>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:24:30
+  --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:27:30
    |
-24 |     let stuff = users::table.select((posts::id, users::name));
+LL |     let stuff = users::table.select((posts::id, users::name));
    |                              ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:14:9
    |
-14 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 1 redundant requirement hidden

--- a/diesel_compile_tests/tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.rs
+++ b/diesel_compile_tests/tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.rs
@@ -1,9 +1,9 @@
 extern crate diesel;
 
-use diesel::prelude::*;
-use diesel::connection::{LoadConnection, DefaultLoadingMode};
-use diesel::sql_query;
+use diesel::connection::{DefaultLoadingMode, LoadConnection};
 use diesel::pg::PgRowByRowLoadingMode;
+use diesel::prelude::*;
+use diesel::sql_query;
 
 fn main() {
     let conn = &mut SqliteConnection::establish("foo").unwrap();
@@ -13,6 +13,7 @@ fn main() {
     // for the same connection
     let row_iter1 = LoadConnection::load(conn, sql_query("bar")).unwrap();
     let row_iter2 = LoadConnection::load(conn, sql_query("bar")).unwrap();
+    //~^ ERROR: cannot borrow `*conn` as mutable more than once at a time
 
     let _ = row_iter1.zip(row_iter2);
 
@@ -20,6 +21,7 @@ fn main() {
     // The same argument applies to mysql
     let row_iter1 = LoadConnection::load(conn, sql_query("bar")).unwrap();
     let row_iter2 = LoadConnection::load(conn, sql_query("bar")).unwrap();
+    //~^ ERROR: cannot borrow `*conn` as mutable more than once at a time
 
     let _ = row_iter1.zip(row_iter2);
 
@@ -34,6 +36,7 @@ fn main() {
     // It does not work for the libpq row by row mode
     let row_iter1 = LoadConnection::<PgRowByRowLoadingMode>::load(conn, sql_query("bar")).unwrap();
     let row_iter2 = LoadConnection::<PgRowByRowLoadingMode>::load(conn, sql_query("bar")).unwrap();
+    //~^ ERROR: cannot borrow `*conn` as mutable more than once at a time
 
     let _ = row_iter1.zip(row_iter2);
 }

--- a/diesel_compile_tests/tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.stderr
+++ b/diesel_compile_tests/tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.stderr
@@ -1,32 +1,33 @@
 error[E0499]: cannot borrow `*conn` as mutable more than once at a time
   --> tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.rs:15:42
    |
-14 |     let row_iter1 = LoadConnection::load(conn, sql_query("bar")).unwrap();
+LL |     let row_iter1 = LoadConnection::load(conn, sql_query("bar")).unwrap();
    |                                          ---- first mutable borrow occurs here
-15 |     let row_iter2 = LoadConnection::load(conn, sql_query("bar")).unwrap();
+LL |     let row_iter2 = LoadConnection::load(conn, sql_query("bar")).unwrap();
    |                                          ^^^^ second mutable borrow occurs here
-16 |
-17 |     let _ = row_iter1.zip(row_iter2);
+...
+LL |     let _ = row_iter1.zip(row_iter2);
    |             --------- first borrow later used here
 
 error[E0499]: cannot borrow `*conn` as mutable more than once at a time
-  --> tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.rs:22:42
+  --> tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.rs:23:42
    |
-21 |     let row_iter1 = LoadConnection::load(conn, sql_query("bar")).unwrap();
+LL |     let row_iter1 = LoadConnection::load(conn, sql_query("bar")).unwrap();
    |                                          ---- first mutable borrow occurs here
-22 |     let row_iter2 = LoadConnection::load(conn, sql_query("bar")).unwrap();
+LL |     let row_iter2 = LoadConnection::load(conn, sql_query("bar")).unwrap();
    |                                          ^^^^ second mutable borrow occurs here
-23 |
-24 |     let _ = row_iter1.zip(row_iter2);
+...
+LL |     let _ = row_iter1.zip(row_iter2);
    |             --------- first borrow later used here
 
 error[E0499]: cannot borrow `*conn` as mutable more than once at a time
-  --> tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.rs:36:67
+  --> tests/fail/sqlite_and_mysql_do_not_allow_multiple_iterators.rs:38:67
    |
-35 |     let row_iter1 = LoadConnection::<PgRowByRowLoadingMode>::load(conn, sql_query("bar")).unwrap();
+LL |     let row_iter1 = LoadConnection::<PgRowByRowLoadingMode>::load(conn, sql_query("bar")).unwrap();
    |                                                                   ---- first mutable borrow occurs here
-36 |     let row_iter2 = LoadConnection::<PgRowByRowLoadingMode>::load(conn, sql_query("bar")).unwrap();
+LL |     let row_iter2 = LoadConnection::<PgRowByRowLoadingMode>::load(conn, sql_query("bar")).unwrap();
    |                                                                   ^^^^ second mutable borrow occurs here
-37 |
-38 |     let _ = row_iter1.zip(row_iter2);
+...
+LL |     let _ = row_iter1.zip(row_iter2);
    |             --------- first borrow later used here
+For more information about this error, try `rustc --explain E0499`.

--- a/diesel_compile_tests/tests/fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.rs
+++ b/diesel_compile_tests/tests/fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.rs
@@ -19,5 +19,6 @@ fn main() {
     insert_or_ignore_into(users::table)
         .values(users::id.eq(1))
         .execute(&mut connection)
+        //~^ ERROR: `diesel::query_builder::insert_statement::private::InsertOrIgnore` is no valid SQL fragment for the `Pg` backend
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.stderr
+++ b/diesel_compile_tests/tests/fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.stderr
@@ -1,23 +1,25 @@
 error[E0277]: `diesel::query_builder::insert_statement::private::InsertOrIgnore` is no valid SQL fragment for the `Pg` backend
-  --> tests/fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.rs:21:18
-   |
-21 |         .execute(&mut connection)
-   |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::insert_statement::private::InsertOrIgnore`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Pg` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::insert_statement::private::InsertOrIgnore` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::insert_statement::private::InsertOrIgnore` implements `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>, diesel::query_builder::insert_statement::private::InsertOrIgnore>` to implement `QueryFragment<Pg>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, users::table>, diesel::query_builder::insert_statement::private::InsertOrIgnore>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
+    --> tests/fail/sqlite_insert_or_ignore_cannot_be_used_on_pg.rs:21:18
+     |
+21   |         .execute(&mut connection)
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::insert_statement::private::InsertOrIgnore`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::insert_statement::private::InsertOrIgnore` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::insert_statement::private::InsertOrIgnore` implements `QueryFragment<Sqlite>`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ...>` to implement `QueryFragment<Pg>`
+     = note: required for `InsertStatement<table, ValuesClause<..., ...>, ...>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/sqlite_upsert_cannot_be_used_on_pg.rs
+++ b/diesel_compile_tests/tests/fail/sqlite_upsert_cannot_be_used_on_pg.rs
@@ -19,4 +19,5 @@ fn main() {
     replace_into(users::table)
         .values(&User { id: 1 })
         .execute(&mut connection);
+    //~^ ERROR: `diesel::query_builder::insert_statement::private::Replace` is no valid SQL fragment for the `Pg` backend
 }

--- a/diesel_compile_tests/tests/fail/sqlite_upsert_cannot_be_used_on_pg.stderr
+++ b/diesel_compile_tests/tests/fail/sqlite_upsert_cannot_be_used_on_pg.stderr
@@ -1,23 +1,25 @@
 error[E0277]: `diesel::query_builder::insert_statement::private::Replace` is no valid SQL fragment for the `Pg` backend
-  --> tests/fail/sqlite_upsert_cannot_be_used_on_pg.rs:21:18
-   |
-21 |         .execute(&mut connection);
-   |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::insert_statement::private::Replace`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Pg` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `diesel::query_builder::insert_statement::private::Replace` implements `QueryFragment<Mysql>`
-             `diesel::query_builder::insert_statement::private::Replace` implements `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, &i32>>>,), users::table>, diesel::query_builder::insert_statement::private::Replace>` to implement `QueryFragment<Pg>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, &i32>>>,), users::table>, diesel::query_builder::insert_statement::private::Replace>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
+    --> tests/fail/sqlite_upsert_cannot_be_used_on_pg.rs:21:18
+     |
+21   |         .execute(&mut connection);
+     |          ------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `diesel::query_builder::insert_statement::private::Replace`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `diesel::query_builder::insert_statement::private::Replace` implements `QueryFragment<Mysql>`
+               `diesel::query_builder::insert_statement::private::Replace` implements `QueryFragment<Sqlite>`
+     = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ...>` to implement `QueryFragment<Pg>`
+     = note: required for `InsertStatement<table, ValuesClause<(...,), ...>, ...>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/subselect_cannot_reference_random_tables.rs
+++ b/diesel_compile_tests/tests/fail/subselect_cannot_reference_random_tables.rs
@@ -30,14 +30,17 @@ fn main() {
     let _ = users::table
         .filter(users::id.eq_any(posts::table.select(posts::id).filter(comments::id.eq(1))))
         .load::<(i32,)>(&mut conn);
+    //~^ ERROR: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
 
     let _ = users::table
         .filter(users::id.eq(any(
             posts::table.select(posts::id).filter(comments::id.eq(1)),
         )))
         .load::<(i32,)>(&mut conn);
+    //~^ ERROR: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
 
     let _ = users::table
         .filter(exists(posts::table.filter(comments::id.eq(1))))
         .load::<(i32,)>(&mut conn);
+    //~^ ERROR: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/subselect_cannot_reference_random_tables.stderr
+++ b/diesel_compile_tests/tests/fail/subselect_cannot_reference_random_tables.stderr
@@ -1,7 +1,7 @@
 warning: use of deprecated function `diesel::dsl::any`: Use `ExpressionMethods::eq_any` instead
-  --> tests/fail/subselect_cannot_reference_random_tables.rs:35:30
+  --> tests/fail/subselect_cannot_reference_random_tables.rs:36:30
    |
-35 |         .filter(users::id.eq(any(
+LL |         .filter(users::id.eq(any(
    |                              ^^^
    |
    = note: `#[warn(deprecated)]` on by default
@@ -9,98 +9,102 @@ warning: use of deprecated function `diesel::dsl::any`: Use `ExpressionMethods::
 warning: use of deprecated function `diesel::dsl::any`: Use `ExpressionMethods::eq_any` instead
   --> tests/fail/subselect_cannot_reference_random_tables.rs:26:23
    |
-26 |     use diesel::dsl::{any, exists};
+LL |     use diesel::dsl::{any, exists};
    |                       ^^^
 
 error[E0271]: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/subselect_cannot_reference_random_tables.rs:32:25
-   |
-32 |         .load::<(i32,)>(&mut conn);
-   |          ----           ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/subselect_cannot_reference_random_tables.rs:32:25
+     |
+32   |         .load::<(i32,)>(&mut conn);
+     |          ----           ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `comments::columns::id` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
-  --> tests/fail/subselect_cannot_reference_random_tables.rs:19:9
-   |
-19 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<query_source::joins::Join<posts::table, users::table, Inner>>>`
-   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>` to implement `diesel::expression::subselect::ValidSubselect<users::table>`
-   = note: 4 redundant requirements hidden
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<In<users::columns::id, diesel::expression::subselect::Subselect<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>, diesel::sql_types::Integer>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<In<users::columns::id, diesel::expression::subselect::Subselect<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>, diesel::sql_types::Integer>>>>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<In<users::columns::id, diesel::expression::subselect::Subselect<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>, diesel::sql_types::Integer>>>>>` to implement `LoadQuery<'_, _, (i32,)>`
+    --> tests/fail/subselect_cannot_reference_random_tables.rs:19:9
+     |
+19   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 2 redundant requirements hidden
+     = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
+     = note: required for `WhereClause<Grouped<Eq<id, Bound<Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<query_source::joins::Join<posts::table, users::table, Inner>>>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `diesel::expression::subselect::ValidSubselect<users::table>`
+     = note: 4 redundant requirements hidden
+     = note: required for `WhereClause<Grouped<In<id, Subselect<..., ...>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, _, (i32,)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/subselect_cannot_reference_random_tables.rs:38:25
-   |
-38 |         .load::<(i32,)>(&mut conn);
-   |          ----           ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/subselect_cannot_reference_random_tables.rs:39:25
+     |
+39   |         .load::<(i32,)>(&mut conn);
+     |          ----           ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `comments::columns::id` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
-  --> tests/fail/subselect_cannot_reference_random_tables.rs:19:9
-   |
-19 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<query_source::joins::Join<posts::table, users::table, Inner>>>`
-   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>` to implement `diesel::expression::subselect::ValidSubselect<users::table>`
-   = note: 5 redundant requirements hidden
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::pg::expression::array_comparison::Any<diesel::expression::subselect::Subselect<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>, Array<diesel::sql_types::Integer>>>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::pg::expression::array_comparison::Any<diesel::expression::subselect::Subselect<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>, Array<diesel::sql_types::Integer>>>>>>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::pg::expression::array_comparison::Any<diesel::expression::subselect::Subselect<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::SelectClause<posts::columns::id>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>, Array<diesel::sql_types::Integer>>>>>>>` to implement `LoadQuery<'_, _, (i32,)>`
+    --> tests/fail/subselect_cannot_reference_random_tables.rs:19:9
+     |
+19   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 2 redundant requirements hidden
+     = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
+     = note: required for `WhereClause<Grouped<Eq<id, Bound<Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<query_source::joins::Join<posts::table, users::table, Inner>>>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<id>, ..., ...>` to implement `diesel::expression::subselect::ValidSubselect<users::table>`
+     = note: 5 redundant requirements hidden
+     = note: required for `WhereClause<Grouped<Eq<id, Any<Subselect<..., ...>>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, _, (i32,)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<Join<table, table, Inner> as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/subselect_cannot_reference_random_tables.rs:42:25
-   |
-42 |         .load::<(i32,)>(&mut conn);
-   |          ----           ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/subselect_cannot_reference_random_tables.rs:44:25
+     |
+44   |         .load::<(i32,)>(&mut conn);
+     |          ----           ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `comments::columns::id` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
-  --> tests/fail/subselect_cannot_reference_random_tables.rs:19:9
-   |
-19 |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<query_source::joins::Join<posts::table, users::table, Inner>>>`
-   = note: required for `SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>` to implement `diesel::expression::subselect::ValidSubselect<users::table>`
-   = note: 3 redundant requirements hidden
-   = note: required for `diesel::query_builder::where_clause::WhereClause<Exists<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<Exists<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>>>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<Exists<SelectStatement<FromClause<posts::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<posts::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<comments::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>>>>` to implement `LoadQuery<'_, _, (i32,)>`
+    --> tests/fail/subselect_cannot_reference_random_tables.rs:19:9
+     |
+19   |         id -> Integer,
+     |         ^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 2 redundant requirements hidden
+     = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<query_source::joins::Join<posts::table, users::table, Inner>>`
+     = note: required for `WhereClause<Grouped<Eq<id, Bound<Integer, i32>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<query_source::joins::Join<posts::table, users::table, Inner>>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `diesel::expression::subselect::ValidSubselect<users::table>`
+     = note: 3 redundant requirements hidden
+     = note: required for `WhereClause<Exists<SelectStatement<FromClause<table>, ..., ..., ...>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, _, (i32,)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/subselect_requires_correct_type.rs
+++ b/diesel_compile_tests/tests/fail/subselect_requires_correct_type.rs
@@ -2,7 +2,7 @@ extern crate diesel;
 
 use diesel::*;
 
-table!{
+table! {
     users{
        id -> Integer,
        name -> Text,
@@ -20,4 +20,5 @@ fn main() {
     let mut conn = PgConnection::establish("").unwrap();
     let subquery = users::table.filter(users::id.eq(1));
     let query = posts::table.filter(posts::user_id.eq_any(subquery));
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: AsInExpression<...>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/subselect_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/subselect_requires_correct_type.stderr
@@ -1,19 +1,21 @@
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: AsInExpression<diesel::sql_types::Integer>` is not satisfied
-  --> tests/fail/subselect_requires_correct_type.rs:22:59
-   |
-22 |     let query = posts::table.filter(posts::user_id.eq_any(subquery));
-   |                                                    ------ ^^^^^^^^ unsatisfied trait bound
-   |                                                    |
-   |                                                    required by a bound introduced by this call
-   |
-   = help: the trait `AsInExpression<diesel::sql_types::Integer>` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
-           but trait `AsInExpression<(diesel::sql_types::Integer, diesel::sql_types::Text)>` is implemented for it
-   = help: for that trait implementation, expected `(diesel::sql_types::Integer, diesel::sql_types::Text)`, found `diesel::sql_types::Integer`
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: AsInExpression<...>` is not satisfied
+   --> tests/fail/subselect_requires_correct_type.rs:22:59
+    |
+22  |     let query = posts::table.filter(posts::user_id.eq_any(subquery));
+    |                                                    ------ ^^^^^^^^ unsatisfied trait bound
+    |                                                    |
+    |                                                    required by a bound introduced by this call
+    |
+    = help: the trait `AsInExpression<diesel::sql_types::Integer>` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
+            but trait `AsInExpression<(diesel::sql_types::Integer, diesel::sql_types::Text)>` is implemented for it
+    = help: for that trait implementation, expected `(diesel::sql_types::Integer, diesel::sql_types::Text)`, found `diesel::sql_types::Integer`
 note: required by a bound in `eq_any`
-  --> $DIESEL/src/expression_methods/global_expression_methods.rs
-   |
-   |     fn eq_any<T>(self, values: T) -> dsl::EqAny<Self, T>
-   |        ------ required by a bound in this associated function
+   --> DIESEL/diesel/diesel/src/expression_methods/global_expression_methods.rs
+    |
+LL |     fn eq_any<T>(self, values: T) -> dsl::EqAny<Self, T>
+    |        ------ required by a bound in this associated function
 ...
-   |         T: AsInExpression<Self::SqlType>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ExpressionMethods::eq_any`
+LL |         T: AsInExpression<Self::SqlType>,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ExpressionMethods::eq_any`
+ 
+    For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/table_column_names.rs
+++ b/diesel_compile_tests/tests/fail/table_column_names.rs
@@ -1,9 +1,11 @@
-#[macro_use] extern crate diesel;
+#[macro_use]
+extern crate diesel;
 
 table! {
     users {
         id -> Integer,
         users -> Integer,
+        //~^ ERROR: Column `users` cannot be named the same as it's table.
     }
 }
 // error-pattern: Column `users` cannot be named the same as its table.

--- a/diesel_compile_tests/tests/fail/table_column_names.stderr
+++ b/diesel_compile_tests/tests/fail/table_column_names.stderr
@@ -1,7 +1,7 @@
 error: Column `users` cannot be named the same as it's table.
-       You may use `#[sql_name = "users"]` to reference the table's `users` column
+       You may use `#[sql_name = "users"]` to reference the table's `users` column 
        Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
- --> tests/fail/table_column_names.rs:6:9
+ --> tests/fail/table_column_names.rs:7:9
   |
-6 |         users -> Integer,
+LL |         users -> Integer,
   |         ^^^^^

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_1.rs
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_1.rs
@@ -1,8 +1,9 @@
-#[macro_use] extern crate diesel;
+#[macro_use]
+extern crate diesel;
 
 table! {
     12
 }
-// error-pattern: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
+//~^^^ ERROR: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_1.stderr
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_1.stderr
@@ -1,10 +1,10 @@
 error: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
        Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
- --> tests/fail/table_invalid_syntax_1.rs:3:1
+ --> tests/fail/table_invalid_syntax_1.rs:4:1
   |
-3 | / table! {
-4 | |     12
-5 | | }
+LL | / table! {
+LL | |     12
+LL | | }
   | |_^
   |
   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_2.rs
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_2.rs
@@ -1,8 +1,9 @@
-#[macro_use] extern crate diesel;
+#[macro_use]
+extern crate diesel;
 
 table! {
      some wrong syntax
 }
-// error-pattern: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
+//~^^^ ERROR: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_2.stderr
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_2.stderr
@@ -1,10 +1,10 @@
 error: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
        Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
- --> tests/fail/table_invalid_syntax_2.rs:3:1
+ --> tests/fail/table_invalid_syntax_2.rs:4:1
   |
-3 | / table! {
-4 | |      some wrong syntax
-5 | | }
+LL | / table! {
+LL | |      some wrong syntax
+LL | | }
   | |_^
   |
   = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/table_without_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.rs
@@ -1,7 +1,9 @@
-#[macro_use] extern crate diesel;
+#[macro_use]
+extern crate diesel;
 
 table! {
     user {
+        //~^ ERROR: Neither an explicit primary key found nor does an `id` column exist.
         user_id -> Integer,
         name -> Text,
     }

--- a/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
@@ -1,14 +1,14 @@
 error: Neither an explicit primary key found nor does an `id` column exist.
-       Consider explicitly defining a primary key.
+       Consider explicitly defining a primary key. 
        For example for specifying `user_id` as primary key:
-
+       
        table! {
            user (user_id) {
                user_id -> Integer,
                name -> Text,
            }
        }
- --> tests/fail/table_without_primary_key.rs:4:5
+ --> tests/fail/table_without_primary_key.rs:5:5
   |
-4 |     user {
+LL |     user {
   |     ^^^^

--- a/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.rs
@@ -22,5 +22,7 @@ fn main() {
     use self::users::dsl::*;
 
     let command = update(users).set(posts::title.eq("Hello"));
+    //~^ ERROR: type mismatch resolving `<Grouped<Eq<title, Bound<Text, &str>>> as AsChangeset>::Target == table`
     let command = update(users).set(name.eq(posts::title));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_column_be_from_same_table.stderr
@@ -1,7 +1,7 @@
 error[E0271]: type mismatch resolving `<Grouped<Eq<title, Bound<Text, &str>>> as AsChangeset>::Target == table`
   --> tests/fail/update_requires_column_be_from_same_table.rs:24:37
    |
-24 |     let command = update(users).set(posts::title.eq("Hello"));
+LL |     let command = update(users).set(posts::title.eq("Hello"));
    |                                 --- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `users::table`, found `posts::table`
    |                                 |
    |                                 required by a bound introduced by this call
@@ -10,12 +10,12 @@ error[E0271]: type mismatch resolving `<Grouped<Eq<title, Bound<Text, &str>>> as
 note: `posts::table` is defined in module `crate::posts` of the current crate
   --> tests/fail/update_requires_column_be_from_same_table.rs:12:1
    |
-12 | / table! {
-13 | |     posts {
-14 | |         id -> Integer,
-15 | |         title -> VarChar,
-16 | |     }
-17 | | }
+LL | / table! {
+LL | |     posts {
+LL | |         id -> Integer,
+LL | |         title -> VarChar,
+LL | |     }
+LL | | }
    | |_^
 note: `users::table` is defined in module `crate::users` of the current crate
   --> tests/fail/update_requires_column_be_from_same_table.rs:5:1
@@ -25,35 +25,36 @@ note: `users::table` is defined in module `crate::users` of the current crate
 7  | |         id -> Integer,
 8  | |         name -> VarChar,
 9  | |     }
-10 | | }
+LL | | }
    | |_^
 note: the method call chain might not have had the expected associated types
   --> tests/fail/update_requires_column_be_from_same_table.rs:24:50
    |
-24 |     let command = update(users).set(posts::title.eq("Hello"));
+LL |     let command = update(users).set(posts::title.eq("Hello"));
    |                                     ------------ ^^^^^^^^^^^ `AsChangeset::Target` is `table` here
    |                                     |
    |                                     this expression has type `title`
 note: required by a bound in `UpdateStatement::<T, U>::set`
-  --> $DIESEL/src/query_builder/update_statement/mod.rs
+  --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
    |
-   |     pub fn set<V>(self, values: V) -> UpdateStatement<T, U, V::Changeset>
+LL |     pub fn set<V>(self, values: V) -> UpdateStatement<T, U, V::Changeset>
    |            --- required by a bound in this associated function
 ...
-   |         V: changeset::AsChangeset<Target = T>,
+LL |         V: changeset::AsChangeset<Target = T>,
    |                                   ^^^^^^^^^^ required by this bound in `UpdateStatement::<T, U>::set`
    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/update_requires_column_be_from_same_table.rs:25:33
+  --> tests/fail/update_requires_column_be_from_same_table.rs:26:33
    |
-25 |     let command = update(users).set(name.eq(posts::title));
+LL |     let command = update(users).set(name.eq(posts::title));
    |                                 ^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
   --> tests/fail/update_requires_column_be_from_same_table.rs:15:9
    |
-15 |         title -> VarChar,
+LL |         title -> VarChar,
    |         ^^^^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: required for `diesel::expression::operators::Eq<users::columns::name, posts::columns::title>` to implement `AsChangeset`
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/update_requires_left_side_of_eq_to_be_a_column.rs
+++ b/diesel_compile_tests/tests/fail/update_requires_left_side_of_eq_to_be_a_column.rs
@@ -14,4 +14,5 @@ fn main() {
 
     let foo = "foo".into_sql::<sql_types::VarChar>();
     let command = update(users).set(foo.eq(name));
+    //~^ ERROR: the trait bound `diesel::expression::bound::Bound<diesel::sql_types::Text, &str>: Column` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/update_requires_left_side_of_eq_to_be_a_column.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_left_side_of_eq_to_be_a_column.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `diesel::expression::bound::Bound<diesel::sql_types::Text, &str>: Column` is not satisfied
   --> tests/fail/update_requires_left_side_of_eq_to_be_a_column.rs:16:33
    |
-16 |     let command = update(users).set(foo.eq(name));
+LL |     let command = update(users).set(foo.eq(name));
    |                                 ^^^ the trait `Column` is not implemented for `diesel::expression::bound::Bound<diesel::sql_types::Text, &str>`
    |
    = help: the following other types implement trait `Column`:
@@ -14,4 +14,6 @@ error[E0277]: the trait bound `diesel::expression::bound::Bound<diesel::sql_type
              pg::metadata_lookup::pg_type::columns::typname
              pg::metadata_lookup::pg_type::columns::typnamespace
    = note: required for `diesel::expression::bound::Bound<diesel::sql_types::Text, &str>` to implement `diesel::query_builder::update_statement::changeset::AssignmentTarget`
-   = note: required for `diesel::expression::operators::Eq<diesel::expression::bound::Bound<diesel::sql_types::Text, &str>, columns::name>` to implement `AsChangeset`
+   = note: required for `Eq<Bound<Text, &str>, name>` to implement `AsChangeset`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/update_requires_set.rs
+++ b/diesel_compile_tests/tests/fail/update_requires_set.rs
@@ -10,6 +10,6 @@ table! {
 
 fn main() {
     let mut conn = SqliteConnection::establish(":memory:").unwrap();
-    update(users::table)
-        .execute(&mut conn);
+    update(users::table).execute(&mut conn);
+    //~^ ERROR: `diesel::query_builder::update_statement::SetNotCalled` is no valid SQL fragment for the `_` backend
 }

--- a/diesel_compile_tests/tests/fail/update_requires_set.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_set.stderr
@@ -1,30 +1,31 @@
 error[E0277]: `diesel::query_builder::update_statement::SetNotCalled` is no valid SQL fragment for the `_` backend
-  --> tests/fail/update_requires_set.rs:14:18
-   |
-14 |         .execute(&mut conn);
-   |          ------- ^^^^^^^^^ the trait `QueryFragment<_>` is not implemented for `diesel::query_builder::update_statement::SetNotCalled`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `_` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `&T` implements `QueryFragment<DB>`
-             `()` implements `QueryFragment<DB>`
-             `(T0, T1)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
-             `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
-           and $N others
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `QueryFragment<_>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `ExecuteDsl<_, _>`
+    --> tests/fail/update_requires_set.rs:13:34
+     |
+13   |     update(users::table).execute(&mut conn);
+     |                          ------- ^^^^^^^^^ the trait `QueryFragment<_>` is not implemented for `diesel::query_builder::update_statement::SetNotCalled`
+     |                          |
+     |                          required by a bound introduced by this call
+     |
+     = note: this usually means that the `_` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `&T` implements `QueryFragment<DB>`
+               `()` implements `QueryFragment<DB>`
+               `(T0, T1)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5)` implements `QueryFragment<__DB>`
+               `(T0, T1, T2, T3, T4, T5, T6)` implements `QueryFragment<__DB>`
+             and N others
+     = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `QueryFragment<_>`
+     = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `ExecuteDsl<_, _>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.rs
+++ b/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.rs
@@ -21,10 +21,14 @@ fn main() {
     update(users::table).filter(users::id.eq(1));
 
     update(users::table.filter(posts::id.eq(1)));
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: IntoUpdateTarget` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: IntoUpdateTarget` is not satisfied
 
     update(users::table).filter(posts::id.eq(1));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 
     update(users::table)
         .set(users::id.eq(1))
         .filter(posts::id.eq(1));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
@@ -1,61 +1,62 @@
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: IntoUpdateTarget` is not satisfied
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: IntoUpdateTarget` is not satisfied
   --> tests/fail/update_requires_valid_where_clause.rs:23:12
    |
-23 |     update(users::table.filter(posts::id.eq(1)));
-   |     ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+LL |     update(users::table.filter(posts::id.eq(1)));
+   |     ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoUpdateTarget` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `IntoUpdateTarget` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
 note: required by a bound in `diesel::update`
-  --> $DIESEL/src/query_builder/functions.rs
+  --> DIESEL/diesel/diesel/src/query_builder/functions.rs
    |
-   | pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {
+LL | pub fn update<T: IntoUpdateTarget>(source: T) -> UpdateStatement<T::Table, T::WhereClause> {
    |                  ^^^^^^^^^^^^^^^^ required by this bound in `update`
-help: consider removing this method call, as the receiver has type `users::table` and `users::table: IntoUpdateTarget` trivially holds
+
+   help: consider removing this method call, as the receiver has type `users::table` and `users::table: IntoUpdateTarget` trivially holds
    |
 23 -     update(users::table.filter(posts::id.eq(1)));
 23 +     update(users::table);
    |
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/update_requires_valid_where_clause.rs:25:26
+  --> tests/fail/update_requires_valid_where_clause.rs:27:26
    |
-25 |     update(users::table).filter(posts::id.eq(1));
+LL |     update(users::table).filter(posts::id.eq(1));
    |                          ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/update_requires_valid_where_clause.rs:13:9
    |
-13 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
+   
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/update_requires_valid_where_clause.rs:29:10
+  --> tests/fail/update_requires_valid_where_clause.rs:32:10
    |
-29 |         .filter(posts::id.eq(1));
+LL |         .filter(posts::id.eq(1));
    |          ^^^^^^ expected `Once`, found `Never`
    |
 note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
   --> tests/fail/update_requires_valid_where_clause.rs:13:9
    |
-13 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
    = note: 2 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<users::columns::id>, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
+   = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `UpdateStatement<table, NoWhereClause, Assign<..., ...>>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
-error[E0277]: the trait bound `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>: IntoUpdateTarget` is not satisfied
+   
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: IntoUpdateTarget` is not satisfied
   --> tests/fail/update_requires_valid_where_clause.rs:23:5
    |
-23 |     update(users::table.filter(posts::id.eq(1)));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+LL |     update(users::table.filter(posts::id.eq(1)));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoUpdateTarget` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
    |
-   = help: the trait `IntoUpdateTarget` is not implemented for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>`
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`

--- a/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -16,9 +16,12 @@ fn main() {
     update(users.filter(id.eq(1)))
         .set(name.eq("Bill"))
         .get_result(&mut connection);
+    //~^ ERROR: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
+    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
 
     update(users.filter(id.eq(1)))
         .set(name.eq("Bill"))
         .returning(name)
         .get_result(&mut connection);
+    //~^ ERROR: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
 }

--- a/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -1,87 +1,91 @@
 error[E0277]: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:18:21
-   |
-18 |         .get_result(&mut connection);
-   |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<(columns::id, columns::name)>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB>`
-   = note: required for `ReturningClause<(columns::id, columns::name)>` to implement `QueryFragment<Sqlite>`
-   = note: 1 redundant requirement hidden
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<(columns::id, columns::name)>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
+    --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:18:21
+     |
+18   |         .get_result(&mut connection);
+     |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<(columns::id, columns::name)>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB>`
+     = note: required for `ReturningClause<(columns::id, columns::name)>` to implement `QueryFragment<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:23:21
-   |
-23 |         .get_result(&mut connection);
-   |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
-             `ReturningClause<Expr>` implements `QueryFragment<DB>`
-   = note: required for `ReturningClause<columns::name>` to implement `QueryFragment<Sqlite>`
-   = note: 1 redundant requirement hidden
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<columns::name>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>, ReturningClause<columns::name>>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
+    --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:25:21
+     |
+25   |         .get_result(&mut connection);
+     |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+               `ReturningClause<Expr>` implements `QueryFragment<DB>`
+     = note: required for `ReturningClause<columns::name>` to implement `QueryFragment<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
 error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
-  --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:18:21
-   |
-18 |         .get_result(&mut connection);
-   |          ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-   = note: `diesel::sql_query` requires the loading target to column names for loading values.
-           You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-   = help: the following other types implement trait `SingleValue`:
-             Array<ST>
-             BigInt
-             Bool
-             CChar
-             Cidr
-             Citext
-             Datetime
-             Inet
-           and $N others
-   = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-   = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-   = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-   = note: required for `UpdateStatement<users::table, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, diesel::query_builder::update_statement::changeset::Assign<diesel::query_builder::update_statement::changeset::ColumnWrapperForUpdate<columns::name>, diesel::expression::bound::Bound<diesel::sql_types::Text, &str>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
+    --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:18:21
+     |
+18   |         .get_result(&mut connection);
+     |          ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
+     = note: `diesel::sql_query` requires the loading target to column names for loading values.
+             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
+     = help: the following other types implement trait `SingleValue`:
+               Array<ST>
+               BigInt
+               Bool
+               CChar
+               Cidr
+               Citext
+               Datetime
+               Inet
+             and N others
+     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
+     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
+     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
+     = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `get_result`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-   |        ---------- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs
@@ -31,5 +31,7 @@ fn main() {
         .values(Vec::<NewUser>::new())
         .on_conflict_do_nothing()
         .execute(&mut connection)
+        //~^ ERROR: type mismatch resolving `<Sqlite as SqlDialect>::InsertWithDefaultKeyword == IsoSqlDefaultKeyword`
+        //~| ERROR: `BatchInsert<Vec<ValuesClause<(...,), ...>>, ..., (), false>` is no valid SQL fragment for the `Sqlite` backend
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.stderr
@@ -1,48 +1,49 @@
 error[E0271]: type mismatch resolving `<Sqlite as SqlDialect>::InsertWithDefaultKeyword == IsoSqlDefaultKeyword`
-  --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:33:18
-   |
-33 |         .execute(&mut connection)
-   |          ------- ^^^^^^^^^^^^^^^ expected `IsoSqlDefaultKeyword`, found `DoesNotSupportDefaultKeyword`
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = note: required for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>` to implement `CanInsertInSingleQuery<Sqlite>`
-   = note: 1 redundant requirement hidden
-   = note: required for `diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>` to implement `CanInsertInSingleQuery<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
+    --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:33:18
+     |
+33   |         .execute(&mut connection)
+     |          ------- ^^^^^^^^^^^^^^^ expected `IsoSqlDefaultKeyword`, found `DoesNotSupportDefaultKeyword`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: required for `BatchInsert<Vec<ValuesClause<(...,), ...>>, ..., (), false>` to implement `CanInsertInSingleQuery<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `OnConflictValues<BatchInsert<Vec<...>, ..., (), false>, ..., ...>` to implement `CanInsertInSingleQuery<Sqlite>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Sqlite>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
-
-error[E0277]: `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>` is no valid SQL fragment for the `Sqlite` backend
-  --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:33:18
-   |
-33 |         .execute(&mut connection)
-   |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `QueryFragment<Sqlite, sqlite::backend::SqliteBatchInsert>` is not implemented for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>`
-   = note: this usually means that the `Sqlite` database system does not support
-           this SQL syntax
-   = help: the following other types implement trait `QueryFragment<DB, SP>`:
-             `BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>` implements `QueryFragment<DB>`
-             `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<V, Tab>>, Tab, QId, HAS_STATIC_QUERY_ID>` implements `QueryFragment<DB, PostgresLikeBatchInsertSupport>`
-   = note: required for `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>` to implement `QueryFragment<Sqlite>`
-   = note: 3 redundant requirements hidden
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `QueryFragment<Sqlite>`
-   = note: required for `InsertStatement<users::table, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<(DefaultableColumnInsertValue<ColumnInsertValue<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>,), users::table>>, users::table, (), false>, diesel::query_builder::upsert::on_conflict_target::NoConflictTarget, diesel::query_builder::upsert::on_conflict_actions::DoNothing<users::table>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: `BatchInsert<Vec<ValuesClause<(...,), ...>>, ..., (), false>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/upsert_with_multiple_values_not_supported_on_sqlite.rs:33:18
+     |
+33   |         .execute(&mut connection)
+     |          ------- ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Sqlite, sqlite::backend::SqliteBatchInsert>` is not implemented for `BatchInsert<Vec<ValuesClause<(...,), ...>>, ..., (), false>`
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the following other types implement trait `QueryFragment<DB, SP>`:
+               `BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>` implements `QueryFragment<DB>`
+               `BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<V, Tab>>, Tab, QId, HAS_STATIC_QUERY_ID>` implements `QueryFragment<DB, PostgresLikeBatchInsertSupport>`
+     = note: required for `BatchInsert<Vec<ValuesClause<(...,), ...>>, ..., (), false>` to implement `QueryFragment<Sqlite>`
+     = note: 3 redundant requirements hidden
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `QueryFragment<Sqlite>`
+     = note: required for `InsertStatement<table, OnConflictValues<..., ..., ...>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
 note: required by a bound in `diesel::RunQueryDsl::execute`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
-   |        ------- required by a bound in this associated function
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
 ...
-   |         Self: methods::ExecuteDsl<Conn>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`

--- a/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.rs
+++ b/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.rs
@@ -38,8 +38,10 @@ fn main() {
     let mut conn = PgConnection::establish("").unwrap();
 
     let _ = users::table.filter(name.eq(foo(1)));
+    //~^ ERROR: type mismatch resolving `<foo<Bound<Integer, i32>> as Expression>::SqlType == Text
 
     let _ = users::table
         .filter(name.eq(bar(title)))
         .load::<User>(&mut conn);
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
+++ b/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
@@ -1,35 +1,37 @@
 error[E0271]: type mismatch resolving `<foo<Bound<Integer, i32>> as Expression>::SqlType == Text`
   --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:40:38
    |
-40 |     let _ = users::table.filter(name.eq(foo(1)));
+LL |     let _ = users::table.filter(name.eq(foo(1)));
    |                                      ^^ expected `Text`, found `Integer`
    |
    = note: required for `foo_utils::foo<diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>` to implement `AsExpression<diesel::sql_types::Text>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:44:23
-   |
-44 |         .load::<User>(&mut conn);
-   |          ----         ^^^^^^^^^ expected `Once`, found `Never`
-   |          |
-   |          required by a bound introduced by this call
-   |
+    --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:45:23
+     |
+45   |         .load::<User>(&mut conn);
+     |          ----         ^^^^^^^^^ expected `Once`, found `Never`
+     |          |
+     |          required by a bound introduced by this call
+     |
 note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
-  --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:16:9
-   |
-16 |         title -> VarChar,
-   |         ^^^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 3 redundant requirements hidden
-   = note: required for `diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, bar_utils::bar<posts::columns::title>>>` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, bar_utils::bar<posts::columns::title>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, bar_utils::bar<posts::columns::title>>>>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, bar_utils::bar<posts::columns::title>>>>>` to implement `LoadQuery<'_, _, User>`
+    --> tests/fail/user_defined_functions_follow_same_selection_rules.rs:16:9
+     |
+16   |         title -> VarChar,
+     |         ^^^^^
+     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+     = note: 3 redundant requirements hidden
+     = note: required for `Grouped<Eq<name, bar<title>>>` to implement `AppearsOnTable<users::table>`
+     = note: required for `WhereClause<Grouped<Eq<name, bar<title>>>>` to implement `diesel::query_builder::where_clause::ValidWhereClause<FromClause<users::table>>`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.stderr
+++ b/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.stderr
@@ -1,95 +1,98 @@
 warning: unused import: `MixedAggregates`
- --> tests/fail/valid_grouping_and_boxed_expressions.rs:3:40
+ --> tests/fail/valid_grouping_and_boxed_expressions.rs:4:40
   |
-3 | use diesel::expression::{is_aggregate, MixedAggregates, ValidGrouping};
+LL | use diesel::expression::{is_aggregate, MixedAggregates, ValidGrouping};
   |                                        ^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
 
-error[E0277]: the trait bound `dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>: ValidGrouping<columns::id>` is not satisfied
-  --> tests/fail/valid_grouping_and_boxed_expressions.rs:71:10
+error[E0277]: the trait bound `dyn BoxableExpression<table, Pg, SqlType = Integer>: ValidGrouping<id>` is not satisfied
+  --> tests/fail/valid_grouping_and_boxed_expressions.rs:72:10
    |
-71 |         .select(some_ungrouped_expression(true))
+LL |         .select(some_ungrouped_expression(true))
    |          ^^^^^^ unsatisfied trait bound
    |
    = help: the trait `ValidGrouping<columns::id>` is not implemented for `dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>`
            but trait `ValidGrouping<()>` is implemented for it
    = help: for that trait implementation, expected `()`, found `columns::id`
    = note: required for `Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>` to implement `ValidGrouping<columns::id>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>` to implement `SelectDsl<Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>>`
+   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>>`
 
-error[E0277]: the trait bound `dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>: ValidGrouping<columns::id>` is not satisfied
-  --> tests/fail/valid_grouping_and_boxed_expressions.rs:72:22
-   |
-72 |         .load::<i32>(&mut conn);
-   |          ----        ^^^^^^^^^ unsatisfied trait bound
-   |          |
-   |          required by a bound introduced by this call
-   |
-   = help: the trait `ValidGrouping<columns::id>` is not implemented for `dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>`
-           but trait `ValidGrouping<()>` is implemented for it
-   = help: for that trait implementation, expected `()`, found `columns::id`
-   = note: required for `Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>` to implement `ValidGrouping<columns::id>`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>` to implement `Query`
-   = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::GroupByClause<columns::id>>` to implement `LoadQuery<'_, _, i32>`
+   
+error[E0277]: the trait bound `dyn BoxableExpression<table, Pg, SqlType = Integer>: ValidGrouping<id>` is not satisfied
+    --> tests/fail/valid_grouping_and_boxed_expressions.rs:74:22
+     |
+74   |         .load::<i32>(&mut conn);
+     |          ----        ^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `ValidGrouping<columns::id>` is not implemented for `dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>`
+             but trait `ValidGrouping<()>` is implemented for it
+     = help: for that trait implementation, expected `()`, found `columns::id`
+     = note: required for `Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>` to implement `ValidGrouping<columns::id>`
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, _, i32>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-  --> $DIESEL/src/query_dsl/mod.rs
-   |
-   |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-   |        ---- required by a bound in this associated function
-   |     where
-   |         Self: LoadQuery<'query, Conn, U>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/valid_grouping_and_boxed_expressions.rs:88:17
+  --> tests/fail/valid_grouping_and_boxed_expressions.rs:93:17
    |
-88 |         .select(maybe_grouped(true))
+LL |         .select(maybe_grouped(true))
    |                 ^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
-  --> tests/fail/valid_grouping_and_boxed_expressions.rs:11:9
+  --> tests/fail/valid_grouping_and_boxed_expressions.rs:12:9
    |
-11 |         name -> Text,
+LL |         name -> Text,
    |         ^^^^
 note: required for `columns::id` to implement `ValidGrouping<columns::name>`
-  --> tests/fail/valid_grouping_and_boxed_expressions.rs:10:9
+  --> tests/fail/valid_grouping_and_boxed_expressions.rs:11:9
    |
-10 |         id -> Integer,
+LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
 
 error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
-   --> tests/fail/valid_grouping_and_boxed_expressions.rs:104:10
+   --> tests/fail/valid_grouping_and_boxed_expressions.rs:110:10
     |
-104 |         .select((
+LL |         .select((
     |          ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
     |
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
-    = note: required for `(Box<dyn diesel::BoxableExpression<users::table, Pg, (), diesel::expression::is_aggregate::Yes, SqlType = Nullable<diesel::sql_types::Integer>>>, Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>)` to implement `ValidGrouping<()>`
+    = note: required for `(Box<dyn BoxableExpression<table, Pg, (), Yes, SqlType = ...>>, ...)` to implement `ValidGrouping<()>`
     = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(Box<dyn diesel::BoxableExpression<users::table, Pg, (), diesel::expression::is_aggregate::Yes, SqlType = Nullable<diesel::sql_types::Integer>>>, Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>)>`
-
+ 
+    
 error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
-   --> tests/fail/valid_grouping_and_boxed_expressions.rs:108:37
-    |
-108 |         .load::<(Option<i32>, i32)>(&mut conn);
-    |          ----                       ^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
-    |          |
-    |          required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `MixedAggregates<Other>`:
-              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
-              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
-    = note: required for `(Box<dyn diesel::BoxableExpression<users::table, Pg, (), diesel::expression::is_aggregate::Yes, SqlType = Nullable<diesel::sql_types::Integer>>>, Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>)` to implement `ValidGrouping<()>`
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<(Box<dyn diesel::BoxableExpression<users::table, Pg, (), diesel::expression::is_aggregate::Yes, SqlType = Nullable<diesel::sql_types::Integer>>>, Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>)>>` to implement `Query`
-    = note: required for `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::SelectClause<(Box<dyn diesel::BoxableExpression<users::table, Pg, (), diesel::expression::is_aggregate::Yes, SqlType = Nullable<diesel::sql_types::Integer>>>, Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>)>>` to implement `LoadQuery<'_, _, (Option<i32>, i32)>`
+    --> tests/fail/valid_grouping_and_boxed_expressions.rs:115:37
+     |
+115  |         .load::<(Option<i32>, i32)>(&mut conn);
+     |          ----                       ^^^^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `MixedAggregates<Other>`:
+               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
+     = note: required for `(Box<dyn BoxableExpression<table, Pg, (), Yes, SqlType = ...>>, ...)` to implement `ValidGrouping<()>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<(Box<...>, ...)>>` to implement `Query`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<(Box<...>, ...)>>` to implement `LoadQuery<'_, _, (Option<i32>, i32)>`
 note: required by a bound in `diesel::RunQueryDsl::load`
-   --> $DIESEL/src/query_dsl/mod.rs
-    |
-    |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-    |        ---- required by a bound in this associated function
-    |     where
-    |         Self: LoadQuery<'query, Conn, U>,
-    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`

--- a/diesel_compile_tests/tests/src/lib.rs
+++ b/diesel_compile_tests/tests/src/lib.rs
@@ -1,0 +1,2 @@
+// required to force ui test to build stuff
+extern crate diesel;

--- a/diesel_compile_tests/tests/trybuild.rs
+++ b/diesel_compile_tests/tests/trybuild.rs
@@ -1,9 +1,60 @@
-extern crate trybuild;
+use std::env;
+use std::path::PathBuf;
 
-#[test]
-fn trybuild() {
-    let t = trybuild::TestCases::new();
-    t.compile_fail("tests/fail/*.rs");
-    t.compile_fail("tests/fail/derive/*.rs");
-    t.compile_fail("tests/fail/derive_deprecated/*.rs");
+fn main() -> ui_test::color_eyre::Result<()> {
+    let mut config = ui_test::Config::rustc("tests/fail");
+    config.bless_command = Some("BLESS=1 cargo test".into());
+    config.filter(
+        "   = note: the full name for the type has been written to '.*",
+        "",
+    );
+    let diesel_root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR").to_owned() + "/../")
+        .canonicalize()
+        .unwrap();
+    config.path_filter(&diesel_root_path, "DIESEL");
+    config.filter("and [0-9]* others", "and N others");
+    config.filter(
+        "= note: consider using `--verbose` to print the full type name to the console\n",
+        "",
+    );
+    config.filter("\nerror: aborting due to [0-9]* previous error[s]?\n\n", "");
+    config.filter(
+        "\nerror: aborting due to [0-9]* previous error[s]?; [0-9]* warning[s]? emitted\n\n",
+        "",
+    );
+    config.filter(
+        "\n\\s*Some errors have detailed explanations: [E0-9, ]*.",
+        "",
+    );
+    config.filter(
+        "\n\\s*For more information about an error, try `rustc --explain E[0-9]*`.",
+        "",
+    );
+    // not sure how well that works on windows
+    config.filter(
+        "diesel\\/diesel\\/([a-zA-Z_0-9\\/]*)\\.rs:[0-9]*:[0-9]*",
+        "diesel/diesel/$1.rs",
+    );
+    // that's not perfect as it might
+    // as it breaks layout it some cases
+    config.filter("[0-9]+ \\|", "LL |");
+
+    config.comment_defaults.base().set_custom(
+        "dependencies",
+        ui_test::dependencies::DependencyBuilder {
+            crate_manifest_path: PathBuf::from(
+                env!("CARGO_MANIFEST_DIR").to_owned() + "/tests/Cargo.toml",
+            ),
+            program: ui_test::CommandBuilder::cargo(),
+            ..Default::default()
+        },
+    );
+
+    if env::var("BLESS").is_ok() {
+        config.output_conflict_handling = ui_test::bless_output_files;
+    } else {
+        config.output_conflict_handling = ui_test::error_on_output_conflict;
+    }
+
+    ui_test::run_tests(config)
 }


### PR DESCRIPTION
ui_test is one of the crates used by rustc for compile_tests. I choose to replace trybuild with ui_test as the former does not perform const evaluation for the tests, which results in certain patterns not beeing testable. It also does not seem to be planned to fix that in trybuild.  See for details https://github.com/dtolnay/trybuild/issues/225

Another thing that I see as advantage of ui_test is that it requires us to annotate which lines emitt errors, which makes it harder to accidently change something from not compiling to compiling by accident.

This is a large diff due to that the output of all tests change slightly. I tried my best to adjust the output via filters us much as possible to match the trybuild output, but there are still some differences. If it turns out to be problematic in the future we can continue to tweak the output.

Finally I also added some docs for the compile tests to the CONTRIBUTING manual.