### PR TITLE
Fix diesel_derives compilation with syn 2.0

### DIFF
--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 include = ["src/**/*.rs", "src/tests/snapshots/*", "LICENSE-*", "README.md", "build.rs"]
 
 [dependencies]
-syn = { version = "2.0", features = ["derive", "fold", "full"] }
+syn = { version = "2.0", features = ["derive", "fold", "full", "parsing"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.27"
 diesel_table_macro_syntax = {version = "0.3", path = "../diesel_table_macro_syntax"}


### PR DESCRIPTION
## Problem

The `diesel_derives` crate fails to compile with newer versions of `syn` due to missing the `parsing` feature. The `require_ident()` method is gated behind the `parsing` feature flag in `syn` 2.0, but `diesel_derives` was not enabling this feature.

## Root Cause Analysis

The issue occurs because:

1. **Diesel enables `with-deprecated` by default**: In `diesel/Cargo.toml`, the default features include `with-deprecated`:
   ```toml
   default = ["with-deprecated", "32-column-tables"]
   ```

2. **`with-deprecated` enables `sql_function` code**: The `sql_function_proc_inner` function (which uses `require_ident()`) is gated behind the `with-deprecated` feature:
   ```rust
   #[cfg(all(feature = "with-deprecated", not(feature = "without-deprecated")))]
   fn sql_function_proc_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
       // This function uses require_ident() which needs the 'parsing' feature
   }
   ```

3. **Any crate depending on Diesel triggers the issue**: When `diesel-derive-enum` or other crates depend on Diesel, they automatically get the `with-deprecated` feature enabled, which triggers compilation of the `sql_function` code.

## Why Tests Weren't Failing

The `diesel_derives` tests weren't failing because:

- `diesel_derives` doesn't enable `with-deprecated` by default (its `Cargo.toml` shows `default = []`)
- The `sql_function` code is only compiled when `with-deprecated` is explicitly enabled
- The tests don't exercise the `sql_function` functionality unless that feature is enabled

## Solution

Add the `parsing` feature to the `syn` dependency in `diesel_derives/Cargo.toml`.

## Changes

- Updated `syn` dependency features from `["derive", "fold", "full"]` to `["derive", "fold", "full", "parsing"]`

## Testing

This fix resolves compilation errors when using `diesel_derives` with the latest version of `syn` and enables the use of the latest Diesel version (2.3.2) with `diesel-derive-enum` and other crates that depend on `diesel_derives`.

### Verification

- ✅ **With default features**: `diesel-derive-enum` now compiles successfully with Diesel 2.3.2
- ✅ **Without default features**: `diesel-derive-enum` continues to work as before
- ✅ **All existing tests pass**: No regressions in functionality

Fixes compatibility issues with:
- `diesel-derive-enum` 
- Other procedural macro crates that depend on `diesel_derives`
- Projects using the latest versions of `syn` and `diesel`

## Impact

This is a low-risk change that:
- Only adds a feature flag that was already available in `syn`
- Doesn't change any existing functionality
- Enables compatibility with the latest `syn` version
- Allows users to use the latest Diesel version (2.3.2) without compilation issues