### PR TITLE
Define built-in window functions

### DIFF
--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -338,6 +338,13 @@ pub trait SqlDialect: self::private::TrustedBackend {
         doc = "See [`sql_dialect::window_frame_clause_group_support`] for provided default implementations"
     )]
     type AggregateFunctionExpressions;
+
+    /// Configures whether built-in window functions require order clauses for this backend or not
+    #[cfg_attr(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+        doc = "See [`sql_dialect::built_in_window_function_require_order`] for provided default implementations"
+    )]
+    type BuiltInWindowFunctionRequireOrder;
 }
 
 /// This module contains all options provided by diesel to configure the [`SqlDialect`] trait.
@@ -603,6 +610,16 @@ pub(crate) mod sql_dialect {
         /// for window functions
         #[derive(Debug, Copy, Clone)]
         pub struct NoFrameFrameExclusionSupport;
+    }
+    /// This module contains all reusable options to configure [`SqlDialect::BuiltInWindowFunctionRequireOrder`]
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    pub mod built_in_window_function_require_order {
+        /// Indicates that this backend doesn't require any order clause
+        /// for built-in window functions
+        #[derive(Debug, Copy, Clone)]
+        pub struct NoOrderRequired;
     }
 }
 

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -1,3 +1,7 @@
+#[cfg(doc)]
+use super::functions::aggregate_expressions::{
+    AggregateExpressionMethods, WindowExpressionMethods,
+};
 use super::functions::declare_sql_function;
 use super::{Expression, ValidGrouping};
 use crate::backend::Backend;

--- a/diesel/src/expression/functions/aggregate_expressions/aggregate_order.rs
+++ b/diesel/src/expression/functions/aggregate_expressions/aggregate_order.rs
@@ -14,6 +14,7 @@ use crate::{Expression, QueryResult};
 
 empty_clause!(NoOrder);
 
+/// A order clause for window and aggregate function expressions
 #[derive(QueryId, Copy, Clone, Debug)]
 pub struct Order<T, const WINDOW: bool>(OrderClause<T>);
 

