### PR TITLE
Bump to toml 0.9

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -42,7 +42,7 @@ clap_complete = "4"
 dotenvy = "0.15"
 heck = "0.5.0"
 serde = { version = "1.0.193", features = ["derive", "std"] }
-toml = "0.8"
+toml = "0.9"
 url = "2.2.2"
 libsqlite3-sys = { workspace = true, optional = true }
 pq-sys = { workspace = true, optional = true }

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["diesel", "internal"]
 
 [dependencies]
 serde = {version = "1.0.0", features = ["derive"]}
-toml = "0.8"
+toml = "0.9"


### PR DESCRIPTION
This just updates this dependency. No other changes are required. It shouldn't require a major version bump as this is an internal dependency.