### PR TITLE
Drafted first version of `WithRawConnection`, with extensive documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ## Unreleased
 
+### Added
+
+* Added `SqliteConnection::with_raw_connection` to provide safe, callback-based access to the raw `*mut sqlite3` handle for advanced SQLite C APIs (session extension, hooks, etc.)
+
 ### Changed
 
 * The minimal supported Rust version is now 1.88.0

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -613,8 +613,6 @@ impl SqliteConnection {
     ///
     /// - The connection handle is **not closed** during the callback.
     /// - The connection handle is **not stored** beyond the callback's scope.
-    /// - Any state changes made through the raw handle are **compatible** with
-    ///   Diesel's expectations about the connection state.
     /// - Concurrent access rules are respected (SQLite connections are not thread-safe
     ///   unless using serialized threading mode).
     ///

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -706,31 +706,6 @@ mod tests {
 
     #[diesel_test_helper::test]
     #[allow(unsafe_code)]
-    fn with_raw_connection_provides_valid_handle() {
-        let connection = &mut connection();
-
-        // SAFETY: We only read the SQLite version, which is a safe operation
-        // that doesn't modify connection state.
-        let version = unsafe {
-            connection.with_raw_connection(|raw_conn| {
-                assert!(!raw_conn.is_null());
-                // Use sqlite3_libversion to verify we have a valid connection
-                let version_ptr = ffi::sqlite3_libversion();
-                let version_cstr = core::ffi::CStr::from_ptr(version_ptr);
-                version_cstr.to_str().unwrap().to_owned()
-            })
-        };
-
-        // SQLite version should start with "3."
-        assert!(
-            version.starts_with("3."),
-            "Unexpected SQLite version: {}",
-            version
-        );
-    }
-
-    #[diesel_test_helper::test]
-    #[allow(unsafe_code)]
     fn with_raw_connection_can_return_values() {
         let connection = &mut connection();
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -691,7 +691,6 @@ impl SqliteConnection {
     }
 }
 
-
 fn error_message(err_code: libc::c_int) -> &'static str {
     ffi::code_to_str(err_code)
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -742,7 +742,11 @@ mod tests {
         };
 
         // SQLite version should start with "3."
-        assert!(version.starts_with("3."), "Unexpected SQLite version: {}", version);
+        assert!(
+            version.starts_with("3."),
+            "Unexpected SQLite version: {}",
+            version
+        );
     }
 
     #[diesel_test_helper::test]
@@ -752,9 +756,7 @@ mod tests {
 
         // SAFETY: We only read connection status, which doesn't modify state.
         let autocommit_status = unsafe {
-            connection.with_raw_connection(|raw_conn| {
-                ffi::sqlite3_get_autocommit(raw_conn)
-            })
+            connection.with_raw_connection(|raw_conn| ffi::sqlite3_get_autocommit(raw_conn))
         };
 
         // Outside a transaction, autocommit should be enabled (returns non-zero)
@@ -767,15 +769,14 @@ mod tests {
         let connection = &mut connection();
 
         // SAFETY: We only read the pointer value, not dereferencing in unsafe ways.
-        let ptr1 = unsafe {
-            connection.with_raw_connection(|raw_conn| raw_conn as usize)
-        };
+        let ptr1 = unsafe { connection.with_raw_connection(|raw_conn| raw_conn as usize) };
 
-        let ptr2 = unsafe {
-            connection.with_raw_connection(|raw_conn| raw_conn as usize)
-        };
+        let ptr2 = unsafe { connection.with_raw_connection(|raw_conn| raw_conn as usize) };
 
-        assert_eq!(ptr1, ptr2, "Raw connection handle should be stable across calls");
+        assert_eq!(
+            ptr1, ptr2,
+            "Raw connection handle should be stable across calls"
+        );
     }
 
     #[diesel_test_helper::test]
@@ -793,9 +794,7 @@ mod tests {
 
         // SAFETY: We only read the last insert rowid, which is a read-only operation.
         let last_rowid = unsafe {
-            connection.with_raw_connection(|raw_conn| {
-                ffi::sqlite3_last_insert_rowid(raw_conn)
-            })
+            connection.with_raw_connection(|raw_conn| ffi::sqlite3_last_insert_rowid(raw_conn))
         };
 
         assert_eq!(last_rowid, 1, "Last insert rowid should be 1");
@@ -860,31 +859,35 @@ mod tests {
             .execute(connection)
             .unwrap();
 
-        connection.transaction::<_, crate::result::Error, _>(|conn| {
-            crate::sql_query("INSERT INTO txn_test (value) VALUES (42)")
-                .execute(conn)
-                .unwrap();
+        connection
+            .transaction::<_, crate::result::Error, _>(|conn| {
+                crate::sql_query("INSERT INTO txn_test (value) VALUES (42)")
+                    .execute(conn)
+                    .unwrap();
 
-            // SAFETY: We only read the autocommit status inside a transaction.
-            let autocommit = unsafe {
-                conn.with_raw_connection(|raw_conn| {
-                    ffi::sqlite3_get_autocommit(raw_conn)
-                })
-            };
+                // SAFETY: We only read the autocommit status inside a transaction.
+                let autocommit = unsafe {
+                    conn.with_raw_connection(|raw_conn| ffi::sqlite3_get_autocommit(raw_conn))
+                };
 
-            // Inside a transaction, autocommit should be disabled (returns 0)
-            assert_eq!(autocommit, 0, "Autocommit should be disabled inside transaction");
+                // Inside a transaction, autocommit should be disabled (returns 0)
+                assert_eq!(
+                    autocommit, 0,
+                    "Autocommit should be disabled inside transaction"
+                );
 
-            Ok(())
-        }).unwrap();
+                Ok(())
+            })
+            .unwrap();
 
         // After transaction commits, autocommit should be re-enabled
         let autocommit = unsafe {
-            connection.with_raw_connection(|raw_conn| {
-                ffi::sqlite3_get_autocommit(raw_conn)
-            })
+            connection.with_raw_connection(|raw_conn| ffi::sqlite3_get_autocommit(raw_conn))
         };
-        assert_ne!(autocommit, 0, "Autocommit should be enabled after transaction");
+        assert_ne!(
+            autocommit, 0,
+            "Autocommit should be enabled after transaction"
+        );
     }
 
     #[diesel_test_helper::test]
@@ -909,7 +912,10 @@ mod tests {
 
         // For in-memory databases, filename is typically empty or a special value
         // The important thing is that the call succeeded without crashing
-        assert!(filename.is_some() || filename.is_none(), "Should handle filename query");
+        assert!(
+            filename.is_some() || filename.is_none(),
+            "Should handle filename query"
+        );
     }
 
     #[diesel_test_helper::test]

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -912,8 +912,10 @@ mod tests {
         assert_eq!(values, vec![11, 12, 13]);
     }
 
+    // catch_unwind is not available in WASM (panic = "abort")
     #[diesel_test_helper::test]
     #[allow(unsafe_code)]
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     fn with_raw_connection_recovers_after_panic() {
         let connection = &mut connection();
 
@@ -940,8 +942,10 @@ mod tests {
         assert_eq!(count, 1, "Connection should work after panic in callback");
     }
 
+    // Filesystem access is not available in WASM
     #[diesel_test_helper::test]
     #[allow(unsafe_code)]
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     fn with_raw_connection_can_read_file_database_filename() {
         let dir = std::env::temp_dir().join("diesel_test_filename.db");
         let db_path = dir.to_str().unwrap();

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -615,6 +615,17 @@ impl SqliteConnection {
     /// - The connection handle is **not stored** beyond the callback's scope.
     /// - Concurrent access rules are respected (SQLite connections are not thread-safe
     ///   unless using serialized threading mode).
+    /// - **Transaction state is not modified** — do not execute `BEGIN`, `COMMIT`,
+    ///   `ROLLBACK`, or `SAVEPOINT` statements via the raw handle. Diesel's
+    ///   [`AnsiTransactionManager`] tracks transaction nesting internally, and
+    ///   bypassing it will cause Diesel's view of the transaction state to diverge
+    ///   from SQLite's actual state.
+    /// - **Diesel's prepared statements are not disturbed** — do not call
+    ///   `sqlite3_finalize()` or `sqlite3_reset()` on statements that belong to
+    ///   Diesel's `StatementCache`. Doing so will cause use-after-free or
+    ///   double-free when Diesel later accesses those statements.
+    ///
+    /// [`AnsiTransactionManager`]: crate::connection::AnsiTransactionManager
     ///
     /// # Example
     ///
@@ -625,16 +636,17 @@ impl SqliteConnection {
     /// let mut conn = SqliteConnection::establish(":memory:").unwrap();
     ///
     /// // SAFETY: We do not close or store the connection handle,
-    /// // and we do not modify state that Diesel depends on.
-    /// let version = unsafe {
-    ///     conn.with_raw_connection(|_raw_conn| {
-    ///         // Use raw_conn with SQLite C API functions from your own
-    ///         // `libsqlite3-sys` (native) or `sqlite-wasm-rs` (WASM) dependency.
-    ///         // For example: ffi::sqlite3session_create(raw_conn, ...)
-    ///         42 // return a value
+    /// // and we do not modify Diesel-managed state (transactions, cached statements).
+    /// let is_valid = unsafe {
+    ///     conn.with_raw_connection(|raw_conn| {
+    ///         // The raw connection pointer can be passed to SQLite C API functions
+    ///         // from your own `libsqlite3-sys` (native) or `sqlite-wasm-rs` (WASM)
+    ///         // dependency — for example, `sqlite3_get_autocommit(raw_conn)` or
+    ///         // `sqlite3session_create(raw_conn, ...)`.
+    ///         !raw_conn.is_null()
     ///     })
     /// };
-    /// assert_eq!(version, 42);
+    /// assert!(is_valid);
     /// ```
     ///
     /// # Platform Notes
@@ -716,22 +728,6 @@ mod tests {
 
         // Outside a transaction, autocommit should be enabled (returns non-zero)
         assert_ne!(autocommit_status, 0, "Expected autocommit to be enabled");
-    }
-
-    #[diesel_test_helper::test]
-    #[allow(unsafe_code)]
-    fn with_raw_connection_handle_is_same_across_calls() {
-        let connection = &mut connection();
-
-        // SAFETY: We only read the pointer value, not dereferencing in unsafe ways.
-        let ptr1 = unsafe { connection.with_raw_connection(|raw_conn| raw_conn as usize) };
-
-        let ptr2 = unsafe { connection.with_raw_connection(|raw_conn| raw_conn as usize) };
-
-        assert_eq!(
-            ptr1, ptr2,
-            "Raw connection handle should be stable across calls"
-        );
     }
 
     #[diesel_test_helper::test]
@@ -865,45 +861,13 @@ mod tests {
             })
         };
 
-        // For in-memory databases, filename is typically empty or a special value
-        // The important thing is that the call succeeded without crashing
-        assert!(
-            filename.is_some() || filename.is_none(),
-            "Should handle filename query"
+        // For in-memory databases, sqlite3_db_filename returns a non-null pointer
+        // to an empty string
+        assert_eq!(
+            filename,
+            Some(String::new()),
+            "In-memory database filename should be an empty string"
         );
-    }
-
-    #[diesel_test_helper::test]
-    #[allow(unsafe_code)]
-    fn with_raw_connection_error_handling() {
-        let connection = &mut connection();
-
-        // SAFETY: We attempt an operation that will fail (querying non-existent table)
-        // but handle the error properly.
-        let result = unsafe {
-            connection.with_raw_connection(|raw_conn| {
-                let sql = c"SELECT * FROM nonexistent_table_xyz";
-                let mut stmt: *mut ffi::sqlite3_stmt = core::ptr::null_mut();
-                let rc = ffi::sqlite3_prepare_v2(
-                    raw_conn,
-                    sql.as_ptr(),
-                    -1,
-                    &mut stmt,
-                    core::ptr::null_mut(),
-                );
-                if rc != ffi::SQLITE_OK {
-                    return Err(rc);
-                }
-                // Clean up if we somehow succeeded
-                if !stmt.is_null() {
-                    ffi::sqlite3_finalize(stmt);
-                }
-                Ok(())
-            })
-        };
-
-        // Should fail because table doesn't exist
-        assert!(result.is_err(), "Query on non-existent table should fail");
     }
 
     #[diesel_test_helper::test]
@@ -946,6 +910,69 @@ mod tests {
             .load(connection)
             .unwrap();
         assert_eq!(values, vec![11, 12, 13]);
+    }
+
+    #[diesel_test_helper::test]
+    #[allow(unsafe_code)]
+    fn with_raw_connection_recovers_after_panic() {
+        let connection = &mut connection();
+
+        crate::sql_query("CREATE TABLE panic_test (id INTEGER PRIMARY KEY, value TEXT)")
+            .execute(connection)
+            .unwrap();
+
+        // Panic inside the callback
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            connection.with_raw_connection(|_raw_conn| {
+                panic!("intentional panic inside with_raw_connection");
+            })
+        }));
+        assert!(result.is_err(), "Should have caught the panic");
+
+        // Connection should still be usable after the panic
+        crate::sql_query("INSERT INTO panic_test (value) VALUES ('after_panic')")
+            .execute(connection)
+            .unwrap();
+
+        let count: i64 = sql::<crate::sql_types::BigInt>("SELECT COUNT(*) FROM panic_test")
+            .get_result(connection)
+            .unwrap();
+        assert_eq!(count, 1, "Connection should work after panic in callback");
+    }
+
+    #[diesel_test_helper::test]
+    #[allow(unsafe_code)]
+    fn with_raw_connection_can_read_file_database_filename() {
+        let dir = std::env::temp_dir().join("diesel_test_filename.db");
+        let db_path = dir.to_str().unwrap();
+
+        // Clean up from any previous run
+        let _ = std::fs::remove_file(db_path);
+
+        let connection = &mut SqliteConnection::establish(db_path).unwrap();
+
+        // SAFETY: We only read the database filename, which is a read-only operation.
+        let filename = unsafe {
+            connection.with_raw_connection(|raw_conn| {
+                let db_name = c"main";
+                let filename_ptr = ffi::sqlite3_db_filename(raw_conn, db_name.as_ptr());
+                if filename_ptr.is_null() {
+                    None
+                } else {
+                    let cstr = core::ffi::CStr::from_ptr(filename_ptr);
+                    Some(cstr.to_string_lossy().into_owned())
+                }
+            })
+        };
+
+        let filename = filename.expect("File-based database should have a filename");
+        assert!(
+            filename.contains("diesel_test_filename.db"),
+            "Filename should contain the database name, got: {filename}"
+        );
+
+        // Clean up
+        let _ = std::fs::remove_file(db_path);
     }
 
     #[declare_sql_function]

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -17,7 +17,6 @@ pub use self::connection::SerializedDatabase;
 pub use self::connection::SqliteBindValue;
 pub use self::connection::SqliteConnection;
 pub use self::connection::SqliteValue;
-pub use self::connection::WithRawConnection;
 pub use self::query_builder::SqliteQueryBuilder;
 
 /// Trait for the implementation of a SQLite aggregate function

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -17,6 +17,7 @@ pub use self::connection::SerializedDatabase;
 pub use self::connection::SqliteBindValue;
 pub use self::connection::SqliteConnection;
 pub use self::connection::SqliteValue;
+pub use self::connection::WithRawConnection;
 pub use self::query_builder::SqliteQueryBuilder;
 
 /// Trait for the implementation of a SQLite aggregate function


### PR DESCRIPTION
This PR introduces the `WithRawConnection` trait for `SqliteConnection`, providing scoped access to the underlying `sqlite3*` handle. This enables users to leverage advanced SQLite C APIs, such as the [Session Extension](https://www.sqlite.org/sessionintro.html), [Backup API](https://www.sqlite.org/backup.html), and [Pre-update Hooks](https://www.sqlite.org/c3ref/update_hook.html), without requiring Diesel to wrap these optional, ABI-variable features.

**Related Discussion:** [#4965 - Exposing SQLite's Variable ABI: Scoped Raw Connection Access](https://github.com/diesel-rs/diesel/discussions/4965)

The new trait is **extensively** documented, and is tested using only stable ABI methods. Ideally, we would want to test also with the session ABI etc, but the point of this trait is exactly that we cannot have those maybe-linkable ABI in the crate in the first place.