### PR TITLE
Added a first version of `UntypedExpressionMethods`

### DIFF
--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -3,7 +3,7 @@ use crate::expression::array_comparison::{AsInExpression, In, NotIn};
 use crate::expression::grouped::Grouped;
 use crate::expression::operators::*;
 use crate::expression::{assume_not_null, cast, nullable, AsExpression, Expression};
-use crate::sql_types::{SingleValue, SqlType};
+use crate::sql_types::{SingleValue, SqlType, Untyped};
 
 /// Methods present on all expressions, except tuples
 pub trait ExpressionMethods: Expression + Sized {
@@ -588,6 +588,35 @@ where
     T::SqlType: SingleValue,
 {
 }
+
+/// Methods present on untyped expressions.
+pub trait UntypedExpressionMethods: Sized {
+    /// Creates a SQL `IS NULL` expression.
+    #[allow(clippy::wrong_self_convention)]
+    fn is_null(self) -> dsl::IsNull<Self> {
+        Grouped(IsNull::new(self))
+    }
+
+    /// Creates a SQL `IS NOT NULL` expression.
+    #[allow(clippy::wrong_self_convention)]
+    fn is_not_null(self) -> dsl::IsNotNull<Self> {
+        Grouped(IsNotNull::new(self))
+    }
+
+    /// Creates a SQL `DESC` expression, representing this expression in
+    /// descending order.
+    fn desc(self) -> dsl::Desc<Self> {
+        Desc::new(self)
+    }
+
+    /// Creates a SQL `ASC` expression, representing this expression in
+    /// ascending order.
+    fn asc(self) -> dsl::Asc<Self> {
+        Asc::new(self)
+    }
+}
+
+impl UntypedExpressionMethods for Untyped {}
 
 /// Methods present on all expressions
 pub trait NullableExpressionMethods: Expression + Sized {

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -590,6 +590,12 @@ where
 }
 
 /// Methods present on untyped expressions.
+///
+/// This trait is implemented for expressions where the sql type is [`Untyped`].
+/// This allows calling common operators on these expressions.
+///
+/// This trait is primarily meant to be used for untyped queries in
+/// [`diesel_dynamic_schema`](https://docs.rs/diesel-dynamic-schema/latest/diesel_dynamic_schema/).
 pub trait UntypedExpressionMethods: Sized {
     /// Creates a SQL `IS NULL` expression.
     ///

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -592,12 +592,62 @@ where
 /// Methods present on untyped expressions.
 pub trait UntypedExpressionMethods: Sized {
     /// Creates a SQL `IS NULL` expression.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// use diesel::sql_types::Untyped;
+    /// use diesel::dsl::sql;
+    ///
+    /// let data = animals
+    ///     .select(species)
+    ///     .filter(sql::<Untyped>("name").is_null())
+    ///     .first::<String>(connection)?;
+    /// assert_eq!("spider", data);
+    /// #     Ok(())
+    /// # }
+    /// ```
     #[allow(clippy::wrong_self_convention)]
     fn is_null(self) -> dsl::IsNull<Self> {
         Grouped(IsNull::new(self))
     }
 
     /// Creates a SQL `IS NOT NULL` expression.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::animals::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// use diesel::sql_types::Untyped;
+    /// use diesel::dsl::sql;
+    ///
+    /// let data = animals
+    ///     .select(species)
+    ///     .filter(sql::<Untyped>("name").is_not_null())
+    ///     .first::<String>(connection)?;
+    /// assert_eq!("dog", data);
+    /// #     Ok(())
+    /// # }
+    /// ```
     #[allow(clippy::wrong_self_convention)]
     fn is_not_null(self) -> dsl::IsNotNull<Self> {
         Grouped(IsNotNull::new(self))
@@ -605,12 +655,64 @@ pub trait UntypedExpressionMethods: Sized {
 
     /// Creates a SQL `DESC` expression, representing this expression in
     /// descending order.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// use diesel::sql_types::Untyped;
+    /// use diesel::dsl::sql;
+    ///
+    /// let data = users
+    ///     .select(name)
+    ///     .order(sql::<Untyped>("name").desc())
+    ///     .load::<String>(connection)?;
+    /// let expected = vec!["Tess", "Sean"];
+    /// assert_eq!(expected, data);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn desc(self) -> dsl::Desc<Self> {
         Desc::new(self)
     }
 
     /// Creates a SQL `ASC` expression, representing this expression in
     /// ascending order.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #
+    /// use diesel::sql_types::Untyped;
+    /// use diesel::dsl::sql;
+    ///
+    /// let data = users
+    ///     .select(name)
+    ///     .order(sql::<Untyped>("name").asc())
+    ///     .load::<String>(connection)?;
+    /// let expected = vec!["Sean", "Tess"];
+    /// assert_eq!(expected, data);
+    /// #     Ok(())
+    /// # }
+    /// ```
     fn asc(self) -> dsl::Asc<Self> {
         Asc::new(self)
     }

--- a/diesel/src/expression_methods/global_expression_methods.rs
+++ b/diesel/src/expression_methods/global_expression_methods.rs
@@ -616,7 +616,7 @@ pub trait UntypedExpressionMethods: Sized {
     }
 }
 
-impl UntypedExpressionMethods for Untyped {}
+impl<T> UntypedExpressionMethods for T where T: Expression<SqlType = Untyped> {}
 
 /// Methods present on all expressions
 pub trait NullableExpressionMethods: Expression + Sized {

--- a/diesel/src/expression_methods/mod.rs
+++ b/diesel/src/expression_methods/mod.rs
@@ -19,7 +19,9 @@ pub use self::eq_all::EqAll;
 #[doc(inline)]
 pub use self::escape_expression_methods::EscapeExpressionMethods;
 #[doc(inline)]
-pub use self::global_expression_methods::{ExpressionMethods, NullableExpressionMethods};
+pub use self::global_expression_methods::{
+    ExpressionMethods, NullableExpressionMethods, UntypedExpressionMethods,
+};
 #[doc(inline)]
 #[cfg(any(feature = "sqlite", feature = "postgres_backend"))]
 pub use self::json_expression_methods::{AnyJsonExpressionMethods, JsonIndex};

--- a/diesel_compile_tests/tests/fail/cannot_use_expression_methods_on_tuples.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_use_expression_methods_on_tuples.stderr
@@ -7,10 +7,18 @@ LL |     users.filter((id, name).is_not_null());
    = note: the following trait bounds were not satisfied:
            `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue`
            which is required by `(columns::id, columns::name): diesel::ExpressionMethods`
+           `<(columns::id, columns::name) as diesel::Expression>::SqlType = Untyped`
+           which is required by `(columns::id, columns::name): diesel::UntypedExpressionMethods`
            `(diesel::sql_types::Integer, diesel::sql_types::Text): SingleValue`
            which is required by `&(columns::id, columns::name): diesel::ExpressionMethods`
+           `<&(columns::id, columns::name) as diesel::Expression>::SqlType = Untyped`
+           which is required by `&(columns::id, columns::name): diesel::UntypedExpressionMethods`
            `&mut (columns::id, columns::name): diesel::Expression`
            which is required by `&mut (columns::id, columns::name): diesel::ExpressionMethods`
+           `<&mut (columns::id, columns::name) as diesel::Expression>::SqlType = Untyped`
+           which is required by `&mut (columns::id, columns::name): diesel::UntypedExpressionMethods`
+           `&mut (columns::id, columns::name): diesel::Expression`
+           which is required by `&mut (columns::id, columns::name): diesel::UntypedExpressionMethods`
 
 error[E0599]: the method `eq_any` exists for tuple `(columns::id, columns::name)`, but its trait bounds were not satisfied
   --> tests/fail/cannot_use_expression_methods_on_tuples.rs:20:29


### PR DESCRIPTION
This PR introduces the `UntypedExpressionMethods` trait, enabling the use of `is_null`, `is_not_null`, `asc`, and `desc` methods on expressions where the SQL type is `Untyped`.

Previously, these methods were provided solely by `ExpressionMethods`, which restricts usage to expressions where `SqlType` implements `SingleValue`. Since `Untyped` does not implement `SingleValue`, users could not use these helper methods on untyped expressions (e.g., in certain dynamic query scenarios common in [diesel_dynamic_schema](https://docs.rs/diesel-dynamic-schema/latest/diesel_dynamic_schema/)).

While it might be preferable to split the `ExpressionMethods` trait into two traits to reduce code redoundancy, it would change the APIs and is therefore undesirable not being nearing a major release.

## Changes
- **Added `UntypedExpressionMethods` trait**: Defined in global_expression_methods.rs with the following methods:
  - `is_null()`
  - `is_not_null()`
  - `asc()`
  - `desc()`
- **Implemented Trait**: Added a blanket implementation for any `Expression` where `SqlType = Untyped`.
- **Exported Trait**: Exposed `UntypedExpressionMethods` in mod.rs so it is available by default.
- **Updated Tests**: Updated existing compile-fail tests (`cannot_use_expression_methods_on_tuples`) to reflect that `UntypedExpressionMethods` is now considered during trait resolution.

## Motivation
This change improves ergonomics for users working with `Untyped` expressions, allowing them to perform standard null checks and ordering without needing to manually construct the expression objects or cast types unnecessarily.

See discussion #4929