### PR TITLE
Try to fix metrics job

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,17 +4,14 @@ on:
   push:
     branches:
       - try_to_fix_metrics_job
-
 name: Metrics
 permissions:
   contents: "read"
-
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
   RUSTFLAGS: "-C target-cpu=native"
-
 jobs:
   metrics:
     runs-on: ubuntu-latest
@@ -25,12 +22,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-
       - name: cache
         uses: Swatinem/rust-cache@v2
         with:
           key: metrics-${{matrix.backend}}-cargo-${{ hashFiles('diesel_bench/Cargo.toml')}}
-
       - name: Install postgres (Linux)
         if: matrix.backend == 'postgres'
         env:
@@ -53,7 +48,6 @@ jobs:
           sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
           sudo service postgresql restart $PG_VERSION && sleep 3
           echo 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/' >> $GITHUB_ENV
-
       - name: Install sqlite (Linux)
         if: matrix.backend == 'sqlite'
         run: |
@@ -61,7 +55,6 @@ jobs:
           sudo apt-get install -y libsqlite3-dev
           echo 'SQLITE_DATABASE_URL=/tmp/test.db' >> $GITHUB_ENV
           echo 'DATABASE_URL=sqlite:///tmp/test.db' >> $GITHUB_ENV
-
       - name: Install mysql (Linux)
         if: matrix.backend == 'mysql'
         run: |
@@ -70,22 +63,17 @@ jobs:
           sudo apt-get -y install libmysqlclient-dev
           mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'localhost';" -uroot -proot
           echo 'DATABASE_URL=mysql://root:root@localhost/diesel_test' >> $GITHUB_ENV
-
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
-
       - name: Run Benchmarks (Postgres)
         if: matrix.backend == 'postgres'
-        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "postgres sqlx-bench sqlx/postgres rand_chacha rust_postgres tokio_postgres futures futures-util sea-orm sea-orm/sqlx-postgres criterion/async_tokio serde diesel-async diesel-async/postgres wtx"
-
+        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "postgres sqlx-bench sqlx/postgres rand_chacha rust_postgres tokio_postgres futures futures-util sea-orm sea-orm/sqlx-postgres criterion/async_tokio serde diesel-async diesel-async/postgres wtx wtx/postgres"
       - name: Run Benchmarks (Sqlite)
         if: matrix.backend == 'sqlite'
         run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "sqlite sqlx-bench sqlx/sqlite tokio rusqlite futures sea-orm sea-orm/sqlx-sqlite criterion/async_tokio diesel-async diesel-async/sqlite"
-
       - name: Run Benchmarks (Mysql)
         if: matrix.backend == 'mysql'
-        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "mysql sqlx-bench sqlx/mysql tokio rustorm rustorm/with-mysql rand_chacha rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-mysql criterion/async_tokio serde diesel-async diesel-async/mysql wtx"
-
+        run: cargo +stable bench --no-fail-fast --manifest-path diesel_bench/Cargo.toml --no-default-features --features "mysql sqlx-bench sqlx/mysql tokio rustorm rustorm/with-mysql rand_chacha rustorm_dao rust_mysql futures sea-orm sea-orm/sqlx-mysql criterion/async_tokio serde diesel-async diesel-async/mysql wtx wtx/mysql"
       - name: Push metrics
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
@@ -126,7 +114,6 @@ jobs:
           git -c user.name=Bot -c user.email=dummy@example.com commit --message "📈"
 
           git push origin master
-
       - name: cleanup
         if: always()
         env:

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -34,9 +34,7 @@ futures-util = { version = "0.3", optional = true }
 criterion-perf-events = { version = "0.4", optional = true }
 perfcnt = { version = "0.8", optional = true }
 wtx = { default-features = false, features = [
-  "mysql",
   "optimization",
-  "postgres",
   "rand_chacha",
   "std",
   "tokio",

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -40,7 +40,7 @@ wtx = { default-features = false, features = [
   "rand_chacha",
   "std",
   "tokio",
-], optional = true, version = "0.35" }
+], optional = true, version = "0.34.0" }
 
 [dependencies.diesel-async]
 git = "https://github.com/weiznich/diesel_async"

--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -10,11 +10,11 @@ autobenches = false
 
 [dependencies]
 dotenvy = "0.15"
-criterion = { version = "0.5", default-features = false, features = [
+criterion = { version = "0.6", default-features = false, features = [
   "csv_output",
   "cargo_bench_support",
 ] }
-sqlx = { version = "0.8.3", features = [
+sqlx = { version = "0.8.6", features = [
   "runtime-tokio-rustls",
 ], optional = true }
 tokio = { version = "1", optional = true, features = ["rt-multi-thread"] }
@@ -22,7 +22,7 @@ rusqlite = { version = "0.32", optional = true }
 rust_postgres = { version = "0.19.7", optional = true, package = "postgres" }
 tokio_postgres = { version = "0.7.10", optional = true, package = "tokio-postgres" }
 rand_chacha = { features = ["os_rng"], optional = true, version = "0.9" }
-rust_mysql = { version = "25.0", optional = true, package = "mysql" }
+rust_mysql = { version = "26.0", optional = true, package = "mysql" }
 rustorm = { version = "0.20", optional = true }
 rustorm_dao = { version = "0.20", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
@@ -31,10 +31,22 @@ sea-orm = { version = "1.1.0", optional = true, features = [
 ] }
 futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true }
-diesel-async = { version = "0.5.0", optional = true, default-features = false }
 criterion-perf-events = { version = "0.4", optional = true }
 perfcnt = { version = "0.8", optional = true }
-wtx = { default-features = false, features = ["mysql", "optimization", "postgres", "rand_chacha", "std", "tokio"], optional = true, version = "0.28" }
+wtx = { default-features = false, features = [
+  "mysql",
+  "optimization",
+  "postgres",
+  "rand_chacha",
+  "std",
+  "tokio",
+], optional = true, version = "0.35" }
+
+[dependencies.diesel-async]
+git = "https://github.com/weiznich/diesel_async"
+branch = "main"
+optional = true
+default-features = false
 
 [dependencies.diesel]
 path = "../diesel"


### PR DESCRIPTION
What's changed:

- Properly defined `async-diesel` integral dependency via git and without versioning. It always tries to fetch the latest commit to be in sync with the latest `diesel` changes.
- Pinned `wtx` dependency to `v0.34.0` as the new `v0.35.0` uses `rsa v0.10.0-rc1` dependency and causes failed compilation.
- Separated `wtx` `postgres` and `mysql` features.