### PR TITLE
Print user supplied error in `test_transaction()`

### DIFF
--- a/diesel/src/connection/mod.rs
+++ b/diesel/src/connection/mod.rs
@@ -377,10 +377,11 @@ where
     {
         let mut user_result = None;
         let _ = self.transaction::<(), _, _>(|conn| {
-            user_result = f(conn).ok();
+            user_result = Some(f(conn));
             Err(Error::RollbackTransaction)
         });
-        user_result.expect("Transaction did not succeed")
+        user_result.expect("Transaction never executed")
+            .unwrap_or_else(|e| panic!("Transaction did not succeed: {:?}", e))
     }
 
     /// Execute a single SQL statements given by a query and return


### PR DESCRIPTION
See discussion [1]. The first half of this was completed in 2017. This pull request makes `test_transaction()` print the user supplied error when it panics rather than just "Transaction did not succeed".

I did a small test and it appears to work as expected.
```rust
use diesel::prelude::*;

#[derive(Debug, thiserror::Error)]
pub enum MyError {
    #[error("generic test error: {0}")]
    GenericTestError(
        &'static str,
    ),
}

fn main() {
    let url = "postgres://username:password@some-valid-domain/some_db";
    let mut db_connection = PgConnection::establish(&url).unwrap();

    db_connection.test_transaction::<_, MyError, _>(|con| {
        Err::<(), MyError>(MyError::GenericTestError("foo"))
    });

}

```
```
thread 'main' panicked at /home/.../connection/mod.rs:384:33:
Transaction did not succeed: GenericTestError("foo")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

[1] https://github.com/diesel-rs/diesel/discussions/4752