### PR TITLE
Fix cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,31 @@
+[licenses]
+# We have to be careful on this part since we set 'unlicensed' to be allowed in order to minimize the output
+# (Only show unallowed licenses as error)
+#unlicensed = "allow"
+confidence-threshold = 0.90
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "PostgreSQL",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
+    "BSD-3-Clause",
+    "GPL-2.0"
+]
+# ignore private packages
+private = { ignore = true }
+
+[bans]
+multiple-versions = "deny"
+skip-tree = [
+    "windows-targets",
+    "windows-sys",
+    "wasi",
+    "rand",
+]
+
+[bans.build]
+executables = "deny"
+#interpreted = "deny"
+#include-archives = true
+

--- a/diesel_test_helper/Cargo.toml
+++ b/diesel_test_helper/Cargo.toml
@@ -2,6 +2,7 @@
 name = "diesel_test_helper"
 version = "0.1.0"
 edition.workspace = true
+publish = false
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This adds a deny.toml file that configures which licenses are allowed.

This also enables a few more deny settings to deny various stuff during builds. I would like to enable more of the settings but some of the dependencies fail them. We likely need to fix these dependencies first.