### PR TITLE
Added support for `HasTable` for `Rc`, `Box` and `Arc`

### DIFF
--- a/diesel/src/associations/mod.rs
+++ b/diesel/src/associations/mod.rs
@@ -440,6 +440,30 @@ impl<T: HasTable> HasTable for Option<T> {
     }
 }
 
+impl<T: HasTable> HasTable for Box<T> {
+    type Table = T::Table;
+
+    fn table() -> Self::Table {
+        T::table()
+    }
+}
+
+impl<T: HasTable> HasTable for std::rc::Rc<T> {
+    type Table = T::Table;
+
+    fn table() -> Self::Table {
+        T::table()
+    }
+}
+
+impl<T: HasTable> HasTable for std::sync::Arc<T> {
+    type Table = T::Table;
+
+    fn table() -> Self::Table {
+        T::table()
+    }
+}
+
 // Implement HasTable for tuples of types which implement `HasTable` for
 // the same table.
 // This is useful for multi-column constraints like composite foreign keys.

--- a/diesel_tests/tests/option_has_table.rs
+++ b/diesel_tests/tests/option_has_table.rs
@@ -1,5 +1,7 @@
 use diesel::associations::HasTable;
 use diesel::prelude::*;
+use std::rc::Rc;
+use std::sync::Arc;
 
 table! {
     users (id) {
@@ -24,4 +26,7 @@ fn option_user_implements_has_table() {
     assert_has_table::<User>();
     assert_has_table::<Option<User>>();
     assert_has_table::<Option<&User>>();
+    assert_has_table::<Box<User>>();
+    assert_has_table::<Rc<User>>();
+    assert_has_table::<Arc<User>>();
 }


### PR DESCRIPTION
As per discussion #4934, this PR adds blanket impls for `HasTable` for `Box`, `Rc` and `Arc`.

Luca