### PR TITLE
Improve migration error message "cannot run inside a transaction block"

### DIFF
--- a/diesel_migrations/src/errors.rs
+++ b/diesel_migrations/src/errors.rs
@@ -104,7 +104,16 @@ impl fmt::Display for RunMigrationsError {
                 write!(f, "Failed to run {v} with: {err}")
             }
             RunMigrationsError::QueryError(v, err) => {
-                write!(f, "Failed to run {v} with: {err}")
+                write!(f, "Failed to run {v} with: {err}")?;
+
+                if let diesel::result::Error::DatabaseError(_, error_info) = err {
+                    let message = error_info.message();
+                    if message.ends_with("cannot run inside a transaction block") {
+                        write!(f, " (see https://docs.diesel.rs/master/diesel_migrations/struct.FileBasedMigrations.html#transactions)")?;
+                    }
+                }
+
+                Ok(())
             }
             RunMigrationsError::EmptyMigration(v) => write!(
                 f,

--- a/diesel_migrations/src/file_based_migrations.rs
+++ b/diesel_migrations/src/file_based_migrations.rs
@@ -17,11 +17,25 @@ use crate::errors::{MigrationError, RunMigrationsError};
 /// A valid migration directory contains a sub folder per migration.
 /// Each migration folder contains a `up.sql` file containing the migration itself
 /// and a `down.sql` file containing the necessary SQL to revert the migration.
-/// Additionally each folder can contain a `metadata.toml` file controlling how the
-/// individual migration should be handled by the migration harness.
 ///
 /// To embed an existing migration folder into the final binary see
 /// [`embed_migrations!`](crate::embed_migrations!).
+///
+/// ## Transactions
+///
+/// Each migration folder can additionally contain a `metadata.toml` file,
+/// controlling how the individual migration should be handled by the migration
+/// harness.
+///
+/// By default, each migration is run inside a dedicated transaction block.
+/// If the metadata file contains `run_in_transaction = false`, then this
+/// behavior will be disabled.
+///
+/// **Important:** If you see "cannot run inside a transaction block" errors
+/// despite having set `run_in_transaction = false`, then your migration likely
+/// contains multiple instructions, which some databases automatically wrap in
+/// a transaction block. In this case we recommend splitting the migration into
+/// multiple migrations.
 ///
 /// ## Example
 ///


### PR DESCRIPTION
This PR addresses https://github.com/diesel-rs/diesel/discussions/4782#discussioncomment-14523252 by a) improving the documentation regarding transaction usage in migrations, and b) adding a URL to the documentation section to the error message if we detect that it ends with "cannot run inside a transaction block".