### PR TITLE
Implement window traits for CountStar

### DIFF
--- a/diesel_compile_tests/tests/fail/require_order_for_certain_window_functions_with_mysql.stderr
+++ b/diesel_compile_tests/tests/fail/require_order_for_certain_window_functions_with_mysql.stderr
@@ -8,6 +8,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::rank_utils::rank, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -15,7 +16,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::rank_utils::rank, Mysql>`
      = note: required for `AggregateExpression<rank, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
@@ -42,6 +42,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -49,7 +50,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
      = note: required for `AggregateExpression<dense_rank, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
@@ -76,6 +76,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::percent_rank_utils::percent_rank, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -83,7 +84,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::percent_rank_utils::percent_rank, Mysql>`
      = note: required for `AggregateExpression<percent_rank, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
@@ -110,6 +110,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -117,7 +118,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
      = note: required for `AggregateExpression<cume_dist, NoPrefix, NoOrder, NoFilter, ...>` to implement `QueryFragment<Mysql>`
@@ -144,6 +144,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<diesel::sql_types::Integer, columns::id>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -151,7 +152,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<diesel::sql_types::Integer, columns::id>, Mysql>`
      = note: required for `AggregateExpression<lag<Integer, id>, NoPrefix, NoOrder, ..., ...>` to implement `QueryFragment<Mysql>`
@@ -178,6 +178,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -185,7 +186,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql>`
      = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
@@ -212,6 +212,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -219,7 +220,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_and_default_utils::lag_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql>`
      = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
@@ -246,6 +246,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<diesel::sql_types::Integer, columns::id>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -253,7 +254,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<diesel::sql_types::Integer, columns::id>, Mysql>`
      = note: required for `AggregateExpression<lead<Integer, id>, NoPrefix, NoOrder, ..., ...>` to implement `QueryFragment<Mysql>`
@@ -280,6 +280,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -287,7 +288,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<diesel::sql_types::Integer, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>>, Mysql>`
      = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`
@@ -314,6 +314,7 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
      |
      = help: the trait `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql, mysql::backend::MysqlRequiresOrderForWindowFunctions>` is not implemented for `OverClause<PartitionBy<id>>`
      = help: the following other types implement trait `WindowFunctionFragment<Fn, DB, SP>`:
+               `OverClause<Partition, Order, Frame>` implements `WindowFunctionFragment<CountStar, DB>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::cume_dist_utils::cume_dist, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::dense_rank_utils::dense_rank, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_utils::lag<T, value>, Mysql>`
@@ -321,7 +322,6 @@ error[E0277]: the trait bound `OverClause<PartitionBy<id>>: WindowFunctionFragme
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lag_with_offset_utils::lag_with_offset<T, value, offset>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_utils::lead<T, value>, Mysql>`
                `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<T, T2, value, offset, default>, Mysql>`
-               `OverClause<__P, Order<__O, true>, __F>` implements `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_utils::lead_with_offset<T, value, offset>, Mysql>`
              and N others
      = note: required for `OverClause<PartitionBy<id>>` to implement `WindowFunctionFragment<diesel::expression::functions::window_functions::lead_with_offset_and_default_utils::lead_with_offset_and_default<diesel::sql_types::Integer, _, columns::id, diesel::expression::bound::Bound<diesel::sql_types::Integer, i32>, _>, Mysql>`
      = note: required for `AggregateExpression<..., ..., ..., ..., ...>` to implement `QueryFragment<Mysql>`

--- a/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.stderr
+++ b/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.stderr
@@ -26,6 +26,7 @@ LL |     users::table.select(lower(users::name).partition_by(users::id));
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -33,7 +34,6 @@ LL |     users::table.select(lower(users::name).partition_by(users::id));
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::partition_by::PartitionByDsl<_>`
 
