### PR TITLE
Fix diesel setup always using absolute migrations dir paths

### DIFF
--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -40,6 +40,7 @@ chrono = { version = "0.4.20", default-features = false, features = [
 clap = { version = "4.4.14", features = ["cargo", "string"] }
 clap_complete = "4"
 dotenvy = "0.15"
+dunce = "1.0.5"
 heck = "0.5.0"
 serde = { version = "1.0.193", features = ["derive", "std"] }
 toml = { version = "0.9", default-features = false, features = ["parse", "serde"] }

--- a/diesel_cli/tests/setup.rs
+++ b/diesel_cli/tests/setup.rs
@@ -308,3 +308,40 @@ fn setup_respects_migrations_dir_from_diesel_toml() {
     assert!(result.is_success(), "Result was unsuccessful {:?}", result);
     assert!(p.has_file("custom_migrations"));
 }
+
+#[test]
+fn setup_writes_migration_dir_as_relative_path() {
+    let p = project("setup_writes_migration_dir_as_relative_path").build();
+
+    let result = p.command("setup").run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(p
+        .file_contents("diesel.toml")
+        .contains("dir = \"migrations\""));
+}
+
+#[test]
+fn setup_writes_migration_dir_as_arg_as_relative_path() {
+    let p = project("setup_writes_migration_dir_as_arg_as_relative_path").build();
+
+    let migrations_dir_arg = dunce::canonicalize(p.directory_path())
+        .unwrap()
+        .join("foo")
+        .display()
+        .to_string();
+    let result = p
+        .command("setup")
+        .arg(format!("--migration-dir={}", migrations_dir_arg))
+        .run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+
+    let file_contents = p.file_contents("diesel.toml");
+    assert!(
+        file_contents.contains("dir = \"foo\""),
+        "Migrations directory {:?} not relative in diesel.toml:\n{}",
+        migrations_dir_arg,
+        file_contents
+    );
+}

--- a/diesel_cli/tests/support/project_builder.rs
+++ b/diesel_cli/tests/support/project_builder.rs
@@ -191,6 +191,10 @@ impl Project {
     pub fn skip_drop_db(&mut self) {
         self.skip_drop_db = true;
     }
+
+    pub fn directory_path(&self) -> &Path {
+        self.directory.path()
+    }
 }
 
 #[cfg(not(feature = "sqlite"))]


### PR DESCRIPTION
Fixes #4436. The [`dunce`](https://crates.io/crates/dunce) crate is required to avoid unwanted Windows-specific behaviour in [`std::fs::canonicalize`](https://doc.rust-lang.org/stable/std/fs/fn.canonicalize.html).