### PR TITLE
Added helper traits for `NamedField` and `DynamicRow`

### DIFF
--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -5,7 +5,7 @@ use diesel::query_builder::*;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 /// A database table column.
 /// This type is created by the [`column`](crate::Table::column()) function.
 pub struct Column<T, U, ST> {

--- a/diesel_dynamic_schema/src/dynamic_select.rs
+++ b/diesel_dynamic_schema/src/dynamic_select.rs
@@ -53,6 +53,16 @@ impl<'a, DB, QS> DynamicSelectClause<'a, DB, QS> {
             self.add_field(field);
         }
     }
+
+    /// Returns the number of fields in the select clause
+    pub fn len(&self) -> usize {
+        self.selects.len()
+    }
+
+    /// Returns whether the select clause is empty
+    pub fn is_empty(&self) -> bool {
+        self.selects.is_empty()
+    }
 }
 
 impl<DB, QS> AppearsOnTable<QS> for DynamicSelectClause<'_, DB, QS> where Self: Expression {}
@@ -88,14 +98,6 @@ impl<DB, QS> ValidGrouping<()> for DynamicSelectClause<'_, DB, QS> {
     type IsAggregate = is_aggregate::No;
 }
 
-impl<'a, DB, QS> AsRef<[Box<dyn QueryFragment<DB> + Send + 'a>]>
-    for DynamicSelectClause<'a, DB, QS>
-{
-    fn as_ref(&self) -> &[Box<dyn QueryFragment<DB> + Send + 'a>] {
-        &self.selects
-    }
-}
-
 impl<'a, DB, QS, F> FromIterator<F> for DynamicSelectClause<'a, DB, QS>
 where
     F: QueryFragment<DB> + SelectableExpression<QS> + NonAggregate + Send + 'a,
@@ -115,26 +117,5 @@ where
 {
     fn extend<I: IntoIterator<Item = F>>(&mut self, iter: I) {
         self.add_fields(iter)
-    }
-}
-
-impl<'a, DB, QS> IntoIterator for DynamicSelectClause<'a, DB, QS> {
-    type Item = Box<dyn QueryFragment<DB> + Send + 'a>;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.selects.into_iter()
-    }
-}
-
-impl<'a, 'b, DB, QS> IntoIterator for &'b DynamicSelectClause<'a, DB, QS> {
-    type Item = &'b (dyn QueryFragment<DB> + Send + 'a);
-    type IntoIter = std::iter::Map<
-        std::slice::Iter<'b, Box<dyn QueryFragment<DB> + Send + 'a>>,
-        fn(&'b Box<dyn QueryFragment<DB> + Send + 'a>) -> &'b (dyn QueryFragment<DB> + Send + 'a),
-    >;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.selects.iter().map(|b| &**b)
     }
 }

--- a/diesel_dynamic_schema/src/dynamic_select.rs
+++ b/diesel_dynamic_schema/src/dynamic_select.rs
@@ -74,3 +74,11 @@ where
 impl<DB, QS> ValidGrouping<()> for DynamicSelectClause<'_, DB, QS> {
     type IsAggregate = is_aggregate::No;
 }
+
+impl<'a, DB, QS> AsRef<[Box<dyn QueryFragment<DB> + Send + 'a>]>
+    for DynamicSelectClause<'a, DB, QS>
+{
+    fn as_ref(&self) -> &[Box<dyn QueryFragment<DB> + Send + 'a>] {
+        &self.selects
+    }
+}

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -152,7 +152,6 @@ use diesel::deserialize::{self, FromSql};
 use diesel::expression::TypedExpressionType;
 use diesel::row::{Field, NamedRow, Row};
 use diesel::QueryableByName;
-use std::borrow::Borrow;
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -152,6 +152,7 @@ use diesel::deserialize::{self, FromSql};
 use diesel::expression::TypedExpressionType;
 use diesel::row::{Field, NamedRow, Row};
 use diesel::QueryableByName;
+use std::borrow::Borrow;
 use std::iter::FromIterator;
 use std::ops::Index;
 
@@ -197,6 +198,18 @@ impl<I> From<DynamicRow<I>> for Vec<I> {
     }
 }
 
+impl<I> From<DynamicRow<NamedField<I>>> for Vec<I> {
+    fn from(row: DynamicRow<NamedField<I>>) -> Self {
+        row.values.into_iter().map(|f| f.value).collect()
+    }
+}
+
+impl<I> AsRef<DynamicRow<I>> for DynamicRow<I> {
+    fn as_ref(&self) -> &DynamicRow<I> {
+        self
+    }
+}
+
 /// A helper struct used as field type in `DynamicRow`
 /// to also return the name of the field along with the
 /// value
