### PR TITLE
Run wasm tests directly using wasm-bindgen-test-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,14 +324,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "rust-src"
-          targets: "wasm32-unknown-unknown"
+          # It seems not to work
+          # targets: "wasm32-unknown-unknown"
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
         with:
           key: sqlite_wasm-cargo-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --locked
 
       - name: Install emscripten toolchains
         run: |

--- a/examples/sqlite/wasm/README.md
+++ b/examples/sqlite/wasm/README.md
@@ -10,11 +10,14 @@ Compile wasm and start the web server:
 rustup target add wasm32-unknown-unknown
 # Add wasm32-unknown-unknown toolchain
 
-cargo install wasm-pack
-# Install the wasm-pack toolchain
+cargo install wasm-bindgen-cli --locked
+# Install the wasm-bindgen cli
 
-wasm-pack build --target web
+cargo build --target wasm32-unknown-unknown
 # Build wasm
+
+wasm-bindgen ../../../target/wasm32-unknown-unknown/debug/sqlite_wasm_example.wasm --out-dir pkg --web
+# bindgen
 
 python3 server.py
 # Start server


### PR DESCRIPTION
`wasm-pack` will no longer be maintained by the `wasm-bindgen` team, so when `wasm-bindgen` releases a new version, `wasm-pack test` may become invalid.