### PR TITLE
Add run_pending_migrations_in_range and revert_last_migrations_in_range

### DIFF
--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -40,7 +40,7 @@ mod migration_harness;
 
 pub use crate::embedded_migrations::EmbeddedMigrations;
 pub use crate::file_based_migrations::FileBasedMigrations;
-pub use crate::migration_harness::{HarnessWithOutput, MigrationHarness};
+pub use crate::migration_harness::{HarnessWithOutput, MigrationHarness, Range};
 pub use migrations_macros::embed_migrations;
 
 #[doc(hidden)]

--- a/diesel_migrations/src/migration_harness.rs
+++ b/diesel_migrations/src/migration_harness.rs
@@ -20,6 +20,18 @@ diesel::table! {
     }
 }
 
+/// Controls the amount of migrations that are run or reverted
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Range {
+    /// Run all pending migrations, or revert all applied migrations
+    All,
+    /// Stop after the specified number of migrations have been run or reverted
+    ///
+    /// If this number exceeds the number of available migrations, then this has the same result as [`Range::All`]
+    NumberOfMigrations(u64),
+}
+
 /// A migration harness is an entity which applies migration to an existing database
 pub trait MigrationHarness<DB: Backend> {
     /// Checks if the database represented by the current harness has unapplied migrations
@@ -40,7 +52,21 @@ pub trait MigrationHarness<DB: Backend> {
         &mut self,
         source: S,
     ) -> Result<Vec<MigrationVersion<'_>>> {
-        let pending = self.pending_migrations(source)?;
+        self.run_pending_migrations_in_range(source, &Range::All)
+    }
+
+    /// Execute unapplied migrations for a given migration source, limited to the given range
+    fn run_pending_migrations_in_range<S: MigrationSource<DB>>(
+        &mut self,
+        source: S,
+        range: &Range,
+    ) -> Result<Vec<MigrationVersion<'_>>> {
+        let mut pending = self.pending_migrations(source)?;
+
+        if let &Range::NumberOfMigrations(number) = range {
+            pending.truncate(number.try_into().unwrap_or(usize::MAX));
+        }
+
         self.run_migrations(&pending)
     }
 
@@ -72,7 +98,21 @@ pub trait MigrationHarness<DB: Backend> {
         &mut self,
         source: S,
     ) -> Result<Vec<MigrationVersion<'_>>> {
-        let applied_versions = self.applied_migrations()?;
+        self.revert_last_migrations_in_range(source, &Range::All)
+    }
+
+    /// Revert applied migrations from a given migration source, limited to the given range
+    fn revert_last_migrations_in_range<S: MigrationSource<DB>>(
+        &mut self,
+        source: S,
+        range: &Range,
+    ) -> Result<Vec<MigrationVersion<'_>>> {
+        let mut applied_versions = self.applied_migrations()?;
+
+        if let &Range::NumberOfMigrations(number) = range {
+            applied_versions.truncate(number.try_into().unwrap_or(usize::MAX));
+        }
+
         let mut migrations = source
             .migrations()?
             .into_iter()


### PR DESCRIPTION
With this change, the code for running a specific number of migrations is now in the diesel_migrations library instead of diesel_cli, so it can be used by a custom migration CLI. There's now a lot less code in diesel_cli, and a custom migration CLI would be similarly affected.

In the future, variant(s) like `Range::StopBefore(MigrationVersion)` could be added to allow reverting to a specific version of the schema without manually counting the number of migrations to revert.