### PR TITLE
Fix `.try_into()` regression

### DIFF
--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -536,8 +536,16 @@ fn derive_query_id_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenS
 /// * `#[diesel(deserialize_as = Type)]`, instead of deserializing directly
 ///   into the field type, the implementation will deserialize into `Type`.
 ///   Then `Type` is converted via
-///   [`.try_into`](https://doc.rust-lang.org/stable/std/convert/trait.TryInto.html#tymethod.try_into)
-///   into the field type. By default, this derive will deserialize directly into the field type
+///   `.try_into()` call into the field type. By default, this derive will deserialize directly into the field type
+///   The `try_into()` method can be provided by:
+///   + Implementing any of the [`TryInto`]/[`TryFrom`]/[`Into`]/[`From`] traits
+///   + Using an method on the type directly (Useful if it's not possible to implement the traits mentioned above
+///     due to the orphan rule)
+///
+/// [`TryInto`]: https://doc.rust-lang.org/stable/std/convert/trait.TryInto.html
+/// [`TryFrom`]: https://doc.rust-lang.org/stable/std/convert/trait.TryFrom.html
+/// [`Into`]: https://doc.rust-lang.org/stable/std/convert/trait.Into.html
+/// [`From`]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
 ///
 /// # Examples
 ///

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_1.snap
@@ -19,9 +19,10 @@ const _: () = {
     {
         type Row = (i32, String);
         fn build(row: (i32, String)) -> diesel::deserialize::Result<Self> {
+            use std::convert::TryInto;
             Ok(Self {
-                id: std::convert::TryInto::try_into(row.0)?,
-                name: std::convert::TryInto::try_into(row.1)?,
+                id: row.0.try_into()?,
+                name: row.1.try_into()?,
             })
         }
     }


### PR DESCRIPTION
While cleaning up how we call methods in our proc-macros I broke a pattern that seemed to be used. This commit restores using a `.try_into()` call instead of a fully qualified trait call for converting fields as part of `#[derive(Queryable)]` this unblocks using a method on the type itself. 
This commit also adds comments, tests + documentations for this use-case to make sure we don't break it again.

cc @Ten0 as that broke for you