### PR TITLE
Bump sqlite-wasm-rs version to 0.4.0

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,13 +53,13 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.35.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.3.4, <0.4.0", optional = true, default-features = false }
+sqlite-wasm-rs = { version = "0.4.0", optional = true, default-features = false }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on it, we use feature to override it.
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
-sqlite-wasm-rs = { version = ">=0.3.4, <0.4.0", default-features = false, features = ["bundled"] }
+sqlite-wasm-rs = "0.4.0"
 
 [dev-dependencies]
 cfg-if = "1"

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -214,7 +214,7 @@ impl Connection for SqliteConnection {
     ///
     /// * The database is stored in memory by default.
     /// * Persistent VFS (Virtual File Systems) is optional,
-    ///   see <https://github.com/Spxg/sqlite-wasm-rs/blob/master/VFS.md> for details
+    ///   see <https://github.com/Spxg/sqlite-wasm-rs/blob/master/sqlite-wasm-rs/src/vfs/README.md> for details
     fn establish(database_url: &str) -> ConnectionResult<Self> {
         let mut instrumentation = DynInstrumentation::default_instrumentation();
         instrumentation.on_connection_event(InstrumentationEvent::StartEstablishConnection {

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -33,7 +33,7 @@ diesel_test_helper = { path = "../diesel_test_helper" }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 getrandom_02 = { version = "0.2", package = "getrandom", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
-sqlite-wasm-rs = { version = ">=0.3.4, <0.4.0", default-features = false, features = ["bundled"] }
+sqlite-wasm-rs = "0.4.0"
 
 [features]
 default = []

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -13,7 +13,7 @@ wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = ">=0.3.4, <0.4.0", default-features = false, features = ["bundled"] }
+sqlite-wasm-rs = { version = "0.4.0", features = ["relaxed-idb"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sqlite/wasm/src/lib.rs
+++ b/examples/sqlite/wasm/src/lib.rs
@@ -52,17 +52,15 @@ pub fn establish_connection() -> SqliteConnection {
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 #[wasm_bindgen(js_name = installOpfsSahpool)]
 pub async fn install_opfs_sahpool() {
-    sqlite_wasm_rs::sahpool_vfs::install(None, false)
-        .await
-        .unwrap();
+    use sqlite_wasm_rs::sahpool_vfs::{install, OpfsSAHPoolCfg};
+    install(&OpfsSAHPoolCfg::default(), false).await.unwrap();
 }
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 #[wasm_bindgen(js_name = installRelaxedIdb)]
 pub async fn install_relaxed_idb() {
-    sqlite_wasm_rs::relaxed_idb_vfs::install(None, false)
-        .await
-        .unwrap();
+    use sqlite_wasm_rs::relaxed_idb_vfs::{install, RelaxedIdbCfg};
+    install(&RelaxedIdbCfg::default(), false).await.unwrap();
 }
 
 #[wasm_bindgen(js_name = switchVfs)]


### PR DESCRIPTION
https://github.com/Spxg/sqlite-wasm-rs/releases/tag/0.4.0

A major version update, introducing some breaking changes. Actually, it has no impact on diesel, because the SQLite C API is stable, only the example needs to be updated.

The sqlite-wasm-rs version from `0.x` to `0.x+1` is considered a major version update, so some unnecessary range restrictions are removed, and bundled is the default feature, so some useless configurations are removed.

Playground: https://sqlight.dev