### PR TITLE
Remove a misleading documentation comment for concurrent usage of `run_pending_migrations`

### DIFF
--- a/diesel_migrations/src/migration_harness.rs
+++ b/diesel_migrations/src/migration_harness.rs
@@ -28,14 +28,6 @@ pub trait MigrationHarness<DB: Backend> {
     }
 
     /// Execute all unapplied migrations for a given migration source
-    ///
-    /// # Concurrent Usage Safety
-    /// This method can be safely called concurrently from multiple processes. The behavior is as follows:
-    ///
-    /// * All migrations are applied atomically by the first process that successfully acquires the database lock
-    /// * Concurrent processes attempting to run migrations while the lock is held will receive a "database is locked" error
-    /// * Processes that start after successful migration completion will find no pending migrations and complete successfully
-    /// * Each migration is guaranteed to be applied exactly once
     fn run_pending_migrations<S: MigrationSource<DB>>(
         &mut self,
         source: S,


### PR DESCRIPTION


This commit removes a comment that states running
`run_pending_migrations` concurrently was actually safe. This is not the case as we e.g don't lock the migrations table to prevent other processes running migrations itself. In the long run we likely want to implment a proper fix for this, for now it's better to just correct the documentation.

Fix #4862