### PR TITLE
Update WTX

### DIFF
--- a/diesel_bench/Cargo.toml
+++ b/diesel_bench/Cargo.toml
@@ -38,7 +38,7 @@ wtx = { default-features = false, features = [
   "optimization",
   "std",
   "tokio"
-], optional = true, version = "0.40.0" }
+], optional = true, version = "0.41" }
 
 [dependencies.diesel-async]
 git = "https://github.com/weiznich/diesel_async"


### PR DESCRIPTION
https://github.com/diesel-rs/diesel/actions/runs/20515428089/job/58942512816

```
error[E0277]: the trait bound `R: crypto_bigint::rand_core::CryptoRng` is not satisfied
```

The new version updates crypto dependencies that were causing CI errors