### PR TITLE
Add more migration sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ an up to date version of the specific dependency. We check this by using the uns
 Increasing the minimal supported Rust version will always be coupled at least with a minor release.
 
 ## Unreleased
+### Added
+* Diesel-Migrations now contains a migration source that easily allows you to register Rust based migrations
+* Diesel-Migrations now contains a migration source that allows you to combine migrations from several different sources
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,17 @@ To run rustfmt tests locally:
 You can also use rustfmt to make corrections or highlight issues in your editor.
 Check out [their README](https://github.com/rust-lang/rustfmt) for details.
 
+### Usage of LLMs and AI agents
+
+The Diesel project doesn't completely disallow to usage of LLMs and AI agents for contributions. There are still a number of restrictions and rules you as a PR author are asked to follow.
+
+Most importantly you as the author of the PR are responsible for carefully reviewing the generated code to make sure that:
+
+* It is correct to your best knowledge
+* It does not contain any copyrighted code that is incompatible with the license used by Diesel
+
+Furthermore you are asked to disclose the usage of any such tools in your PR description. 
+
 ### Common Abbreviations
 
 `ST`: Sql Type. Basically always has the `NativeSqlType` constraint

--- a/diesel/src/connection/instrumentation.rs
+++ b/diesel/src/connection/instrumentation.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use core::fmt::{Debug, Display};
 use core::num::NonZeroU32;
-use core::ops::{Deref, DerefMut};
+use core::ops::DerefMut;
 use downcast_rs::Downcast;
 
 #[cfg(feature = "std")]
@@ -327,6 +327,12 @@ where
 #[diesel_derives::__diesel_public_if(
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
 /// An optional dyn instrumentation.
 ///
 /// For ease of use, this type implements [`Deref`] and [`DerefMut`] to `&dyn Instrumentation`,
@@ -341,7 +347,13 @@ pub(crate) struct DynInstrumentation {
     inner: Option<Box<dyn Instrumentation>>,
 }
 
-impl Deref for DynInstrumentation {
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
+impl core::ops::Deref for DynInstrumentation {
     type Target = dyn Instrumentation;
 
     fn deref(&self) -> &Self::Target {
@@ -349,6 +361,12 @@ impl Deref for DynInstrumentation {
     }
 }
 
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
 impl DerefMut for DynInstrumentation {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner
@@ -357,6 +375,12 @@ impl DerefMut for DynInstrumentation {
     }
 }
 
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
 impl DynInstrumentation {
     /// Create a instance of the default instrumentation provider
     #[diesel_derives::__diesel_public_if(
@@ -412,6 +436,12 @@ impl DynInstrumentation {
     }
 }
 
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
 impl<I: Instrumentation> From<I> for DynInstrumentation {
     fn from(instrumentation: I) -> Self {
         Self {
@@ -420,14 +450,31 @@ impl<I: Instrumentation> From<I> for DynInstrumentation {
         }
     }
 }
-
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
 struct NoInstrumentation;
 
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
 impl Instrumentation for NoInstrumentation {
     fn on_connection_event(&mut self, _: InstrumentationEvent<'_>) {}
 }
 
 /// Unwrap unnecessary boxing levels
+#[cfg(any(
+    feature = "postgres",
+    feature = "sqlite",
+    feature = "mysql",
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+))]
 fn unpack_instrumentation(
     mut instrumentation: Box<dyn Instrumentation>,
 ) -> Box<dyn Instrumentation> {

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -142,13 +142,15 @@ pub trait AppearsInFromClause<QS> {
 ///
 /// (Notably, a bunch of [`AppearsInFromClause`] for the tables and their aliases.)
 ///
-/// This trait is implemented by the [`allow_tables_to_appear_in_same_query!`] macro.
+/// This trait is implemented by the
+/// [`allow_tables_to_appear_in_same_query!`](crate::allow_tables_to_appear_in_same_query)
+/// macro.
 ///
 /// Troubleshooting
 /// ---------------
 /// If you encounter an error mentioning this trait, it could mean that either:
 /// - You are attempting to use tables that don't belong to the same database together
-///   (no call to [`allow_tables_to_appear_in_same_query!`] was made)
+///   (no call to [`allow_tables_to_appear_in_same_query!`](crate::allow_tables_to_appear_in_same_query) was made)
 /// - You are attempting to use two aliases to the same table in the same query, but they
 ///   were declared through different calls to [`alias!`](crate::alias)
 #[diagnostic::on_unimplemented(

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -41,6 +41,11 @@ pub(crate) mod std_compat {
 #[cfg(feature = "std")]
 pub(crate) mod std_compat {
     pub(crate) use std::collections::HashMap;
+    #[cfg(any(
+        feature = "__sqlite-shared",
+        feature = "mysql_backend",
+        feature = "postgres_backend"
+    ))]
     pub(crate) use std::collections::hash_map::Entry;
     #[cfg(feature = "__sqlite-shared")]
     pub(crate) use std::panic::catch_unwind;

--- a/diesel_migrations/src/combined_migrations.rs
+++ b/diesel_migrations/src/combined_migrations.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use diesel::backend::Backend;
+use diesel::migration::{Migration, MigrationSource};
+
+/// A diesel migration source that combines several other sources
+///
+/// This source will act like all migrations came from a single source.
+/// It orders all the migrations by version
+///
+/// # Example
+/// ```
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// use diesel::prelude::*;
+/// use diesel_migrations::EmbeddedMigrations;
+/// use diesel_migrations::CombinedMigrationSource;
+/// use crate::diesel_migrations::MigrationHarness;
+/// use migrations_macros::embed_migrations;
+///
+/// pub const PG_MIGRATIONS: EmbeddedMigrations = embed_migrations!("../migrations/postgres");
+/// pub const SQLITE_MIGRATIONS: EmbeddedMigrations = embed_migrations!("../migrations/sqlite");
+///
+/// # #[cfg(feature = "postgres")]
+/// # let connection_url = database_url_from_env("PG_DATABASE_URL");
+/// # #[cfg(feature = "sqlite")]
+/// # let connection_url = database_url_from_env("SQLITE_DATABASE_URL");
+/// # #[cfg(feature = "mysql")]
+/// # let connection_url = database_url_from_env("MYSQL_DATABASE_URL");
+/// # #[cfg(feature = "postgres")]
+/// # type SqliteConnection = PgConnection;
+/// # #[cfg(feature = "mysql")]
+/// # type SqliteConnection = MysqlConnection;
+/// #
+/// // Create a new empty combined source
+/// let mut combined_sources = CombinedMigrationSource::default();
+///
+/// // It's not particular meaningful to combine PostgreSQL and SQLite like this,
+/// // but that reasonable demonstrates the API
+/// combined_sources.add_source(PG_MIGRATIONS);
+/// combined_sources.add_source(SQLITE_MIGRATIONS);
+///
+/// // run the migrations
+/// let mut connection = SqliteConnection::establish(&connection_url)?;
+/// let res = connection.run_pending_migrations(combined_sources);
+/// # assert!(res.is_err(), "This is supposed to fail as you cannot run postgres migrations using sqlite");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Default, Clone)]
+pub struct CombinedMigrationSource<DB> {
+    sources: Vec<Arc<dyn MigrationSource<DB> + Send + Sync>>,
+}
+
+impl<DB> CombinedMigrationSource<DB>
+where
+    DB: Backend,
+{
+    /// Register another source with the given migration source
+    pub fn add_source(&mut self, source: impl MigrationSource<DB> + Send + Sync + 'static) {
+        self.sources.push(Arc::new(source))
+    }
+}
+
+impl<DB> MigrationSource<DB> for CombinedMigrationSource<DB>
+where
+    DB: Backend,
+{
+    fn migrations(&self) -> diesel::migration::Result<Vec<Box<dyn Migration<DB>>>> {
+        let mut migrations = Vec::new();
+        for source in &self.sources {
+            migrations.extend(source.migrations()?);
+        }
+        migrations.sort_by(|m1, m2| m1.name().version().cmp(&m2.name().version()));
+        Ok(migrations)
+    }
+}

--- a/diesel_migrations/src/lib.rs
+++ b/diesel_migrations/src/lib.rs
@@ -32,15 +32,23 @@
 //! Migrations can either be run with the CLI or embedded into the compiled application
 //! and executed with code, for example right after establishing a database connection.
 //! For more information, consult the [`embed_migrations!`] macro.
+//!
+//! You can also define migrations in your rust code by using the [`RustMigrationSource`].
+//! The [`CombinedMigrationSource`] allows you to combine migrations from different sources
+//! to execute them together
 
+mod combined_migrations;
 mod embedded_migrations;
 mod errors;
 mod file_based_migrations;
 mod migration_harness;
+mod rust_migrations;
 
-pub use crate::embedded_migrations::EmbeddedMigrations;
-pub use crate::file_based_migrations::FileBasedMigrations;
-pub use crate::migration_harness::{HarnessWithOutput, MigrationHarness};
+pub use self::embedded_migrations::EmbeddedMigrations;
+pub use self::file_based_migrations::FileBasedMigrations;
+pub use self::migration_harness::{HarnessWithOutput, MigrationHarness};
+pub use self::rust_migrations::{RustMigration, RustMigrationSource, TypedMigration};
+pub use combined_migrations::CombinedMigrationSource;
 pub use migrations_macros::embed_migrations;
 
 #[doc(hidden)]

--- a/diesel_migrations/src/migration_harness.rs
+++ b/diesel_migrations/src/migration_harness.rs
@@ -118,7 +118,6 @@ pub trait MigrationHarness<DB: Backend> {
             .into_iter()
             .map(|m| (m.name().version().as_owned(), m))
             .collect::<HashMap<_, _>>();
-
         for applied_version in applied_versions {
             migrations.remove(&applied_version);
         }

--- a/diesel_migrations/src/rust_migrations.rs
+++ b/diesel_migrations/src/rust_migrations.rs
@@ -1,0 +1,382 @@
+use std::sync::Arc;
+
+use diesel::migration::{
+    Migration, MigrationMetadata, MigrationName, MigrationSource, MigrationVersion,
+};
+use diesel::{Connection, QueryResult};
+
+use crate::MigrationError;
+
+/// A migration source that allows to register rust functions as migrations
+///
+/// The main use-case of this migration source is to allow writing migrations in Rust
+/// instead of in SQL. You need to specify at construction time which for which connection
+/// type this migration source is indented to be used with.
+/// It allows you to register different kinds of hooks to be executed as migrations later:
+///
+/// * A closure `Fn(&mut Conn) -> QueryResult<()>` that accepts a mutable connection
+///   reference as argument and returns a `QueryResult<()>`. This closure is executed as
+///   **up migration**.
+/// * A function with a signature of `fn(&mut Conn) -> QueryResult<()>`. This function
+///   is executed as **up migration**.
+/// * An instance of [`RustMigration`], which allows you to register an up and a down migration
+///   as required. This type allows you also to configure the migration behaviour.
+///   See the documentation there for details.
+/// * Any type implementing [`TypedMigration`]. This allows you to provide a custom type with
+///   custom fields to supply additional information to your migration. This trait gives you the
+///   full control over how the migration should behave. See the documentation there for details.
+///
+/// A single migration source can mix all of the variants of migrations listed above.
+///
+/// # Example
+/// ```
+/// # include!("../../diesel/src/doctest_setup.rs");
+/// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// use diesel::prelude::*;
+/// use diesel_migrations::MigrationHarness;
+/// use diesel_migrations::RustMigration;
+/// use diesel_migrations::RustMigrationSource;
+/// use diesel_migrations::TypedMigration;
+///
+/// # #[cfg(feature = "postgres")]
+/// # let connection_url = database_url_from_env("PG_DATABASE_URL");
+/// # #[cfg(feature = "sqlite")]
+/// # let connection_url = database_url_from_env("SQLITE_DATABASE_URL");
+/// # #[cfg(feature = "mysql")]
+/// # let connection_url = database_url_from_env("MYSQL_DATABASE_URL");
+/// # #[cfg(feature = "postgres")]
+/// # type SqliteConnection = PgConnection;
+/// # #[cfg(feature = "mysql")]
+/// # type SqliteConnection = MysqlConnection;
+/// fn migration_function(conn: &mut SqliteConnection) -> QueryResult<()> {
+///     diesel::sql_query("SELECT 'EXECUTE YOUR MIGRATION HERE'").execute(conn)?;
+///     Ok(())
+/// }
+///
+/// struct CustomMigration(&'static str);
+///
+/// impl TypedMigration<SqliteConnection> for CustomMigration {
+///     fn up(&self, conn: &mut SqliteConnection) -> QueryResult<()> {
+/// #       #[cfg(feature = "sqlite")]
+///         diesel::sql_query("SELECT 'YOUR MIGRATION', ?")
+///             .bind::<diesel::sql_types::Text, _>(self.0)
+///             .execute(conn)?;
+///         Ok(())
+///     }
+/// }
+///
+/// let mut rust_migrations = RustMigrationSource::<SqliteConnection>::new();
+///
+/// // register migrations callback
+/// rust_migrations.add_migration(
+///     "2026-01-30-121720",
+///     "callback",
+///     |conn: &mut SqliteConnection| {
+///         diesel::sql_query("SELECT 'EXECUTE YOUR MIGRATION HERE'").execute(conn)?;
+///         Ok(())
+///     },
+/// );
+///
+/// // register a migration as function
+/// rust_migrations.add_migration("2026-01-30-122420", "function", migration_function);
+///
+/// // register a RustMigration
+/// let migration = RustMigration::new(|conn| {
+///     diesel::sql_query("SELECT 'EXECUTE YOUR MIGRATION HERE'").execute(conn)?;
+///     Ok(())
+/// })
+/// .with_down(|conn| {
+///     diesel::sql_query("SELECT 'REVERT YOUR MIGRATION HERE'").execute(conn)?;
+///     Ok(())
+/// });
+/// rust_migrations.add_migration("2026-01-30-122520", "rust_migration", migration);
+///
+/// // register a custom migration type
+/// rust_migrations.add_migration(
+///     "2026-01-30-122920", "custom_type",
+///     CustomMigration("your custom args"),
+/// );
+///
+/// // run the migrations
+/// let mut conn = SqliteConnection::establish(&connection_url)?;
+/// conn.run_pending_migrations(rust_migrations)?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct RustMigrationSource<Conn>
+where
+    Conn: Connection,
+{
+    migrations: Vec<FunctionBasedMigration<Conn>>,
+}
+
+impl<Conn> Default for RustMigrationSource<Conn>
+where
+    Conn: Connection,
+{
+    fn default() -> Self {
+        Self {
+            migrations: Default::default(),
+        }
+    }
+}
+
+impl<Conn> Clone for RustMigrationSource<Conn>
+where
+    Conn: Connection,
+{
+    fn clone(&self) -> Self {
+        Self {
+            migrations: self.migrations.clone(),
+        }
+    }
+}
+
+impl<Conn> MigrationSource<Conn::Backend> for RustMigrationSource<Conn>
+where
+    Conn: Connection + 'static,
+{
+    fn migrations(&self) -> diesel::migration::Result<Vec<Box<dyn Migration<Conn::Backend>>>> {
+        Ok(self
+            .migrations
+            .iter()
+            .map(|m| Box::new(m.clone()) as Box<dyn Migration<Conn::Backend>>)
+            .collect())
+    }
+}
+
+impl<Conn> RustMigrationSource<Conn>
+where
+    Conn: Connection,
+{
+    /// Create a new empty migration source
+    pub fn new() -> Self {
+        Self {
+            migrations: Vec::new(),
+        }
+    }
+
+    /// Register a new migration
+    ///
+    /// See the documentation on the type itself for examples
+    pub fn add_migration(
+        &mut self,
+        version: impl Into<String>,
+        name: impl Into<String>,
+        migration: impl TypedMigration<Conn> + 'static,
+    ) -> Result<&mut Self, MigrationError> {
+        self.migrations.push(FunctionBasedMigration {
+            migration: Arc::new(migration),
+            name: RustMigrationName {
+                version: version.into(),
+                name: name.into(),
+            },
+        });
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RustMigrationName {
+    version: String,
+    name: String,
+}
+
+impl std::fmt::Display for RustMigrationName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}_{}", self.version, self.name)
+    }
+}
+
+impl MigrationName for RustMigrationName {
+    fn version(&self) -> MigrationVersion<'_> {
+        MigrationVersion::from(&self.version)
+    }
+}
+
+/// A typed rust migration for a given connection type
+///
+/// This type describes a typed rust migration for a specific connection type `Conn`
+///
+/// This trait only requires you to provide an up migration by implementing the relevant function.
+/// Optionally you can overwrite the down migration and the migration settings by providing a custom
+/// implementation for the relevant functions.
+pub trait TypedMigration<Conn> {
+    /// The implementation of the up migration.
+    ///
+    /// This function is supposed to migrate your database from an old schema version
+    /// considered valid before this migration was written to a new schema version expected
+    /// after this migration was written.
+    ///
+    /// This will be run inside of a transaction if `Self::run_in_transaction` is
+    /// is not customized to return `false`
+    fn up(&self, conn: &mut Conn) -> QueryResult<()>;
+
+    /// The implementation of the down migration.
+    ///
+    /// This function is supposed to revert everything that's done in your up migration.
+    ///
+    /// The default implementation doesn't perform any action. If you never plan to
+    /// revert migrations it can be fine to not provide a custom implementation of
+    /// this function.
+    ///
+    /// This will be run inside of a transaction if `Self::run_in_transaction` is
+    /// is not customized to return `false`
+    fn down(&self, _conn: &mut Conn) -> QueryResult<()> {
+        Ok(())
+    }
+
+    /// Should the given migration be run in a transaction or not
+    ///
+    /// By default diesel runs migrations inside of transactions
+    /// (if the underlying database system supports that). This ensures
+    /// that each migration is ever only executed as single unit or fails as
+    /// single unit.
+    ///
+    /// Nevertheless specific database operations might require to be run
+    /// outside of transactions. If you plan to use such an operation you
+    /// want to provide a custom implementation of this function that returns
+    /// `false`
+    fn run_in_transaction(&self) -> bool {
+        true
+    }
+}
+
+impl<Conn, F> TypedMigration<Conn> for F
+where
+    F: Fn(&mut Conn) -> QueryResult<()>,
+{
+    fn up(&self, conn: &mut Conn) -> QueryResult<()> {
+        self(conn)
+    }
+}
+
+type MigrationFunction<Conn> = dyn Fn(&mut Conn) -> QueryResult<()>;
+
+/// A rust side migration
+///
+/// This type represents a simple rust side migration builder
+/// that allows you to register a rust callback as up and down migration
+/// and that also allows you to customize the migration settings
+///
+/// Constructing a `RustMigration` requires to specify an up migration that
+/// describes how to migrate your database schema from an old to an new version.
+///
+/// Down migrations, that describe how to revert the changes done by the up migrations,
+/// are optional. If you don't plan to revert migrations you don't need to provide them.
+pub struct RustMigration<Conn> {
+    up: Box<MigrationFunction<Conn>>,
+    down: Option<Box<MigrationFunction<Conn>>>,
+    run_in_transaction: bool,
+}
+
+impl<Conn> RustMigration<Conn> {
+    /// Construct a new instance of this type with a given up migration function.
+    ///
+    /// This function needs to perform any action to migrate your database from an old version
+    /// to the expected new version
+    pub fn new(up: impl Fn(&mut Conn) -> QueryResult<()> + 'static) -> Self {
+        Self {
+            up: Box::new(up),
+            down: None,
+            run_in_transaction: true,
+        }
+    }
+
+    /// Register a down migration
+    ///
+    /// This function allows you to register a down migration to revert any changes done
+    /// by the up migration. It is used to restore the database schema used before this migration
+    /// was applied in the case of an revert. If you don't plan to revert migrations you don't need to
+    /// provide a down migration.
+    pub fn with_down(mut self, down: impl Fn(&mut Conn) -> QueryResult<()> + 'static) -> Self {
+        self.down = Some(Box::new(down));
+        self
+    }
+
+    /// Customizes the migration settings to not run this migration in a transaction
+    ///
+    /// By default diesel will execute migrations inside of a transaction on all database systems
+    /// supporting this to ensure that migrations are either fully executed or not.
+    ///
+    /// Some database operations require to be run outside transactions. If you use such an
+    /// operation in either your up or down migration you need to use this function to disable
+    /// the default transaction behaviour.
+    pub fn without_transaction(mut self) -> Self {
+        self.run_in_transaction = false;
+        self
+    }
+}
+
+impl<Conn> TypedMigration<Conn> for RustMigration<Conn> {
+    fn up(&self, conn: &mut Conn) -> QueryResult<()> {
+        (self.up)(conn)
+    }
+
+    fn down(&self, conn: &mut Conn) -> QueryResult<()> {
+        if let Some(down) = self.down.as_deref() {
+            down(conn)?
+        }
+        Ok(())
+    }
+
+    fn run_in_transaction(&self) -> bool {
+        self.run_in_transaction
+    }
+}
+
+struct FunctionBasedMigration<Conn> {
+    migration: Arc<dyn TypedMigration<Conn>>,
+    name: RustMigrationName,
+}
+
+impl<Conn> Clone for FunctionBasedMigration<Conn> {
+    fn clone(&self) -> Self {
+        Self {
+            migration: self.migration.clone(),
+            name: self.name.clone(),
+        }
+    }
+}
+
+impl<Conn> Migration<Conn::Backend> for FunctionBasedMigration<Conn>
+where
+    Conn: Connection + 'static,
+    Conn::Backend: 'static,
+{
+    fn run(
+        &self,
+        conn: &mut dyn diesel::connection::BoxableConnection<Conn::Backend>,
+    ) -> diesel::migration::Result<()> {
+        let conn = conn
+            .downcast_mut::<Conn>()
+            .ok_or("Unable to downcast connection type to the right type")?;
+        self.migration.up(conn)?;
+        Ok(())
+    }
+
+    fn revert(
+        &self,
+        conn: &mut dyn diesel::connection::BoxableConnection<Conn::Backend>,
+    ) -> diesel::migration::Result<()> {
+        let conn = conn
+            .downcast_mut::<Conn>()
+            .ok_or("Unable to downcast connection type to the right type")?;
+        self.migration.down(conn)?;
+        Ok(())
+    }
+
+    fn metadata(&self) -> &dyn MigrationMetadata {
+        self as &dyn MigrationMetadata
+    }
+
+    fn name(&self) -> &dyn diesel::migration::MigrationName {
+        &self.name
+    }
+}
+
+impl<Conn> MigrationMetadata for FunctionBasedMigration<Conn> {
+    fn run_in_transaction(&self) -> bool {
+        self.migration.run_in_transaction()
+    }
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -41,6 +41,7 @@ mod internal_details;
 mod joins;
 mod limit_offset;
 mod macros;
+mod migrations;
 #[cfg(feature = "postgres")]
 mod only;
 #[cfg(not(feature = "sqlite"))]

--- a/diesel_tests/tests/migrations.rs
+++ b/diesel_tests/tests/migrations.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+
+use crate::schema::TestConnection;
+use diesel::QueryResult;
+use diesel_migrations::{MigrationHarness, RustMigration};
+use diesel_migrations::{RustMigrationSource, TypedMigration};
+
+static GLOBAL_FLAG: AtomicU16 = AtomicU16::new(0);
+
+fn function(_conn: &mut TestConnection) -> QueryResult<()> {
+    GLOBAL_FLAG.fetch_add(1, Ordering::Relaxed);
+    Ok(())
+}
+
+struct Typed(Arc<AtomicBool>);
+
+impl TypedMigration<TestConnection> for Typed {
+    fn up(&self, _conn: &mut TestConnection) -> QueryResult<()> {
+        self.0.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[diesel_test_helper::test]
+fn test_rust_migrations() {
+    let mut source = RustMigrationSource::<TestConnection>::new();
+    let callback_called = Arc::new(AtomicBool::new(false));
+    let callback_called2 = callback_called.clone();
+    let typed_called = Arc::new(AtomicBool::new(false));
+    let rust_migration_called = Arc::new(AtomicBool::new(false));
+    let rust_migration_called2 = rust_migration_called.clone();
+
+    source
+        .add_migration(
+            "2026-01-23-173320",
+            "test1",
+            move |_conn: &mut TestConnection| {
+                callback_called.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .unwrap();
+    source
+        .add_migration("2026-01-23-173920", "test2", function)
+        .unwrap();
+    source
+        .add_migration("2026-01-23-174320", "test3", Typed(typed_called.clone()))
+        .unwrap();
+    let migration = RustMigration::new(move |_conn: &mut TestConnection| {
+        rust_migration_called.store(true, Ordering::Relaxed);
+        Ok(())
+    })
+    .with_down(|_| Ok(()))
+    .without_transaction();
+
+    source
+        .add_migration("2026-01-23-174620", "test4", migration)
+        .unwrap();
+
+    #[cfg(not(feature = "mysql"))]
+    let conn = &mut crate::schema::connection();
+    #[cfg(feature = "mysql")]
+    let conn = &mut crate::schema::connection_without_transaction();
+
+    assert!(!typed_called.load(Ordering::Relaxed));
+    assert!(!callback_called2.load(Ordering::Relaxed));
+    assert!(!rust_migration_called2.load(Ordering::Relaxed));
+    assert_eq!(GLOBAL_FLAG.load(Ordering::Relaxed), 0);
+    let res = conn.run_pending_migrations(source.clone()).map(|c| c.len());
+    if cfg!(feature = "mysql") {
+        let _ = conn.revert_all_migrations(source);
+    }
+
+    let res = res.unwrap();
+    assert_eq!(res, 4);
+
+    assert!(typed_called.load(Ordering::Relaxed));
+    assert!(callback_called2.load(Ordering::Relaxed));
+    assert!(rust_migration_called2.load(Ordering::Relaxed));
+    assert_eq!(GLOBAL_FLAG.load(Ordering::Relaxed), 1);
+}

--- a/xtask/src/tests/mod.rs
+++ b/xtask/src/tests/mod.rs
@@ -161,6 +161,8 @@ impl TestArgs {
                 .arg(format!("diesel_tests/{backend}"))
                 .arg("-F")
                 .arg(format!("diesel-dynamic-schema/{backend}"))
+                .arg("-F")
+                .arg(format!("diesel_migrations/{backend}"))
                 .args(&self.flags);
 
             if matches!(self.backend, Backend::Mysql) {
@@ -223,7 +225,9 @@ impl TestArgs {
                 .arg("-F")
                 .arg(format!("diesel_derives/{backend}"))
                 .arg("-F")
-                .arg(format!("diesel-dynamic-schema/{backend}"));
+                .arg(format!("diesel-dynamic-schema/{backend}"))
+                .arg("-F")
+                .arg(format!("diesel_migrations/{backend}"));
             if matches!(backend, Backend::Mysql) {
                 // cannot run mysql tests in parallel
                 command.args(["-j", "1"]);


### PR DESCRIPTION
This PR adds more migration sources to diesel_migrations with the goal to make it easier to write different kinds of migrations in multi-crate deployments.

It adds a CombinedMigrations source that is essentially just a list of sources. The resulting list of migrations is just all migrations from all sources. That is useful for multi-crate projects as then each sub-project can have their own set of migrations (by using files or embedded migrations etc) and then combine them into a final list using this migration source.

As a second variant a RustMigrationSource is added. The goal there is to make it much easier to register rust based migrations by having some sort of typed interface for this. This migration source needs to know the connection type, not only the backend. This information is then used to internally receive the right connection type from the migration connection for the user. The user has the ability to provide different kinds of rust structs/functions all "migration. This includes closures, functions, a migration builder (that in turn accepts clousures but allows more fine grained configuration) or even custom types (via the provided trait).

# Rust migration source example:


```rust
use diesel::prelude::*;
use diesel_migrations::MigrationHarness;
use diesel_migrations::RustMigration;
use diesel_migrations::RustMigrationSource;
use diesel_migrations::TypedMigration;

fn migration_function(conn: &mut SqliteConnection) -> QueryResult<()> {
    diesel::sql_query("SELECT 'EXECUTE YOUR MIGRATION HERE'").execute(conn)?;
    Ok(())
}

struct CustomMigration(&'static str);

impl TypedMigration<SqliteConnection> for CustomMigration {
    fn up(&self, conn: &mut SqliteConnection) -> QueryResult<()> {
        diesel::sql_query("SELECT 'YOUR MIGRATION', ?")
            .bind::<diesel::sql_types::Text, _>(self.0)
            .execute(conn)?;
        Ok(())
    }
}

let mut rust_migrations = RustMigrationSource::<SqliteConnection>::new();

// register migrations callback
rust_migrations.add_migration(
    "2026-01-30-121720_callback",
    |conn: &mut SqliteConnection| {
        diesel::sql_query("SELECT 'EXECUTE YOUR MIGRATION HERE'").execute(conn)?;
        Ok(())
    },
);

// register a migration as function
rust_migrations.add_migration("2026-01-30-122420_function", migration_function);

// register a RustMigration
let migration = RustMigration::new(|conn| {
    diesel::sql_query("SELECT 'EXECUTE YOUR MIGRATION HERE'").execute(conn)?;
    Ok(())
})
.with_down(|conn| {
    diesel::sql_query("SELECT 'REVERT YOUR MIGRATION HERE'").execute(conn)?;
    Ok(())
});
rust_migrations.add_migration("2026-01-30-122520_rust_migration", migration);

// register a custom migration type
rust_migrations.add_migration(
    "2026-01-30-122920_custom_type",
    CustomMigration("your custom args"),
);

// run the migrations
let mut conn = SqliteConnection::establish(&connection_url)?;
conn.run_pending_migrations(rust_migrations)?;
```

# Combined migration source example

```rust


use diesel::prelude::*;
use diesel_migrations::EmbeddedMigrations;
use diesel_migrations::CombinedMigrationSource;
use crate::diesel_migrations::MigrationHarness;
use migrations_macros::embed_migrations;

pub const PG_MIGRATIONS: EmbeddedMigrations = embed_migrations!("../migrations/postgres");
pub const SQLITE_MIGRATIONS: EmbeddedMigrations = embed_migrations!("../migrations/sqlite");

// Create a new empty combined source
let mut combined_sources = CombinedMigrationSource::default();

// It's not particular meaningful to combine PostgreSQL and SQLite like this,
// but that reasonable demonstrates the API
combined_sources.add_source(PG_MIGRATIONS);
combined_sources.add_source(SQLITE_MIGRATIONS);

// run the migrations
let mut connection = SqliteConnection::establish(&connection_url)?;
let res = connection.run_pending_migrations(combined_sources);

```
---

This is currently marked as draft as it is still missing some more tests + drastically more documentation on how to use this new sources. I'm nevertheless interested in feedback on the design and the exposed interface. One question that I would like to discuss is whether we want something more typed for the migration name for the `RustMigrationSource` than the string interface that all the other sources use. Technically we could also use at least two arguments there: a required version (string?) + an optional name (as `Option<String>`).