### PR TITLE
feat(sqlite): add -> and ->> JSON operators

### DIFF
--- a/diesel/src/expression/helper_types.rs
+++ b/diesel/src/expression/helper_types.rs
@@ -6,6 +6,8 @@ use super::grouped::Grouped;
 use super::select_by::SelectBy;
 use super::{AsExpression, Expression};
 use crate::expression;
+#[cfg(any(feature = "postgres_backend", feature = "sqlite"))]
+use crate::expression_methods::JsonIndex;
 use crate::expression_methods::PreferredBoolSqlType;
 use crate::sql_types;
 
@@ -222,3 +224,15 @@ pub use crate::sqlite::expression::helper_types::*;
 #[cfg(all(feature = "sqlite", feature = "postgres_backend"))]
 #[allow(unreachable_pub, ambiguous_glob_reexports)]
 pub use crate::sqlite::expression::helper_types::*;
+
+/// The return type of [`lhs.retrieve_as_text(rhs)`](crate::expression_methods::AnyJsonExpressionMethods::retrieve_as_text)
+#[cfg(any(feature = "postgres_backend", feature = "sqlite"))]
+pub type RetrieveAsText<Lhs, Rhs> = Grouped<
+    crate::expression::operators::RetrieveAsTextJson<
+        Lhs,
+        AsExprOf<
+            <Rhs as JsonIndex>::Expression,
+            <<Rhs as JsonIndex>::Expression as Expression>::SqlType,
+        >,
+    >,
+>;

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -620,12 +620,6 @@ infix_operator!(NotLike, " NOT LIKE ");
 infix_operator!(Between, " BETWEEN ");
 infix_operator!(NotBetween, " NOT BETWEEN ");
 
-// JSON operators (PostgreSQL and SQLite)
-__diesel_infix_operator!(
-    RetrieveAsObjectJson,
-    " -> ",
-    __diesel_internal_SameResultAsInput
-);
 infix_operator!(RetrieveAsTextJson, " ->> ", crate::sql_types::Text);
 
 postfix_operator!(IsNull, " IS NULL");

