### PR TITLE
feat(sqlite): add `json_patch` and `jsonb_patch` functions

### DIFF
--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -1425,6 +1425,137 @@ extern "SQL" {
         json: J,
         path: Text,
     ) -> Nullable<Jsonb>;
+
+    /// Applies an RFC 7396 MergePatch `patch` to the input JSON `target` and
+    /// returns the patched JSON value.
+    ///
+    /// MergePatch can add, modify, or delete elements of a JSON object. Arrays are
+    /// treated as atomic values: they can only be inserted, replaced, or deleted as a
+    /// whole, not modified element-wise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::json_patch;
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Json, Nullable};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let result = diesel::select(json_patch::<Json, Json, _, _>(
+    ///     json!( {"a":1,"b":2} ),
+    ///     json!( {"c":3,"d":4} ),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert_eq!(Some(json!({"a":1,"b":2,"c":3,"d":4})), result);
+    ///
+    /// let result = diesel::select(json_patch::<Json, Json, _, _>(
+    ///     json!( {"a":[1,2],"b":2} ),
+    ///     json!( {"a":9} ),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert_eq!(Some(json!({"a":9,"b":2})), result);
+    ///
+    /// let result = diesel::select(json_patch::<Json, Json, _, _>(
+    ///     json!( {"a":[1,2],"b":2} ),
+    ///     json!( {"a":null} ),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert_eq!(Some(json!({"b":2})), result);
+    ///
+    /// let result = diesel::select(json_patch::<Json, Json, _, _>(
+    ///     json!( {"a":1,"b":2} ),
+    ///     json!( {"a":9,"b":null,"c":8} ),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert_eq!(Some(json!({"a":9,"c":8})), result);
+    ///
+    /// let result = diesel::select(json_patch::<Json, Json, _, _>(
+    ///     json!( {"a":{"x":1,"y":2},"b":3} ),
+    ///     json!( {"a":{"y":9},"c":8} ),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert_eq!(
+    ///     Some(json!({"a":{"x":1,"y":9},"b":3,"c":8})),
+    ///     result
+    /// );
+    ///
+    /// // Nullable input yields nullable output
+    /// let result = diesel::select(json_patch::<Nullable<Json>, Json, _, _>(
+    ///     None::<Value>,
+    ///     json!({}),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert!(result.is_none());
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "sqlite")]
+    fn json_patch<
+        T: JsonOrNullableJsonOrJsonbOrNullableJsonb + SingleValue,
+        P: JsonOrNullableJsonOrJsonbOrNullableJsonb + SingleValue,
+    >(
+        target: T,
+        patch: P,
+    ) -> Nullable<Json>;
+
+    /// Applies an RFC 7396 MergePatch `patch` to the input JSON `target` and
+    /// returns the patched JSON value in SQLite's binary JSONB format.
+    ///
+    /// See [`json_patch`](json_patch()) for details about the MergePatch semantics.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::jsonb_patch;
+    /// #     use serde_json::{json, Value};
+    /// #     use diesel::sql_types::{Jsonb, Nullable};
+    /// #     let connection = &mut establish_connection();
+    ///
+    /// let result = diesel::select(jsonb_patch::<Jsonb, Jsonb, _, _>(
+    ///     json!( {"a":1,"b":2} ),
+    ///     json!( {"c":3,"d":4} ),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert_eq!(Some(json!({"a":1,"b":2,"c":3,"d":4})), result);
+    ///
+    /// // Nullable input yields nullable output
+    /// let result = diesel::select(jsonb_patch::<Nullable<Jsonb>, Jsonb, _, _>(
+    ///     None::<Value>,
+    ///     json!({}),
+    /// ))
+    /// .get_result::<Option<Value>>(connection)?;
+    /// assert!(result.is_none());
+    ///
+    /// #     Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "sqlite")]
+    fn jsonb_patch<
+        T: JsonOrNullableJsonOrJsonbOrNullableJsonb + SingleValue,
+        P: JsonOrNullableJsonOrJsonbOrNullableJsonb + SingleValue,
+    >(
+        target: T,
+        patch: P,
+    ) -> Nullable<Jsonb>;
 }
 
 pub(super) mod return_type_helpers_reexported {

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -516,6 +516,8 @@ fn sqlite_functions() -> _ {
         json_type(sqlite_extras::json),
         json_type_with_path(sqlite_extras::json, sqlite_extras::text),
         json_quote(sqlite_extras::json),
+        json_patch(sqlite_extras::json, sqlite_extras::json),
+        jsonb_patch(sqlite_extras::jsonb, sqlite_extras::jsonb),
     )
 }
 


### PR DESCRIPTION
Adds SQLite support for the following functions : 
*  `json_patch` 
*  `jsonb_patch`