### PR TITLE
chore: fix typo

### DIFF
--- a/diesel/src/migration/mod.rs
+++ b/diesel/src/migration/mod.rs
@@ -82,10 +82,10 @@ impl Display for MigrationVersion<'_> {
 
 /// Represents the name of a migration
 ///
-/// Users should threat this as `impl Display` type,
-/// for implementors of custom migration types
-/// this opens the possibility to roll out their own versioning
-/// schema.
+/// Users should treat this as `impl Display` type,
+/// for implementors of custom migration types this
+/// opens the possibility to roll out their own
+/// versioning schema.
 pub trait MigrationName: Display {
     /// The version corresponding to the current migration name
     fn version(&self) -> MigrationVersion<'_>;


### PR DESCRIPTION
Change "threat" to "treat". Also shuffle a few words around to make comment line lengths more consistent for better readability.