### PR TITLE
Made `Inner` and `JoinWithImplicitOnClause` accessible

### DIFF
--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -32,8 +32,10 @@ mod private {
 /// `JoinDsl` support trait to emulate associated type constructors and grab
 /// the known on clause from the associations API
 pub trait JoinWithImplicitOnClause<Rhs, Kind>: private::Sealed<Rhs, Kind> {
+    #[doc(hidden)]
     type Output;
 
+    #[doc(hidden)]
     fn join_with_implicit_on_clause(self, rhs: Rhs, kind: Kind) -> Self::Output;
 }
 

--- a/diesel/src/query_dsl/join_dsl.rs
+++ b/diesel/src/query_dsl/join_dsl.rs
@@ -23,13 +23,25 @@ where
     }
 }
 
-#[doc(hidden)]
+mod private {
+    #[doc(hidden)]
+    /// Sealed trait for `JoinWithImplicitOnClause`
+    pub trait Sealed<Rhs, Kind> {}
+}
+
 /// `JoinDsl` support trait to emulate associated type constructors and grab
 /// the known on clause from the associations API
-pub trait JoinWithImplicitOnClause<Rhs, Kind> {
+pub trait JoinWithImplicitOnClause<Rhs, Kind>: private::Sealed<Rhs, Kind> {
     type Output;
 
     fn join_with_implicit_on_clause(self, rhs: Rhs, kind: Kind) -> Self::Output;
+}
+
+impl<Lhs, Rhs, Kind> private::Sealed<Rhs, Kind> for Lhs
+where
+    Lhs: JoinTo<Rhs>,
+    Lhs: InternalJoinDsl<<Lhs as JoinTo<Rhs>>::FromClause, Kind, <Lhs as JoinTo<Rhs>>::OnClause>,
+{
 }
 
 impl<Lhs, Rhs, Kind> JoinWithImplicitOnClause<Rhs, Kind> for Lhs

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -284,8 +284,8 @@ where
     }
 }
 
-#[doc(hidden)]
 #[derive(Debug, Clone, Copy, Default, QueryId)]
+/// Represents an inner join between two tables
 pub struct Inner;
 
 impl<DB> QueryFragment<DB> for Inner

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -12,6 +12,7 @@ use crate::expression::{Expression, SelectableExpression, ValidGrouping};
 use crate::query_builder::*;
 
 pub use self::aliasing::{Alias, AliasSource, AliasedField};
+pub use self::joins::Inner;
 pub use self::joins::JoinTo;
 pub use self::peano_numbers::*;
 pub(crate) use self::private::Pick;


### PR DESCRIPTION
This PR addresses discussion #4942:

* Exports [`JoinWithImplicitOnClause`](https://docs.rs/diesel/latest/src/diesel/query_dsl/join_dsl.rs.html#29-33) as a sealed trait
* Exports the [`joins::Inner`](https://docs.rs/diesel/latest/src/diesel/query_source/joins.rs.html#286) marker struct

This is done in order to specify trait constraints necessary to use the [`inner_join`](https://docs.rs/diesel/latest/diesel/query_dsl/trait.QueryDsl.html#method.inner_join) method on a generic type `T`, which requires: `T: JoinWithImplicitOnClause<Rhs, Inner>`.