### PR TITLE
Match syntax generation with what migration run expects

### DIFF
--- a/diesel_cli/src/migrations/diff_schema.rs
+++ b/diesel_cli/src/migrations/diff_schema.rs
@@ -614,11 +614,11 @@ where
 {
     // TODO: handle schema
     query_builder.push_sql(&format!(" {}", ty.sql_name.to_uppercase()));
-    if let Some(max_length) = ty.max_length {
-        query_builder.push_sql(&format!("({max_length})"));
-    }
     if ty.is_array {
         query_builder.push_sql("[]");
+    }
+    if let Some(max_length) = ty.max_length {
+        query_builder.push_sql(&format!("({max_length})"));
     }
     if !ty.is_nullable {
         query_builder.push_sql(" NOT NULL");


### PR DESCRIPTION
Change the SQL generation output so it matches what `diesel migration run` expects.
I opened an issue about this issue: [here](https://github.com/diesel-rs/diesel/issues/4705)

According to [custom_typed.md](https://github.com/diesel-rs/diesel/blob/master/guide_drafts/custom_types.md) and my testing, `diesel migration run` expects the Array modifier `[]` to come immediatly after the type, and not at the end of the line like in most standard SQL versions.

This fix just slightly moves the line that appends the array modifier up.