### PR TITLE
Diagnostic improvements for some compiler errors

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -756,6 +756,12 @@ pub mod is_contained_in_group_by {
 /// themselves or [`is_aggregate::Never`]. [`is_aggregate::Never`] can appear
 /// with anything.
 ///
+#[diagnostic::on_unimplemented(
+    message = "mixing aggregate and not aggregate expressions is not allowed in SQL",
+    note = "you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column",
+    note = "try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause",
+    note = "also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all"
+)]
 pub trait MixedAggregates<Other> {
     /// What is the resulting `IsAggregate` type?
     type Output;

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -328,7 +328,7 @@ where
 /// join. To select a column or expression using a column from the right side of
 /// a left join, you must call `.nullable()` on it.
 #[diagnostic::on_unimplemented(
-    message = "Cannot select `{Self}` from `{QS}`",
+    message = "cannot select `{Self}` from `{QS}`",
     note = "`{Self}` is no valid selection for `{QS}`"
 )]
 pub trait SelectableExpression<QS: ?Sized>: AppearsOnTable<QS> {}

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -819,14 +819,14 @@ where
 }
 
 #[diagnostic::on_unimplemented(
-    message = "Cannot use the `LIKE` operator with expressions of the type `{ST}` for the backend `{Self}`",
-    note = "Expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are \n\
+    message = "cannot use the `LIKE` operator with expressions of the type `{ST}` for the backend `{Self}`",
+    note = "expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are \n\
             allowed for all backends"
 )]
 #[cfg_attr(
     feature = "postgres_backend",
     diagnostic::on_unimplemented(
-        note = "Expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are \n\
+        note = "expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are \n\
             allowed for the PostgreSQL backend"
     )
 )]

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -67,7 +67,7 @@ pub type array<ST, T> = <T as IntoArrayExpression<ST>>::ArrayExpression;
 ///
 /// This includes tuples of expressions with the same SQL type, and subselects with a single column.
 #[diagnostic::on_unimplemented(
-    message = "Cannot convert `{Self}` into an expression of type `Array<{ST}>`",
+    message = "cannot convert `{Self}` into an expression of type `Array<{ST}>`",
     note = "`the trait bound `{Self}: IntoArrayExpression<{ST}>` is not satisfied. \
         (`AsExpressionList` is a deprecated trait alias for `IntoArrayExpression`)"
 )]

--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -58,6 +58,7 @@ macro_rules! valid_ordering {
         [distinct: $D:ident]
         [order: $($O: ty,)*]
     ) => {
+        #[diagnostic::do_not_recommend]
         impl<$($T,)*> ValidOrderingForDistinct<DistinctOnClause<$D>>
             for OrderClause<($($O,)*)>
         {}
@@ -68,6 +69,7 @@ macro_rules! valid_ordering {
         [distinct: $($D:ident)*]
         [order: $O: ty,]
     ) => {
+        #[diagnostic::do_not_recommend]
         impl<$($T,)*> ValidOrderingForDistinct<DistinctOnClause<($($D,)*)>>
             for OrderClause<$O>
         {}
@@ -99,6 +101,7 @@ macro_rules! valid_ordering {
      [other: $($O:ident)*]
      [$($Ty:ty, )*]
     ) => {
+        #[diagnostic::do_not_recommend]
         impl<$($T,)*> ValidOrderingForDistinct<DistinctOnClause<($($D, )*)>>
             for OrderClause<($($Ty, )* $($O,)*)>
         {}

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -363,6 +363,7 @@ where
 {
 }
 
+#[diagnostic::do_not_recommend]
 impl<'query, V, T, QId, Op, U, B, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
     for (
@@ -407,6 +408,7 @@ where
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<'query, V, T, QId, Op, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
     for (
@@ -600,6 +602,7 @@ where
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<'query, V, T, QId, Op, U, B, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
     for (
@@ -633,6 +636,7 @@ where
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<'query, V, T, QId, Op, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
     for (

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -336,6 +336,9 @@ where
 /// A trait used to construct type erased boxed variant of the current query node
 ///
 /// Mainly useful for implementing third party backends
+#[diagnostic::on_unimplemented(
+    note = "this usually means that `{Self}` is no valid SQL for `{DB}`"
+)]
 pub trait IntoBoxedClause<'a, DB> {
     /// Resulting type
     type BoxedClause;

--- a/diesel/src/query_builder/update_statement/target.rs
+++ b/diesel/src/query_builder/update_statement/target.rs
@@ -25,6 +25,9 @@ pub struct UpdateTarget<Table, WhereClause> {
 /// [`update`]: crate::update()
 /// [`delete`]: crate::delete()
 /// [`filter`]: crate::query_builder::UpdateStatement::filter()
+#[diagnostic::on_unimplemented(
+    note = "only tables or select statements with only the filter clause applied are valid update targets"
+)]
 pub trait IntoUpdateTarget: HasTable {
     /// What is the `WHERE` clause of this target?
     type WhereClause;

--- a/diesel/src/query_dsl/boxed_dsl.rs
+++ b/diesel/src/query_dsl/boxed_dsl.rs
@@ -14,6 +14,11 @@ use crate::Expression;
 /// to call `into_boxed` from generic code.
 ///
 /// [`QueryDsl`]: crate::QueryDsl
+#[diagnostic::on_unimplemented(
+    message = "cannot box `{Self}` for backend `{DB}`",
+    note = "this either means `{Self}` is no valid SQL for `{DB}`",
+    note = "or this means `{Self}` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause"
+)]
 pub trait BoxedDsl<'a, DB> {
     /// The return type of `internal_into_boxed`
     type Output;
@@ -22,6 +27,7 @@ pub trait BoxedDsl<'a, DB> {
     fn internal_into_boxed(self) -> dsl::IntoBoxed<'a, Self, DB>;
 }
 
+#[diagnostic::do_not_recommend]
 impl<'a, T, DB> BoxedDsl<'a, DB> for T
 where
     T: Table + AsQuery<Query = SelectStatement<FromClause<T>>>,

--- a/diesel/src/query_dsl/distinct_dsl.rs
+++ b/diesel/src/query_dsl/distinct_dsl.rs
@@ -15,6 +15,9 @@ use crate::Expression;
 /// to call `distinct` from generic code.
 ///
 /// [`QueryDsl`]: crate::QueryDsl
+#[diagnostic::on_unimplemented(
+    note = "a `DISTINCT` clause is not compatible with various other clauses like `LOCKING` clauses"
+)]
 pub trait DistinctDsl {
     /// The type returned by `.distinct`
     type Output;
@@ -23,6 +26,7 @@ pub trait DistinctDsl {
     fn distinct(self) -> dsl::Distinct<Self>;
 }
 
+#[diagnostic::do_not_recommend]
 impl<T> DistinctDsl for T
 where
     T: Table + AsQuery<Query = SelectStatement<FromClause<T>>>,
@@ -44,6 +48,10 @@ where
 ///
 /// [`QueryDsl`]: crate::QueryDsl
 #[cfg(feature = "postgres_backend")]
+#[diagnostic::on_unimplemented(
+    note = "a `DISTINCT ON` clause is not compatible with various other clauses like `LOCKING` clauses",
+    note = "a `DISTINCT ON` clause also disallows mixing aggregate and non-aggregate expressions with the `SELECT` clause"
+)]
 pub trait DistinctOnDsl<Selection> {
     /// The type returned by `.distinct_on`
     type Output;
@@ -53,6 +61,7 @@ pub trait DistinctOnDsl<Selection> {
 }
 
 #[cfg(feature = "postgres_backend")]
+#[diagnostic::do_not_recommend]
 impl<T, Selection> DistinctOnDsl<Selection> for T
 where
     Selection: SelectableExpression<T>,

--- a/diesel/src/query_dsl/group_by_dsl.rs
+++ b/diesel/src/query_dsl/group_by_dsl.rs
@@ -21,6 +21,7 @@ pub trait GroupByDsl<Expr: Expression> {
     fn group_by(self, expr: Expr) -> dsl::GroupBy<Self, Expr>;
 }
 
+#[diagnostic::do_not_recommend]
 impl<T, Expr> GroupByDsl<Expr> for T
 where
     Expr: Expression,

--- a/diesel/src/query_dsl/having_dsl.rs
+++ b/diesel/src/query_dsl/having_dsl.rs
@@ -7,6 +7,9 @@ use crate::dsl;
 /// to call `having` from generic code.
 ///
 /// [`QueryDsl`]: crate::QueryDsl
+#[diagnostic::on_unimplemented(
+    note = "a `HAVING` clause requires setting a `GROUP BY` clause first"
+)]
 pub trait HavingDsl<Predicate> {
     /// The type returned by `.having`.
     type Output;

--- a/diesel/src/query_dsl/locking_dsl.rs
+++ b/diesel/src/query_dsl/locking_dsl.rs
@@ -13,6 +13,9 @@ use crate::Expression;
 /// to call `for_update` from generic code.
 ///
 /// [`QueryDsl`]: crate::QueryDsl
+#[diagnostic::on_unimplemented(
+    note = "a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause"
+)]
 pub trait LockingDsl<Lock> {
     /// The type returned by `set_lock`. See [`dsl::ForUpdate`] and friends for
     /// convenient access to this type.
@@ -24,6 +27,7 @@ pub trait LockingDsl<Lock> {
     fn with_lock(self, lock: Lock) -> Self::Output;
 }
 
+#[diagnostic::do_not_recommend]
 impl<T, Lock> LockingDsl<Lock> for T
 where
     T: Table + AsQuery<Query = SelectStatement<FromClause<T>>>,

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -1393,6 +1393,7 @@ pub trait QueryDsl: Sized {
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<T: Table> QueryDsl for T {}
 
 /// Methods used to execute queries.

--- a/diesel/src/query_dsl/order_dsl.rs
+++ b/diesel/src/query_dsl/order_dsl.rs
@@ -57,4 +57,9 @@ where
     }
 }
 
+#[diagnostic::on_unimplemented(
+    message = "invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause",
+    note = "the elements in your `DISTINCT ON` clause needs to match the elements \
+            in your `ORDER BY` clause up to which clause contains less elements"
+)]
 pub trait ValidOrderingForDistinct<D> {}

--- a/diesel/src/query_source/aliasing/joins.rs
+++ b/diesel/src/query_source/aliasing/joins.rs
@@ -13,6 +13,7 @@ use crate::query_source::{
     AppearsInFromClause, FromClause, Never, Pick, QuerySource, SelectStatement, Table,
 };
 
+#[diagnostic::do_not_recommend]
 impl<T, S> JoinTo<T> for Alias<S>
 where
     T: Table,

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -223,6 +223,11 @@ where
 /// [`joinable!`]: crate::joinable!
 /// [`.on`]: crate::query_dsl::JoinOnDsl::on()
 /// [`inner_join`]: crate::query_dsl::QueryDsl::inner_join()
+#[diagnostic::on_unimplemented(
+    message = "cannot join `{T}` to `{Self}` due to missing relation",
+    note = "joining tables directly either requires a `diesel::joinable!` definition \
+            or calling `JoinOnDsl::on` to manually specify the `ON` clause of the join`"
+)]
 pub trait JoinTo<T> {
     #[doc(hidden)]
     type FromClause;

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -42,6 +42,7 @@ macro_rules! tuple_impls {
             impl_from_sql_row!(($($T,)+), ($($ST,)+));
 
 
+            #[diagnostic::do_not_recommend]
             impl<$($T: Expression),+> Expression for ($($T,)+)
             where ($($T::SqlType, )*): TypedExpressionType
             {
@@ -90,6 +91,8 @@ macro_rules! tuple_impls {
                 }
             }
 
+            // cannot use `#[diagnostic::do_not_recommend]` here yet to hide tuple impls
+            // as this makes the error message worse (not saying which column is problematic)
             impl<$($T,)+ Tab> ColumnList for ($($T,)+)
             where
                 $($T: ColumnList<Table = Tab>,)+
@@ -189,6 +192,9 @@ macro_rules! tuple_impls {
                 }
             }
 
+            // not possible to use diagnostic::do_not_recommend to hide the tuple impls
+            // yet as it gives worse error messages
+            // (doesn't show anymore which tuple element doesn't implement the trait)
             impl<$($T,)+ QS> SelectableExpression<QS> for ($($T,)+) where
                 $($T: SelectableExpression<QS>,)+
                 ($($T,)+): AppearsOnTable<QS>,
@@ -327,6 +333,7 @@ macro_rules! tuple_impls {
                 }
             }
 
+            #[diagnostic::do_not_recommend]
             impl<__T, $($ST,)* __DB> CompatibleType<__T, __DB> for ($($ST,)*)
             where
                 __DB: Backend,
