### PR TITLE
Include expanded code for derives in our documentation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build documentation
         env:
           RUSTFLAGS: "--cfg docsrs"
-          RUSTDOCFLAGS: "--cfg docsrs"
+          RUSTDOCFLAGS: "--cfg docsrs  -Z unstable-options --generate-link-to-definition"
         run: cargo +nightly doc --manifest-path diesel/Cargo.toml --features "postgres sqlite mysql extras i-implement-a-third-party-backend-and-opt-into-breaking-changes" --workspace
 
       - name: Publish documentation

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -108,4 +108,4 @@ __with_asan_tests = [
 features = ["postgres", "mysql", "sqlite", "extras"]
 no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", " -Z", "unstable-options", "--generate-link-to-definition"]

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/diesel-rs/diesel/"
 autotests = false
 rust-version.workspace = true
 edition = "2021"
-include = ["src/*.rs", "src/deprecated/*.rs", "src/parsers/*.rs", "LICENSE-*", "README.md"]
+include = ["src/**/*.rs", "src/tests/snapshots/*", "LICENSE-*", "README.md"]
 
 [dependencies]
 syn = { version = "2.0", features = ["derive", "fold", "full"] }

--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -1,0 +1,187 @@
+#[cfg(docsrs)]
+fn inner_format(input: String, expanded: String) -> String {
+    format!(
+        r#"
+
+#### Input
+
+```rust,ignore
+{input}
+```
+
+#### Expanded Code
+
+<div class="warning">Expanded code might use diesel internal API's and is only shown for educational purpose</div>
+
+The macro expands the input to the following Rust code:
+
+
+```rust,ignore
+{expanded}
+```
+"#
+    )
+}
+
+#[cfg(docsrs)]
+fn normal_format(input: String, expanded: String) -> String {
+    let doc = inner_format(input, expanded);
+    write_detail_section(doc)
+}
+
+#[cfg(docsrs)]
+fn write_detail_section(content: String) -> String {
+    format!(
+        r#"
+# Expanded Code
+
+<details>
+<summary> Expanded Code </summary>
+
+{content}
+
+</details>
+"#
+    )
+}
+
+#[cfg(docsrs)]
+fn read_snapshot(snapshot_dir: &std::path::Path, file: &str) -> (String, String) {
+    let file = snapshot_dir.join(file);
+    let content = std::fs::read_to_string(file).expect("Failed to read snapshot");
+    let mut lines = content
+        .lines()
+        .skip_while(|l| !l.trim().starts_with("input:"));
+    let input = lines.next().expect("input field exists");
+    let input = input.trim().strip_prefix("input:").unwrap_or(input).trim();
+    let input = input.strip_prefix("\"").unwrap_or(input);
+    let input = input.strip_suffix("\"").unwrap_or(input);
+    let input = input.replace("\\n", "\n").replace("\\\"", "\"");
+
+    let lines = lines.skip_while(|l| *l != "---").skip(1);
+    let content = lines.collect::<Vec<_>>().join("\n");
+
+    (input, content)
+}
+
+#[cfg(docsrs)]
+fn write_sql_type_part(
+    snapshot_dir: &std::path::Path,
+    file: &str,
+    heading: &str,
+    out: &mut String,
+) {
+    use std::fmt::Write;
+    let (input, content) = read_snapshot(&snapshot_dir, file);
+    writeln!(out).expect("This doesn't fail");
+    writeln!(out, "### {heading}").expect("This doesn't fail");
+    writeln!(out).expect("This doesn't fail");
+    let doc = inner_format(input, content);
+    writeln!(out, "{doc}").expect("This doesn't fail");
+}
+
+#[cfg(docsrs)]
+fn main() {
+    use std::path::PathBuf;
+
+    let snapshot_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("tests")
+        .join("snapshots");
+    let out = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let has_sqlite = std::env::var("CARGO_FEATURE_SQLITE").is_ok();
+    let has_postgres = std::env::var("CARGO_FEATURE_POSTGRES").is_ok();
+    let has_mysql = std::env::var("CARGO_FEATURE_MYSQL").is_ok();
+
+    let mapping = [
+        ("as_changeset", "diesel_derives__tests__as_changeset_1.snap"),
+        (
+            "as_expression",
+            "diesel_derives__tests__as_expression_1.snap",
+        ),
+        ("associations", "diesel_derives__tests__associations_1.snap"),
+        ("auto_type", "diesel_derives__tests__auto_type_1.snap"),
+        (
+            "declare_sql_function",
+            if has_sqlite {
+                "diesel_derives__tests__declare_sql_function_1 (sqlite).snap"
+            } else {
+                "diesel_derives__tests__declare_sql_function_1.snap"
+            },
+        ),
+        (
+            "define_sql_function",
+            if has_sqlite {
+                "diesel_derives__tests__define_sql_function_1 (sqlite).snap"
+            } else {
+                "diesel_derives__tests__define_sql_function_1.snap"
+            },
+        ),
+        ("from_sql_row", "diesel_derives__tests__from_sql_row_1.snap"),
+        ("identifiable", "diesel_derives__tests__identifiable_1.snap"),
+        ("insertable", "diesel_derives__tests__insertable_1.snap"),
+        (
+            "multiconnection",
+            "diesel_derives__tests__multiconnection_1.snap",
+        ),
+        ("queryable", "diesel_derives__tests__queryable_1.snap"),
+        (
+            "queryable_by_name",
+            "diesel_derives__tests__queryable_by_name_1.snap",
+        ),
+        ("query_id", "diesel_derives__tests__query_id_1.snap"),
+        ("selectable", "diesel_derives__tests__selectable_1.snap"),
+        ("table", "diesel_derives__tests__table_1.snap"),
+        (
+            "valid_grouping",
+            "diesel_derives__tests__valid_grouping_1.snap",
+        ),
+    ];
+
+    for (derive, file) in mapping {
+        let (input, content) = read_snapshot(&snapshot_dir, file);
+        let doc = normal_format(input, content);
+        let out_path = out.join(format!("{derive}.md"));
+        std::fs::write(out_path, doc).unwrap();
+    }
+
+    // sql_type is special as it depends on all feature flags
+    // so we have a custom block here:
+    let mut doc = String::new();
+    if has_sqlite {
+        write_sql_type_part(
+            &snapshot_dir,
+            "diesel_derives__tests__sql_type_1 (sqlite).snap",
+            "SQLite",
+            &mut doc,
+        );
+    }
+
+    if has_postgres {
+        write_sql_type_part(
+            &snapshot_dir,
+            "diesel_derives__tests__sql_type_1 (postgres).snap",
+            "PostgreSQL",
+            &mut doc,
+        );
+    }
+
+    if has_mysql {
+        write_sql_type_part(
+            &snapshot_dir,
+            "diesel_derives__tests__sql_type_1 (mysql).snap",
+            "MySQL",
+            &mut doc,
+        );
+    }
+    if !doc.is_empty() {
+        doc = write_detail_section(doc);
+    }
+    let out_path = out.join(format!("sql_type.md"));
+    std::fs::write(out_path, doc).unwrap();
+}
+
+#[cfg(not(docsrs))]
+fn main() {
+    // just do nothing
+}

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -116,6 +116,7 @@ mod valid_grouping;
 ///   `treat_none_as_null` attribute for the current field.
 /// * `#[diesel(skip_update)]`, skips updating this field. Useful for working with
 ///   generated columns.
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/as_changeset.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(
@@ -166,6 +167,8 @@ fn derive_as_changeset_inner(input: proc_macro2::TokenStream) -> proc_macro2::To
 ///
 /// * `#[diesel(not_sized)]`, to skip generating impls that require
 ///   that the type is `Sized`
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/as_expression.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(AsExpression, attributes(diesel, sql_type))
@@ -218,6 +221,8 @@ fn derive_as_expression_inner(input: proc_macro2::TokenStream) -> proc_macro2::T
 /// * `#[diesel(column_name = some_column_name)]`, overrides the column the current
 ///   field maps to `some_column_name`. By default, the field name is used
 ///   as a column name.
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/associations.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(Associations, attributes(diesel, belongs_to, column_name, table_name))
@@ -254,6 +259,8 @@ fn derive_diesel_numeric_ops_inner(input: proc_macro2::TokenStream) -> proc_macr
 /// into rust types not supported by Diesel itself.
 ///
 /// There are no options or special considerations needed for this derive.
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/from_sql_row.md")))]
 #[proc_macro_derive(FromSqlRow, attributes(diesel))]
 pub fn derive_from_sql_row(input: TokenStream) -> TokenStream {
     derive_from_sql_row_inner(input.into()).into()
@@ -301,6 +308,8 @@ fn derive_from_sql_row_inner(input: proc_macro2::TokenStream) -> proc_macro2::To
 /// * `#[diesel(column_name = some_column_name)]`, overrides the column the current
 ///   field maps to `some_column_name`. By default, the field name is used
 ///   as a column name.
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/identifiable.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(Identifiable, attributes(diesel, table_name, column_name, primary_key))
@@ -444,6 +453,8 @@ fn derive_identifiable_inner(input: proc_macro2::TokenStream) -> proc_macro2::To
 /// # Ok(())
 /// # }
 /// ```
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/insertable.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(Insertable, attributes(diesel, table_name, column_name))
@@ -496,6 +507,8 @@ fn derive_insertable_inner(input: proc_macro2::TokenStream) -> proc_macro2::Toke
 /// meaning that `HAS_STATIC_QUERY_ID` should always be false,
 /// you shouldn't derive this trait.
 /// In that case, you should implement it manually instead.
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/query_id.md")))]
 #[proc_macro_derive(QueryId, attributes(diesel))]
 pub fn derive_query_id(input: TokenStream) -> TokenStream {
     derive_query_id_inner(input.into()).into()
@@ -686,6 +699,8 @@ fn derive_query_id_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenS
 /// #     Ok(())
 /// # }
 /// ```
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/queryable.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(Queryable, attributes(diesel, column_name))
@@ -897,6 +912,8 @@ fn derive_queryable_inner(input: proc_macro2::TokenStream) -> proc_macro2::Token
 /// #     Ok(())
 /// # }
 /// ```
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/queryable_by_name.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(QueryableByName, attributes(diesel, table_name, column_name, sql_type))
@@ -974,6 +991,8 @@ fn derive_queryable_by_name_inner(input: proc_macro2::TokenStream) -> proc_macro
 ///   function call that doesn't have the corresponding associated type defined at the same path.
 ///   Example use (this would actually be inferred):
 ///   `#[diesel(select_expression_type = dsl::IsNotNull<my_table::some_field>)]`
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/selectable.md")))]
 #[proc_macro_derive(Selectable, attributes(diesel))]
 pub fn derive_selectable(input: TokenStream) -> TokenStream {
     derive_selectable_inner(input.into()).into()
@@ -1023,6 +1042,8 @@ fn derive_selectable_inner(input: proc_macro2::TokenStream) -> proc_macro2::Toke
 /// * `#[diesel(mysql_type(name = "TypeName"))]`, specifies support for a mysql type
 ///   with the given name. `TypeName` needs to be one of the possible values
 ///   in `MysqlType`
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/sql_type.md")))]
 #[cfg_attr(
     all(not(feature = "without-deprecated"), feature = "with-deprecated"),
     proc_macro_derive(SqlType, attributes(diesel, postgres, sqlite_type, mysql_type))
@@ -1080,6 +1101,8 @@ fn derive_sql_type_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenS
 ///
 /// * `#[diesel(aggregate)]` for cases where the type represents an aggregating
 ///   SQL expression
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/valid_grouping.md")))]
 #[proc_macro_derive(ValidGrouping, attributes(diesel))]
 pub fn derive_valid_grouping(input: TokenStream) -> TokenStream {
     derive_valid_grouping_inner(input.into()).into()
@@ -1163,6 +1186,8 @@ fn derive_valid_grouping_inner(input: proc_macro2::TokenStream) -> proc_macro2::
 ///   - The SQL to be generated is different from the Rust name of the function.
 ///     This can be used to represent functions which can take many argument
 ///     types, or to capitalize function names.
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/define_sql_function.md")))]
 #[proc_macro]
 pub fn define_sql_function(input: TokenStream) -> TokenStream {
     define_sql_function_inner(input.into()).into()
@@ -1413,6 +1438,8 @@ fn __diesel_public_if_inner(
 /// ```ignore
 /// pub type BoxedQuery<'a, DB, ST = SqlType> = BoxedSelectStatement<'a, ST, table, DB>;
 /// ```
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/table.md")))]
 #[proc_macro]
 pub fn table_proc(input: TokenStream) -> TokenStream {
     table_proc_inner(input.into()).into()
@@ -1611,6 +1638,8 @@ fn table_proc_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream
 /// # }
 /// # fn main() {}
 /// ```
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/multiconnection.md")))]
 #[proc_macro_derive(MultiConnection)]
 pub fn derive_multiconnection(input: TokenStream) -> TokenStream {
     derive_multiconnection_inner(input.into()).into()
@@ -1773,6 +1802,8 @@ fn derive_multiconnection_inner(input: proc_macro2::TokenStream) -> proc_macro2:
 /// #     Ok(())
 /// # }
 /// ```
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/auto_type.md")))]
 #[proc_macro_attribute]
 pub fn auto_type(
     attr: proc_macro::TokenStream,
@@ -2283,6 +2314,8 @@ const AUTO_TYPE_DEFAULT_FUNCTION_TYPE_CASE: dsl_auto_type::Case = dsl_auto_type:
 ///
 /// # type skipped_type = return_type_helpers::f;
 /// ```
+///
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/declare_sql_function.md")))]
 #[proc_macro_attribute]
 pub fn declare_sql_function(
     attr: proc_macro::TokenStream,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mysql).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mysql).snap
@@ -2,7 +2,7 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\n#[diesel(mysql_type(name = \"Integer\"))]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
+  input: "#[derive(SqlType)]\n#[diesel(mysql_type(name = \"Long\"))]\nstruct Integer;\n"
 ---
 const _: () = {
     use diesel;
@@ -13,7 +13,7 @@ const _: () = {
     impl diesel::sql_types::SingleValue for Integer {}
     impl diesel::sql_types::HasSqlType<Integer> for diesel::mysql::Mysql {
         fn metadata(_: &mut ()) -> diesel::mysql::MysqlType {
-            diesel::mysql::MysqlType::Integer
+            diesel::mysql::MysqlType::Long
         }
     }
 };

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (postgres).snap
@@ -2,7 +2,7 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\n#[diesel(mysql_type(name = \"Integer\"))]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
+  input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\nstruct Integer;\n"
 ---
 const _: () = {
     use diesel;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (sqlite).snap
@@ -2,7 +2,7 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\n#[diesel(mysql_type(name = \"Integer\"))]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
+  input: "#[derive(SqlType)]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
 ---
 const _: () = {
     use diesel;

--- a/diesel_derives/src/tests/sql_type.rs
+++ b/diesel_derives/src/tests/sql_type.rs
@@ -4,10 +4,18 @@ use super::expand_with;
 
 #[test]
 pub(crate) fn sql_type_1() {
+    let input = if cfg!(feature = "postgres") {
+        quote::quote! {#[diesel(postgres_type(oid = 42, array_oid = 142))]}
+    } else if cfg!(feature = "sqlite") {
+        quote::quote! {#[diesel(sqlite_type(name = "Integer"))]}
+    } else if cfg!(feature = "mysql") {
+        quote::quote! {#[diesel(mysql_type(name = "Long"))]}
+    } else {
+        unreachable!("At least one featuer must be enabled");
+    };
+
     let input = quote::quote! {
-        #[diesel(postgres_type(oid = 42, array_oid = 142))]
-        #[diesel(mysql_type(name = "Integer"))]
-        #[diesel(sqlite_type(name = "Integer"))]
+        #input
         struct Integer;
     };
 


### PR DESCRIPTION
This change includes the expanded code for all our derives in our API documentation. This makes it hopefully a bit easier for our users to understand what the macros actually do and also to estimate how much code they generate.

Technically we just take the snapshots from the tests #4701 and use a build script to generate the relevant documentation snippets. The output of the build script is then included into the documentation. It's a bit unfortune that we cannot check in the build script if it's run by rustdoc vs some other compilation feature so I decided to gate this on the `docsrs` cfg flag to not run that step in "normal" builds.

This change also enables the `--generate-link-to-definition` option for rustdoc.

Example Documentation:

<img width="1396" height="951" alt="image" src="https://github.com/user-attachments/assets/0e8aa1f8-7160-4322-96c6-d8517e2bcc01" />
