### PR TITLE
Add support for JSON columns in schema inference

### DIFF
--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -363,6 +363,8 @@ pub fn determine_column_type(
         String::from("Date")
     } else if type_name == "time" {
         String::from("Time")
+    } else if type_name == "json" {
+        String::from("Json")
     } else {
         return Err(crate::errors::Error::UnsupportedType(type_name));
     };

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -71,6 +71,7 @@ fn common_diesel_types(types: &mut HashSet<&str>) {
     types.insert("Timestamp");
     types.insert("Date");
     types.insert("Time");
+	types.insert("Json");
 
     // hidden type defs
     types.insert("Float4");
@@ -109,7 +110,6 @@ fn pg_diesel_types() -> HashSet<&'static str> {
     types.insert("Range");
     types.insert("Timestamptz");
     types.insert("Uuid");
-    types.insert("Json");
     types.insert("PgLsn");
     types.insert("Record");
     types.insert("Interval");
@@ -147,7 +147,6 @@ fn mysql_diesel_types() -> HashSet<&'static str> {
     types.insert("TinyInt");
     types.insert("Tinyint");
     types.insert("Datetime");
-    types.insert("Json");
     types
 }
 


### PR DESCRIPTION
Running `diesel migration generate --diff-schema <whatever>` doesn't work for SQLite databases + JSON columns. If I manually create migrations, they work fine, so it looks like this was just missed when JSON support was added for SQLite. 

To test this, I applied the patch locally and generated migration. 