### PR TITLE
Support casting between cidr, inet and text for postgres backend

### DIFF
--- a/diesel/src/expression/cast.rs
+++ b/diesel/src/expression/cast.rs
@@ -125,6 +125,8 @@ type_name! {
         Uuid => "uuid",
         Json => "json",
         Jsonb => "jsonb",
+        Inet => "inet",
+        Cidr => "cidr",
     }
     diesel::mysql::Mysql: "mysql_backend" {
         Int8 => "signed",
@@ -217,7 +219,10 @@ casts_impl!(
     (Jsonb <- Json),
     "mysql_backend": (Text <- Datetime),
     "postgres_backend": (Text <- Uuid),
-
+    "postgres_backend": (Text <- Inet),
+    "postgres_backend": (Text <- Cidr),
+    "postgres_backend": (Inet <- Cidr),
+    "postgres_backend": (Cidr <- Inet),
 );
 
 macro_rules! fallible_casts_impl {
@@ -253,4 +258,6 @@ fallible_casts_impl!(
     (Decimal <- Text),
     "mysql_backend": (Datetime <- Text),
     "postgres_backend": (Uuid <- Text),
+    "postgres_backend": (Inet <- Text),
+    "postgres_backend": (Cidr <- Text),
 );

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -38,7 +38,7 @@ sqlite-wasm-rs = "0.4.0"
 [features]
 default = []
 unstable = ["diesel/unstable"]
-postgres = ["diesel/postgres"]
+postgres = ["diesel/postgres", "diesel/network-address", "diesel/ipnet-address"]
 sqlite = ["diesel/sqlite"]
 mysql = ["diesel/mysql"]
 returning_clauses_for_sqlite_3_35 = ["diesel/returning_clauses_for_sqlite_3_35"]
@@ -47,4 +47,3 @@ returning_clauses_for_sqlite_3_35 = ["diesel/returning_clauses_for_sqlite_3_35"]
 name = "integration_tests"
 path = "tests/lib.rs"
 harness = true
-

--- a/diesel_tests/tests/cast.rs
+++ b/diesel_tests/tests/cast.rs
@@ -88,6 +88,42 @@ mod fallible_cast {
     test_fallible_cast!(text_to_uuid, "9d755438-5ad5-42b8-bc6a-a15ace143975" => &str, Text => Uuid, "9d755438-5ad5-42b8-bc6a-a15ace143975".parse().unwrap() => uuid::Uuid);
     #[cfg(feature = "mysql")]
     test_fallible_cast!(text_to_datetime, "2025-09-19 10:21:42" => &str, Text => Datetime, chrono::NaiveDateTime::from_str("2025-09-19T10:21:42").unwrap() => chrono::NaiveDateTime);
+
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetv4_without_prefix, String::from("1.1.1.1") => String, Text => Inet, "1.1.1.1/32".parse().unwrap() => ipnet::IpNet);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetv4, String::from("1.1.1.1/32") => String, Text => Inet, "1.1.1.1/32".parse().unwrap() => ipnet::IpNet);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetv6_without_prefix, String::from("1::1") => String, Text => Inet, "1::1/128".parse().unwrap() => ipnet::IpNet);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetv6, String::from("1::1/128") => String, Text => Inet, "1::1/128".parse().unwrap() => ipnet::IpNet);
+
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetv4_without_prefix, String::from("1.1.1.1") => String, Text => Cidr, "1.1.1.1/32".parse().unwrap() => ipnet::IpNet);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetv4, String::from("1.1.1.1/32") => String, Text => Cidr, "1.1.1.1/32".parse().unwrap() => ipnet::IpNet);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetv6_without_prefix, String::from("1::1") => String, Text => Cidr, "1::1/128".parse().unwrap() => ipnet::IpNet);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetv6, String::from("1::1/128") => String, Text => Cidr, "1::1/128".parse().unwrap() => ipnet::IpNet);
+
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetworkv4_without_prefix, String::from("1.1.1.1") => String, Text => Inet, "1.1.1.1/32".parse().unwrap() => ipnetwork::IpNetwork);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetworkv4, String::from("1.1.1.1/32") => String, Text => Inet, "1.1.1.1/32".parse().unwrap() => ipnetwork::IpNetwork);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetworkv6_without_prefix, String::from("1::1") => String, Text => Inet, "1::1/128".parse().unwrap() => ipnetwork::IpNetwork);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_inet_ipnetworkv6, String::from("1::1/128") => String, Text => Inet, "1::1/128".parse().unwrap() => ipnetwork::IpNetwork);
+
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetworkv4_without_prefix, String::from("1.1.1.1") => String, Text => Cidr, "1.1.1.1/32".parse().unwrap() => ipnetwork::IpNetwork);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetworkv4, String::from("1.1.1.1/32") => String, Text => Cidr, "1.1.1.1/32".parse().unwrap() => ipnetwork::IpNetwork);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetworkv6_without_prefix, String::from("1::1") => String, Text => Cidr, "1::1/128".parse().unwrap() => ipnetwork::IpNetwork);
+    #[cfg(feature = "postgres")]
+    test_fallible_cast!(text_to_cidr_ipnetworkv6, String::from("1::1/128") => String, Text => Cidr, "1::1/128".parse().unwrap() => ipnetwork::IpNetwork);
 }
 
 mod infallible_cast {
@@ -151,4 +187,22 @@ mod infallible_cast {
     test_infallible_cast!(float4_to_decimal, 1.1 => f32, Float4 => Decimal, "1.1".parse().unwrap() => bigdecimal::BigDecimal);
     #[cfg(feature = "postgres")]
     test_infallible_cast!(float8_to_decimal, 1.1 => f64, Float8 => Decimal, "1.1".parse().unwrap() => bigdecimal::BigDecimal);
+
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(inet_ipnet_to_text, "1.1.1.1/32".parse().unwrap() => ipnet::IpNet, Inet => Text, String::from("1.1.1.1/32") => String);
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(cidr_ipnet_to_text, "1.1.1.1/32".parse().unwrap() => ipnet::IpNet, Cidr => Text, String::from("1.1.1.1/32") => String);
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(cidr_ipnet_to_inet_ipnet, "192.168.1.0/24".parse().unwrap() => ipnet::IpNet, Cidr => Inet, "192.168.1.0/24".parse().unwrap() => ipnet::IpNet);
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(inet_ipnet_to_cidr_ipnet, "192.168.1.1/24".parse().unwrap() => ipnet::IpNet, Inet => Cidr, "192.168.1.0/24".parse().unwrap() => ipnet::IpNet);
+
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(inet_ipnetwork_to_text, "1.1.1.1/32".parse().unwrap() => ipnetwork::IpNetwork, Inet => Text, String::from("1.1.1.1/32") => String);
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(cidr_ipnetwork_to_text, "1.1.1.1/32".parse().unwrap() => ipnetwork::IpNetwork, Cidr => Text, String::from("1.1.1.1/32") => String);
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(cidr_ipnetwork_to_inet_ipnetwork, "192.168.1.0/24".parse().unwrap() => ipnetwork::IpNetwork, Cidr => Inet, "192.168.1.0/24".parse().unwrap() => ipnetwork::IpNetwork);
+    #[cfg(feature = "postgres")]
+    test_infallible_cast!(inet_ipnetwork_to_cidr_ipnetwork, "192.168.1.1/24".parse().unwrap() => ipnetwork::IpNetwork, Inet => Cidr, "192.168.1.0/24".parse().unwrap() => ipnetwork::IpNetwork);
 }


### PR DESCRIPTION
This PR adds casting support for the `Cidr` and `Inet` type in PostgreSQL. Conversions to `Text` are infallible, conversions from `Text` is fallible and conversion from `Inet` to `Cidr` will truncate the inet value as specified in https://www.postgresql.org/docs/current/functions-net.html.