### PR TITLE
Fix docs.rs build now for real

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -108,4 +108,4 @@ __with_asan_tests = [
 features = ["postgres", "mysql", "sqlite", "extras"]
 no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs", " -Z", "unstable-options", "--generate-link-to-definition"]
+rustdoc-args = ["--cfg", "docsrs", "-Z", "unstable-options", "--generate-link-to-definition"]

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -19,7 +19,7 @@ pub use diesel_derives::table_proc as table;
 /// explicit `ON` clause.
 ///
 /// The generated `ON` clause will always join to the primary key of the parent
-/// table. This macro removes the need to call [`.on`] explicitly, you will
+/// table. This macro removes the need to call [`.on`](crate::query_dsl::JoinOnDsl::on) explicitly, you will
 /// still need to invoke
 /// [`allow_tables_to_appear_in_same_query!`](crate::allow_tables_to_appear_in_same_query)
 /// for these two tables to be able to use the resulting query, unless you are

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -184,7 +184,7 @@ pub type ContainsNetLoose<Lhs, Rhs> =
 #[doc(hidden)] // used by `#[auto_type]`
 pub type ContainsOrEq<Lhs, Rhs> = ContainsNetLoose<Lhs, Rhs>;
 
-/// The return type of [`lhs.is_contained_by(rhs)`]((super::expression_methods::PgNetExpressionMethods::is_contained_by)
+/// The return type of [`lhs.is_contained_by(rhs)`](super::expression_methods::PgNetExpressionMethods::is_contained_by)
 /// for network types
 #[cfg(feature = "postgres_backend")]
 pub type IsContainedByNet<Lhs, Rhs> =

--- a/diesel/src/query_builder/has_query.rs
+++ b/diesel/src/query_builder/has_query.rs
@@ -14,7 +14,7 @@ pub use diesel_derives::HasQuery;
 /// Consumers of this trait should use the `query()` associated function
 /// to construct a query including a matching select clause for their type
 ///
-/// This trait can be [derived](derive@HasTable)
+/// This trait can be [derived](derive@HasQuery)
 ///
 /// It's important to note that for Diesel mappings between the database and rust types always happen
 /// on query and not on table level. This enables you to write several queries related to the

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -53,5 +53,4 @@ numeric = []
 features = ["postgres", "mysql", "sqlite", "chrono", "numeric", "time", "r2d2"]
 no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs", " -Z", "unstable-options", "--generate-link-to-definition"]
-
+rustdoc-args = ["--cfg", "docsrs", "-Z", "unstable-options", "--generate-link-to-definition"]


### PR DESCRIPTION
This commit tries to fix the docrs.rs build by removing a whitespace from the docs.rs build metadata. That seems to cause the problem that could be observed.

This commit also fixes several links that were reported as broken.