### PR TITLE
Another mariadb fix

### DIFF
--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -427,11 +427,13 @@ impl BindData {
             // We assert that we don't read more than capacity bytes below as that's
             // the most important invariant to uphold here
             let length = if let Some(length) = known_buffer_size_for_ffi_type(self.tpe) {
-                debug_assert!(length <= self.length.try_into().expect("Usize is at least 32 bit"),
+                debug_assert!(
+                    length <= self.capacity
+                    && <usize as TryFrom<_>>::try_from(self.length).expect("32bit integer fits in a usize")  <= self.capacity,
                     "Libmysqlclient reported a larger size for a fixed size buffer without setting the truncated flag. \n\
                      This is a bug somewhere. Please open an issue with reproduction steps at \
                      https://github.com/diesel-rs/diesel/issues/new \n\
-                     Length: {length}, Capacity: {}, Type: {:?}", self.capacity, self.tpe
+                     Calculated Length: {length}, Buffer Capacity: {}, Reported Length {}, Type: {:?}", self.capacity, self.length, self.tpe
                 );
                 length
             } else {


### PR DESCRIPTION
This commit fixes another issue with libmariadb. In this case again the libmariadb documentation/behaviour is inconsistent. They stated that with the last version they won't set the lenght field for statically sized types. Turns out that even that is not correct, as it is set for the datetime type. Now this on it's own wouldn't be an issue, but libmariadb has a slightly different definition of `MYSQL_TIME` that libmysqlclient. It misses a field in the end. While this is normally not a problem as that field is just zero initialized by diesel, it becomes problematic if libmariadb returns the size of their definition, which results in the assert mentioned in the issue to fail. So it's yet another needless incompatiblity on their side we need to workaround.

Fixes #4889

cc @BlackDex It would be great to know if the fix works for you. As already written in #4889 we should find a better solution for testing and maintaining support for libmariadb in the future. Possibly it would already help if someone sets up at least one CI job that runs tests with libmariadb + mariadb instead of libmysqlclient + mysql and also if someone at least helps looking into issues that come up. To be upfront here: If the situation around the mysql/mariadb backend doesn't change much in the next year or so, I consider issuing a diesel 3.0 release that moves this backend out of tree and marks it as unmaintained by me.