### PR TITLE
Deny using backend specific SQL functions on other backends

### DIFF
--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -84,7 +84,9 @@ pub(crate) mod dsl {
     /// The return type of [`count_star()`](crate::dsl::count_star())
     pub type count_star = super::count::CountStar;
 
-    /// The return type of [`count_distinct()`](crate::dsl::count_distinct())
+    #[cfg(all(feature = "with-deprecated", not(feature = "without-deprecated")))]
+    #[deprecated]
+    #[doc(hidden)]
     pub type count_distinct<Expr> = super::count::CountDistinct<SqlTypeOf<Expr>, Expr>;
 
     /// The return type of [`date(expr)`](crate::dsl::date())

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -16,6 +16,7 @@ use crate::pg::expression::expression_methods::TextArrayOrNullableTextArray;
 use crate::sql_types::*;
 
 #[declare_sql_function]
+#[backends(crate::pg::Pg)]
 extern "SQL" {
     /// Creates an abbreviated display format as text.
     #[cfg(feature = "postgres_backend")]

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -11,6 +11,7 @@ use crate::sqlite::expression::expression_methods::TextOrNullableTextOrBinaryOrN
 
 #[cfg(feature = "sqlite")]
 #[declare_sql_function(generate_return_type_helpers = true)]
+#[backends(crate::sqlite::Sqlite)]
 extern "SQL" {
     /// Verifies that its argument is a valid JSON string or JSONB blob and returns a minified
     /// version of that JSON string with all unnecessary whitespace removed.

--- a/diesel_compile_tests/tests/fail/cannot_use_postgres_functions_with_sqlite_mysql.rs
+++ b/diesel_compile_tests/tests/fail/cannot_use_postgres_functions_with_sqlite_mysql.rs
@@ -1,0 +1,24 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+fn main() {
+    use diesel::dsl::*;
+
+    let sqlite_connection = &mut SqliteConnection::establish("…").unwrap();
+    let mysql_connection = &mut MysqlConnection::establish("…").unwrap();
+
+    let query = users::table.select(to_json(users::name));
+
+    let _ = query.execute(sqlite_connection);
+    //~^ ERROR: `to_json<Text, name>` is no valid SQL fragment for the `Sqlite` backend
+    let _ = query.execute(mysql_connection);
+    //~^ ERROR: `to_json<Text, name>` is no valid SQL fragment for the `Mysql` backend
+}

--- a/diesel_compile_tests/tests/fail/cannot_use_postgres_functions_with_sqlite_mysql.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_use_postgres_functions_with_sqlite_mysql.stderr
@@ -1,0 +1,54 @@
+error[E0277]: `to_json<Text, name>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/cannot_use_postgres_functions_with_sqlite_mysql.rs:20:27
+     |
+20   |     let _ = query.execute(sqlite_connection);
+     |                   ------- ^^^^^^^^^^^^^^^^^ the trait `QueryFragment<Sqlite>` is not implemented for `to_json<Text, name>`
+     |                   |
+     |                   required by a bound introduced by this call
+     |
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is not implemented for `to_json<Text, name>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Sqlite`
+     = note: required for `SelectClause<to_json<Text, name>>` to implement `QueryFragment<Sqlite>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<to_json<Text, name>>>` to implement `QueryFragment<Sqlite>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<to_json<Text, name>>>` to implement `ExecuteDsl<diesel::SqliteConnection, Sqlite>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: `to_json<Text, name>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/cannot_use_postgres_functions_with_sqlite_mysql.rs:22:27
+     |
+22   |     let _ = query.execute(mysql_connection);
+     |                   ------- ^^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `to_json<Text, name>`
+     |                   |
+     |                   required by a bound introduced by this call
+     |
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `to_json<Text, name>`
+             but trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Pg`, found `Mysql`
+     = note: required for `SelectClause<to_json<Text, name>>` to implement `QueryFragment<Mysql>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<to_json<Text, name>>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<to_json<Text, name>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_use_sqlite_functions_with_postgres_mysql.rs
+++ b/diesel_compile_tests/tests/fail/cannot_use_sqlite_functions_with_postgres_mysql.rs
@@ -1,0 +1,24 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+fn main() {
+    use diesel::dsl::*;
+
+    let pg_connection = &mut PgConnection::establish("…").unwrap();
+    let mysql_connection = &mut MysqlConnection::establish("…").unwrap();
+
+    let query = users::table.select(json(users::name));
+
+    let _ = query.execute(pg_connection);
+    //~^ ERROR: `json<Text, name>` is no valid SQL fragment for the `Pg` backend
+    let _ = query.execute(mysql_connection);
+    //~^ ERROR: `json<Text, name>` is no valid SQL fragment for the `Mysql` backend
+}

--- a/diesel_compile_tests/tests/fail/cannot_use_sqlite_functions_with_postgres_mysql.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_use_sqlite_functions_with_postgres_mysql.stderr
@@ -1,0 +1,54 @@
+error[E0277]: `json<Text, name>` is no valid SQL fragment for the `Pg` backend
+    --> tests/fail/cannot_use_sqlite_functions_with_postgres_mysql.rs:20:27
+     |
+20   |     let _ = query.execute(pg_connection);
+     |                   ------- ^^^^^^^^^^^^^ the trait `QueryFragment<Pg>` is not implemented for `json<Text, name>`
+     |                   |
+     |                   required by a bound introduced by this call
+     |
+     = note: this usually means that the `Pg` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Pg, diesel::query_builder::private::NotSpecialized>` is not implemented for `json<Text, name>`
+             but trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Sqlite`, found `Pg`
+     = note: required for `SelectClause<json<Text, name>>` to implement `QueryFragment<Pg>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<json<Text, name>>>` to implement `QueryFragment<Pg>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<json<Text, name>>>` to implement `ExecuteDsl<diesel::PgConnection, Pg>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: `json<Text, name>` is no valid SQL fragment for the `Mysql` backend
+    --> tests/fail/cannot_use_sqlite_functions_with_postgres_mysql.rs:22:27
+     |
+22   |     let _ = query.execute(mysql_connection);
+     |                   ------- ^^^^^^^^^^^^^^^^ the trait `QueryFragment<Mysql>` is not implemented for `json<Text, name>`
+     |                   |
+     |                   required by a bound introduced by this call
+     |
+     = note: this usually means that the `Mysql` database system does not support 
+             this SQL syntax
+     = help: the trait `QueryFragment<Mysql, diesel::query_builder::private::NotSpecialized>` is not implemented for `json<Text, name>`
+             but trait `QueryFragment<Sqlite, diesel::query_builder::private::NotSpecialized>` is implemented for it
+     = help: for that trait implementation, expected `Sqlite`, found `Mysql`
+     = note: required for `SelectClause<json<Text, name>>` to implement `QueryFragment<Mysql>`
+     = note: 2 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<json<Text, name>>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<json<Text, name>>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This commit denies using backend specific SQL functions on other backends. Technically that is a breaking change as some of these function were usable on diesel 2.2.x or earlier. Practially speaking I would consider that as a bug fix as it just prevents additional queries to not compile that would otherwise fail at runtime.