### PR TITLE
Fix generated function links

### DIFF
--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -454,7 +454,7 @@ fn expand_nonvariadic(
         numeric_derive = Some(quote!(#[derive(diesel::sql_types::DieselNumericOps)]));
     }
 
-    let helper_type_doc = format!("The return type of [`{fn_name}()`](super::fn_name)");
+    let helper_type_doc = format!("The return type of [`{fn_name}()`](fn@{fn_name})");
     let query_fragment_impl =
         can_be_called_directly.then_some(restrictions.generate_all_queryfragment_impls(
             generics.clone(),

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1 (sqlite).snap
@@ -14,7 +14,7 @@ where
     }
 }
 #[allow(non_camel_case_types, non_snake_case)]
-///The return type of [`lower()`](super::fn_name)
+///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
     <input as diesel::expression::AsExpression<Text>>::Expression,
 >;
@@ -34,7 +34,7 @@ pub(crate) mod lower_utils {
     pub struct lower<input> {
         pub(super) input: input,
     }
-    ///The return type of [`lower()`](super::fn_name)
+    ///The return type of [`lower()`](fn@lower)
     pub type HelperType<input> = lower<<input as AsExpression<Text>>::Expression>;
     impl<input> Expression for lower<input>
     where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1.snap
@@ -14,7 +14,7 @@ where
     }
 }
 #[allow(non_camel_case_types, non_snake_case)]
-///The return type of [`lower()`](super::fn_name)
+///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
     <input as diesel::expression::AsExpression<Text>>::Expression,
 >;
@@ -34,7 +34,7 @@ pub(crate) mod lower_utils {
     pub struct lower<input> {
         pub(super) input: input,
     }
-    ///The return type of [`lower()`](super::fn_name)
+    ///The return type of [`lower()`](fn@lower)
     pub type HelperType<input> = lower<<input as AsExpression<Text>>::Expression>;
     impl<input> Expression for lower<input>
     where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1 (sqlite).snap
@@ -14,7 +14,7 @@ where
     }
 }
 #[allow(non_camel_case_types, non_snake_case)]
-///The return type of [`lower()`](super::fn_name)
+///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
     <input as diesel::expression::AsExpression<Text>>::Expression,
 >;
@@ -34,7 +34,7 @@ pub(crate) mod lower_utils {
     pub struct lower<input> {
         pub(super) input: input,
     }
-    ///The return type of [`lower()`](super::fn_name)
+    ///The return type of [`lower()`](fn@lower)
     pub type HelperType<input> = lower<<input as AsExpression<Text>>::Expression>;
     impl<input> Expression for lower<input>
     where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1.snap
@@ -14,7 +14,7 @@ where
     }
 }
 #[allow(non_camel_case_types, non_snake_case)]
-///The return type of [`lower()`](super::fn_name)
+///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
     <input as diesel::expression::AsExpression<Text>>::Expression,
 >;
@@ -34,7 +34,7 @@ pub(crate) mod lower_utils {
     pub struct lower<input> {
         pub(super) input: input,
     }
-    ///The return type of [`lower()`](super::fn_name)
+    ///The return type of [`lower()`](fn@lower)
     pub type HelperType<input> = lower<<input as AsExpression<Text>>::Expression>;
     impl<input> Expression for lower<input>
     where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1 (sqlite).snap
@@ -29,7 +29,7 @@ pub(crate) mod lower {
     pub struct lower<input> {
         pub(super) input: input,
     }
-    ///The return type of [`lower()`](super::fn_name)
+    ///The return type of [`lower()`](fn@lower)
     pub type HelperType<input> = lower<<input as AsExpression<Text>>::Expression>;
     impl<input> Expression for lower<input>
     where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1.snap
@@ -29,7 +29,7 @@ pub(crate) mod lower {
     pub struct lower<input> {
         pub(super) input: input,
     }
-    ///The return type of [`lower()`](super::fn_name)
+    ///The return type of [`lower()`](fn@lower)
     pub type HelperType<input> = lower<<input as AsExpression<Text>>::Expression>;
     impl<input> Expression for lower<input>
     where


### PR DESCRIPTION
The links on the return type helper back to the function generated by `#[declare_sql_function]` were broken. This commit fixes these links.

See the links in our documentation:
https://docs.diesel.rs/main/diesel/sqlite/expression/dsl/index.html#types for broken examples. For example the `json()` link at the `json` type alias is expected to link back to the `json` function defined a bit above.