### PR TITLE
Fix MySQL benchmarks

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -61,8 +61,8 @@ jobs:
           sudo systemctl start mysql.service
           sudo apt-get update
           sudo apt-get -y install libmysqlclient-dev
-          mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'localhost';" -uroot -proot
-          echo 'DATABASE_URL=mysql://root:root@localhost/diesel_test' >> $GITHUB_ENV
+          mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'127.0.0.1';" -uroot -proot
+          echo 'DATABASE_URL=mysql://root:root@127.0.0.1/diesel_test' >> $GITHUB_ENV
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run Benchmarks (Postgres)


### PR DESCRIPTION
https://github.com/diesel-rs/diesel/actions/runs/17170711667/job/48719768348#step:12:18

> thread 'main' panicked at benches/mysql_benches.rs:32:36:
called `Result::unwrap()` on an `Err` value: DriverError { Could not connect to address `localhost:3306': Connection refused (os error 111) }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Other locations also use `127.0.0.1` instead of `localhost` but I don't know why.