--- a/diesel/src/expression/functions/aggregate_expressions/frame_clause.rs
+++ b/diesel/src/expression/functions/aggregate_expressions/frame_clause.rs
@@ -185,7 +185,7 @@ simple_frame_expr_with_bound!(
 #[derive(Clone, Copy, Debug)]
 pub struct OffsetPreceding<T = u64>(T);
 
-// manual impl as the derive makes this dependent on a `T: QuerId` impl
+// manual impl as the derive makes this dependent on a `T: QueryId` impl
 // which is wrong
 impl QueryId for OffsetPreceding {
     type QueryId = ();
@@ -215,7 +215,7 @@ where
 #[derive(Clone, Copy, Debug)]
 pub struct OffsetFollowing<I = u64>(I);
 
-// manual impl as the derive makes this dependent on a `T: QuerId` impl
+// manual impl as the derive makes this dependent on a `T: QueryId` impl
 // which is wrong
 impl QueryId for OffsetFollowing {
     type QueryId = ();
@@ -415,7 +415,7 @@ impl FrameBoundDsl for u64 {
 // TODO: We might want to implement
 // it for datetime and date intervals?
 // The postgres documentation indicates that
-// something like `RANGE BETWEEN '1 day' PRECEDING AND '10 days' FOlLOWING`
+// something like `RANGE BETWEEN '1 day' PRECEDING AND '10 days' FOLLOWING`
 // is valid
 
 empty_clause!(NoExclusion);

--- a/diesel/src/expression/functions/aggregate_folding.rs
+++ b/diesel/src/expression/functions/aggregate_folding.rs
@@ -1,3 +1,5 @@
+#[cfg(doc)]
+use super::aggregate_expressions::AggregateExpressionMethods;
 use crate::expression::functions::declare_sql_function;
 use crate::sql_types::Foldable;
 

--- a/diesel/src/expression/functions/aggregate_ordering.rs
+++ b/diesel/src/expression/functions/aggregate_ordering.rs
@@ -1,4 +1,6 @@
 use self::private::SqlOrdAggregate;
+#[cfg(doc)]
+use super::aggregate_expressions::AggregateExpressionMethods;
 use crate::expression::functions::declare_sql_function;
 
 #[declare_sql_function]

--- a/diesel/src/expression/functions/helper_types.rs
+++ b/diesel/src/expression/functions/helper_types.rs
@@ -22,5 +22,26 @@ pub type avg<Expr> = super::aggregate_folding::avg<SqlTypeOf<Expr>, Expr>;
 /// The return type of [`exists(expr)`](crate::dsl::exists())
 pub type exists<Expr> = crate::expression::exists::Exists<Expr>;
 
+/// The return type of [`lag(expr)`](crate::dsl::lag())
+pub type lag<Expr> = super::window_functions::lag<SqlTypeOf<Expr>, Expr>;
+/// The return type of [`lag_with_offset(expr, offset)`](crate::dsl::lag_with_offset())
+pub type lag_with_offset<V, O> = super::window_functions::lag_with_offset<SqlTypeOf<V>, V, O>;
+/// The return type of [`lag_with_offset_and_default(expr, offset)`](crate::dsl::lag_with_offset_and_default())
+pub type lag_with_offset_and_default<V, O, D> =
+    super::window_functions::lag_with_offset_and_default<SqlTypeOf<V>, SqlTypeOf<D>, V, O, D>;
+/// The return type of [`lead(expr)`](crate::dsl::lead())
+pub type lead<Expr> = super::window_functions::lead<SqlTypeOf<Expr>, Expr>;
+/// The return type of [`lead_with_offset(expr, offset)`](crate::dsl::lead_with_offset())
+pub type lead_with_offset<V, O> = super::window_functions::lead_with_offset<SqlTypeOf<V>, V, O>;
+/// The return type of [`lead_with_offset_and_default(expr, offset)`](crate::dsl::lead_with_offset_and_default())
+pub type lead_with_offset_and_default<V, O, D> =
+    super::window_functions::lead_with_offset_and_default<SqlTypeOf<V>, SqlTypeOf<D>, V, O, D>;
+/// The return type of [`first_value(expr)`](crate::dsl::first_value())
+pub type first_value<Expr> = super::window_functions::first_value<SqlTypeOf<Expr>, Expr>;
+/// The return type of [`last_value(expr)`](crate::dsl::last_value())
+pub type last_value<Expr> = super::window_functions::last_value<SqlTypeOf<Expr>, Expr>;
+/// The return type of [`nth_value(expr, n)`](crate::dsl::nth_value())
+pub type nth_value<V, N> = super::window_functions::nth_value<SqlTypeOf<V>, V, N>;
+
 #[doc(inline)]
 pub use super::aggregate_expressions::dsl::*;

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -102,3 +102,4 @@ pub(crate) mod aggregate_folding;
 pub(crate) mod aggregate_ordering;
 pub(crate) mod date_and_time;
 pub(crate) mod helper_types;
+pub(crate) mod window_functions;

--- a/diesel/src/expression/functions/window_functions.rs
+++ b/diesel/src/expression/functions/window_functions.rs
@@ -1,0 +1,696 @@
+#[cfg(doc)]
+use super::aggregate_expressions::WindowExpressionMethods;
+use crate::sql_types::helper::CombinedNullableValue;
+use crate::sql_types::{Integer, IntoNotNullable, IntoNullable, SingleValue, SqlType};
+use diesel_derives::declare_sql_function;
+
+#[declare_sql_function]
+extern "SQL" {
+
+    /// Number of th current row within its partition
+    ///
+    /// Returns the number of the current row within its partition, counting from 1.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts.select((title, user_id, row_number().partition_by(user_id))).load::<(String, i32, i64)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 1),
+    ///     ("About Rust".into(), 1, 2),
+    ///     ("My first post too".into(), 2, 1),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window]
+    fn row_number() -> BigInt;
+
+    /// Rank of current row within its partition, with gaps
+    ///
+    /// Returns the rank of the current row, with gaps;
+    /// that is, the row_number of the first row in its peer group.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, rank().partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, i64)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 1),
+    ///     ("About Rust".into(), 1, 1),
+    ///     ("My first post too".into(), 2, 1),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn rank() -> BigInt;
+
+    /// Rank of current row within its partition, without gaps
+    ///
+    /// Returns the rank of the current row, without gaps;
+    /// this function effectively counts peer groups.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, dense_rank().partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, i64)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 1),
+    ///     ("About Rust".into(), 1, 1),
+    ///     ("My first post too".into(), 2, 1),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn dense_rank() -> BigInt;
+
+    /// Percentage rank value
+    ///
+    /// Returns the relative rank of the current row,
+    /// that is (rank - 1) / (total partition rows - 1).
+    /// The value thus ranges from 0 to 1 inclusive.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, percent_rank().partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, f64)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 0.0),
+    ///     ("About Rust".into(), 1, 0.0),
+    ///     ("My first post too".into(), 2, 0.0),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn percent_rank() -> Double;
+
+    /// Cumulative distribution value
+    ///
+    /// Returns the cumulative distribution,
+    /// that is (number of partition rows preceding or peers with current row) / (total partition rows).
+    /// The value thus ranges from 1/N to 1.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, cume_dist().partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, f64)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 1.0),
+    ///     ("About Rust".into(), 1, 1.0),
+    ///     ("My first post too".into(), 2, 1.0),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn cume_dist() -> Double;
+
+    /// Bucket number of current row within its partition
+    ///
+    /// Returns an integer ranging from 1 to the argument value,
+    /// dividing the partition as equally as possible.
+    ///
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts.select((title, user_id, ntile(2).partition_by(user_id))).load::<(String, i32, i32)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 1),
+    ///     ("About Rust".into(), 1, 2),
+    ///     ("My first post too".into(), 2, 1),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window]
+    fn ntile(num_buckets: Integer) -> Integer;
+
+    /// Value of argument from row lagging current row within partition
+    ///
+    /// Returns value evaluated at the row that is one row before the current
+    /// row within the partition. If there is no such row, NULL is returned instead.
+    ///
+    /// See [`lag_with_offset`] and [`lag_with_offset_and_default`] for variants with configurable offset
+    /// and default values.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, lag(id).partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, None),
+    ///     ("About Rust".into(), 1, Some(1)),
+    ///     ("My first post too".into(), 2, None),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn lag<T: SqlType + SingleValue + IntoNullable<Nullable: SingleValue>>(value: T)
+        -> T::Nullable;
+
+    /// Value of argument from row lagging current row within partition
+    ///
+    /// Returns value evaluated at the row that is offset rows before the current
+    /// row within the partition; If there is no such row, NULL is returned instead.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, lag_with_offset(id, 1).partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, None),
+    ///     ("About Rust".into(), 1, Some(1)),
+    ///     ("My first post too".into(), 2, None),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "lag")]
+    #[sql_name = "lag"]
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn lag_with_offset<T: SqlType + SingleValue + IntoNullable<Nullable: SingleValue>>(
+        value: T,
+        offset: Integer,
+    ) -> T::Nullable;
+
+    /// Value of argument from row lagging current row within partition
+    ///
+    /// Returns value evaluated at the row that is offset rows before the current
+    /// row within the partition; if there is no such row, instead returns default
+    /// (which must be of a type compatible with value).
+    /// Both offset and default are evaluated with respect to the current row.
+    /// If omitted, offset defaults to 1 and default to NULL.
+    ///
+    /// This function returns a nullable value if either the value or the default expression are
+    /// nullable.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # #[cfg(not(feature = "mysql"))] // mariadb doesn't support this variant
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     use diesel::sql_types::{Integer, Nullable};
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, lag_with_offset_and_default(id, 1, user_id).partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, i32)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 1),
+    ///     ("About Rust".into(), 1, 1),
+    ///     ("My first post too".into(), 2, 2),
+    /// ];
+    /// assert_eq!(expected, res);
+    ///
+    /// let res = posts
+    ///     .select((
+    ///         title,
+    ///         user_id,
+    ///         lag_with_offset_and_default(None::<i32>.into_sql::<Nullable<Integer>>(), 1, user_id)
+    ///             .partition_by(user_id)
+    ///             .window_order(user_id)
+    ///     ))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, Some(1)),
+    ///     ("About Rust".into(), 1, None),
+    ///     ("My first post too".into(), 2, Some(2)),
+    /// ];
+    /// assert_eq!(expected, res);
+    ///
+    /// let res = posts
+    ///     .select((
+    ///         title,
+    ///         user_id,
+    ///         lag_with_offset_and_default(id, 1, None::<i32>.into_sql::<Nullable<Integer>>())
+    ///             .partition_by(user_id)
+    ///             .window_order(user_id)
+    ///     ))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, None),
+    ///     ("About Rust".into(), 1, Some(1)),
+    ///     ("My first post too".into(), 2, None),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(feature = "mysql")]
+    /// # fn main() {}
+    /// ```
+    #[doc(alias = "lag")]
+    #[sql_name = "lag"]
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn lag_with_offset_and_default<
+        T: SqlType
+            + SingleValue
+            + IntoNotNullable<NotNullable: self::private::SameType<T2::NotNullable>>
+            + CombinedNullableValue<T2, T::NotNullable>,
+        T2: SqlType + SingleValue + IntoNotNullable,
+    >(
+        value: T,
+        offset: Integer,
+        default: T2,
+    ) -> T::Out;
+
+    /// Value of argument from row leading current row within partition
+    ///
+    /// Returns value evaluated at the row that is offset rows after the current
+    /// row within the partition; if there is no such row,
+    /// `NULL` will be returned instead.
+    ///
+    /// See [`lead_with_offset`] and [`lead_with_offset_and_default`] for variants with configurable offset
+    /// and default values.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, lead(id).partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, Some(2)),
+    ///     ("About Rust".into(), 1, None),
+    ///     ("My first post too".into(), 2, None),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn lead<T: SqlType + SingleValue + IntoNullable<Nullable: SingleValue>>(
+        value: T,
+    ) -> T::Nullable;
+
+    /// Value of argument from row leading current row within partition
+    ///
+    /// Returns value evaluated at the row that is offset rows after the current
+    /// row within the partition; if there is no such row,
+    /// `NULL` is returned instead
+    ///
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, lead_with_offset(id, 1).partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, Some(2)),
+    ///     ("About Rust".into(), 1, None),
+    ///     ("My first post too".into(), 2, None),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[doc(alias = "lead")]
+    #[sql_name = "lead"]
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn lead_with_offset<T: SqlType + SingleValue + IntoNullable<Nullable: SingleValue>>(
+        value: T,
+        offset: Integer,
+    ) -> T::Nullable;
+
+    /// Value of argument from row leading current row within partition
+    ///
+    /// Returns value evaluated at the row that is offset rows after the current
+    /// row within the partition; if there is no such row,
+    /// instead returns default (which must be of a type compatible with value).
+    /// Both offset and default are evaluated with respect to the current row.
+    /// If omitted, offset defaults to 1 and default to NULL.
+    ///
+    /// This function returns a nullable value if either the value or the default expression are
+    /// nullable.
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// For MySQL this function requires you to call [`.window_order()](WindowExpressionMethods::window_order())
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # #[cfg(not(feature = "mysql"))] // mariadb doesn't support this variant
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     use diesel::sql_types::{Integer, Nullable};
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts
+    ///     .select((title, user_id, lead_with_offset_and_default(id, 1, user_id).partition_by(user_id).window_order(user_id)))
+    ///     .load::<(String, i32, i32)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 2),
+    ///     ("About Rust".into(), 1, 1),
+    ///     ("My first post too".into(), 2, 2),
+    /// ];
+    /// assert_eq!(expected, res);
+    ///
+    /// let res = posts
+    ///     .select((
+    ///         title,
+    ///         user_id,
+    ///         lead_with_offset_and_default(None::<i32>.into_sql::<Nullable<Integer>>(), 1, user_id)
+    ///             .partition_by(user_id)
+    ///             .window_order(user_id)
+    ///     ))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, None),
+    ///     ("About Rust".into(), 1, Some(1)),
+    ///     ("My first post too".into(), 2, Some(2)),
+    /// ];
+    /// assert_eq!(expected, res);
+    ///
+    /// let res = posts
+    ///     .select((
+    ///         title,
+    ///         user_id,
+    ///         lead_with_offset_and_default(id, 1, None::<i32>.into_sql::<Nullable<Integer>>())
+    ///             .partition_by(user_id)
+    ///             .window_order(user_id)
+    ///     ))
+    ///     .load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, Some(2)),
+    ///     ("About Rust".into(), 1, None),
+    ///     ("My first post too".into(), 2, None),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(feature = "mysql")]
+    /// fn main() {}
+    /// ```
+    #[doc(alias = "lead")]
+    #[sql_name = "lead"]
+    #[window(dialect(
+        BuiltInWindowFunctionRequireOrder,
+        crate::backend::sql_dialect::built_in_window_function_require_order::NoOrderRequired
+    ))]
+    #[cfg_attr(
+        feature = "mysql_backend",
+        window(backends(diesel::mysql::Mysql), require_order = true)
+    )]
+    fn lead_with_offset_and_default<
+        T: SqlType
+            + SingleValue
+            + IntoNotNullable<NotNullable: self::private::SameType<T2::NotNullable>>
+            + CombinedNullableValue<T2, T::NotNullable>,
+        T2: SqlType + SingleValue + IntoNotNullable,
+    >(
+        value: T,
+        offset: Integer,
+        default: T2,
+    ) -> T::Out;
+
+    /// Value of argument from first row of window frame
+    ///
+    /// Returns value evaluated at the row that is the first row of the window frame.
+    ///
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts.select((title, user_id, first_value(id).partition_by(user_id))).load::<(String, i32, i32)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 1),
+    ///     ("About Rust".into(), 1, 1),
+    ///     ("My first post too".into(), 2, 3),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window]
+    fn first_value<T: SqlType + SingleValue>(value: T) -> T;
+
+    /// Value of argument from last row of window frame
+    ///
+    /// Returns value evaluated at the row that is the last row of the window frame.
+    ///
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts.select((title, user_id, last_value(id).partition_by(user_id))).load::<(String, i32, i32)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, 2),
+    ///     ("About Rust".into(), 1, 2),
+    ///     ("My first post too".into(), 2, 3),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window]
+    fn last_value<T: SqlType + SingleValue>(value: T) -> T;
+
+    /// Value of argument from N-th row of window frame
+    ///
+    /// Returns value evaluated at the row that is the n'th row of the window frame (counting from 1);
+    /// returns NULL if there is no such row.
+    ///
+    ///
+    /// This function must be used as window function. You need to call at least one
+    /// of the methods [`WindowExpressionMethods`] from to use this function in your `SELECT`
+    /// clause. It cannot be used outside of `SELECT` clauses.
+    ///
+    /// ```
+    /// # include!("../../doctest_setup.rs");
+    /// # use diesel::dsl::*;
+    /// #
+    /// # fn main() -> QueryResult<()> {
+    /// #     use schema::posts::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// let res = posts.select((title, user_id, nth_value(id, 2).partition_by(user_id))).load::<(String, i32, Option<i32>)>(connection)?;
+    /// let expected = vec![
+    ///     ("My first post".to_owned(), 1, Some(2)),
+    ///     ("About Rust".into(), 1, Some(2)),
+    ///     ("My first post too".into(), 2, None),
+    /// ];
+    /// assert_eq!(expected, res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[window]
+    fn nth_value<T: SqlType + SingleValue + IntoNullable<Nullable: SingleValue>>(
+        value: T,
+        n: Integer,
+    ) -> T::Nullable;
+}
+
+mod private {
+    pub trait SameType<T> {}
+
+    impl<T> SameType<T> for T {}
+}

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -66,6 +66,8 @@ pub(crate) mod dsl {
     #[doc(inline)]
     pub use super::functions::date_and_time::*;
     #[doc(inline)]
+    pub use super::functions::window_functions::*;
+    #[doc(inline)]
     pub use super::helper_types::{case_when, IntoSql, Otherwise, When};
     #[doc(inline)]
     pub use super::not::not;
@@ -723,6 +725,10 @@ impl<T: ValidGrouping<GB> + ?Sized, GB> ValidGrouping<GB> for Box<T> {
 
 impl<T: ValidGrouping<GB> + ?Sized, GB> ValidGrouping<GB> for &T {
     type IsAggregate = T::IsAggregate;
+}
+
+impl<GB> ValidGrouping<GB> for () {
+    type IsAggregate = is_aggregate::Never;
 }
 
 #[doc(inline)]

--- a/diesel/src/internal/sql_functions.rs
+++ b/diesel/src/internal/sql_functions.rs
@@ -1,4 +1,5 @@
 #[doc(hidden)]
 pub use crate::expression::functions::aggregate_expressions::{
-    FunctionFragment, IsAggregateFunction, IsWindowFunction, OverClause, WindowFunctionFragment,
+    FunctionFragment, IsAggregateFunction, IsWindowFunction, Order, OverClause,
+    WindowFunctionFragment,
 };

--- a/diesel/src/mysql/backend.rs
+++ b/diesel/src/mysql/backend.rs
@@ -99,6 +99,8 @@ impl SqlDialect for Mysql {
 
     type AggregateFunctionExpressions =
         sql_dialect::aggregate_function_expressions::NoAggregateFunctionExpressions;
+
+    type BuiltInWindowFunctionRequireOrder = MysqlRequiresOrderForWindowFunctions;
 }
 
 impl DieselReserveSpecialization for Mysql {}
@@ -112,5 +114,8 @@ pub struct MysqlConcatClause;
 
 #[derive(Debug, Clone, Copy)]
 pub struct MysqlOnConflictClause;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MysqlRequiresOrderForWindowFunctions;
 
 impl SupportsOnConflictClause for MysqlOnConflictClause {}

--- a/diesel/src/pg/backend.rs
+++ b/diesel/src/pg/backend.rs
@@ -147,6 +147,9 @@ impl SqlDialect for Pg {
         sql_dialect::window_frame_exclusion_support::FrameExclusionSupport;
     type AggregateFunctionExpressions =
         sql_dialect::aggregate_function_expressions::PostgresLikeAggregateFunctionExpressions;
+
+    type BuiltInWindowFunctionRequireOrder =
+        sql_dialect::built_in_window_function_require_order::NoOrderRequired;
 }
 
 impl DieselReserveSpecialization for Pg {}

--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -1,11 +1,11 @@
 //! PostgreSQL specific expression methods
 
 pub(in crate::pg) use self::private::{
-    ArrayOrNullableArray, CombinedAllNullableValue, CombinedNullableValue, InetOrCidr, JsonIndex,
-    JsonOrNullableJson, JsonOrNullableJsonOrJsonbOrNullableJsonb, JsonRemoveIndex,
-    JsonbOrNullableJsonb, MaybeNullableValue, MultirangeOrNullableMultirange,
-    MultirangeOrRangeMaybeNullable, RangeOrMultirange, RangeOrNullableRange,
-    RecordOrNullableRecord, TextArrayOrNullableTextArray, TextOrNullableText,
+    ArrayOrNullableArray, CombinedAllNullableValue, InetOrCidr, JsonIndex, JsonOrNullableJson,
+    JsonOrNullableJsonOrJsonbOrNullableJsonb, JsonRemoveIndex, JsonbOrNullableJsonb,
+    MaybeNullableValue, MultirangeOrNullableMultirange, MultirangeOrRangeMaybeNullable,
+    RangeOrMultirange, RangeOrNullableRange, RecordOrNullableRecord, TextArrayOrNullableTextArray,
+    TextOrNullableText,
 };
 use super::date_and_time::{AtTimeZone, DateTimeLike};
 use super::operators::*;
@@ -3621,7 +3621,7 @@ where
 pub(in crate::pg) mod private {
     use crate::sql_types::{
         AllAreNullable, Array, Binary, Cidr, Inet, Integer, Json, Jsonb, MaybeNullableType,
-        Multirange, Nullable, OneIsNullable, Range, Record, SingleValue, SqlType, Text,
+        Multirange, Nullable, Range, Record, SingleValue, SqlType, Text,
     };
     use crate::{Expression, IntoSql};
 
@@ -3931,21 +3931,6 @@ pub(in crate::pg) mod private {
         <T::IsNull as MaybeNullableType<O>>::Out: SingleValue,
     {
         type Out = <T::IsNull as MaybeNullableType<O>>::Out;
-    }
-
-    pub trait CombinedNullableValue<O, Out>: SingleValue {
-        type Out: SingleValue;
-    }
-
-    impl<T, O, Out> CombinedNullableValue<O, Out> for T
-    where
-        T: SingleValue,
-        O: SingleValue,
-        T::IsNull: OneIsNullable<O::IsNull>,
-        <T::IsNull as OneIsNullable<O::IsNull>>::Out: MaybeNullableType<Out>,
-        <<T::IsNull as OneIsNullable<O::IsNull>>::Out as MaybeNullableType<Out>>::Out: SingleValue,
-    {
-        type Out = <<T::IsNull as OneIsNullable<O::IsNull>>::Out as MaybeNullableType<Out>>::Out;
     }
 
     #[diagnostic::on_unimplemented(

--- a/diesel/src/pg/expression/functions.rs
+++ b/diesel/src/pg/expression/functions.rs
@@ -4,7 +4,6 @@ use super::expression_methods::InetOrCidr;
 use crate::expression::functions::declare_sql_function;
 use crate::pg::expression::expression_methods::ArrayOrNullableArray;
 use crate::pg::expression::expression_methods::CombinedAllNullableValue;
-use crate::pg::expression::expression_methods::CombinedNullableValue;
 use crate::pg::expression::expression_methods::JsonOrNullableJson;
 use crate::pg::expression::expression_methods::JsonbOrNullableJsonb;
 use crate::pg::expression::expression_methods::MaybeNullableValue;
@@ -13,6 +12,7 @@ use crate::pg::expression::expression_methods::MultirangeOrRangeMaybeNullable;
 use crate::pg::expression::expression_methods::RangeOrNullableRange;
 use crate::pg::expression::expression_methods::RecordOrNullableRecord;
 use crate::pg::expression::expression_methods::TextArrayOrNullableTextArray;
+use crate::sql_types::helper::CombinedNullableValue;
 use crate::sql_types::*;
 
 #[declare_sql_function]

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -800,3 +800,22 @@ impl BoolOrNullableBool for Nullable<Bool> {}
 
 #[doc(inline)]
 pub use crate::expression::expression_types::Untyped;
+
+pub(crate) mod helper {
+    use super::{MaybeNullableType, OneIsNullable, SingleValue};
+
+    pub trait CombinedNullableValue<O, Out>: SingleValue {
+        type Out: SingleValue;
+    }
+
+    impl<T, O, Out> CombinedNullableValue<O, Out> for T
+    where
+        T: SingleValue,
+        O: SingleValue,
+        T::IsNull: OneIsNullable<O::IsNull>,
+        <T::IsNull as OneIsNullable<O::IsNull>>::Out: MaybeNullableType<Out>,
+        <<T::IsNull as OneIsNullable<O::IsNull>>::Out as MaybeNullableType<Out>>::Out: SingleValue,
+    {
+        type Out = <<T::IsNull as OneIsNullable<O::IsNull>>::Out as MaybeNullableType<Out>>::Out;
+    }
+}

--- a/diesel/src/sqlite/backend.rs
+++ b/diesel/src/sqlite/backend.rs
@@ -74,6 +74,8 @@ impl SqlDialect for Sqlite {
         sql_dialect::window_frame_exclusion_support::FrameExclusionSupport;
     type AggregateFunctionExpressions =
         sql_dialect::aggregate_function_expressions::PostgresLikeAggregateFunctionExpressions;
+    type BuiltInWindowFunctionRequireOrder =
+        sql_dialect::built_in_window_function_require_order::NoOrderRequired;
 }
 
 impl DieselReserveSpecialization for Sqlite {}

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1,4 +1,6 @@
 //! SQLite specific functions
+#[cfg(doc)]
+use crate::expression::functions::aggregate_expressions::AggregateExpressionMethods;
 use crate::expression::functions::declare_sql_function;
 use crate::sql_types::*;
 use crate::sqlite::expression::expression_methods::BinaryOrNullableBinary;
@@ -898,8 +900,8 @@ extern "SQL" {
     /// ```
     ///
     /// # See also
-    /// - [`jsonb_group_array`] will return data in JSONB format instead of JSON.
-    /// - [`json_group_object`] will return JSON object instead of array.
+    /// - [`jsonb_group_array`](jsonb_group_array()) will return data in JSONB format instead of JSON.
+    /// - [`json_group_object`](json_group_object()) will return JSON object instead of array.
     #[cfg(feature = "sqlite")]
     #[aggregate]
     fn json_group_array<E: SqlType + SingleValue>(elements: E) -> Json;
@@ -970,8 +972,8 @@ extern "SQL" {
     /// ```
     ///
     /// # See also
-    /// - [`json_group_array`] will return data in JSON format instead of JSONB.
-    /// - [`jsonb_group_object`] will return JSONB object instead of array.
+    /// - [`json_group_array`](json_group_array()) will return data in JSON format instead of JSONB.
+    /// - [`jsonb_group_object`](jsonb_group_object()) will return JSONB object instead of array.
     #[cfg(feature = "sqlite")]
     #[aggregate]
     fn jsonb_group_array<E: SqlType + SingleValue>(elements: E) -> Jsonb;
@@ -1057,8 +1059,8 @@ extern "SQL" {
     /// ```
     ///
     /// # See also
-    /// - [`jsonb_group_object`] will return data in JSONB format instead of JSON.
-    /// - [`json_group_array`] will return JSON array instead of object.
+    /// - [`jsonb_group_object`](jsonb_group_object()) will return data in JSONB format instead of JSON.
+    /// - [`json_group_array`](json_group_array()) will return JSON array instead of object.
     #[cfg(feature = "sqlite")]
     #[aggregate]
     fn json_group_object<
@@ -1150,8 +1152,8 @@ extern "SQL" {
     /// ```
     ///
     /// # See also
-    /// - [`json_group_object`] will return data in JSON format instead of JSONB.
-    /// - [`jsonb_group_array`] will return JSONB array instead of object.
+    /// - [`json_group_object`](jsonb_group_array()) will return data in JSON format instead of JSONB.
+    /// - [`jsonb_group_array`](jsonb_group_array()) will return JSONB array instead of object.
     #[cfg(feature = "sqlite")]
     #[aggregate]
     fn jsonb_group_object<

--- a/diesel_compile_tests/tests/fail/aggregate_expressions_disallow_unsupported_features_on_mysql.rs
+++ b/diesel_compile_tests/tests/fail/aggregate_expressions_disallow_unsupported_features_on_mysql.rs
@@ -22,6 +22,6 @@ fn main() {
     users::table
         .select(dsl::count(users::id).aggregate_order(users::name))
         .get_result::<i64>(&mut conn)
-        //~^ ERROR: `Order<name, false>` is no valid SQL fragment for the `Mysql` backend
+        //~^ ERROR: `Order<columns::name, false>` is no valid SQL fragment for the `Mysql` backend
         .unwrap();
 }

--- a/diesel_compile_tests/tests/fail/aggregate_expressions_disallow_unsupported_features_on_mysql.stderr
+++ b/diesel_compile_tests/tests/fail/aggregate_expressions_disallow_unsupported_features_on_mysql.stderr
@@ -26,21 +26,21 @@ LL |         Self: LoadQuery<'query, Conn, U>,
      |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
   
      
-error[E0277]: `Order<name, false>` is no valid SQL fragment for the `Mysql` backend
+error[E0277]: `Order<columns::name, false>` is no valid SQL fragment for the `Mysql` backend
     --> tests/fail/aggregate_expressions_disallow_unsupported_features_on_mysql.rs:24:28
      |
 24   |         .get_result::<i64>(&mut conn)
-     |          ----------        ^^^^^^^^^ the trait `QueryFragment<Mysql, NoAggregateFunctionExpressions>` is not implemented for `Order<name, false>`
+     |          ----------        ^^^^^^^^^ the trait `QueryFragment<Mysql, NoAggregateFunctionExpressions>` is not implemented for `Order<columns::name, false>`
      |          |
      |          required by a bound introduced by this call
      |
      = note: this usually means that the `Mysql` database system does not support 
              this SQL syntax
      = help: the following other types implement trait `QueryFragment<DB, SP>`:
-               `diesel::expression::functions::aggregate_expressions::aggregate_order::Order<E, false>` implements `QueryFragment<DB, PostgresLikeAggregateFunctionExpressions>`
-               `diesel::expression::functions::aggregate_expressions::aggregate_order::Order<E, false>` implements `QueryFragment<DB>`
-               `diesel::expression::functions::aggregate_expressions::aggregate_order::Order<E, true>` implements `QueryFragment<DB>`
-     = note: required for `Order<name, false>` to implement `QueryFragment<Mysql>`
+               `Order<E, false>` implements `QueryFragment<DB, PostgresLikeAggregateFunctionExpressions>`
+               `Order<E, false>` implements `QueryFragment<DB>`
+               `Order<E, true>` implements `QueryFragment<DB>`
+     = note: required for `Order<columns::name, false>` to implement `QueryFragment<Mysql>`
      = note: 4 redundant requirements hidden
      = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
      = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `LoadQuery<'_, diesel::MysqlConnection, i64>`

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -43,13 +43,13 @@ error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
     |
     = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
               `&T` implements `ValidGrouping<GB>`
+              `()` implements `ValidGrouping<GB>`
               `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
             and N others
     = note: required for `(f64, f64)` to implement `ValidGrouping<()>`
     = note: 1 redundant requirement hidden
@@ -111,13 +111,13 @@ error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
      |
      = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
                `&T` implements `ValidGrouping<GB>`
+               `()` implements `ValidGrouping<GB>`
                `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
              and N others
      = note: required for `(f64, f64)` to implement `ValidGrouping<()>`
      = note: 1 redundant requirement hidden

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -43,13 +43,13 @@ error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
     |
     = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
               `&T` implements `ValidGrouping<GB>`
+              `()` implements `ValidGrouping<GB>`
               `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
             and N others
     = note: required for `(f64,)` to implement `ValidGrouping<()>`
     = note: 2 redundant requirements hidden
@@ -111,13 +111,13 @@ error[E0277]: the trait bound `f64: ValidGrouping<()>` is not satisfied
      |
      = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
                `&T` implements `ValidGrouping<GB>`
+               `()` implements `ValidGrouping<GB>`
                `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
              and N others
      = note: required for `(f64,)` to implement `ValidGrouping<()>`
      = note: 2 redundant requirements hidden
@@ -274,13 +274,13 @@ error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
     |
     = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
               `&T` implements `ValidGrouping<GB>`
+              `()` implements `ValidGrouping<GB>`
               `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
             and N others
     = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `ValidGrouping<()>`
     = note: 1 redundant requirement hidden
@@ -342,13 +342,13 @@ error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
      |
      = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
                `&T` implements `ValidGrouping<GB>`
+               `()` implements `ValidGrouping<GB>`
                `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
                `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-               `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
              and N others
      = note: required for `({integer}, diesel::expression::bound::Bound<diesel::sql_types::Double, f64>)` to implement `ValidGrouping<()>`
      = note: 1 redundant requirement hidden

--- a/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/find_requires_correct_type.stderr
@@ -27,13 +27,13 @@ LL |     int_primary_key::table.find("1");
    |
    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
              `&T` implements `ValidGrouping<GB>`
+             `()` implements `ValidGrouping<GB>`
              `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
              `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
              `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
              `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-             `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
            and N others
    = note: required for `&str` to implement `ValidGrouping<()>`
    = note: 1 redundant requirement hidden
@@ -86,13 +86,13 @@ error[E0277]: the trait bound `{integer}: ValidGrouping<()>` is not satisfied
     |
     = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
               `&T` implements `ValidGrouping<GB>`
+              `()` implements `ValidGrouping<GB>`
               `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
               `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
-              `(T0, T1, T2, T3, T4, T5, T6, T7)` implements `ValidGrouping<__GroupByClause>`
             and N others
     = note: required for `diesel::expression::operators::Eq<string_primary_key::columns::id, {integer}>` to implement `ValidGrouping<()>`
     = note: required for `Grouped<Eq<id, {integer}>>` to implement `NonAggregate`

--- a/diesel_compile_tests/tests/fail/reject_group_frames_without_other_frame_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/reject_group_frames_without_other_frame_clauses.stderr
@@ -6,8 +6,8 @@ LL |                 .frame_by(dsl::frame::Groups.frame_start_with(dsl::frame::U
    |
    = note: call `.window_order(some_column)` first
    = help: the trait `ValidFrameClause<diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder>` is not implemented for `Groups`
-           but trait `ValidFrameClause<diesel::expression::functions::aggregate_expressions::aggregate_order::Order<_, true>>` is implemented for it
-   = help: for that trait implementation, expected `diesel::expression::functions::aggregate_expressions::aggregate_order::Order<_, true>`, found `diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder`
+           but trait `ValidFrameClause<Order<_, true>>` is implemented for it
+   = help: for that trait implementation, expected `Order<_, true>`, found `diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder`
    = note: required for `StartFrame<Groups, UnboundedPreceding>` to implement `diesel::expression::functions::aggregate_expressions::frame_clause::ValidFrameClause<diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder>`
    = note: required for `diesel::expression::count::count_utils::count<diesel::sql_types::Integer, columns::id>` to implement `diesel::expression::functions::aggregate_expressions::frame_clause::FrameDsl<diesel::expression::functions::aggregate_expressions::frame_clause::StartFrame<Groups, UnboundedPreceding>>`
 

--- a/diesel_compile_tests/tests/fail/require_order_for_certain_window_functions_with_mysql.rs
+++ b/diesel_compile_tests/tests/fail/require_order_for_certain_window_functions_with_mysql.rs
@@ -1,0 +1,118 @@
+extern crate diesel;
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+fn main() {
+    let conn = &mut MysqlConnection::establish("").unwrap();
+    let _ = users::table
+        .select(dsl::rank().partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<rank, Mysql, ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::dense_rank().partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::percent_rank().partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::cume_dist().partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::lag(users::id).partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::lag_with_offset(users::id, 42).partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::lag_with_offset_and_default(users::id, 42, 42).partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::lead(users::id).partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::lead_with_offset(users::id, 42).partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    let _ = users::table
+        .select(dsl::lead_with_offset_and_default(users::id, 42, 42).partition_by(users::id))
+        .execute(conn);
+    //~^ ERROR: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+
+    // These impls work as Sqlite and Postgres doesn't require the order clause
+    let conn = &mut SqliteConnection::establish("").unwrap();
+    let _ = users::table
+        .select(dsl::rank().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::dense_rank().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::percent_rank().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::cume_dist().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lag(users::id).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lag_with_offset(users::id, 42).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lag_with_offset_and_default(users::id, 42, 42).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lead(users::id).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lead_with_offset(users::id, 42).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lead_with_offset_and_default(users::id, 42, 42).partition_by(users::id))
+        .execute(conn);
+
+    let conn = &mut PgConnection::establish("").unwrap();
+    let _ = users::table
+        .select(dsl::rank().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::dense_rank().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::percent_rank().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::cume_dist().partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lag(users::id).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lag_with_offset(users::id, 42).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lag_with_offset_and_default(users::id, 42, 42).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lead(users::id).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lead_with_offset(users::id, 42).partition_by(users::id))
+        .execute(conn);
+    let _ = users::table
+        .select(dsl::lead_with_offset_and_default(users::id, 42, 42).partition_by(users::id))
+        .execute(conn);
+}

--- a/diesel_compile_tests/tests/fail/require_order_for_certain_window_functions_with_mysql.stderr
+++ b/diesel_compile_tests/tests/fail/require_order_for_certain_window_functions_with_mysql.stderr
@@ -1,0 +1,340 @@
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<rank, Mysql, ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:15:18
+     |
+15   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::rank_utils::rank, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::rank_utils::rank, Mysql>`
+     = note: required for `AggregateExpression<rank, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:19:18
+     |
+19   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+     = note: required for `AggregateExpression<dense_rank, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:23:18
+     |
+23   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::percent_rank_utils::percent_rank, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::percent_rank_utils::percent_rank, Mysql>`
+     = note: required for `AggregateExpression<percent_rank, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:27:18
+     |
+27   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+     = note: required for `AggregateExpression<cume_dist, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:31:18
+     |
+31   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<diesel::sql_types::Integer, columns::id>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<diesel::sql_types::Integer, columns::id>, Mysql>`
+     = note: required for `AggregateExpression<lag<Integer, id>, NoPrefix, NoOrder, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:35:18
+     |
+35   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql>`
+     = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:39:18
+     |
+39   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql>`
+     = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:43:18
+     |
+43   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<diesel::sql_types::Integer, columns::id>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<diesel::sql_types::Integer, columns::id>, Mysql>`
+     = note: required for `AggregateExpression<lead<Integer, id>, NoPrefix, NoOrder, ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:47:18
+     |
+47   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql>`
+     = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     
+error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragment<..., ..., ...>` is not satisfied
+    --> tests/fail/require_order_for_certain_window_functions_with_mysql.rs:51:18
+     |
+51   |         .execute(conn);
+     |          ------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
+     = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
+               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
+             and N others
+     = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql>`
+     = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
+     = note: 3 redundant requirements hidden
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `QueryFragment<Mysql>`
+     = note: required for `SelectStatement<FromClause<table>, SelectClause<...>>` to implement `ExecuteDsl<diesel::MysqlConnection, Mysql>`
+note: required by a bound in `diesel::RunQueryDsl::execute`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn execute(self, conn: &mut Conn) -> QueryResult<usize>
+     |        ------- required by a bound in this associated function
+...
+LL |         Self: methods::ExecuteDsl<Conn>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::execute`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/window_function_can_only_be_called_with_window_expression_applied.rs
+++ b/diesel_compile_tests/tests/fail/window_function_can_only_be_called_with_window_expression_applied.rs
@@ -1,0 +1,20 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+fn main() {
+    use diesel::dsl::*;
+
+    users::table.select(lag(users::name));
+    //~^ ERROR: the trait bound `lag<Text, name>: ValidGrouping<()>` is not satisfied
+
+    users::table.select(rank());
+    //~^ ERROR: the trait bound `diesel::expression::functions::window_functions::rank_utils::rank: ValidGrouping<()>` is not satisfied
+}

--- a/diesel_compile_tests/tests/fail/window_function_can_only_be_called_with_window_expression_applied.stderr
+++ b/diesel_compile_tests/tests/fail/window_function_can_only_be_called_with_window_expression_applied.stderr
@@ -1,0 +1,61 @@
+error[E0277]: the trait bound `lag<Text, name>: ValidGrouping<()>` is not satisfied
+   --> tests/fail/window_function_can_only_be_called_with_window_expression_applied.rs:15:25
+    |
+15  |     users::table.select(lag(users::name));
+    |                  ------ ^^^^^^^^^^^^^^^^ the trait `ValidGrouping<()>` is not implemented for `lag<Text, name>`
+    |                  |
+    |                  required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `&T` implements `ValidGrouping<GB>`
+              `()` implements `ValidGrouping<GB>`
+              `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+            and N others
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::window_functions::lag_utils::lag<diesel::sql_types::Text, columns::name>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `SelectDsl<diesel::expression::functions::window_functions::lag_utils::lag<diesel::sql_types::Text, columns::name>>`
+note: required by a bound in `diesel::QueryDsl::select`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
+...
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+ 
+    
+error[E0277]: the trait bound `diesel::expression::functions::window_functions::rank_utils::rank: ValidGrouping<()>` is not satisfied
+   --> tests/fail/window_function_can_only_be_called_with_window_expression_applied.rs:18:25
+    |
+18  |     users::table.select(rank());
+    |                  ------ ^^^^^^ the trait `ValidGrouping<()>` is not implemented for `diesel::expression::functions::window_functions::rank_utils::rank`
+    |                  |
+    |                  required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `ValidGrouping<GroupByClause>`:
+              `&T` implements `ValidGrouping<GB>`
+              `()` implements `ValidGrouping<GB>`
+              `(T0, T1)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5)` implements `ValidGrouping<__GroupByClause>`
+              `(T0, T1, T2, T3, T4, T5, T6)` implements `ValidGrouping<__GroupByClause>`
+            and N others
+    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::window_functions::rank_utils::rank>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `SelectDsl<diesel::expression::functions::window_functions::rank_utils::rank>`
+note: required by a bound in `diesel::QueryDsl::select`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
+...
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.rs
+++ b/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.rs
@@ -1,0 +1,44 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+fn main() {
+    use diesel::dsl::*;
+
+    users::table.select(lower(users::name).partition_by(users::id));
+    //~^ ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+    //~| ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+
+    users::table.select(lower(users::name).over());
+    //~^ ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+    //~| ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+
+    users::table.select(lower(users::name).window_filter(users::id.eq(42)));
+    //~^ ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+    //~| ERROR: the trait bound `lower<Text, name>: IsAggregateFunction` is not satisfied
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+
+    users::table.select(lower(users::name).window_order(users::id));
+    //~^ ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+    //~| ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+
+    users::table
+        .select(lower(users::name).frame_by(frame::Rows.frame_start_with(frame::CurrentRow)));
+    //~^ ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+    //~| ERROR: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+    //~| ERROR: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+}

--- a/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.stderr
+++ b/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.stderr
@@ -1,0 +1,378 @@
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+   --> tests/fail/window_functions_expression_requires_window_function.rs:15:25
+    |
+15  |     users::table.select(lower(users::name).partition_by(users::id));
+    |                         ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+    = note: try to provide an expression that produces one of the expected sql types
+    = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+              Multirange<ST>
+              Nullable<Multirange<ST>>
+              Nullable<diesel::sql_types::Range<ST>>
+              diesel::sql_types::Range<ST>
+note: required by a bound in `diesel::dsl::lower`
+   --> DIESEL/diesel/diesel/src/pg/expression/functions.rs
+    |
+LL |     fn lower<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<R::Inner>;
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:15:44
+   |
+LL |     users::table.select(lower(users::name).partition_by(users::id));
+   |                                            ^^^^^^^^^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::partition_by::PartitionByDsl<_>`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:15:18
+   |
+LL |     users::table.select(lower(users::name).partition_by(users::id));
+   |                  ^^^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::PartitionBy<columns::id>>>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+  --> tests/fail/window_functions_expression_requires_window_function.rs:15:18
+   |
+LL |     users::table.select(lower(users::name).partition_by(users::id));
+   |                  ^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+   = note: try to provide an expression that produces one of the expected sql types
+   = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+             Multirange<ST>
+             Nullable<Multirange<ST>>
+             Nullable<diesel::sql_types::Range<ST>>
+             diesel::sql_types::Range<ST>
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::Expression`
+   = note: 1 redundant requirement hidden
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `diesel::Expression`
+   = note: required for `users::table` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::PartitionBy<columns::id>>>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+   --> tests/fail/window_functions_expression_requires_window_function.rs:21:25
+    |
+21  |     users::table.select(lower(users::name).over());
+    |                         ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+    = note: try to provide an expression that produces one of the expected sql types
+    = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+              Multirange<ST>
+              Nullable<Multirange<ST>>
+              Nullable<diesel::sql_types::Range<ST>>
+              diesel::sql_types::Range<ST>
+note: required by a bound in `diesel::dsl::lower`
+   --> DIESEL/diesel/diesel/src/pg/expression/functions.rs
+    |
+LL |     fn lower<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<R::Inner>;
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:21:44
+   |
+LL |     users::table.select(lower(users::name).over());
+   |                                            ^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::over_clause::OverDsl`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:21:18
+   |
+LL |     users::table.select(lower(users::name).over());
+   |                  ^^^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+  --> tests/fail/window_functions_expression_requires_window_function.rs:21:18
+   |
+LL |     users::table.select(lower(users::name).over());
+   |                  ^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+   = note: try to provide an expression that produces one of the expected sql types
+   = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+             Multirange<ST>
+             Nullable<Multirange<ST>>
+             Nullable<diesel::sql_types::Range<ST>>
+             diesel::sql_types::Range<ST>
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::Expression`
+   = note: 1 redundant requirement hidden
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `diesel::Expression`
+   = note: required for `users::table` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+   --> tests/fail/window_functions_expression_requires_window_function.rs:27:25
+    |
+27  |     users::table.select(lower(users::name).window_filter(users::id.eq(42)));
+    |                         ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+    = note: try to provide an expression that produces one of the expected sql types
+    = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+              Multirange<ST>
+              Nullable<Multirange<ST>>
+              Nullable<diesel::sql_types::Range<ST>>
+              diesel::sql_types::Range<ST>
+note: required by a bound in `diesel::dsl::lower`
+   --> DIESEL/diesel/diesel/src/pg/expression/functions.rs
+    |
+LL |     fn lower<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<R::Inner>;
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
+
+error[E0277]: the trait bound `lower<Text, name>: IsAggregateFunction` is not satisfied
+  --> tests/fail/window_functions_expression_requires_window_function.rs:27:44
+   |
+LL |     users::table.select(lower(users::name).window_filter(users::id.eq(42)));
+   |                                            ^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `IsAggregateFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = help: the following other types implement trait `IsAggregateFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::sqlite::expression::functions::json_group_array_utils::json_group_array<E, elements>
+             diesel::sqlite::expression::functions::json_group_object_utils::json_group_object<N, V, names, values>
+             diesel::sqlite::expression::functions::jsonb_group_array_utils::jsonb_group_array<E, elements>
+             diesel::sqlite::expression::functions::jsonb_group_object_utils::jsonb_group_object<N, V, names, values>
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::aggregate_filter::FilterDsl<_>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+  --> tests/fail/window_functions_expression_requires_window_function.rs:27:18
+   |
+LL |     users::table.select(lower(users::name).window_filter(users::id.eq(42)));
+   |                  ^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+   = note: try to provide an expression that produces one of the expected sql types
+   = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+             Multirange<ST>
+             Nullable<Multirange<ST>>
+             Nullable<diesel::sql_types::Range<ST>>
+             diesel::sql_types::Range<ST>
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::Expression`
+   = note: 1 redundant requirement hidden
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, Filter<...>>` to implement `diesel::Expression`
+   = note: required for `users::table` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::Filter<diesel::query_builder::where_clause::WhereClause<diesel::expression::grouped::Grouped<diesel::expression::operators::Eq<columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>>>>>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+   --> tests/fail/window_functions_expression_requires_window_function.rs:32:25
+    |
+32  |     users::table.select(lower(users::name).window_order(users::id));
+    |                         ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+    = note: try to provide an expression that produces one of the expected sql types
+    = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+              Multirange<ST>
+              Nullable<Multirange<ST>>
+              Nullable<diesel::sql_types::Range<ST>>
+              diesel::sql_types::Range<ST>
+note: required by a bound in `diesel::dsl::lower`
+   --> DIESEL/diesel/diesel/src/pg/expression/functions.rs
+    |
+LL |     fn lower<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<R::Inner>;
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:32:44
+   |
+LL |     users::table.select(lower(users::name).window_order(users::id));
+   |                                            ^^^^^^^^^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::aggregate_order::OrderWindowDsl<_>`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:32:18
+   |
+LL |     users::table.select(lower(users::name).window_order(users::id));
+   |                  ^^^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::NoPartition, Order<columns::id, true>>>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+  --> tests/fail/window_functions_expression_requires_window_function.rs:32:18
+   |
+LL |     users::table.select(lower(users::name).window_order(users::id));
+   |                  ^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+   = note: try to provide an expression that produces one of the expected sql types
+   = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+             Multirange<ST>
+             Nullable<Multirange<ST>>
+             Nullable<diesel::sql_types::Range<ST>>
+             diesel::sql_types::Range<ST>
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::Expression`
+   = note: 1 redundant requirement hidden
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `diesel::Expression`
+   = note: required for `users::table` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::NoPartition, Order<columns::id, true>>>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+   --> tests/fail/window_functions_expression_requires_window_function.rs:39:17
+    |
+39  |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(frame::CurrentRow)));
+    |                 ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+    = note: try to provide an expression that produces one of the expected sql types
+    = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+              Multirange<ST>
+              Nullable<Multirange<ST>>
+              Nullable<diesel::sql_types::Range<ST>>
+              diesel::sql_types::Range<ST>
+note: required by a bound in `diesel::dsl::lower`
+   --> DIESEL/diesel/diesel/src/pg/expression/functions.rs
+    |
+LL |     fn lower<R: MultirangeOrRangeMaybeNullable + SingleValue>(range: R) -> Nullable<R::Inner>;
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `lower`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:39:36
+   |
+LL |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(frame::CurrentRow)));
+   |                                    ^^^^^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::frame_clause::FrameDsl<_>`
+
+error[E0277]: diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name> is not a window function
+  --> tests/fail/window_functions_expression_requires_window_function.rs:39:10
+   |
+LL |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(frame::CurrentRow)));
+   |          ^^^^^^ remove this function call to use `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` as normal SQL function
+   |
+   = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
+   = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
+   = help: the following other types implement trait `IsWindowFunction`:
+             diesel::expression::count::count_utils::count<T, expr>
+             diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
+             diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
+             diesel::expression::functions::aggregate_ordering::max_utils::max<ST, expr>
+             diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
+             diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
+             diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
+             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
+           and N others
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
+   = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::NoPartition, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::frame_clause::FrameClause<diesel::expression::functions::aggregate_expressions::frame_clause::StartFrame<Rows, CurrentRow>>>>>`
+
+   
+error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`
+  --> tests/fail/window_functions_expression_requires_window_function.rs:39:10
+   |
+LL |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(frame::CurrentRow)));
+   |          ^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable` is not implemented for `diesel::sql_types::Text`
+   = note: try to provide an expression that produces one of the expected sql types
+   = help: the following other types implement trait `diesel::pg::expression::expression_methods::private::MultirangeOrRangeMaybeNullable`:
+             Multirange<ST>
+             Nullable<Multirange<ST>>
+             Nullable<diesel::sql_types::Range<ST>>
+             diesel::sql_types::Range<ST>
+   = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::Expression`
+   = note: 1 redundant requirement hidden
+   = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `diesel::Expression`
+   = note: required for `users::table` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::NoPartition, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::frame_clause::FrameClause<diesel::expression::functions::aggregate_expressions::frame_clause::StartFrame<Rows, CurrentRow>>>>>`
+
+   For more information about this error, try `rustc --explain E0277`.

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -1641,6 +1641,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         pub struct MultiWindowFrameClauseGroupSupport;
         pub struct MultiWindowFrameExclusionSupport;
         pub struct MultiAggregateFunctionExpressions;
+        pub struct MultiBuiltInWindowFunctionRequireOrder;
 
         impl diesel::backend::SqlDialect for MultiBackend {
             type ReturningClause = MultiReturningClause;
@@ -1658,6 +1659,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
             type WindowFrameClauseGroupSupport = MultiWindowFrameClauseGroupSupport;
             type WindowFrameExclusionSupport = MultiWindowFrameExclusionSupport;
             type AggregateFunctionExpressions = MultiAggregateFunctionExpressions;
+            type BuiltInWindowFunctionRequireOrder = MultiBuiltInWindowFunctionRequireOrder;
         }
 
         impl diesel::internal::derives::multiconnection::TrustedBackend for MultiBackend {}

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -660,3 +660,24 @@ fn aggregate_function_expressions() -> _ {
         count(users::id).aggregate_order(users::id.desc()),
     )
 }
+
+#[auto_type]
+fn window_functions2() -> _ {
+    (
+        row_number().over(),
+        rank().over(),
+        dense_rank().over(),
+        percent_rank().over(),
+        cume_dist().over(),
+        ntile(users::id).over(),
+        lag(users::id).over(),
+        lag_with_offset(users::id, users::id).over(),
+        lag_with_offset_and_default(users::id, users::id, users::id).over(),
+        lead(users::id).over(),
+        lead_with_offset(users::id, users::id).over(),
+        lead_with_offset_and_default(users::id, users::id, users::id).over(),
+        first_value(users::id).over(),
+        last_value(users::id).over(),
+        nth_value(users::id, 1_i32).over(),
+    )
+}


### PR DESCRIPTION
This commit defines a number of built-in window-only functions. It adds tests and documentation for these functions.

Marked as draft as I still need to figure out what we want to do with the additional function specific requirements (requires an order clause) on the Mysql backend. I'm tempted to just disallow these functions with Mysql.