--- a/diesel/src/expression_methods/json_expression_methods.rs
+++ b/diesel/src/expression_methods/json_expression_methods.rs
@@ -1,0 +1,200 @@
+use crate::expression::grouped::Grouped;
+use crate::expression::operators::RetrieveAsTextJson;
+use crate::expression::Expression;
+use crate::sql_types::SqlType;
+
+/// PostgreSQL specific methods present on JSON and JSONB expressions.
+#[cfg(any(feature = "postgres_backend", feature = "sqlite"))]
+pub trait AnyJsonExpressionMethods: Expression + Sized {
+    /// Creates a `->>` expression JSON.
+    ///
+    /// This operator extracts the value associated with the given key, that is provided on the
+    /// Right Hand Side of the operator.
+    ///
+    /// Extracts n'th element of JSON array (array elements are indexed from zero, but negative integers count from the end).
+    /// Extracts JSON object field as Text with the given key.
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # table! {
+    /// #    contacts {
+    /// #        id -> Integer,
+    /// #        name -> VarChar,
+    /// #        address -> Jsonb,
+    /// #    }
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    ///
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use self::contacts::dsl::*;
+    /// #     let conn = &mut establish_connection();
+    /// #     diesel::sql_query("DROP TABLE IF EXISTS contacts").execute(conn).unwrap();
+    /// #     diesel::sql_query("CREATE TABLE contacts (
+    /// #         id SERIAL PRIMARY KEY,
+    /// #         name VARCHAR NOT NULL,
+    /// #         address JSONB NOT NULL
+    /// #     )").execute(conn)
+    /// #        .unwrap();
+    /// #
+    /// let santas_address: serde_json::Value = serde_json::json!({
+    ///     "street": "Article Circle Expressway 1",
+    ///     "city": "North Pole",
+    ///     "postcode": "99705",
+    ///     "state": "Alaska"
+    /// });
+    /// diesel::insert_into(contacts)
+    ///     .values((name.eq("Claus"), address.eq(&santas_address)))
+    ///     .execute(conn)?;
+    ///
+    /// let santas_postcode = contacts.select(address.retrieve_as_text("postcode")).get_result::<String>(conn)?;
+    /// assert_eq!(santas_postcode, "99705");
+    ///
+    ///
+    /// let robert_downey_jr_addresses: serde_json::Value = serde_json::json!([
+    ///     {
+    ///         "street": "Somewhere In La 251",
+    ///         "city": "Los Angeles",
+    ///         "postcode": "12231223",
+    ///         "state": "California"
+    ///     },
+    ///     {
+    ///         "street": "Somewhere In Ny 251",
+    ///         "city": "New York",
+    ///         "postcode": "3213212",
+    ///         "state": "New York"
+    ///     }
+    /// ]);
+    ///
+    /// diesel::insert_into(contacts)
+    ///     .values((name.eq("Robert Downey Jr."), address.eq(&robert_downey_jr_addresses)))
+    ///     .execute(conn)?;
+    ///
+    /// let roberts_second_address_in_db = contacts
+    ///                             .filter(name.eq("Robert Downey Jr."))
+    ///                             .select(address.retrieve_as_text(1))
+    ///                             .get_result::<String>(conn)?;
+    ///
+    /// let roberts_second_address = serde_json::json!{{
+    ///     "city": "New York",
+    ///     "state": "New York",
+    ///     "street": "Somewhere In Ny 251",
+    ///     "postcode": "3213212"
+    ///     }};
+    /// assert_eq!(roberts_second_address, serde_json::from_str::<serde_json::Value>(&roberts_second_address_in_db).unwrap());
+    /// #     Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "serde_json"))]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn retrieve_as_text<T>(
+        self,
+        other: T,
+    ) -> crate::expression::helper_types::RetrieveAsText<Self, T>
+    where
+        T: JsonIndex,
+        <T::Expression as Expression>::SqlType: SqlType,
+    {
+        Grouped(RetrieveAsTextJson::new(
+            self,
+            other.into_json_index_expression(),
+        ))
+    }
+}
+
+/// A marker trait indicating which types can be used as index into a json field
+pub trait JsonIndex: self::private::Sealed {
+    #[doc(hidden)]
+    type Expression: Expression;
+
+    #[doc(hidden)]
+    fn into_json_index_expression(self) -> Self::Expression;
+}
+
+impl<T> AnyJsonExpressionMethods for T
+where
+    T: Expression,
+    T::SqlType: private::JsonOrNullableJsonOrJsonbOrNullableJsonb,
+{
+}
+
+pub(crate) mod private {
+    use super::JsonIndex;
+    use crate::expression::IntoSql;
+    use crate::sql_types::{Integer, Json, Jsonb, Nullable, Text};
+    use crate::Expression;
+
+    pub trait Sealed {}
+
+    #[diagnostic::on_unimplemented(
+        message = "`{Self}` is neither `diesel::sql_types::Text` nor `diesel::sql_types::Integer`",
+        note = "try to provide an expression that produces one of the expected sql types"
+    )]
+    pub trait TextOrInteger {}
+    impl TextOrInteger for Text {}
+    impl TextOrInteger for Integer {}
+
+    /// Marker trait used to implement `PgAnyJsonExpressionMethods` on the appropriate types.
+    #[diagnostic::on_unimplemented(
+        message = "`{Self}` is neither `diesel::sql_types::Json`, `diesel::sql_types::Jsonb`, `diesel::sql_types::Nullable<Json>` nor `diesel::sql_types::Nullable<Jsonb>`",
+        note = "try to provide an expression that produces one of the expected sql types"
+    )]
+    pub trait JsonOrNullableJsonOrJsonbOrNullableJsonb {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Json {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Nullable<Json> {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Jsonb {}
+    impl JsonOrNullableJsonOrJsonbOrNullableJsonb for Nullable<Jsonb> {}
+
+    impl Sealed for &'_ str {}
+    impl Sealed for String {}
+    impl Sealed for i32 {}
+    impl<T> Sealed for T
+    where
+        T: Expression,
+        T::SqlType: TextOrInteger,
+    {
+    }
+
+    impl<'a> JsonIndex for &'a str {
+        type Expression = crate::dsl::AsExprOf<&'a str, crate::sql_types::Text>;
+
+        fn into_json_index_expression(self) -> Self::Expression {
+            self.into_sql::<Text>()
+        }
+    }
+
+    impl JsonIndex for String {
+        type Expression = crate::dsl::AsExprOf<String, crate::sql_types::Text>;
+
+        fn into_json_index_expression(self) -> Self::Expression {
+            self.into_sql::<Text>()
+        }
+    }
+
+    impl JsonIndex for i32 {
+        type Expression = crate::dsl::AsExprOf<i32, crate::sql_types::Int4>;
+
+        fn into_json_index_expression(self) -> Self::Expression {
+            self.into_sql::<crate::sql_types::Int4>()
+        }
+    }
+
+    impl<T> JsonIndex for T
+    where
+        T: Expression,
+        T::SqlType: TextOrInteger,
+    {
+        type Expression = Self;
+
+        fn into_json_index_expression(self) -> Self::Expression {
+            self
+        }
+    }
+}

--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -8,6 +8,8 @@ mod bool_expression_methods;
 mod eq_all;
 mod escape_expression_methods;
 mod global_expression_methods;
+#[cfg(any(feature = "sqlite", feature = "postgres_backend"))]
+pub(crate) mod json_expression_methods;
 mod text_expression_methods;
 
 #[doc(inline)]
@@ -18,6 +20,9 @@ pub use self::eq_all::EqAll;
 pub use self::escape_expression_methods::EscapeExpressionMethods;
 #[doc(inline)]
 pub use self::global_expression_methods::{ExpressionMethods, NullableExpressionMethods};
+#[doc(inline)]
+#[cfg(any(feature = "sqlite", feature = "postgres_backend"))]
+pub use self::json_expression_methods::{AnyJsonExpressionMethods, JsonIndex};
 #[doc(inline)]
 pub use self::text_expression_methods::TextExpressionMethods;
 #[doc(inline)]

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -1,7 +1,8 @@
 use crate::dsl::{AsExpr, AsExprOf, SqlTypeOf};
 use crate::expression::grouped::Grouped;
 use crate::expression::Expression;
-use crate::pg::expression::expression_methods::private::{JsonIndex, JsonRemoveIndex};
+use crate::expression_methods::JsonIndex;
+use crate::pg::expression::expression_methods::private::JsonRemoveIndex;
 use crate::pg::types::sql_types::Array;
 use crate::sql_types::{Inet, Integer, VarChar};
 
@@ -276,29 +277,25 @@ pub type Remove<Lhs, Rhs> = RemoveFromJsonb<
     <<Rhs as JsonRemoveIndex>::Expression as Expression>::SqlType,
 >;
 
+#[doc(hidden)] // deprecated
+pub type RetrieveAsObjectJson<Lhs, Rhs, ST> =
+    Grouped<crate::pg::expression::operators::RetrieveAsObjectJson<Lhs, AsExprOf<Rhs, ST>>>;
+
 /// The return type of [`lhs.retrieve_as_object(rhs)`](super::expression_methods::PgAnyJsonExpressionMethods::retrieve_as_object)
 #[cfg(feature = "postgres_backend")]
-pub type RetrieveAsObjectJson<Lhs, Rhs, ST> =
-    Grouped<crate::expression::operators::RetrieveAsObjectJson<Lhs, AsExprOf<Rhs, ST>>>;
-
-#[doc(hidden)] // needed for `#[auto_type]`
-pub type RetrieveAsObject<Lhs, Rhs> = RetrieveAsObjectJson<
-    Lhs,
-    <Rhs as JsonIndex>::Expression,
-    <<Rhs as JsonIndex>::Expression as Expression>::SqlType,
+pub type RetrieveAsObject<Lhs, Rhs> = Grouped<
+    crate::pg::expression::operators::RetrieveAsObjectJson<
+        Lhs,
+        AsExprOf<
+            <Rhs as JsonIndex>::Expression,
+            <<Rhs as JsonIndex>::Expression as Expression>::SqlType,
+        >,
+    >,
 >;
 
-/// The return type of [`lhs.retrieve_as_text(rhs)`](super::expression_methods::PgAnyJsonExpressionMethods::retrieve_as_text)
-#[cfg(feature = "postgres_backend")]
+#[doc(hidden)] // deprecated
 pub type RetrieveAsTextJson<Lhs, Rhs, ST> =
     Grouped<crate::expression::operators::RetrieveAsTextJson<Lhs, AsExprOf<Rhs, ST>>>;
-
-#[doc(hidden)] // needed for `#[auto_type]`
-pub type RetrieveAsText<Lhs, Rhs> = RetrieveAsTextJson<
-    Lhs,
-    <Rhs as JsonIndex>::Expression,
-    <<Rhs as JsonIndex>::Expression as Expression>::SqlType,
->;
 
 /// The return type of [`lhs.retrieve_by_path_as_object(rhs)`](super::expression_methods::PgAnyJsonExpressionMethods::retrieve_by_path_as_object)
 #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/expression/operators.rs
+++ b/diesel/src/pg/expression/operators.rs
@@ -43,8 +43,7 @@ infix_operator!(HasAnyKeyJsonb, " ?| ", backend: Pg);
 infix_operator!(HasAllKeysJsonb, " ?& ", backend: Pg);
 infix_operator!(RangeAdjacent, " -|- ", backend: Pg);
 infix_operator!(RemoveFromJsonb, " - ", Jsonb, backend: Pg);
-// RetrieveAsObjectJson and RetrieveAsTextJson have been moved to crate::expression::operators
-// to avoid conflicts when both postgres_backend and sqlite features are enabled
+__diesel_infix_operator!(RetrieveAsObjectJson, " -> ", __diesel_internal_SameResultAsInput, backend: Pg);
 __diesel_infix_operator!(
     RetrieveByPathAsObjectJson,
     " #> ",

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -2,10 +2,10 @@
 #[cfg(doc)]
 use crate::expression::functions::aggregate_expressions::AggregateExpressionMethods;
 use crate::expression::functions::declare_sql_function;
+use crate::expression_methods::json_expression_methods::private::JsonOrNullableJsonOrJsonbOrNullableJsonb;
 use crate::sql_types::*;
 use crate::sqlite::expression::expression_methods::BinaryOrNullableBinary;
 use crate::sqlite::expression::expression_methods::JsonOrNullableJson;
-use crate::sqlite::expression::expression_methods::JsonOrNullableJsonOrJsonbOrNullableJsonb;
 use crate::sqlite::expression::expression_methods::MaybeNullableValue;
 use crate::sqlite::expression::expression_methods::NotBlob;
 use crate::sqlite::expression::expression_methods::TextOrNullableText;

--- a/diesel/src/sqlite/expression/helper_types.rs
+++ b/diesel/src/sqlite/expression/helper_types.rs
@@ -1,6 +1,7 @@
 use crate::dsl::AsExpr;
 use crate::expression::grouped::Grouped;
 use crate::expression::Expression;
+use crate::expression_methods::JsonIndex;
 
 /// The return type of `lhs.is(rhs)`.
 pub type Is<Lhs, Rhs> = Grouped<super::operators::Is<Lhs, AsExpr<Rhs, Lhs>>>;
@@ -12,28 +13,14 @@ pub type IsNot<Lhs, Rhs> = Grouped<super::operators::IsNot<Lhs, AsExpr<Rhs, Lhs>
 ///
 /// Note: SQLite's `->` operator always returns JSON (TEXT representation), not JSONB
 #[cfg(feature = "sqlite")]
-pub type RetrieveAsObjectJson<Lhs, Rhs, ST> =
-    Grouped<crate::expression::operators::RetrieveAsObjectJson<Lhs, crate::dsl::AsExprOf<Rhs, ST>>>;
-
-#[doc(hidden)] // needed for `#[auto_type]`
-#[cfg(feature = "sqlite")]
-pub type RetrieveAsObject<Lhs, Rhs> = RetrieveAsObjectJson<
-    Lhs,
-    <Rhs as crate::sqlite::expression::expression_methods::JsonIndex>::Expression,
-    <<Rhs as crate::sqlite::expression::expression_methods::JsonIndex>::Expression as Expression>::SqlType,
->;
-
-/// The return type of [`lhs.retrieve_as_text(rhs)`](super::expression_methods::SqliteAnyJsonExpressionMethods::retrieve_as_text)
-#[cfg(feature = "sqlite")]
-pub type RetrieveAsTextJson<Lhs, Rhs, ST> =
-    Grouped<crate::expression::operators::RetrieveAsTextJson<Lhs, crate::dsl::AsExprOf<Rhs, ST>>>;
-
-#[doc(hidden)] // needed for `#[auto_type]`
-#[cfg(feature = "sqlite")]
-pub type RetrieveAsText<Lhs, Rhs> = RetrieveAsTextJson<
-    Lhs,
-    <Rhs as crate::sqlite::expression::expression_methods::JsonIndex>::Expression,
-    <<Rhs as crate::sqlite::expression::expression_methods::JsonIndex>::Expression as Expression>::SqlType,
+pub type RetrieveAsObjectSqlite<Lhs, Rhs> = Grouped<
+    crate::sqlite::expression::operators::RetrieveAsObjectSqlite<
+        Lhs,
+        crate::dsl::AsExprOf<
+            <Rhs as JsonIndex>::Expression,
+            <<Rhs as JsonIndex>::Expression as Expression>::SqlType,
+        >,
+    >,
 >;
 
 #[doc(inline)]

--- a/diesel/src/sqlite/expression/operators.rs
+++ b/diesel/src/sqlite/expression/operators.rs
@@ -1,9 +1,7 @@
 use crate::sql_types::Bool;
+use crate::sql_types::Json;
 use crate::sqlite::Sqlite;
 
 __diesel_infix_operator!(Is, " IS ", ConstantNullability Bool, backend: Sqlite);
 __diesel_infix_operator!(IsNot, " IS NOT ", ConstantNullability Bool, backend: Sqlite);
-// RetrieveAsObjectJson and RetrieveAsTextJson have been moved to crate::expression::operators
-// to avoid conflicts when both postgres_backend and sqlite features are enabled
-// SQLite's -> operator always returns TEXT JSON representation, not JSONB
-// See: https://www.sqlite.org/json1.html#jptr
+infix_operator!(RetrieveAsObjectSqlite, " -> ", Json, backend: Sqlite);

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -371,6 +371,13 @@ fn test_pg_any_json_expression_methods() -> _ {
         .and(pg_extras::name.is_not_json_scalar())
 }
 
+#[cfg(feature = "sqlite")]
+#[auto_type]
+fn test_sqlite_any_json_expression_methods() -> _ {
+    let s: &'static str = "";
+    sqlite_extras::json.retrieve_as_object_sqlite(s)
+}
+
 #[cfg(feature = "postgres")]
 #[auto_type]
 fn test_pg_timestamp_expression_methods() -> _ {


### PR DESCRIPTION
Add support for SQLite's [->](https://sqlite.org/draft/json1.html#jptr) and [->>](https://sqlite.org/draft/json1.html#jptr) JSON extraction operators.

The [->](https://sqlite.org/draft/json1.html#jptr) operator extracts a JSON subcomponent and returns it as a TEXT JSON representation (always returns Json type, never Jsonb).

The [->>](https://sqlite.org/draft/json1.html#jptr)  operator extracts a JSON subcomponent and returns it as an SQL TEXT value (unwrapped).

partially completes #4366 