### PR TITLE
feat(sqlite): add `json_object` and `jsonb_object` functions

### DIFF
--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -1,4 +1,5 @@
 use diesel::prelude::*;
+use diesel::sql_types::*;
 use dotenvy::dotenv;
 
 cfg_if::cfg_if! {

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -995,6 +995,109 @@ extern "SQL" {
     #[aggregate]
     fn jsonb_group_array<E: SqlType + SingleValue>(elements: E) -> Jsonb;
 
+    /// The `json_object()` SQL function accepts zero or more pairs of arguments and returns a
+    /// well-formed JSON object composed from those pairs. The first argument of each pair is the
+    /// label (key) and the second argument is the value. If any argument to `json_object()` is a
+    /// BLOB then an error is thrown.
+    ///
+    /// An argument with SQL type TEXT is normally converted into a quoted JSON string even if the
+    /// input text is well-formed JSON. However, if the argument is the direct result from another
+    /// JSON function, then it is treated as JSON and all of its JSON type information and
+    /// substructure is preserved. This allows calls to `json_object()` and `json_array()` to be
+    /// nested. The [`json()`] function can also be used to force strings to be recognized as JSON.
+    ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Text, Integer};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #     assert_version!(connection, 3, 38, 0);
+    /// #
+    /// let result = diesel::select(json_object_0()).get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({}), result);
+    ///
+    /// let result = diesel::select(json_object_1::<Text, Integer, _, _>("a", 2))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 2}), result);
+    ///
+    /// let result = diesel::select(
+    ///     json_object_2::<Text, Integer, Text, Text, _, _, _, _>("a", 2, "c", "{e:5}")
+    /// )
+    /// .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 2, "c": "{e:5}"}), result);
+    ///
+    /// let result = diesel::select(
+    ///     json_object_2::<Text, Integer, Text, Json, _, _, _, _>("a", 2, "c", json_object_1::<Text, Integer, _, _>("e", 5))
+    /// )
+    /// .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 2, "c": {"e": 5}}), result);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "sqlite")]
+    #[variadic(2)]
+    fn json_object<K: NotBlob, V: NotBlob>(key: K, value: V) -> Json;
+
+    /// The `jsonb_object()` SQL function works just like the [`json_object()`](json_object_1())
+    /// function except that the generated object is returned in SQLite's private binary JSONB
+    /// format rather than in the standard RFC 8259 text format.
+    ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Text, Integer};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #     assert_version!(connection, 3, 38, 0);
+    /// #
+    /// let result = diesel::select(jsonb_object_0()).get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({}), result);
+    ///
+    /// let result = diesel::select(jsonb_object_1::<Text, Integer, _, _>("a", 2))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 2}), result);
+    ///
+    /// let result = diesel::select(
+    ///     jsonb_object_2::<Text, Integer, Text, Text, _, _, _, _>("a", 2, "c", "{e:5}")
+    /// )
+    /// .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 2, "c": "{e:5}"}), result);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "sqlite")]
+    #[variadic(2)]
+    fn jsonb_object<K: NotBlob, V: NotBlob>(key: K, value: V) -> Jsonb;
+
     /// The json_group_object(NAME,VALUE) function returns a JSON object comprised of all NAME/VALUE pairs in
     /// the aggregation.
     ///

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -544,6 +544,22 @@ fn sqlite_variadic_functions() -> _ {
         jsonb_array_0(),
         jsonb_array_1(sqlite_extras::text),
         jsonb_array_2(sqlite_extras::id, sqlite_extras::json),
+        json_object_0(),
+        json_object_1(sqlite_extras::text, sqlite_extras::id),
+        json_object_2(
+            sqlite_extras::text,
+            sqlite_extras::id,
+            sqlite_extras::text,
+            sqlite_extras::json,
+        ),
+        jsonb_object_0(),
+        jsonb_object_1(sqlite_extras::text, sqlite_extras::id),
+        jsonb_object_2(
+            sqlite_extras::text,
+            sqlite_extras::id,
+            sqlite_extras::text,
+            sqlite_extras::json,
+        ),
         json_remove_0(sqlite_extras::json),
         json_remove_1(sqlite_extras::jsonb, sqlite_extras::text),
         json_remove_2(


### PR DESCRIPTION
Adds SQLite support for the following functions :

* `json_object`
* `jsonb_object`

Partially completes https://github.com/diesel-rs/diesel/issues/4366