### PR TITLE
diesel_cli: escape column named table in print-schema

### DIFF
--- a/diesel_cli/src/infer_schema_internals/inference.rs
+++ b/diesel_cli/src/infer_schema_internals/inference.rs
@@ -64,6 +64,7 @@ static RESERVED_NAMES: &[&str] = &[
     "while",
     "yield",
     "bool",
+    "table",
     "columns",
     "is_nullable",
 ];

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -386,6 +386,11 @@ fn print_schema_reserved_names() {
 }
 
 #[test]
+fn print_schema_column_named_table() {
+    test_print_schema("print_schema_column_named_table", vec![])
+}
+
+#[test]
 #[cfg(feature = "postgres")]
 fn print_schema_regression_3446_ignore_compound_foreign_keys() {
     test_print_schema("print_schema_regression_3446_compound_keys", vec![])

--- a/diesel_cli/tests/print_schema/print_schema_column_named_table/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_column_named_table/diesel.toml
@@ -1,0 +1,4 @@
+[print_schema]
+file = "src/schema.rs"
+with_docs = false
+

--- a/diesel_cli/tests/print_schema/print_schema_column_named_table/mysql/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_column_named_table/mysql/expected.snap
@@ -1,0 +1,16 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_column_named_table"
+snapshot_kind: text
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    column_named_table (id) {
+        id -> Integer,
+        #[sql_name = "table"]
+        table_ -> Integer,
+    }
+}
+
+

--- a/diesel_cli/tests/print_schema/print_schema_column_named_table/mysql/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_column_named_table/mysql/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE column_named_table (
+    id INTEGER PRIMARY KEY,
+    `table` INTEGER NOT NULL
+);
+

--- a/diesel_cli/tests/print_schema/print_schema_column_named_table/postgres/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_column_named_table/postgres/expected.snap
@@ -1,0 +1,16 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_column_named_table"
+snapshot_kind: text
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    column_named_table (id) {
+        id -> Int4,
+        #[sql_name = "table"]
+        table_ -> Int4,
+    }
+}
+
+

--- a/diesel_cli/tests/print_schema/print_schema_column_named_table/postgres/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_column_named_table/postgres/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE column_named_table (
+    id SERIAL PRIMARY KEY,
+    "table" INTEGER NOT NULL
+);
+

--- a/diesel_cli/tests/print_schema/print_schema_column_named_table/sqlite/expected.snap
+++ b/diesel_cli/tests/print_schema/print_schema_column_named_table/sqlite/expected.snap
@@ -1,0 +1,16 @@
+---
+source: diesel_cli/tests/print_schema.rs
+description: "Test: print_schema_column_named_table"
+snapshot_kind: text
+---
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    column_named_table (id) {
+        id -> Nullable<Integer>,
+        #[sql_name = "table"]
+        table_ -> Integer,
+    }
+}
+
+

--- a/diesel_cli/tests/print_schema/print_schema_column_named_table/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_column_named_table/sqlite/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE column_named_table (
+    id INTEGER PRIMARY KEY,
+    "table" INTEGER NOT NULL
+);
+


### PR DESCRIPTION
Fixes #4928

- This pull request improves Diesel CLI's handling of reserved names in schema inference, specifically addressing the case where a column is named "table". The changes ensure that columns named "table" are properly escaped and mapped to valid Rust identifiers in generated schema code. The update is covered by new tests across supported databases.