@@ -46,6 +46,7 @@ LL |     users::table.select(lower(users::name).partition_by(users::id));
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -53,7 +54,6 @@ LL |     users::table.select(lower(users::name).partition_by(users::id));
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::PartitionBy<columns::id>>>>`
@@ -106,6 +106,7 @@ LL |     users::table.select(lower(users::name).over());
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -113,7 +114,6 @@ LL |     users::table.select(lower(users::name).over());
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::over_clause::OverDsl`
 
@@ -126,6 +126,7 @@ LL |     users::table.select(lower(users::name).over());
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -133,7 +134,6 @@ LL |     users::table.select(lower(users::name).over());
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause>>`
@@ -244,6 +244,7 @@ LL |     users::table.select(lower(users::name).window_order(users::id));
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -251,7 +252,6 @@ LL |     users::table.select(lower(users::name).window_order(users::id));
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::aggregate_order::OrderWindowDsl<_>`
 
@@ -264,6 +264,7 @@ LL |     users::table.select(lower(users::name).window_order(users::id));
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -271,7 +272,6 @@ LL |     users::table.select(lower(users::name).window_order(users::id));
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::NoPartition, Order<columns::id, true>>>>`
@@ -324,6 +324,7 @@ LL |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(fr
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -331,7 +332,6 @@ LL |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(fr
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>` to implement `diesel::expression::functions::aggregate_expressions::frame_clause::FrameDsl<_>`
 
@@ -344,6 +344,7 @@ LL |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(fr
    = help: the trait `IsWindowFunction` is not implemented for `diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>`
    = note: try removing any method call to `WindowExpressionMethods` and use it as normal SQL function
    = help: the following other types implement trait `IsWindowFunction`:
+             CountStar
              diesel::expression::count::count_utils::count<T, expr>
              diesel::expression::functions::aggregate_folding::avg_utils::avg<ST, expr>
              diesel::expression::functions::aggregate_folding::sum_utils::sum<ST, expr>
@@ -351,7 +352,6 @@ LL |         .select(lower(users::name).frame_by(frame::Rows.frame_start_with(fr
              diesel::expression::functions::aggregate_ordering::min_utils::min<ST, expr>
              diesel::expression::functions::window_functions::cume_dist_utils::cume_dist
              diesel::expression::functions::window_functions::dense_rank_utils::dense_rank
-             diesel::expression::functions::window_functions::first_value_utils::first_value<T, value>
            and N others
    = note: required for `AggregateExpression<lower<Text, name>, NoPrefix, NoOrder, ..., ...>` to implement `ValidGrouping<()>`
    = note: required for `SelectStatement<FromClause<users::table>>` to implement `SelectDsl<diesel::expression::functions::aggregate_expressions::AggregateExpression<diesel::pg::expression::functions::lower_utils::lower<diesel::sql_types::Text, columns::name>, diesel::expression::functions::aggregate_expressions::prefix::NoPrefix, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::aggregate_filter::NoFilter, OverClause<diesel::expression::functions::aggregate_expressions::partition_by::NoPartition, diesel::expression::functions::aggregate_expressions::aggregate_order::NoOrder, diesel::expression::functions::aggregate_expressions::frame_clause::FrameClause<diesel::expression::functions::aggregate_expressions::frame_clause::StartFrame<Rows, CurrentRow>>>>>`

--- a/diesel_tests/tests/window_functions.rs
+++ b/diesel_tests/tests/window_functions.rs
@@ -16,6 +16,18 @@ fn simple_window() {
 }
 
 #[diesel_test_helper::test]
+fn window_count_star() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+
+    let res = users::table
+        .select(dsl::count_star().over())
+        .load::<i64>(&mut conn)
+        .unwrap();
+
+    assert_eq!(res, vec![2, 2]);
+}
+
+#[diesel_test_helper::test]
 fn partition_by() {
     let mut conn = connection_with_sean_and_tess_in_users_table();
 


### PR DESCRIPTION
This allows using `OVER()` clause with `COUNT(*)`.

The trait `IsAggregateFunction` cannot be implemented since the `aggregate_distinct()` method will generate `COUNT(DISTINCT *)`, which is not valid SQL.