### PR TITLE
Fix is_contained_by_or_eq() documentation

### DIFF
--- a/diesel/src/pg/expression/expression_methods.rs
+++ b/diesel/src/pg/expression/expression_methods.rs
@@ -2378,7 +2378,7 @@ pub trait PgNetExpressionMethods: Expression + Sized {
         Grouped(IsContainedByNet::new(self, other.as_expression()))
     }
 
-    /// Creates a PostgreSQL `>>=` expression.
+    /// Creates a PostgreSQL `<<= expression.
     ///
     /// This operator returns whether a subnet is contained by or equal to another subnet.
     ///


### PR DESCRIPTION
Fix wrong operator in the documentation.