### PR TITLE
Fix MySQL benchmarks (again)

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -61,7 +61,7 @@ jobs:
           sudo systemctl start mysql.service
           sudo apt-get update
           sudo apt-get -y install libmysqlclient-dev
-          mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'127.0.0.1';" -uroot -proot
+          mysql -e "create database diesel_test; create database diesel_unit_test; grant all on \`diesel_%\`.* to 'root'@'localhost';" -uroot -proot
           echo 'DATABASE_URL=mysql://root:root@127.0.0.1/diesel_test' >> $GITHUB_ENV
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
At least on my machine it is not possible to connect to MySQL using `localhost`. However, it seems that CLI commands do require `localhost` for whatever the reason.

* `Current`: https://github.com/diesel-rs/diesel/actions/runs/18484639507/job/52665850375
* `Before` (https://github.com/diesel-rs/diesel/pull/4726): https://github.com/diesel-rs/diesel/actions/runs/16586242685/job/46911932778