@@ -371,6 +378,7 @@ macro_rules! impl_from_sql_row {
         }
     };
     (($T1: ident, $($T: ident,)*), ($ST1: ident, $($ST: ident,)*)) => {
+        #[diagnostic::do_not_recommend]
         impl<$T1, $($T,)* $($ST,)* __DB> FromSqlRow<($($ST,)* crate::sql_types::Untyped), __DB> for ($($T,)* $T1)
         where __DB: Backend,
               $T1: FromSqlRow<crate::sql_types::Untyped, __DB>,

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.rs
@@ -19,15 +19,15 @@ allow_tables_to_appear_in_same_query!(users, posts);
 fn main() {
     use diesel::dsl::*;
     let source = users::table.select(sum(posts::id));
-    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~^ ERROR: cannot select `posts::columns::id` from `users::table`
     //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let source = users::table.select(avg(posts::id));
-    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~^ ERROR: cannot select `posts::columns::id` from `users::table`
     //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let source = users::table.select(max(posts::id));
-    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~^ ERROR: cannot select `posts::columns::id` from `users::table`
     //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let source = users::table.select(min(posts::id));
-    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~^ ERROR: cannot select `posts::columns::id` from `users::table`
     //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:21:31
    |
 LL |     let source = users::table.select(sum(posts::id));
@@ -35,7 +35,7 @@ LL |         id -> Integer,
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::sum_utils::sum<diesel::sql_types::Integer, posts::columns::id>>`
 
    
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:24:31
    |
 LL |     let source = users::table.select(avg(posts::id));
@@ -72,7 +72,7 @@ LL |         id -> Integer,
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_folding::avg_utils::avg<diesel::sql_types::Integer, posts::columns::id>>`
 
    
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:27:31
    |
 LL |     let source = users::table.select(max(posts::id));
@@ -109,7 +109,7 @@ LL |         id -> Integer,
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Integer, posts::columns::id>>`
 
    
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/aggregate_expression_requires_column_from_same_table.rs:30:31
    |
 LL |     let source = users::table.select(min(posts::id));

--- a/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
+++ b/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs
@@ -33,5 +33,4 @@ fn main() {
         .filter(name.eq(any(more_stuff::names)))
         .load(&mut conn);
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
+++ b/diesel_compile_tests/tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.stderr
@@ -34,37 +34,4 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
-error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>` is not satisfied
-    --> tests/fail/any_is_only_selectable_if_inner_expr_is_selectable.rs:34:15
-     |
-34   |         .load(&mut conn);
-     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-               Interval
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ---- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+     For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.rs
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.rs
@@ -7,13 +7,13 @@ fn main() {
     let mut connection = PgConnection::establish("").unwrap();
     select(array((1, 3))).get_result::<Vec<i32>>(&mut connection);
     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
-    //~^ ERROR: Cannot select `f64` from `NoFromClause`
+    //~^ ERROR: cannot select `f64` from `NoFromClause`
     //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
     //~| ERROR: the trait bound `f64: QueryId` is not satisfied
     //~| ERROR: `f64` is no valid SQL fragment for the `Pg` backend
     //~| ERROR: the trait bound `f64: diesel::Expression` is not satisfied
-    //~| ERROR: Cannot select `f64` from `NoFromClause`
+    //~| ERROR: cannot select `f64` from `NoFromClause`
     //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
-    //~| ERROR: Cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
+    //~| ERROR: cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
     select(array((1f64, 3f64))).get_result::<Vec<f64>>(&mut connection);
 }

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `f64` from `NoFromClause`
+error[E0277]: cannot select `f64` from `NoFromClause`
    --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
     |
 9   |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
@@ -66,7 +66,7 @@ LL |     crate::dsl::select<T>: AsQuery,
     |                            ^^^^^^^ required by this bound in `select`
  
     
-error[E0277]: Cannot select `f64` from `NoFromClause`
+error[E0277]: cannot select `f64` from `NoFromClause`
     --> tests/fail/array_expressions_must_be_correct_type.rs:9:56
      |
 9    |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
@@ -229,7 +229,7 @@ LL | where
 LL |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
-error[E0277]: Cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
+error[E0277]: cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
  --> tests/fail/array_expressions_must_be_correct_type.rs:9:12
   |
 LL |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -210,13 +210,13 @@ error[E0277]: the trait bound `f64: diesel::Expression` is not satisfied
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `f64` to implement `AsExpression<diesel::sql_types::Integer>`
    = note: required for `(f64, f64)` to implement `AsExpressionList<diesel::sql_types::Integer>`

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.rs
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.rs
@@ -14,22 +14,22 @@ fn main() {
 
     select(array((1, 3f64)))
         //~^ ERROR: the trait bound `f64: diesel::Expression` is not satisfied
-        //~| ERROR: Cannot select `f64` from `NoFromClause`
+        //~| ERROR: cannot select `f64` from `NoFromClause`
         //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
-        //~| ERROR: Cannot convert `(i32, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
+        //~| ERROR: cannot convert `(i32, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
         .get_result::<Vec<i32>>(&mut connection)
-        //~^ ERROR: Cannot select `f64` from `NoFromClause`
+        //~^ ERROR: cannot select `f64` from `NoFromClause`
         //~| ERROR: the trait bound `f64: ValidGrouping<()>` is not satisfied
         //~| ERROR: the trait bound `f64: QueryId` is not satisfied
         //~| ERROR: `f64` is no valid SQL fragment for the `Pg` backend
         .unwrap();
     select(array((1, 3f64)))
         //~^ ERROR: the trait bound `{integer}: diesel::Expression` is not satisfied
-        //~| ERROR: Cannot select `{integer}` from `NoFromClause`
+        //~| ERROR: cannot select `{integer}` from `NoFromClause`
         //~| ERROR: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
-        //~| ERROR: Cannot convert `({integer}, f64)` into an expression of type `Array<diesel::sql_types::Double>`
+        //~| ERROR: cannot convert `({integer}, f64)` into an expression of type `Array<diesel::sql_types::Double>`
         .get_result::<Vec<f64>>(&mut connection)
-        //~^ ERROR: Cannot select `{integer}` from `NoFromClause`
+        //~^ ERROR: cannot select `{integer}` from `NoFromClause`
         //~| ERROR: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
         //~| ERROR: the trait bound `{integer}: QueryId` is not satisfied
         //~| ERROR: `{integer}` is no valid SQL fragment for the `Pg` backend

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `f64` from `NoFromClause`
+error[E0277]: cannot select `f64` from `NoFromClause`
    --> tests/fail/array_expressions_must_be_same_type.rs:15:12
     |
 15  |     select(array((1, 3f64)))
@@ -66,7 +66,7 @@ LL |     crate::dsl::select<T>: AsQuery,
     |                            ^^^^^^^ required by this bound in `select`
  
     
-error[E0277]: Cannot select `f64` from `NoFromClause`
+error[E0277]: cannot select `f64` from `NoFromClause`
     --> tests/fail/array_expressions_must_be_same_type.rs:20:33
      |
 20   |         .get_result::<Vec<i32>>(&mut connection)
@@ -229,7 +229,7 @@ LL | where
 LL |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
-error[E0277]: Cannot select `{integer}` from `NoFromClause`
+error[E0277]: cannot select `{integer}` from `NoFromClause`
    --> tests/fail/array_expressions_must_be_same_type.rs:26:12
     |
 26  |     select(array((1, 3f64)))
@@ -297,7 +297,7 @@ LL |     crate::dsl::select<T>: AsQuery,
     |                            ^^^^^^^ required by this bound in `select`
  
     
-error[E0277]: Cannot select `{integer}` from `NoFromClause`
+error[E0277]: cannot select `{integer}` from `NoFromClause`
     --> tests/fail/array_expressions_must_be_same_type.rs:31:33
      |
 31   |         .get_result::<Vec<f64>>(&mut connection)
@@ -460,7 +460,7 @@ LL | where
 LL |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
 
-error[E0277]: Cannot convert `(i32, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
+error[E0277]: cannot convert `(i32, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
   --> tests/fail/array_expressions_must_be_same_type.rs:15:12
    |
 LL |     select(array((1, 3f64)))
@@ -478,7 +478,7 @@ LL |     select(array((1, 3f64)))
              (T0, T1, T2, T3, T4, T5, T6, T7, T8)
            and N others
 
-error[E0277]: Cannot convert `({integer}, f64)` into an expression of type `Array<diesel::sql_types::Double>`
+error[E0277]: cannot convert `({integer}, f64)` into an expression of type `Array<diesel::sql_types::Double>`
   --> tests/fail/array_expressions_must_be_same_type.rs:26:12
    |
 LL |     select(array((1, 3f64)))

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -210,13 +210,13 @@ LL |     select(array((1, 3f64)))
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `f64` to implement `AsExpression<diesel::sql_types::Integer>`
    = note: required for `(i32, f64)` to implement `AsExpressionList<diesel::sql_types::Integer>`
@@ -441,13 +441,13 @@ LL |     select(array((1, 3f64)))
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `{integer}` to implement `AsExpression<diesel::sql_types::Double>`
    = note: required for `({integer}, f64)` to implement `AsExpressionList<diesel::sql_types::Double>`

--- a/diesel_compile_tests/tests/fail/auto_type.rs
+++ b/diesel_compile_tests/tests/fail/auto_type.rs
@@ -44,7 +44,7 @@ fn user_has_post_with_id_greater_than_2() -> _ {
     // (Literals must have type suffix for auto_type, e.g. 2i64), and that it's properly spanned
     // (on the `2`)
     let n = 2;
-    //~^ ERROR: Literals must have type suffix for auto_type, e.g. 2i64
+    //~^ ERROR: literals must have type suffix for auto_type, e.g. `2_i64`
     //~| ERROR: the placeholder `_` is not allowed within types on item signatures for type aliases
     let m = 3;
     dsl::exists(
@@ -57,7 +57,7 @@ fn user_has_post_with_id_greater_than_2() -> _ {
 #[dsl::auto_type]
 fn less_arguments_than_generics() -> _ {
     posts::user_id.eq::<_>()
-    //~^ ERROR: auto_type: Can't infer generic argument because there is no function argument to infer from (less function arguments than generic arguments)
+    //~^ ERROR: can't infer generic argument because there is no function argument to infer from (less function arguments than generic arguments)
     //~| ERROR: the placeholder `_` is not allowed within types on item signatures for type aliases
     //~| ERROR: this method takes 1 argument but 0 arguments were supplied
 }
@@ -70,7 +70,7 @@ struct User {
         posts::table
             .filter(posts::user_id.eq(users::id))
             .filter(posts::id.gt(2)),
-        //~^ ERROR: Literals must have type suffix for auto_type, e.g. 2i64
+        //~^ ERROR: literals must have type suffix for auto_type, e.g. `2_i64`
         //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated types
     ))]
     user_has_post_with_id_greater_than_2: bool,

--- a/diesel_compile_tests/tests/fail/auto_type.stderr
+++ b/diesel_compile_tests/tests/fail/auto_type.stderr
@@ -1,16 +1,16 @@
-error: Literals must have type suffix for auto_type, e.g. 2i64
+error: literals must have type suffix for auto_type, e.g. `2_i64`
   --> tests/fail/auto_type.rs:46:13
    |
 LL |     let n = 2;
    |             ^
 
-error: auto_type: Can't infer generic argument because there is no function argument to infer from (less function arguments than generic arguments)
+error: can't infer generic argument because there is no function argument to infer from (less function arguments than generic arguments)
   --> tests/fail/auto_type.rs:59:25
    |
 LL |     posts::user_id.eq::<_>()
    |                         ^
 
-error: Literals must have type suffix for auto_type, e.g. 2i64
+error: literals must have type suffix for auto_type, e.g. `2_i64`
   --> tests/fail/auto_type.rs:72:34
    |
 LL |             .filter(posts::id.gt(2)),

--- a/diesel_compile_tests/tests/fail/boxed_queries_and_group_by.rs
+++ b/diesel_compile_tests/tests/fail/boxed_queries_and_group_by.rs
@@ -53,14 +53,14 @@ fn main() {
 
     // cannot box a query with default select clause + a group by clause
     users::table.group_by(users::name).into_boxed();
-    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: BoxedDsl<'_, _>` is not satisfied
+    //~^ ERROR: cannot box `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` for backend `_`
 
     users::table
         .group_by(users::name)
         .select(users::id)
         //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
         .into_boxed();
-    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: BoxedDsl<'_, _>` is not satisfied
+    //~^ ERROR: cannot box `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` for backend `_`
 
     users::table
         .group_by(users::name)
@@ -89,7 +89,7 @@ fn main() {
     users::table
         .into_boxed()
         .group_by(users::id)
-        //~^ ERROR: type mismatch resolving `<BoxedSelectStatement<'_, ..., ..., _> as AsQuery>::Query == SelectStatement<...>`
+        //~^ ERROR: the trait bound `BoxedSelectStatement<'_, (Integer, Text), ..., _>: GroupByDsl<_>` is not satisfied
         //~| ERROR: the trait bound `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>: Table` is not satisfied
         //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
         .select(users::name)

--- a/diesel_compile_tests/tests/fail/boxed_queries_and_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_queries_and_group_by.stderr
@@ -1,9 +1,11 @@
-error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: BoxedDsl<'_, _>` is not satisfied
+error[E0277]: cannot box `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` for backend `_`
   --> tests/fail/boxed_queries_and_group_by.rs:55:40
    |
 LL |     users::table.group_by(users::name).into_boxed();
    |                                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
    |
+   = note: this either means `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` is no valid SQL for `_`
+   = note: or this means `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
@@ -29,12 +31,14 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
 
    
-error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: BoxedDsl<'_, _>` is not satisfied
+error[E0277]: cannot box `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` for backend `_`
   --> tests/fail/boxed_queries_and_group_by.rs:62:10
    |
 LL |         .into_boxed();
    |          ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
    |
+   = note: this either means `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` is no valid SQL for `_`
+   = note: or this means `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
@@ -116,31 +120,26 @@ LL |     a = users::table.group_by(users::id).into_boxed();
    = note: expected struct `BoxedSelectStatement<'_, _, _, _, ()>`
               found struct `BoxedSelectStatement<'_, _, _, _, users::columns::id>`
 
-error[E0271]: type mismatch resolving `<BoxedSelectStatement<'_, ..., ..., _> as AsQuery>::Query == SelectStatement<...>`
+error[E0277]: the trait bound `BoxedSelectStatement<'_, (Integer, Text), ..., _>: GroupByDsl<_>` is not satisfied
   --> tests/fail/boxed_queries_and_group_by.rs:91:10
    |
 LL |         .group_by(users::id)
-   |          ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `BoxedSelectStatement<'_, ..., ..., _>`
+   |          ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>`
    |
-   = note: expected struct `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>>>`
-              found struct `BoxedSelectStatement<'_, (diesel::sql_types::Integer, diesel::sql_types::Text), FromClause<users::table>, _>`
-   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>` to implement `GroupByDsl<_>`
+   = help: the following other types implement trait `GroupByDsl<Expr>`:
+             Alias<S>
+             SelectStatement<F, S, D, W, O, LOf, G, H>
 
    
 error[E0277]: the trait bound `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>: Table` is not satisfied
   --> tests/fail/boxed_queries_and_group_by.rs:91:10
    |
 LL |         .group_by(users::id)
-   |          ^^^^^^^^ the trait `Table` is not implemented for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>`
+   |          ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>`
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             posts::table
-             users::table
-   = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>` to implement `GroupByDsl<_>`
+   = help: the following other types implement trait `GroupByDsl<Expr>`:
+             Alias<S>
+             SelectStatement<F, S, D, W, O, LOf, G, H>
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
@@ -104,16 +104,9 @@ error[E0277]: the trait bound `User: FromSqlRow<_, _>` is not satisfied
      = note: double check your type mappings via the documentation of `_`
      = note: `diesel::sql_query` requires the loading target to column names for loading values.
              You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `FromSqlRow<ST, DB>`:
-               `(T1, T0)` implements `FromSqlRow<(ST1, Untyped), __DB>`
-               `(T1, T2, T0)` implements `FromSqlRow<(ST1, ST2, Untyped), __DB>`
-               `(T1, T2, T3, T0)` implements `FromSqlRow<(ST1, ST2, ST3, Untyped), __DB>`
-               `(T1, T2, T3, T4, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, Untyped), __DB>`
-               `(T1, T2, T3, T4, T5, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, Untyped), __DB>`
-               `(T1, T2, T3, T4, T5, T6, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, Untyped), __DB>`
-               `(T1, T2, T3, T4, T5, T6, T7, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, Untyped), __DB>`
-               `(T1, T2, T3, T4, T5, T6, T7, T8, T0)` implements `FromSqlRow<(ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8, Untyped), __DB>`
-             and N others
+     = help: the following other types implement trait `LoadQuery<'query, Conn, U, B>`:
+               InsertStatement<T, BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Op>
+               InsertStatement<T, diesel::query_builder::upsert::on_conflict_clause::OnConflictValues<BatchInsert<Vec<diesel::query_builder::insert_statement::ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Target, ConflictOpt>, Op>
      = note: required for `SqlQuery` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`
     --> DIESEL/diesel/diesel/src/query_dsl/mod.rs

--- a/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.rs
+++ b/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.rs
@@ -28,13 +28,13 @@ allow_tables_to_appear_in_same_query!(comments, posts, users);
 
 fn main() {
     let _ = users::table.inner_join(posts::table);
-    //~^ ERROR: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
+    //~^ ERROR:  cannot join `posts::table` to `users::table` due to missing relation
     let _ = users::table.left_outer_join(posts::table);
-    //~^ ERROR: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
+    //~^ ERROR: cannot join `posts::table` to `users::table` due to missing relation
 
     // Sanity check to make sure the error is when users
     // become involved
     let join = posts::table.inner_join(comments::table);
     let _ = users::table.inner_join(join);
-    //~^ ERROR: the trait bound `posts::table: JoinTo<users::table>` is not satisfied
+    //~^ ERROR: cannot join `users::table` to `posts::table` due to missing relation
 }

--- a/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
+error[E0277]: cannot join `posts::table` to `users::table` due to missing relation
    --> tests/fail/cannot_join_to_non_joinable_table.rs:30:37
     |
 30  |     let _ = users::table.inner_join(posts::table);
@@ -6,6 +6,7 @@ error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisf
     |                          |
     |                          required by a bound introduced by this call
     |
+    = note: joining tables directly either requires a `diesel::joinable!` definition or calling `JoinOnDsl::on` to manually specify the `ON` clause of the join`
     = help: the following other types implement trait `JoinTo<T>`:
               `users::table` implements `JoinTo<Alias<S>>`
               `users::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`
@@ -24,7 +25,7 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::Inner>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::inner_join`
 
-error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisfied
+error[E0277]: cannot join `posts::table` to `users::table` due to missing relation
    --> tests/fail/cannot_join_to_non_joinable_table.rs:32:42
     |
 32  |     let _ = users::table.left_outer_join(posts::table);
@@ -32,6 +33,7 @@ error[E0277]: the trait bound `users::table: JoinTo<posts::table>` is not satisf
     |                          |
     |                          required by a bound introduced by this call
     |
+    = note: joining tables directly either requires a `diesel::joinable!` definition or calling `JoinOnDsl::on` to manually specify the `ON` clause of the join`
     = help: the following other types implement trait `JoinTo<T>`:
               `users::table` implements `JoinTo<Alias<S>>`
               `users::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`
@@ -50,12 +52,13 @@ LL |     where
 LL |         Self: JoinWithImplicitOnClause<Rhs, joins::LeftOuter>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::left_outer_join`
 
-error[E0277]: the trait bound `posts::table: JoinTo<users::table>` is not satisfied
+error[E0277]: cannot join `users::table` to `posts::table` due to missing relation
   --> tests/fail/cannot_join_to_non_joinable_table.rs:38:26
    |
 LL |     let _ = users::table.inner_join(join);
    |                          ^^^^^^^^^^ the trait `JoinTo<users::table>` is not implemented for `posts::table`
    |
+   = note: joining tables directly either requires a `diesel::joinable!` definition or calling `JoinOnDsl::on` to manually specify the `ON` clause of the join`
    = help: the following other types implement trait `JoinTo<T>`:
              `posts::table` implements `JoinTo<Alias<S>>`
              `posts::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs
@@ -21,11 +21,11 @@ fn main() {
     use diesel::dsl::max;
 
     let source = users.select((id, count_star()));
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
     let source = users.select(nullable_int_col + max(nullable_int_col));
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
     let source = users.select(f(nullable_int_col, max(nullable_int_col)));
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 }

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.stderr
@@ -1,21 +1,27 @@
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:23:24
    |
 LL |     let source = users.select((id, count_star()));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
    |
+   = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+   = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+   = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
    = note: required for `(columns::id, CountStar)` to implement `ValidGrouping<()>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(columns::id, CountStar)>`
 
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:26:24
    |
 LL |     let source = users.select(nullable_int_col + max(nullable_int_col));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
    |
+   = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+   = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+   = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
@@ -23,12 +29,15 @@ LL |     let source = users.select(nullable_int_col + max(nullable_int_col));
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::ops::numeric::Add<columns::nullable_int_col, diesel::expression::functions::aggregate_ordering::max_utils::max<diesel::sql_types::Nullable<diesel::sql_types::Integer>, columns::nullable_int_col>>>`
 
    
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.rs:29:24
    |
 LL |     let source = users.select(f(nullable_int_col, max(nullable_int_col)));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
    |
+   = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+   = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+   = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`

--- a/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.rs
+++ b/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.rs
@@ -13,5 +13,5 @@ fn main() {
     use self::users::dsl::*;
 
     let source = users.filter(count(id).gt(3));
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+    //~^ ERROR:  mixing aggregate and not aggregate expressions is not allowed in SQL
 }

--- a/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_pass_aggregate_to_where.stderr
@@ -1,9 +1,12 @@
-error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
   --> tests/fail/cannot_pass_aggregate_to_where.rs:15:24
    |
 LL |     let source = users.filter(count(id).gt(3));
    |                        ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
    |
+   = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+   = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+   = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`

--- a/diesel_compile_tests/tests/fail/cannot_update_target_with_methods_other_than_filter_called.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_update_target_with_methods_other_than_filter_called.stderr
@@ -6,6 +6,7 @@ LL |     let command = update(users.select(id)).set(id.eq(1));
    |                   |
    |                   required by a bound introduced by this call
    |
+   = note: only tables or select statements with only the filter clause applied are valid update targets
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
    = note: required for `SelectStatement<FromClause<table>, SelectClause<id>>` to implement `IntoUpdateTarget`
 note: required by a bound in `diesel::update`
@@ -23,6 +24,7 @@ LL |     let command = update(users.order(id)).set(id.eq(1));
    |                   |
    |                   required by a bound introduced by this call
    |
+   = note: only tables or select statements with only the filter clause applied are valid update targets
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
    = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `IntoUpdateTarget`
 note: required by a bound in `diesel::update`

--- a/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.rs
+++ b/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.rs
@@ -21,6 +21,6 @@ table! {
         column_18 -> Integer,
     }
 }
-//~^^^^^^^^^^^^^^^^^^^^^ ERROR: Table contains more than 16 columns. Consider enabling the `32-column-tables` feature to enable diesels support for tables with more than 16 columns.
+//~^^^^^^^^^^^^^^^^^^^^^ ERROR: table contains more than 16 columns.
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.stderr
+++ b/diesel_compile_tests/tests/fail/check_message_for_to_many_columns.stderr
@@ -1,4 +1,5 @@
-error: Table contains more than 16 columns. Consider enabling the `32-column-tables` feature to enable diesels support for tables with more than 16 columns.
+error: table contains more than 16 columns. 
+       help: consider enabling the `32-column-tables` feature to enable diesels support for tables with more than 16 columns.
   --> tests/fail/check_message_for_to_many_columns.rs:3:1
    |
 3  | / table! {

--- a/diesel_compile_tests/tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/codegen_does_not_add_save_changes_method_on_structs_without_primary_key.stderr
@@ -36,7 +36,7 @@ LL | pub trait HasTable {
     |
    ::: DIESEL/diesel/diesel/src/query_builder/update_statement/target.rs
     |
-28  | pub trait IntoUpdateTarget: HasTable {
+31  | pub trait IntoUpdateTarget: HasTable {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider annotating `User` with `#[derive(Clone, Copy)]`
     |

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.rs
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.rs
@@ -22,7 +22,7 @@ fn main() {
     let stmt = update(users.filter(id.eq(1)))
         .set(name.eq("Bill"))
         .returning(count(id));
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
     let new_user = NewUser {
         name: "Foobar".to_string(),
@@ -30,5 +30,5 @@ fn main() {
     let stmt = insert_into(users)
         .values(&new_user)
         .returning((name, count(name)));
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 }

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_nonaggregate.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/custom_returning_requires_nonaggregate.rs:24:20
     |
 24  |         .returning(count(id));
@@ -6,6 +6,9 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggre
     |          |
     |          required by a bound introduced by this call
     |
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
@@ -20,7 +23,7 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
  
     
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/custom_returning_requires_nonaggregate.rs:32:20
     |
 32  |         .returning((name, count(name)));
@@ -28,6 +31,9 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggreg
     |          |
     |          required by a bound introduced by this call
     |
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
@@ -30,7 +30,7 @@ fn main() {
     let stmt = update(users.filter(id.eq(1)))
         .set(name.eq("Bill"))
         .returning(bad::age);
-    //~^ ERROR: Cannot select `bad::columns::age` from `users::table`
+    //~^ ERROR: cannot select `bad::columns::age` from `users::table`
 
     let new_user = NewUser {
         name: "Foobar".to_string(),
@@ -38,6 +38,6 @@ fn main() {
     let stmt = insert_into(users)
         .values(&new_user)
         .returning((name, bad::age));
-    //~^ ERROR: Cannot select `bad::columns::age` from `users::table`
+    //~^ ERROR: cannot select `bad::columns::age` from `users::table`
     //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `bad::columns::age` from `users::table`
+error[E0277]: cannot select `bad::columns::age` from `users::table`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:32:20
     |
 32  |         .returning(bad::age);
@@ -26,7 +26,7 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
  
     
-error[E0277]: Cannot select `bad::columns::age` from `users::table`
+error[E0277]: cannot select `bad::columns::age` from `users::table`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:40:20
     |
 40  |         .returning((name, bad::age));

--- a/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -15,7 +15,6 @@ fn main() {
 
     delete(users.filter(name.eq("Bill"))).get_result(&mut connection);
     //~^ ERROR: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
-    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
 
     delete(users.filter(name.eq("Bill")))
         .returning(name)

--- a/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -27,9 +27,9 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
-    --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:22:21
+    --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:21:21
      |
-22   |         .get_result(&mut connection);
+21   |         .get_result(&mut connection);
      |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
      |          |
      |          required by a bound introduced by this call
@@ -44,41 +44,6 @@ error[E0277]: `ReturningClause<columns::name>` is no valid SQL fragment for the 
      = note: 1 redundant requirement hidden
      = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>, ...>` to implement `QueryFragment<Sqlite>`
      = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
-note: required by a bound in `get_result`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-     |        ---------- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-  
-     
-error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
-    --> tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.rs:16:54
-     |
-16   |     delete(users.filter(name.eq("Bill"))).get_result(&mut connection);
-     |                                           ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     |                                           |
-     |                                           required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-     = note: required for `DeleteStatement<table, WhereClause<Grouped<Eq<name, ...>>>>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `get_result`
     --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
      |

--- a/diesel_compile_tests/tests/fail/derive/aliases.rs
+++ b/diesel_compile_tests/tests/fail/derive/aliases.rs
@@ -58,7 +58,7 @@ pub fn check(conn: &mut PgConnection) {
     // don't allow joins to not joinable tables
     pets::table
         .inner_join(user_alias)
-        //~^ ERROR: the trait bound `users::table: JoinTo<pets::table>` is not satisfied
+        //~^ ERROR: cannot join `pets::table` to `Alias<users2>` due to missing relation
         .select(pets::id)
         .load::<i32>(conn)
         .unwrap();

--- a/diesel_compile_tests/tests/fail/derive/aliases.rs
+++ b/diesel_compile_tests/tests/fail/derive/aliases.rs
@@ -50,8 +50,8 @@ pub fn check(conn: &mut PgConnection) {
 
     // Selecting the raw field on the aliased table
     user_alias.select(users::id).load::<i32>(conn).unwrap();
-    //~^ ERROR: Cannot select `users::columns::id` from `Alias<users2>`
-    //~| ERROR: Cannot select `users::columns::id` from `Alias<users2>`
+    //~^ ERROR: cannot select `users::columns::id` from `Alias<users2>`
+    //~| ERROR: cannot select `users::columns::id` from `Alias<users2>`
 
     let user2_alias = alias!(users as user3);
 

--- a/diesel_compile_tests/tests/fail/derive/aliases.stderr
+++ b/diesel_compile_tests/tests/fail/derive/aliases.stderr
@@ -160,22 +160,17 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: the trait bound `users::table: JoinTo<pets::table>` is not satisfied
+error[E0277]: cannot join `pets::table` to `Alias<users2>` due to missing relation
   --> tests/fail/derive/aliases.rs:60:10
    |
 LL |         .inner_join(user_alias)
-   |          ^^^^^^^^^^ the trait `JoinTo<pets::table>` is not implemented for `users::table`
+   |          ^^^^^^^^^^ the trait `JoinTo<pets::table>` is not implemented for `Alias<users2>`
    |
+   = note: joining tables directly either requires a `diesel::joinable!` definition or calling `JoinOnDsl::on` to manually specify the `ON` clause of the join`
    = help: the following other types implement trait `JoinTo<T>`:
-             `users::table` implements `JoinTo<Alias<S>>`
-             `users::table` implements `JoinTo<BoxedSelectStatement<'_, FromClause<QS>, ST, DB>>`
-             `users::table` implements `JoinTo<JoinOn<Join, On>>`
-             `users::table` implements `JoinTo<Only<S>>`
-             `users::table` implements `JoinTo<SelectStatement<FromClause<F>, S, D, W, O, L, Of, G>>`
-             `users::table` implements `JoinTo<Tablesample<S, TSM>>`
-             `users::table` implements `JoinTo<posts::table>`
-             `users::table` implements `JoinTo<query_source::joins::Join<Left, Right, Kind>>`
-   = note: required for `Alias<users2>` to implement `JoinTo<pets::table>`
+             `Alias<S>` implements `JoinTo<Alias<S2>>`
+             `Alias<S>` implements `JoinTo<SelectStatement<FromClause<F>, Select, D, W, O, L, Of, G>>`
+             `Alias<S>` implements `JoinTo<query_source::joins::OnClauseWrapper<Rhs, On>>`
    = note: required for `pets::table` to implement `JoinWithImplicitOnClause<Alias<users2>, Inner>`
 
 error[E0277]: the trait bound `Alias<posts3>: AppearsInFromClause<Alias<posts2>>` is not satisfied

--- a/diesel_compile_tests/tests/fail/derive/aliases.stderr
+++ b/diesel_compile_tests/tests/fail/derive/aliases.stderr
@@ -101,7 +101,7 @@ LL | |         .select(users::id)
            `&mut SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>>>: Table`
            which is required by `&mut SelectStatement<FromClause<JoinOn<query_source::joins::Join<JoinOn<query_source::joins::Join<users::table, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>, Alias<posts2>, Inner>, diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<NullableExpression<AliasedField<posts2, posts::columns::author>>, NullableExpression<users::columns::id>>>>>>: diesel::QueryDsl`
 
-error[E0277]: Cannot select `users::columns::id` from `Alias<users2>`
+error[E0277]: cannot select `users::columns::id` from `Alias<users2>`
    --> tests/fail/derive/aliases.rs:52:23
     |
 52  |     user_alias.select(users::id).load::<i32>(conn).unwrap();
@@ -130,7 +130,7 @@ LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Select
 LL |         Self: methods::SelectDsl<Selection>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
 
-error[E0277]: Cannot select `users::columns::id` from `Alias<users2>`
+error[E0277]: cannot select `users::columns::id` from `Alias<users2>`
     --> tests/fail/derive/aliases.rs:52:46
      |
 52   |     user_alias.select(users::id).load::<i32>(conn).unwrap();

--- a/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.rs
@@ -16,14 +16,14 @@ struct Foo1 {
 }
 
 #[derive(AsChangeset)]
-//~^ ERROR: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
+//~^ ERROR: deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
 #[diesel(table_name = foo)]
 struct Foo2 {
     id: i32,
 }
 
 #[derive(AsChangeset)]
-//~^ ERROR: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
+//~^ ERROR: deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
 #[diesel(table_name = foo, primary_key(id, bar))]
 struct Foo3 {
     id: i32,

--- a/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/derive/as_changeset_struct_with_only_primary_key.stderr
@@ -1,5 +1,5 @@
-error: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
-       help: If you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
+error: deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
+       help: if you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
        note: `#[derive(AsChangeset)]` never changes the primary key of a row.
   --> tests/fail/derive/as_changeset_struct_with_only_primary_key.rs:18:10
    |
@@ -8,8 +8,8 @@ LL | #[derive(AsChangeset)]
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
-       help: If you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
+error: deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
+       help: if you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
        note: `#[derive(AsChangeset)]` never changes the primary key of a row.
   --> tests/fail/derive/as_changeset_struct_with_only_primary_key.rs:25:10
    |

--- a/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.rs
+++ b/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.rs
@@ -2,7 +2,7 @@ extern crate diesel;
 use diesel::expression::AsExpression;
 
 #[derive(AsExpression)]
-//~^ ERROR: At least one `sql_type` is needed for deriving `AsExpression` on a structure.
+//~^ ERROR: at least one `sql_type` is needed for deriving `AsExpression` on a structure.
 struct Lol;
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/as_expression_without_sql_type.stderr
@@ -1,4 +1,4 @@
-error: At least one `sql_type` is needed for deriving `AsExpression` on a structure.
+error: at least one `sql_type` is needed for deriving `AsExpression` on a structure.
  --> tests/fail/derive/as_expression_without_sql_type.rs:4:10
   |
 LL | #[derive(AsExpression)]

--- a/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.rs
+++ b/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 #[derive(Associations)]
-//~^ ERROR: At least one `belongs_to` is needed for deriving `Associations` on a structure.
+//~^ ERROR: at least one `belongs_to` is needed for deriving `Associations` on a structure.
 struct User {
     id: i32,
 }

--- a/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.stderr
+++ b/diesel_compile_tests/tests/fail/derive/associations_without_belongs_to.stderr
@@ -1,4 +1,4 @@
-error: At least one `belongs_to` is needed for deriving `Associations` on a structure.
+error: at least one `belongs_to` is needed for deriving `Associations` on a structure.
  --> tests/fail/derive/associations_without_belongs_to.rs:4:10
   |
 LL | #[derive(Associations)]

--- a/diesel_compile_tests/tests/fail/derive/bad_belongs_to.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_belongs_to.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected parentheses
-       help: The correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
+       help: the correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
   --> tests/fail/derive/bad_belongs_to.rs:29:20
    |
 LL | #[diesel(belongs_to)]
@@ -30,7 +30,7 @@ LL | #[diesel(belongs_to(Bar = "bar_id"))]
    |                         ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
+       help: the correct format looks like `#[diesel(belongs_to(Foo, foreign_key = foo_id))]`
   --> tests/fail/derive/bad_belongs_to.rs:69:37
    |
 LL | #[diesel(belongs_to(Bar, foreign_key))]

--- a/diesel_compile_tests/tests/fail/derive/bad_column_name.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_column_name.rs
@@ -38,7 +38,7 @@ struct User3 {
 #[diesel(table_name = users)]
 struct User4 {
     #[diesel(column_name = "spa ce")]
-    //~^ ERROR:  Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
+    //~^ ERROR:  expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
     space: String,
 }
 
@@ -46,7 +46,7 @@ struct User4 {
 #[diesel(table_name = users)]
 struct User5 {
     #[diesel(column_name = "spa ce")]
-    //~^ ERROR:  Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
+    //~^ ERROR:  expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
     space: String,
 }
 

--- a/diesel_compile_tests/tests/fail/derive/bad_column_name.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_column_name.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(column_name = foo)]`
+       help: the correct format looks like `#[diesel(column_name = foo)]`
   --> tests/fail/derive/bad_column_name.rs:16:25
    |
 LL |     #[diesel(column_name)]
@@ -17,13 +17,13 @@ error: expected string literal
 LL |     #[diesel(column_name = true)]
    |                            ^^^^
 
-error: Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
+error: expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
   --> tests/fail/derive/bad_column_name.rs:40:28
    |
 LL |     #[diesel(column_name = "spa ce")]
    |                            ^^^^^^^^
 
-error: Expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
+error: expected valid identifier, found `spa ce`. Diesel does not support column names with whitespaces yet
   --> tests/fail/derive/bad_column_name.rs:48:28
    |
 LL |     #[diesel(column_name = "spa ce")]

--- a/diesel_compile_tests/tests/fail/derive/bad_derive_input.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_derive_input.rs
@@ -10,12 +10,12 @@ table! {
 }
 
 #[derive(AsChangeset)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 enum UserEnum {}
 
 #[derive(AsChangeset)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct UserStruct;
 

--- a/diesel_compile_tests/tests/fail/derive/bad_derive_input.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_derive_input.stderr
@@ -1,4 +1,4 @@
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/bad_derive_input.rs:12:10
    |
 LL | #[derive(AsChangeset)]
@@ -6,7 +6,7 @@ LL | #[derive(AsChangeset)]
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/bad_derive_input.rs:17:10
    |
 LL | #[derive(AsChangeset)]

--- a/diesel_compile_tests/tests/fail/derive/bad_deserialize_as.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_deserialize_as.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(deserialize_as = Foo)]`
+       help: the correct format looks like `#[diesel(deserialize_as = Foo)]`
  --> tests/fail/derive/bad_deserialize_as.rs:7:28
   |
 LL |     #[diesel(deserialize_as)]

--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
@@ -6,13 +6,13 @@ LL | #[derive(Insertable)]
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -25,13 +25,13 @@ LL | #[derive(Insertable)]
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `i32` to implement `AsExpression<diesel::sql_types::Text>`
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -44,13 +44,13 @@ LL | #[derive(Insertable)]
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `&'insert std::string::String` to implement `diesel::Expression`
    = note: required for `&'insert std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
@@ -64,13 +64,13 @@ LL | #[derive(Insertable)]
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `&'insert i32` to implement `diesel::Expression`
    = note: required for `&'insert i32` to implement `AsExpression<diesel::sql_types::Text>`
@@ -84,13 +84,13 @@ LL |     id: String,
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
 
@@ -102,13 +102,13 @@ LL |     name: i32,
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `i32` to implement `AsExpression<diesel::sql_types::Text>`
 
@@ -120,13 +120,13 @@ LL |     id: String,
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `&'insert std::string::String` to implement `diesel::Expression`
    = note: required for `&'insert std::string::String` to implement `AsExpression<diesel::sql_types::Integer>`
@@ -139,13 +139,13 @@ LL |     name: i32,
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `&'insert i32` to implement `diesel::Expression`
    = note: required for `&'insert i32` to implement `AsExpression<diesel::sql_types::Text>`

--- a/diesel_compile_tests/tests/fail/derive/bad_mysql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_mysql_type.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected parentheses
-       help: The correct format looks like `#[diesel(mysql_type(name = "foo"))]`
+       help: the correct format looks like `#[diesel(mysql_type(name = "foo"))]`
  --> tests/fail/derive/bad_mysql_type.rs:6:20
   |
 LL | #[diesel(mysql_type)]
@@ -19,7 +19,7 @@ LL | #[diesel(mysql_type = "foo")]
    |                     ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(mysql_type(name = "foo"))]`
+       help: the correct format looks like `#[diesel(mysql_type(name = "foo"))]`
   --> tests/fail/derive/bad_mysql_type.rs:21:25
    |
 LL | #[diesel(mysql_type(name))]

--- a/diesel_compile_tests/tests/fail/derive/bad_postgres_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_postgres_type.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected parentheses
-       help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
+       help: the correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
  --> tests/fail/derive/bad_postgres_type.rs:6:23
   |
 LL | #[diesel(postgres_type)]
@@ -19,7 +19,7 @@ LL | #[diesel(postgres_type = "foo")]
    |                        ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
+       help: the correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
   --> tests/fail/derive/bad_postgres_type.rs:21:28
    |
 LL | #[diesel(postgres_type(name))]
@@ -84,21 +84,21 @@ LL | #[diesel(postgres_type(what))]
    |                        ^^^^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
+       help: the correct format looks like `#[diesel(postgres_type(name = "foo", schema = "public"))]`
   --> tests/fail/derive/bad_postgres_type.rs:71:30
    |
 LL | #[diesel(postgres_type(schema))]
    |                              ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
+       help: the correct format looks like `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
   --> tests/fail/derive/bad_postgres_type.rs:76:27
    |
 LL | #[diesel(postgres_type(oid))]
    |                           ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
+       help: the correct format looks like `#[diesel(postgres_type(oid = 37, array_oid = 54))]`
   --> tests/fail/derive/bad_postgres_type.rs:81:33
    |
 LL | #[diesel(postgres_type(array_oid))]

--- a/diesel_compile_tests/tests/fail/derive/bad_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_primary_key.stderr
@@ -11,7 +11,7 @@ LL | #[diesel(primary_key(id, qux(id)))]
    |                             ^
 
 error: unexpected end of input, expected parentheses
-       help: The correct format looks like `#[diesel(key1, key2)]`
+       help: the correct format looks like `#[diesel(key1, key2)]`
   --> tests/fail/derive/bad_primary_key.rs:28:21
    |
 LL | #[diesel(primary_key)]

--- a/diesel_compile_tests/tests/fail/derive/bad_serialize_as.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_serialize_as.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(serialize_as = Foo)]`
+       help: the correct format looks like `#[diesel(serialize_as = Foo)]`
   --> tests/fail/derive/bad_serialize_as.rs:15:26
    |
 LL |     #[diesel(serialize_as)]

--- a/diesel_compile_tests/tests/fail/derive/bad_sql_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_sql_type.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(sql_type = Foo)]`
+       help: the correct format looks like `#[diesel(sql_type = Foo)]`
  --> tests/fail/derive/bad_sql_type.rs:5:18
   |
 LL | #[diesel(sql_type)]

--- a/diesel_compile_tests/tests/fail/derive/bad_sqlite_type.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_sqlite_type.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected parentheses
-       help: The correct format looks like `#[diesel(sqlite_type(name = "foo"))]`
+       help: the correct format looks like `#[diesel(sqlite_type(name = "foo"))]`
  --> tests/fail/derive/bad_sqlite_type.rs:6:21
   |
 LL | #[diesel(sqlite_type)]
@@ -19,7 +19,7 @@ LL | #[diesel(sqlite_type = "foo")]
    |                      ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(sqlite_type(name = "foo"))]`
+       help: the correct format looks like `#[diesel(sqlite_type(name = "foo"))]`
   --> tests/fail/derive/bad_sqlite_type.rs:21:26
    |
 LL | #[diesel(sqlite_type(name))]

--- a/diesel_compile_tests/tests/fail/derive/bad_table_name.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_table_name.stderr
@@ -1,5 +1,5 @@
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(table_name = foo)]`
+       help: the correct format looks like `#[diesel(table_name = foo)]`
   --> tests/fail/derive/bad_table_name.rs:12:20
    |
 LL | #[diesel(table_name)]

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_default_value.stderr
@@ -5,7 +5,7 @@ LL | #[diesel(treat_none_as_default_value())]
    |                                     ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(treat_none_as_default_value = true)]`
+       help: the correct format looks like `#[diesel(treat_none_as_default_value = true)]`
   --> tests/fail/derive/bad_treat_none_as_default_value.rs:22:37
    |
 LL | #[diesel(treat_none_as_default_value)]

--- a/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_treat_none_as_null.stderr
@@ -5,7 +5,7 @@ LL | #[diesel(treat_none_as_null("true"))]
    |                            ^
 
 error: unexpected end of input, expected `=`
-       help: The correct format looks like `#[diesel(treat_none_as_null = true)]`
+       help: the correct format looks like `#[diesel(treat_none_as_null = true)]`
   --> tests/fail/derive/bad_treat_none_as_null.rs:22:28
    |
 LL | #[diesel(treat_none_as_null)]

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.rs
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.rs
@@ -5,17 +5,17 @@ struct Bar;
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar))]
-//~^ ERROR: No field with column name bar_id
+//~^ ERROR: no field with column name `bar_id`
 struct Foo1 {}
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key = bar_id))]
-//~^ ERROR: No field with column name bar_id
+//~^ ERROR: no field with column name `bar_id`
 struct Foo2 {}
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar))]
-//~^ ERROR: No field with column name bar_id
+//~^ ERROR: no field with column name `bar_id`
 struct Baz1 {
     #[diesel(column_name = baz_id)]
     bar_id: i32,
@@ -23,7 +23,7 @@ struct Baz1 {
 
 #[derive(Associations)]
 #[diesel(belongs_to(Bar, foreign_key = bar_id))]
-//~^ ERROR: No field with column name bar_id
+//~^ ERROR: no field with column name `bar_id`
 struct Baz2 {
     #[diesel(column_name = baz_id)]
     bar_id: i32,

--- a/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.stderr
+++ b/diesel_compile_tests/tests/fail/derive/belongs_to_missing_foreign_key_field.stderr
@@ -1,22 +1,22 @@
-error: No field with column name bar_id
+error: no field with column name `bar_id`
  --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:7:21
   |
 LL | #[diesel(belongs_to(Bar))]
   |                     ^^^
 
-error: No field with column name bar_id
+error: no field with column name `bar_id`
   --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:12:40
    |
 LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]
    |                                        ^^^^^^
 
-error: No field with column name bar_id
+error: no field with column name `bar_id`
   --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:17:21
    |
 LL | #[diesel(belongs_to(Bar))]
    |                     ^^^
 
-error: No field with column name bar_id
+error: no field with column name `bar_id`
   --> tests/fail/derive/belongs_to_missing_foreign_key_field.rs:25:40
    |
 LL | #[diesel(belongs_to(Bar, foreign_key = bar_id))]

--- a/diesel_compile_tests/tests/fail/derive/empty_struct.rs
+++ b/diesel_compile_tests/tests/fail/derive/empty_struct.rs
@@ -8,34 +8,34 @@ table! {
 }
 
 #[derive(AsChangeset)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User1;
 
 #[derive(Identifiable)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User2;
 
 #[derive(Insertable)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User3;
 
 #[derive(Queryable)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 struct User4;
 
 #[derive(QueryableByName)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 struct User5;
 
 #[derive(Selectable)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 struct User6;
 
 #[derive(Associations)]
-//~^ ERROR: This derive can only be used on non-unit structs
+//~^ ERROR: this derive can only be used on non-unit structs
 #[diesel(table_name = users)]
 struct User7;
 

--- a/diesel_compile_tests/tests/fail/derive/empty_struct.stderr
+++ b/diesel_compile_tests/tests/fail/derive/empty_struct.stderr
@@ -1,4 +1,4 @@
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:10:10
    |
 LL | #[derive(AsChangeset)]
@@ -6,7 +6,7 @@ LL | #[derive(AsChangeset)]
    |
    = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:15:10
    |
 LL | #[derive(Identifiable)]
@@ -14,7 +14,7 @@ LL | #[derive(Identifiable)]
    |
    = note: this error originates in the derive macro `Identifiable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:20:10
    |
 LL | #[derive(Insertable)]
@@ -22,7 +22,7 @@ LL | #[derive(Insertable)]
    |
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:25:10
    |
 LL | #[derive(Queryable)]
@@ -30,7 +30,7 @@ LL | #[derive(Queryable)]
    |
    = note: this error originates in the derive macro `Queryable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:29:10
    |
 LL | #[derive(QueryableByName)]
@@ -38,7 +38,7 @@ LL | #[derive(QueryableByName)]
    |
    = note: this error originates in the derive macro `QueryableByName` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:33:10
    |
 LL | #[derive(Selectable)]
@@ -46,7 +46,7 @@ LL | #[derive(Selectable)]
    |
    = note: this error originates in the derive macro `Selectable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: This derive can only be used on non-unit structs
+error: this derive can only be used on non-unit structs
   --> tests/fail/derive/empty_struct.rs:37:10
    |
 LL | #[derive(Associations)]

--- a/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.rs
+++ b/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.rs
@@ -8,12 +8,12 @@ table! {
 }
 
 #[derive(Identifiable)]
-//~^ ERROR: No field with column name id
+//~^ ERROR: no field with column name `id`
 #[diesel(table_name = foo)]
 struct Foo1 {}
 
 #[derive(Identifiable)]
-//~^ ERROR: No field with column name id
+//~^ ERROR: no field with column name `id`
 #[diesel(table_name = foo)]
 struct Foo2 {
     #[diesel(column_name = foo)]
@@ -22,13 +22,13 @@ struct Foo2 {
 
 #[derive(Identifiable)]
 #[diesel(primary_key(bar))]
-//~^ ERROR: No field with column name bar
+//~^ ERROR: no field with column name `bar`
 #[diesel(table_name = foo)]
 struct Foo3 {}
 
 #[derive(Identifiable)]
 #[diesel(primary_key(baz))]
-//~^ ERROR: No field with column name baz
+//~^ ERROR: no field with column name `baz`
 #[diesel(table_name = foo)]
 struct Foo4 {
     #[diesel(column_name = bar)]
@@ -37,7 +37,7 @@ struct Foo4 {
 
 #[derive(Identifiable)]
 #[diesel(primary_key(foo, bar))]
-//~^ ERROR: No field with column name bar
+//~^ ERROR: no field with column name `bar`
 #[diesel(table_name = foo)]
 struct Foo5 {
     foo: i32,
@@ -45,7 +45,7 @@ struct Foo5 {
 
 #[derive(Identifiable)]
 #[diesel(primary_key(foo, bar))]
-//~^ ERROR: No field with column name bar
+//~^ ERROR: no field with column name `bar`
 #[diesel(table_name = foo)]
 struct Foo6 {
     foo: i32,

--- a/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.stderr
+++ b/diesel_compile_tests/tests/fail/derive/identifiable_missing_pk_field.stderr
@@ -1,4 +1,4 @@
-error: No field with column name id
+error: no field with column name `id`
   --> tests/fail/derive/identifiable_missing_pk_field.rs:10:10
    |
 LL | #[derive(Identifiable)]
@@ -6,7 +6,7 @@ LL | #[derive(Identifiable)]
    |
    = note: this error originates in the derive macro `Identifiable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: No field with column name id
+error: no field with column name `id`
   --> tests/fail/derive/identifiable_missing_pk_field.rs:15:10
    |
 LL | #[derive(Identifiable)]
@@ -14,25 +14,25 @@ LL | #[derive(Identifiable)]
    |
    = note: this error originates in the derive macro `Identifiable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: No field with column name bar
+error: no field with column name `bar`
   --> tests/fail/derive/identifiable_missing_pk_field.rs:24:22
    |
 LL | #[diesel(primary_key(bar))]
    |                      ^^^
 
-error: No field with column name baz
+error: no field with column name `baz`
   --> tests/fail/derive/identifiable_missing_pk_field.rs:30:22
    |
 LL | #[diesel(primary_key(baz))]
    |                      ^^^
 
-error: No field with column name bar
+error: no field with column name `bar`
   --> tests/fail/derive/identifiable_missing_pk_field.rs:39:27
    |
 LL | #[diesel(primary_key(foo, bar))]
    |                           ^^^
 
-error: No field with column name bar
+error: no field with column name `bar`
   --> tests/fail/derive/identifiable_missing_pk_field.rs:47:27
    |
 LL | #[diesel(primary_key(foo, bar))]

--- a/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
+++ b/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs
@@ -9,7 +9,7 @@ struct Foo {
 }
 
 #[derive(QueryableByName)]
-//~^ ERROR: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
+//~^ ERROR: all fields of tuple structs must be annotated with `#[diesel(column_name)]`
 struct Bar(i32, String);
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
+++ b/diesel_compile_tests/tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.stderr
@@ -1,4 +1,4 @@
-error: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
+error: all fields of tuple structs must be annotated with `#[diesel(column_name)]`
   --> tests/fail/derive/queryable_by_name_requires_table_name_or_sql_type_annotation.rs:11:10
    |
 LL | #[derive(QueryableByName)]

--- a/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
+++ b/diesel_compile_tests/tests/fail/derive/queryable_type_mismatch.stderr
@@ -11,14 +11,14 @@ error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<.
      = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
              on your struct `UserWithToFewFields` and in your query `.select(UserWithToFewFields::as_select())` to get a better error message
      = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-               (ST0, ST1)
-               (ST0, ST1, ST2)
-               (ST0, ST1, ST2, ST3)
-               (ST0, ST1, ST2, ST3, ST4)
-               (ST0, ST1, ST2, ST3, ST4, ST5)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+               `Untyped` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::expression::select_by::SelectBy<U, DB>` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
              and N others
      = note: required for `users::table` to implement `LoadQuery<'_, _, UserWithToFewFields>`
 note: required by a bound in `diesel::RunQueryDsl::load`
@@ -44,14 +44,14 @@ error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<.
      = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
              on your struct `UserWithToManyFields` and in your query `.select(UserWithToManyFields::as_select())` to get a better error message
      = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-               (ST0, ST1)
-               (ST0, ST1, ST2)
-               (ST0, ST1, ST2, ST3)
-               (ST0, ST1, ST2, ST3, ST4)
-               (ST0, ST1, ST2, ST3, ST4, ST5)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+               `Untyped` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::expression::select_by::SelectBy<U, DB>` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
              and N others
      = note: required for `users::table` to implement `LoadQuery<'_, _, UserWithToManyFields>`
 note: required by a bound in `diesel::RunQueryDsl::load`
@@ -77,14 +77,14 @@ error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<U
      = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
              on your struct `UserWrongOrder` and in your query `.select(UserWrongOrder::as_select())` to get a better error message
      = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-               (ST0, ST1)
-               (ST0, ST1, ST2)
-               (ST0, ST1, ST2, ST3)
-               (ST0, ST1, ST2, ST3, ST4)
-               (ST0, ST1, ST2, ST3, ST4, ST5)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+               `Untyped` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::expression::select_by::SelectBy<U, DB>` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
              and N others
      = note: required for `users::table` to implement `LoadQuery<'_, _, UserWrongOrder>`
 note: required by a bound in `diesel::RunQueryDsl::load`
@@ -110,14 +110,14 @@ error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<U
      = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
              on your struct `UserTypeMismatch` and in your query `.select(UserTypeMismatch::as_select())` to get a better error message
      = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-               (ST0, ST1)
-               (ST0, ST1, ST2)
-               (ST0, ST1, ST2, ST3)
-               (ST0, ST1, ST2, ST3, ST4)
-               (ST0, ST1, ST2, ST3, ST4, ST5)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+               `Untyped` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::expression::select_by::SelectBy<U, DB>` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
              and N others
      = note: required for `users::table` to implement `LoadQuery<'_, _, UserTypeMismatch>`
 note: required by a bound in `diesel::RunQueryDsl::load`
@@ -143,14 +143,14 @@ error[E0277]: the trait bound `(Integer, Text, Nullable<Text>): CompatibleType<.
      = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
              on your struct `UserNullableTypeMismatch` and in your query `.select(UserNullableTypeMismatch::as_select())` to get a better error message
      = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-               (ST0, ST1)
-               (ST0, ST1, ST2)
-               (ST0, ST1, ST2, ST3)
-               (ST0, ST1, ST2, ST3, ST4)
-               (ST0, ST1, ST2, ST3, ST4, ST5)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+               `Untyped` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::expression::select_by::SelectBy<U, DB>` implements `load_dsl::private::CompatibleType<U, DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `diesel::sql_types::Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
              and N others
      = note: required for `users::table` to implement `LoadQuery<'_, _, UserNullableTypeMismatch>`
 note: required by a bound in `diesel::RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/derive/selectable.rs
+++ b/diesel_compile_tests/tests/fail/derive/selectable.rs
@@ -53,7 +53,7 @@ struct User {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 struct User1<'a> {
     name: &'a str,
-    //~^ ERROR: References are not supported in `Queryable` types
+    //~^ ERROR: references are not supported in `Queryable` types
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/selectable.stderr
@@ -1,5 +1,5 @@
-error: References are not supported in `Queryable` types
-       Consider using `std::borrow::Cow<'a, str>` instead
+error: references are not supported in `Queryable` types
+       consider using `std::borrow::Cow<'a, str>` instead
   --> tests/fail/derive/selectable.rs:55:11
    |
 LL |     name: &'a str,

--- a/diesel_compile_tests/tests/fail/derive/tuple_struct.rs
+++ b/diesel_compile_tests/tests/fail/derive/tuple_struct.rs
@@ -10,7 +10,7 @@ table! {
 }
 
 #[derive(AsChangeset)]
-//~^ ERROR: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
+//~^ ERROR: all fields of tuple structs must be annotated with `#[diesel(column_name)]`
 #[diesel(table_name = users)]
 struct User(i32, #[diesel(column_name = name)] String, String);
 

--- a/diesel_compile_tests/tests/fail/derive/tuple_struct.stderr
+++ b/diesel_compile_tests/tests/fail/derive/tuple_struct.stderr
@@ -1,4 +1,4 @@
-error: All fields of tuple structs must be annotated with `#[diesel(column_name)]`
+error: all fields of tuple structs must be annotated with `#[diesel(column_name)]`
   --> tests/fail/derive/tuple_struct.rs:12:10
    |
 LL | #[derive(AsChangeset)]

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.rs
@@ -42,7 +42,7 @@ struct UserForm4 {
 }
 
 #[derive(AsChangeset)]
-//~^ ERROR: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
+//~^ ERROR: deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
 #[diesel(table_name = users)]
 #[primary_key(id, name)]
 struct UserForm5 {

--- a/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/derive_deprecated/deprecated_primary_key.stderr
@@ -25,8 +25,8 @@ LL | #[primary_key = id]
 warning: #[primary_key] attribute form is deprecated
   = help: use `#[diesel(primary_key(id, name))]` instead
 
-error: Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
-       help: If you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
+error: deriving `AsChangeset` on a structure that only contains primary keys isn't supported.
+       help: if you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.
        note: `#[derive(AsChangeset)]` never changes the primary key of a row.
   --> tests/fail/derive_deprecated/deprecated_primary_key.rs:44:10
    |

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
@@ -26,12 +26,10 @@ fn main() {
         .distinct_on(posts::id)
         //~^ ERROR: cannot select `posts::columns::id` from `users::table`
         .get_results(&mut connection);
-    //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
 
     posts::table
         .distinct_on((posts::name, users::name))
         //~^ ERROR: cannot select `users::columns::name` from `posts::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .get_result(&mut connection);
-    //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text): SingleValue` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
@@ -24,13 +24,13 @@ fn main() {
 
     users::table
         .distinct_on(posts::id)
-        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
         .get_results(&mut connection);
     //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
 
     posts::table
         .distinct_on((posts::name, users::name))
-        //~^ ERROR: Cannot select `users::columns::name` from `posts::table`
+        //~^ ERROR: cannot select `users::columns::name` from `posts::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .get_result(&mut connection);
     //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text): SingleValue` is not satisfied

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.rs
@@ -24,12 +24,11 @@ fn main() {
 
     users::table
         .distinct_on(posts::id)
-        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+        //~^ ERROR: the trait bound `users::table: DistinctOnDsl<posts::columns::id>` is not satisfied
         .get_results(&mut connection);
 
     posts::table
         .distinct_on((posts::name, users::name))
-        //~^ ERROR: cannot select `users::columns::name` from `posts::table`
-        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        //~^ ERROR: the trait bound `posts::table: DistinctOnDsl<(posts::columns::name, users::columns::name)>` is not satisfied
         .get_result(&mut connection);
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
@@ -1,21 +1,14 @@
-error[E0277]: cannot select `posts::columns::id` from `users::table`
+error[E0277]: the trait bound `users::table: DistinctOnDsl<posts::columns::id>` is not satisfied
    --> tests/fail/distinct_on_allows_only_fields_of_table.rs:26:22
     |
 26  |         .distinct_on(posts::id)
-    |          ----------- ^^^^^^^^^ the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-    |          |
-    |          required by a bound introduced by this call
+    |                      ^^^^^^^^^ the trait `DistinctOnDsl<posts::columns::id>` is not implemented for `users::table`
     |
-    = note: `posts::columns::id` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::id` implements `SelectableExpression<posts::table>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-    = note: required for `users::table` to implement `DistinctOnDsl<posts::columns::id>`
+    = note: a `DISTINCT ON` clause is not compatible with various other clauses like `LOCKING` clauses
+    = note: a `DISTINCT ON` clause also disallows mixing aggregate and non-aggregate expressions with the `SELECT` clause
+    = help: the following other types implement trait `DistinctOnDsl<Selection>`:
+              Alias<S>
+              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -25,37 +18,15 @@ LL |     where
 LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
 
-error[E0277]: cannot select `users::columns::name` from `posts::table`
+error[E0277]: the trait bound `posts::table: DistinctOnDsl<(posts::columns::name, users::columns::name)>` is not satisfied
   --> tests/fail/distinct_on_allows_only_fields_of_table.rs:31:10
    |
 LL |         .distinct_on((posts::name, users::name))
-   |          ^^^^^^^^^^^ the trait `SelectableExpression<posts::table>` is not implemented for `users::columns::name`
+   |          ^^^^^^^^^^^ the trait `DistinctOnDsl<(posts::columns::name, users::columns::name)>` is not implemented for `posts::table`
    |
-   = note: `users::columns::name` is no valid selection for `posts::table`
-   = help: the following other types implement trait `SelectableExpression<QS>`:
-             `users::columns::name` implements `SelectableExpression<JoinOn<Join, On>>`
-             `users::columns::name` implements `SelectableExpression<Only<users::table>>`
-             `users::columns::name` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-             `users::columns::name` implements `SelectableExpression<Tablesample<users::table, TSM>>`
-             `users::columns::name` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-             `users::columns::name` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-             `users::columns::name` implements `SelectableExpression<users::table>`
-   = note: required for `(posts::columns::name, users::columns::name)` to implement `SelectableExpression<posts::table>`
-   = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
-
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:31:10
-   |
-LL |         .distinct_on((posts::name, users::name))
-   |          ^^^^^^^^^^^ expected `Once`, found `Never`
-   |
-note: required for `users::columns::name` to implement `AppearsOnTable<posts::table>`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:8:9
-   |
-8  |         name -> VarChar,
-   |         ^^^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `(posts::columns::name, users::columns::name)` to implement `AppearsOnTable<posts::table>`
-   = note: required for `(posts::columns::name, users::columns::name)` to implement `SelectableExpression<posts::table>`
-   = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
+   = note: a `DISTINCT ON` clause is not compatible with various other clauses like `LOCKING` clauses
+   = note: a `DISTINCT ON` clause also disallows mixing aggregate and non-aggregate expressions with the `SELECT` clause
+   = help: the following other types implement trait `DistinctOnDsl<Selection>`:
+             Alias<S>
+             SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
@@ -26,7 +26,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
 
 error[E0277]: cannot select `users::columns::name` from `posts::table`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:32:10
+  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:31:10
    |
 LL |         .distinct_on((posts::name, users::name))
    |          ^^^^^^^^^^^ the trait `SelectableExpression<posts::table>` is not implemented for `users::columns::name`
@@ -44,7 +44,7 @@ LL |         .distinct_on((posts::name, users::name))
    = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:32:10
+  --> tests/fail/distinct_on_allows_only_fields_of_table.rs:31:10
    |
 LL |         .distinct_on((posts::name, users::name))
    |          ^^^^^^^^^^^ expected `Once`, found `Never`
@@ -59,66 +59,3 @@ note: required for `users::columns::name` to implement `AppearsOnTable<posts::ta
    = note: required for `(posts::columns::name, users::columns::name)` to implement `AppearsOnTable<posts::table>`
    = note: required for `(posts::columns::name, users::columns::name)` to implement `SelectableExpression<posts::table>`
    = note: required for `posts::table` to implement `DistinctOnDsl<(posts::columns::name, users::columns::name)>`
-
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
-    --> tests/fail/distinct_on_allows_only_fields_of_table.rs:28:22
-     |
-28   |         .get_results(&mut connection);
-     |          ----------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
-note: required by a bound in `get_results`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ----------- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
-  
-     
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text): SingleValue` is not satisfied
-    --> tests/fail/distinct_on_allows_only_fields_of_table.rs:35:21
-     |
-35   |         .get_result(&mut connection);
-     |          ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text), Pg>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text), Pg>`
-     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
-note: required by a bound in `get_result`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-     |        ---------- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`

--- a/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_allows_only_fields_of_table.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/distinct_on_allows_only_fields_of_table.rs:26:22
     |
 26  |         .distinct_on(posts::id)
@@ -25,7 +25,7 @@ LL |     where
 LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
 
-error[E0277]: Cannot select `users::columns::name` from `posts::table`
+error[E0277]: cannot select `users::columns::name` from `posts::table`
   --> tests/fail/distinct_on_allows_only_fields_of_table.rs:32:10
    |
 LL |         .distinct_on((posts::name, users::name))

--- a/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.rs
@@ -15,7 +15,6 @@ fn main() {
 
     users.distinct_on(name).get_results(&mut sqlite_connection);
     //~^ ERROR: `DistinctOnClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
-    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
 
     let mut mysql_connection = MysqlConnection::establish("mysql://foo").unwrap();
 

--- a/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_clause_only_supported_for_pg.stderr
@@ -26,9 +26,9 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: `DistinctOnClause<columns::name>` is no valid SQL fragment for the `Mysql` backend
-    --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:22:41
+    --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:21:41
      |
-22   |     users.distinct_on(name).get_results(&mut mysql_connection);
+21   |     users.distinct_on(name).get_results(&mut mysql_connection);
      |                             ----------- ^^^^^^^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `DistinctOnClause<columns::name>`
      |                             |
      |                             required by a bound introduced by this call
@@ -42,41 +42,6 @@ error[E0277]: `DistinctOnClause<columns::name>` is no valid SQL fragment for the
      = note: 1 redundant requirement hidden
      = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `QueryFragment<Mysql>`
      = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::MysqlConnection, _>`
-note: required by a bound in `get_results`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn get_results<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ----------- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_results`
-  
-     
-error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
-    --> tests/fail/distinct_on_clause_only_supported_for_pg.rs:16:41
-     |
-16   |     users.distinct_on(name).get_results(&mut sqlite_connection);
-     |                             ----------- ^^^^^^^^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     |                             |
-     |                             required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `get_results`
     --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
      |

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
@@ -118,32 +118,32 @@ fn main() {
     //
     // we do not allow queries with order clauses that does not contain the distinct value
     let _ = users::table.order_by(users::id).distinct_on(users::name);
-    //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+    //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
 
     // we do not allow queries where the distinct on expression is not the first expression
     // in our order clause
     let _ = users::table
         .order_by((users::id, users::name))
         .distinct_on(users::name);
-    //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+    //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
 
     // we cannot workaround that with `then_order_by`
     let _ = users::table
         .order_by(users::id)
         .then_order_by(users::name)
         .distinct_on(users::name);
-    //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+    //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
 
     // it's not possible to set an invalid order clause after we set
     // the distinct on clause
     let _ = users::table.distinct_on(users::name).order_by(users::id);
-    //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+    //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
 
     // we cannot box invalid queries
     let _ = users::table
         .order_by(users::id)
         .distinct_on(users::name)
-        //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+        //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
         .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
@@ -151,7 +151,7 @@ fn main() {
     let _ = users::table
         .order_by((users::id, users::name))
         .distinct_on(users::name)
-        //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+        //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
         .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
@@ -159,7 +159,7 @@ fn main() {
     let _ = users::table
         .order_by((users::id, users::name))
         .distinct_on((users::name, users::id))
-        //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+        //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
         .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
@@ -167,7 +167,7 @@ fn main() {
     let _ = users::table
         .order_by(users::id)
         .distinct_on((users::name, users::id))
-        //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<...>>` is not satisfied
+        //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
         .into_boxed();
 
     // we cannot workaround that with `then_order_by`
@@ -175,7 +175,7 @@ fn main() {
         .order_by(users::id)
         .then_order_by(users::name)
         .distinct_on(users::name)
-        //~^ ERROR: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+        //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
         .into_boxed();
 
     // it's not possible to set an invalid order clause after we set
@@ -183,6 +183,6 @@ fn main() {
     let _ = users::table
         .distinct_on(users::name)
         .order_by(users::id)
-        //~^ ERROR: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+        //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
         .into_boxed();
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -8,15 +8,10 @@ LL |     let _ = users::table.order_by(users::id).distinct_on(users::name);
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -38,15 +33,10 @@ LL |         .distinct_on(users::name);
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -68,15 +58,10 @@ LL |         .distinct_on(users::name);
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -98,15 +83,10 @@ LL |     let _ = users::table.distinct_on(users::name).order_by(users::id);
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `OrderDsl<columns::id>`
 note: required by a bound in `order_by`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -128,15 +108,10 @@ LL |         .distinct_on(users::name)
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -158,15 +133,10 @@ LL |         .distinct_on(users::name)
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -188,15 +158,10 @@ LL |         .distinct_on((users::name, users::id))
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -218,15 +183,10 @@ LL |         .distinct_on((users::name, users::id))
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -248,15 +208,10 @@ LL |         .distinct_on(users::name)
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
@@ -278,15 +233,10 @@ LL |         .order_by(users::id)
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
-              `diesel::query_builder::order_clause::OrderClause<(T,)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3, T4)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0,)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<T0>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1)>>`
-              `diesel::query_builder::order_clause::OrderClause<(T0, T1, T2)>` implements `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(T0, T1, T2, T3)>>`
-            and N others
+              diesel::query_builder::order_clause::OrderClause<(T,)>
+              diesel::query_builder::order_clause::OrderClause<T>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Asc<T>>
+              diesel::query_builder::order_clause::OrderClause<diesel::expression::operators::Desc<T>>
     = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `OrderDsl<columns::id>`
 note: required by a bound in `order_by`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:120:58
     |
 LL |     let _ = users::table.order_by(users::id).distinct_on(users::name);
@@ -7,6 +7,7 @@ LL |     let _ = users::table.order_by(users::id).distinct_on(users::name);
     |                                              required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -23,7 +24,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:127:22
     |
 LL |         .distinct_on(users::name);
@@ -32,6 +33,7 @@ LL |         .distinct_on(users::name);
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -48,7 +50,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:134:22
     |
 LL |         .distinct_on(users::name);
@@ -57,6 +59,7 @@ LL |         .distinct_on(users::name);
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -73,7 +76,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:139:60
     |
 LL |     let _ = users::table.distinct_on(users::name).order_by(users::id);
@@ -82,6 +85,7 @@ LL |     let _ = users::table.distinct_on(users::name).order_by(users::id);
     |                                                   required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -98,7 +102,7 @@ LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
  
     
-error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:145:22
     |
 LL |         .distinct_on(users::name)
@@ -107,6 +111,7 @@ LL |         .distinct_on(users::name)
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -123,7 +128,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:153:22
     |
 LL |         .distinct_on(users::name)
@@ -132,6 +137,7 @@ LL |         .distinct_on(users::name)
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -148,7 +154,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:161:22
     |
 LL |         .distinct_on((users::name, users::id))
@@ -157,6 +163,7 @@ LL |         .distinct_on((users::name, users::id))
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -173,7 +180,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<...>>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:169:22
     |
 LL |         .distinct_on((users::name, users::id))
@@ -182,6 +189,7 @@ LL |         .distinct_on((users::name, users::id))
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -198,7 +206,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<(id, name)>: ValidOrderingForDistinct<...>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:177:22
     |
 LL |         .distinct_on(users::name)
@@ -207,6 +215,7 @@ LL |         .distinct_on(users::name)
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<(columns::id, columns::name)>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>
@@ -223,7 +232,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: the trait bound `OrderClause<id>: ValidOrderingForDistinct<DistinctOnClause<name>>` is not satisfied
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
    --> tests/fail/distinct_on_requires_matching_order_clause.rs:185:19
     |
 LL |         .order_by(users::id)
@@ -232,6 +241,7 @@ LL |         .order_by(users::id)
     |          required by a bound introduced by this call
     |
     = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
     = help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`:
               diesel::query_builder::order_clause::OrderClause<(T,)>
               diesel::query_builder::order_clause::OrderClause<T>

--- a/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
@@ -6,13 +6,13 @@ LL |     let pred = id.eq("string");
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `&str` to implement `diesel::Expression`
    = note: required for `&str` to implement `AsExpression<diesel::sql_types::Integer>`

--- a/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
+++ b/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs
@@ -35,7 +35,7 @@ fn main() {
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 
     let _ = users::table.filter(posts::id.eq(1)).into_boxed::<Pg>();
-    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+    //~^ ERROR: cannot box `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` for backend `Pg`
     // FIXME: It'd be great if this mentioned `AppearsInFromClause` instead...
 
     let _ = users::table
@@ -51,6 +51,6 @@ fn main() {
     let _ = users::table
         .filter(users::name.eq(posts::title))
         .into_boxed::<Pg>();
-    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+    //~^ ERROR: cannot box `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` for backend `Pg`
     // FIXME: It'd be great if this mentioned `AppearsInFromClause` instead...
 }

--- a/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.stderr
+++ b/diesel_compile_tests/tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.stderr
@@ -44,12 +44,14 @@ LL |         id -> Integer,
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
 
    
-error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+error[E0277]: cannot box `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` for backend `Pg`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:37:50
    |
 LL |     let _ = users::table.filter(posts::id.eq(1)).into_boxed::<Pg>();
    |                                                  ^^^^^^^^^^ the trait `BoxedDsl<'_, Pg>` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
    |
+   = note: this either means `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` is no valid SQL for `Pg`
+   = note: or this means `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
@@ -101,12 +103,14 @@ LL |         title -> VarChar,
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `FilterDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<users::columns::name, posts::columns::title>>>`
 
    
-error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>: BoxedDsl<'_, ...>` is not satisfied
+error[E0277]: cannot box `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` for backend `Pg`
   --> tests/fail/filter_cannot_take_comparison_for_columns_from_another_table.rs:53:10
    |
 LL |         .into_boxed::<Pg>();
    |          ^^^^^^^^^^ the trait `BoxedDsl<'_, Pg>` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
    |
+   = note: this either means `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` is no valid SQL for `Pg`
+   = note: or this means `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>

--- a/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.rs
+++ b/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.rs
@@ -15,5 +15,5 @@ fn main() {
     let _ = users::table.filter(users::name);
     //~^ ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Bool` nor `diesel::sql_types::Nullable<Bool>`
     let _ = users::table.filter(sum(users::id).eq(1));
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 }

--- a/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.stderr
+++ b/diesel_compile_tests/tests/fail/filter_requires_bool_nonaggregate_expression.stderr
@@ -22,12 +22,15 @@ LL |     where
 LL |         Self: methods::FilterDsl<Predicate>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::filter`
 
-error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
   --> tests/fail/filter_requires_bool_nonaggregate_expression.rs:17:26
    |
 LL |     let _ = users::table.filter(sum(users::id).eq(1));
    |                          ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
    |
+   = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+   = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+   = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
    = help: the following other types implement trait `MixedAggregates<Other>`:
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
              `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
@@ -6,13 +6,13 @@ LL |     int_primary_key::table.find("1");
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `&str` to implement `diesel::Expression`
    = note: 1 redundant requirement hidden
@@ -52,13 +52,13 @@ error[E0277]: the trait bound `{integer}: diesel::Expression` is not satisfied
     |
     = help: the following other types implement trait `diesel::Expression`:
               &T
-              (T0, T1)
-              (T0, T1, T2)
-              (T0, T1, T2, T3)
-              (T0, T1, T2, T3, T4)
-              (T0, T1, T2, T3, T4, T5)
-              (T0, T1, T2, T3, T4, T5, T6)
-              (T0, T1, T2, T3, T4, T5, T6, T7)
+              AliasedField<S, C>
+              Box<T>
+              CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+              CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+              CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+              CountDistinct<T, E>
+              CountStar
             and N others
     = note: required for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>` to implement `diesel::Expression`
 note: required for `string_primary_key::columns::id` to implement `EqAll<{integer}>`

--- a/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.rs
+++ b/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.rs
@@ -34,7 +34,6 @@ fn main() {
         .having(users::id.gt(1))
         //~^ ERROR: the trait bound `(): diesel::Expression` is not satisfied
         .load(&mut conn);
-    //~^ ERROR: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
 
     users::table
         .select(users::name)

--- a/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
@@ -16,20 +16,20 @@ LL |         .having(users::id.gt(1))
    |          ^^^^^^ the trait `diesel::Expression` is not implemented for `()`
    |
    = help: the following other types implement trait `diesel::Expression`:
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
-             (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+             &T
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, _>` to implement `HavingDsl<_>`
 
    
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/having_cant_be_used_without_group_by.rs:42:10
+  --> tests/fail/having_cant_be_used_without_group_by.rs:41:10
    |
 LL |         .having(posts::id.eq(42))
    |          ^^^^^^ expected `Once`, found `Never`
@@ -46,7 +46,7 @@ LL |         id -> Integer,
 
    
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-  --> tests/fail/having_cant_be_used_without_group_by.rs:50:10
+  --> tests/fail/having_cant_be_used_without_group_by.rs:49:10
    |
 LL |         .having(posts::id.eq(42))
    |          ^^^^^^ expected `Once`, found `Never`
@@ -60,35 +60,3 @@ LL |         id -> Integer,
    = note: 2 redundant requirements hidden
    = note: required for `Grouped<Eq<id, Bound<Integer, i32>>>` to implement `AppearsOnTable<users::table>`
    = note: required for `BoxedSelectStatement<'_, Text, FromClause<table>, _, id>` to implement `HavingDsl<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<posts::columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>`
-
-   
-error[E0277]: the trait bound `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue` is not satisfied
-    --> tests/fail/having_cant_be_used_without_group_by.rs:36:15
-     |
-36   |         .load(&mut conn);
-     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Pg>`
-     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Pg>`
-     = note: required for `BoxedSelectStatement<'_, (Integer, Text), FromClause<table>, Pg>` to implement `LoadQuery<'_, diesel::PgConnection, {type error}>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ---- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/having_cant_be_used_without_group_by.stderr
@@ -4,6 +4,7 @@ error[E0277]: the trait bound `SelectStatement<FromClause<table>, SelectClause<n
 LL |         .having(users::id.gt(1))
    |          ^^^^^^ the trait `HavingDsl<_>` is not implemented for `SelectStatement<FromClause<table>, SelectClause<name>>`
    |
+   = note: a `HAVING` clause requires setting a `GROUP BY` clause first
    = help: the trait `HavingDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, _>`
            but it is implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::GroupByClause<_>, _, _>`
    = help: for that trait implementation, expected `diesel::query_builder::group_by_clause::GroupByClause<_>`, found `diesel::query_builder::group_by_clause::NoGroupByClause`

--- a/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
+++ b/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
@@ -6,13 +6,13 @@ LL |     insert_into(users).values(&name.eq(1));
    |
    = help: the following other types implement trait `diesel::Expression`:
              &T
-             (T0, T1)
-             (T0, T1, T2)
-             (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
-             (T0, T1, T2, T3, T4, T5, T6)
-             (T0, T1, T2, T3, T4, T5, T6, T7)
+             AliasedField<S, C>
+             Box<T>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsIntermediateNode<W, T, Whens>, E>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::ElseExpression<E>>
+             CaseWhen<diesel::expression::case_when::non_public_types::CaseWhenConditionsLeaf<W, T>, diesel::expression::case_when::non_public_types::NoElseExpression>
+             CountDistinct<T, E>
+             CountStar
            and N others
    = note: required for `{integer}` to implement `AsExpression<diesel::sql_types::Text>`
 For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.stderr
+++ b/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.stderr
@@ -39,6 +39,7 @@ LL |         .into_boxed()
    |          ^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `IntoBoxedClause<'_, Mysql>` is not implemented for `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>`
+   = note: this usually means that `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>` is no valid SQL for `Mysql`
    = help: the following other types implement trait `IntoBoxedClause<'a, DB>`:
              `LimitOffsetClause<L, O>` implements `IntoBoxedClause<'_, Pg>`
              `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `IntoBoxedClause<'_, Mysql>`
@@ -58,6 +59,7 @@ error[E0277]: the trait bound `LimitOffsetClause<NoLimitClause, ...>: IntoBoxedC
      |          ^^^^^^^^^^ unsatisfied trait bound
      |
      = help: the trait `IntoBoxedClause<'_, Mysql>` is not implemented for `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>`
+     = note: this usually means that `LimitOffsetClause<NoLimitClause, OffsetClause<diesel::expression::bound::Bound<BigInt, i64>>>` is no valid SQL for `Mysql`
      = help: the following other types implement trait `IntoBoxedClause<'a, DB>`:
                `LimitOffsetClause<L, O>` implements `IntoBoxedClause<'_, Pg>`
                `LimitOffsetClause<LimitClause<L>, NoOffsetClause>` implements `IntoBoxedClause<'_, Mysql>`

--- a/diesel_compile_tests/tests/fail/only_only_on_table.rs
+++ b/diesel_compile_tests/tests/fail/only_only_on_table.rs
@@ -21,7 +21,6 @@ fn main() {
     let mut conn = SqliteConnection::establish("").unwrap();
     foo::table.only().load(&mut conn).unwrap();
     //~^ ERROR: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::SqliteConnection, _>` is not satisfied
-    //~| ERROR: the trait bound `{type error}: FromSqlRow<(BigInt,), Sqlite>` is not satisfied
 
     // .only() is not supported for MySql
     let mut conn = MysqlConnection::establish("").unwrap();

--- a/diesel_compile_tests/tests/fail/only_only_on_table.stderr
+++ b/diesel_compile_tests/tests/fail/only_only_on_table.stderr
@@ -96,9 +96,9 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
 
 error[E0277]: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::MysqlConnection, _>` is not satisfied
-    --> tests/fail/only_only_on_table.rs:28:28
+    --> tests/fail/only_only_on_table.rs:27:28
      |
-28   |     foo::table.only().load(&mut conn).unwrap();
+27   |     foo::table.only().load(&mut conn).unwrap();
      |                       ---- ^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `Only<foo::table>`
      |                       |
      |                       required by a bound introduced by this call
@@ -110,40 +110,6 @@ error[E0277]: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::MysqlConn
      = note: 2 redundant requirements hidden
      = note: required for `SelectStatement<FromClause<Only<foo::table>>>` to implement `QueryFragment<Mysql>`
      = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::MysqlConnection, _>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ---- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-
-error[E0277]: the trait bound `{type error}: FromSqlRow<(BigInt,), Sqlite>` is not satisfied
-    --> tests/fail/only_only_on_table.rs:22:28
-     |
-22   |     foo::table.only().load(&mut conn).unwrap();
-     |                       ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(BigInt,)`
-     |                       |
-     |                       required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(BigInt,)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(BigInt,), Sqlite>`
-     = note: required for `{type error}` to implement `FromSqlRow<(BigInt,), Sqlite>`
-     = note: required for `(BigInt,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-     = note: required for `Only<foo::table>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `diesel::RunQueryDsl::load`
     --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
      |

--- a/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs
+++ b/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs
@@ -19,7 +19,7 @@ fn main() {
         .filter(name.like(b"bar".to_vec()))
         .filter(name.not_like(b"baz".to_vec()))
         .get_result::<Vec<u8>>(&mut connection)
-        //~^ ERROR: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Sqlite`
+        //~^ ERROR: cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Sqlite`
         .unwrap();
 
     let mut connection = MysqlConnection::establish("").unwrap();
@@ -29,6 +29,6 @@ fn main() {
         .filter(name.like(b"bar".to_vec()))
         .filter(name.not_like(b"baz".to_vec()))
         .get_result::<Vec<u8>>(&mut connection)
-        //~^ ERROR: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Mysql`
+        //~^ ERROR: cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Mysql`
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.stderr
+++ b/diesel_compile_tests/tests/fail/pg_specific_binary_expressions_only_usable_with_pg.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Sqlite`
+error[E0277]: cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Sqlite`
     --> tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs:21:32
      |
 21   |         .get_result::<Vec<u8>>(&mut connection)
@@ -6,9 +6,9 @@ error[E0277]: Cannot use the `LIKE` operator with expressions of the type `diese
      |          |
      |          required by a bound introduced by this call
      |
-     = note: Expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are 
+     = note: expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are 
              allowed for all backends
-     = note: Expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are 
+     = note: expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are 
              allowed for the PostgreSQL backend
      = help: the following other types implement trait `diesel::expression::operators::LikeIsAllowedForType<ST>`:
                `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<Citext>`
@@ -27,7 +27,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
   
      
-error[E0277]: Cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Mysql`
+error[E0277]: cannot use the `LIKE` operator with expressions of the type `diesel::sql_types::Binary` for the backend `Mysql`
     --> tests/fail/pg_specific_binary_expressions_only_usable_with_pg.rs:31:32
      |
 31   |         .get_result::<Vec<u8>>(&mut connection)
@@ -35,9 +35,9 @@ error[E0277]: Cannot use the `LIKE` operator with expressions of the type `diese
      |          |
      |          required by a bound introduced by this call
      |
-     = note: Expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are 
+     = note: expressions of the type `diesel::sql_types::Text` and `diesel::sql_types::Nullable<Text>` are 
              allowed for all backends
-     = note: Expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are 
+     = note: expressions of the type `diesel::sql_types::Binary` and `diesel::sql_types::Nullable<Binary>` are 
              allowed for the PostgreSQL backend
      = help: the following other types implement trait `diesel::expression::operators::LikeIsAllowedForType<ST>`:
                `Pg` implements `diesel::expression::operators::LikeIsAllowedForType<Citext>`

--- a/diesel_compile_tests/tests/fail/queryable_with_typemismatch.stderr
+++ b/diesel_compile_tests/tests/fail/queryable_with_typemismatch.stderr
@@ -11,14 +11,14 @@ error[E0277]: the trait bound `(Integer, Text): CompatibleType<User, _>` is not 
      = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
              on your struct `User` and in your query `.select(User::as_select())` to get a better error message
      = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-               (ST0, ST1)
-               (ST0, ST1, ST2)
-               (ST0, ST1, ST2, ST3)
-               (ST0, ST1, ST2, ST3, ST4)
-               (ST0, ST1, ST2, ST3, ST4, ST5)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+               `Nullable<(ST0, ST1)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
              and N others
      = note: required for `users::table` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `diesel::RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs
+++ b/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs
@@ -38,13 +38,13 @@ fn main() {
     let _ = posts::table
         .distinct_on(posts::user_id)
         .select(dsl::count(posts::id))
-        //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+        //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
         .get_result::<i64>(&mut conn);
 
     let _ = posts::table
         .select(dsl::count(posts::id))
         .distinct_on(posts::user_id)
-        //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+        //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
         .get_result::<i64>(&mut conn);
 
     let _ = posts::table
@@ -56,6 +56,6 @@ fn main() {
     let _ = posts::table
         .count()
         .distinct_on(posts::user_id)
-        //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+        //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
         .get_result::<i64>(&mut conn);
 }

--- a/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
@@ -4,6 +4,8 @@ error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...
 LL |         .distinct_on(posts::id)
    |          ^^^^^^^^^^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
    |
+   = note: a `DISTINCT ON` clause is not compatible with various other clauses like `LOCKING` clauses
+   = note: a `DISTINCT ON` clause also disallows mixing aggregate and non-aggregate expressions with the `SELECT` clause
    = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
 
    
@@ -18,7 +20,7 @@ LL |         .select(posts::user_id)
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
 
    
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:40:17
     |
 40  |         .select(dsl::count(posts::id))
@@ -26,6 +28,9 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggreg
     |          |
     |          required by a bound introduced by this call
     |
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
@@ -42,7 +47,7 @@ LL |         Self: methods::SelectDsl<Selection>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
  
     
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:46:22
     |
 46  |         .distinct_on(posts::user_id)
@@ -50,6 +55,9 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggreg
     |          |
     |          required by a bound introduced by this call
     |
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`
@@ -76,7 +84,7 @@ LL |         .count()
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
 
    
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.rs:58:22
     |
 58  |         .distinct_on(posts::user_id)
@@ -84,6 +92,9 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggreg
     |          |
     |          required by a bound introduced by this call
     |
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`

--- a/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.rs
@@ -25,15 +25,15 @@ fn main() {
 
     delete(users::table.filter(users::columns::name.eq("Bill")))
         .returning(non_users::columns::noname);
-    //~^ ERROR: Cannot select `non_users::columns::noname` from `users::table`
+    //~^ ERROR: cannot select `non_users::columns::noname` from `users::table`
 
     insert_into(users::table)
         .values(&NewUser("Hello".into()))
         .returning(non_users::columns::noname);
-    //~^ ERROR: Cannot select `non_users::columns::noname` from `users::table`
+    //~^ ERROR: cannot select `non_users::columns::noname` from `users::table`
 
     update(users::table)
         .set(users::columns::name.eq("Bill"))
         .returning(non_users::columns::noname);
-    //~^ ERROR: Cannot select `non_users::columns::noname` from `users::table`
+    //~^ ERROR: cannot select `non_users::columns::noname` from `users::table`
 }

--- a/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `non_users::columns::noname` from `users::table`
+error[E0277]: cannot select `non_users::columns::noname` from `users::table`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:27:20
     |
 27  |         .returning(non_users::columns::noname);
@@ -24,7 +24,7 @@ LL |     where
 LL |         E: SelectableExpression<T>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
 
-error[E0277]: Cannot select `non_users::columns::noname` from `users::table`
+error[E0277]: cannot select `non_users::columns::noname` from `users::table`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:32:20
     |
 32  |         .returning(non_users::columns::noname);
@@ -52,7 +52,7 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
  
     
-error[E0277]: Cannot select `non_users::columns::noname` from `users::table`
+error[E0277]: cannot select `non_users::columns::noname` from `users::table`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:37:20
     |
 37  |         .returning(non_users::columns::noname);

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.rs
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.rs
@@ -66,7 +66,7 @@ fn nested_outer_joins_left_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+    //~| ERROR: cannot select `posts::columns::title` from `users::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
@@ -74,7 +74,7 @@ fn nested_outer_joins_left_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+    //~| ERROR: cannot select `posts::columns::title` from `users::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
@@ -89,7 +89,7 @@ fn nested_mixed_joins_left_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+    //~| ERROR: cannot select `posts::columns::title` from `users::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
@@ -97,7 +97,7 @@ fn nested_mixed_joins_left_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+    //~| ERROR: cannot select `posts::columns::title` from `users::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
@@ -110,7 +110,7 @@ fn nested_outer_joins_right_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
     //~^ ERROR: type mismatch resolving `<SelectStatement<...> as AppearsInFromClause<...>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `pets::table`
+    //~| ERROR: cannot select `posts::columns::title` from `pets::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
@@ -118,7 +118,7 @@ fn nested_outer_joins_right_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
     //~^ ERROR: type mismatch resolving `<SelectStatement<...> as AppearsInFromClause<...>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `pets::table`
+    //~| ERROR: cannot select `posts::columns::title` from `pets::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`
@@ -131,7 +131,7 @@ fn nested_mixed_joins_right_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(posts::title);
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+    //~| ERROR: cannot select `posts::columns::title` from `users::table`
     // Valid
     let _ = join.select(posts::title.nullable());
     // Valid -- NULL to a function will return null
@@ -139,7 +139,7 @@ fn nested_mixed_joins_right_associative() {
     // Invalid, only Nullable<title> is selectable
     let _ = join.select(lower(posts::title));
     //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-    //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+    //~| ERROR: cannot select `posts::columns::title` from `users::table`
     // Invalid, Nullable<title> is selectable, but lower expects not-null
     let _ = join.select(lower(posts::title.nullable()));
     //~^ ERROR: type mismatch resolving `<Nullable<title> as Expression>::SqlType == Text`

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
@@ -19,7 +19,7 @@ LL |         title -> Text,
    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
    
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:44:18
    |
 LL |     let _ = join.select(posts::title);
@@ -65,7 +65,7 @@ LL |         title -> Text,
    = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
    
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:52:18
    |
 LL |     let _ = join.select(lower(posts::title));
@@ -142,7 +142,7 @@ LL |         title -> Text,
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
    
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:67:18
    |
 LL |     let _ = join.select(posts::title);
@@ -188,7 +188,7 @@ LL |         title -> Text,
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
    
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:75:18
    |
 LL |     let _ = join.select(lower(posts::title));
@@ -265,7 +265,7 @@ LL |         title -> Text,
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
 
    
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:90:18
    |
 LL |     let _ = join.select(posts::title);
@@ -311,7 +311,7 @@ LL |         title -> Text,
    = note: required for `SelectStatement<FromClause<JoinOn<Join<..., ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
 
    
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:98:18
    |
 LL |     let _ = join.select(lower(posts::title));
@@ -388,7 +388,7 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
  
     
-error[E0277]: Cannot select `posts::columns::title` from `pets::table`
+error[E0277]: cannot select `posts::columns::title` from `pets::table`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:111:18
     |
 LL |     let _ = join.select(posts::title);
@@ -434,7 +434,7 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
  
     
-error[E0277]: Cannot select `posts::columns::title` from `pets::table`
+error[E0277]: cannot select `posts::columns::title` from `pets::table`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:119:18
     |
 LL |     let _ = join.select(lower(posts::title));
@@ -511,7 +511,7 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<posts::columns::title>`
  
     
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:132:18
     |
 LL |     let _ = join.select(posts::title);
@@ -557,7 +557,7 @@ note: required for `posts::columns::title` to implement `SelectableExpression<qu
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, ..., ...>, ...>>>` to implement `SelectDsl<lower_utils::lower<posts::columns::title>>`
  
     
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:140:18
     |
 LL |     let _ = join.select(lower(posts::title));

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
@@ -12,49 +12,44 @@ fn main() {
     use self::users::dsl::*;
 
     users.for_update().distinct();
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctDsl`
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctDsl` is not satisfied
     users.distinct().for_update();
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: LockingDsl<...>` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
     users.for_update().distinct_on(id);
-    //~^ ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
-    //~| ERROR: cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-    //~| ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<_>` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<...>` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<_>` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
-    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
     users.distinct_on(id).for_update();
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
-
+    //~| ERROR: the trait bound `SelectStatement<FromClause<table>, ..., ...>: LockingDsl<...>` is not satisfied
     users.for_update().group_by(id);
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: GroupByDsl<_>` is not satisfied
     users.group_by(id).for_update();
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~^ ERROR: the trait bound `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>: Table` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
-
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: LockingDsl<...>` is not satisfied
     users.into_boxed().for_update();
-    //~^ ERROR: type mismatch resolving `<BoxedSelectStatement<'_, ..., ..., _> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>: Table` is not satisfied
+    //~^ ERROR: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>: Table` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
+    //~| ERROR: the trait bound `BoxedSelectStatement<'_, (Integer,), ..., _>: LockingDsl<...>` is not satisfied
     users.for_update().into_boxed();
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
-    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
-    //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
-
+    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~| ERROR: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` for backend `_`
+    //~| ERROR: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` for backend `_`
     users.for_update().group_by(id).having(id.gt(1));
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: GroupByDsl<_>` is not satisfied
     users.group_by(id).having(id.gt(1)).for_update();
-    //~^ ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
+    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
+    //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>: LockingDsl<...>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs
@@ -21,7 +21,7 @@ fn main() {
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
     users.for_update().distinct_on(id);
     //~^ ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
-    //~| ERROR: Cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+    //~| ERROR: cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
     //~| ERROR: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
     //~| ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
     //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
@@ -125,7 +125,7 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: Cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+error[E0277]: cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:36
     |
 22  |     users.for_update().distinct_on(id);

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.stderr
@@ -1,27 +1,20 @@
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctDsl` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:14:24
    |
 LL |     users.for_update().distinct();
-   |                        ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^ the trait `DistinctDsl` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<...>>`
-              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctDsl`
+   = note: a `DISTINCT` clause is not compatible with various other clauses like `LOCKING` clauses
+   = help: the trait `DistinctDsl` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
 
    
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:14:24
    |
 LL |     users.for_update().distinct();
-   |                        ^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^ the trait `DistinctDsl` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctDsl`
+   = help: the trait `DistinctDsl` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: DistinctDsl` is not satisfied
@@ -30,33 +23,31 @@ error[E0277]: the trait bound `SelectStatement<FromClause<...>>: DistinctDsl` is
 LL |     users.for_update().distinct();
    |                        ^^^^^^^^ the trait `DistinctDsl` is not implemented for `SelectStatement<FromClause<...>>`
    |
+   = note: a `DISTINCT` clause is not compatible with various other clauses like `LOCKING` clauses
    = help: the trait `DistinctDsl` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
 
    
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ...>: LockingDsl<...>` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:18:22
    |
 LL |     users.distinct().for_update();
-   |                      ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ...>`
+   |                      ^^^^^^^^^^ unsatisfied trait bound
    |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
-              found struct `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>`
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, diesel::query_builder::distinct_clause::DistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, _, _, _>`
+           but it is implemented for `SelectStatement<_, _, diesel::query_builder::distinct_clause::NoDistinctClause, _, _, _, _, _, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::distinct_clause::NoDistinctClause`, found `diesel::query_builder::distinct_clause::DistinctClause`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:18:22
    |
 LL |     users.distinct().for_update();
-   |                      ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>`
+   |                      ^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, diesel::query_builder::distinct_clause::DistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, _, _, _>`
+           but it is implemented for `SelectStatement<_, _, diesel::query_builder::distinct_clause::NoDistinctClause, _, _, _, _, _, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::distinct_clause::NoDistinctClause`, found `diesel::query_builder::distinct_clause::DistinctClause`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
@@ -66,55 +57,45 @@ LL |     users.distinct().for_update();
    |                      ^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
 
    
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<_>` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
    |
 LL |     users.for_update().distinct_on(id);
-   |                        ^^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^^^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<...>>`
-              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
+   = note: a `DISTINCT ON` clause is not compatible with various other clauses like `LOCKING` clauses
+   = note: a `DISTINCT ON` clause also disallows mixing aggregate and non-aggregate expressions with the `SELECT` clause
+   = help: the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+   = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 
    
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
   --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
    |
 LL |     users.for_update().distinct_on(id);
-   |                        ^^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^^^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
+   = help: the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+   = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 
    
-error[E0277]: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:24
-   |
-LL |     users.for_update().distinct_on(id);
-   |                        ^^^^^^^^^^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
-   |
-   = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
-
-   
-error[E0277]: the trait bound `SelectStatement<FromClause<...>>: DistinctOnDsl<_>` is not satisfied
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<_>` is not satisfied
    --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:36
     |
 22  |     users.for_update().distinct_on(id);
-    |                        ----------- ^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
-    |                        |
-    |                        required by a bound introduced by this call
+    |                                    ^^ the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
     |
-    = help: the trait `DistinctOnDsl<Selection>` is implemented for `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<_>`
+    = note: a `DISTINCT ON` clause is not compatible with various other clauses like `LOCKING` clauses
+    = note: a `DISTINCT ON` clause also disallows mixing aggregate and non-aggregate expressions with the `SELECT` clause
+    = help: the trait `DistinctOnDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+            but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+    = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -125,25 +106,17 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0277]: cannot select `columns::id` from `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: DistinctOnDsl<...>` is not satisfied
    --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:22:36
     |
 22  |     users.for_update().distinct_on(id);
-    |                        ----------- ^^ unsatisfied trait bound
-    |                        |
-    |                        required by a bound introduced by this call
+    |                                    ^^ the trait `DistinctOnDsl<columns::id>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
     |
-    = help: the trait `SelectableExpression<SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, diesel::query_builder::distinct_clause::NoDistinctClause, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, diesel::query_builder::locking_clause::LockingClause>>` is not implemented for `columns::id`
-    = note: `columns::id` is no valid selection for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `columns::id` implements `SelectableExpression<JoinOn<Join, On>>`
-              `columns::id` implements `SelectableExpression<Only<users::table>>`
-              `columns::id` implements `SelectableExpression<SelectStatement<FromClause<From>>>`
-              `columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
-              `columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, Inner>>`
-              `columns::id` implements `SelectableExpression<query_source::joins::Join<Left, Right, LeftOuter>>`
-              `columns::id` implements `SelectableExpression<users::table>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::id>`
+    = note: a `DISTINCT ON` clause is not compatible with various other clauses like `LOCKING` clauses
+    = note: a `DISTINCT ON` clause also disallows mixing aggregate and non-aggregate expressions with the `SELECT` clause
+    = help: the trait `DistinctOnDsl<columns::id>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+            but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+    = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -154,70 +127,64 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::distinct_on`
  
     
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:28:27
+error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ...>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:27:27
    |
 LL |     users.distinct_on(id).for_update();
-   |                           ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ...>`
+   |                           ^^^^^^^^^^ unsatisfied trait bound
    |
-   = note: expected struct `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
-              found struct `SelectStatement<FromClause<users::table>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<users::table>>, DistinctOnClause<columns::id>, _, _, _, _, _, _>`
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, DistinctOnClause<columns::id>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, _, _, _>`
+           but it is implemented for `SelectStatement<_, _, diesel::query_builder::distinct_clause::NoDistinctClause, _, _, _, _, _, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::distinct_clause::NoDistinctClause`, found `DistinctOnClause<columns::id>`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ...>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:28:27
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:27:27
    |
 LL |     users.distinct_on(id).for_update();
-   |                           ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>`
+   |                           ^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, DistinctOnClause<columns::id>, diesel::query_builder::where_clause::NoWhereClause, diesel::query_builder::order_clause::NoOrderClause, LimitOffsetClause<NoLimitClause, NoOffsetClause>, _, _, _>`
+           but it is implemented for `SelectStatement<_, _, diesel::query_builder::distinct_clause::NoDistinctClause, _, _, _, _, _, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::distinct_clause::NoDistinctClause`, found `DistinctOnClause<columns::id>`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:28:27
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:27:27
    |
 LL |     users.distinct_on(id).for_update();
    |                           ^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<SelectStatement<..., ..., ...>>>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
 
    
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:33:24
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: GroupByDsl<_>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:31:24
    |
 LL |     users.for_update().group_by(id);
-   |                        ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<...>>`
-              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
+   = help: the trait `GroupByDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+   = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 
    
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:33:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:31:24
    |
 LL |     users.for_update().group_by(id);
-   |                        ^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
+   = help: the trait `GroupByDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+   = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:33:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:31:24
    |
 LL |     users.for_update().group_by(id);
    |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
@@ -225,124 +192,109 @@ LL |     users.for_update().group_by(id);
    = help: the trait `GroupByDsl<Expr>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
 
    
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:37:24
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:35:24
    |
 LL |     users.group_by(id).for_update();
-   |                        ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^^^ unsatisfied trait bound
    |
-   = note: expected struct `SelectStatement<FromClause<...>>`
-              found struct `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
-   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, _, _>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::NoGroupByClause, _, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::group_by_clause::NoGroupByClause`, found `diesel::query_builder::group_by_clause::GroupByClause<columns::id>`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:37:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:35:24
    |
 LL |     users.group_by(id).for_update();
-   |                        ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, _, _>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::NoGroupByClause, _, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::group_by_clause::NoGroupByClause`, found `diesel::query_builder::group_by_clause::GroupByClause<columns::id>`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:37:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:35:24
    |
 LL |     users.group_by(id).for_update();
    |                        ^^^^^^^^^^ the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<...>>`
    |
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
 
    
-error[E0271]: type mismatch resolving `<BoxedSelectStatement<'_, ..., ..., _> as AsQuery>::Query == SelectStatement<...>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:42:24
+error[E0277]: the trait bound `BoxedSelectStatement<'_, (Integer,), ..., _>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:39:24
    |
 LL |     users.into_boxed().for_update();
-   |                        ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `BoxedSelectStatement<'_, (...,), ..., _>`
+   |                        ^^^^^^^^^^ unsatisfied trait bound
    |
-   = note: expected struct `SelectStatement<FromClause<BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>>>`
-              found struct `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>`
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
+   = help: the following other types implement trait `LockingDsl<Lock>`:
+             Alias<S>
+             SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>
 
    
 error[E0277]: the trait bound `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:42:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:39:24
    |
 LL |     users.into_boxed().for_update();
-   |                        ^^^^^^^^^^ the trait `Table` is not implemented for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>`
+   |                        ^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `BoxedSelectStatement<'_, (diesel::sql_types::Integer,), FromClause<users::table>, _>`
+   = help: the following other types implement trait `LockingDsl<Lock>`:
+             Alias<S>
+             SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>
 
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:42:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:39:24
    |
 LL |     users.into_boxed().for_update();
    |                        ^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<BoxedSelectStatement<'_, (...,), ..., _>>>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
 
    
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
+error[E0277]: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` for backend `_`
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:43:24
    |
 LL |     users.for_update().into_boxed();
-   |                        ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<...>>`
-              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
+   = note: this either means `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` is no valid SQL for `_`
+   = note: or this means `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
+   = help: the following other types implement trait `BoxedDsl<'a, DB>`:
+             SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
+             SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
 
    
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:43:24
    |
 LL |     users.for_update().into_boxed();
-   |                        ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
-
-   
-error[E0277]: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
-   |
-LL |     users.for_update().into_boxed();
-   |                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<...>>`
+   |                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
    = help: the following other types implement trait `BoxedDsl<'a, DB>`:
              SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
              SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
 
    
-error[E0277]: the trait bound `SelectStatement<FromClause<...>>: BoxedDsl<'_, _>` is not satisfied
-    --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:46:24
+error[E0277]: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` for backend `_`
+    --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:43:5
      |
-46   |     users.for_update().into_boxed();
-     |                        ^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<FromClause<...>>`
+43   |     users.for_update().into_boxed();
+     |     ^^^^^^^^^^^^^^^^^^ the trait `BoxedDsl<'_, _>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
      |
+     = note: this either means `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` is no valid SQL for `_`
+     = note: or this means `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
      = help: the following other types implement trait `BoxedDsl<'a, DB>`:
                SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
                SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
-     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `BoxedDsl<'_, _>`
 note: required by a bound in `diesel::QueryDsl::into_boxed`
     --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
      |
@@ -353,34 +305,30 @@ LL |         Self: methods::BoxedDsl<'a, DB>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::into_boxed`
   
      
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:52:24
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: GroupByDsl<_>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:47:24
    |
 LL |     users.for_update().group_by(id).having(id.gt(1));
-   |                        ^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = note: expected struct `SelectStatement<FromClause<...>>`
-              found struct `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
+   = help: the trait `GroupByDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+   = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 
    
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:52:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:47:24
    |
 LL |     users.for_update().group_by(id).having(id.gt(1));
-   |                        ^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+   |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `GroupByDsl<_>`
+   = help: the trait `GroupByDsl<_>` is not implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::LockingClause>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, _, _, diesel::query_builder::locking_clause::NoLockingClause>`
+   = help: for that trait implementation, expected `diesel::query_builder::locking_clause::NoLockingClause`, found `diesel::query_builder::locking_clause::LockingClause`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:52:24
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:47:24
    |
 LL |     users.for_update().group_by(id).having(id.gt(1));
    |                        ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
@@ -388,36 +336,36 @@ LL |     users.for_update().group_by(id).having(id.gt(1));
    = help: the trait `GroupByDsl<Expr>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
 
    
-error[E0271]: type mismatch resolving `<SelectStatement<..., ..., ..., ..., ..., ..., ..., ...> as AsQuery>::Query == SelectStatement<...>`
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:56:41
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>: LockingDsl<...>` is not satisfied
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:51:41
    |
 LL |     users.group_by(id).having(id.gt(1)).for_update();
-   |                                         ^^^^^^^^^^ expected `SelectStatement<FromClause<...>>`, found `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>`
+   |                                         ^^^^^^^^^^ unsatisfied trait bound
    |
-   = note: expected struct `SelectStatement<FromClause<...>>`
-              found struct `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>`
-   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, _>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::group_by_clause::NoGroupByClause`, found `diesel::query_builder::group_by_clause::GroupByClause<columns::id>`
 
    
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>: Table` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:56:41
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:51:41
    |
 LL |     users.group_by(id).having(id.gt(1)).for_update();
-   |                                         ^^^^^^^^^^ the trait `Table` is not implemented for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>`
+   |                                         ^^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the following other types implement trait `Table`:
-             Only<S>
-             Tablesample<S, TSM>
-             pg::metadata_lookup::pg_namespace::table
-             pg::metadata_lookup::pg_type::table
-             users::table
-   = note: required for `SelectStatement<FromClause<table>, ..., ..., ..., ..., ..., ..., ...>` to implement `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>`
+   = help: the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::GroupByClause<columns::id>, diesel::query_builder::having_clause::HavingClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Gt<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>, _>`
+           but it is implemented for `SelectStatement<_, _, _, _, _, _, diesel::query_builder::group_by_clause::NoGroupByClause, diesel::query_builder::having_clause::NoHavingClause, _>`
+   = help: for that trait implementation, expected `diesel::query_builder::group_by_clause::NoGroupByClause`, found `diesel::query_builder::group_by_clause::GroupByClause<columns::id>`
 
    
 error[E0277]: the trait bound `SelectStatement<FromClause<...>>: LockingDsl<...>` is not satisfied
-  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:56:41
+  --> tests/fail/select_for_update_cannot_be_mixed_with_some_clauses.rs:51:41
    |
 LL |     users.group_by(id).having(id.gt(1)).for_update();
    |                                         ^^^^^^^^^^ the trait `LockingDsl<diesel::query_builder::locking_clause::ForUpdate>` is not implemented for `SelectStatement<FromClause<...>>`
    |
+   = note: a `LOCKING` clause is incompatible with various other clauses like a `DISTINCT` clause
    = help: the trait `LockingDsl<Lock>` is implemented for `SelectStatement<F, S, diesel::query_builder::distinct_clause::NoDistinctClause, W, O, LOf>`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.rs
@@ -16,6 +16,5 @@ fn main() {
         .load(&mut conn)
         //~^ ERROR: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
         //~| ERROR: `diesel::query_builder::locking_clause::NoModifier` is no valid SQL fragment for the `Sqlite` backend
-        //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_cannot_be_used_on_sqlite.stderr
@@ -51,39 +51,4 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
-error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
-    --> tests/fail/select_for_update_cannot_be_used_on_sqlite.rs:16:15
-     |
-16   |         .load(&mut conn)
-     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-     = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ---- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-  
      For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs
@@ -17,6 +17,5 @@ fn main() {
         .load(&mut conn)
         //~^ ERROR: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
         //~| ERROR: `diesel::query_builder::locking_clause::NoWait` is no valid SQL fragment for the `Sqlite` backend
-        //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.stderr
@@ -51,39 +51,4 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
-error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
-    --> tests/fail/select_for_update_no_wait_cannot_be_used_on_sqlite.rs:17:15
-     |
-17   |         .load(&mut conn)
-     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-     = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ---- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-  
      For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs
@@ -17,6 +17,5 @@ fn main() {
         .load(&mut conn)
         //~^ ERROR: `diesel::query_builder::locking_clause::ForUpdate` is no valid SQL fragment for the `Sqlite` backend
         //~| ERROR: `diesel::query_builder::locking_clause::SkipLocked` is no valid SQL fragment for the `Sqlite` backend
-        //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.stderr
@@ -51,39 +51,4 @@ LL |     where
 LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
-     
-error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer,), Sqlite>` is not satisfied
-    --> tests/fail/select_for_update_skip_locked_cannot_be_used_on_sqlite.rs:17:15
-     |
-17   |         .load(&mut conn)
-     |          ---- ^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer,)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer,)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer,), Sqlite>`
-     = note: required for `(diesel::sql_types::Integer,)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, SqliteConnection, {type error}>`
-note: required by a bound in `diesel::RunQueryDsl::load`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
-     |        ---- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
-  
      For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.rs
+++ b/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.rs
@@ -18,5 +18,5 @@ table! {
 
 fn main() {
     let select_id = users::table.select(posts::id);
-    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~^ ERROR: cannot select `posts::columns::id` from `users::table`
 }

--- a/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/select_requires_column_from_same_table.rs:20:41
     |
 20  |     let select_id = users::table.select(posts::id);

--- a/diesel_compile_tests/tests/fail/selectable.rs
+++ b/diesel_compile_tests/tests/fail/selectable.rs
@@ -164,12 +164,12 @@ fn main() {
         .left_join(posts::table)
         .select(UserWithEmbeddedPost::as_select())
         //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-        //~| ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~| ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         .load(&mut conn)
         //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Never`
-        //~| ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~| ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         .unwrap();
 
     // group by clauses are considered
@@ -195,12 +195,12 @@ fn main() {
     let _ = diesel::insert_into(users::table)
         .values(users::name.eq(""))
         .returning(UserWithEmbeddedPost::as_select())
-        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .load(&mut conn)
-        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .unwrap();
 
@@ -209,12 +209,12 @@ fn main() {
     let _ = diesel::update(users::table)
         .set(users::name.eq(""))
         .returning(UserWithEmbeddedPost::as_select())
-        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .load(&mut conn)
-        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .unwrap();
 
@@ -222,12 +222,12 @@ fn main() {
     // returning clauses
     let _ = diesel::delete(users::table)
         .returning(UserWithEmbeddedPost::as_select())
-        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .load(&mut conn)
-        //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: Cannot select `posts::columns::title` from `users::table`
+        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+        //~| ERROR: cannot select `posts::columns::title` from `users::table`
         //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
         .unwrap();
 

--- a/diesel_compile_tests/tests/fail/selectable.rs
+++ b/diesel_compile_tests/tests/fail/selectable.rs
@@ -186,7 +186,7 @@ fn main() {
     let _ = users::table
         .inner_join(posts::table)
         .select(UserWithPostCount::as_select())
-        //~^ ERROR: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+        //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
         .load(&mut conn)
         .unwrap();
 

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -978,14 +978,14 @@ error[E0277]: the trait bound `(SelectBy<Post, _>, Text): CompatibleType<((i32, 
      = note: consider using `#[diesel(check_for_backend(_))]` on either `#[derive(Selectable)]` or `#[derive(QueryableByName)]` 
              on your struct `((i32, std::string::String), std::string::String)` and in your query `.select(((i32, std::string::String), std::string::String)::as_select())` to get a better error message
      = help: the following other types implement trait `load_dsl::private::CompatibleType<U, DB>`:
-               (ST0, ST1)
-               (ST0, ST1, ST2)
-               (ST0, ST1, ST2, ST3)
-               (ST0, ST1, ST2, ST3, ST4)
-               (ST0, ST1, ST2, ST3, ST4, ST5)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)
-               (ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)
+               `Nullable<(ST0, ST1)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
+               `Nullable<(ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8)>` implements `load_dsl::private::CompatibleType<Option<__T>, __DB>`
              and N others
      = note: required for `SelectStatement<FromClause<table>, SelectClause<(..., ...)>>` to implement `LoadQuery<'_, _, ((i32, std::string::String), std::string::String)>`
 note: required by a bound in `diesel::RunQueryDsl::load`

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -247,12 +247,15 @@ note: required for `users::columns::name` to implement `ValidGrouping<posts::col
     = note: required for `SelectStatement<FromClause<...>, ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
  
     
-error[E0277]: the trait bound `diesel::expression::is_aggregate::No: MixedAggregates<diesel::expression::is_aggregate::Yes>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/selectable.rs:188:10
     |
 LL |         .select(UserWithPostCount::as_select())
     |          ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
     |
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::No` implements `MixedAggregates<diesel::expression::is_aggregate::No>`

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -48,7 +48,7 @@ note: required for `posts::columns::id` to implement `SelectableExpression<query
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
  
     
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/selectable.rs:165:10
     |
 LL |         .select(UserWithEmbeddedPost::as_select())
@@ -73,7 +73,7 @@ note: required for `posts::columns::id` to implement `SelectableExpression<query
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, ...>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>>`
  
     
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
    --> tests/fail/selectable.rs:165:10
     |
 LL |         .select(UserWithEmbeddedPost::as_select())
@@ -131,7 +131,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
     --> tests/fail/selectable.rs:169:15
      |
 169  |         .load(&mut conn)
@@ -168,7 +168,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
     --> tests/fail/selectable.rs:169:15
      |
 169  |         .load(&mut conn)
@@ -262,7 +262,7 @@ LL |         .select(UserWithPostCount::as_select())
     = note: required for `SelectStatement<FromClause<JoinOn<Join<table, table, Inner>, ...>>>` to implement `SelectDsl<diesel::expression::select_by::SelectBy<UserWithPostCount, Pg>>`
  
     
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/selectable.rs:197:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -293,7 +293,7 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
  
     
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
    --> tests/fail/selectable.rs:197:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -354,7 +354,7 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
     |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
  
     
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
     --> tests/fail/selectable.rs:201:15
      |
 201  |         .load(&mut conn)
@@ -386,7 +386,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
     --> tests/fail/selectable.rs:201:15
      |
 201  |         .load(&mut conn)
@@ -449,7 +449,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/selectable.rs:211:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -480,7 +480,7 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
  
     
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
    --> tests/fail/selectable.rs:211:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -541,7 +541,7 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
     |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
  
     
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
     --> tests/fail/selectable.rs:215:15
      |
 215  |         .load(&mut conn)
@@ -573,7 +573,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
     --> tests/fail/selectable.rs:215:15
      |
 215  |         .load(&mut conn)
@@ -636,7 +636,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
    --> tests/fail/selectable.rs:224:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -665,7 +665,7 @@ LL |     where
 LL |         E: SelectableExpression<T>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
 
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
    --> tests/fail/selectable.rs:224:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -722,7 +722,7 @@ LL |     where
 LL |         E: SelectableExpression<T>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
 
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
     --> tests/fail/selectable.rs:228:15
      |
 228  |         .load(&mut conn)
@@ -754,7 +754,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
   
      
-error[E0277]: Cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `users::table`
     --> tests/fail/selectable.rs:228:15
      |
 228  |         .load(&mut conn)

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs
@@ -21,10 +21,10 @@ allow_tables_to_appear_in_same_query!(users, posts);
 
 fn main() {
     let stuff = users::table.select((posts::id, posts::user_id));
-    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
-    //~| ERROR: Cannot select `posts::columns::user_id` from `users::table`
+    //~^ ERROR: cannot select `posts::columns::id` from `users::table`
+    //~| ERROR: cannot select `posts::columns::user_id` from `users::table`
     //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
     let stuff = users::table.select((posts::id, users::name));
-    //~^ ERROR: Cannot select `posts::columns::id` from `users::table`
+    //~^ ERROR: cannot select `posts::columns::id` from `users::table`
     //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
 }

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
@@ -1,4 +1,4 @@
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
 LL |     let stuff = users::table.select((posts::id, posts::user_id));
@@ -16,7 +16,7 @@ LL |     let stuff = users::table.select((posts::id, posts::user_id));
    = note: required for `(posts::columns::id, posts::columns::user_id)` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
 
-error[E0277]: Cannot select `posts::columns::user_id` from `users::table`
+error[E0277]: cannot select `posts::columns::user_id` from `users::table`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:23:30
    |
 LL |     let stuff = users::table.select((posts::id, posts::user_id));
@@ -51,7 +51,7 @@ LL |         id -> Integer,
    = note: required for `(posts::columns::id, posts::columns::user_id)` to implement `SelectableExpression<users::table>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(posts::columns::id, posts::columns::user_id)>`
 
-error[E0277]: Cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `users::table`
   --> tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.rs:27:30
    |
 LL |     let stuff = users::table.select((posts::id, users::name));

--- a/diesel_compile_tests/tests/fail/table_column_names.rs
+++ b/diesel_compile_tests/tests/fail/table_column_names.rs
@@ -5,10 +5,8 @@ table! {
     users {
         id -> Integer,
         users -> Integer,
-        //~^ ERROR: Column `users` cannot be named the same as it's table.
+        //~^ ERROR: column `users` cannot be named the same as it's table.
     }
 }
-// error-pattern: Column `users` cannot be named the same as its table.
-// error-pattern: You may use `#[sql_name = "users"]` to reference the table's `users` column.
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/table_column_names.stderr
+++ b/diesel_compile_tests/tests/fail/table_column_names.stderr
@@ -1,6 +1,6 @@
-error: Column `users` cannot be named the same as it's table.
-       You may use `#[sql_name = "users"]` to reference the table's `users` column 
-       Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
+error: column `users` cannot be named the same as it's table.
+       you may use `#[sql_name = "users"]` to reference the table's `users` column 
+       docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
  --> tests/fail/table_column_names.rs:7:9
   |
 LL |         users -> Integer,

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_1.rs
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_1.rs
@@ -3,7 +3,8 @@ extern crate diesel;
 
 table! {
     12
+    //~^ ERROR: macro expansion ignores `12` and any tokens following
 }
-//~^^^ ERROR: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
+//~^^^^ ERROR: invalid `table!` syntax
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_1.stderr
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_1.stderr
@@ -1,9 +1,23 @@
-error: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
-       Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
+error: macro expansion ignores `12` and any tokens following
+ --> tests/fail/table_invalid_syntax_1.rs:5:5
+  |
+LL | / table! {
+LL | |     12
+  | |     ^^
+LL | |
+LL | | }
+  | |_- caused by the macro expansion here
+  |
+  = note: the usage of `table!` is likely invalid in item context
+
+error: invalid `table!` syntax 
+       help: please see the `table!` macro docs for more info
+       help: docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
  --> tests/fail/table_invalid_syntax_1.rs:4:1
   |
 LL | / table! {
 LL | |     12
+LL | |
 LL | | }
   | |_^
   |

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_2.rs
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_2.rs
@@ -3,7 +3,7 @@ extern crate diesel;
 
 table! {
      some wrong syntax
+     //~^ ERROR: expected one of `!` or `::`, found `wrong`
 }
-//~^^^ ERROR: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/table_invalid_syntax_2.stderr
+++ b/diesel_compile_tests/tests/fail/table_invalid_syntax_2.stderr
@@ -1,10 +1,5 @@
-error: Invalid `table!` syntax. Please see the `table!` macro docs for more info.
-       Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`
- --> tests/fail/table_invalid_syntax_2.rs:4:1
+error: expected one of `!` or `::`, found `wrong`
+ --> tests/fail/table_invalid_syntax_2.rs:5:11
   |
-LL | / table! {
-LL | |      some wrong syntax
-LL | | }
-  | |_^
-  |
-  = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |      some wrong syntax
+  |           ^^^^^ expected one of `!` or `::`

--- a/diesel_compile_tests/tests/fail/table_without_primary_key.rs
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.rs
@@ -3,7 +3,7 @@ extern crate diesel;
 
 table! {
     user {
-        //~^ ERROR: Neither an explicit primary key found nor does an `id` column exist.
+        //~^ ERROR: neither an explicit primary key found nor does an `id` column exist.
         user_id -> Integer,
         name -> Text,
     }

--- a/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
+++ b/diesel_compile_tests/tests/fail/table_without_primary_key.stderr
@@ -1,8 +1,10 @@
-error: Neither an explicit primary key found nor does an `id` column exist.
-       Consider explicitly defining a primary key. 
-       For example for specifying `user_id` as primary key:
+error: neither an explicit primary key found nor does an `id` column exist.
+       consider explicitly defining a primary key. 
+       for example for specifying `user_id` as primary key:
        
        table! {
+       
+                            user(user_id){
            user (user_id) {
                user_id -> Integer,
                name -> Text,

--- a/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
+++ b/diesel_compile_tests/tests/fail/update_requires_valid_where_clause.stderr
@@ -6,6 +6,7 @@ LL |     update(users::table.filter(posts::id.eq(1)));
    |     |
    |     required by a bound introduced by this call
    |
+   = note: only tables or select statements with only the filter clause applied are valid update targets
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`
 note: required by a bound in `diesel::update`
   --> DIESEL/diesel/diesel/src/query_builder/functions.rs
@@ -59,4 +60,5 @@ error[E0277]: the trait bound `SelectStatement<FromClause<table>, ..., ..., ...>
 LL |     update(users::table.filter(posts::id.eq(1)));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoUpdateTarget` is not implemented for `SelectStatement<FromClause<table>, DefaultSelectClause<...>, ..., ...>`
    |
+   = note: only tables or select statements with only the filter clause applied are valid update targets
    = help: the trait `IntoUpdateTarget` is implemented for `SelectStatement<FromClause<F>, diesel::query_builder::select_clause::DefaultSelectClause<FromClause<F>>, diesel::query_builder::distinct_clause::NoDistinctClause, W>`

--- a/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs
+++ b/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs
@@ -17,7 +17,6 @@ fn main() {
         .set(name.eq("Bill"))
         .get_result(&mut connection);
     //~^ ERROR: `ReturningClause<(columns::id, columns::name)>` is no valid SQL fragment for the `Sqlite` backend
-    //~| ERROR: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
 
     update(users.filter(id.eq(1)))
         .set(name.eq("Bill"))

--- a/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -27,9 +27,9 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: `ReturningClause<columns::name>` is no valid SQL fragment for the `Sqlite` backend
-    --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:25:21
+    --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:24:21
      |
-25   |         .get_result(&mut connection);
+24   |         .get_result(&mut connection);
      |          ---------- ^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite, DoesNotSupportReturningClause>` is not implemented for `ReturningClause<columns::name>`
      |          |
      |          required by a bound introduced by this call
@@ -44,41 +44,6 @@ error[E0277]: `ReturningClause<columns::name>` is no valid SQL fragment for the 
      = note: 1 redundant requirement hidden
      = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ..., ...>` to implement `QueryFragment<Sqlite>`
      = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, _>`
-note: required by a bound in `get_result`
-    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
-     |
-LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
-     |        ---------- required by a bound in this associated function
-LL |     where
-LL |         Self: LoadQuery<'query, Conn, U>,
-     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
-  
-     
-error[E0277]: the trait bound `{type error}: FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>` is not satisfied
-    --> tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.rs:18:21
-     |
-18   |         .get_result(&mut connection);
-     |          ---------- ^^^^^^^^^^^^^^^ the trait `SingleValue` is not implemented for `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     |          |
-     |          required by a bound introduced by this call
-     |
-     = note: double check your type mappings via the documentation of `(diesel::sql_types::Integer, diesel::sql_types::Text)`
-     = note: `diesel::sql_query` requires the loading target to column names for loading values.
-             You need to provide a type that explicitly derives `diesel::deserialize::QueryableByName`
-     = help: the following other types implement trait `SingleValue`:
-               Array<ST>
-               BigInt
-               Bool
-               CChar
-               Cidr
-               Citext
-               Datetime
-               Inet
-             and N others
-     = note: required for `{type error}` to implement `FromStaticSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-     = note: required for `{type error}` to implement `FromSqlRow<(diesel::sql_types::Integer, diesel::sql_types::Text), Sqlite>`
-     = note: required for `(diesel::sql_types::Integer, diesel::sql_types::Text)` to implement `load_dsl::private::CompatibleType<{type error}, Sqlite>`
-     = note: required for `UpdateStatement<table, WhereClause<Grouped<Eq<id, ...>>>, ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, {type error}>`
 note: required by a bound in `get_result`
     --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
      |

--- a/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.rs
+++ b/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.rs
@@ -108,12 +108,12 @@ fn main() {
     // but we cannot mix a aggregated expression with an non aggregate one
     users::table
         .select((
-            //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+            //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
             something_that_is_aggregate(),
             some_ungrouped_expression(false),
         ))
         .load::<(Option<i32>, i32)>(&mut conn);
-    //~^ ERROR: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
     // using two potential aggregated expressions works
     users::table

--- a/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.stderr
+++ b/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.stderr
@@ -61,12 +61,15 @@ LL |         id -> Integer,
    |         ^^
    = note: associated types for the current `impl` cannot be restricted in `where` clauses
 
-error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/valid_grouping_and_boxed_expressions.rs:110:10
     |
 LL |         .select((
     |          ^^^^^^ the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
     |
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
     = help: the following other types implement trait `MixedAggregates<Other>`:
               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
               `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
@@ -74,7 +77,7 @@ LL |         .select((
     = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<(Box<dyn diesel::BoxableExpression<users::table, Pg, (), diesel::expression::is_aggregate::Yes, SqlType = Nullable<diesel::sql_types::Integer>>>, Box<dyn diesel::BoxableExpression<users::table, Pg, SqlType = diesel::sql_types::Integer>>)>`
  
     
-error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggregates<diesel::expression::is_aggregate::No>` is not satisfied
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
     --> tests/fail/valid_grouping_and_boxed_expressions.rs:115:37
      |
 115  |         .load::<(Option<i32>, i32)>(&mut conn);
@@ -82,6 +85,9 @@ error[E0277]: the trait bound `diesel::expression::is_aggregate::Yes: MixedAggre
      |          |
      |          required by a bound introduced by this call
      |
+     = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+     = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+     = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
      = help: the following other types implement trait `MixedAggregates<Other>`:
                `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
                `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -28,8 +28,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     if fields_for_update.is_empty() {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
-            "Deriving `AsChangeset` on a structure that only contains primary keys isn't supported.\n\
-             help: If you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.\n\
+            "deriving `AsChangeset` on a structure that only contains primary keys isn't supported.\n\
+             help: if you want to change the primary key of a row, you should do so with `.set(table::id.eq(new_id))`.\n\
              note: `#[derive(AsChangeset)]` never changes the primary key of a row."
         ));
     }

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -13,7 +13,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     if model.sql_types.is_empty() {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
-            "At least one `sql_type` is needed for deriving `AsExpression` on a structure.",
+            "at least one `sql_type` is needed for deriving `AsExpression` on a structure.",
         ));
     }
 

--- a/diesel_derives/src/associations.rs
+++ b/diesel_derives/src/associations.rs
@@ -14,7 +14,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     if model.belongs_to.is_empty() {
         return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
-            "At least one `belongs_to` is needed for deriving `Associations` on a structure.",
+            "at least one `belongs_to` is needed for deriving `Associations` on a structure.",
         ));
     }
 

--- a/diesel_derives/src/attrs.rs
+++ b/diesel_derives/src/attrs.rs
@@ -66,7 +66,7 @@ impl SqlIdentifier {
             Err(_e) if self.field_name.contains(' ') => Err(syn::Error::new(
                 self.span(),
                 format!(
-                    "Expected valid identifier, found `{0}`. \
+                    "expected valid identifier, found `{0}`. \
                  Diesel does not support column names with whitespaces yet",
                     self.field_name
                 ),
@@ -74,7 +74,7 @@ impl SqlIdentifier {
             Err(_e) => Err(syn::Error::new(
                 self.span(),
                 format!(
-                    "Expected valid identifier, found `{0}`. \
+                    "expected valid identifier, found `{0}`. \
                  Diesel automatically renames invalid identifiers, \
                  perhaps you meant to write `{0}_`?",
                     self.field_name

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -160,7 +160,7 @@ impl Field {
                 FieldName::Named(ref x) => Ok(x.into()),
                 FieldName::Unnamed(ref x) => Err(syn::Error::new(
                     x.span(),
-                    "All fields of tuple structs must be annotated with `#[diesel(column_name)]`",
+                    "all fields of tuple structs must be annotated with `#[diesel(column_name)]`",
                 )),
             }
         }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -1307,13 +1307,16 @@ pub fn __diesel_public_if(attrs: TokenStream, input: TokenStream) -> TokenStream
 /// ```
 #[proc_macro]
 pub fn table_proc(input: TokenStream) -> TokenStream {
+    // include the input in the error output so that rust-analyzer is happy
+    let tokenstream2 = proc_macro2::TokenStream::from(input.clone());
     match syn::parse(input) {
         Ok(input) => table::expand(input).into(),
         Err(_) => quote::quote! {
             compile_error!(
-                "Invalid `table!` syntax. Please see the `table!` macro docs for more info.\n\
-                 Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`\n"
+                "invalid `table!` syntax \nhelp: please see the `table!` macro docs for more info\n\
+                 help: docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`\n"
             );
+            #tokenstream2
         }
         .into(),
     }

--- a/diesel_derives/src/model.rs
+++ b/diesel_derives/src/model.rs
@@ -53,7 +53,7 @@ impl Model {
             _ if !allow_unit_structs => {
                 return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
-                    "This derive can only be used on non-unit structs",
+                    "this derive can only be used on non-unit structs",
                 ));
             }
             _ => None,
@@ -149,7 +149,7 @@ impl Model {
             .ok_or_else(|| {
                 syn::Error::new(
                     column_name.span(),
-                    format!("No field with column name {column_name}"),
+                    format!("no field with column name `{column_name}`"),
                 )
             })
     }

--- a/diesel_derives/src/selectable.rs
+++ b/diesel_derives/src/selectable.rs
@@ -112,8 +112,8 @@ fn to_field_ty_bound(field_ty: &syn::Type) -> Result<TokenStream> {
             Err(syn::Error::new(
                 field_ty.span(),
                 format!(
-                    "References are not supported in `Queryable` types\n\
-                         Consider using `std::borrow::Cow<'{}, {}>` instead",
+                    "references are not supported in `Queryable` types\n\
+                         consider using `std::borrow::Cow<'{}, {}>` instead",
                     r.lifetime
                         .as_ref()
                         .expect("It's a struct field so it must have a named lifetime")

--- a/diesel_derives/src/table.rs
+++ b/diesel_derives/src/table.rs
@@ -8,18 +8,18 @@ const DEFAULT_PRIMARY_KEY_NAME: &str = "id";
 pub(crate) fn expand(input: TableDecl) -> TokenStream {
     if input.column_defs.len() > super::diesel_for_each_tuple::MAX_TUPLE_SIZE as usize {
         let txt = if input.column_defs.len() > 128 {
-            "You reached the end. Diesel does not support tables with \
-             more than 128 columns. Consider using less columns."
+            "you reached the end. \nhelp: diesel does not support tables with \
+             more than 128 columns.\nhelp: consider using less columns."
         } else if input.column_defs.len() > 64 {
-            "Table contains more than 64 columns. Consider enabling the \
+            "table contains more than 64 columns. \n consider enabling the \
              `128-column-tables` feature to enable diesels support for \
              tables with more than 64 columns."
         } else if input.column_defs.len() > 32 {
-            "Table contains more than 32 columns. Consider enabling the \
+            "table contains more than 32 columns. \nhelp: consider enabling the \
              `64-column-tables` feature to enable diesels support for \
              tables with more than 32 columns."
         } else {
-            "Table contains more than 16 columns. Consider enabling the \
+            "table contains more than 16 columns. \nhelp: consider enabling the \
              `32-column-tables` feature to enable diesels support for \
              tables with more than 16 columns."
         };
@@ -56,11 +56,13 @@ pub(crate) fn expand(input: TableDecl) -> TokenStream {
         }
         None => {
             let mut message = format!(
-                "Neither an explicit primary key found nor does an `id` column exist.\n\
-                 Consider explicitly defining a primary key. \n\
-                 For example for specifying `{}` as primary key:\n\n\
-                 table! {{\n",
-                column_names[0],
+                "neither an explicit primary key found nor does an `id` column exist.\n\
+                 consider explicitly defining a primary key. \n\
+                 for example for specifying `{key}` as primary key:\n\n\
+                 table! {{\n
+                     {table}({key}){{\n",
+                key = column_names[0],
+                table = input.table_name,
             );
             message += &format!("\t{table_name} ({}) {{\n", &column_names[0]);
             for c in &input.column_defs {
@@ -131,10 +133,10 @@ pub(crate) fn expand(input: TableDecl) -> TokenStream {
         if c.column_name == *table_name {
             let span = c.column_name.span();
             let message = format!(
-                "Column `{column_name}` cannot be named the same as it's table.\n\
-                 You may use `#[sql_name = \"{column_name}\"]` to reference the table's \
+                "column `{column_name}` cannot be named the same as it's table.\n\
+                 you may use `#[sql_name = \"{column_name}\"]` to reference the table's \
                  `{column_name}` column \n\
-                 Docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`\n"
+                 docs available at: `https://docs.diesel.rs/master/diesel/macro.table.html`\n"
             );
             quote::quote_spanned! { span =>
                 compile_error!(#message);

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -42,7 +42,7 @@ pub fn parse_eq<T: Parse>(input: ParseStream, help: &str) -> Result<T> {
             input.span(),
             format!(
                 "unexpected end of input, expected `=`\n\
-                 help: The correct format looks like `#[diesel({help})]`",
+                 help: the correct format looks like `#[diesel({help})]`",
             ),
         ));
     }
@@ -57,7 +57,7 @@ pub fn parse_paren<T: Parse>(input: ParseStream, help: &str) -> Result<T> {
             input.span(),
             format!(
                 "unexpected end of input, expected parentheses\n\
-                 help: The correct format looks like `#[diesel({help})]`",
+                 help: the correct format looks like `#[diesel({help})]`",
             ),
         ));
     }
@@ -82,7 +82,7 @@ where
             input.span(),
             format!(
                 "unexpected end of input, expected parentheses\n\
-                 help: The correct format looks like `#[diesel({help})]`",
+                 help: the correct format looks like `#[diesel({help})]`",
             ),
         ));
     }

--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -397,7 +397,7 @@ impl TypeInferrer<'_> {
                                 ) => syn::GenericArgument::Type(self.register_error(
                                     syn::Error::new_spanned(
                                         generic_argument,
-                                        "auto_type: Can't infer generic argument because \
+                                        "can't infer generic argument because \
                                             there is no function argument to infer from \
                                             (less function arguments than generic arguments)",
                                     ),
@@ -431,9 +431,9 @@ fn literal_type(t: &proc_macro2::Literal) -> Result<syn::Type, syn::Error> {
         .ok_or_else(|| {
             syn::Error::new_spanned(
                 t,
-                format_args!("Literals must have type suffix for auto_type, e.g. {val}i64"),
+                format_args!("literals must have type suffix for auto_type, e.g. `{val}_i64`"),
             )
         })?..];
     syn::parse_str(type_suffix)
-        .map_err(|_| syn::Error::new_spanned(t, "Invalid type suffix for literal"))
+        .map_err(|_| syn::Error::new_spanned(t, "invalid type suffix for literal"))
 }


### PR DESCRIPTION
This commit introduces various improvements for compiler errors. It's build on top of #4655.

It's likely best to review the changes commit by commit to not get overwhelmed with what's all changing.

Merging is blocked on merging #4655 first