### PR TITLE
Bump `sqlite-wasm-rs` to 0.5

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -53,13 +53,12 @@ path = "../diesel_derives"
 libsqlite3-sys = { version = ">=0.17.2, <0.36.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = "0.4.0", optional = true, default-features = false }
+sqlite-wasm-rs = { version = "0.5.0", optional = true, default-features = false }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on it, we use feature to override it.
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
-sqlite-wasm-rs = "0.4.0"
 
 [dev-dependencies]
 cfg-if = "1"

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -33,7 +33,7 @@ diesel_test_helper = { path = "../diesel_test_helper" }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 getrandom_02 = { version = "0.2", package = "getrandom", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
-sqlite-wasm-rs = "0.4.0"
+sqlite-wasm-rs = "0.5.0"
 
 [features]
 default = []

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -13,7 +13,8 @@ wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-rs = { version = "0.4.0", features = ["relaxed-idb"] }
+sqlite-wasm-vfs = "0.1.0"
+sqlite-wasm-rs = "0.5.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sqlite/wasm/src/lib.rs
+++ b/examples/sqlite/wasm/src/lib.rs
@@ -52,14 +52,14 @@ pub fn establish_connection() -> SqliteConnection {
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 #[wasm_bindgen(js_name = installOpfsSahpool)]
 pub async fn install_opfs_sahpool() {
-    use sqlite_wasm_rs::sahpool_vfs::{install, OpfsSAHPoolCfg};
+    use sqlite_wasm_vfs::sahpool::{install, OpfsSAHPoolCfg};
     install(&OpfsSAHPoolCfg::default(), false).await.unwrap();
 }
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 #[wasm_bindgen(js_name = installRelaxedIdb)]
 pub async fn install_relaxed_idb() {
-    use sqlite_wasm_rs::relaxed_idb_vfs::{install, RelaxedIdbCfg};
+    use sqlite_wasm_vfs::relaxed_idb::{install, RelaxedIdbCfg};
     install(&RelaxedIdbCfg::default(), false).await.unwrap();
 }
 


### PR DESCRIPTION
Now `sqlite-wasm-rs` will only be compiled with bundled, and the prebuild lib can be utilized by overriding the cargo links configuration.

Additionally, it will like other sys crates without excessive dependencies, as the vfs implementation has been moved to `sqlite-wasm-vfs`. Thanks to this change, can now be compiled with `#![no_std]`.