### PR TITLE
Add support for more expression types in diesel_infer_schema

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,8 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
     "BSD-3-Clause",
-    "GPL-2.0"
+    "GPL-2.0",
+    "MPL-2.0",
 ]
 # ignore private packages
 private = { ignore = true }

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -70,6 +70,7 @@ version = "~2.3.0"
 path = "../diesel_migrations/"
 
 [dependencies.diesel_infer_query]
+version = "0.1.0"
 path = "../diesel_infer_query"
 
 [dev-dependencies]

--- a/diesel_cli/src/errors.rs
+++ b/diesel_cli/src/errors.rs
@@ -106,8 +106,10 @@ impl Error {
 impl From<diesel_infer_query::Error> for Error {
     fn from(value: diesel_infer_query::Error) -> Self {
         match value {
-            diesel_infer_query::Error::ResolverFailure(e) if e.downcast_ref::<Self>().is_some() => {
-                *e.downcast().expect("We checked this before")
+            diesel_infer_query::Error::ResolverFailure { inner, .. }
+                if inner.downcast_ref::<Self>().is_some() =>
+            {
+                *inner.downcast().expect("We checked this before")
             }
             e => Self::InferError(e),
         }

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -471,7 +471,7 @@ fn print_schema_view_infer_nullable_from_table() {
     test_print_schema(
         "print_schema_view_infer_nullable_from_table",
         vec!["--include-views", "--experimental-infer-nullable-for-views"],
-    )
+    );
 }
 
 #[test]

--- a/diesel_cli/tests/print_schema/print_schema_view_infer_nullable_from_table/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_view_infer_nullable_from_table/sqlite/expected.snap
@@ -14,8 +14,8 @@ diesel::table! {
 
 diesel::view! {
     test {
-        id -> Nullable<Integer>,
-        name -> Nullable<Text>,
+        id -> Integer,
+        name -> Text,
         hair_color -> Nullable<Text>,
     }
 }

--- a/diesel_cli/tests/print_schema/print_schema_view_infer_nullable_only_view/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_view_infer_nullable_only_view/sqlite/expected.snap
@@ -1,13 +1,13 @@
 ---
 source: diesel_cli/tests/print_schema.rs
-description: "Test: print_schema_view_infer_nullable_from_table_only_view"
+description: "Test: print_schema_view_infer_nullable_only_view"
 ---
 // @generated automatically by Diesel CLI.
 
 diesel::view! {
     test {
-        id -> Nullable<Integer>,
-        name -> Nullable<Text>,
+        id -> Integer,
+        name -> Text,
         hair_color -> Nullable<Text>,
     }
 }

--- a/diesel_infer_query/LICENSE
+++ b/diesel_infer_query/LICENSE
@@ -1,0 +1,374 @@
+ Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+means each individual or legal entity that creates, contributes to
+the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+means the combination of the Contributions of others (if any) used
+by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+means Source Code Form to which the initial Contributor has attached
+the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+means
+
+(a) that the initial Contributor has attached the notice described
+in Exhibit B to the Covered Software; or
+
+(b) that the Covered Software was made available under the terms of
+version 1.1 or earlier of the License, but not also under the
+terms of a Secondary License.
+
+1.6. "Executable Form"
+means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+means a work that combines Covered Software with other material, in
+a separate file or files, that is not Covered Software.
+
+1.8. "License"
+means this document.
+
+1.9. "Licensable"
+means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications"
+means any of the following:
+
+(a) any file in Source Code Form that results from an addition to,
+deletion from, or modification of the contents of Covered
+Software; or
+
+(b) any new file in Source Code Form that contains any Covered
+Software.
+
+1.11. "Patent Claims" of a Contributor
+means any patent claim(s), including without limitation, method,
+process, and apparatus claims, in any patent Licensable by such
+Contributor that would be infringed, but for the grant of the
+License, by the making, using, selling, offering for sale, having
+made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. "Secondary License"
+means either the GNU General Public License, Version 2.0, the GNU
+Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those
+licenses.
+
+1.13. "Source Code Form"
+means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+means an individual or a legal entity exercising rights under this
+License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For
+purposes of this definition, "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of more than
+fifty percent (50%) of the outstanding shares or beneficial
+ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+Licensable by such Contributor to use, reproduce, make available,
+modify, display, perform, distribute, and otherwise exploit its
+Contributions, either on an unmodified basis, with Modifications, or
+as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+for sale, have made, import, and otherwise transfer either its
+Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+or
+
+(b) for infringements caused by: (i) Your and any other third party's
+modifications of Covered Software, or (ii) the combination of its
+Contributions with other software (except as part of its Contributor
+Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+Form, as described in Section 3.1, and You must inform recipients of
+the Executable Form how they can obtain a copy of such Source Code
+Form by reasonable means in a timely manner, at a charge no more
+than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+License, or sublicense it under different terms, provided that the
+license for the Executable Form does not attempt to limit or alter
+the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+* *
+* 6. Disclaimer of Warranty *
+* ------------------------- *
+* *
+* Covered Software is provided under this License on an "as is" *
+* basis, without warranty of any kind, either expressed, implied, or *
+* statutory, including, without limitation, warranties that the *
+* Covered Software is free of defects, merchantable, fit for a *
+* particular purpose or non-infringing. The entire risk as to the *
+* quality and performance of the Covered Software is with You. *
+* Should any Covered Software prove defective in any respect, You *
+* (not any Contributor) assume the cost of any necessary servicing, *
+* repair, or correction. This disclaimer of warranty constitutes an *
+* essential part of this License. No use of any Covered Software is *
+* authorized under this License except under this disclaimer. *
+* *
+************************************************************************
+
+************************************************************************
+* *
+* 7. Limitation of Liability *
+* -------------------------- *
+* *
+* Under no circumstances and under no legal theory, whether tort *
+* (including negligence), contract, or otherwise, shall any *
+* Contributor, or anyone who distributes Covered Software as *
+* permitted above, be liable to You for any direct, indirect, *
+* special, incidental, or consequential damages of any character *
+* including, without limitation, damages for lost profits, loss of *
+* goodwill, work stoppage, computer failure or malfunction, or any *
+* and all other commercial damages or losses, even if such party *
+* shall have been informed of the possibility of such damages. This *
+* limitation of liability shall not apply to liability for death or *
+* personal injury resulting from such party's negligence to the *
+* extent applicable law prohibits such limitation. Some *
+* jurisdictions do not allow the exclusion or limitation of *
+* incidental or consequential damages, so this exclusion and *
+* limitation may not apply to You. *
+* *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.
+

--- a/diesel_infer_query/src/error.rs
+++ b/diesel_infer_query/src/error.rs
@@ -8,6 +8,7 @@
 pub enum Error {
     /// Parsing the SQL failed with the provided error message
     #[error("Failed to parse sql: {0:?}")]
+    #[non_exhaustive]
     ParserError(#[from] sqlparser::parser::ParserError),
     /// Handling this kind of SQL is currently not supported by this crate
     #[error("Unsupported SQL: {msg}")]
@@ -17,13 +18,18 @@ pub enum Error {
     },
     /// The query referenced a unknown query source
     #[error("Querysource was not found in the from clause: `{query_source}`")]
+    #[non_exhaustive]
     InvalidQuerySource {
         /// Which query source is unknown
         query_source: String,
     },
     /// The schema resolver returned an error
-    #[error("Could not resolve view data: {0}")]
-    ResolverFailure(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("Could not resolve view data: {inner}")]
+    #[non_exhaustive]
+    ResolverFailure {
+        /// The inner resolver failure
+        inner: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
 
 /// A result type using the error provided by this crate as default

--- a/diesel_infer_query/src/expression.rs
+++ b/diesel_infer_query/src/expression.rs
@@ -4,16 +4,18 @@
 
 use crate::error::{Error, Result};
 use crate::query_source::QuerySource;
-use crate::select::SelectFieldKind;
-use sqlparser::ast::{Expr, Value};
+use crate::select::{CaseCondition, Expression};
+use sqlparser::ast::{
+    Expr, FunctionArg, FunctionArgExpr, FunctionArguments, ObjectNamePart, Value,
+};
 use std::collections::HashMap;
 
 pub(crate) fn infer_expr(
     expr: &sqlparser::ast::Expr,
     query_source_lookup: &HashMap<&str, QuerySource>,
-) -> Result<SelectFieldKind> {
+) -> Result<Expression> {
     match expr {
-        Expr::Value(v) => Ok(SelectFieldKind::Literal {
+        Expr::Value(v) => Ok(Expression::Literal {
             value: v.value.clone().into_string(),
             is_null: matches!(v.value, Value::Null),
         }),
@@ -23,7 +25,7 @@ pub(crate) fn infer_expr(
                     .values()
                     .next()
                     .expect("We checked there is only one value");
-                Ok(SelectFieldKind::Field {
+                Ok(Expression::Field {
                     schema: table.schema.map(|s| s.to_owned()),
                     query_source: table.name.to_owned(),
                     field_name: id.value.clone(),
@@ -46,8 +48,8 @@ pub(crate) fn infer_expr(
                         query_source: table.value.clone(),
                     })?;
                 // lookup if this field comes in via a `LEFT JOIN` somewhere in the chain
-                let via_left_join = table.contains_left_join(&query_source_lookup)?;
-                Ok(SelectFieldKind::Field {
+                let via_left_join = table.contains_left_join(query_source_lookup)?;
+                Ok(Expression::Field {
                     schema: table.schema.map(|s| s.to_owned()),
                     query_source: table.name.to_owned(),
                     field_name: field.value.clone(),
@@ -64,12 +66,226 @@ pub(crate) fn infer_expr(
             expr, data_type, ..
         } => {
             let inner = infer_expr(expr, query_source_lookup)?;
-            Ok(SelectFieldKind::Cast {
+            Ok(Expression::Cast {
                 inner: Box::new(inner),
                 tpe: data_type.to_string(),
             })
         }
+        Expr::BinaryOp { left, op, right } => {
+            let left = Box::new(infer_expr(left, query_source_lookup)?);
+            let right = Box::new(infer_expr(right, query_source_lookup)?);
+            Ok(Expression::BinaryOp {
+                left,
+                right,
+                op: op.to_string(),
+                statically_not_null: false,
+            })
+        }
+        Expr::IsNull(e) => {
+            let inner = Box::new(infer_expr(e, query_source_lookup)?);
+            Ok(Expression::PostfixOp {
+                expr: inner,
+                op: String::from("IS NULL"),
+                statically_not_null: true,
+            })
+        }
+        Expr::IsNotNull(e) => {
+            let inner = Box::new(infer_expr(e, query_source_lookup)?);
+            Ok(Expression::PostfixOp {
+                expr: inner,
+                op: String::from("IS NOT NULL"),
+                statically_not_null: true,
+            })
+        }
+        Expr::Function(f) => infer_functions(f, query_source_lookup),
+        Expr::Like {
+            negated,
+            any,
+            expr,
+            pattern,
+            escape_char,
+        } if !*any && escape_char.is_none() => {
+            let op = if *negated { "NOT LIKE" } else { "LIKE" };
+            Ok(Expression::BinaryOp {
+                left: Box::new(infer_expr(expr, query_source_lookup)?),
+                right: Box::new(infer_expr(pattern, query_source_lookup)?),
+                op: String::from(op),
+                statically_not_null: false,
+            })
+        }
+        Expr::ILike {
+            negated,
+            any,
+            expr,
+            pattern,
+            escape_char,
+        } if !*any && escape_char.is_none() => {
+            let op = if *negated { "NOT ILIKE" } else { "ILIKE" };
+            Ok(Expression::BinaryOp {
+                left: Box::new(infer_expr(expr, query_source_lookup)?),
+                right: Box::new(infer_expr(pattern, query_source_lookup)?),
+                op: String::from(op),
+                statically_not_null: false,
+            })
+        }
+        Expr::IsDistinctFrom(a, b) => Ok(Expression::BinaryOp {
+            left: Box::new(infer_expr(a, query_source_lookup)?),
+            right: Box::new(infer_expr(b, query_source_lookup)?),
+            op: String::from("IS DISTINCT FROM"),
+            statically_not_null: true,
+        }),
+        Expr::IsNotDistinctFrom(a, b) => Ok(Expression::BinaryOp {
+            left: Box::new(infer_expr(a, query_source_lookup)?),
+            right: Box::new(infer_expr(b, query_source_lookup)?),
+            op: String::from("IS NOT DISTINCT FROM"),
+            statically_not_null: true,
+        }),
+        Expr::Between {
+            expr,
+            negated,
+            low,
+            high,
+        } => Ok(Expression::Between {
+            left: Box::new(infer_expr(expr, query_source_lookup)?),
+            negated: *negated,
+            low: Box::new(infer_expr(low, query_source_lookup)?),
+            high: Box::new(infer_expr(high, query_source_lookup)?),
+        }),
+        Expr::SimilarTo {
+            negated,
+            expr,
+            pattern,
+            escape_char,
+        } if escape_char.is_none() => {
+            let op = if *negated {
+                "NOT SIMILAR TO"
+            } else {
+                "SIMILAR TO"
+            };
+            Ok(Expression::BinaryOp {
+                left: Box::new(infer_expr(expr, query_source_lookup)?),
+                right: Box::new(infer_expr(pattern, query_source_lookup)?),
+                op: String::from(op),
+                statically_not_null: false,
+            })
+        }
+        Expr::RLike {
+            negated,
+            expr,
+            pattern,
+            regexp,
+        } => {
+            let op = if *regexp {
+                if *negated { "NOT REGEXP" } else { "REGEXP" }
+            } else if *negated {
+                "NOT RLIKE"
+            } else {
+                "RLIKE"
+            };
+            Ok(Expression::BinaryOp {
+                left: Box::new(infer_expr(expr, query_source_lookup)?),
+                right: Box::new(infer_expr(pattern, query_source_lookup)?),
+                op: String::from(op),
+                statically_not_null: false,
+            })
+        }
+        Expr::Case {
+            operand,
+            conditions,
+            else_result,
+            ..
+        } => {
+            let operand = operand
+                .as_ref()
+                .map(|o| infer_expr(o, query_source_lookup))
+                .transpose()?
+                .map(Box::new);
+            let else_clause = else_result
+                .as_ref()
+                .map(|e| infer_expr(e, query_source_lookup))
+                .transpose()?
+                .map(Box::new);
+            let conditions = conditions
+                .iter()
+                .map(|c| -> std::result::Result<_, _> {
+                    let condition = infer_expr(&c.condition, query_source_lookup)?;
+                    let result = infer_expr(&c.result, query_source_lookup)?;
+                    Ok(CaseCondition { condition, result })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Expression::Case {
+                operand,
+                conditions,
+                else_clause,
+            })
+        }
         // other kinds of expressions still need to be supported
-        _e => Ok(SelectFieldKind::Unknown),
+        _e => {
+            dbg!(_e);
+            Ok(Expression::Unknown)
+        }
     }
+}
+
+fn infer_functions(
+    f: &sqlparser::ast::Function,
+    query_source_lookup: &HashMap<&str, QuerySource<'_>>,
+) -> Result<Expression> {
+    let (name, schema) = match f.name.0.as_slice() {
+        [ObjectNamePart::Identifier(name)] => (&name.value, None),
+        [
+            ObjectNamePart::Identifier(schema),
+            ObjectNamePart::Identifier(name),
+        ] => (&name.value, Some(&schema.value)),
+        _ => return Ok(Expression::Unknown),
+    };
+    let args = match &f.args {
+        FunctionArguments::List(l) if l.duplicate_treatment.is_none() && l.clauses.is_empty() => l
+            .args
+            .iter()
+            .map(|arg| match arg {
+                FunctionArg::Named { arg, .. }
+                | FunctionArg::ExprNamed { arg, .. }
+                | FunctionArg::Unnamed(arg) => match arg {
+                    FunctionArgExpr::Expr(expr) => infer_expr(expr, query_source_lookup),
+                    FunctionArgExpr::QualifiedWildcard(object_name) => {
+                        if let Some(item) = object_name
+                            .0
+                            .last()
+                            .and_then(|a| a.as_ident())
+                            .map(|a| a.value.as_str())
+                            .and_then(|k| query_source_lookup.get(k))
+                        {
+                            let is_left_joined = item.contains_left_join(query_source_lookup)?;
+                            Ok(Expression::Wildcard {
+                                is_left_joined,
+                                relation: item.name.to_string(),
+                                schema: item.schema.map(|t| t.to_owned()),
+                            })
+                        } else {
+                            Ok(Expression::Unknown)
+                        }
+                    }
+                    FunctionArgExpr::Wildcard if query_source_lookup.len() == 1 => {
+                        let query_source_lookup = query_source_lookup
+                            .values()
+                            .next()
+                            .expect("We have exactly one element");
+                        Ok(Expression::Wildcard {
+                            is_left_joined: false,
+                            relation: query_source_lookup.name.to_string(),
+                            schema: query_source_lookup.schema.map(|t| t.to_owned()),
+                        })
+                    }
+                    FunctionArgExpr::Wildcard => Ok(Expression::Unknown),
+                },
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => return Ok(Expression::Unknown),
+    };
+    Ok(Expression::Function {
+        name: name.clone(),
+        schema: schema.cloned(),
+        arguments: args,
+    })
 }

--- a/diesel_infer_query/src/query_source.rs
+++ b/diesel_infer_query/src/query_source.rs
@@ -85,7 +85,7 @@ impl<'a> QuerySource<'a> {
     /// used to include this query source is joined via a `LEFT JOIN`
     pub(crate) fn contains_left_join(
         &self,
-        query_source_lookup: &&HashMap<&str, QuerySource<'_>>,
+        query_source_lookup: &HashMap<&str, QuerySource<'_>>,
     ) -> Result<bool> {
         if let Some(join) = &self.join {
             match join.kind {

--- a/diesel_infer_query/src/resolver.rs
+++ b/diesel_infer_query/src/resolver.rs
@@ -13,10 +13,20 @@ pub trait SchemaResolver {
         query_relation: &str,
         field_name: &str,
     ) -> Result<&'s dyn SchemaField, Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    /// Get a list of fields for a specific database relation
+    /// in the order returned by the database
+    fn list_fields<'s>(
+        &'s mut self,
+        relation_schema: Option<&str>,
+        query_relation: &str,
+    ) -> Result<Vec<&'s dyn SchemaField>, Box<dyn std::error::Error + Send + Sync + 'static>>;
 }
 
 /// A generic representation of a database field
 pub trait SchemaField {
     /// Is this field nullable
     fn is_nullable(&self) -> bool;
+    /// The database side name of the field
+    fn name(&self) -> &str;
 }

--- a/diesel_infer_query/src/select.rs
+++ b/diesel_infer_query/src/select.rs
@@ -6,13 +6,13 @@ use super::SchemaResolver;
 use crate::error::Error;
 use crate::error::Result;
 use crate::query_source::QuerySource;
-use sqlparser::ast::SelectItem;
+use sqlparser::ast::{SelectItem, SelectItemQualifiedWildcardKind};
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct SelectField {
     pub(crate) ident: Option<String>,
-    pub(crate) kind: SelectFieldKind,
+    pub(crate) kind: Expression,
 }
 
 impl SelectField {
@@ -24,10 +24,17 @@ impl SelectField {
     }
 }
 
+#[derive(Debug, PartialEq)]
+/// WHEN [condition] THEN [result]` exrpession
+pub(crate) struct CaseCondition {
+    pub(crate) condition: Expression,
+    pub(crate) result: Expression,
+}
+
 /// Different kind of expressions in a SELECT clause
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
-pub enum SelectFieldKind {
+pub enum Expression {
     /// A literal value like `1` or `'foo'`
     Literal {
         /// The actual value
@@ -49,32 +56,68 @@ pub enum SelectFieldKind {
     /// A cast expression
     Cast {
         /// inner expression
-        inner: Box<SelectFieldKind>,
+        inner: Box<Expression>,
         /// target cast type
         tpe: String,
+    },
+    /// A binary operation
+    BinaryOp {
+        /// left side of the operation
+        left: Box<Expression>,
+        /// right side of the operation
+        right: Box<Expression>,
+        /// operator
+        op: String,
+        /// is this operation statically known not to produce null values
+        statically_not_null: bool,
+    },
+    // A postfix operation like `IS NULL`
+    PostfixOp {
+        expr: Box<Expression>,
+        op: String,
+        statically_not_null: bool,
+    },
+    /// A function call
+    Function {
+        name: String,
+        schema: Option<String>,
+        arguments: Vec<Expression>,
+    },
+    /// A wild card `*` expression
+    Wildcard {
+        schema: Option<String>,
+        relation: String,
+        is_left_joined: bool,
+    },
+    /// A `left BETWEEN low AND high` expression
+    Between {
+        left: Box<Expression>,
+        negated: bool,
+        low: Box<Expression>,
+        high: Box<Expression>,
+    },
+    // A `CASE [operand] [conditions] ELSE [else]` expression
+    Case {
+        operand: Option<Box<Expression>>,
+        conditions: Vec<CaseCondition>,
+        else_clause: Option<Box<Expression>>,
     },
     /// A unknown select expression
     Unknown,
 }
 
-impl SelectFieldKind {
+impl Expression {
     pub(crate) fn infer_nullability(
         &self,
         resolver: &mut (dyn SchemaResolver + '_),
     ) -> Result<Option<bool>> {
         match self {
-            // literals are null for literal `NULL` values
-            // Otherwise they cannot be null
-            SelectFieldKind::Literal { is_null, .. } => Ok(Some(*is_null)),
-            // If the field comes in via an `LEFT JOIN`
-            // we unconditionally assume it is nullable
-            SelectFieldKind::Field {
+            Self::Literal { is_null, .. } => Ok(Some(*is_null)),
+            Self::Field {
                 via_left_join: true,
                 ..
             } => Ok(Some(true)),
-            // Otherwise we ask the schema resolver for  more information about
-            // this particular field
-            SelectFieldKind::Field {
+            Self::Field {
                 schema,
                 query_source: table,
                 field_name,
@@ -82,13 +125,73 @@ impl SelectFieldKind {
             } => Ok(Some(
                 resolver
                     .resolve_field(schema.as_deref(), table, field_name)
-                    .map_err(Error::ResolverFailure)?
+                    .map_err(|inner| Error::ResolverFailure { inner })?
                     .is_nullable(),
             )),
-            // for casts we assume that they return `NULL` only if the inner expression is `NULL`
-            SelectFieldKind::Cast { inner, .. } => inner.infer_nullability(resolver),
-            // unknown is not known, so return None
-            SelectFieldKind::Unknown => Ok(None),
+            Self::Cast { inner, .. } => inner.infer_nullability(resolver),
+            Self::BinaryOp {
+                left,
+                right,
+                statically_not_null,
+                ..
+            } => {
+                if *statically_not_null {
+                    Ok(Some(false))
+                } else {
+                    match (
+                        left.infer_nullability(resolver)?,
+                        right.infer_nullability(resolver)?,
+                    ) {
+                        (None, _) | (_, None) => Ok(None),
+                        (Some(a), Some(b)) => Ok(Some(a || b)),
+                    }
+                }
+            }
+            Expression::PostfixOp {
+                expr,
+                statically_not_null,
+                ..
+            } => {
+                if *statically_not_null {
+                    Ok(Some(false))
+                } else {
+                    expr.infer_nullability(resolver)
+                }
+            }
+            Expression::Function { name, schema, .. } => {
+                match name.to_lowercase().as_str() {
+                    // we consider count as only not nullable function for now
+                    "count" if schema.is_none() => Ok(Some(false)),
+                    _ => Ok(Some(true)),
+                }
+            }
+            Expression::Between {
+                left, low, high, ..
+            } => {
+                let nullability = [
+                    left.infer_nullability(resolver)?,
+                    low.infer_nullability(resolver)?,
+                    high.infer_nullability(resolver)?,
+                ];
+                Ok(nullability
+                    .into_iter()
+                    .try_fold(false, |agg, v| Some(agg || v?)))
+            }
+            Expression::Unknown => Ok(None),
+            Expression::Case {
+                conditions,
+                else_clause,
+                ..
+            } => conditions
+                .iter()
+                .map(|c| &c.result)
+                .chain(else_clause.iter().map(|c| &**c))
+                .map(|c| c.infer_nullability(resolver))
+                .try_fold(Some(false), |agg, v| match (agg, v?) {
+                    (Some(agg), Some(v)) => Ok(Some(agg || v)),
+                    _ => Ok(None),
+                }),
+            Expression::Wildcard { .. } => unreachable!(),
         }
     }
 }
@@ -126,13 +229,48 @@ pub(crate) fn infer_projection(
             ident: Some(alias.value.clone()),
             kind: crate::expression::infer_expr(expr, query_source_lookup)?,
         }),
+        SelectItem::QualifiedWildcard(
+            SelectItemQualifiedWildcardKind::ObjectName(name),
+            _wildcard_additional_options,
+        ) => {
+            if let Some(item) = name
+                .0
+                .last()
+                .and_then(|a| a.as_ident())
+                .map(|a| a.value.as_str())
+                .and_then(|k| query_source_lookup.get(k))
+            {
+                let is_left_joined = item.contains_left_join(query_source_lookup)?;
+                Ok(SelectField {
+                    ident: None,
+                    kind: Expression::Wildcard {
+                        schema: item.schema.map(|s| s.to_owned()),
+                        relation: item.name.to_owned(),
+                        is_left_joined,
+                    },
+                })
+            } else {
+                todo!()
+            }
+        }
+        SelectItem::Wildcard(_) if query_source_lookup.len() == 1 => {
+            let wildcard = query_source_lookup.values().next().expect("Is exactly one");
+            Ok(SelectField {
+                ident: None,
+                kind: Expression::Wildcard {
+                    schema: wildcard.schema.map(|c| c.to_owned()),
+                    relation: wildcard.name.to_owned(),
+                    is_left_joined: false,
+                },
+            })
+        }
+        s @ SelectItem::Wildcard(_wildcard_additional_options) => Err(Error::UnsupportedSql {
+            msg: format!("Unsupported `SELECT` expression: `{s}`"),
+        }),
         s @ SelectItem::QualifiedWildcard(
             _select_item_qualified_wildcard_kind,
             _wildcard_additional_options,
         ) => Err(Error::UnsupportedSql {
-            msg: format!("Unsupported `SELECT` expression: `{s}`"),
-        }),
-        s @ SelectItem::Wildcard(_wildcard_additional_options) => Err(Error::UnsupportedSql {
             msg: format!("Unsupported `SELECT` expression: `{s}`"),
         }),
     }

--- a/diesel_infer_query/tests/parsing.rs
+++ b/diesel_infer_query/tests/parsing.rs
@@ -44,3 +44,104 @@ pub(crate) fn simple_table_with_alias() {
         "CREATE VIEW test AS SELECT u.id, name, u.hair_color AS hair_colour FROM users as u",
     );
 }
+
+#[test]
+pub(crate) fn using_ops() {
+    check_parse_view(
+        "using_ops",
+        "CREATE VIEW ops AS SELECT 1 + 2, json @> 'json', name IS NULL FROM bar",
+    );
+}
+
+#[test]
+pub(crate) fn using_function() {
+    check_parse_view(
+        "using_functions",
+        "CREATE VIEW ops AS SELECT count(*), sum(foo) FROM bar",
+    );
+}
+
+#[test]
+pub(crate) fn is_null_and_not_null() {
+    check_parse_view(
+        "is_null_and_not_null",
+        "CREATE VIEW test AS SELECT 1 IS NOT NULL, 2 IS NULL",
+    );
+}
+
+#[test]
+fn wildcard_select() {
+    check_parse_view("wildcard_select", "CREATE VIEW test AS SELECT * FROM users");
+}
+
+#[test]
+fn qualified_wildcard_select() {
+    check_parse_view(
+        "qualified_wildcard_select",
+        "CREATE VIEW test AS SELECT users.* FROM users",
+    );
+}
+
+#[test]
+fn qualified_wildcard_select_left_join() {
+    check_parse_view(
+        "qualified_wildcard_select_left_join",
+        "CREATE VIEW test AS SELECT users.*, posts.* FROM users LEFT JOIN posts ON users.id = posts.user_id",
+    );
+}
+
+#[test]
+fn is_distinct_from() {
+    check_parse_view(
+        "is_distinct_from",
+        "CREATE VIEW test AS SELECT 'abc' IS DISTINCT FROM NULL, 'def' IS NOT DISTINCT FROM NULL",
+    )
+}
+
+#[test]
+
+fn like() {
+    check_parse_view(
+        "like",
+        "CREATE VIEW test AS SELECT 'abc' LIKE 'foo', 'cde' LIKE NULL, \
+              'fgh' ILIKE '%', 'ijk' ILIKE NULL, 'abc' NOT LIKE '%', 'abc' NOT LIKE NULL",
+    );
+}
+
+#[test]
+fn between() {
+    check_parse_view(
+        "between",
+        "CREATE VIEW test AS SELECT 1 BETWEEN 0 AND 10, 1 BETWEEN NULL AND 25, 1 NOT BETWEEN 0 AND 10, 1 NOT BETWEEN NULL AND 25",
+    )
+}
+
+#[test]
+fn similar_to() {
+    check_parse_view(
+        "similar_to",
+        "CREATE VIEW test AS SELECT 'abc' SIMILAR TO 'cde', 'ABC' NOT SIMILAR TO NULL, NULL SIMILAR TO 'abc'",
+    )
+}
+
+#[test]
+fn regexp() {
+    // TODO: not supported by the parser?
+    // also 'abc' RLIKE NULL is not supported
+    check_parse_view(
+        "regexp",
+        "CREATE VIEW test AS SELECT 'abc' REGEXP 'abc', NULL REGEXP 'abc', 'abc' REGEXP NULL,\
+        'abc' RLIKE 'abc', NULL RLIKE 'abc'",
+    )
+}
+
+#[test]
+fn case_when() {
+    check_parse_view(
+        "case_when",
+        "CREATE VIEW test AS SELECT \
+              CASE WHEN 1 = 1 THEN 1 WHEN NULL THEN 1 ELSE 1 END,
+              CASE WHEN 1 = 1 THEN 1 WHEN NULL THEN 1 ELSE NULL END,
+              CASE WHEN 1 = 1 THEN NULL WHEN NULL THEN 1 ELSE 1 END",
+    );
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__between.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__between.snap
@@ -1,0 +1,81 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT 1 BETWEEN 0 AND 10, 1 BETWEEN NULL AND 25, 1 NOT BETWEEN 0 AND 10, 1 NOT BETWEEN NULL AND 25"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: Between {
+                left: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                negated: false,
+                low: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                high: Literal {
+                    value: None,
+                    is_null: false,
+                },
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: Between {
+                left: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                negated: false,
+                low: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                high: Literal {
+                    value: None,
+                    is_null: false,
+                },
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: Between {
+                left: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                negated: true,
+                low: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                high: Literal {
+                    value: None,
+                    is_null: false,
+                },
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: Between {
+                left: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                negated: true,
+                low: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                high: Literal {
+                    value: None,
+                    is_null: false,
+                },
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__case_when.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__case_when.snap
@@ -1,0 +1,135 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT CASE WHEN 1 = 1 THEN 1 WHEN NULL THEN 1 ELSE 1 END,\n              CASE WHEN 1 = 1 THEN 1 WHEN NULL THEN 1 ELSE NULL END,\n              CASE WHEN 1 = 1 THEN NULL WHEN NULL THEN 1 ELSE 1 END"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: Case {
+                operand: None,
+                conditions: [
+                    CaseCondition {
+                        condition: BinaryOp {
+                            left: Literal {
+                                value: None,
+                                is_null: false,
+                            },
+                            right: Literal {
+                                value: None,
+                                is_null: false,
+                            },
+                            op: "=",
+                            statically_not_null: false,
+                        },
+                        result: Literal {
+                            value: None,
+                            is_null: false,
+                        },
+                    },
+                    CaseCondition {
+                        condition: Literal {
+                            value: None,
+                            is_null: true,
+                        },
+                        result: Literal {
+                            value: None,
+                            is_null: false,
+                        },
+                    },
+                ],
+                else_clause: Some(
+                    Literal {
+                        value: None,
+                        is_null: false,
+                    },
+                ),
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: Case {
+                operand: None,
+                conditions: [
+                    CaseCondition {
+                        condition: BinaryOp {
+                            left: Literal {
+                                value: None,
+                                is_null: false,
+                            },
+                            right: Literal {
+                                value: None,
+                                is_null: false,
+                            },
+                            op: "=",
+                            statically_not_null: false,
+                        },
+                        result: Literal {
+                            value: None,
+                            is_null: false,
+                        },
+                    },
+                    CaseCondition {
+                        condition: Literal {
+                            value: None,
+                            is_null: true,
+                        },
+                        result: Literal {
+                            value: None,
+                            is_null: false,
+                        },
+                    },
+                ],
+                else_clause: Some(
+                    Literal {
+                        value: None,
+                        is_null: true,
+                    },
+                ),
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: Case {
+                operand: None,
+                conditions: [
+                    CaseCondition {
+                        condition: BinaryOp {
+                            left: Literal {
+                                value: None,
+                                is_null: false,
+                            },
+                            right: Literal {
+                                value: None,
+                                is_null: false,
+                            },
+                            op: "=",
+                            statically_not_null: false,
+                        },
+                        result: Literal {
+                            value: None,
+                            is_null: true,
+                        },
+                    },
+                    CaseCondition {
+                        condition: Literal {
+                            value: None,
+                            is_null: true,
+                        },
+                        result: Literal {
+                            value: None,
+                            is_null: false,
+                        },
+                    },
+                ],
+                else_clause: Some(
+                    Literal {
+                        value: None,
+                        is_null: false,
+                    },
+                ),
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__is_distinct_from.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__is_distinct_from.snap
@@ -1,0 +1,43 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT 'abc' IS DISTINCT FROM NULL, 'def' IS NOT DISTINCT FROM NULL"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                op: "IS DISTINCT FROM",
+                statically_not_null: true,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "def",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                op: "IS NOT DISTINCT FROM",
+                statically_not_null: true,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__is_null_and_not_null.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__is_null_and_not_null.snap
@@ -1,0 +1,31 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT 1 IS NOT NULL, 2 IS NULL"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: PostfixOp {
+                expr: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                op: "IS NOT NULL",
+                statically_not_null: true,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: PostfixOp {
+                expr: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                op: "IS NULL",
+                statically_not_null: true,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__like.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__like.snap
@@ -1,0 +1,117 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT 'abc' LIKE 'foo', 'cde' LIKE NULL, 'fgh' ILIKE '%', 'ijk' ILIKE NULL, 'abc' NOT LIKE '%', 'abc' NOT LIKE NULL"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: Some(
+                        "foo",
+                    ),
+                    is_null: false,
+                },
+                op: "LIKE",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "cde",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                op: "LIKE",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "fgh",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: Some(
+                        "%",
+                    ),
+                    is_null: false,
+                },
+                op: "ILIKE",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "ijk",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                op: "ILIKE",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: Some(
+                        "%",
+                    ),
+                    is_null: false,
+                },
+                op: "NOT LIKE",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                op: "NOT LIKE",
+                statically_not_null: false,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__qualified_wildcard_select.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__qualified_wildcard_select.snap
@@ -1,0 +1,17 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: CREATE VIEW test AS SELECT users.* FROM users
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: Wildcard {
+                schema: None,
+                relation: "users",
+                is_left_joined: false,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__qualified_wildcard_select_left_join.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__qualified_wildcard_select_left_join.snap
@@ -1,0 +1,25 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT users.*, posts.* FROM users LEFT JOIN posts ON users.id = posts.user_id"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: Wildcard {
+                schema: None,
+                relation: "users",
+                is_left_joined: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: Wildcard {
+                schema: None,
+                relation: "posts",
+                is_left_joined: true,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__regexp.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__regexp.snap
@@ -1,0 +1,98 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT 'abc' REGEXP 'abc', NULL REGEXP 'abc', 'abc' REGEXP NULL,'abc' RLIKE 'abc', NULL RLIKE 'abc'"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                op: "REGEXP",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                right: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                op: "REGEXP",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                op: "REGEXP",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                op: "RLIKE",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                right: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                op: "RLIKE",
+                statically_not_null: false,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__similar_to.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__similar_to.snap
@@ -1,0 +1,62 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW test AS SELECT 'abc' SIMILAR TO 'cde', 'ABC' NOT SIMILAR TO NULL, NULL SIMILAR TO 'abc'"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: Some(
+                        "cde",
+                    ),
+                    is_null: false,
+                },
+                op: "SIMILAR TO",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: Some(
+                        "ABC",
+                    ),
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                op: "NOT SIMILAR TO",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: None,
+                    is_null: true,
+                },
+                right: Literal {
+                    value: Some(
+                        "abc",
+                    ),
+                    is_null: false,
+                },
+                op: "SIMILAR TO",
+                statically_not_null: false,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__using_functions.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__using_functions.snap
@@ -1,0 +1,38 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW ops AS SELECT count(*), sum(foo) FROM bar"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: Function {
+                name: "count",
+                schema: None,
+                arguments: [
+                    Wildcard {
+                        schema: None,
+                        relation: "bar",
+                        is_left_joined: false,
+                    },
+                ],
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: Function {
+                name: "sum",
+                schema: None,
+                arguments: [
+                    Field {
+                        schema: None,
+                        query_source: "bar",
+                        field_name: "foo",
+                        via_left_join: false,
+                    },
+                ],
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__using_ops.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__using_ops.snap
@@ -1,0 +1,56 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: "CREATE VIEW ops AS SELECT 1 + 2, json @> 'json', name IS NULL FROM bar"
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                right: Literal {
+                    value: None,
+                    is_null: false,
+                },
+                op: "+",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: BinaryOp {
+                left: Field {
+                    schema: None,
+                    query_source: "bar",
+                    field_name: "json",
+                    via_left_join: false,
+                },
+                right: Literal {
+                    value: Some(
+                        "json",
+                    ),
+                    is_null: false,
+                },
+                op: "@>",
+                statically_not_null: false,
+            },
+        },
+        SelectField {
+            ident: None,
+            kind: PostfixOp {
+                expr: Field {
+                    schema: None,
+                    query_source: "bar",
+                    field_name: "name",
+                    via_left_join: false,
+                },
+                op: "IS NULL",
+                statically_not_null: true,
+            },
+        },
+    ],
+}

--- a/diesel_infer_query/tests/snapshots/integration_tests__parsing__wildcard_select.snap
+++ b/diesel_infer_query/tests/snapshots/integration_tests__parsing__wildcard_select.snap
@@ -1,0 +1,17 @@
+---
+source: diesel_infer_query/tests/parsing.rs
+expression: res
+info: CREATE VIEW test AS SELECT * FROM users
+---
+ViewData {
+    fields: [
+        SelectField {
+            ident: None,
+            kind: Wildcard {
+                schema: None,
+                relation: "users",
+                is_left_joined: false,
+            },
+        },
+    ],
+}


### PR DESCRIPTION
This commit adds support for more expression types to diesel_infer_schema. After this change we have limited support for wild cards, function calls, binary operations and some special operations like `BETWEEN` and `CASE WHEN`. This hopefully helps to infer slightly more complex view definitions correctly. 

I still expect at least one or two other rounds of additions here to support subqueries and more complicated constructs (CTE's, UNION's, etc) as well.