### PR TITLE
Fix print-schema crash with mariadb client library

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -410,6 +410,12 @@ impl BindData {
         } else {
             let data = self.bytes?;
             let tpe = (self.tpe, self.flags).into();
+            // On some distributions, the mariadb client library returns length 0 for NULL fields of type DECIMAL
+            // instead of using is_null for unknown reasons
+            if self.tpe == self::ffi::enum_field_types::MYSQL_TYPE_LONGLONG && self.length == 0 {
+                return None;
+            }
+
             let slice = unsafe {
                 // We know that this points to a slice and the pointer is not null at this
                 // location


### PR DESCRIPTION
In certain Linux distributions, the MariaDB client library incorrectly returns a length of 0 for NULL Decimal fields, rather than utilizing the is_null flag as expected.

`diesel print-schema` fails in this case with
`Failed to execute a database query: Error deserializing field 'character_maximum_length': could not convert slice to array`.

This patch introduces an additional check to handle this specific case.

See discussion #4630.