### PR TITLE
Fix regression in `#[derive(Insertable)]` while having the same bound

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
     "BSD-3-Clause",
-    "GPL-2.0",
+    "GPL-2.0-only",
     "MPL-2.0",
     "Zlib",
 ]
@@ -30,4 +30,3 @@ skip-tree = [
 executables = "deny"
 #interpreted = "deny"
 #include-archives = true
-

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 include = ["src/**/*.rs", "src/tests/snapshots/*", "LICENSE-*", "README.md", "build.rs"]
 
 [dependencies]
-syn = { version = "2.0", features = ["derive", "fold", "full"] }
+syn = { version = "2.0", features = ["derive", "fold", "full", "visit-mut"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.27"
 diesel_table_macro_syntax = {version = "0.3", path = "../diesel_table_macro_syntax"}

--- a/diesel_derives/tests/insertable.rs
+++ b/diesel_derives/tests/insertable.rs
@@ -568,3 +568,21 @@ fn serialize_as_with_option() {
     let expected = vec![(1, "Sean".to_string(), Some("Black".to_string()))];
     assert_eq!(Ok(expected), saved);
 }
+
+// this is a compile test to verify that we don't
+// emit bounds that cannot be evaluated by rustc
+//
+// That's to workaround https://github.com/rust-lang/rust/issues/21974
+table! {
+    lists (list, identifier) {
+        list -> Text,
+        identifier -> Text,
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = lists)]
+pub struct List<'a> {
+    list: &'a str,
+    identifier: &'static str,
+}


### PR DESCRIPTION
with different lifetimes

This commit fixes a regression in `#[derive(Insertable)]` if the struct contains several fields with the same type, but different lifetimes. The most simple example for this is something like:

```rust
#[derive(Insertable)]
struct List<'a> {
	list: &'a str,
	identifier: &'static str,
}
```

The improved diagnostic code introduced in
https://github.com/diesel-rs/diesel/pull/4884 would then generate bounds like

```
where
    &'a str: AsExpression<<lists::list as Expression>::SqlType>,
    &'static str: AsExpression<<lists::identifier as
Expression>::SqlType>,
```

which in turn results in an error like this:

```
error[E0284]: type annotations needed
  --> src/main.rs:10:10
   |
10 | #[derive(Insertable)]
   |          ^^^^^^^^^^ cannot infer type
   |
   = note: cannot satisfy `<&'a str as AsExpression<diesel::sql_types::Text>>::Expression == _`
   = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0283]: type annotations needed: cannot satisfy `&str: AsExpression<diesel::sql_types::Text>`
  --> src/main.rs:12:12
   |
12 | pub struct List<'a> {
   |            ^^^^^^^^^^^^^^^^^
   |
note: multiple `impl`s or `where` clauses satisfying `&str: AsExpression<diesel::sql_types::Text>` found
  --> src/main.rs:13:5
   |
10 | #[derive(Insertable)]
   |          ---------- in this derive macro expansion
...
13 |     list: &'a str,
   |     ^^^^
14 |     identifier: &'static str,
   |     ^^^^^^^^^^^
   = note: and another `impl` found in the `diesel` crate: `impl<'__expr> AsExpression<diesel::sql_types::Text> for &'__expr str;`
note: required for `CodeListEntry<'a>` to implement `diesel::Insertable<lists::table>`
  --> src/main.rs:10:10
   |
10 | #[derive(Insertable)]
   |          ^^^^^^^^^^
11 | pub struct List<'a> {
   |            ^^^^^^^^^^^^^^^^^
12 |     list: &'a str,
   |     ---- unsatisfied trait bound introduced in this `derive` macro
   = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This is in the end caused by a bug in rustc's trait resulution: https://github.com/rust-lang/rust/issues/21974, which might at least partically get resolved with the new trait solver. 

Until then we just filter out bounds if they appear with different lifetimes. This is might lead to worse diagnostics in these edge cases, but that should be acceptable.

cc @sim-hash as you might find that interesting as you wrote the original implementation