### PR TITLE
Artifact attestation + updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    reviewers:
+      - "diesel/reviewers"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "rust-toolchain"
+    reviewers:
+      - "diesel/reviewers"
+    schedule:
+      interval: "weekly"
+      day: "friday" # rust releases are on thursdays
   - package-ecosystem: "cargo"
     directory: "/"
     allow:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/audit@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - run: |
+          cargo binstall cargo-deny
+          cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -287,7 +287,7 @@ jobs:
     name: Check rustfmt style && run clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -326,7 +326,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "rust-src"
@@ -360,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "rust-src"
@@ -392,7 +392,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "rust-src"
@@ -435,7 +435,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "rust-src"
@@ -489,7 +489,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.86.0
       - uses: dtolnay/rust-toolchain@nightly
       - uses: taiki-e/install-action@cargo-hack
@@ -518,7 +518,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt_and_clippy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -21,7 +21,7 @@ jobs:
         backend: ["postgres", "sqlite", "mysql"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@
 
 name: Release
 permissions:
+  "attestations": "write"
   "contents": "write"
+  "id-token": "write"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -144,6 +146,10 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
+      - name: Attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/.github/workflows/run_benches.yml
+++ b/.github/workflows/run_benches.yml
@@ -16,7 +16,7 @@ jobs:
         backend: ["postgres", "sqlite", "mysql"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install postgres (Linux)
         if: matrix.backend == 'postgres'
@@ -73,7 +73,7 @@ jobs:
           path: ./pr_${{ matrix.backend }}.txt
 
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           repository: ${{ github.event.pull_request.base.repo.full_name }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,6 +21,8 @@ install-updater = false
 install-path = "CARGO_HOME"
 # Whether to use cargo-cyclonedx to generate an SBOM
 cargo-cyclonedx = true
+# Whether to enable GitHub Attestations
+github-attestations = true
 
 [dist.min-glibc-version]
 "*" = "2.17"


### PR DESCRIPTION
This commit enables githubs artifact attestation for the binaries we build via cargo-dist, updates the checkout action to checkout@v5 and tweaks the dependabot settings.