### PR TITLE
Reduce generic code instanciation in one of the postgres connection functions

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -218,15 +218,30 @@ fn update_transaction_manager_status<T>(
     instrumentation: &mut DynInstrumentation,
     query: &dyn DebugQuery,
 ) -> QueryResult<T> {
-    if let Err(Error::DatabaseError(DatabaseErrorKind::SerializationFailure, _)) = query_result {
-        transaction_manager
-            .status
-            .set_requires_rollback_maybe_up_to_top_level(true)
+    fn non_generic_inner(
+        query_result: Result<(), &Error>,
+        transaction_manager: &mut AnsiTransactionManager,
+        instrumentation: &mut DynInstrumentation,
+        query: &dyn DebugQuery,
+    ) {
+        if let Err(Error::DatabaseError(DatabaseErrorKind::SerializationFailure, _)) = query_result
+        {
+            transaction_manager
+                .status
+                .set_requires_rollback_maybe_up_to_top_level(true)
+        }
+        instrumentation.on_connection_event(InstrumentationEvent::FinishQuery {
+            query,
+            error: query_result.err(),
+        });
     }
-    instrumentation.on_connection_event(InstrumentationEvent::FinishQuery {
+
+    non_generic_inner(
+        query_result.as_ref().map(|_| ()),
+        transaction_manager,
+        instrumentation,
         query,
-        error: query_result.as_ref().err(),
-    });
+    );
     query_result
 }
 


### PR DESCRIPTION
This commit turns the instrumentation code in
`update_transaction_manager_status` in the `PgConnection` and `MysqlConnection`  implementation
into a non-generic function, which hopefully should reduce the number of times rustc tries to generate that function. The relevant code doesn't depend on the generic paramater at all.