@@ -210,6 +223,12 @@ pub struct NamedField<I> {
 
 impl<I> AsRef<I> for NamedField<I> {
     fn as_ref(&self) -> &I {
+        &self.value
+    }
+}
+
+impl<I> Borrow<I> for NamedField<I> {
+    fn borrow(&self) -> &I {
         &self.value
     }
 }

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -186,20 +186,38 @@ impl diesel::expression::QueryMetadata<Any> for diesel::mysql::Mysql {
 
 /// A dynamically sized container that allows to receive
 /// a not at compile time known number of columns from the database
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DynamicRow<I> {
     values: Vec<I>,
+}
+
+impl<I> From<DynamicRow<I>> for Vec<I> {
+    fn from(row: DynamicRow<I>) -> Self {
+        row.values
+    }
 }
 
 /// A helper struct used as field type in `DynamicRow`
 /// to also return the name of the field along with the
 /// value
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NamedField<I> {
     /// Name of the field
     pub name: String,
     /// Actual field value
     pub value: I,
+}
+
+impl<I> From<NamedField<I>> for I {
+    fn from(field: NamedField<I>) -> Self {
+        field.value
+    }
+}
+
+impl<I> AsRef<I> for NamedField<I> {
+    fn as_ref(&self) -> &I {
+        &self.value
+    }
 }
 
 impl<I> FromIterator<I> for DynamicRow<I> {

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -208,12 +208,6 @@ pub struct NamedField<I> {
     pub value: I,
 }
 
-impl<I> From<NamedField<I>> for I {
-    fn from(field: NamedField<I>) -> Self {
-        field.value
-    }
-}
-
 impl<I> AsRef<I> for NamedField<I> {
     fn as_ref(&self) -> &I {
         &self.value

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -227,32 +227,6 @@ pub struct NamedField<I> {
     pub value: I,
 }
 
-impl<I> AsRef<I> for NamedField<I> {
-    fn as_ref(&self) -> &I {
-        &self.value
-    }
-}
-
-impl<I> Borrow<I> for NamedField<I> {
-    fn borrow(&self) -> &I {
-        &self.value
-    }
-}
-
-impl<I> Deref for NamedField<I> {
-    type Target = I;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
-}
-
-impl<I> DerefMut for NamedField<I> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
-}
-
 impl<I> FromIterator<I> for DynamicRow<I> {
     fn from_iter<T>(iter: T) -> Self
     where
@@ -290,12 +264,12 @@ impl<I> DynamicRow<I> {
     }
 
     /// Returns an iterator over the values of the row
-    pub fn iter(&self) -> std::slice::Iter<'_, I> {
+    pub fn iter(&self) -> impl Iterator<Item = &I> {
         self.values.iter()
     }
 
     /// Returns a mutable iterator over the values of the row
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, I> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut I> {
         self.values.iter_mut()
     }
 

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -154,7 +154,7 @@ use diesel::row::{Field, NamedRow, Row};
 use diesel::QueryableByName;
 use std::borrow::Borrow;
 use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::ops::{Index, IndexMut};
 
 /// A marker type used to indicate that
 /// the provided `FromSql` impl does handle

--- a/diesel_dynamic_schema/src/schema.rs
+++ b/diesel_dynamic_schema/src/schema.rs
@@ -1,10 +1,22 @@
 use crate::table::Table;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 /// A database schema.
 /// This type is created by the [`schema`](crate::schema()) function.
 pub struct Schema<T> {
     name: T,
+}
+
+impl<'a> From<&'a str> for Schema<&'a str> {
+    fn from(name: &'a str) -> Self {
+        Schema::new(name)
+    }
+}
+
+impl From<String> for Schema<String> {
+    fn from(name: String) -> Self {
+        Schema::new(name)
+    }
 }
 
 impl<T> Schema<T> {
@@ -21,6 +33,14 @@ impl<T> Schema<T> {
     }
 
     /// Gets the name of the schema, as specified on creation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel_dynamic_schema::Schema;
+    /// let schema: Schema<&str> = "public".into();
+    /// assert_eq!(schema.name(), &"public");
+    /// ```
     pub fn name(&self) -> &T {
         &self.name
     }

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -3,7 +3,6 @@ use diesel::expression::expression_types;
 use diesel::internal::table_macro::{FromClause, SelectStatement};
 use diesel::prelude::*;
 use diesel::query_builder::*;
-use std::borrow::Borrow;
 
 use crate::column::Column;
 use crate::dummy_expression::*;

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -8,12 +8,24 @@ use std::borrow::Borrow;
 use crate::column::Column;
 use crate::dummy_expression::*;
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 /// A database table.
 /// This type is created by the [`table`](crate::table()) function.
 pub struct Table<T, U = T> {
     name: T,
     schema: Option<U>,
+}
+
+impl<'a> From<&'a str> for Table<&'a str> {
+    fn from(name: &'a str) -> Self {
+        Table::new(name)
+    }
+}
+
+impl From<String> for Table<String> {
+    fn from(name: String) -> Self {
+        Table::new(name)
+    }
 }
 
 impl<T, U> Table<T, U> {
@@ -37,8 +49,35 @@ impl<T, U> Table<T, U> {
     }
 
     /// Gets the name of the table, as specified on creation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel_dynamic_schema::{Table, Schema};
+    /// let table: Table<&str> = "users".into();
+    /// assert_eq!(table.name(), &"users");
+    /// let schema: Schema<&str> = "public".into();
+    /// let table_with_schema: Table<&str> = schema.table("posts");
+    /// assert_eq!(table_with_schema.name(), &"posts");
+    /// ```
     pub fn name(&self) -> &T {
         &self.name
+    }
+
+    /// Gets the schema of the table, if one was specified on creation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel_dynamic_schema::{Table, Schema};
+    /// let schema: Schema<&str> = "public".into();
+    /// let table: Table<&str> = schema.table("users");
+    /// assert_eq!(table.schema(), Some(&"public"));
+    /// let schema_less_table: Table<&str> = "posts".into();
+    /// assert_eq!(schema_less_table.schema(), None);
+    /// ```
+    pub fn schema(&self) -> Option<&U> {
+        self.schema.as_ref()
     }
 }
 

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -3,6 +3,7 @@ use diesel::expression::expression_types;
 use diesel::internal::table_macro::{FromClause, SelectStatement};
 use diesel::prelude::*;
 use diesel::query_builder::*;
+use std::borrow::Borrow;
 
 use crate::column::Column;
 use crate::dummy_expression::*;

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -132,11 +132,14 @@ fn test_ergonomics() {
 
     // Deref/DerefMut
     let field = &mut row[0];
-    if let MyDynamicValue::String(ref mut s) = **field {
+    if let MyDynamicValue::String(ref mut s) = field.value {
         *s = "DerefUpdated".to_string();
     }
     // Check via deref
-    assert_eq!(**field, MyDynamicValue::String("DerefUpdated".to_string()));
+    assert_eq!(
+        field.value,
+        MyDynamicValue::String("DerefUpdated".to_string())
+    );
 
     // Iter/IterMut on Row
     for field in row.iter_mut() {

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -97,7 +97,8 @@ fn test_ergonomics() {
     select_clause.extend(fields);
 
     // IntoIterator
-    assert_eq!(select_clause.into_iter().count(), 2);
+    assert_eq!(select_clause.len(), 2);
+    assert!(!select_clause.is_empty());
 
     // Test DynamicRow ergonomics
     // Re-create query since select_clause was consumed

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -67,6 +67,108 @@ impl FromSql<Any, diesel::mysql::Mysql> for MyDynamicValue {
     }
 }
 
+#[cfg(feature = "postgres")]
+type TestDB = diesel::pg::Pg;
+#[cfg(feature = "mysql")]
+type TestDB = diesel::mysql::Mysql;
+#[cfg(feature = "sqlite")]
+type TestDB = diesel::sqlite::Sqlite;
+
+#[test]
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
+fn test_ergonomics() {
+    let connection = &mut super::establish_connection();
+    crate::create_user_table(connection);
+    sql_query("INSERT INTO users (name, hair_color) VALUES ('Sean', 'black'), ('Tess', 'black')")
+        .execute(connection)
+        .unwrap();
+
+    let users = diesel_dynamic_schema::table("users");
+    let name = users.column::<Untyped, _>("name");
+
+    // Test DynamicSelectClause: Extend & IntoIterator
+    let mut select_clause: DynamicSelectClause<TestDB, diesel_dynamic_schema::Table<&str>> =
+        DynamicSelectClause::new();
+    select_clause.add_field(name);
+
+    // Extend
+    let hair = users.column::<Untyped, _>("hair_color");
+    let fields = vec![hair];
+    select_clause.extend(fields);
+
+    // IntoIterator
+    assert_eq!(select_clause.into_iter().count(), 2);
+
+    // Test DynamicRow ergonomics
+    // Re-create query since select_clause was consumed
+    let name = users.column::<Untyped, _>("name");
+    let hair_color = users.column::<Untyped, _>("hair_color");
+    let mut select = DynamicSelectClause::new();
+    select.add_fields(vec![name, hair_color]);
+
+    let mut actual_data: Vec<DynamicRow<NamedField<MyDynamicValue>>> =
+        users.select(select).load(connection).unwrap();
+
+    let row = &mut actual_data[0];
+
+    // IndexMut (usize)
+    if let MyDynamicValue::String(ref mut s) = row[0].value {
+        *s = "UpdatedName".to_string();
+    }
+    assert_eq!(
+        row[0].value,
+        MyDynamicValue::String("UpdatedName".to_string())
+    );
+
+    // IndexMut (str)
+    if let MyDynamicValue::String(ref mut s) = row["hair_color"] {
+        *s = "UpdatedHair".to_string();
+    }
+    assert_eq!(
+        row["hair_color"],
+        MyDynamicValue::String("UpdatedHair".to_string())
+    );
+
+    // Deref/DerefMut
+    let field = &mut row[0];
+    if let MyDynamicValue::String(ref mut s) = **field {
+        *s = "DerefUpdated".to_string();
+    }
+    // Check via deref
+    assert_eq!(**field, MyDynamicValue::String("DerefUpdated".to_string()));
+
+    // Iter/IterMut on Row
+    for field in row.iter_mut() {
+        // field is &mut NamedField<MyDynamicValue>
+        if let MyDynamicValue::String(ref mut s) = field.value {
+            *s = format!("Iter_{}", s);
+        }
+    }
+    assert_eq!(
+        row[0].value,
+        MyDynamicValue::String("Iter_DerefUpdated".to_string())
+    );
+
+    // IntoIterator for &mut DynamicRow
+    for field in &mut *row {
+        // field is &mut NamedField<MyDynamicValue>
+        if let MyDynamicValue::String(ref mut s) = field.value {
+            *s = format!("IntoIter_{}", s);
+        }
+    }
+    assert_eq!(
+        row[0].value,
+        MyDynamicValue::String("IntoIter_Iter_DerefUpdated".to_string())
+    );
+
+    // From<Vec> and Into<Vec>
+    // Construct simple row without names
+    let raw_vec = vec![MyDynamicValue::Integer(1), MyDynamicValue::Integer(2)];
+    let dyn_row: DynamicRow<MyDynamicValue> = raw_vec.into();
+    let back_to_vec: Vec<MyDynamicValue> = dyn_row.into();
+    assert_eq!(back_to_vec.len(), 2);
+}
+
 #[test]
 fn dynamic_query() {
     let connection = &mut super::establish_connection();

--- a/diesel_dynamic_schema/tests/lib.rs
+++ b/diesel_dynamic_schema/tests/lib.rs
@@ -71,6 +71,7 @@ fn columns_used_in_where_clause() {
 }
 
 #[test]
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 fn providing_custom_schema_name() {
     let table = schema("information_schema").table("users");
     let sql = debug_query::<Backend, _>(&table);


### PR DESCRIPTION
This PR implements standard Rust traits for `diesel_dynamic_schema` types to improve usability and allow common patterns like mutation, collection, and transparent field access.

For `DynamicSelectClause`, I've added `Extend` and `FromIterator` implementations to allow building clauses dynamically from iterators. `IntoIterator` and `AsRef` have also been implemented to facilitate inspection and composition.

`DynamicRow` now supports mutable access via `IndexMut` (by index or name) and `iter_mut()`. `IntoIterator` implementations for owned, borrowed, and mutable borrowed `DynamicRow`s enable flexible iteration. Additionally, `From` and `Into` conversions for `Vec` and `AsRef` are added to simplify data extraction and construction.

Finally, `NamedField` has been enhanced with `Deref` and `DerefMut` implementations targeting the inner value, making it act transparently like the value it holds. `AsRef`, `Borrow`, and standard derives like `Clone`, `Hash`, and `Eq` have also been added.

New tests covering these implementations were added to dynamic_values.rs and verified with the `diesel-dynamic-schema` test suite.