### PR TITLE
Fix debug binds for sqlite in diesel-async

### DIFF
--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -282,7 +282,7 @@ where
                 metadata_lookup: _,
             } => collector.append_bind_data(bind_collector_data),
             AstPassInternals::DebugBinds(ref mut f) => {
-                f.push(Box::new("Opaque bind collector data"))
+                DB::BindCollector::push_debug_binds(bind_collector_data, f);
             }
             _ => {}
         }

--- a/diesel/src/query_builder/bind_collector.rs
+++ b/diesel/src/query_builder/bind_collector.rs
@@ -60,6 +60,12 @@ pub trait MoveableBindCollector<DB: TypeMetadata> {
 
     /// Refill the bind collector with its bind data
     fn append_bind_data(&mut self, from: &Self::BindData);
+
+    /// Push bind data as debug representation
+    fn push_debug_binds<'a, 'b>(
+        bind_data: &Self::BindData,
+        f: &'a mut Vec<Box<dyn std::fmt::Debug + 'b>>,
+    );
 }
 
 #[derive(Debug)]
@@ -144,7 +150,7 @@ where
 impl<DB> MoveableBindCollector<DB> for RawBytesBindCollector<DB>
 where
     for<'a> DB: Backend<BindCollector<'a> = Self> + TypeMetadata + 'static,
-    <DB as TypeMetadata>::TypeMetadata: Clone + Send,
+    <DB as TypeMetadata>::TypeMetadata: std::fmt::Debug + Clone + Send,
 {
     type BindData = Self;
 
@@ -158,6 +164,18 @@ where
     fn append_bind_data(&mut self, from: &Self::BindData) {
         self.binds.extend(from.binds.iter().cloned());
         self.metadata.extend(from.metadata.clone());
+    }
+
+    fn push_debug_binds<'a, 'b>(
+        bind_data: &Self::BindData,
+        f: &'a mut Vec<Box<dyn std::fmt::Debug + 'b>>,
+    ) {
+        f.extend(
+            bind_data
+                .metadata
+                .iter()
+                .map(|m| Box::new(m.clone()) as Box<dyn std::fmt::Debug>),
+        );
     }
 }
 

--- a/diesel/src/sqlite/connection/bind_collector.rs
+++ b/diesel/src/sqlite/connection/bind_collector.rs
@@ -208,7 +208,7 @@ impl<'a> BindCollector<'a, Sqlite> for SqliteBindCollector<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum OwnedSqliteBindValue {
     String(Box<str>),
     Binary(Box<[u8]>),
@@ -277,6 +277,18 @@ impl MoveableBindCollector<Sqlite> for SqliteBindCollector<'_> {
             from.binds
                 .iter()
                 .map(|(bind, tpe)| (InternalSqliteBindValue::from(bind), *tpe)),
+        );
+    }
+
+    fn push_debug_binds<'a, 'b>(
+        bind_data: &Self::BindData,
+        f: &'a mut Vec<Box<dyn std::fmt::Debug + 'b>>,
+    ) {
+        f.extend(
+            bind_data
+                .binds
+                .iter()
+                .map(|(b, _)| Box::new(b.clone()) as Box<dyn std::fmt::Debug>),
         );
     }
 }


### PR DESCRIPTION
We did not emit proper debug information for binds that were moved due to the async connection wrapper. This commit does improve that by emitting what information are still there.

Fixes https://github.com/weiznich/diesel_async/issues/256