### PR TITLE
Try to fix binds for multiconnection

### DIFF
--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -385,6 +385,15 @@ where
     /// This function allows to access the inner bind collector if
     /// this `AstPass` represents a collect binds pass.
     fn bind_collector(&mut self) -> Option<(&mut DB::BindCollector<'b>, &mut DB::MetadataLookup)>;
+
+    /// This function allows to access the inner debug bind collector pass
+    fn debug_binds(&mut self) -> Option<(&mut Vec<Box<dyn fmt::Debug + 'b>>, &'b DB)>;
+
+    /// Construct a new AstPass for collecting bind values into the provided buffer
+    fn collect_debug_binds_pass(
+        formatter: &'a mut Vec<Box<dyn fmt::Debug + 'b>>,
+        backend: &'b DB,
+    ) -> AstPass<'a, 'b, DB>;
 }
 
 impl<'a, 'b, DB> AstPassHelper<'a, 'b, DB> for AstPass<'a, 'b, DB>
@@ -441,5 +450,20 @@ where
         } else {
             None
         }
+    }
+
+    fn debug_binds(&mut self) -> Option<(&mut Vec<Box<dyn fmt::Debug + 'b>>, &'b DB)> {
+        if let AstPassInternals::DebugBinds(formatter) = &mut self.internals {
+            Some((formatter, self.backend))
+        } else {
+            None
+        }
+    }
+
+    fn collect_debug_binds_pass(
+        formatter: &'a mut Vec<Box<dyn fmt::Debug + 'b>>,
+        backend: &'b DB,
+    ) -> AstPass<'a, 'b, DB> {
+        AstPass::debug_binds(formatter, backend)
     }
 }

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -317,6 +317,10 @@ fn generate_connection_impl(
                 if let Some((outer_collector, lookup)) = pass.bind_collector() {
                     C::handle_inner_pass(outer_collector, lookup, &self.backend, &self.inner)?;
                 }
+                if let Some((formatter, _backend)) = pass.debug_binds() {
+                    let pass = diesel::query_builder::AstPass::<MultiBackend>::collect_debug_binds_pass(formatter, &self.backend);
+                    self.inner.walk_ast(pass)?;
+                }
                 Ok(())
             }
         }

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
@@ -1747,6 +1747,12 @@ mod multi_connection_impl {
                         &self.inner,
                     )?;
                 }
+                if let Some((formatter, _backend)) = pass.debug_binds() {
+                    let pass = diesel::query_builder::AstPass::<
+                        MultiBackend,
+                    >::collect_debug_binds_pass(formatter, &self.backend);
+                    self.inner.walk_ast(pass)?;
+                }
                 Ok(())
             }
         }


### PR DESCRIPTION
This commit fixes the ability to correctly log bind params in queries using `MultiConnection` via the provided `Instrumentation` functionality. This was just missing, it just requires forwarding the right query pass to the underlying query.