### PR TITLE
Revert "Fix print-schema crash with mariadb client library"

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -406,12 +406,6 @@ impl BindData {
         } else {
             let data = self.bytes?;
             let tpe = (self.tpe, self.flags).into();
-            // On some distributions, the mariadb client library returns length 0 for NULL fields of type DECIMAL
-            // instead of using is_null for unknown reasons
-            if self.tpe == self::ffi::enum_field_types::MYSQL_TYPE_LONGLONG && self.length == 0 {
-                return None;
-            }
-
             let slice = unsafe {
                 // We know that this points to a slice and the pointer is not null at this
                 // location


### PR DESCRIPTION
This reverts commit b81ec1cfa2fd5fef03ac3727628e2262e4e167af.

This fix is incorrect as the real issue is in libmariadb and needs to be fixed there. See #4806, #4699 and https://jira.mariadb.org/browse/CONC-782 for details