### PR TITLE
Added SQLite hooks helper methods

### DIFF
--- a/diesel/src/sqlite/connection/authorizer.rs
+++ b/diesel/src/sqlite/connection/authorizer.rs
@@ -90,6 +90,50 @@ pub enum AuthorizerAction {
 }
 
 impl AuthorizerAction {
+    /// Returns `true` if this action modifies the database schema.
+    ///
+    /// Schema-modifying actions include creating, dropping, or altering
+    /// tables, indexes, triggers, views, and virtual tables.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::sqlite::AuthorizerAction;
+    ///
+    /// assert!(AuthorizerAction::CreateTable.is_schema_modifying());
+    /// assert!(AuthorizerAction::DropIndex.is_schema_modifying());
+    /// assert!(AuthorizerAction::AlterTable.is_schema_modifying());
+    ///
+    /// assert!(!AuthorizerAction::Select.is_schema_modifying());
+    /// assert!(!AuthorizerAction::Insert.is_schema_modifying());
+    /// assert!(!AuthorizerAction::Update.is_schema_modifying());
+    /// assert!(!AuthorizerAction::Delete.is_schema_modifying());
+    /// ```
+    pub fn is_schema_modifying(&self) -> bool {
+        matches!(
+            self,
+            Self::CreateIndex
+                | Self::CreateTable
+                | Self::CreateTempIndex
+                | Self::CreateTempTable
+                | Self::CreateTempTrigger
+                | Self::CreateTempView
+                | Self::CreateTrigger
+                | Self::CreateView
+                | Self::CreateVTable
+                | Self::DropIndex
+                | Self::DropTable
+                | Self::DropTempIndex
+                | Self::DropTempTable
+                | Self::DropTempTrigger
+                | Self::DropTempView
+                | Self::DropTrigger
+                | Self::DropView
+                | Self::DropVTable
+                | Self::AlterTable
+        )
+    }
+
     /// Converts an FFI action code to the Rust enum variant.
     pub(crate) fn from_ffi(code: i32) -> Self {
         match code {

--- a/diesel/src/sqlite/connection/authorizer.rs
+++ b/diesel/src/sqlite/connection/authorizer.rs
@@ -1,0 +1,211 @@
+//! Types for the SQLite authorizer callback.
+//!
+//! See [`sqlite3_set_authorizer`](https://sqlite.org/c3ref/set_authorizer.html)
+//! and the [action code constants](https://sqlite.org/c3ref/c_alter_table.html).
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+extern crate libsqlite3_sys as ffi;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use sqlite_wasm_rs as ffi;
+
+/// Authorizer action codes.
+///
+/// These correspond to the action codes passed to the authorizer callback
+/// by SQLite. The callback is invoked during SQL statement compilation
+/// (not during execution).
+///
+/// Added in SQLite 3.0.0 (June 2004).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AuthorizerAction {
+    /// CREATE INDEX
+    CreateIndex,
+    /// CREATE TABLE
+    CreateTable,
+    /// CREATE TEMP INDEX
+    CreateTempIndex,
+    /// CREATE TEMP TABLE
+    CreateTempTable,
+    /// CREATE TEMP TRIGGER
+    CreateTempTrigger,
+    /// CREATE TEMP VIEW
+    CreateTempView,
+    /// CREATE TRIGGER
+    CreateTrigger,
+    /// CREATE VIEW
+    CreateView,
+    /// DELETE
+    Delete,
+    /// DROP INDEX
+    DropIndex,
+    /// DROP TABLE
+    DropTable,
+    /// DROP TEMP INDEX
+    DropTempIndex,
+    /// DROP TEMP TABLE
+    DropTempTable,
+    /// DROP TEMP TRIGGER
+    DropTempTrigger,
+    /// DROP TEMP VIEW
+    DropTempView,
+    /// DROP TRIGGER
+    DropTrigger,
+    /// DROP VIEW
+    DropView,
+    /// INSERT
+    Insert,
+    /// PRAGMA
+    Pragma,
+    /// Read a column value
+    Read,
+    /// SELECT statement
+    Select,
+    /// BEGIN/COMMIT/ROLLBACK
+    Transaction,
+    /// UPDATE
+    Update,
+    /// ATTACH DATABASE
+    Attach,
+    /// DETACH DATABASE
+    Detach,
+    /// ALTER TABLE
+    AlterTable,
+    /// REINDEX
+    Reindex,
+    /// ANALYZE
+    Analyze,
+    /// CREATE VIRTUAL TABLE
+    CreateVTable,
+    /// DROP VIRTUAL TABLE
+    DropVTable,
+    /// SQL function call
+    Function,
+    /// SAVEPOINT
+    Savepoint,
+    /// Recursive SELECT
+    Recursive,
+    /// Unknown action code (for future compatibility)
+    Unknown(i32),
+}
+
+impl AuthorizerAction {
+    /// Converts an FFI action code to the Rust enum variant.
+    pub(crate) fn from_ffi(code: i32) -> Self {
+        match code {
+            ffi::SQLITE_CREATE_INDEX => Self::CreateIndex,
+            ffi::SQLITE_CREATE_TABLE => Self::CreateTable,
+            ffi::SQLITE_CREATE_TEMP_INDEX => Self::CreateTempIndex,
+            ffi::SQLITE_CREATE_TEMP_TABLE => Self::CreateTempTable,
+            ffi::SQLITE_CREATE_TEMP_TRIGGER => Self::CreateTempTrigger,
+            ffi::SQLITE_CREATE_TEMP_VIEW => Self::CreateTempView,
+            ffi::SQLITE_CREATE_TRIGGER => Self::CreateTrigger,
+            ffi::SQLITE_CREATE_VIEW => Self::CreateView,
+            ffi::SQLITE_DELETE => Self::Delete,
+            ffi::SQLITE_DROP_INDEX => Self::DropIndex,
+            ffi::SQLITE_DROP_TABLE => Self::DropTable,
+            ffi::SQLITE_DROP_TEMP_INDEX => Self::DropTempIndex,
+            ffi::SQLITE_DROP_TEMP_TABLE => Self::DropTempTable,
+            ffi::SQLITE_DROP_TEMP_TRIGGER => Self::DropTempTrigger,
+            ffi::SQLITE_DROP_TEMP_VIEW => Self::DropTempView,
+            ffi::SQLITE_DROP_TRIGGER => Self::DropTrigger,
+            ffi::SQLITE_DROP_VIEW => Self::DropView,
+            ffi::SQLITE_INSERT => Self::Insert,
+            ffi::SQLITE_PRAGMA => Self::Pragma,
+            ffi::SQLITE_READ => Self::Read,
+            ffi::SQLITE_SELECT => Self::Select,
+            ffi::SQLITE_TRANSACTION => Self::Transaction,
+            ffi::SQLITE_UPDATE => Self::Update,
+            ffi::SQLITE_ATTACH => Self::Attach,
+            ffi::SQLITE_DETACH => Self::Detach,
+            ffi::SQLITE_ALTER_TABLE => Self::AlterTable,
+            ffi::SQLITE_REINDEX => Self::Reindex,
+            ffi::SQLITE_ANALYZE => Self::Analyze,
+            ffi::SQLITE_CREATE_VTABLE => Self::CreateVTable,
+            ffi::SQLITE_DROP_VTABLE => Self::DropVTable,
+            ffi::SQLITE_FUNCTION => Self::Function,
+            ffi::SQLITE_SAVEPOINT => Self::Savepoint,
+            ffi::SQLITE_RECURSIVE => Self::Recursive,
+            other => Self::Unknown(other),
+        }
+    }
+}
+
+/// Context information passed to the authorizer callback.
+///
+/// The meaning of the string arguments depends on the action code:
+///
+/// | Action | arg1 | arg2 | db_name | accessor |
+/// |--------|------|------|---------|----------|
+/// | `CreateIndex` | Index name | Table name | db | - |
+/// | `CreateTable` | Table name | - | db | - |
+/// | `CreateTrigger` | Trigger name | Table name | db | - |
+/// | `CreateView` | View name | - | db | - |
+/// | `Delete` | Table name | - | db | - |
+/// | `DropIndex` | Index name | Table name | db | - |
+/// | `DropTable` | Table name | - | db | - |
+/// | `DropTrigger` | Trigger name | Table name | db | - |
+/// | `DropView` | View name | - | db | - |
+/// | `Insert` | Table name | - | db | - |
+/// | `Pragma` | Pragma name | Argument | db | - |
+/// | `Read` | Table name | Column name | db | trigger/view |
+/// | `Select` | - | - | - | - |
+/// | `Transaction` | Operation | - | - | - |
+/// | `Update` | Table name | Column name | db | - |
+/// | `Attach` | Filename | - | - | - |
+/// | `Detach` | Database name | - | - | - |
+/// | `AlterTable` | Database name | Table name | - | - |
+/// | `Reindex` | Index name | - | db | - |
+/// | `Analyze` | Table name | - | db | - |
+/// | `CreateVTable` | Table name | Module name | db | - |
+/// | `DropVTable` | Table name | Module name | db | - |
+/// | `Function` | - | Function name | - | - |
+/// | `Savepoint` | Operation | Name | - | - |
+/// | `Recursive` | - | - | - | - |
+///
+/// Where "db" means `"main"`, `"temp"`, or an `ATTACH` alias.
+/// The "accessor" field indicates which trigger or view is causing
+/// the access, if applicable.
+#[derive(Debug, Clone, Copy)]
+pub struct AuthorizerContext<'a> {
+    /// The action being authorized.
+    pub action: AuthorizerAction,
+    /// First argument (meaning depends on action).
+    pub arg1: Option<&'a str>,
+    /// Second argument (meaning depends on action).
+    pub arg2: Option<&'a str>,
+    /// Database name (`"main"`, `"temp"`, or `ATTACH` alias).
+    pub db_name: Option<&'a str>,
+    /// Trigger or view name causing the access (if applicable).
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizer callback decision.
+///
+/// Returned by the authorizer callback to indicate whether to allow,
+/// ignore, or deny the requested operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorizerDecision {
+    /// Allow the operation to proceed (`SQLITE_OK`).
+    Allow,
+    /// Ignore the operation (`SQLITE_IGNORE`).
+    ///
+    /// For `Read` actions, returns `NULL` instead of the column value.
+    /// For other actions, treats the operation as a no-op.
+    Ignore,
+    /// Deny the operation (`SQLITE_DENY`).
+    ///
+    /// Causes the entire SQL statement to fail with an authorization error.
+    Deny,
+}
+
+impl AuthorizerDecision {
+    /// Converts the decision to the FFI return code.
+    pub(crate) fn to_ffi(self) -> i32 {
+        match self {
+            Self::Allow => ffi::SQLITE_OK,
+            Self::Ignore => ffi::SQLITE_IGNORE,
+            Self::Deny => ffi::SQLITE_DENY,
+        }
+    }
+}

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -721,16 +721,91 @@ impl SqliteConnection {
         self.register_change_hook(None, ops, Box::new(hook))
     }
 
+    /// Registers a callback invoked for any change on table `T` that matches
+    /// the given [`SqliteChangeOps`] mask.
+    ///
+    /// This is the typed counterpart to [`on_change`](Self::on_change):
+    /// `on_change` matches every table, this matches one table. The table is
+    /// identified by the [`table!`](macro@crate::table)-generated type `T`
+    /// (e.g. `users::table`),
+    /// so a table rename is a compile error rather than a silently dead hook.
+    ///
+    /// [`on_insert`](Self::on_insert), [`on_update`](Self::on_update), and
+    /// [`on_delete`](Self::on_delete) are thin wrappers over this method with a
+    /// single-op mask.
+    ///
+    /// See [`on_change`](Self::on_change) for the threading and `Send`
+    /// rationale, reentrancy rules, diesel's ownership of the single update
+    /// hook slot, and the recommended notify-then-requery usage pattern.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, SqliteChangeOps, SqliteChangeOp};
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let ops = Arc::new(Mutex::new(Vec::new()));
+    /// let ops2 = ops.clone();
+    ///
+    /// // Fire for inserts and updates on `users`, but not deletes.
+    /// conn.on_table_change::<users::table, _>(
+    ///     SqliteChangeOps::INSERT | SqliteChangeOps::UPDATE,
+    ///     move |event| ops2.lock().unwrap().push(event.op),
+    /// );
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn).unwrap();
+    /// diesel::update(users::table.filter(users::id.eq(1)))
+    ///     .set(users::name.eq("Bob"))
+    ///     .execute(conn).unwrap();
+    /// diesel::delete(users::table.filter(users::id.eq(1)))
+    ///     .execute(conn).unwrap();
+    ///
+    /// // The DELETE did not match the mask.
+    /// assert_eq!(
+    ///     *ops.lock().unwrap(),
+    ///     vec![SqliteChangeOp::Insert, SqliteChangeOp::Update],
+    /// );
+    /// ```
+    pub fn on_table_change<T, F>(&mut self, ops: SqliteChangeOps, hook: F) -> ChangeHookId
+    where
+        T: StaticQueryFragment<Component = Identifier<'static>>,
+        F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
+    {
+        let table_name = T::STATIC_COMPONENT.0;
+        self.register_change_hook(Some(table_name), ops, Box::new(hook))
+    }
+
     /// Registers a callback invoked when a row is inserted into table `T`.
     ///
-    /// The generic parameter `T` is a [`table!`]-generated table type (e.g.
-    /// `users::table`). The table name is extracted at registration time via
+    /// Sugar for [`on_table_change::<T>`](Self::on_table_change) with
+    /// [`SqliteChangeOps::INSERT`].
+    ///
+    /// The generic parameter `T` is a [`table!`](macro@crate::table)-generated
+    /// table type (e.g. `users::table`). The table name is extracted at
+    /// registration time via
     /// [`StaticQueryFragment`].
     ///
     /// The callback fires synchronously during `sqlite3_step()`.
     /// The connection is **not** available inside the callback.
     ///
-    /// Multiple hooks can be registered on the same table; they fire in
+    /// See [`on_change`](Self::on_change) for the threading and `Send`
+    /// rationale, reentrancy rules, diesel's ownership of the single update
+    /// hook slot, and the recommended notify-then-requery usage pattern.
+    ///
+    /// Multiple hooks can be registered on the same table. They fire in
     /// registration order. The returned [`ChangeHookId`] can be passed to
     /// [`remove_change_hook`](Self::remove_change_hook) to remove just this
     /// hook, or use [`clear_change_hooks_for`](Self::clear_change_hooks_for)
@@ -773,8 +848,7 @@ impl SqliteConnection {
         T: StaticQueryFragment<Component = Identifier<'static>>,
         F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
     {
-        let table_name = T::STATIC_COMPONENT.0;
-        self.register_change_hook(Some(table_name), SqliteChangeOps::INSERT, Box::new(hook))
+        self.on_table_change::<T, F>(SqliteChangeOps::INSERT, hook)
     }
 
     /// Registers a callback invoked when a row is updated in table `T`.
@@ -821,8 +895,7 @@ impl SqliteConnection {
         T: StaticQueryFragment<Component = Identifier<'static>>,
         F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
     {
-        let table_name = T::STATIC_COMPONENT.0;
-        self.register_change_hook(Some(table_name), SqliteChangeOps::UPDATE, Box::new(hook))
+        self.on_table_change::<T, F>(SqliteChangeOps::UPDATE, hook)
     }
 
     /// Registers a callback invoked when a row is deleted from table `T`.
@@ -866,8 +939,7 @@ impl SqliteConnection {
         T: StaticQueryFragment<Component = Identifier<'static>>,
         F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
     {
-        let table_name = T::STATIC_COMPONENT.0;
-        self.register_change_hook(Some(table_name), SqliteChangeOps::DELETE, Box::new(hook))
+        self.on_table_change::<T, F>(SqliteChangeOps::DELETE, hook)
     }
 
     /// Removes a previously registered change hook by its [`ChangeHookId`].
@@ -4201,6 +4273,40 @@ mod tests {
             "change hook did not fire after the connection was moved"
         );
     }
+
+    #[diesel_test_helper::test]
+    fn on_table_change_respects_mask_and_table() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+
+        // Fire for INSERT and UPDATE on hook_users only, not DELETE.
+        conn.on_table_change::<hook_users::table, _>(
+            SqliteChangeOps::INSERT | SqliteChangeOps::UPDATE,
+            move |event| fired2.lock().unwrap().push(event.op),
+        );
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('Alice')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("UPDATE hook_users SET name = 'Bob' WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("DELETE FROM hook_users WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+        // A change on a different table must not fire this hook.
+        crate::sql_query("INSERT INTO hook_posts (title) VALUES ('Hello')")
+            .execute(conn)
+            .unwrap();
+
+        let events = fired.lock().unwrap().clone();
+        assert_eq!(events, vec![SqliteChangeOp::Insert, SqliteChangeOp::Update]);
+    }
+
     // ===================================================================
     // Commit / rollback hook tests
     // ===================================================================

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1570,10 +1570,10 @@ impl SqliteConnection {
     /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
     /// conn.on_trace(SqliteTraceFlags::STMT | SqliteTraceFlags::PROFILE, |event| {
     ///     match event {
-    ///         SqliteTraceEvent::Statement { sql } => {
-    ///             println!("Executing: {}", sql);
+    ///         SqliteTraceEvent::Statement { sql, readonly } => {
+    ///             println!("Executing ({}): {}", if readonly { "read" } else { "write" }, sql);
     ///         }
-    ///         SqliteTraceEvent::Profile { sql, duration_ns } => {
+    ///         SqliteTraceEvent::Profile { sql, duration_ns, .. } => {
     ///             println!("{} took {} ns", sql, duration_ns);
     ///         }
     ///         _ => {}

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1597,6 +1597,64 @@ impl SqliteConnection {
         self.raw_connection.remove_trace();
     }
 
+    /// Registers a callback for read-only statement execution (SELECT, read-only PRAGMA, etc.).
+    ///
+    /// This is a convenience wrapper around [`on_trace`](Self::on_trace) that filters for
+    /// read-only statements only. Fires once per statement, not per row.
+    ///
+    /// # How it works
+    ///
+    /// Uses [`sqlite3_stmt_readonly`](https://sqlite.org/c3ref/stmt_readonly.html) to determine
+    /// if a statement is read-only, which is more reliable than string matching.
+    ///
+    /// # What counts as read-only
+    ///
+    /// - `SELECT` statements (including `WITH ... SELECT`)
+    /// - Read-only `PRAGMA` statements (e.g., `PRAGMA table_info(t)`)
+    ///
+    /// # What does NOT count as read-only
+    ///
+    /// - `INSERT`, `UPDATE`, `DELETE` statements
+    /// - `CREATE`, `DROP`, `ALTER` statements
+    /// - `WITH ... INSERT/UPDATE/DELETE ... RETURNING` (the outer statement modifies data)
+    /// - Write `PRAGMA` statements (e.g., `PRAGMA foreign_keys = ON`)
+    ///
+    /// # Edge cases (not detected)
+    ///
+    /// - User-defined functions that modify the database via a separate connection
+    ///   are **not** detected; the statement itself is still considered read-only
+    /// - Virtual tables with write side effects are **not** detected
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use diesel::prelude::*;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    ///
+    /// conn.on_read(|sql| {
+    ///     println!("Read query executed: {}", sql);
+    /// });
+    /// ```
+    ///
+    /// # Note
+    ///
+    /// This replaces any existing trace callback. If you need both `on_read` and
+    /// custom tracing, use [`on_trace`](Self::on_trace) directly and check the
+    /// `readonly` field on [`SqliteTraceEvent::Statement`].
+    pub fn on_read<F>(&mut self, mut hook: F)
+    where
+        F: FnMut(&str) + Send + 'static,
+    {
+        self.on_trace(SqliteTraceFlags::STMT, move |event| {
+            if let SqliteTraceEvent::Statement { sql, readonly } = event {
+                if readonly {
+                    hook(sql);
+                }
+            }
+        });
+    }
+
     /// Serialize the current SQLite database into a byte buffer.
     ///
     /// The serialized data is identical to the data that would be written to disk if the database

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1044,7 +1044,7 @@ impl SqliteConnection {
     ///
     /// If the row cannot be found (e.g. it was deleted by a trigger), this
     /// returns [`Err(NotFound)`](crate::result::Error::NotFound).
-    /// 
+    ///
     /// This is NOT a shortcut for loading by primary key.
     /// It always queries by `rowid`, which may not be the same column
     /// as the primary key, or may not even exist for [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
@@ -3582,11 +3582,9 @@ mod tests {
         use std::sync::{Arc, Mutex};
         let conn = &mut connection();
 
-        crate::sql_query(
-            "CREATE TABLE kv (key TEXT PRIMARY KEY, val TEXT NOT NULL) WITHOUT ROWID",
-        )
-        .execute(conn)
-        .unwrap();
+        crate::sql_query("CREATE TABLE kv (key TEXT PRIMARY KEY, val TEXT NOT NULL) WITHOUT ROWID")
+            .execute(conn)
+            .unwrap();
 
         let events: Arc<Mutex<Vec<SqliteChangeOp>>> = Arc::new(Mutex::new(Vec::new()));
         let e2 = events.clone();
@@ -3622,18 +3620,15 @@ mod tests {
         use std::sync::{Arc, Mutex};
         let conn = &mut connection();
 
-        crate::sql_query(
-            "CREATE TABLE uq (id INTEGER PRIMARY KEY, val TEXT NOT NULL UNIQUE)",
-        )
-        .execute(conn)
-        .unwrap();
+        crate::sql_query("CREATE TABLE uq (id INTEGER PRIMARY KEY, val TEXT NOT NULL UNIQUE)")
+            .execute(conn)
+            .unwrap();
 
         crate::sql_query("INSERT INTO uq (id, val) VALUES (1, 'original')")
             .execute(conn)
             .unwrap();
 
-        let events: Arc<Mutex<Vec<(SqliteChangeOp, i64)>>> =
-            Arc::new(Mutex::new(Vec::new()));
+        let events: Arc<Mutex<Vec<(SqliteChangeOp, i64)>>> = Arc::new(Mutex::new(Vec::new()));
         let e2 = events.clone();
 
         conn.on_change(SqliteChangeOps::ALL, move |ev| {
@@ -3645,11 +3640,9 @@ mod tests {
         // INSERT OR REPLACE with a conflicting val: the old row (id=1) is
         // silently deleted by SQLite and the new row (id=2) is inserted.
         // The hook fires only for the INSERT of the new row.
-        crate::sql_query(
-            "INSERT OR REPLACE INTO uq (id, val) VALUES (2, 'original')",
-        )
-        .execute(conn)
-        .unwrap();
+        crate::sql_query("INSERT OR REPLACE INTO uq (id, val) VALUES (2, 'original')")
+            .execute(conn)
+            .unwrap();
 
         let recorded = events.lock().unwrap();
         assert_eq!(
@@ -3674,11 +3667,9 @@ mod tests {
         //   1. No WHERE clause
         //   2. No RETURNING clause
         //   3. No triggers on the table
-        crate::sql_query(
-            "CREATE TABLE bulk (id INTEGER PRIMARY KEY, data TEXT NOT NULL)",
-        )
-        .execute(conn)
-        .unwrap();
+        crate::sql_query("CREATE TABLE bulk (id INTEGER PRIMARY KEY, data TEXT NOT NULL)")
+            .execute(conn)
+            .unwrap();
 
         crate::sql_query("INSERT INTO bulk (data) VALUES ('a'), ('b'), ('c')")
             .execute(conn)
@@ -3709,11 +3700,9 @@ mod tests {
         use std::sync::{Arc, Mutex};
         let conn = &mut connection();
 
-        crate::sql_query(
-            "CREATE TABLE triggered (id INTEGER PRIMARY KEY, data TEXT NOT NULL)",
-        )
-        .execute(conn)
-        .unwrap();
+        crate::sql_query("CREATE TABLE triggered (id INTEGER PRIMARY KEY, data TEXT NOT NULL)")
+            .execute(conn)
+            .unwrap();
         // A no-op trigger is enough to disable the truncate optimization.
         crate::sql_query(
             "CREATE TRIGGER trg_triggered BEFORE DELETE ON triggered \
@@ -3722,11 +3711,9 @@ mod tests {
         .execute(conn)
         .unwrap();
 
-        crate::sql_query(
-            "INSERT INTO triggered (data) VALUES ('x'), ('y'), ('z')",
-        )
-        .execute(conn)
-        .unwrap();
+        crate::sql_query("INSERT INTO triggered (data) VALUES ('x'), ('y'), ('z')")
+            .execute(conn)
+            .unwrap();
 
         let deletes: Arc<Mutex<Vec<i64>>> = Arc::new(Mutex::new(Vec::new()));
         let d2 = deletes.clone();
@@ -3796,18 +3783,15 @@ mod tests {
         use std::sync::{Arc, Mutex};
         let conn = &mut connection();
 
-        crate::sql_query(
-            "CREATE TABLE rep (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
-        )
-        .execute(conn)
-        .unwrap();
+        crate::sql_query("CREATE TABLE rep (id INTEGER PRIMARY KEY, val TEXT NOT NULL)")
+            .execute(conn)
+            .unwrap();
 
         crate::sql_query("INSERT INTO rep (id, val) VALUES (1, 'old')")
             .execute(conn)
             .unwrap();
 
-        let events: Arc<Mutex<Vec<(SqliteChangeOp, i64)>>> =
-            Arc::new(Mutex::new(Vec::new()));
+        let events: Arc<Mutex<Vec<(SqliteChangeOp, i64)>>> = Arc::new(Mutex::new(Vec::new()));
         let e2 = events.clone();
 
         conn.on_change(SqliteChangeOps::ALL, move |ev| {

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -15,12 +15,14 @@ pub(in crate::sqlite) mod sqlite_blob;
 mod sqlite_value;
 mod statement_iterator;
 mod stmt;
+mod update_hook;
 
 pub(in crate::sqlite) use self::bind_collector::SqliteBindCollector;
 pub use self::bind_collector::SqliteBindValue;
 pub use self::limits::SqliteLimit;
 pub use self::serialized_database::SerializedDatabase;
 pub use self::sqlite_value::SqliteValue;
+pub use self::update_hook::{ChangeHookId, SqliteChangeEvent, SqliteChangeOp, SqliteChangeOps};
 
 use self::raw::RawConnection;
 use self::statement_iterator::*;
@@ -31,6 +33,7 @@ use crate::connection::statement_cache::StatementCache;
 use crate::connection::*;
 use crate::deserialize::{FromSqlRow, StaticallySizedRow};
 use crate::expression::QueryMetadata;
+use crate::query_builder::nodes::{Identifier, StaticQueryFragment};
 use crate::query_builder::*;
 use crate::result::*;
 use crate::serialize::ToSql;
@@ -623,6 +626,715 @@ impl SqliteConnection {
     {
         self.raw_connection
             .register_collation_function(collation_name, collation)
+    }
+
+    /// Registers a callback invoked for any row change (insert, update, or
+    /// delete) on any table, filtered by the given [`SqliteChangeOps`] mask.
+    ///
+    /// This is the untyped variant — the table name is provided as a string
+    /// in [`SqliteChangeEvent::table_name`], suitable for logging all changes
+    /// regardless of table.
+    ///
+    /// The callback fires **synchronously during `sqlite3_step()`**, i.e.
+    /// while the triggering statement is executing. The connection is **not**
+    /// available inside the callback.
+    ///
+    /// Multiple hooks can be registered on the same connection (and even
+    /// the same table); they fire in registration order.
+    ///
+    /// Returns a [`ChangeHookId`] that can be used to remove the hook later
+    /// via [`remove_change_hook`](Self::remove_change_hook). You can also
+    /// remove all hooks for a specific table with
+    /// [`clear_change_hooks_for`](Self::clear_change_hooks_for), or remove
+    /// every hook at once with
+    /// [`clear_all_change_hooks`](Self::clear_all_change_hooks).
+    ///
+    /// # Limitations
+    ///
+    /// These limitations come from the underlying
+    /// [`sqlite3_update_hook`](https://www.sqlite.org/c3ref/update_hook.html)
+    /// API:
+    ///
+    /// - Only fires for [rowid tables](https://www.sqlite.org/rowidtable.html).
+    ///   [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables do
+    ///   not trigger this callback.
+    /// - Not invoked for changes to internal system tables (e.g.
+    ///   `sqlite_sequence`).
+    /// - Not invoked for implicit deletes caused by
+    ///   [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html).
+    /// - Not invoked for deletes using the
+    ///   [truncate optimization](https://www.sqlite.org/lang_delete.html#truncateopt).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, SqliteChangeOps, SqliteChangeOp};
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// #[derive(Insertable)]
+    /// #[diesel(table_name = users)]
+    /// struct NewUser<'a> {
+    ///     name: &'a str,
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let log = Arc::new(Mutex::new(Vec::new()));
+    /// let log2 = log.clone();
+    ///
+    /// conn.on_change(SqliteChangeOps::ALL, move |event| {
+    ///     log2.lock().unwrap().push((
+    ///         event.op,
+    ///         event.table_name.to_owned(),
+    ///         event.rowid,
+    ///     ));
+    /// });
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(&NewUser { name: "Alice" })
+    ///     .execute(conn)
+    ///     .unwrap();
+    ///
+    /// let entries = log.lock().unwrap();
+    /// assert_eq!(entries.len(), 1);
+    /// assert_eq!(entries[0].0, SqliteChangeOp::Insert);
+    /// assert_eq!(entries[0].1, "users");
+    /// ```
+    pub fn on_change<F>(&mut self, ops: SqliteChangeOps, hook: F) -> ChangeHookId
+    where
+        F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
+    {
+        self.raw_connection.register_raw_update_hook();
+        self.raw_connection
+            .change_hooks
+            .borrow_mut()
+            .add(None, ops, Box::new(hook))
+    }
+
+    /// Registers a callback invoked when a row is inserted into table `T`.
+    ///
+    /// The generic parameter `T` is a [`table!`]-generated table type (e.g.
+    /// `users::table`). The table name is extracted at registration time via
+    /// [`StaticQueryFragment`].
+    ///
+    /// The callback fires synchronously during `sqlite3_step()`.
+    /// The connection is **not** available inside the callback.
+    ///
+    /// Multiple hooks can be registered on the same table; they fire in
+    /// registration order. The returned [`ChangeHookId`] can be passed to
+    /// [`remove_change_hook`](Self::remove_change_hook) to remove just this
+    /// hook, or use [`clear_change_hooks_for`](Self::clear_change_hooks_for)
+    /// / [`clear_all_change_hooks`](Self::clear_all_change_hooks) to remove
+    /// hooks in bulk.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let ids = Arc::new(Mutex::new(Vec::new()));
+    /// let ids2 = ids.clone();
+    ///
+    /// conn.on_insert::<users::table, _>(move |event| {
+    ///     ids2.lock().unwrap().push(event.rowid);
+    /// });
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn)
+    ///     .unwrap();
+    ///
+    /// assert_eq!(*ids.lock().unwrap(), vec![1i64]);
+    /// ```
+    pub fn on_insert<T, F>(&mut self, hook: F) -> ChangeHookId
+    where
+        T: StaticQueryFragment<Component = Identifier<'static>>,
+        F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
+    {
+        let table_name = T::STATIC_COMPONENT.0;
+        self.raw_connection.register_raw_update_hook();
+        self.raw_connection.change_hooks.borrow_mut().add(
+            Some(table_name),
+            SqliteChangeOps::INSERT,
+            Box::new(hook),
+        )
+    }
+
+    /// Registers a callback invoked when a row is updated in table `T`.
+    /// See [`on_insert`](Self::on_insert) for details on multiplicity,
+    /// dispatch timing, and removal.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let count = Arc::new(Mutex::new(0u32));
+    /// let count2 = count.clone();
+    ///
+    /// conn.on_update::<users::table, _>(move |_event| {
+    ///     *count2.lock().unwrap() += 1;
+    /// });
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn).unwrap();
+    /// // Insert does not trigger the update hook.
+    /// assert_eq!(*count.lock().unwrap(), 0);
+    ///
+    /// diesel::update(users::table.filter(users::id.eq(1)))
+    ///     .set(users::name.eq("Bob"))
+    ///     .execute(conn).unwrap();
+    /// assert_eq!(*count.lock().unwrap(), 1);
+    /// ```
+    pub fn on_update<T, F>(&mut self, hook: F) -> ChangeHookId
+    where
+        T: StaticQueryFragment<Component = Identifier<'static>>,
+        F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
+    {
+        let table_name = T::STATIC_COMPONENT.0;
+        self.raw_connection.register_raw_update_hook();
+        self.raw_connection.change_hooks.borrow_mut().add(
+            Some(table_name),
+            SqliteChangeOps::UPDATE,
+            Box::new(hook),
+        )
+    }
+
+    /// Registers a callback invoked when a row is deleted from table `T`.
+    /// See [`on_insert`](Self::on_insert) for details on multiplicity,
+    /// dispatch timing, and removal.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let deleted = Arc::new(Mutex::new(Vec::new()));
+    /// let deleted2 = deleted.clone();
+    ///
+    /// conn.on_delete::<users::table, _>(move |event| {
+    ///     deleted2.lock().unwrap().push(event.rowid);
+    /// });
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn).unwrap();
+    /// diesel::delete(users::table.filter(users::id.eq(1)))
+    ///     .execute(conn).unwrap();
+    ///
+    /// assert_eq!(*deleted.lock().unwrap(), vec![1i64]);
+    /// ```
+    pub fn on_delete<T, F>(&mut self, hook: F) -> ChangeHookId
+    where
+        T: StaticQueryFragment<Component = Identifier<'static>>,
+        F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
+    {
+        let table_name = T::STATIC_COMPONENT.0;
+        self.raw_connection.register_raw_update_hook();
+        self.raw_connection.change_hooks.borrow_mut().add(
+            Some(table_name),
+            SqliteChangeOps::DELETE,
+            Box::new(hook),
+        )
+    }
+
+    /// Removes a previously registered change hook by its [`ChangeHookId`].
+    ///
+    /// Returns `true` if a hook with that ID was found and removed, `false`
+    /// if no hook matched (e.g. it was already removed).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let count = Arc::new(Mutex::new(0u32));
+    /// let count2 = count.clone();
+    ///
+    /// let id = conn.on_insert::<users::table, _>(move |_| {
+    ///     *count2.lock().unwrap() += 1;
+    /// });
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn).unwrap();
+    /// assert_eq!(*count.lock().unwrap(), 1);
+    ///
+    /// assert!(conn.remove_change_hook(id));
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Bob"))
+    ///     .execute(conn).unwrap();
+    /// // Still 1 — the hook was removed.
+    /// assert_eq!(*count.lock().unwrap(), 1);
+    /// ```
+    pub fn remove_change_hook(&mut self, id: ChangeHookId) -> bool {
+        let removed = self.raw_connection.change_hooks.borrow_mut().remove(id);
+        if self.raw_connection.change_hooks.borrow().is_empty() {
+            self.raw_connection.unregister_raw_update_hook();
+        }
+        removed
+    }
+
+    /// Removes all change hooks registered for table `T`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// diesel::table! {
+    ///     posts (id) {
+    ///         id -> Integer,
+    ///         title -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// # conn.batch_execute("CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL)").unwrap();
+    /// let user_count = Arc::new(Mutex::new(0u32));
+    /// let post_count = Arc::new(Mutex::new(0u32));
+    /// let uc = user_count.clone();
+    /// let pc = post_count.clone();
+    ///
+    /// conn.on_insert::<users::table, _>(move |_| { *uc.lock().unwrap() += 1; });
+    /// conn.on_insert::<posts::table, _>(move |_| { *pc.lock().unwrap() += 1; });
+    ///
+    /// conn.clear_change_hooks_for::<users::table>();
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn).unwrap();
+    /// diesel::insert_into(posts::table)
+    ///     .values(posts::title.eq("Hello"))
+    ///     .execute(conn).unwrap();
+    ///
+    /// assert_eq!(*user_count.lock().unwrap(), 0); // cleared
+    /// assert_eq!(*post_count.lock().unwrap(), 1); // still active
+    /// ```
+    pub fn clear_change_hooks_for<T>(&mut self)
+    where
+        T: StaticQueryFragment<Component = Identifier<'static>>,
+    {
+        let table_name = T::STATIC_COMPONENT.0;
+        self.raw_connection
+            .change_hooks
+            .borrow_mut()
+            .clear_for_table(table_name);
+        if self.raw_connection.change_hooks.borrow().is_empty() {
+            self.raw_connection.unregister_raw_update_hook();
+        }
+    }
+
+    /// Removes all registered change hooks and unregisters the underlying
+    /// [`sqlite3_update_hook`](https://www.sqlite.org/c3ref/update_hook.html).
+    ///
+    /// After calling this, no change-related callbacks will fire until new
+    /// hooks are registered.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let count = Arc::new(Mutex::new(0u32));
+    /// let count2 = count.clone();
+    ///
+    /// conn.on_insert::<users::table, _>(move |_| { *count2.lock().unwrap() += 1; });
+    ///
+    /// conn.clear_all_change_hooks();
+    ///
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn).unwrap();
+    ///
+    /// assert_eq!(*count.lock().unwrap(), 0);
+    /// ```
+    pub fn clear_all_change_hooks(&mut self) {
+        self.raw_connection.change_hooks.borrow_mut().clear_all();
+        self.raw_connection.unregister_raw_update_hook();
+    }
+
+    /// Loads a single row from table `T` by its SQLite `rowid`.
+    ///
+    /// This is useful for retrieving the full row data after receiving a
+    /// [`SqliteChangeEvent`] from a change hook, since the event only
+    /// contains the `rowid` of the affected row.
+    ///
+    /// If the row cannot be found (e.g. it was deleted by a trigger), this
+    /// returns [`Err(NotFound)`](crate::result::Error::NotFound).
+    /// 
+    /// This is NOT a shortcut for loading by primary key.
+    /// It always queries by `rowid`, which may not be the same column
+    /// as the primary key, or may not even exist for [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
+    /// The caller must ensure that the provided `rowid` is correct
+    /// for the intended query.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// #[derive(Queryable)]
+    /// struct User {
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// diesel::insert_into(users::table)
+    ///     .values(users::name.eq("Alice"))
+    ///     .execute(conn)
+    ///     .unwrap();
+    ///
+    /// let user: User = conn.find_by_rowid::<users::table, _>(1).unwrap();
+    /// assert_eq!(user.name, "Alice");
+    /// ```
+    pub fn find_by_rowid<T, M>(&mut self, rowid: i64) -> QueryResult<M>
+    where
+        T: crate::Table
+            + crate::associations::HasTable<Table = T>
+            + crate::query_dsl::methods::FilterDsl<
+                crate::expression::UncheckedBind<
+                    crate::expression::SqlLiteral<crate::sql_types::Bool>,
+                    crate::expression::bound::Bound<crate::sql_types::BigInt, i64>,
+                >,
+            >,
+        crate::dsl::Filter<
+            T,
+            crate::expression::UncheckedBind<
+                crate::expression::SqlLiteral<crate::sql_types::Bool>,
+                crate::expression::bound::Bound<crate::sql_types::BigInt, i64>,
+            >,
+        >: crate::query_dsl::RunQueryDsl<SqliteConnection> + crate::query_dsl::methods::LimitDsl,
+        crate::dsl::Limit<
+            crate::dsl::Filter<
+                T,
+                crate::expression::UncheckedBind<
+                    crate::expression::SqlLiteral<crate::sql_types::Bool>,
+                    crate::expression::bound::Bound<crate::sql_types::BigInt, i64>,
+                >,
+            >,
+        >: crate::query_dsl::LoadQuery<'static, SqliteConnection, M>,
+    {
+        use crate::query_dsl::RunQueryDsl;
+        T::table()
+            .filter(
+                crate::dsl::sql::<crate::sql_types::Bool>("rowid = ")
+                    .bind::<crate::sql_types::BigInt, _>(rowid),
+            )
+            .first::<M>(self)
+    }
+
+    /// Registers a callback invoked when a transaction is about to be
+    /// committed.
+    ///
+    /// The callback returns a `bool`:
+    /// - `false` — the commit proceeds normally.
+    /// - `true` — the commit is converted into a rollback.
+    ///
+    /// Only one commit hook can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// The callback must not use the database connection. Panics in the
+    /// callback abort the process.
+    ///
+    /// See: [`sqlite3_commit_hook`](https://www.sqlite.org/c3ref/commit_hook.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let commits = Arc::new(Mutex::new(0u32));
+    /// let commits2 = commits.clone();
+    ///
+    /// conn.on_commit(move || {
+    ///     *commits2.lock().unwrap() += 1;
+    ///     false // allow the commit to proceed
+    /// });
+    ///
+    /// conn.immediate_transaction(|conn| {
+    ///     diesel::insert_into(users::table)
+    ///         .values(users::name.eq("Alice"))
+    ///         .execute(conn)?;
+    ///     Ok::<_, diesel::result::Error>(())
+    /// }).unwrap();
+    ///
+    /// assert_eq!(*commits.lock().unwrap(), 1);
+    /// ```
+    pub fn on_commit<F>(&mut self, hook: F)
+    where
+        F: FnMut() -> bool + Send + 'static,
+    {
+        self.raw_connection.set_commit_hook(hook);
+    }
+
+    /// Removes the commit hook. Subsequent commits will not invoke any
+    /// callback.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let count = Arc::new(Mutex::new(0u32));
+    /// let count2 = count.clone();
+    /// conn.on_commit(move || { *count2.lock().unwrap() += 1; false });
+    ///
+    /// conn.remove_commit_hook();
+    ///
+    /// conn.immediate_transaction(|conn| {
+    ///     diesel::insert_into(users::table)
+    ///         .values(users::name.eq("Alice"))
+    ///         .execute(conn)?;
+    ///     Ok::<_, diesel::result::Error>(())
+    /// }).unwrap();
+    ///
+    /// assert_eq!(*count.lock().unwrap(), 0);
+    /// ```
+    pub fn remove_commit_hook(&mut self) {
+        self.raw_connection.remove_commit_hook();
+    }
+
+    /// Registers a callback invoked after a transaction is rolled back.
+    ///
+    /// This is **not** invoked for the implicit rollback that occurs when
+    /// the connection is closed. It **is** invoked when a commit hook
+    /// forces a rollback by returning `true`.
+    ///
+    /// Only one rollback hook can be active at a time per connection.
+    ///
+    /// The callback must not use the database connection. Panics in the
+    /// callback abort the process.
+    ///
+    /// See: [`sqlite3_rollback_hook`](https://www.sqlite.org/c3ref/commit_hook.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// # use diesel::connection::SimpleConnection;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// let rollbacks = Arc::new(Mutex::new(0u32));
+    /// let rb2 = rollbacks.clone();
+    ///
+    /// conn.on_rollback(move || {
+    ///     *rb2.lock().unwrap() += 1;
+    /// });
+    ///
+    /// // Force a rollback by returning an error.
+    /// let _ = conn.immediate_transaction(|_conn| {
+    ///     Err::<(), _>(diesel::result::Error::RollbackTransaction)
+    /// });
+    ///
+    /// assert_eq!(*rollbacks.lock().unwrap(), 1);
+    /// ```
+    pub fn on_rollback<F>(&mut self, hook: F)
+    where
+        F: FnMut() + Send + 'static,
+    {
+        self.raw_connection.set_rollback_hook(hook);
+    }
+
+    /// Removes the rollback hook.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// # use diesel::connection::SimpleConnection;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// let count = Arc::new(Mutex::new(0u32));
+    /// let count2 = count.clone();
+    /// conn.on_rollback(move || { *count2.lock().unwrap() += 1; });
+    ///
+    /// conn.remove_rollback_hook();
+    ///
+    /// let _ = conn.immediate_transaction(|_conn| {
+    ///     Err::<(), _>(diesel::result::Error::RollbackTransaction)
+    /// });
+    ///
+    /// assert_eq!(*count.lock().unwrap(), 0);
+    /// ```
+    pub fn remove_rollback_hook(&mut self) {
+        self.raw_connection.remove_rollback_hook();
+    }
+
+    /// Registers a callback invoked after a commit completes in
+    /// [WAL mode](https://www.sqlite.org/wal.html).
+    ///
+    /// The callback receives:
+    /// - `db_name` — the database name (`"main"`, `"temp"`, or an `ATTACH` alias).
+    /// - `n_pages` — the number of pages currently in the WAL file.
+    ///
+    /// Useful for triggering custom checkpoint logic via
+    /// [`PRAGMA wal_checkpoint`](https://www.sqlite.org/pragma.html#pragma_wal_checkpoint).
+    ///
+    /// Only one WAL hook can be active at a time per connection.
+    ///
+    /// **Warning:** [`PRAGMA wal_autocheckpoint`](https://www.sqlite.org/pragma.html#pragma_wal_autocheckpoint)
+    /// and `sqlite3_wal_autocheckpoint()` internally call `sqlite3_wal_hook()`
+    /// and will **overwrite** this hook.
+    ///
+    /// See: [`sqlite3_wal_hook`](https://www.sqlite.org/c3ref/wal_hook.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use diesel::prelude::*;
+    /// # use diesel::connection::SimpleConnection;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// # let conn = &mut SqliteConnection::establish("test.db").unwrap();
+    /// # conn.batch_execute("PRAGMA journal_mode = WAL;").unwrap();
+    /// conn.on_wal(|db_name, n_pages| {
+    ///     println!("WAL for {db_name}: {n_pages} pages");
+    /// });
+    /// ```
+    pub fn on_wal<F>(&mut self, hook: F)
+    where
+        F: FnMut(&str, i32) + Send + 'static,
+    {
+        self.raw_connection.set_wal_hook(hook);
+    }
+
+    /// Removes the WAL hook.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use diesel::prelude::*;
+    /// # use diesel::connection::SimpleConnection;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// # let conn = &mut SqliteConnection::establish("test.db").unwrap();
+    /// # conn.batch_execute("PRAGMA journal_mode = WAL;").unwrap();
+    /// conn.on_wal(|_db, _pages| { /* ... */ });
+    /// conn.remove_wal_hook();
+    /// ```
+    pub fn remove_wal_hook(&mut self) {
+        self.raw_connection.remove_wal_hook();
     }
 
     /// Serialize the current SQLite database into a byte buffer.
@@ -2437,6 +3149,1064 @@ mod tests {
         assert_eq!(
             conn.get_limit(SqliteLimit::WorkerThreads),
             SqliteLimit::SAFE_WORKER_THREADS_LIMIT
+        );
+    }
+
+    // ===================================================================
+    // Change-hook integration tests
+    // ===================================================================
+
+    table! {
+        hook_users {
+            id -> Integer,
+            name -> Text,
+        }
+    }
+
+    table! {
+        hook_posts {
+            id -> Integer,
+            title -> Text,
+        }
+    }
+
+    fn setup_hook_tables(conn: &mut SqliteConnection) {
+        crate::sql_query(
+            "CREATE TABLE hook_users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+        )
+        .execute(conn)
+        .unwrap();
+        crate::sql_query(
+            "CREATE TABLE hook_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL)",
+        )
+        .execute(conn)
+        .unwrap();
+    }
+
+    #[diesel_test_helper::test]
+    fn on_insert_fires_for_insert() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+
+        conn.on_insert::<hook_users::table, _>(move |event| {
+            fired2.lock().unwrap().push((event.op, event.rowid));
+        });
+
+        // INSERT a row — the hook fires immediately during sqlite3_step().
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('Alice')")
+            .execute(conn)
+            .unwrap();
+
+        let events = fired.lock().unwrap().clone();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, SqliteChangeOp::Insert);
+        assert_eq!(events[0].1, 1); // rowid
+    }
+
+    #[diesel_test_helper::test]
+    fn on_delete_fires_only_for_delete() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+
+        conn.on_delete::<hook_users::table, _>(move |event| {
+            fired2.lock().unwrap().push(event.op);
+        });
+
+        // INSERT + UPDATE + DELETE
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('Alice')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("UPDATE hook_users SET name = 'Bob' WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("DELETE FROM hook_users WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+
+        let events = fired.lock().unwrap().clone();
+        // Only the DELETE should have matched.
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], SqliteChangeOp::Delete);
+    }
+
+    #[diesel_test_helper::test]
+    fn multiple_hooks_fire_in_order() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let o1 = order.clone();
+        let o2 = order.clone();
+
+        conn.on_insert::<hook_users::table, _>(move |_| {
+            o1.lock().unwrap().push(1);
+        });
+        conn.on_insert::<hook_users::table, _>(move |_| {
+            o2.lock().unwrap().push(2);
+        });
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('X')")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(*order.lock().unwrap(), vec![1, 2]);
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_hook_prevents_dispatch() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let fired = Arc::new(Mutex::new(0u32));
+        let f2 = fired.clone();
+
+        let id = conn.on_insert::<hook_users::table, _>(move |_| {
+            *f2.lock().unwrap() += 1;
+        });
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('A')")
+            .execute(conn)
+            .unwrap();
+        assert_eq!(*fired.lock().unwrap(), 1);
+
+        // Remove the hook.
+        assert!(conn.remove_change_hook(id));
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('B')")
+            .execute(conn)
+            .unwrap();
+        // Should still be 1 — hook was removed.
+        assert_eq!(*fired.lock().unwrap(), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn events_fire_immediately_during_statement() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        // Insert a row without a hook first.
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('Z')")
+            .execute(conn)
+            .unwrap();
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        conn.on_update::<hook_users::table, _>(move |event| {
+            f2.lock().unwrap().push(event.rowid);
+        });
+
+        // UPDATE triggers the C hook immediately during sqlite3_step().
+        crate::sql_query("UPDATE hook_users SET name = 'W' WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(*fired.lock().unwrap(), vec![1i64]);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_update_fires_for_update_only() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_update::<hook_users::table, _>(move |event| {
+            assert_eq!(event.op, SqliteChangeOp::Update);
+            *c2.lock().unwrap() += 1;
+        });
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('A')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("UPDATE hook_users SET name = 'B' WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("DELETE FROM hook_users WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(*count.lock().unwrap(), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_change_catches_all_ops() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let e2 = events.clone();
+
+        conn.on_change(SqliteChangeOps::ALL, move |event| {
+            e2.lock()
+                .unwrap()
+                .push((event.op, event.table_name.to_owned()));
+        });
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('A')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("INSERT INTO hook_posts (title) VALUES ('P')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("UPDATE hook_users SET name = 'B' WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("DELETE FROM hook_posts WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+
+        let evts = events.lock().unwrap().clone();
+        assert_eq!(evts.len(), 4);
+        assert_eq!(evts[0], (SqliteChangeOp::Insert, "hook_users".to_owned()));
+        assert_eq!(evts[1], (SqliteChangeOp::Insert, "hook_posts".to_owned()));
+        assert_eq!(evts[2], (SqliteChangeOp::Update, "hook_users".to_owned()));
+        assert_eq!(evts[3], (SqliteChangeOp::Delete, "hook_posts".to_owned()));
+    }
+
+    #[diesel_test_helper::test]
+    fn on_change_with_partial_mask() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_change(
+            SqliteChangeOps::INSERT | SqliteChangeOps::DELETE,
+            move |_| {
+                *c2.lock().unwrap() += 1;
+            },
+        );
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('A')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("UPDATE hook_users SET name = 'B' WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("DELETE FROM hook_users WHERE id = 1")
+            .execute(conn)
+            .unwrap();
+
+        // INSERT + DELETE = 2, not UPDATE
+        assert_eq!(*count.lock().unwrap(), 2);
+    }
+
+    #[diesel_test_helper::test]
+    fn clear_hooks_for_table_only_removes_that_table() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let user_count = Arc::new(Mutex::new(0u32));
+        let post_count = Arc::new(Mutex::new(0u32));
+        let uc = user_count.clone();
+        let pc = post_count.clone();
+
+        conn.on_insert::<hook_users::table, _>(move |_| {
+            *uc.lock().unwrap() += 1;
+        });
+        conn.on_insert::<hook_posts::table, _>(move |_| {
+            *pc.lock().unwrap() += 1;
+        });
+
+        conn.clear_change_hooks_for::<hook_users::table>();
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('X')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("INSERT INTO hook_posts (title) VALUES ('Y')")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(*user_count.lock().unwrap(), 0); // cleared
+        assert_eq!(*post_count.lock().unwrap(), 1); // still active
+    }
+
+    #[diesel_test_helper::test]
+    fn clear_all_removes_everything() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+        let c3 = count.clone();
+
+        conn.on_insert::<hook_users::table, _>(move |_| {
+            *c2.lock().unwrap() += 1;
+        });
+        conn.on_insert::<hook_posts::table, _>(move |_| {
+            *c3.lock().unwrap() += 1;
+        });
+
+        conn.clear_all_change_hooks();
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('X')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("INSERT INTO hook_posts (title) VALUES ('Y')")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(*count.lock().unwrap(), 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn hooks_fire_across_transactions() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        // Register hook BEFORE the transaction.
+        conn.on_insert::<hook_users::table, _>(move |event| {
+            f2.lock().unwrap().push(event.rowid);
+        });
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO hook_users (name) VALUES ('TxUser')")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(fired.lock().unwrap().len(), 1);
+    }
+
+    #[derive(Debug, Clone, PartialEq, crate::Queryable)]
+    struct HookUser {
+        id: i32,
+        name: String,
+    }
+
+    #[diesel_test_helper::test]
+    fn find_by_rowid_loads_row() {
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('Alice')")
+            .execute(conn)
+            .unwrap();
+
+        let user: HookUser = conn.find_by_rowid::<hook_users::table, _>(1).unwrap();
+        assert_eq!(user.name, "Alice");
+    }
+
+    #[diesel_test_helper::test]
+    fn find_by_rowid_returns_not_found_for_missing_row() {
+        let conn = &mut connection();
+        setup_hook_tables(conn);
+
+        let result = conn.find_by_rowid::<hook_users::table, HookUser>(999);
+        assert!(matches!(result, Err(crate::result::Error::NotFound)));
+    }
+
+    table! {
+        products {
+            id -> Text,
+            name -> Text,
+            price -> Integer,
+        }
+    }
+
+    #[derive(Debug, crate::Queryable)]
+    struct Product {
+        id: String,
+        name: String,
+        price: i32,
+    }
+
+    #[diesel_test_helper::test]
+    fn find_by_rowid_with_text_pk_after_hook() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query(
+            "CREATE TABLE products (id TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, price INTEGER NOT NULL)",
+        )
+        .execute(conn)
+        .unwrap();
+
+        let inserted = Arc::new(Mutex::new(Vec::<i64>::new()));
+        let inserted_hook = inserted.clone();
+
+        conn.on_insert::<products::table, _>(move |event| {
+            inserted_hook.lock().unwrap().push(event.rowid);
+        });
+
+        crate::sql_query("INSERT INTO products (id, name, price) VALUES ('sku-42', 'Widget', 999)")
+            .execute(conn)
+            .unwrap();
+
+        let rowids = inserted.lock().unwrap();
+        let rowid = rowids[0];
+
+        let product: Product = conn.find_by_rowid::<products::table, _>(rowid).unwrap();
+
+        assert_eq!(product.id, "sku-42");
+        assert_eq!(product.name, "Widget");
+        assert_eq!(product.price, 999);
+    }
+
+    // ===================================================================
+    // Negative tests: cases where the update hook must NOT fire
+    //
+    // These are documented SQLite limitations of sqlite3_update_hook():
+    // https://www.sqlite.org/c3ref/update_hook.html
+    // ===================================================================
+
+    /// The update hook is not invoked for WITHOUT ROWID tables.
+    /// See: https://www.sqlite.org/c3ref/update_hook.html
+    #[diesel_test_helper::test]
+    fn update_hook_silent_for_without_rowid_tables() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query(
+            "CREATE TABLE kv (key TEXT PRIMARY KEY, val TEXT NOT NULL) WITHOUT ROWID",
+        )
+        .execute(conn)
+        .unwrap();
+
+        let events: Arc<Mutex<Vec<SqliteChangeOp>>> = Arc::new(Mutex::new(Vec::new()));
+        let e2 = events.clone();
+
+        conn.on_change(SqliteChangeOps::ALL, move |ev| {
+            if ev.table_name == "kv" {
+                e2.lock().unwrap().push(ev.op);
+            }
+        });
+
+        crate::sql_query("INSERT INTO kv (key, val) VALUES ('a', '1')")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("UPDATE kv SET val = '2' WHERE key = 'a'")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("DELETE FROM kv WHERE key = 'a'")
+            .execute(conn)
+            .unwrap();
+
+        assert!(
+            events.lock().unwrap().is_empty(),
+            "update hook must not fire for WITHOUT ROWID tables"
+        );
+    }
+
+    /// When a UNIQUE constraint conflict is resolved via ON CONFLICT REPLACE,
+    /// the implicit deletion of the conflicting row does NOT fire the update
+    /// hook. Only the INSERT for the new row fires.
+    /// See: https://www.sqlite.org/c3ref/update_hook.html
+    #[diesel_test_helper::test]
+    fn update_hook_silent_for_on_conflict_replace_deletion() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query(
+            "CREATE TABLE uq (id INTEGER PRIMARY KEY, val TEXT NOT NULL UNIQUE)",
+        )
+        .execute(conn)
+        .unwrap();
+
+        crate::sql_query("INSERT INTO uq (id, val) VALUES (1, 'original')")
+            .execute(conn)
+            .unwrap();
+
+        let events: Arc<Mutex<Vec<(SqliteChangeOp, i64)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let e2 = events.clone();
+
+        conn.on_change(SqliteChangeOps::ALL, move |ev| {
+            if ev.table_name == "uq" {
+                e2.lock().unwrap().push((ev.op, ev.rowid));
+            }
+        });
+
+        // INSERT OR REPLACE with a conflicting val: the old row (id=1) is
+        // silently deleted by SQLite and the new row (id=2) is inserted.
+        // The hook fires only for the INSERT of the new row.
+        crate::sql_query(
+            "INSERT OR REPLACE INTO uq (id, val) VALUES (2, 'original')",
+        )
+        .execute(conn)
+        .unwrap();
+
+        let recorded = events.lock().unwrap();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "expected only 1 event (INSERT), got: {:?}",
+            *recorded
+        );
+        assert_eq!(recorded[0].0, SqliteChangeOp::Insert);
+        assert_eq!(recorded[0].1, 2, "new row should have rowid 2");
+    }
+
+    /// DELETE FROM without a WHERE clause triggers the truncate optimization,
+    /// which bypasses the update hook entirely: no per-row DELETE events fire.
+    /// See: https://www.sqlite.org/lang_delete.html#truncateopt
+    #[diesel_test_helper::test]
+    fn update_hook_silent_for_truncate_optimization() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        // The truncate optimization applies when:
+        //   1. No WHERE clause
+        //   2. No RETURNING clause
+        //   3. No triggers on the table
+        crate::sql_query(
+            "CREATE TABLE bulk (id INTEGER PRIMARY KEY, data TEXT NOT NULL)",
+        )
+        .execute(conn)
+        .unwrap();
+
+        crate::sql_query("INSERT INTO bulk (data) VALUES ('a'), ('b'), ('c')")
+            .execute(conn)
+            .unwrap();
+
+        let events: Arc<Mutex<Vec<SqliteChangeOp>>> = Arc::new(Mutex::new(Vec::new()));
+        let e2 = events.clone();
+
+        conn.on_change(SqliteChangeOps::ALL, move |ev| {
+            if ev.table_name == "bulk" {
+                e2.lock().unwrap().push(ev.op);
+            }
+        });
+
+        // DELETE without WHERE — truncate optimization kicks in.
+        crate::sql_query("DELETE FROM bulk").execute(conn).unwrap();
+
+        assert!(
+            events.lock().unwrap().is_empty(),
+            "truncate optimization should bypass the update hook"
+        );
+    }
+
+    /// When a table has triggers, the truncate optimization is disabled, so
+    /// DELETE without WHERE fires per-row DELETE events as normal.
+    #[diesel_test_helper::test]
+    fn update_hook_fires_for_delete_all_when_triggers_disable_truncate() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query(
+            "CREATE TABLE triggered (id INTEGER PRIMARY KEY, data TEXT NOT NULL)",
+        )
+        .execute(conn)
+        .unwrap();
+        // A no-op trigger is enough to disable the truncate optimization.
+        crate::sql_query(
+            "CREATE TRIGGER trg_triggered BEFORE DELETE ON triggered \
+             BEGIN SELECT 1; END",
+        )
+        .execute(conn)
+        .unwrap();
+
+        crate::sql_query(
+            "INSERT INTO triggered (data) VALUES ('x'), ('y'), ('z')",
+        )
+        .execute(conn)
+        .unwrap();
+
+        let deletes: Arc<Mutex<Vec<i64>>> = Arc::new(Mutex::new(Vec::new()));
+        let d2 = deletes.clone();
+
+        conn.on_change(SqliteChangeOps::DELETE, move |ev| {
+            if ev.table_name == "triggered" {
+                d2.lock().unwrap().push(ev.rowid);
+            }
+        });
+
+        // DELETE without WHERE, but triggers exist ⇒ no truncate optimization.
+        crate::sql_query("DELETE FROM triggered")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(
+            deletes.lock().unwrap().len(),
+            3,
+            "with triggers present, DELETE without WHERE fires per-row hooks"
+        );
+    }
+
+    /// Modifications to internal system tables like sqlite_sequence
+    /// (used by AUTOINCREMENT) do not trigger the update hook.
+    /// See: https://www.sqlite.org/c3ref/update_hook.html
+    #[diesel_test_helper::test]
+    fn update_hook_silent_for_internal_sqlite_sequence() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        // AUTOINCREMENT causes SQLite to maintain sqlite_sequence.
+        crate::sql_query(
+            "CREATE TABLE seq_test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+        )
+        .execute(conn)
+        .unwrap();
+
+        let tables: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let t2 = tables.clone();
+
+        conn.on_change(SqliteChangeOps::ALL, move |ev| {
+            t2.lock().unwrap().push(ev.table_name.to_owned());
+        });
+
+        crate::sql_query("INSERT INTO seq_test (name) VALUES ('row1')")
+            .execute(conn)
+            .unwrap();
+
+        let recorded = tables.lock().unwrap();
+        // Only the user table should appear; sqlite_sequence must be absent.
+        assert!(
+            recorded.iter().all(|t| t == "seq_test"),
+            "expected only 'seq_test' events, got: {:?}",
+            *recorded
+        );
+        assert!(
+            !recorded.iter().any(|t| t == "sqlite_sequence"),
+            "sqlite_sequence modifications must not trigger the update hook"
+        );
+    }
+
+    /// INSERT OR REPLACE on the primary key itself: when a row with the same
+    /// PK already exists, the old row is silently deleted and the new row is
+    /// inserted. The hook reports only the INSERT, not the implicit DELETE.
+    #[diesel_test_helper::test]
+    fn update_hook_silent_for_replace_into_on_pk_conflict() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query(
+            "CREATE TABLE rep (id INTEGER PRIMARY KEY, val TEXT NOT NULL)",
+        )
+        .execute(conn)
+        .unwrap();
+
+        crate::sql_query("INSERT INTO rep (id, val) VALUES (1, 'old')")
+            .execute(conn)
+            .unwrap();
+
+        let events: Arc<Mutex<Vec<(SqliteChangeOp, i64)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let e2 = events.clone();
+
+        conn.on_change(SqliteChangeOps::ALL, move |ev| {
+            if ev.table_name == "rep" {
+                e2.lock().unwrap().push((ev.op, ev.rowid));
+            }
+        });
+
+        // REPLACE INTO with a conflicting PK.
+        crate::sql_query("REPLACE INTO rep (id, val) VALUES (1, 'new')")
+            .execute(conn)
+            .unwrap();
+
+        let recorded = events.lock().unwrap();
+        // Only one INSERT event, no DELETE for the old row.
+        assert_eq!(
+            recorded.len(),
+            1,
+            "expected 1 event for REPLACE INTO, got: {:?}",
+            *recorded
+        );
+        assert_eq!(recorded[0].0, SqliteChangeOp::Insert);
+        assert_eq!(recorded[0].1, 1);
+    }
+
+    // ===================================================================
+    // Commit / rollback hook tests
+    // ===================================================================
+
+    #[derive(crate::QueryableByName)]
+    struct CountResult {
+        #[diesel(sql_type = crate::sql_types::BigInt)]
+        c: i64,
+    }
+
+    #[diesel_test_helper::test]
+    fn on_commit_fires_on_commit() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_commit(move || {
+            *c2.lock().unwrap() += 1;
+            false // allow commit
+        });
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t1 (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(*count.lock().unwrap(), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_commit_returning_true_forces_rollback() {
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_commit (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        conn.on_commit(|| true /* convert commit to rollback */);
+
+        // The transaction will attempt to commit, but the hook will convert
+        // it to a rollback. diesel's AnsiTransactionManager will see the
+        // failure from the COMMIT statement (sqlite returns an error when
+        // the commit hook returns non-zero and the commit is aborted).
+        let result = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_commit (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        });
+
+        // The transaction should have been rolled back.
+        assert!(result.is_err());
+
+        // Remove the hook so subsequent queries don't fail.
+        conn.remove_commit_hook();
+
+        // Verify the row was not persisted.
+        let cnt: i64 = crate::sql_query("SELECT COUNT(*) as c FROM t_commit")
+            .get_result::<CountResult>(conn)
+            .unwrap()
+            .c;
+        assert_eq!(cnt, 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_rollback_fires_on_explicit_rollback() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_rb (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_rollback(move || {
+            *c2.lock().unwrap() += 1;
+        });
+
+        // Force a rollback by returning Err from the transaction closure.
+        let _ = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_rb (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Err::<(), _>(crate::result::Error::RollbackTransaction)
+        });
+
+        assert_eq!(*count.lock().unwrap(), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_rollback_fires_when_commit_hook_forces_rollback() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_rb2 (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let rb_count = Arc::new(Mutex::new(0u32));
+        let rb2 = rb_count.clone();
+
+        conn.on_commit(|| true /* force rollback */);
+        conn.on_rollback(move || {
+            *rb2.lock().unwrap() += 1;
+        });
+
+        let _ = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_rb2 (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        });
+
+        // Rollback hook should have fired.
+        assert_eq!(*rb_count.lock().unwrap(), 1);
+
+        conn.remove_commit_hook();
+        conn.remove_rollback_hook();
+    }
+
+    #[diesel_test_helper::test]
+    fn on_rollback_does_not_fire_on_connection_close() {
+        use std::sync::{Arc, Mutex};
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        {
+            let conn = &mut connection();
+            conn.on_rollback(move || {
+                *c2.lock().unwrap() += 1;
+            });
+            // conn is dropped here — implicit close, not a rollback.
+        }
+
+        assert_eq!(*count.lock().unwrap(), 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn replacing_commit_hook_drops_old() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        let old_count = Arc::new(Mutex::new(0u32));
+        let new_count = Arc::new(Mutex::new(0u32));
+        let oc = old_count.clone();
+        let nc = new_count.clone();
+
+        conn.on_commit(move || {
+            *oc.lock().unwrap() += 1;
+            false
+        });
+
+        // Replace with a new hook.
+        conn.on_commit(move || {
+            *nc.lock().unwrap() += 1;
+            false
+        });
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t_replace (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(*old_count.lock().unwrap(), 0);
+        assert_eq!(*new_count.lock().unwrap(), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_commit_hook_disables_callback() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_commit(move || {
+            *c2.lock().unwrap() += 1;
+            false
+        });
+
+        conn.remove_commit_hook();
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t_rem (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(*count.lock().unwrap(), 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_rollback_hook_disables_callback() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_rem_rb (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_rollback(move || {
+            *c2.lock().unwrap() += 1;
+        });
+
+        conn.remove_rollback_hook();
+
+        let _ = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_rem_rb (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Err::<(), _>(crate::result::Error::RollbackTransaction)
+        });
+
+        assert_eq!(*count.lock().unwrap(), 0);
+    }
+
+    // ---------------------------------------------------------------
+    // WAL hook tests
+    // ---------------------------------------------------------------
+
+    /// Helper: create a file-backed connection (WAL requires a real file).
+    fn wal_connection() -> (SqliteConnection, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let conn = SqliteConnection::establish(path.to_str().unwrap()).unwrap();
+        (conn, dir)
+    }
+
+    #[diesel_test_helper::test]
+    fn on_wal_fires_in_wal_mode() {
+        use std::sync::{Arc, Mutex};
+        let (conn, _dir) = &mut wal_connection();
+
+        // Enable WAL mode.
+        crate::sql_query("PRAGMA journal_mode=WAL")
+            .execute(conn)
+            .unwrap();
+
+        crate::sql_query("CREATE TABLE t_wal (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let calls: Arc<Mutex<Vec<(String, i32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let c2 = calls.clone();
+
+        conn.on_wal(move |db_name, n_pages| {
+            c2.lock().unwrap().push((db_name.to_owned(), n_pages));
+        });
+
+        crate::sql_query("INSERT INTO t_wal (id) VALUES (1)")
+            .execute(conn)
+            .unwrap();
+
+        let recorded = calls.lock().unwrap();
+        assert!(
+            !recorded.is_empty(),
+            "WAL hook should have fired at least once"
+        );
+        assert_eq!(recorded.last().unwrap().0, "main");
+        assert!(recorded.last().unwrap().1 > 0, "n_pages should be positive");
+    }
+
+    #[diesel_test_helper::test]
+    fn replacing_wal_hook_drops_old() {
+        use std::sync::{Arc, Mutex};
+        let (conn, _dir) = &mut wal_connection();
+
+        crate::sql_query("PRAGMA journal_mode=WAL")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("CREATE TABLE t_wal2 (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let old_count = Arc::new(Mutex::new(0u32));
+        let new_count = Arc::new(Mutex::new(0u32));
+
+        let c_old = old_count.clone();
+        conn.on_wal(move |_, _| {
+            *c_old.lock().unwrap() += 1;
+        });
+
+        // Replace with a new hook.
+        let c_new = new_count.clone();
+        conn.on_wal(move |_, _| {
+            *c_new.lock().unwrap() += 1;
+        });
+
+        crate::sql_query("INSERT INTO t_wal2 (id) VALUES (1)")
+            .execute(conn)
+            .unwrap();
+
+        // Old hook should NOT have fired after replacement.
+        let old_before = *old_count.lock().unwrap();
+        crate::sql_query("INSERT INTO t_wal2 (id) VALUES (2)")
+            .execute(conn)
+            .unwrap();
+        assert_eq!(
+            *old_count.lock().unwrap(),
+            old_before,
+            "old WAL hook should not fire after replacement"
+        );
+        assert!(*new_count.lock().unwrap() > 0, "new WAL hook should fire");
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_wal_hook_disables_callback() {
+        use std::sync::{Arc, Mutex};
+        let (conn, _dir) = &mut wal_connection();
+
+        crate::sql_query("PRAGMA journal_mode=WAL")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("CREATE TABLE t_wal3 (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_wal(move |_, _| {
+            *c2.lock().unwrap() += 1;
+        });
+
+        conn.remove_wal_hook();
+
+        crate::sql_query("INSERT INTO t_wal3 (id) VALUES (1)")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(*count.lock().unwrap(), 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn wal_hook_does_not_fire_in_default_journal_mode() {
+        use std::sync::{Arc, Mutex};
+        let (conn, _dir) = &mut wal_connection();
+
+        // Default journal mode for file-based databases is "delete" (not WAL).
+        crate::sql_query("CREATE TABLE t_wal4 (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_wal(move |_, _| {
+            *c2.lock().unwrap() += 1;
+        });
+
+        crate::sql_query("INSERT INTO t_wal4 (id) VALUES (1)")
+            .execute(conn)
+            .unwrap();
+
+        assert_eq!(
+            *count.lock().unwrap(),
+            0,
+            "WAL hook should not fire when not in WAL mode"
         );
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1045,7 +1045,12 @@ impl SqliteConnection {
     /// assert_eq!(*count.lock().unwrap(), 1);
     /// ```
     pub fn remove_change_hook(&mut self, id: ChangeHookId) -> bool {
-        let mut hooks = self.raw_connection.change_hooks.borrow_mut();
+        // If no hook was ever registered the dispatcher was never allocated,
+        // so there is nothing to remove.
+        let Some(hooks) = self.raw_connection.change_hooks.get() else {
+            return false;
+        };
+        let mut hooks = hooks.borrow_mut();
         let removed = hooks.remove(id);
         let is_empty = hooks.is_empty();
         drop(hooks);
@@ -1107,7 +1112,10 @@ impl SqliteConnection {
         T: StaticQueryFragment<Component = Identifier<'static>>,
     {
         let table_name = T::STATIC_COMPONENT.0;
-        let mut hooks = self.raw_connection.change_hooks.borrow_mut();
+        let Some(hooks) = self.raw_connection.change_hooks.get() else {
+            return;
+        };
+        let mut hooks = hooks.borrow_mut();
         hooks.clear_for_table(table_name);
         let is_empty = hooks.is_empty();
         drop(hooks);
@@ -1153,7 +1161,9 @@ impl SqliteConnection {
     /// assert_eq!(*count.lock().unwrap(), 0);
     /// ```
     pub fn clear_all_change_hooks(&mut self) {
-        self.raw_connection.change_hooks.borrow_mut().clear_all();
+        if let Some(hooks) = self.raw_connection.change_hooks.get() {
+            hooks.borrow_mut().clear_all();
+        }
         self.raw_connection.unregister_raw_update_hook();
     }
 
@@ -1165,7 +1175,7 @@ impl SqliteConnection {
     ) -> ChangeHookId {
         self.raw_connection.register_raw_update_hook();
         self.raw_connection
-            .change_hooks
+            .dispatcher()
             .borrow_mut()
             .add(table_name, ops, hook)
     }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -4133,6 +4133,74 @@ mod tests {
         assert_eq!(recorded[0].1, 1);
     }
 
+    /// Regression test for the dangling-pointer soundness bug.
+    ///
+    /// `sqlite3_update_hook` is handed the address of the connection's change
+    /// hook dispatcher at registration time. If that dispatcher is stored
+    /// inline in the connection, moving the (freely movable, `Sized`)
+    /// `SqliteConnection` relocates the dispatcher while SQLite keeps pointing
+    /// at the old address, so the trampoline later dereferences freed memory.
+    ///
+    /// A purely behavioral test (move the connection, then write, then check
+    /// the callback fired) is not a reliable detector: reading the stale
+    /// pointer is undefined behavior that often happens to observe still-intact
+    /// memory, so the callback fires anyway and the test passes even on the
+    /// buggy code. Instead we assert the property the fix guarantees directly:
+    /// the registered pointer must stay valid across a move, i.e. the
+    /// dispatcher address must not change when the connection is relocated.
+    #[diesel_test_helper::test]
+    fn change_hook_dispatcher_address_is_stable_across_move() {
+        let mut conn = connection();
+        setup_hook_tables(&mut conn);
+        conn.on_insert::<hook_users::table, _>(|_| {});
+
+        // The exact pointer that was handed to sqlite3_update_hook.
+        let registered = conn.raw_connection.change_hooks_ptr();
+
+        // Relocate the connection by moving it onto the heap. With an inline
+        // dispatcher this changes the dispatcher's address. SQLite still holds
+        // `registered`, which now dangles.
+        let boxed = Box::new(conn);
+        let after_move = boxed.raw_connection.change_hooks_ptr();
+
+        assert_eq!(
+            registered, after_move,
+            "the change hook dispatcher moved with the connection, leaving the \
+             pointer registered with sqlite3_update_hook dangling"
+        );
+    }
+
+    /// End-to-end companion to the test above: after the connection is moved,
+    /// a write still fires the registered callback. On the fixed (boxed)
+    /// implementation this is deterministic. It documents that the feature
+    /// works through the move that real code performs (returning a connection,
+    /// storing it in a struct, handing it to a pool, etc.).
+    #[diesel_test_helper::test]
+    fn change_hook_fires_after_connection_move() {
+        use std::sync::{Arc, Mutex};
+
+        let count = Arc::new(Mutex::new(0u32));
+        let count2 = count.clone();
+
+        let mut conn = connection();
+        setup_hook_tables(&mut conn);
+        conn.on_insert::<hook_users::table, _>(move |_| {
+            *count2.lock().unwrap() += 1;
+        });
+
+        // Move the connection onto the heap after the hook was registered.
+        let mut boxed = Box::new(conn);
+
+        crate::sql_query("INSERT INTO hook_users (name) VALUES ('Alice')")
+            .execute(&mut *boxed)
+            .unwrap();
+
+        assert_eq!(
+            *count.lock().unwrap(),
+            1,
+            "change hook did not fire after the connection was moved"
+        );
+    }
     // ===================================================================
     // Commit / rollback hook tests
     // ===================================================================

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -718,11 +718,7 @@ impl SqliteConnection {
     where
         F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
     {
-        self.raw_connection.register_raw_update_hook();
-        self.raw_connection
-            .change_hooks
-            .borrow_mut()
-            .add(None, ops, Box::new(hook))
+        self.register_change_hook(None, ops, Box::new(hook))
     }
 
     /// Registers a callback invoked when a row is inserted into table `T`.
@@ -778,12 +774,7 @@ impl SqliteConnection {
         F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
     {
         let table_name = T::STATIC_COMPONENT.0;
-        self.raw_connection.register_raw_update_hook();
-        self.raw_connection.change_hooks.borrow_mut().add(
-            Some(table_name),
-            SqliteChangeOps::INSERT,
-            Box::new(hook),
-        )
+        self.register_change_hook(Some(table_name), SqliteChangeOps::INSERT, Box::new(hook))
     }
 
     /// Registers a callback invoked when a row is updated in table `T`.
@@ -831,12 +822,7 @@ impl SqliteConnection {
         F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
     {
         let table_name = T::STATIC_COMPONENT.0;
-        self.raw_connection.register_raw_update_hook();
-        self.raw_connection.change_hooks.borrow_mut().add(
-            Some(table_name),
-            SqliteChangeOps::UPDATE,
-            Box::new(hook),
-        )
+        self.register_change_hook(Some(table_name), SqliteChangeOps::UPDATE, Box::new(hook))
     }
 
     /// Registers a callback invoked when a row is deleted from table `T`.
@@ -881,12 +867,7 @@ impl SqliteConnection {
         F: FnMut(SqliteChangeEvent<'_>) + Send + 'static,
     {
         let table_name = T::STATIC_COMPONENT.0;
-        self.raw_connection.register_raw_update_hook();
-        self.raw_connection.change_hooks.borrow_mut().add(
-            Some(table_name),
-            SqliteChangeOps::DELETE,
-            Box::new(hook),
-        )
+        self.register_change_hook(Some(table_name), SqliteChangeOps::DELETE, Box::new(hook))
     }
 
     /// Removes a previously registered change hook by its [`ChangeHookId`].
@@ -932,8 +913,11 @@ impl SqliteConnection {
     /// assert_eq!(*count.lock().unwrap(), 1);
     /// ```
     pub fn remove_change_hook(&mut self, id: ChangeHookId) -> bool {
-        let removed = self.raw_connection.change_hooks.borrow_mut().remove(id);
-        if self.raw_connection.change_hooks.borrow().is_empty() {
+        let mut hooks = self.raw_connection.change_hooks.borrow_mut();
+        let removed = hooks.remove(id);
+        let is_empty = hooks.is_empty();
+        drop(hooks);
+        if is_empty {
             self.raw_connection.unregister_raw_update_hook();
         }
         removed
@@ -991,11 +975,11 @@ impl SqliteConnection {
         T: StaticQueryFragment<Component = Identifier<'static>>,
     {
         let table_name = T::STATIC_COMPONENT.0;
-        self.raw_connection
-            .change_hooks
-            .borrow_mut()
-            .clear_for_table(table_name);
-        if self.raw_connection.change_hooks.borrow().is_empty() {
+        let mut hooks = self.raw_connection.change_hooks.borrow_mut();
+        hooks.clear_for_table(table_name);
+        let is_empty = hooks.is_empty();
+        drop(hooks);
+        if is_empty {
             self.raw_connection.unregister_raw_update_hook();
         }
     }
@@ -1039,6 +1023,19 @@ impl SqliteConnection {
     pub fn clear_all_change_hooks(&mut self) {
         self.raw_connection.change_hooks.borrow_mut().clear_all();
         self.raw_connection.unregister_raw_update_hook();
+    }
+
+    fn register_change_hook(
+        &mut self,
+        table_name: Option<&'static str>,
+        ops: SqliteChangeOps,
+        hook: Box<dyn FnMut(SqliteChangeEvent<'_>) + Send>,
+    ) -> ChangeHookId {
+        self.raw_connection.register_raw_update_hook();
+        self.raw_connection
+            .change_hooks
+            .borrow_mut()
+            .add(table_name, ops, hook)
     }
 
     /// Loads a single row from table `T` by its SQLite `rowid`.
@@ -1642,6 +1639,7 @@ impl SqliteConnection {
     /// This replaces any existing trace callback. If you need both `on_read` and
     /// custom tracing, use [`on_trace`](Self::on_trace) directly and check the
     /// `readonly` field on [`SqliteTraceEvent::Statement`].
+    #[doc(alias = "on_trace")]
     pub fn on_read<F>(&mut self, mut hook: F)
     where
         F: FnMut(&str) + Send + 'static,

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -39,6 +39,7 @@ use crate::result::*;
 use crate::serialize::ToSql;
 use crate::sql_types::{HasSqlType, TypeMetadata};
 use crate::sqlite::Sqlite;
+use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::ffi as libc;
@@ -4051,8 +4052,14 @@ mod tests {
 
     // ---------------------------------------------------------------
     // WAL hook tests
+    //
+    // Gated out on WASM because these tests need a file-backed database
+    // (WAL mode does not work with `:memory:`), and `tempfile::tempdir()`
+    // panics on WASM due to the lack of a filesystem. The WAL *API* itself
+    // is not feature-gated — only these tests are.
     // ---------------------------------------------------------------
 
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     /// Helper: create a file-backed connection (WAL requires a real file).
     fn wal_connection() -> (SqliteConnection, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
@@ -4061,6 +4068,7 @@ mod tests {
         (conn, dir)
     }
 
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     #[diesel_test_helper::test]
     fn on_wal_fires_in_wal_mode() {
         use std::sync::{Arc, Mutex};
@@ -4095,6 +4103,7 @@ mod tests {
         assert!(recorded.last().unwrap().1 > 0, "n_pages should be positive");
     }
 
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     #[diesel_test_helper::test]
     fn replacing_wal_hook_drops_old() {
         use std::sync::{Arc, Mutex};
@@ -4138,6 +4147,7 @@ mod tests {
         assert!(*new_count.lock().unwrap() > 0, "new WAL hook should fire");
     }
 
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     #[diesel_test_helper::test]
     fn remove_wal_hook_disables_callback() {
         use std::sync::{Arc, Mutex};
@@ -4166,6 +4176,7 @@ mod tests {
         assert_eq!(*count.lock().unwrap(), 0);
     }
 
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     #[diesel_test_helper::test]
     fn wal_hook_does_not_fire_in_default_journal_mode() {
         use std::sync::{Arc, Mutex};

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1647,10 +1647,10 @@ impl SqliteConnection {
         F: FnMut(&str) + Send + 'static,
     {
         self.on_trace(SqliteTraceFlags::STMT, move |event| {
-            if let SqliteTraceEvent::Statement { sql, readonly } = event {
-                if readonly {
-                    hook(sql);
-                }
+            if let SqliteTraceEvent::Statement { sql, readonly } = event
+                && readonly
+            {
+                hook(sql);
             }
         });
     }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -636,16 +636,19 @@ impl SqliteConnection {
     /// Registers a callback invoked for any row change (insert, update, or
     /// delete) on any table, filtered by the given [`SqliteChangeOps`] mask.
     ///
-    /// This is the untyped variant — the table name is provided as a string
+    /// This is the untyped variant: the table name is provided as a string
     /// in [`SqliteChangeEvent::table_name`], suitable for logging all changes
     /// regardless of table.
     ///
-    /// The callback fires **synchronously during `sqlite3_step()`**, i.e.
-    /// while the triggering statement is executing. The connection is **not**
-    /// available inside the callback.
+    /// [`SqliteChangeOps::ALL`] also matches operation codes diesel does not
+    /// recognize (delivered as [`SqliteChangeOp::Unknown`]); see that constant
+    /// for the rationale.
     ///
     /// Multiple hooks can be registered on the same connection (and even
-    /// the same table); they fire in registration order.
+    /// the same table). They fire in registration order. Unlike the
+    /// single-slot commit, rollback, and WAL hooks (where re-registering
+    /// replaces the previous callback), change hooks are multiplexed and each
+    /// is removable individually by its [`ChangeHookId`].
     ///
     /// Returns a [`ChangeHookId`] that can be used to remove the hook later
     /// via [`remove_change_hook`](Self::remove_change_hook). You can also
@@ -669,6 +672,63 @@ impl SqliteConnection {
     ///   [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html).
     /// - Not invoked for deletes using the
     ///   [truncate optimization](https://www.sqlite.org/lang_delete.html#truncateopt).
+    ///
+    /// # Threading and the `Send` bound
+    ///
+    /// The callback runs synchronously on the same thread that drives
+    /// `sqlite3_step()`, never on another thread, and the connection is not
+    /// available inside it. The `Send + 'static` bound is therefore structural
+    /// rather than a hint of concurrency: because [`SqliteConnection`] is itself
+    /// `Send`, a stored callback must also be `Send`, so that moving the
+    /// connection to another thread cannot smuggle a non-`Send` value across the
+    /// boundary.
+    ///
+    /// When a connection is confined to one thread the callback never actually
+    /// crosses a thread, yet the `Send` bound is still enforced. This is the
+    /// common case on `wasm32-unknown-unknown`: a default build is
+    /// single-threaded, and separate web workers each have their own memory, so
+    /// a connection created in one worker is never accessed from another. There
+    /// you can wrap `!Send` state (for example `Rc`-based UI state) in a newtype
+    /// with an `unsafe impl Send`:
+    ///
+    /// ```ignore
+    /// struct UiState { /* Rc-based, !Send signals */ }
+    /// // SAFETY: the connection, and therefore this callback, is only ever used
+    /// // from one thread, so the value never actually crosses a thread.
+    /// unsafe impl Send for UiState {}
+    /// ```
+    ///
+    /// This relies on that single-thread confinement. If you enable wasm threads
+    /// (shared-memory atomics) or otherwise move the connection to another
+    /// thread, the `unsafe impl Send` is unsound.
+    ///
+    /// # Reentrancy
+    ///
+    /// A callback must not run SQL that would re-enter the change hook (for
+    /// example an `INSERT` from inside the callback). The dispatcher is borrowed
+    /// for the duration of the dispatch loop, so any change produced while a
+    /// callback is running is not re-dispatched, and the callback cannot
+    /// register or remove hooks. Such reentrant changes are silently dropped
+    /// rather than panicking inside the C callback. Record what changed and act
+    /// on it after the statement finishes (see "Recommended usage" below).
+    ///
+    /// # Ownership of the update hook
+    ///
+    /// SQLite allows exactly one `sqlite3_update_hook` per connection, and
+    /// diesel owns that slot. Installing your own `sqlite3_update_hook` directly
+    /// on the same connection is unsupported: diesel will override it when a
+    /// change hook is registered and clear it on teardown. This does not collide
+    /// with the session extension, which uses the separate preupdate hook.
+    ///
+    /// # Recommended usage: notify, then re-query
+    ///
+    /// The callback receives a `rowid`, not the row itself, and the connection
+    /// is not usable while the triggering statement is mid-step. For a `DELETE`
+    /// the row is already gone. The robust pattern is to use the callback only
+    /// to record that something changed (for example bump a per-table dirty
+    /// flag or push the rowid into a shared queue), then re-query from
+    /// application code once the statement has finished, using
+    /// [`find_by_rowid`](Self::find_by_rowid) for inserts and updates.
     ///
     /// # Example
     ///
@@ -981,7 +1041,7 @@ impl SqliteConnection {
     /// diesel::insert_into(users::table)
     ///     .values(users::name.eq("Bob"))
     ///     .execute(conn).unwrap();
-    /// // Still 1 — the hook was removed.
+    /// // Still 1, the hook was removed.
     /// assert_eq!(*count.lock().unwrap(), 1);
     /// ```
     pub fn remove_change_hook(&mut self, id: ChangeHookId) -> bool {
@@ -1195,8 +1255,8 @@ impl SqliteConnection {
     /// committed.
     ///
     /// The callback returns a `bool`:
-    /// - `false` — the commit proceeds normally.
-    /// - `true` — the commit is converted into a rollback.
+    /// - `false`: the commit proceeds normally.
+    /// - `true`: the commit is converted into a rollback.
     ///
     /// Only one commit hook can be active at a time per connection.
     /// Registering a new one replaces the previous.
@@ -1250,38 +1310,7 @@ impl SqliteConnection {
     /// Removes the commit hook. Subsequent commits will not invoke any
     /// callback.
     ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use diesel::prelude::*;
-    /// use diesel::sqlite::SqliteConnection;
-    /// use std::sync::{Arc, Mutex};
-    ///
-    /// diesel::table! {
-    ///     users (id) {
-    ///         id -> Integer,
-    ///         name -> Text,
-    ///     }
-    /// }
-    ///
-    /// # use diesel::connection::SimpleConnection;
-    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
-    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
-    /// let count = Arc::new(Mutex::new(0u32));
-    /// let count2 = count.clone();
-    /// conn.on_commit(move || { *count2.lock().unwrap() += 1; false });
-    ///
-    /// conn.remove_commit_hook();
-    ///
-    /// conn.immediate_transaction(|conn| {
-    ///     diesel::insert_into(users::table)
-    ///         .values(users::name.eq("Alice"))
-    ///         .execute(conn)?;
-    ///     Ok::<_, diesel::result::Error>(())
-    /// }).unwrap();
-    ///
-    /// assert_eq!(*count.lock().unwrap(), 0);
-    /// ```
+    /// See [`on_commit`](Self::on_commit) for usage example.
     pub fn remove_commit_hook(&mut self) {
         self.raw_connection.remove_commit_hook();
     }
@@ -1332,27 +1361,7 @@ impl SqliteConnection {
 
     /// Removes the rollback hook.
     ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use diesel::prelude::*;
-    /// # use diesel::connection::SimpleConnection;
-    /// # use diesel::sqlite::SqliteConnection;
-    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
-    /// use std::sync::{Arc, Mutex};
-    ///
-    /// let count = Arc::new(Mutex::new(0u32));
-    /// let count2 = count.clone();
-    /// conn.on_rollback(move || { *count2.lock().unwrap() += 1; });
-    ///
-    /// conn.remove_rollback_hook();
-    ///
-    /// let _ = conn.immediate_transaction(|_conn| {
-    ///     Err::<(), _>(diesel::result::Error::RollbackTransaction)
-    /// });
-    ///
-    /// assert_eq!(*count.lock().unwrap(), 0);
-    /// ```
+    /// See [`on_rollback`](Self::on_rollback) for usage example.
     pub fn remove_rollback_hook(&mut self) {
         self.raw_connection.remove_rollback_hook();
     }
@@ -1361,8 +1370,8 @@ impl SqliteConnection {
     /// [WAL mode](https://www.sqlite.org/wal.html).
     ///
     /// The callback receives:
-    /// - `db_name` — the database name (`"main"`, `"temp"`, or an `ATTACH` alias).
-    /// - `n_pages` — the number of pages currently in the WAL file.
+    /// - `db_name`: the database name (`"main"`, `"temp"`, or an `ATTACH` alias).
+    /// - `n_pages`: the number of pages currently in the WAL file.
     ///
     /// Useful for triggering custom checkpoint logic via
     /// [`PRAGMA wal_checkpoint`](https://www.sqlite.org/pragma.html#pragma_wal_checkpoint).
@@ -1396,17 +1405,7 @@ impl SqliteConnection {
 
     /// Removes the WAL hook.
     ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use diesel::prelude::*;
-    /// # use diesel::connection::SimpleConnection;
-    /// # use diesel::sqlite::SqliteConnection;
-    /// # let conn = &mut SqliteConnection::establish("test.db").unwrap();
-    /// # conn.batch_execute("PRAGMA journal_mode = WAL;").unwrap();
-    /// conn.on_wal(|_db, _pages| { /* ... */ });
-    /// conn.remove_wal_hook();
-    /// ```
+    /// See [`on_wal`](Self::on_wal) for usage example.
     pub fn remove_wal_hook(&mut self) {
         self.raw_connection.remove_wal_hook();
     }
@@ -1613,10 +1612,10 @@ impl SqliteConnection {
     /// The callback receives events based on the provided [`SqliteTraceFlags`]
     /// mask. Available event types:
     ///
-    /// - `STMT` — Statement start (receives SQL text)
-    /// - `PROFILE` — Statement complete (receives SQL text and elapsed time)
-    /// - `ROW` — Each row returned (no data, very frequent!)
-    /// - `CLOSE` — Connection close
+    /// - `STMT`: Statement start (receives SQL text)
+    /// - `PROFILE`: Statement complete (receives SQL text and elapsed time)
+    /// - `ROW`: Each row returned (no data, very frequent!)
+    /// - `CLOSE`: Connection close
     ///
     /// **Performance Warning**: `SQLITE_TRACE_ROW` fires for EVERY row
     /// returned by a query. For large result sets, this can significantly
@@ -1688,22 +1687,32 @@ impl SqliteConnection {
     /// - `WITH ... INSERT/UPDATE/DELETE ... RETURNING` (the outer statement modifies data)
     /// - Write `PRAGMA` statements (e.g., `PRAGMA foreign_keys = ON`)
     ///
-    /// # Edge cases (not detected)
+    /// # Edge cases
     ///
-    /// - User-defined functions that modify the database via a separate connection
-    ///   are **not** detected; the statement itself is still considered read-only
-    /// - Virtual tables with write side effects are **not** detected
+    /// Some writes are not detected (for example writes via a user-defined
+    /// function on a separate connection, or virtual tables with side effects),
+    /// so the statement is still reported as read-only. See
+    /// [`SqliteTraceEvent::Statement::readonly`] for the full list.
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```rust
     /// # use diesel::prelude::*;
     /// # use diesel::sqlite::SqliteConnection;
-    /// let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// use std::sync::{Arc, Mutex};
     ///
-    /// conn.on_read(|sql| {
-    ///     println!("Read query executed: {}", sql);
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// let seen = Arc::new(Mutex::new(Vec::new()));
+    /// let seen2 = seen.clone();
+    ///
+    /// conn.on_read(move |sql| {
+    ///     seen2.lock().unwrap().push(sql.to_owned());
     /// });
+    ///
+    /// // A SELECT is read-only, so on_read fires for it.
+    /// diesel::sql_query("SELECT 1").execute(conn).unwrap();
+    ///
+    /// assert!(seen.lock().unwrap().iter().any(|s| s.contains("SELECT 1")));
     /// ```
     ///
     /// # Note
@@ -3584,7 +3593,7 @@ mod tests {
             fired2.lock().unwrap().push((event.op, event.rowid));
         });
 
-        // INSERT a row — the hook fires immediately during sqlite3_step().
+        // INSERT a row: the hook fires immediately during sqlite3_step().
         crate::sql_query("INSERT INTO hook_users (name) VALUES ('Alice')")
             .execute(conn)
             .unwrap();
@@ -3673,7 +3682,7 @@ mod tests {
         crate::sql_query("INSERT INTO hook_users (name) VALUES ('B')")
             .execute(conn)
             .unwrap();
-        // Should still be 1 — hook was removed.
+        // Should still be 1, hook was removed.
         assert_eq!(*fired.lock().unwrap(), 1);
     }
 
@@ -4072,7 +4081,7 @@ mod tests {
             }
         });
 
-        // DELETE without WHERE — truncate optimization kicks in.
+        // DELETE without WHERE: truncate optimization kicks in.
         crate::sql_query("DELETE FROM bulk").execute(conn).unwrap();
 
         assert!(
@@ -4151,7 +4160,7 @@ mod tests {
             .unwrap();
 
         let recorded = tables.lock().unwrap();
-        // Only the user table should appear; sqlite_sequence must be absent.
+        // Only the user table should appear, sqlite_sequence must be absent.
         assert!(
             recorded.iter().all(|t| t == "seq_test"),
             "expected only 'seq_test' events, got: {:?}",
@@ -4446,7 +4455,7 @@ mod tests {
             conn.on_rollback(move || {
                 *c2.lock().unwrap() += 1;
             });
-            // conn is dropped here — implicit close, not a rollback.
+            // conn is dropped here: implicit close, not a rollback.
         }
 
         assert_eq!(*count.lock().unwrap(), 0);

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -4055,8 +4055,20 @@ mod tests {
     //
     // Gated out on WASM because these tests need a file-backed database
     // (WAL mode does not work with `:memory:`), and `tempfile::tempdir()`
-    // panics on WASM due to the lack of a filesystem. The WAL *API* itself
-    // is not feature-gated — only these tests are.
+    // panics on WASM due to the lack of a filesystem.
+    //
+    // The WAL *API* itself (`on_wal`, `remove_wal_hook`) is available on
+    // all platforms, including WASM. In principle WAL could work on WASM
+    // with the `sahpool` VFS (OPFS-backed), but that VFS is only usable
+    // inside a Dedicated Worker context. The default `memory` VFS has no
+    // persistent storage, and `relaxed-idb` (IndexedDB) does not provide
+    // the file-level I/O (WAL/SHM sidecar files) that WAL mode requires.
+    // Additionally, `sqlite-wasm-rs` compiles SQLite with
+    // `-DSQLITE_THREADSAFE=0` and none of its VFS backends support
+    // multiple connections, further limiting WAL's utility on WASM.
+    //
+    // Testing WAL on specific WASM VFS backends is better suited for
+    // downstream integration tests.
     // ---------------------------------------------------------------
 
     #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -4,6 +4,7 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+mod authorizer;
 mod bind_collector;
 mod functions;
 mod limits;
@@ -15,13 +16,16 @@ pub(in crate::sqlite) mod sqlite_blob;
 mod sqlite_value;
 mod statement_iterator;
 mod stmt;
+mod trace;
 mod update_hook;
 
+pub use self::authorizer::{AuthorizerAction, AuthorizerContext, AuthorizerDecision};
 pub(in crate::sqlite) use self::bind_collector::SqliteBindCollector;
 pub use self::bind_collector::SqliteBindValue;
 pub use self::limits::SqliteLimit;
 pub use self::serialized_database::SerializedDatabase;
 pub use self::sqlite_value::SqliteValue;
+pub use self::trace::{SqliteTraceEvent, SqliteTraceFlags};
 pub use self::update_hook::{ChangeHookId, SqliteChangeEvent, SqliteChangeOp, SqliteChangeOps};
 
 use self::raw::RawConnection;
@@ -1336,6 +1340,261 @@ impl SqliteConnection {
     /// ```
     pub fn remove_wal_hook(&mut self) {
         self.raw_connection.remove_wal_hook();
+    }
+
+    /// Registers a progress handler for long-running query interruption.
+    /// Added in SQLite 3.0.0 (June 2004).
+    ///
+    /// The callback is invoked periodically during long-running SQL queries.
+    /// `n` is the approximate number of VM instructions between callbacks.
+    /// **Suggested minimum**: 1000 (at N=1, overhead is ~1.5μs per callback).
+    ///
+    /// Return `true` to interrupt the query (causes `SQLITE_INTERRUPT`),
+    /// or `false` to continue.
+    ///
+    /// Only one progress handler can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// **Callback restriction**: The callback must not use the database
+    /// connection. Since SQLite 3.41.0, the handler may also fire during
+    /// `sqlite3_prepare()` for complex queries.
+    ///
+    /// Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_progress_handler`](https://sqlite.org/c3ref/progress_handler.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// use std::sync::atomic::{AtomicBool, Ordering};
+    /// use std::sync::Arc;
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// let cancelled = Arc::new(AtomicBool::new(false));
+    /// let cancelled_clone = cancelled.clone();
+    ///
+    /// conn.on_progress(1000, move || {
+    ///     cancelled_clone.load(Ordering::Relaxed)
+    /// });
+    ///
+    /// // Later: remove the handler
+    /// conn.remove_progress_handler();
+    /// ```
+    pub fn on_progress<F>(&mut self, n: i32, hook: F)
+    where
+        F: FnMut() -> bool + Send + 'static,
+    {
+        self.raw_connection.set_progress_handler(n, hook);
+    }
+
+    /// Removes the progress handler.
+    ///
+    /// See [`on_progress`](Self::on_progress) for usage example.
+    pub fn remove_progress_handler(&mut self) {
+        self.raw_connection.remove_progress_handler();
+    }
+
+    /// Registers a custom busy handler for lock contention.
+    /// Added in SQLite 3.0.0 (June 2004).
+    ///
+    /// The callback receives the retry count (starting from 0) and returns
+    /// `true` to retry, `false` to abort (returns `SQLITE_BUSY` to caller).
+    ///
+    /// **Warning**: Setting this clears any `busy_timeout` previously set.
+    /// Conversely, calling `set_busy_timeout` clears this handler.
+    ///
+    /// Only one busy handler can be active at a time per connection.
+    ///
+    /// **Callback restriction**: The callback must not use the database
+    /// connection. If the callback modifies the database, behavior is
+    /// undefined. SQLite may return `SQLITE_BUSY` instead of calling the
+    /// handler to prevent deadlocks.
+    ///
+    /// Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_busy_handler`](https://sqlite.org/c3ref/busy_handler.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// use std::thread;
+    /// use std::time::Duration;
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// conn.on_busy(|retry_count| {
+    ///     if retry_count < 5 {
+    ///         thread::sleep(Duration::from_millis(100));
+    ///         true // retry
+    ///     } else {
+    ///         false // give up
+    ///     }
+    /// });
+    ///
+    /// // Later: remove the handler
+    /// conn.remove_busy_handler();
+    /// ```
+    pub fn on_busy<F>(&mut self, hook: F)
+    where
+        F: FnMut(i32) -> bool + Send + 'static,
+    {
+        self.raw_connection.set_busy_handler(hook);
+    }
+
+    /// Removes the custom busy handler.
+    ///
+    /// See [`on_busy`](Self::on_busy) for usage example.
+    pub fn remove_busy_handler(&mut self) {
+        self.raw_connection.remove_busy_handler();
+    }
+
+    /// Sets a simple timeout-based busy handler.
+    /// Added in SQLite 3.0.0 (June 2004).
+    ///
+    /// When a table is locked, SQLite will sleep and retry until `ms`
+    /// milliseconds have elapsed. Pass 0 to disable (return `SQLITE_BUSY`
+    /// immediately).
+    ///
+    /// **Note**: Setting this clears any custom [`on_busy`](Self::on_busy)
+    /// handler. Conversely, calling `on_busy` clears this timeout.
+    ///
+    /// For most use cases, this is simpler than a custom busy handler.
+    ///
+    /// See: [`sqlite3_busy_timeout`](https://sqlite.org/c3ref/busy_timeout.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// # use diesel::sqlite::SqliteConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// // Wait up to 5 seconds for locked tables
+    /// conn.set_busy_timeout(5000);
+    /// ```
+    pub fn set_busy_timeout(&mut self, ms: i32) {
+        self.raw_connection.set_busy_timeout(ms);
+    }
+
+    /// Registers an authorizer callback for SQL compilation access control.
+    /// Added in SQLite 3.0.0 (June 2004).
+    ///
+    /// The callback is invoked during `sqlite3_prepare()` (statement
+    /// compilation) to control access to database objects. It receives
+    /// an [`AuthorizerContext`] describing the operation and returns an
+    /// [`AuthorizerDecision`].
+    ///
+    /// **Security Note**: The authorizer is only called during statement
+    /// compilation, NOT during execution. It cannot prevent all attack
+    /// vectors (e.g., CVE-2015-3659 showed bypasses via fts3_tokenizer).
+    /// Use it as defense-in-depth, not as a sole security mechanism.
+    ///
+    /// **Schema changes**: The authorizer may be re-invoked during
+    /// `sqlite3_step()` if schema changes trigger statement recompilation.
+    ///
+    /// **Callback restriction**: The callback must not modify the database
+    /// connection.
+    ///
+    /// Only one authorizer can be active at a time per connection.
+    /// Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_set_authorizer`](https://sqlite.org/c3ref/set_authorizer.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// use diesel::sqlite::{
+    ///     SqliteConnection, AuthorizerContext, AuthorizerDecision, AuthorizerAction,
+    /// };
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// conn.on_authorize(|ctx| {
+    ///     match ctx.action {
+    ///         AuthorizerAction::Delete => AuthorizerDecision::Deny,
+    ///         AuthorizerAction::DropTable | AuthorizerAction::DropIndex => {
+    ///             AuthorizerDecision::Deny
+    ///         }
+    ///         _ => AuthorizerDecision::Allow,
+    ///     }
+    /// });
+    ///
+    /// // Later: remove the authorizer
+    /// conn.remove_authorizer();
+    /// ```
+    pub fn on_authorize<F>(&mut self, hook: F)
+    where
+        F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send + 'static,
+    {
+        self.raw_connection.set_authorizer(hook);
+    }
+
+    /// Removes the authorizer callback.
+    ///
+    /// See [`on_authorize`](Self::on_authorize) for usage example.
+    pub fn remove_authorizer(&mut self) {
+        self.raw_connection.remove_authorizer();
+    }
+
+    /// Registers a trace callback for SQL execution monitoring.
+    /// Added in SQLite 3.14.0 (2016-08-08).
+    ///
+    /// The callback receives events based on the provided [`SqliteTraceFlags`]
+    /// mask. Available event types:
+    ///
+    /// - `STMT` — Statement start (receives SQL text)
+    /// - `PROFILE` — Statement complete (receives SQL text and elapsed time)
+    /// - `ROW` — Each row returned (no data, very frequent!)
+    /// - `CLOSE` — Connection close
+    ///
+    /// **Performance Warning**: `SQLITE_TRACE_ROW` fires for EVERY row
+    /// returned by a query. For large result sets, this can significantly
+    /// impact performance. Prefer `STMT` and `PROFILE` for most logging
+    /// use cases.
+    ///
+    /// Only one trace callback can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_trace_v2`](https://sqlite.org/c3ref/trace_v2.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, SqliteTraceFlags, SqliteTraceEvent};
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// conn.on_trace(SqliteTraceFlags::STMT | SqliteTraceFlags::PROFILE, |event| {
+    ///     match event {
+    ///         SqliteTraceEvent::Statement { sql } => {
+    ///             println!("Executing: {}", sql);
+    ///         }
+    ///         SqliteTraceEvent::Profile { sql, duration_ns } => {
+    ///             println!("{} took {} ns", sql, duration_ns);
+    ///         }
+    ///         _ => {}
+    ///     }
+    /// });
+    ///
+    /// // Later: remove the trace callback
+    /// conn.remove_trace();
+    /// ```
+    pub fn on_trace<F>(&mut self, mask: SqliteTraceFlags, hook: F)
+    where
+        F: FnMut(SqliteTraceEvent<'_>) + Send + 'static,
+    {
+        self.raw_connection.set_trace(mask, hook);
+    }
+
+    /// Removes the trace callback.
+    ///
+    /// See [`on_trace`](Self::on_trace) for usage example.
+    pub fn remove_trace(&mut self) {
+        self.raw_connection.remove_trace();
     }
 
     /// Serialize the current SQLite database into a byte buffer.

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1928,9 +1928,7 @@ impl SqliteConnection {
 
         let mut conn = Borrowed(core::mem::ManuallyDrop::new(SqliteConnection {
             statement_cache: StatementCache::new(),
-            raw_connection: RawConnection {
-                internal_connection: db,
-            },
+            raw_connection: RawConnection::from_ptr(db),
             transaction_state: AnsiTransactionManager::default(),
             metadata_lookup: (),
             instrumentation: DynInstrumentation::default_instrumentation(),

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -16,10 +16,12 @@ use core::ffi::CStr;
 use core::ptr::NonNull;
 use core::{mem, ptr, slice, str};
 
+use super::authorizer::{AuthorizerAction, AuthorizerContext, AuthorizerDecision};
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
 use super::stmt::ensure_sqlite_ok;
+use super::trace::{SqliteTraceEvent, SqliteTraceFlags};
 use super::update_hook::{ChangeHookDispatcher, SqliteChangeEvent, SqliteChangeOp};
 use super::{Sqlite, SqliteAggregateFunction};
 use crate::deserialize::FromSqlRow;
@@ -60,6 +62,14 @@ pub(super) struct RawConnection {
     rollback_hook: Option<Box<dyn Any + Send>>,
     /// Boxed closure for the WAL hook.
     wal_hook: Option<Box<dyn Any + Send>>,
+    /// Boxed closure for the progress handler.
+    progress_hook: Option<Box<dyn Any + Send>>,
+    /// Boxed closure for the busy handler.
+    busy_handler: Option<Box<dyn Any + Send>>,
+    /// Boxed closure for the authorizer callback.
+    authorizer_hook: Option<Box<dyn Any + Send>>,
+    /// Boxed closure for the trace callback.
+    trace_hook: Option<Box<dyn Any + Send>>,
 }
 
 impl RawConnection {
@@ -86,6 +96,10 @@ impl RawConnection {
                     commit_hook: None,
                     rollback_hook: None,
                     wal_hook: None,
+                    progress_hook: None,
+                    busy_handler: None,
+                    authorizer_hook: None,
+                    trace_hook: None,
                 })
             }
             err_code => {
@@ -473,6 +487,139 @@ impl RawConnection {
         }
         self.wal_hook = None;
     }
+
+    /// Sets a progress handler. Only one can be active at a time.
+    ///
+    /// The callback is invoked periodically during long-running SQL queries.
+    /// `n` is the approximate number of VM instructions between callbacks.
+    /// Return `true` to interrupt the query, `false` to continue.
+    pub(super) fn set_progress_handler<F>(&mut self, n: i32, hook: F)
+    where
+        F: FnMut() -> bool + Send + 'static,
+    {
+        let boxed: Box<F> = Box::new(hook);
+        let ptr = &*boxed as *const F as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_progress_handler(
+                self.internal_connection.as_ptr(),
+                n,
+                Some(progress_handler_trampoline::<F>),
+                ptr,
+            );
+        }
+        self.progress_hook = Some(boxed);
+    }
+
+    /// Removes the progress handler.
+    pub(super) fn remove_progress_handler(&mut self) {
+        unsafe {
+            ffi::sqlite3_progress_handler(
+                self.internal_connection.as_ptr(),
+                0,
+                None,
+                ptr::null_mut(),
+            );
+        }
+        self.progress_hook = None;
+    }
+
+    /// Sets a busy handler. Only one can be active at a time.
+    ///
+    /// The callback receives the retry count and returns `true` to retry,
+    /// `false` to abort. Setting this clears any `busy_timeout`.
+    pub(super) fn set_busy_handler<F>(&mut self, hook: F)
+    where
+        F: FnMut(i32) -> bool + Send + 'static,
+    {
+        let boxed: Box<F> = Box::new(hook);
+        let ptr = &*boxed as *const F as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_busy_handler(
+                self.internal_connection.as_ptr(),
+                Some(busy_handler_trampoline::<F>),
+                ptr,
+            );
+        }
+        self.busy_handler = Some(boxed);
+    }
+
+    /// Removes the busy handler.
+    pub(super) fn remove_busy_handler(&mut self) {
+        unsafe {
+            ffi::sqlite3_busy_handler(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.busy_handler = None;
+    }
+
+    /// Sets a simple timeout-based busy handler.
+    ///
+    /// SQLite will sleep and retry until `ms` milliseconds have elapsed.
+    /// Setting this clears any custom busy handler.
+    pub(super) fn set_busy_timeout(&self, ms: i32) {
+        unsafe {
+            ffi::sqlite3_busy_timeout(self.internal_connection.as_ptr(), ms);
+        }
+        // Note: We don't clear busy_handler here because SQLite handles that
+        // internally. The old handler (if any) becomes inactive but the Box
+        // will be dropped on the next set_busy_handler or connection close.
+    }
+
+    /// Sets an authorizer callback. Only one can be active at a time.
+    ///
+    /// The callback is invoked during SQL statement compilation to control
+    /// access to database objects.
+    pub(super) fn set_authorizer<F>(&mut self, hook: F)
+    where
+        F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send + 'static,
+    {
+        let boxed: Box<F> = Box::new(hook);
+        let ptr = &*boxed as *const F as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_set_authorizer(
+                self.internal_connection.as_ptr(),
+                Some(authorizer_trampoline::<F>),
+                ptr,
+            );
+        }
+        self.authorizer_hook = Some(boxed);
+    }
+
+    /// Removes the authorizer callback.
+    pub(super) fn remove_authorizer(&mut self) {
+        unsafe {
+            ffi::sqlite3_set_authorizer(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.authorizer_hook = None;
+    }
+
+    /// Sets a trace callback. Only one can be active at a time.
+    ///
+    /// The callback is invoked for SQL execution tracing based on the
+    /// provided event mask.
+    pub(super) fn set_trace<F>(&mut self, mask: SqliteTraceFlags, hook: F)
+    where
+        F: FnMut(SqliteTraceEvent<'_>) + Send + 'static,
+    {
+        let boxed: Box<F> = Box::new(hook);
+        let ptr = &*boxed as *const F as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_trace_v2(
+                self.internal_connection.as_ptr(),
+                mask.bits(),
+                Some(trace_trampoline::<F>),
+                ptr,
+            );
+        }
+        self.trace_hook = Some(boxed);
+    }
+
+    /// Removes the trace callback.
+    pub(super) fn remove_trace(&mut self) {
+        unsafe {
+            ffi::sqlite3_trace_v2(self.internal_connection.as_ptr(), 0, None, ptr::null_mut());
+        }
+        self.trace_hook = None;
+    }
 }
 
 /// C trampoline for `sqlite3_update_hook`.
@@ -601,18 +748,212 @@ where
     ffi::SQLITE_OK
 }
 
+/// C trampoline for `sqlite3_progress_handler`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::progress_hook`.
+unsafe extern "C" fn progress_handler_trampoline<F>(user_data: *mut libc::c_void) -> libc::c_int
+where
+    F: FnMut() -> bool,
+{
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::progress_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        f()
+    }));
+
+    match result {
+        Ok(true) => 1,  // interrupt query
+        Ok(false) => 0, // continue
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_progress_handler trampoline. ");
+        }
+    }
+}
+
+/// C trampoline for `sqlite3_busy_handler`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::busy_handler`.
+unsafe extern "C" fn busy_handler_trampoline<F>(
+    user_data: *mut libc::c_void,
+    retry_count: libc::c_int,
+) -> libc::c_int
+where
+    F: FnMut(i32) -> bool,
+{
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::busy_handler`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        f(retry_count)
+    }));
+
+    match result {
+        Ok(true) => 1,  // retry
+        Ok(false) => 0, // abort (return SQLITE_BUSY)
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_busy_handler trampoline. ");
+        }
+    }
+}
+
+/// C trampoline for `sqlite3_set_authorizer`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::authorizer_hook`.
+unsafe extern "C" fn authorizer_trampoline<F>(
+    user_data: *mut libc::c_void,
+    action_code: libc::c_int,
+    arg1: *const libc::c_char,
+    arg2: *const libc::c_char,
+    db_name: *const libc::c_char,
+    accessor: *const libc::c_char,
+) -> libc::c_int
+where
+    F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision,
+{
+    // Helper to convert a nullable C string to Option<&str>
+    fn c_str_to_option(ptr: *const libc::c_char) -> Option<&'static str> {
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFETY: ptr is a valid C string provided by SQLite.
+            match unsafe { CStr::from_ptr(ptr) }.to_str() {
+                Ok(s) => Some(s),
+                Err(_) => {
+                    assert_fail!("sqlite3_set_authorizer delivered invalid UTF-8. ");
+                }
+            }
+        }
+    }
+
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::authorizer_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+
+        let ctx = AuthorizerContext {
+            action: AuthorizerAction::from_ffi(action_code),
+            arg1: c_str_to_option(arg1),
+            arg2: c_str_to_option(arg2),
+            db_name: c_str_to_option(db_name),
+            accessor: c_str_to_option(accessor),
+        };
+
+        f(ctx)
+    }));
+
+    match result {
+        Ok(decision) => decision.to_ffi(),
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_set_authorizer trampoline. ");
+        }
+    }
+}
+
+/// C trampoline for `sqlite3_trace_v2`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::trace_hook`.
+unsafe extern "C" fn trace_trampoline<F>(
+    event_code: libc::c_uint,
+    user_data: *mut libc::c_void,
+    p: *mut libc::c_void,
+    x: *mut libc::c_void,
+) -> libc::c_int
+where
+    F: FnMut(SqliteTraceEvent<'_>),
+{
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::trace_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+
+        let event = match event_code {
+            ffi::SQLITE_TRACE_STMT => {
+                // p = sqlite3_stmt*, x = const char* (unexpanded SQL)
+                let sql_ptr = x as *const libc::c_char;
+                if sql_ptr.is_null() {
+                    return;
+                }
+                let sql = match unsafe { CStr::from_ptr(sql_ptr) }.to_str() {
+                    Ok(s) => s,
+                    Err(_) => {
+                        assert_fail!("sqlite3_trace_v2 STMT delivered invalid UTF-8. ");
+                    }
+                };
+                SqliteTraceEvent::Statement { sql }
+            }
+            ffi::SQLITE_TRACE_PROFILE => {
+                // p = sqlite3_stmt*, x = int64* (nanoseconds)
+                let stmt_ptr = p as *mut ffi::sqlite3_stmt;
+                // Get the expanded SQL from the statement
+                let sql = if stmt_ptr.is_null() {
+                    ""
+                } else {
+                    let sql_ptr = unsafe { ffi::sqlite3_sql(stmt_ptr) };
+                    if sql_ptr.is_null() {
+                        ""
+                    } else {
+                        match unsafe { CStr::from_ptr(sql_ptr) }.to_str() {
+                            Ok(s) => s,
+                            Err(_) => {
+                                assert_fail!("sqlite3_trace_v2 PROFILE delivered invalid UTF-8. ");
+                            }
+                        }
+                    }
+                };
+
+                let duration_ns = if x.is_null() {
+                    0
+                } else {
+                    // x is a pointer to sqlite3_int64 (i64)
+                    unsafe { *(x as *const ffi::sqlite3_int64) as u64 }
+                };
+
+                SqliteTraceEvent::Profile { sql, duration_ns }
+            }
+            ffi::SQLITE_TRACE_ROW => SqliteTraceEvent::Row,
+            ffi::SQLITE_TRACE_CLOSE => SqliteTraceEvent::Close,
+            _ => {
+                // Unknown trace event - ignore
+                return;
+            }
+        };
+
+        f(event);
+    }));
+
+    if result.is_err() {
+        assert_fail!("Panic in sqlite3_trace_v2 trampoline. ");
+    }
+
+    0 // Return value is currently unused by SQLite
+}
+
 impl Drop for RawConnection {
     fn drop(&mut self) {
         use crate::util::std_compat::panicking;
 
         self.unregister_raw_update_hook();
 
-        // Unregister commit/rollback hooks before closing so the
-        // Box'd closures are not dangling during sqlite3_close.
+        // Unregister all hooks before closing so the Box'd closures are not
+        // dangling during sqlite3_close.
         unsafe {
             ffi::sqlite3_commit_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
             ffi::sqlite3_rollback_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
             ffi::sqlite3_wal_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+            ffi::sqlite3_progress_handler(
+                self.internal_connection.as_ptr(),
+                0,
+                None,
+                ptr::null_mut(),
+            );
+            ffi::sqlite3_busy_handler(self.internal_connection.as_ptr(), None, ptr::null_mut());
+            ffi::sqlite3_set_authorizer(self.internal_connection.as_ptr(), None, ptr::null_mut());
+            ffi::sqlite3_trace_v2(self.internal_connection.as_ptr(), 0, None, ptr::null_mut());
         }
         // The Option<Box<dyn Any>> fields drop automatically after this.
 
@@ -690,6 +1031,10 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
             commit_hook: None,
             rollback_hook: None,
             wal_hook: None,
+            progress_hook: None,
+            busy_handler: None,
+            authorizer_hook: None,
+            trace_hook: None,
         }),
         None => {
             unsafe { context_error_str(ctx, NULL_CONN_ERR) };
@@ -1182,5 +1527,244 @@ mod tests {
         conn.exec("INSERT INTO t VALUES (1)").unwrap();
         drop(conn);
         // If we get here, drop succeeded without panic.
+    }
+
+    // ===================================================================
+    // Progress handler tests
+    // ===================================================================
+
+    #[test]
+    fn progress_handler_can_interrupt() {
+        let mut conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        // Insert many rows to make a long-running query
+        for i in 0..1000 {
+            conn.exec(&alloc::format!("INSERT INTO t VALUES ({})", i))
+                .unwrap();
+        }
+
+        let call_count = Arc::new(Mutex::new(0u32));
+        let cc = call_count.clone();
+
+        // Set a progress handler that interrupts after 10 callbacks
+        conn.set_progress_handler(1, move || {
+            let mut c = cc.lock().unwrap();
+            *c += 1;
+            *c > 10 // interrupt after 10 calls
+        });
+
+        // This query should be interrupted
+        let result = conn.exec("SELECT * FROM t WHERE id > 0");
+        assert!(result.is_err());
+
+        // The handler should have been called multiple times
+        assert!(*call_count.lock().unwrap() > 0);
+
+        conn.remove_progress_handler();
+    }
+
+    #[test]
+    fn progress_handler_remove_stops_calls() {
+        let mut conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let called = Arc::new(Mutex::new(false));
+        let c2 = called.clone();
+
+        conn.set_progress_handler(1, move || {
+            *c2.lock().unwrap() = true;
+            false // don't interrupt
+        });
+
+        conn.remove_progress_handler();
+
+        // This should not trigger the handler
+        conn.exec("SELECT 1").unwrap();
+
+        // In practice, for a simple query the handler may not fire even if set,
+        // but after removal it definitely should not fire.
+    }
+
+    // ===================================================================
+    // Busy handler tests
+    // ===================================================================
+
+    #[test]
+    fn busy_handler_receives_retry_count() {
+        // This test is tricky to set up without concurrent connections,
+        // so we just verify the handler can be set and removed without panics.
+        let mut conn = test_connection();
+
+        let retry_counts = Arc::new(Mutex::new(Vec::new()));
+        let rc = retry_counts.clone();
+
+        conn.set_busy_handler(move |count| {
+            rc.lock().unwrap().push(count);
+            false // don't retry
+        });
+
+        // No lock contention in :memory: with single connection,
+        // so the handler won't actually fire, but setup should work.
+        conn.exec("SELECT 1").unwrap();
+
+        conn.remove_busy_handler();
+    }
+
+    #[test]
+    fn busy_timeout_can_be_set() {
+        let conn = test_connection();
+        // Just verify it doesn't panic
+        conn.set_busy_timeout(5000);
+        conn.exec("SELECT 1").unwrap();
+    }
+
+    // ===================================================================
+    // Authorizer tests
+    // ===================================================================
+
+    #[test]
+    fn authorizer_can_deny_operations() {
+        use super::super::authorizer::{AuthorizerAction, AuthorizerDecision};
+
+        let mut conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.exec("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+        // Set an authorizer that denies DELETE
+        conn.set_authorizer(|ctx| {
+            if matches!(ctx.action, AuthorizerAction::Delete) {
+                AuthorizerDecision::Deny
+            } else {
+                AuthorizerDecision::Allow
+            }
+        });
+
+        // This DELETE should fail due to authorization
+        let result = conn.exec("DELETE FROM t WHERE id = 1");
+        assert!(result.is_err());
+
+        // This SELECT should still work
+        conn.exec("SELECT * FROM t").unwrap();
+
+        conn.remove_authorizer();
+
+        // Now DELETE should work
+        conn.exec("DELETE FROM t WHERE id = 1").unwrap();
+    }
+
+    #[test]
+    fn authorizer_ignore_returns_null_for_read() {
+        use super::super::authorizer::{AuthorizerAction, AuthorizerDecision};
+
+        let mut conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, secret TEXT)")
+            .unwrap();
+        conn.exec("INSERT INTO t VALUES (1, 'password123')")
+            .unwrap();
+
+        // Set an authorizer that ignores reads on 'secret' column
+        conn.set_authorizer(|ctx| {
+            if matches!(ctx.action, AuthorizerAction::Read) && ctx.arg2 == Some("secret") {
+                AuthorizerDecision::Ignore
+            } else {
+                AuthorizerDecision::Allow
+            }
+        });
+
+        // Query should succeed but 'secret' column should be NULL
+        // (We can't easily verify the NULL value here without diesel query,
+        // but the query should not fail)
+        conn.exec("SELECT id, secret FROM t").unwrap();
+
+        conn.remove_authorizer();
+    }
+
+    // ===================================================================
+    // Trace tests
+    // ===================================================================
+
+    #[test]
+    fn trace_stmt_fires_on_query() {
+        use super::super::trace::SqliteTraceFlags;
+
+        let mut conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let statements = Arc::new(Mutex::new(Vec::new()));
+        let s2 = statements.clone();
+
+        conn.set_trace(SqliteTraceFlags::STMT, move |event| {
+            if let super::super::trace::SqliteTraceEvent::Statement { sql } = event {
+                s2.lock().unwrap().push(sql.to_owned());
+            }
+        });
+
+        conn.exec("INSERT INTO t VALUES (1)").unwrap();
+        conn.exec("SELECT * FROM t").unwrap();
+
+        let stmts = statements.lock().unwrap();
+        assert!(stmts.len() >= 2);
+        assert!(stmts.iter().any(|s| s.contains("INSERT")));
+        assert!(stmts.iter().any(|s| s.contains("SELECT")));
+
+        conn.remove_trace();
+    }
+
+    #[test]
+    fn trace_profile_reports_duration() {
+        use super::super::trace::{SqliteTraceEvent, SqliteTraceFlags};
+
+        let mut conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let profiles = Arc::new(Mutex::new(Vec::new()));
+        let p2 = profiles.clone();
+
+        conn.set_trace(SqliteTraceFlags::PROFILE, move |event| {
+            if let SqliteTraceEvent::Profile { sql, duration_ns } = event {
+                p2.lock().unwrap().push((sql.to_owned(), duration_ns));
+            }
+        });
+
+        conn.exec("INSERT INTO t VALUES (1)").unwrap();
+
+        let profs = profiles.lock().unwrap();
+        assert!(!profs.is_empty());
+        // Duration should be positive (though very small for simple queries)
+        // Note: duration might be 0 for very fast queries on some systems
+
+        conn.remove_trace();
+    }
+
+    #[test]
+    fn trace_remove_stops_callbacks() {
+        use super::super::trace::SqliteTraceFlags;
+
+        let mut conn = test_connection();
+
+        let called = Arc::new(Mutex::new(0u32));
+        let c2 = called.clone();
+
+        conn.set_trace(SqliteTraceFlags::STMT, move |_| {
+            *c2.lock().unwrap() += 1;
+        });
+
+        conn.exec("SELECT 1").unwrap();
+        let count_before = *called.lock().unwrap();
+        assert!(count_before > 0);
+
+        conn.remove_trace();
+
+        conn.exec("SELECT 2").unwrap();
+        let count_after = *called.lock().unwrap();
+
+        // Should not have increased after removal
+        assert_eq!(count_before, count_after);
     }
 }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -427,7 +427,7 @@ impl RawConnection {
         }
     }
 
-    /// Sets a commit hook. Only one can be active at a time; the previous
+    /// Sets a commit hook. Only one can be active at a time. The previous
     /// hook (if any) is replaced.
     ///
     /// The callback returns `true` to convert the commit into a rollback,

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -83,7 +83,7 @@ pub(super) struct RawConnection {
 }
 
 impl RawConnection {
-    fn from_ptr(conn: NonNull<ffi::sqlite3>) -> Self {
+    pub(super) fn from_ptr(conn: NonNull<ffi::sqlite3>) -> Self {
         RawConnection {
             internal_connection: conn,
             change_hooks: OnceCell::new(),

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -867,12 +867,19 @@ unsafe extern "C" fn trace_trampoline<F>(
 where
     F: FnMut(SqliteTraceEvent<'_>),
 {
+    // Define constants to avoid cast_sign_loss warnings in match guards.
+    // These are compile-time constants so the conversion is verified at build time.
+    const TRACE_STMT: libc::c_uint = ffi::SQLITE_TRACE_STMT as libc::c_uint;
+    const TRACE_PROFILE: libc::c_uint = ffi::SQLITE_TRACE_PROFILE as libc::c_uint;
+    const TRACE_ROW: libc::c_uint = ffi::SQLITE_TRACE_ROW as libc::c_uint;
+    const TRACE_CLOSE: libc::c_uint = ffi::SQLITE_TRACE_CLOSE as libc::c_uint;
+
     let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
         // SAFETY: `user_data` points to a live `F` in `RawConnection::trace_hook`.
         let f = unsafe { &mut *(user_data as *mut F) };
 
         let event = match event_code {
-            ffi::SQLITE_TRACE_STMT => {
+            TRACE_STMT => {
                 // p = sqlite3_stmt*, x = const char* (unexpanded SQL)
                 let stmt_ptr = p as *mut ffi::sqlite3_stmt;
                 let sql_ptr = x as *const libc::c_char;
@@ -892,7 +899,7 @@ where
                 };
                 SqliteTraceEvent::Statement { sql, readonly }
             }
-            ffi::SQLITE_TRACE_PROFILE => {
+            TRACE_PROFILE => {
                 // p = sqlite3_stmt*, x = int64* (nanoseconds)
                 let stmt_ptr = p as *mut ffi::sqlite3_stmt;
                 // Get the SQL and readonly status from the statement
@@ -927,8 +934,8 @@ where
                     readonly,
                 }
             }
-            ffi::SQLITE_TRACE_ROW => SqliteTraceEvent::Row,
-            ffi::SQLITE_TRACE_CLOSE => SqliteTraceEvent::Close,
+            TRACE_ROW => SqliteTraceEvent::Row,
+            TRACE_CLOSE => SqliteTraceEvent::Close,
             _ => {
                 // Unknown trace event - ignore
                 return;

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -5,28 +5,28 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::ffi::{CString, NulError};
+use alloc::string::{String, ToString};
 use core::any::Any;
 use core::cell::{Cell, RefCell};
-
-use super::update_hook::{ChangeHookDispatcher, SqliteChangeEvent, SqliteChangeOp};
+use core::ffi as libc;
+use core::ffi::CStr;
+use core::ptr::NonNull;
+use core::{mem, ptr, slice, str};
 
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
 use super::stmt::ensure_sqlite_ok;
+use super::update_hook::{ChangeHookDispatcher, SqliteChangeEvent, SqliteChangeOp};
 use super::{Sqlite, SqliteAggregateFunction};
 use crate::deserialize::FromSqlRow;
 use crate::result::Error::DatabaseError;
 use crate::result::*;
 use crate::serialize::ToSql;
 use crate::sql_types::HasSqlType;
-use alloc::borrow::ToOwned;
-use alloc::boxed::Box;
-use alloc::ffi::{CString, NulError};
-use alloc::string::{String, ToString};
-use core::ffi as libc;
-use core::ptr::NonNull;
-use core::{mem, ptr, slice, str};
 
 /// For use in FFI function, which cannot unwind.
 /// Print the message, ask to open an issue at Github and [`abort`](std::process::abort).
@@ -490,9 +490,7 @@ unsafe extern "C" fn update_hook_trampoline(
     table_name: *const libc::c_char,
     rowid: ffi::sqlite3_int64,
 ) {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
-
-    let result = catch_unwind(AssertUnwindSafe(|| {
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
         let hooks = &*(user_data as *const RefCell<ChangeHookDispatcher>);
 
         let db_name = CStr::from_ptr(db_name).to_str().unwrap_or_else(|_| {
@@ -526,9 +524,7 @@ unsafe extern "C" fn commit_hook_trampoline<F>(user_data: *mut libc::c_void) -> 
 where
     F: FnMut() -> bool,
 {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
-
-    let result = catch_unwind(AssertUnwindSafe(|| {
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
         let f = &mut *(user_data as *mut F);
         f()
     }));
@@ -551,9 +547,7 @@ unsafe extern "C" fn rollback_hook_trampoline<F>(user_data: *mut libc::c_void)
 where
     F: FnMut(),
 {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
-
-    let result = catch_unwind(AssertUnwindSafe(|| {
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
         let f = &mut *(user_data as *mut F);
         f();
     }));
@@ -577,13 +571,16 @@ unsafe extern "C" fn wal_hook_trampoline<F>(
 where
     F: FnMut(&str, i32),
 {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
-
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        let f = &mut *(user_data as *mut F);
-        let db_name_str = CStr::from_ptr(db_name).to_str().unwrap_or_else(|_| {
-            assert_fail!("sqlite3_wal_hook delivered invalid UTF-8 for db_name. ");
-        });
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` is a valid pointer to `F` stored in
+        // `RawConnection::wal_hook`, guaranteed by the caller contract.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        // SAFETY: `db_name` is a valid C string provided by SQLite.
+        let db_name_str = unsafe { CStr::from_ptr(db_name) }
+            .to_str()
+            .unwrap_or_else(|_| {
+                assert_fail!("sqlite3_wal_hook delivered invalid UTF-8 for db_name. ");
+            });
         f(db_name_str, n_pages);
     }));
 

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -555,13 +555,11 @@ impl RawConnection {
     ///
     /// SQLite will sleep and retry until `ms` milliseconds have elapsed.
     /// Setting this clears any custom busy handler.
-    pub(super) fn set_busy_timeout(&self, ms: i32) {
+    pub(super) fn set_busy_timeout(&mut self, ms: i32) {
         unsafe {
             ffi::sqlite3_busy_timeout(self.internal_connection.as_ptr(), ms);
         }
-        // Note: We don't clear busy_handler here because SQLite handles that
-        // internally. The old handler (if any) becomes inactive but the Box
-        // will be dropped on the next set_busy_handler or connection close.
+        self.busy_handler = None;
     }
 
     /// Sets an authorizer callback. Only one can be active at a time.
@@ -815,7 +813,10 @@ unsafe extern "C" fn authorizer_trampoline<F>(
 where
     F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision,
 {
-    // Helper to convert a nullable C string to Option<&str>
+    // Helper to convert a nullable C string to Option<&str>.
+    // SAFETY: 'static is used because this local function cannot name the
+    // callback's stack lifetime. The returned references are immediately
+    // placed into AuthorizerContext<'a> which cannot escape this invocation.
     fn c_str_to_option(ptr: *const libc::c_char) -> Option<&'static str> {
         if ptr.is_null() {
             None
@@ -1634,7 +1635,7 @@ mod tests {
 
     #[test]
     fn busy_timeout_can_be_set() {
-        let conn = test_connection();
+        let mut conn = test_connection();
         // Just verify it doesn't panic
         conn.set_busy_timeout(5000);
         conn.exec("SELECT 1").unwrap();

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -874,6 +874,7 @@ where
         let event = match event_code {
             ffi::SQLITE_TRACE_STMT => {
                 // p = sqlite3_stmt*, x = const char* (unexpanded SQL)
+                let stmt_ptr = p as *mut ffi::sqlite3_stmt;
                 let sql_ptr = x as *const libc::c_char;
                 if sql_ptr.is_null() {
                     return;
@@ -884,17 +885,22 @@ where
                         assert_fail!("sqlite3_trace_v2 STMT delivered invalid UTF-8. ");
                     }
                 };
-                SqliteTraceEvent::Statement { sql }
+                let readonly = if stmt_ptr.is_null() {
+                    false
+                } else {
+                    unsafe { ffi::sqlite3_stmt_readonly(stmt_ptr) != 0 }
+                };
+                SqliteTraceEvent::Statement { sql, readonly }
             }
             ffi::SQLITE_TRACE_PROFILE => {
                 // p = sqlite3_stmt*, x = int64* (nanoseconds)
                 let stmt_ptr = p as *mut ffi::sqlite3_stmt;
-                // Get the expanded SQL from the statement
-                let sql = if stmt_ptr.is_null() {
-                    ""
+                // Get the SQL and readonly status from the statement
+                let (sql, readonly) = if stmt_ptr.is_null() {
+                    ("", false)
                 } else {
                     let sql_ptr = unsafe { ffi::sqlite3_sql(stmt_ptr) };
-                    if sql_ptr.is_null() {
+                    let sql = if sql_ptr.is_null() {
                         ""
                     } else {
                         match unsafe { CStr::from_ptr(sql_ptr) }.to_str() {
@@ -903,17 +909,23 @@ where
                                 assert_fail!("sqlite3_trace_v2 PROFILE delivered invalid UTF-8. ");
                             }
                         }
-                    }
+                    };
+                    let readonly = unsafe { ffi::sqlite3_stmt_readonly(stmt_ptr) != 0 };
+                    (sql, readonly)
                 };
 
                 let duration_ns = if x.is_null() {
                     0
                 } else {
-                    // x is a pointer to sqlite3_int64 (i64)
-                    unsafe { *(x as *const ffi::sqlite3_int64) as u64 }
+                    // x is a pointer to sqlite3_int64 (i64), but duration is always non-negative
+                    unsafe { (*(x as *const ffi::sqlite3_int64)).cast_unsigned() }
                 };
 
-                SqliteTraceEvent::Profile { sql, duration_ns }
+                SqliteTraceEvent::Profile {
+                    sql,
+                    duration_ns,
+                    readonly,
+                }
             }
             ffi::SQLITE_TRACE_ROW => SqliteTraceEvent::Row,
             ffi::SQLITE_TRACE_CLOSE => SqliteTraceEvent::Close,
@@ -1699,7 +1711,7 @@ mod tests {
         let s2 = statements.clone();
 
         conn.set_trace(SqliteTraceFlags::STMT, move |event| {
-            if let super::super::trace::SqliteTraceEvent::Statement { sql } = event {
+            if let super::super::trace::SqliteTraceEvent::Statement { sql, .. } = event {
                 s2.lock().unwrap().push(sql.to_owned());
             }
         });
@@ -1727,7 +1739,10 @@ mod tests {
         let p2 = profiles.clone();
 
         conn.set_trace(SqliteTraceFlags::PROFILE, move |event| {
-            if let SqliteTraceEvent::Profile { sql, duration_ns } = event {
+            if let SqliteTraceEvent::Profile {
+                sql, duration_ns, ..
+            } = event
+            {
                 p2.lock().unwrap().push((sql.to_owned(), duration_ns));
             }
         });

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -491,12 +491,16 @@ unsafe extern "C" fn update_hook_trampoline(
     rowid: ffi::sqlite3_int64,
 ) {
     let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
-        let hooks = &*(user_data as *const RefCell<ChangeHookDispatcher>);
+        // SAFETY: `user_data` points to the `RefCell<ChangeHookDispatcher>` field
+        // of `RawConnection`, guaranteed by the caller contract.
+        let hooks = unsafe { &*(user_data as *const RefCell<ChangeHookDispatcher>) };
 
-        let db_name = CStr::from_ptr(db_name).to_str().unwrap_or_else(|_| {
+        // SAFETY: `db_name` is a valid C string provided by SQLite.
+        let db_name = unsafe { CStr::from_ptr(db_name) }.to_str().unwrap_or_else(|_| {
             assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for db_name. ");
         });
-        let table_name = CStr::from_ptr(table_name).to_str().unwrap_or_else(|_| {
+        // SAFETY: `table_name` is a valid C string provided by SQLite.
+        let table_name = unsafe { CStr::from_ptr(table_name) }.to_str().unwrap_or_else(|_| {
             assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for table_name. ");
         });
 
@@ -525,7 +529,8 @@ where
     F: FnMut() -> bool,
 {
     let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
-        let f = &mut *(user_data as *mut F);
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::commit_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
         f()
     }));
 
@@ -548,7 +553,8 @@ where
     F: FnMut(),
 {
     let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
-        let f = &mut *(user_data as *mut F);
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::rollback_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
         f();
     }));
 

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -51,7 +51,16 @@ pub(super) struct RawConnection {
     /// dispatches events directly to registered hooks during sqlite3_step().
     /// Uses RefCell because the C callback needs mutable access while the
     /// connection may be immutably borrowed.
-    pub(super) change_hooks: RefCell<ChangeHookDispatcher>,
+    ///
+    /// Boxed so the address handed to sqlite3_update_hook stays valid even if
+    /// the owning SqliteConnection is moved: a move relocates this `Box`
+    /// pointer but not the heap allocation it points at. The other hooks in
+    /// this struct (commit_hook, etc.) rely on the same property. INVARIANT:
+    /// once the address is registered (see register_raw_update_hook), nothing
+    /// may move out of or replace this Box for the lifetime of the
+    /// registration. The code never reassigns it, so a plain Box suffices and
+    /// Pin is not required.
+    pub(super) change_hooks: Box<RefCell<ChangeHookDispatcher>>,
     /// Tracks whether the C-level update hook is currently installed, to
     /// avoid redundant FFI calls.
     update_hook_registered: Cell<bool>,
@@ -76,7 +85,7 @@ impl RawConnection {
     fn from_ptr(conn: NonNull<ffi::sqlite3>) -> Self {
         RawConnection {
             internal_connection: conn,
-            change_hooks: RefCell::new(ChangeHookDispatcher::new()),
+            change_hooks: Box::new(RefCell::new(ChangeHookDispatcher::new())),
             update_hook_registered: Cell::new(false),
             commit_hook: None,
             rollback_hook: None,
@@ -391,11 +400,21 @@ impl RawConnection {
                 ffi::sqlite3_update_hook(
                     self.internal_connection.as_ptr(),
                     Some(update_hook_trampoline),
-                    &self.change_hooks as *const RefCell<ChangeHookDispatcher> as *mut libc::c_void,
+                    self.change_hooks_ptr() as *mut libc::c_void,
                 );
             }
             self.update_hook_registered.set(true);
         }
+    }
+
+    /// Returns the address of the `RefCell<ChangeHookDispatcher>` that is
+    /// handed to `sqlite3_update_hook` as user data. This is the single source
+    /// of truth for that pointer: `register_raw_update_hook` registers exactly
+    /// this address, and tests assert it stays stable across connection moves.
+    pub(super) fn change_hooks_ptr(&self) -> *const RefCell<ChangeHookDispatcher> {
+        // Deref the Box to the heap-stored RefCell, whose address is stable
+        // across moves of RawConnection / SqliteConnection.
+        &*self.change_hooks as *const RefCell<ChangeHookDispatcher>
     }
 
     /// Unregisters the C-level `sqlite3_update_hook`.

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -1702,6 +1702,57 @@ mod tests {
         conn.remove_authorizer();
     }
 
+    #[test]
+    fn is_schema_modifying_blocks_create_allows_dml() {
+        use super::super::authorizer::AuthorizerDecision;
+
+        let mut conn = test_connection();
+
+        // First create a table without the authorizer
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.exec("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+        // Set an authorizer that denies schema-modifying operations
+        conn.set_authorizer(|ctx| {
+            if ctx.action.is_schema_modifying() {
+                AuthorizerDecision::Deny
+            } else {
+                AuthorizerDecision::Allow
+            }
+        });
+
+        // CREATE TABLE should fail
+        let result = conn.exec("CREATE TABLE t2 (id INTEGER PRIMARY KEY)");
+        assert!(result.is_err());
+
+        // CREATE INDEX should fail
+        let result = conn.exec("CREATE INDEX idx_v ON t(v)");
+        assert!(result.is_err());
+
+        // DROP TABLE should fail
+        let result = conn.exec("DROP TABLE t");
+        assert!(result.is_err());
+
+        // SELECT should work
+        conn.exec("SELECT * FROM t").unwrap();
+
+        // INSERT should work
+        conn.exec("INSERT INTO t VALUES (2, 'b')").unwrap();
+
+        // UPDATE should work
+        conn.exec("UPDATE t SET v = 'c' WHERE id = 1").unwrap();
+
+        // DELETE should work
+        conn.exec("DELETE FROM t WHERE id = 2").unwrap();
+
+        conn.remove_authorizer();
+
+        // After removing authorizer, CREATE TABLE should work
+        conn.exec("CREATE TABLE t2 (id INTEGER PRIMARY KEY)")
+            .unwrap();
+    }
+
     // ===================================================================
     // Trace tests
     // ===================================================================

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -496,13 +496,17 @@ unsafe extern "C" fn update_hook_trampoline(
         let hooks = unsafe { &*(user_data as *const RefCell<ChangeHookDispatcher>) };
 
         // SAFETY: `db_name` is a valid C string provided by SQLite.
-        let db_name = unsafe { CStr::from_ptr(db_name) }.to_str().unwrap_or_else(|_| {
-            assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for db_name. ");
-        });
+        let db_name = unsafe { CStr::from_ptr(db_name) }
+            .to_str()
+            .unwrap_or_else(|_| {
+                assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for db_name. ");
+            });
         // SAFETY: `table_name` is a valid C string provided by SQLite.
-        let table_name = unsafe { CStr::from_ptr(table_name) }.to_str().unwrap_or_else(|_| {
-            assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for table_name. ");
-        });
+        let table_name = unsafe { CStr::from_ptr(table_name) }
+            .to_str()
+            .unwrap_or_else(|_| {
+                assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for table_name. ");
+            });
 
         let event = SqliteChangeEvent {
             op: SqliteChangeOp::from_ffi(op),

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -10,7 +10,7 @@ use alloc::boxed::Box;
 use alloc::ffi::{CString, NulError};
 use alloc::string::{String, ToString};
 use core::any::Any;
-use core::cell::{Cell, RefCell};
+use core::cell::{Cell, OnceCell, RefCell};
 use core::ffi as libc;
 use core::ffi::CStr;
 use core::ptr::NonNull;
@@ -52,15 +52,16 @@ pub(super) struct RawConnection {
     /// Uses RefCell because the C callback needs mutable access while the
     /// connection may be immutably borrowed.
     ///
-    /// Boxed so the address handed to sqlite3_update_hook stays valid even if
-    /// the owning SqliteConnection is moved: a move relocates this `Box`
-    /// pointer but not the heap allocation it points at. The other hooks in
-    /// this struct (commit_hook, etc.) rely on the same property. INVARIANT:
-    /// once the address is registered (see register_raw_update_hook), nothing
-    /// may move out of or replace this Box for the lifetime of the
-    /// registration. The code never reassigns it, so a plain Box suffices and
-    /// Pin is not required.
-    pub(super) change_hooks: Box<RefCell<ChangeHookDispatcher>>,
+    /// Allocated lazily on first use (see `dispatcher`) and boxed, so that the
+    /// address handed to sqlite3_update_hook stays valid even if the owning
+    /// SqliteConnection is moved: a move relocates this `OnceCell` and the
+    /// `Box` pointer inside it, but not the heap allocation the box points at.
+    /// The lazy allocation matters because `from_ptr` is also used to build a
+    /// short-lived borrowed wrapper inside `run_custom_function` (kept in a
+    /// `ManuallyDrop`, so `Drop` never runs). Eagerly allocating here would
+    /// leak that box on every SQL-function call. INVARIANT: the box is created
+    /// at most once and never reassigned, so the registered address is stable.
+    pub(super) change_hooks: OnceCell<Box<RefCell<ChangeHookDispatcher>>>,
     /// Tracks whether the C-level update hook is currently installed, to
     /// avoid redundant FFI calls.
     update_hook_registered: Cell<bool>,
@@ -85,7 +86,7 @@ impl RawConnection {
     fn from_ptr(conn: NonNull<ffi::sqlite3>) -> Self {
         RawConnection {
             internal_connection: conn,
-            change_hooks: Box::new(RefCell::new(ChangeHookDispatcher::new())),
+            change_hooks: OnceCell::new(),
             update_hook_registered: Cell::new(false),
             commit_hook: None,
             rollback_hook: None,
@@ -407,14 +408,23 @@ impl RawConnection {
         }
     }
 
+    /// Returns the change-hook dispatcher, allocating it on first use.
+    ///
+    /// The dispatcher lives behind a `Box` whose heap address never changes
+    /// once created, so it is safe to hand to `sqlite3_update_hook`. Borrowed
+    /// wrappers that never register a hook (see `run_custom_function`) never
+    /// allocate it, which avoids leaking the box when their `Drop` is skipped.
+    pub(super) fn dispatcher(&self) -> &RefCell<ChangeHookDispatcher> {
+        self.change_hooks
+            .get_or_init(|| Box::new(RefCell::new(ChangeHookDispatcher::new())))
+    }
+
     /// Returns the address of the `RefCell<ChangeHookDispatcher>` that is
     /// handed to `sqlite3_update_hook` as user data. This is the single source
     /// of truth for that pointer: `register_raw_update_hook` registers exactly
     /// this address, and tests assert it stays stable across connection moves.
     pub(super) fn change_hooks_ptr(&self) -> *const RefCell<ChangeHookDispatcher> {
-        // Deref the Box to the heap-stored RefCell, whose address is stable
-        // across moves of RawConnection / SqliteConnection.
-        &*self.change_hooks as *const RefCell<ChangeHookDispatcher>
+        self.dispatcher() as *const RefCell<ChangeHookDispatcher>
     }
 
     /// Unregisters the C-level `sqlite3_update_hook`.
@@ -1386,7 +1396,7 @@ mod tests {
         let fired = Arc::new(Mutex::new(Vec::new()));
         let f2 = fired.clone();
 
-        conn.change_hooks.borrow_mut().add(
+        conn.dispatcher().borrow_mut().add(
             Some("t"),
             SqliteChangeOps::INSERT,
             Box::new(move |e| {
@@ -1412,7 +1422,7 @@ mod tests {
         let fired = Arc::new(Mutex::new(Vec::new()));
         let f2 = fired.clone();
 
-        conn.change_hooks.borrow_mut().add(
+        conn.dispatcher().borrow_mut().add(
             Some("t"),
             SqliteChangeOps::INSERT,
             Box::new(move |e| {
@@ -1440,7 +1450,7 @@ mod tests {
         let fired = Arc::new(Mutex::new(Vec::new()));
         let f2 = fired.clone();
 
-        conn.change_hooks.borrow_mut().add(
+        conn.dispatcher().borrow_mut().add(
             Some("t"),
             SqliteChangeOps::ALL,
             Box::new(move |e| {
@@ -1467,7 +1477,7 @@ mod tests {
         let fired = Arc::new(Mutex::new(Vec::new()));
         let f2 = fired.clone();
 
-        conn.change_hooks.borrow_mut().add(
+        conn.dispatcher().borrow_mut().add(
             Some("t"),
             SqliteChangeOps::ALL,
             Box::new(move |e| {
@@ -1493,7 +1503,7 @@ mod tests {
         let fired = Arc::new(Mutex::new(Vec::new()));
         let f2 = fired.clone();
 
-        conn.change_hooks.borrow_mut().add(
+        conn.dispatcher().borrow_mut().add(
             Some("t"),
             SqliteChangeOps::INSERT,
             Box::new(move |e| {
@@ -1519,7 +1529,7 @@ mod tests {
         let fired = Arc::new(Mutex::new(Vec::new()));
         let f2 = fired.clone();
 
-        conn.change_hooks.borrow_mut().add(
+        conn.dispatcher().borrow_mut().add(
             Some("t"),
             SqliteChangeOps::INSERT,
             Box::new(move |e| {
@@ -1548,7 +1558,7 @@ mod tests {
         conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
             .unwrap();
 
-        conn.change_hooks
+        conn.dispatcher()
             .borrow_mut()
             .add(Some("t"), SqliteChangeOps::INSERT, Box::new(|_| {}));
 

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -5,6 +5,11 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+use core::any::Any;
+use core::cell::{Cell, RefCell};
+
+use super::update_hook::{ChangeHookDispatcher, SqliteChangeEvent, SqliteChangeOp};
+
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
@@ -40,6 +45,21 @@ macro_rules! assert_fail {
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub(super) struct RawConnection {
     pub(super) internal_connection: NonNull<ffi::sqlite3>,
+    /// Hook dispatcher for sqlite3_update_hook callbacks. The C trampoline
+    /// dispatches events directly to registered hooks during sqlite3_step().
+    /// Uses RefCell because the C callback needs mutable access while the
+    /// connection may be immutably borrowed.
+    pub(super) change_hooks: RefCell<ChangeHookDispatcher>,
+    /// Tracks whether the C-level update hook is currently installed, to
+    /// avoid redundant FFI calls.
+    update_hook_registered: Cell<bool>,
+    /// Boxed closure for the commit hook. Stored to keep the closure alive
+    /// for the duration of the hook registration. Type-erased via `dyn Any`.
+    commit_hook: Option<Box<dyn Any + Send>>,
+    /// Boxed closure for the rollback hook.
+    rollback_hook: Option<Box<dyn Any + Send>>,
+    /// Boxed closure for the WAL hook.
+    wal_hook: Option<Box<dyn Any + Send>>,
 }
 
 impl RawConnection {
@@ -61,6 +81,11 @@ impl RawConnection {
                 let conn_pointer = unsafe { NonNull::new_unchecked(conn_pointer) };
                 Ok(RawConnection {
                     internal_connection: conn_pointer,
+                    change_hooks: RefCell::new(ChangeHookDispatcher::new()),
+                    update_hook_registered: Cell::new(false),
+                    commit_hook: None,
+                    rollback_hook: None,
+                    wal_hook: None,
                 })
             }
             err_code => {
@@ -337,11 +362,252 @@ impl RawConnection {
             _pd: core::marker::PhantomData,
         })
     }
+    /// Registers the C-level `sqlite3_update_hook` if not already registered.
+    ///
+    /// The hook dispatches events directly to registered hooks in
+    /// `self.change_hooks` during `sqlite3_step()`.
+    /// This is a no-op if the hook is already installed.
+    pub(super) fn register_raw_update_hook(&self) {
+        if !self.update_hook_registered.get() {
+            unsafe {
+                ffi::sqlite3_update_hook(
+                    self.internal_connection.as_ptr(),
+                    Some(update_hook_trampoline),
+                    &self.change_hooks as *const RefCell<ChangeHookDispatcher> as *mut libc::c_void,
+                );
+            }
+            self.update_hook_registered.set(true);
+        }
+    }
+
+    /// Unregisters the C-level `sqlite3_update_hook`.
+    pub(super) fn unregister_raw_update_hook(&self) {
+        if self.update_hook_registered.get() {
+            unsafe {
+                ffi::sqlite3_update_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+            }
+            self.update_hook_registered.set(false);
+        }
+    }
+
+    /// Sets a commit hook. Only one can be active at a time; the previous
+    /// hook (if any) is replaced.
+    ///
+    /// The callback returns `true` to convert the commit into a rollback,
+    /// or `false` to allow the commit to proceed.
+    pub(super) fn set_commit_hook<F>(&mut self, hook: F)
+    where
+        F: FnMut() -> bool + Send + 'static,
+    {
+        let boxed: Box<F> = Box::new(hook);
+        let ptr = &*boxed as *const F as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_commit_hook(
+                self.internal_connection.as_ptr(),
+                Some(commit_hook_trampoline::<F>),
+                ptr,
+            );
+        }
+        // The old Box (if any) is dropped here after SQLite has already
+        // switched to the new callback, preventing use-after-free.
+        self.commit_hook = Some(boxed);
+    }
+
+    /// Removes the commit hook.
+    pub(super) fn remove_commit_hook(&mut self) {
+        unsafe {
+            ffi::sqlite3_commit_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.commit_hook = None;
+    }
+
+    /// Sets a rollback hook. Only one can be active at a time.
+    pub(super) fn set_rollback_hook<F>(&mut self, hook: F)
+    where
+        F: FnMut() + Send + 'static,
+    {
+        let boxed: Box<F> = Box::new(hook);
+        let ptr = &*boxed as *const F as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_rollback_hook(
+                self.internal_connection.as_ptr(),
+                Some(rollback_hook_trampoline::<F>),
+                ptr,
+            );
+        }
+        self.rollback_hook = Some(boxed);
+    }
+
+    /// Removes the rollback hook.
+    pub(super) fn remove_rollback_hook(&mut self) {
+        unsafe {
+            ffi::sqlite3_rollback_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.rollback_hook = None;
+    }
+
+    /// Sets a WAL hook. Only one can be active at a time.
+    ///
+    /// The callback receives the database name (e.g. `"main"`) and the
+    /// number of pages currently in the WAL file.
+    pub(super) fn set_wal_hook<F>(&mut self, hook: F)
+    where
+        F: FnMut(&str, i32) + Send + 'static,
+    {
+        let boxed: Box<F> = Box::new(hook);
+        let ptr = &*boxed as *const F as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_wal_hook(
+                self.internal_connection.as_ptr(),
+                Some(wal_hook_trampoline::<F>),
+                ptr,
+            );
+        }
+        self.wal_hook = Some(boxed);
+    }
+
+    /// Removes the WAL hook.
+    pub(super) fn remove_wal_hook(&mut self) {
+        unsafe {
+            ffi::sqlite3_wal_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.wal_hook = None;
+    }
+}
+
+/// C trampoline for `sqlite3_update_hook`.
+///
+/// # Safety
+///
+/// `user_data` must be a valid pointer to `RefCell<ChangeHookDispatcher>`
+/// that outlives the hook registration. This is guaranteed because the
+/// `RefCell` is a field of `RawConnection` and the hook is unregistered
+/// before the connection is dropped.
+unsafe extern "C" fn update_hook_trampoline(
+    user_data: *mut libc::c_void,
+    op: libc::c_int,
+    db_name: *const libc::c_char,
+    table_name: *const libc::c_char,
+    rowid: ffi::sqlite3_int64,
+) {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let hooks = &*(user_data as *const RefCell<ChangeHookDispatcher>);
+
+        let db_name = CStr::from_ptr(db_name).to_str().unwrap_or_else(|_| {
+            assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for db_name. ");
+        });
+        let table_name = CStr::from_ptr(table_name).to_str().unwrap_or_else(|_| {
+            assert_fail!("sqlite3_update_hook delivered invalid UTF-8 for table_name. ");
+        });
+
+        let event = SqliteChangeEvent {
+            op: SqliteChangeOp::from_ffi(op),
+            db_name,
+            table_name,
+            rowid,
+        };
+
+        hooks.borrow_mut().dispatch(event);
+    }));
+
+    if result.is_err() {
+        assert_fail!("Panic in sqlite3_update_hook trampoline. ");
+    }
+}
+
+/// C trampoline for `sqlite3_commit_hook`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::commit_hook`.
+unsafe extern "C" fn commit_hook_trampoline<F>(user_data: *mut libc::c_void) -> libc::c_int
+where
+    F: FnMut() -> bool,
+{
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let f = &mut *(user_data as *mut F);
+        f()
+    }));
+
+    match result {
+        Ok(true) => 1,  // convert commit to rollback
+        Ok(false) => 0, // proceed with commit
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_commit_hook trampoline. ");
+        }
+    }
+}
+
+/// C trampoline for `sqlite3_rollback_hook`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::rollback_hook`.
+unsafe extern "C" fn rollback_hook_trampoline<F>(user_data: *mut libc::c_void)
+where
+    F: FnMut(),
+{
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let f = &mut *(user_data as *mut F);
+        f();
+    }));
+
+    if result.is_err() {
+        assert_fail!("Panic in sqlite3_rollback_hook trampoline. ");
+    }
+}
+
+/// C trampoline for `sqlite3_wal_hook`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::wal_hook`.
+unsafe extern "C" fn wal_hook_trampoline<F>(
+    user_data: *mut libc::c_void,
+    _db: *mut ffi::sqlite3,
+    db_name: *const libc::c_char,
+    n_pages: libc::c_int,
+) -> libc::c_int
+where
+    F: FnMut(&str, i32),
+{
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let f = &mut *(user_data as *mut F);
+        let db_name_str = CStr::from_ptr(db_name).to_str().unwrap_or_else(|_| {
+            assert_fail!("sqlite3_wal_hook delivered invalid UTF-8 for db_name. ");
+        });
+        f(db_name_str, n_pages);
+    }));
+
+    if result.is_err() {
+        assert_fail!("Panic in sqlite3_wal_hook trampoline. ");
+    }
+
+    ffi::SQLITE_OK
 }
 
 impl Drop for RawConnection {
     fn drop(&mut self) {
         use crate::util::std_compat::panicking;
+
+        self.unregister_raw_update_hook();
+
+        // Unregister commit/rollback hooks before closing so the
+        // Box'd closures are not dangling during sqlite3_close.
+        unsafe {
+            ffi::sqlite3_commit_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+            ffi::sqlite3_rollback_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+            ffi::sqlite3_wal_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        // The Option<Box<dyn Any>> fields drop automatically after this.
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -412,6 +678,11 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
         // Drop impl of `RawConnection` as this would close the connection
         Some(conn) => mem::ManuallyDrop::new(RawConnection {
             internal_connection: conn,
+            change_hooks: RefCell::new(ChangeHookDispatcher::new()),
+            update_hook_registered: Cell::new(false),
+            commit_hook: None,
+            rollback_hook: None,
+            wal_hook: None,
         }),
         None => {
             unsafe { context_error_str(ctx, NULL_CONN_ERR) };
@@ -433,6 +704,10 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
     // We need this to move the reference into the catch_unwind part
     // this is sound as `F` itself and the stored string is `UnwindSafe`
     let callback = core::panic::AssertUnwindSafe(&mut data_ptr.callback);
+    // conn contains Box<dyn Any + Send> fields which are not UnwindSafe.
+    // This is safe because the ManuallyDrop wrapper ensures we never run
+    // the RawConnection Drop, and we only read through conn in the closure.
+    let conn = core::panic::AssertUnwindSafe(conn);
 
     let result = crate::util::std_compat::catch_unwind(move || {
         let _ = &callback;
@@ -709,4 +984,196 @@ where
 extern "C" fn destroy_boxed<F>(data: *mut libc::c_void) {
     let ptr = data as *mut F;
     unsafe { core::mem::drop(Box::from_raw(ptr)) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::update_hook::{SqliteChangeOp, SqliteChangeOps};
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    fn test_connection() -> RawConnection {
+        RawConnection::establish(":memory:").expect("failed to establish :memory: connection")
+    }
+
+    #[test]
+    fn insert_event_dispatched_directly() {
+        let conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        conn.change_hooks.borrow_mut().add(
+            Some("t"),
+            SqliteChangeOps::INSERT,
+            Box::new(move |e| {
+                f2.lock().unwrap().push((e.op, e.rowid));
+            }),
+        );
+
+        conn.register_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (1)").unwrap();
+
+        let events = fired.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, SqliteChangeOp::Insert);
+        assert_eq!(events[0].1, 1);
+    }
+
+    #[test]
+    fn consecutive_inserts_dispatch_immediately() {
+        let conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        conn.change_hooks.borrow_mut().add(
+            Some("t"),
+            SqliteChangeOps::INSERT,
+            Box::new(move |e| {
+                f2.lock().unwrap().push(e.rowid);
+            }),
+        );
+
+        conn.register_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (2); INSERT INTO t VALUES (3)")
+            .unwrap();
+
+        let events = fired.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], 2);
+        assert_eq!(events[1], 3);
+    }
+
+    #[test]
+    fn update_event() {
+        let conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.exec("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        conn.change_hooks.borrow_mut().add(
+            Some("t"),
+            SqliteChangeOps::ALL,
+            Box::new(move |e| {
+                f2.lock().unwrap().push((e.op, e.rowid));
+            }),
+        );
+
+        conn.register_raw_update_hook();
+        conn.exec("UPDATE t SET v = 'b' WHERE id = 1").unwrap();
+
+        let events = fired.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, SqliteChangeOp::Update);
+        assert_eq!(events[0].1, 1);
+    }
+
+    #[test]
+    fn delete_event() {
+        let conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        conn.exec("INSERT INTO t VALUES (1)").unwrap();
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        conn.change_hooks.borrow_mut().add(
+            Some("t"),
+            SqliteChangeOps::ALL,
+            Box::new(move |e| {
+                f2.lock().unwrap().push((e.op, e.rowid));
+            }),
+        );
+
+        conn.register_raw_update_hook();
+        conn.exec("DELETE FROM t WHERE id = 1").unwrap();
+
+        let events = fired.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, SqliteChangeOp::Delete);
+        assert_eq!(events[0].1, 1);
+    }
+
+    #[test]
+    fn unregister_stops_events() {
+        let conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        conn.change_hooks.borrow_mut().add(
+            Some("t"),
+            SqliteChangeOps::INSERT,
+            Box::new(move |e| {
+                f2.lock().unwrap().push(e.rowid);
+            }),
+        );
+
+        conn.register_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (1)").unwrap();
+        assert_eq!(fired.lock().unwrap().len(), 1);
+
+        conn.unregister_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (2)").unwrap();
+        assert_eq!(fired.lock().unwrap().len(), 1); // still 1
+    }
+
+    #[test]
+    fn re_register_after_unregister_resumes() {
+        let conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        conn.change_hooks.borrow_mut().add(
+            Some("t"),
+            SqliteChangeOps::INSERT,
+            Box::new(move |e| {
+                f2.lock().unwrap().push(e.rowid);
+            }),
+        );
+
+        conn.register_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (1)").unwrap();
+        assert_eq!(fired.lock().unwrap().len(), 1);
+
+        conn.unregister_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (2)").unwrap();
+        assert_eq!(fired.lock().unwrap().len(), 1);
+
+        conn.register_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (3)").unwrap();
+        let events = fired.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1], 3);
+    }
+
+    #[test]
+    fn drop_does_not_panic() {
+        let conn = test_connection();
+        conn.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        conn.change_hooks
+            .borrow_mut()
+            .add(Some("t"), SqliteChangeOps::INSERT, Box::new(|_| {}));
+
+        conn.register_raw_update_hook();
+        conn.exec("INSERT INTO t VALUES (1)").unwrap();
+        drop(conn);
+        // If we get here, drop succeeded without panic.
+    }
 }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -73,6 +73,21 @@ pub(super) struct RawConnection {
 }
 
 impl RawConnection {
+    fn from_ptr(conn: NonNull<ffi::sqlite3>) -> Self {
+        RawConnection {
+            internal_connection: conn,
+            change_hooks: RefCell::new(ChangeHookDispatcher::new()),
+            update_hook_registered: Cell::new(false),
+            commit_hook: None,
+            rollback_hook: None,
+            wal_hook: None,
+            progress_hook: None,
+            busy_handler: None,
+            authorizer_hook: None,
+            trace_hook: None,
+        }
+    }
+
     pub(super) fn establish(database_url: &str) -> ConnectionResult<Self> {
         let mut conn_pointer = ptr::null_mut();
 
@@ -89,18 +104,7 @@ impl RawConnection {
         match connection_status {
             ffi::SQLITE_OK => {
                 let conn_pointer = unsafe { NonNull::new_unchecked(conn_pointer) };
-                Ok(RawConnection {
-                    internal_connection: conn_pointer,
-                    change_hooks: RefCell::new(ChangeHookDispatcher::new()),
-                    update_hook_registered: Cell::new(false),
-                    commit_hook: None,
-                    rollback_hook: None,
-                    wal_hook: None,
-                    progress_hook: None,
-                    busy_handler: None,
-                    authorizer_hook: None,
-                    trace_hook: None,
-                })
+                Ok(RawConnection::from_ptr(conn_pointer))
             }
             err_code => {
                 let message = super::error_message(err_code);
@@ -413,8 +417,8 @@ impl RawConnection {
     where
         F: FnMut() -> bool + Send + 'static,
     {
-        let boxed: Box<F> = Box::new(hook);
-        let ptr = &*boxed as *const F as *mut libc::c_void;
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
         unsafe {
             ffi::sqlite3_commit_hook(
                 self.internal_connection.as_ptr(),
@@ -440,8 +444,8 @@ impl RawConnection {
     where
         F: FnMut() + Send + 'static,
     {
-        let boxed: Box<F> = Box::new(hook);
-        let ptr = &*boxed as *const F as *mut libc::c_void;
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
         unsafe {
             ffi::sqlite3_rollback_hook(
                 self.internal_connection.as_ptr(),
@@ -468,8 +472,8 @@ impl RawConnection {
     where
         F: FnMut(&str, i32) + Send + 'static,
     {
-        let boxed: Box<F> = Box::new(hook);
-        let ptr = &*boxed as *const F as *mut libc::c_void;
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
         unsafe {
             ffi::sqlite3_wal_hook(
                 self.internal_connection.as_ptr(),
@@ -497,8 +501,8 @@ impl RawConnection {
     where
         F: FnMut() -> bool + Send + 'static,
     {
-        let boxed: Box<F> = Box::new(hook);
-        let ptr = &*boxed as *const F as *mut libc::c_void;
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
         unsafe {
             ffi::sqlite3_progress_handler(
                 self.internal_connection.as_ptr(),
@@ -531,8 +535,8 @@ impl RawConnection {
     where
         F: FnMut(i32) -> bool + Send + 'static,
     {
-        let boxed: Box<F> = Box::new(hook);
-        let ptr = &*boxed as *const F as *mut libc::c_void;
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
         unsafe {
             ffi::sqlite3_busy_handler(
                 self.internal_connection.as_ptr(),
@@ -570,8 +574,8 @@ impl RawConnection {
     where
         F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send + 'static,
     {
-        let boxed: Box<F> = Box::new(hook);
-        let ptr = &*boxed as *const F as *mut libc::c_void;
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
         unsafe {
             ffi::sqlite3_set_authorizer(
                 self.internal_connection.as_ptr(),
@@ -598,8 +602,8 @@ impl RawConnection {
     where
         F: FnMut(SqliteTraceEvent<'_>) + Send + 'static,
     {
-        let boxed: Box<F> = Box::new(hook);
-        let ptr = &*boxed as *const F as *mut libc::c_void;
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
         unsafe {
             ffi::sqlite3_trace_v2(
                 self.internal_connection.as_ptr(),
@@ -660,7 +664,13 @@ unsafe extern "C" fn update_hook_trampoline(
             rowid,
         };
 
-        hooks.borrow_mut().dispatch(event);
+        // Use try_borrow_mut to handle reentrancy gracefully: if a hook
+        // callback triggers another SQL statement that fires the update hook,
+        // the RefCell would already be borrowed, so we silently skip dispatch
+        // rather than panicking inside an extern "C" function.
+        if let Ok(mut guard) = hooks.try_borrow_mut() {
+            guard.dispatch(event);
+        }
     }));
 
     if result.is_err() {
@@ -957,25 +967,16 @@ impl Drop for RawConnection {
     fn drop(&mut self) {
         use crate::util::std_compat::panicking;
 
+        // Unregister all hooks before closing so the Box'd closures are
+        // dropped before sqlite3_close runs.
         self.unregister_raw_update_hook();
-
-        // Unregister all hooks before closing so the Box'd closures are not
-        // dangling during sqlite3_close.
-        unsafe {
-            ffi::sqlite3_commit_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
-            ffi::sqlite3_rollback_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
-            ffi::sqlite3_wal_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
-            ffi::sqlite3_progress_handler(
-                self.internal_connection.as_ptr(),
-                0,
-                None,
-                ptr::null_mut(),
-            );
-            ffi::sqlite3_busy_handler(self.internal_connection.as_ptr(), None, ptr::null_mut());
-            ffi::sqlite3_set_authorizer(self.internal_connection.as_ptr(), None, ptr::null_mut());
-            ffi::sqlite3_trace_v2(self.internal_connection.as_ptr(), 0, None, ptr::null_mut());
-        }
-        // The Option<Box<dyn Any>> fields drop automatically after this.
+        self.remove_commit_hook();
+        self.remove_rollback_hook();
+        self.remove_wal_hook();
+        self.remove_progress_handler();
+        self.remove_busy_handler();
+        self.remove_authorizer();
+        self.remove_trace();
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -1044,18 +1045,7 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
     let conn = match unsafe { NonNull::new(ffi::sqlite3_context_db_handle(ctx)) } {
         // We use `ManuallyDrop` here because we do not want to run the
         // Drop impl of `RawConnection` as this would close the connection
-        Some(conn) => mem::ManuallyDrop::new(RawConnection {
-            internal_connection: conn,
-            change_hooks: RefCell::new(ChangeHookDispatcher::new()),
-            update_hook_registered: Cell::new(false),
-            commit_hook: None,
-            rollback_hook: None,
-            wal_hook: None,
-            progress_hook: None,
-            busy_handler: None,
-            authorizer_hook: None,
-            trace_hook: None,
-        }),
+        Some(conn) => mem::ManuallyDrop::new(RawConnection::from_ptr(conn)),
         None => {
             unsafe { context_error_str(ctx, NULL_CONN_ERR) };
             return;

--- a/diesel/src/sqlite/connection/trace.rs
+++ b/diesel/src/sqlite/connection/trace.rs
@@ -1,0 +1,101 @@
+//! Types for the SQLite trace callback.
+//!
+//! See [`sqlite3_trace_v2`](https://sqlite.org/c3ref/trace_v2.html)
+//! and the [trace event codes](https://sqlite.org/c3ref/c_trace.html).
+
+use core::ops::BitOr;
+
+/// Trace event mask (bitmask) for selecting which events to receive.
+///
+/// Added in SQLite 3.14.0 (2016-08-08).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SqliteTraceFlags(u32);
+
+impl SqliteTraceFlags {
+    /// Statement start event.
+    ///
+    /// Fires when a prepared statement first begins executing.
+    /// The callback receives the SQL text.
+    pub const STMT: Self = Self(0x01);
+
+    /// Statement profiling event.
+    ///
+    /// Fires when a prepared statement finishes executing.
+    /// The callback receives the SQL text and elapsed time in nanoseconds.
+    pub const PROFILE: Self = Self(0x02);
+
+    /// Row event.
+    ///
+    /// **Performance Warning**: Fires for EVERY row returned by a query.
+    /// This can be extremely frequent for large result sets and may
+    /// significantly impact performance. Prefer `STMT` and `PROFILE`
+    /// for most logging use cases.
+    pub const ROW: Self = Self(0x04);
+
+    /// Connection close event.
+    ///
+    /// Fires when the database connection closes.
+    pub const CLOSE: Self = Self(0x08);
+
+    /// All events.
+    ///
+    /// Use with caution: includes `ROW` which is very frequent.
+    pub const ALL: Self = Self(0x0F);
+
+    /// Returns the raw bitmask value.
+    pub fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Creates a new mask from raw bits.
+    pub fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+
+    /// Returns true if this mask contains the given flag.
+    pub fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl BitOr for SqliteTraceFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// Trace events delivered to the trace callback.
+///
+/// The callback receives one of these events based on the mask
+/// registered with [`on_trace`](crate::sqlite::SqliteConnection::on_trace).
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum SqliteTraceEvent<'a> {
+    /// A prepared statement is beginning to execute.
+    ///
+    /// Contains the unexpanded SQL text (with parameter placeholders).
+    Statement {
+        /// The SQL text of the statement.
+        sql: &'a str,
+    },
+
+    /// A prepared statement has finished executing.
+    ///
+    /// Contains the SQL text and elapsed time.
+    Profile {
+        /// The SQL text of the statement.
+        sql: &'a str,
+        /// Time taken in nanoseconds.
+        duration_ns: u64,
+    },
+
+    /// A row has been returned from a query.
+    ///
+    /// **Note**: This fires for every row and does not include row data.
+    Row,
+
+    /// The database connection is closing.
+    Close,
+}

--- a/diesel/src/sqlite/connection/trace.rs
+++ b/diesel/src/sqlite/connection/trace.rs
@@ -70,7 +70,7 @@ impl BitOr for SqliteTraceFlags {
 ///
 /// The callback receives one of these events based on the mask
 /// registered with [`on_trace`](crate::sqlite::SqliteConnection::on_trace).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum SqliteTraceEvent<'a> {
     /// A prepared statement is beginning to execute.

--- a/diesel/src/sqlite/connection/trace.rs
+++ b/diesel/src/sqlite/connection/trace.rs
@@ -90,7 +90,7 @@ pub enum SqliteTraceEvent<'a> {
         /// - Returns `false` for `INSERT`, `UPDATE`, `DELETE`, `CREATE`, etc.
         /// - Returns `false` for `WITH ... INSERT/UPDATE/DELETE ... RETURNING`
         /// - User-defined functions that modify the database via a separate
-        ///   connection are **not** detected; the statement itself is still
+        ///   connection are **not** detected. The statement itself is still
         ///   considered read-only
         /// - Virtual tables with side effects are **not** detected
         readonly: bool,

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -8,6 +8,9 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::ops::{BitAnd, BitOr};
 
 /// A bitmask of SQLite change operations used for filtering which events

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -9,7 +9,6 @@ extern crate libsqlite3_sys as ffi;
 use sqlite_wasm_rs as ffi;
 
 use alloc::boxed::Box;
-use alloc::string::String;
 use alloc::vec::Vec;
 use core::ops::{BitAnd, BitOr};
 

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -1,0 +1,505 @@
+//! Types for SQLite data change notification hooks.
+//!
+//! See [`SqliteConnection::on_change`] and related methods for usage.
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+extern crate libsqlite3_sys as ffi;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use sqlite_wasm_rs as ffi;
+
+use std::ops::{BitAnd, BitOr};
+
+/// A bitmask of SQLite change operations used for filtering which events
+/// a hook should receive.
+///
+/// Combine masks with `|` (bitwise OR):
+///
+/// ```rust
+/// # use diesel::sqlite::SqliteChangeOps;
+/// let insert_or_delete = SqliteChangeOps::INSERT | SqliteChangeOps::DELETE;
+/// assert!(insert_or_delete.contains(SqliteChangeOps::INSERT));
+/// assert!(!insert_or_delete.contains(SqliteChangeOps::UPDATE));
+/// ```
+///
+/// The inner representation is private to prevent construction of invalid masks.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SqliteChangeOps(u8);
+
+impl SqliteChangeOps {
+    /// Match INSERT operations.
+    pub const INSERT: SqliteChangeOps = SqliteChangeOps(1);
+    /// Match UPDATE operations.
+    pub const UPDATE: SqliteChangeOps = SqliteChangeOps(2);
+    /// Match DELETE operations.
+    pub const DELETE: SqliteChangeOps = SqliteChangeOps(4);
+    /// Match unknown/future operation codes.
+    pub const UNKNOWN: SqliteChangeOps = SqliteChangeOps(8);
+    /// Match all row-change operations (INSERT, UPDATE, DELETE, and UNKNOWN).
+    pub const ALL: SqliteChangeOps = SqliteChangeOps(15);
+
+    /// Returns `true` if `self` is a superset of `other` — i.e. every
+    /// operation bit set in `other` is also set in `self`.
+    pub fn contains(self, other: SqliteChangeOps) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Checks whether this mask includes the given [`SqliteChangeOp`].
+    pub(crate) fn matches_op(self, op: SqliteChangeOp) -> bool {
+        self.contains(op.to_ops())
+    }
+}
+
+impl BitOr for SqliteChangeOps {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        SqliteChangeOps(self.0 | rhs.0)
+    }
+}
+
+impl BitAnd for SqliteChangeOps {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        SqliteChangeOps(self.0 & rhs.0)
+    }
+}
+
+impl std::fmt::Debug for SqliteChangeOps {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut parts = Vec::new();
+        if self.contains(Self::INSERT) {
+            parts.push("INSERT");
+        }
+        if self.contains(Self::UPDATE) {
+            parts.push("UPDATE");
+        }
+        if self.contains(Self::DELETE) {
+            parts.push("DELETE");
+        }
+        if self.contains(Self::UNKNOWN) {
+            parts.push("UNKNOWN");
+        }
+        if parts.is_empty() {
+            write!(f, "SqliteChangeOps(0)")
+        } else {
+            write!(f, "SqliteChangeOps({})", parts.join(" | "))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteChangeOp — runtime enum
+// ---------------------------------------------------------------------------
+
+/// Identifies which kind of row change occurred.
+///
+/// Returned as part of [`SqliteChangeEvent`] to callbacks registered via
+/// [`SqliteConnection::on_insert`], [`SqliteConnection::on_change`], etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SqliteChangeOp {
+    /// A row was inserted.
+    Insert,
+    /// A row was updated.
+    Update,
+    /// A row was deleted.
+    Delete,
+    /// An operation code not recognised by this version of diesel.
+    ///
+    /// This can happen if a future SQLite version introduces new op codes.
+    /// The inner value is the raw FFI code.
+    Unknown(i32),
+}
+
+impl SqliteChangeOp {
+    /// Converts a raw FFI operation code to the corresponding enum variant.
+    ///
+    /// Unknown codes are mapped to [`SqliteChangeOp::Unknown`].
+    pub(crate) fn from_ffi(code: i32) -> Self {
+        #[allow(non_upper_case_globals)]
+        match code {
+            ffi::SQLITE_INSERT => SqliteChangeOp::Insert,
+            ffi::SQLITE_UPDATE => SqliteChangeOp::Update,
+            ffi::SQLITE_DELETE => SqliteChangeOp::Delete,
+            other => SqliteChangeOp::Unknown(other),
+        }
+    }
+
+    /// Converts this single operation to the corresponding [`SqliteChangeOps`]
+    /// bitmask.
+    pub fn to_ops(self) -> SqliteChangeOps {
+        match self {
+            SqliteChangeOp::Insert => SqliteChangeOps::INSERT,
+            SqliteChangeOp::Update => SqliteChangeOps::UPDATE,
+            SqliteChangeOp::Delete => SqliteChangeOps::DELETE,
+            SqliteChangeOp::Unknown(_) => SqliteChangeOps::UNKNOWN,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteChangeEvent — borrowed event passed to callbacks
+// ---------------------------------------------------------------------------
+
+/// Describes a single row change event from SQLite.
+///
+/// The `db_name` field identifies which attached database the change occurred
+/// in — `"main"` for the primary database, `"temp"` for temporary tables,
+/// or the alias from an `ATTACH DATABASE` statement.
+///
+/// The `table_name` field is the name of the table that was modified.
+///
+/// The `rowid` field is SQLite's internal 64-bit row identifier. For tables
+/// with an `INTEGER PRIMARY KEY`, this is the same value as the primary key
+/// column. For tables with other primary key types, the rowid is a separate
+/// hidden value managed by SQLite internally.
+///
+/// See: <https://www.sqlite.org/c3ref/update_hook.html>
+/// See: <https://www.sqlite.org/rowidtable.html>
+#[derive(Debug, Clone, Copy)]
+pub struct SqliteChangeEvent<'a> {
+    /// The operation that triggered this event.
+    pub op: SqliteChangeOp,
+    /// The name of the database (e.g. `"main"`, `"temp"`, or an `ATTACH` alias).
+    pub db_name: &'a str,
+    /// The name of the table that was modified.
+    pub table_name: &'a str,
+    /// The rowid of the affected row.
+    pub rowid: i64,
+}
+
+/// An opaque handle to a registered change hook, used to remove it later
+/// via [`SqliteConnection::remove_change_hook`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeHookId(pub(crate) usize);
+
+pub(crate) struct HookEntry {
+    id: usize,
+    table_name: Option<&'static str>, // None = catch-all (on_change)
+    ops: SqliteChangeOps,
+    callback: Box<dyn FnMut(SqliteChangeEvent<'_>) + Send>,
+}
+
+impl HookEntry {
+    pub(crate) fn matches(&self, event: &SqliteChangeEvent<'_>) -> bool {
+        self.ops.matches_op(event.op) && self.table_name.is_none_or(|name| name == event.table_name)
+    }
+}
+
+pub(crate) struct ChangeHookDispatcher {
+    next_id: usize,
+    pub(crate) entries: Vec<HookEntry>,
+}
+
+impl ChangeHookDispatcher {
+    pub(crate) fn new() -> Self {
+        ChangeHookDispatcher {
+            next_id: 0,
+            entries: Vec::new(),
+        }
+    }
+
+    pub(crate) fn add(
+        &mut self,
+        table_name: Option<&'static str>,
+        ops: SqliteChangeOps,
+        callback: Box<dyn FnMut(SqliteChangeEvent<'_>) + Send>,
+    ) -> ChangeHookId {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.entries.push(HookEntry {
+            id,
+            table_name,
+            ops,
+            callback,
+        });
+        ChangeHookId(id)
+    }
+
+    /// Dispatches a change event to all matching hooks.
+    pub(crate) fn dispatch(&mut self, event: SqliteChangeEvent<'_>) {
+        for entry in &mut self.entries {
+            if entry.matches(&event) {
+                (entry.callback)(event);
+            }
+        }
+    }
+
+    pub(crate) fn remove(&mut self, hook_id: ChangeHookId) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|e| e.id != hook_id.0);
+        self.entries.len() < before
+    }
+
+    pub(crate) fn clear_for_table(&mut self, table_name: &str) {
+        self.entries.retain(|e| e.table_name != Some(table_name));
+    }
+
+    pub(crate) fn clear_all(&mut self) {
+        self.entries.clear();
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Maps an FFI operation code to our internal bitmask bit.
+#[cfg(test)]
+fn ffi_op_to_bit(op_code: i32) -> u8 {
+    #[allow(non_upper_case_globals)]
+    match op_code {
+        ffi::SQLITE_INSERT => SqliteChangeOps::INSERT.0,
+        ffi::SQLITE_UPDATE => SqliteChangeOps::UPDATE.0,
+        ffi::SQLITE_DELETE => SqliteChangeOps::DELETE.0,
+        _ => SqliteChangeOps::UNKNOWN.0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test-only helper: check mask vs raw FFI op code.
+    impl SqliteChangeOps {
+        fn matches(self, op_code: i32) -> bool {
+            let bit = ffi_op_to_bit(op_code);
+            (self.0 & bit) != 0
+        }
+    }
+
+    #[test]
+    fn insert_or_delete_matches_both_but_not_update() {
+        let mask = SqliteChangeOps::INSERT | SqliteChangeOps::DELETE;
+        assert!(mask.matches(ffi::SQLITE_INSERT));
+        assert!(mask.matches(ffi::SQLITE_DELETE));
+        assert!(!mask.matches(ffi::SQLITE_UPDATE));
+    }
+
+    #[test]
+    fn all_matches_all_three() {
+        assert!(SqliteChangeOps::ALL.matches(ffi::SQLITE_INSERT));
+        assert!(SqliteChangeOps::ALL.matches(ffi::SQLITE_UPDATE));
+        assert!(SqliteChangeOps::ALL.matches(ffi::SQLITE_DELETE));
+    }
+
+    #[test]
+    fn combining_identical_masks_is_idempotent() {
+        assert_eq!(
+            SqliteChangeOps::INSERT | SqliteChangeOps::INSERT,
+            SqliteChangeOps::INSERT,
+        );
+    }
+
+    #[test]
+    fn contains_single() {
+        assert!(SqliteChangeOps::INSERT.contains(SqliteChangeOps::INSERT));
+    }
+
+    #[test]
+    fn all_contains_insert_or_delete() {
+        assert!(SqliteChangeOps::ALL.contains(SqliteChangeOps::INSERT | SqliteChangeOps::DELETE));
+    }
+
+    #[test]
+    fn insert_does_not_contain_all() {
+        assert!(!SqliteChangeOps::INSERT.contains(SqliteChangeOps::ALL));
+    }
+
+    #[test]
+    fn from_ffi_insert() {
+        assert_eq!(
+            SqliteChangeOp::from_ffi(ffi::SQLITE_INSERT),
+            SqliteChangeOp::Insert
+        );
+    }
+
+    #[test]
+    fn from_ffi_update() {
+        assert_eq!(
+            SqliteChangeOp::from_ffi(ffi::SQLITE_UPDATE),
+            SqliteChangeOp::Update
+        );
+    }
+
+    #[test]
+    fn from_ffi_delete() {
+        assert_eq!(
+            SqliteChangeOp::from_ffi(ffi::SQLITE_DELETE),
+            SqliteChangeOp::Delete
+        );
+    }
+
+    #[test]
+    fn to_ops_roundtrip() {
+        assert_eq!(SqliteChangeOp::Insert.to_ops(), SqliteChangeOps::INSERT);
+        assert_eq!(SqliteChangeOp::Update.to_ops(), SqliteChangeOps::UPDATE);
+        assert_eq!(SqliteChangeOp::Delete.to_ops(), SqliteChangeOps::DELETE);
+        assert_eq!(SqliteChangeOp::Unknown(999).to_ops(), SqliteChangeOps::UNKNOWN);
+    }
+
+    #[test]
+    fn from_ffi_unknown_code() {
+        assert_eq!(SqliteChangeOp::from_ffi(999), SqliteChangeOp::Unknown(999));
+    }
+
+    #[test]
+    fn sqlite_change_event_is_copy() {
+        let event = SqliteChangeEvent {
+            op: SqliteChangeOp::Delete,
+            db_name: "main",
+            table_name: "posts",
+            rowid: 7,
+        };
+        // Verify Copy by assigning to two bindings without a move error.
+        let a = event;
+        let b = event;
+        assert_eq!(a.rowid, b.rowid);
+    }
+
+    #[test]
+    fn debug_formatting() {
+        assert_eq!(
+            format!("{:?}", SqliteChangeOps::INSERT),
+            "SqliteChangeOps(INSERT)",
+        );
+        assert_eq!(
+            format!("{:?}", SqliteChangeOps::ALL),
+            "SqliteChangeOps(INSERT | UPDATE | DELETE | UNKNOWN)",
+        );
+        assert_eq!(format!("{:?}", SqliteChangeOps(0)), "SqliteChangeOps(0)",);
+    }
+
+    #[test]
+    fn bitand_works() {
+        let mask = SqliteChangeOps::ALL & SqliteChangeOps::INSERT;
+        assert_eq!(mask, SqliteChangeOps::INSERT);
+    }
+
+    // -----------------------------------------------------------------------
+    // Dispatcher unit tests
+    // -----------------------------------------------------------------------
+
+    fn make_event(
+        op: SqliteChangeOp,
+        table: &'static str,
+        rowid: i64,
+    ) -> SqliteChangeEvent<'static> {
+        SqliteChangeEvent {
+            op,
+            db_name: "main",
+            table_name: table,
+            rowid,
+        }
+    }
+
+    #[test]
+    fn dispatcher_add_matches_remove() {
+        let mut d = ChangeHookDispatcher::new();
+        assert!(d.is_empty());
+
+        let fired = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+
+        let id = d.add(
+            Some("users"),
+            SqliteChangeOps::INSERT,
+            Box::new(move |e| {
+                fired2.lock().unwrap().push(e.rowid);
+            }),
+        );
+        assert!(!d.is_empty());
+
+        // Match: insert on "users"
+        let ev = make_event(SqliteChangeOp::Insert, "users", 1);
+        assert!(d.entries[0].matches(&ev));
+
+        // No match: update on "users"
+        let ev2 = make_event(SqliteChangeOp::Update, "users", 1);
+        assert!(!d.entries[0].matches(&ev2));
+
+        // No match: insert on "posts"
+        let ev3 = make_event(SqliteChangeOp::Insert, "posts", 1);
+        assert!(!d.entries[0].matches(&ev3));
+
+        // Remove
+        assert!(d.remove(id));
+        assert!(d.is_empty());
+
+        // Double remove returns false
+        assert!(!d.remove(id));
+    }
+
+    #[test]
+    fn dispatcher_catch_all_matches_any_table() {
+        let mut d = ChangeHookDispatcher::new();
+        d.add(
+            None, // catch-all
+            SqliteChangeOps::ALL,
+            Box::new(|_| {}),
+        );
+
+        let ev1 = make_event(SqliteChangeOp::Insert, "users", 1);
+        let ev2 = make_event(SqliteChangeOp::Delete, "posts", 2);
+        assert!(d.entries[0].matches(&ev1));
+        assert!(d.entries[0].matches(&ev2));
+    }
+
+    #[test]
+    fn dispatcher_dispatch_calls_matching_hooks() {
+        let mut d = ChangeHookDispatcher::new();
+
+        let fired = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let f2 = fired.clone();
+
+        d.add(
+            Some("users"),
+            SqliteChangeOps::INSERT,
+            Box::new(move |e| {
+                f2.lock().unwrap().push(e.rowid);
+            }),
+        );
+
+        d.dispatch(make_event(SqliteChangeOp::Insert, "users", 42));
+        d.dispatch(make_event(SqliteChangeOp::Update, "users", 43)); // no match
+        d.dispatch(make_event(SqliteChangeOp::Insert, "posts", 44)); // no match
+
+        assert_eq!(*fired.lock().unwrap(), vec![42]);
+    }
+
+    #[test]
+    fn dispatcher_clear_for_table() {
+        let mut d = ChangeHookDispatcher::new();
+        d.add(Some("users"), SqliteChangeOps::INSERT, Box::new(|_| {}));
+        d.add(Some("posts"), SqliteChangeOps::INSERT, Box::new(|_| {}));
+        d.add(
+            None, // catch-all — should NOT be removed
+            SqliteChangeOps::ALL,
+            Box::new(|_| {}),
+        );
+
+        assert_eq!(d.entries.len(), 3);
+        d.clear_for_table("users");
+        assert_eq!(d.entries.len(), 2);
+        // "posts" entry and catch-all remain
+        assert_eq!(d.entries[0].table_name, Some("posts"));
+        assert_eq!(d.entries[1].table_name, None);
+    }
+
+    #[test]
+    fn dispatcher_clear_all() {
+        let mut d = ChangeHookDispatcher::new();
+        d.add(Some("a"), SqliteChangeOps::ALL, Box::new(|_| {}));
+        d.add(Some("b"), SqliteChangeOps::ALL, Box::new(|_| {}));
+        d.add(None, SqliteChangeOps::ALL, Box::new(|_| {}));
+        assert_eq!(d.entries.len(), 3);
+        d.clear_all();
+        assert!(d.is_empty());
+    }
+}

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -8,7 +8,7 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
-use std::ops::{BitAnd, BitOr};
+use core::ops::{BitAnd, BitOr};
 
 /// A bitmask of SQLite change operations used for filtering which events
 /// a hook should receive.
@@ -341,7 +341,10 @@ mod tests {
         assert_eq!(SqliteChangeOp::Insert.to_ops(), SqliteChangeOps::INSERT);
         assert_eq!(SqliteChangeOp::Update.to_ops(), SqliteChangeOps::UPDATE);
         assert_eq!(SqliteChangeOp::Delete.to_ops(), SqliteChangeOps::DELETE);
-        assert_eq!(SqliteChangeOp::Unknown(999).to_ops(), SqliteChangeOps::UNKNOWN);
+        assert_eq!(
+            SqliteChangeOp::Unknown(999).to_ops(),
+            SqliteChangeOps::UNKNOWN
+        );
     }
 
     #[test]

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -66,8 +66,8 @@ impl BitAnd for SqliteChangeOps {
     }
 }
 
-impl std::fmt::Debug for SqliteChangeOps {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SqliteChangeOps {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut parts = Vec::new();
         if self.contains(Self::INSERT) {
             parts.push("INSERT");

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -70,24 +70,26 @@ impl BitAnd for SqliteChangeOps {
 
 impl core::fmt::Debug for SqliteChangeOps {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut parts = Vec::new();
-        if self.contains(Self::INSERT) {
-            parts.push("INSERT");
+        write!(f, "SqliteChangeOps(")?;
+        let mut first = true;
+        for (flag, name) in [
+            (Self::INSERT, "INSERT"),
+            (Self::UPDATE, "UPDATE"),
+            (Self::DELETE, "DELETE"),
+            (Self::UNKNOWN, "UNKNOWN"),
+        ] {
+            if self.contains(flag) {
+                if !first {
+                    write!(f, " | ")?;
+                }
+                write!(f, "{name}")?;
+                first = false;
+            }
         }
-        if self.contains(Self::UPDATE) {
-            parts.push("UPDATE");
+        if first {
+            write!(f, "0")?;
         }
-        if self.contains(Self::DELETE) {
-            parts.push("DELETE");
-        }
-        if self.contains(Self::UNKNOWN) {
-            parts.push("UNKNOWN");
-        }
-        if parts.is_empty() {
-            write!(f, "SqliteChangeOps(0)")
-        } else {
-            write!(f, "SqliteChangeOps({})", parts.join(" | "))
-        }
+        write!(f, ")")
     }
 }
 
@@ -210,7 +212,7 @@ impl ChangeHookDispatcher {
         callback: Box<dyn FnMut(SqliteChangeEvent<'_>) + Send>,
     ) -> ChangeHookId {
         let id = self.next_id;
-        self.next_id += 1;
+        self.next_id = self.next_id.wrapping_add(1);
         self.entries.push(HookEntry {
             id,
             table_name,

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -250,18 +250,6 @@ impl ChangeHookDispatcher {
     }
 }
 
-/// Maps an FFI operation code to our internal bitmask bit.
-#[cfg(test)]
-fn ffi_op_to_bit(op_code: i32) -> u8 {
-    #[allow(non_upper_case_globals)]
-    match op_code {
-        ffi::SQLITE_INSERT => SqliteChangeOps::INSERT.0,
-        ffi::SQLITE_UPDATE => SqliteChangeOps::UPDATE.0,
-        ffi::SQLITE_DELETE => SqliteChangeOps::DELETE.0,
-        _ => SqliteChangeOps::UNKNOWN.0,
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -273,8 +261,7 @@ mod tests {
     /// Test-only helper: check mask vs raw FFI op code.
     impl SqliteChangeOps {
         fn matches(self, op_code: i32) -> bool {
-            let bit = ffi_op_to_bit(op_code);
-            (self.0 & bit) != 0
+            self.matches_op(SqliteChangeOp::from_ffi(op_code))
         }
     }
 

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -133,7 +133,7 @@ impl SqliteChangeOp {
 
     /// Converts this single operation to the corresponding [`SqliteChangeOps`]
     /// bitmask.
-    pub fn to_ops(self) -> SqliteChangeOps {
+    pub(crate) fn to_ops(self) -> SqliteChangeOps {
         match self {
             SqliteChangeOp::Insert => SqliteChangeOps::INSERT,
             SqliteChangeOp::Update => SqliteChangeOps::UPDATE,

--- a/diesel/src/sqlite/connection/update_hook.rs
+++ b/diesel/src/sqlite/connection/update_hook.rs
@@ -38,9 +38,14 @@ impl SqliteChangeOps {
     /// Match unknown/future operation codes.
     pub const UNKNOWN: SqliteChangeOps = SqliteChangeOps(8);
     /// Match all row-change operations (INSERT, UPDATE, DELETE, and UNKNOWN).
+    ///
+    /// `UNKNOWN` is included deliberately: if a future SQLite version emits an
+    /// operation code diesel does not recognize, a hook registered with `ALL`
+    /// still fires (with [`SqliteChangeOp::Unknown`] carrying the raw code)
+    /// rather than silently dropping the change.
     pub const ALL: SqliteChangeOps = SqliteChangeOps(15);
 
-    /// Returns `true` if `self` is a superset of `other` — i.e. every
+    /// Returns `true` if `self` is a superset of `other`, i.e. every
     /// operation bit set in `other` is also set in `self`.
     pub fn contains(self, other: SqliteChangeOps) -> bool {
         (self.0 & other.0) == other.0
@@ -94,13 +99,14 @@ impl core::fmt::Debug for SqliteChangeOps {
 }
 
 // ---------------------------------------------------------------------------
-// SqliteChangeOp — runtime enum
+// SqliteChangeOp: runtime enum
 // ---------------------------------------------------------------------------
 
 /// Identifies which kind of row change occurred.
 ///
 /// Returned as part of [`SqliteChangeEvent`] to callbacks registered via
-/// [`SqliteConnection::on_insert`], [`SqliteConnection::on_change`], etc.
+/// [`on_insert`](super::SqliteConnection::on_insert),
+/// [`on_change`](super::SqliteConnection::on_change), etc.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SqliteChangeOp {
@@ -144,38 +150,30 @@ impl SqliteChangeOp {
 }
 
 // ---------------------------------------------------------------------------
-// SqliteChangeEvent — borrowed event passed to callbacks
+// SqliteChangeEvent: borrowed event passed to callbacks
 // ---------------------------------------------------------------------------
 
 /// Describes a single row change event from SQLite.
 ///
-/// The `db_name` field identifies which attached database the change occurred
-/// in — `"main"` for the primary database, `"temp"` for temporary tables,
-/// or the alias from an `ATTACH DATABASE` statement.
-///
-/// The `table_name` field is the name of the table that was modified.
-///
-/// The `rowid` field is SQLite's internal 64-bit row identifier. For tables
-/// with an `INTEGER PRIMARY KEY`, this is the same value as the primary key
-/// column. For tables with other primary key types, the rowid is a separate
-/// hidden value managed by SQLite internally.
-///
 /// See: <https://www.sqlite.org/c3ref/update_hook.html>
-/// See: <https://www.sqlite.org/rowidtable.html>
 #[derive(Debug, Clone, Copy)]
 pub struct SqliteChangeEvent<'a> {
     /// The operation that triggered this event.
     pub op: SqliteChangeOp,
-    /// The name of the database (e.g. `"main"`, `"temp"`, or an `ATTACH` alias).
+    /// The name of the database the change occurred in: `"main"` for the
+    /// primary database, `"temp"` for temporary tables, or the alias from an
+    /// `ATTACH DATABASE` statement.
     pub db_name: &'a str,
     /// The name of the table that was modified.
     pub table_name: &'a str,
-    /// The rowid of the affected row.
+    /// SQLite's internal 64-bit [rowid](https://www.sqlite.org/rowidtable.html)
+    /// of the affected row. For an `INTEGER PRIMARY KEY` table this equals the
+    /// primary key, otherwise it is a separate hidden value.
     pub rowid: i64,
 }
 
 /// An opaque handle to a registered change hook, used to remove it later
-/// via [`SqliteConnection::remove_change_hook`].
+/// via [`remove_change_hook`](super::SqliteConnection::remove_change_hook).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeHookId(pub(crate) usize);
 
@@ -473,7 +471,7 @@ mod tests {
         d.add(Some("users"), SqliteChangeOps::INSERT, Box::new(|_| {}));
         d.add(Some("posts"), SqliteChangeOps::INSERT, Box::new(|_| {}));
         d.add(
-            None, // catch-all — should NOT be removed
+            None, // catch-all, should NOT be removed
             SqliteChangeOps::ALL,
             Box::new(|_| {}),
         );

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -23,6 +23,7 @@ pub use self::connection::SqliteConnection;
 pub use self::connection::SqliteLimit;
 pub use self::connection::SqliteValue;
 pub use self::connection::sqlite_blob::SqliteReadOnlyBlob;
+pub use self::connection::{ChangeHookId, SqliteChangeEvent, SqliteChangeOp, SqliteChangeOps};
 pub use self::query_builder::SqliteQueryBuilder;
 
 /// Trait for the implementation of a SQLite aggregate function

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -23,7 +23,9 @@ pub use self::connection::SqliteConnection;
 pub use self::connection::SqliteLimit;
 pub use self::connection::SqliteValue;
 pub use self::connection::sqlite_blob::SqliteReadOnlyBlob;
+pub use self::connection::{AuthorizerAction, AuthorizerContext, AuthorizerDecision};
 pub use self::connection::{ChangeHookId, SqliteChangeEvent, SqliteChangeOp, SqliteChangeOps};
+pub use self::connection::{SqliteTraceEvent, SqliteTraceFlags};
 pub use self::query_builder::SqliteQueryBuilder;
 
 /// Trait for the implementation of a SQLite aggregate function

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -41,6 +41,12 @@ name = "integration_tests"
 path = "tests/lib.rs"
 harness = true
 
+[[test]]
+name = "change_hooks"
+path = "tests/change_hooks.rs"
+harness = true
+required-features = ["sqlite"]
+
 [features]
 default = []
 postgres = ["diesel/postgres_backend"]

--- a/diesel_dynamic_schema/tests/change_hooks.rs
+++ b/diesel_dynamic_schema/tests/change_hooks.rs
@@ -25,17 +25,14 @@ fn establish_connection() -> SqliteConnection {
 fn on_change_works_with_dynamic_schema() {
     let conn = &mut establish_connection();
 
-    diesel::sql_query(
-        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
-    )
-    .execute(conn)
-    .unwrap();
+    diesel::sql_query("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+        .execute(conn)
+        .unwrap();
 
     let items = table("items");
     let name = items.column::<Text, _>("name");
 
-    let events: Arc<Mutex<Vec<(SqliteChangeOp, String, i64)>>> =
-        Arc::new(Mutex::new(Vec::new()));
+    let events: Arc<Mutex<Vec<(SqliteChangeOp, String, i64)>>> = Arc::new(Mutex::new(Vec::new()));
     let events_hook = events.clone();
 
     conn.on_change(SqliteChangeOps::ALL, move |ev: SqliteChangeEvent<'_>| {
@@ -83,14 +80,11 @@ fn on_change_works_with_dynamic_schema() {
 fn on_change_ops_filter_with_dynamic_schema() {
     let conn = &mut establish_connection();
 
-    diesel::sql_query(
-        "CREATE TABLE widgets (id INTEGER PRIMARY KEY, label TEXT NOT NULL)",
-    )
-    .execute(conn)
-    .unwrap();
+    diesel::sql_query("CREATE TABLE widgets (id INTEGER PRIMARY KEY, label TEXT NOT NULL)")
+        .execute(conn)
+        .unwrap();
 
-    let events: Arc<Mutex<Vec<(SqliteChangeOp, String)>>> =
-        Arc::new(Mutex::new(Vec::new()));
+    let events: Arc<Mutex<Vec<(SqliteChangeOp, String)>>> = Arc::new(Mutex::new(Vec::new()));
     let events_hook = events.clone();
 
     conn.on_change(

--- a/diesel_dynamic_schema/tests/change_hooks.rs
+++ b/diesel_dynamic_schema/tests/change_hooks.rs
@@ -1,0 +1,125 @@
+//! Verify that `on_change` hooks work with `diesel_dynamic_schema`
+//! tables, where the table type does not implement `StaticQueryFragment`.
+//!
+//! `on_change` is the correct API for dynamic schema users because it
+//! accepts no generic table type parameter and filters purely on string
+//! comparison of the table name.
+
+#![cfg(feature = "sqlite")]
+
+use diesel::prelude::*;
+use diesel::sql_types::*;
+use diesel::sqlite::{SqliteChangeEvent, SqliteChangeOp, SqliteChangeOps};
+use diesel_dynamic_schema::table;
+use std::sync::{Arc, Mutex};
+
+fn establish_connection() -> SqliteConnection {
+    SqliteConnection::establish(":memory:").unwrap()
+}
+
+/// Verify that the untyped `on_change` hook fires for insert, update,
+/// and delete operations performed via `sql_query` (the typical DML path
+/// for dynamic schema users), and that `event.table_name` matches the
+/// runtime table name used by `diesel_dynamic_schema::table`.
+#[test]
+fn on_change_works_with_dynamic_schema() {
+    let conn = &mut establish_connection();
+
+    diesel::sql_query(
+        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+
+    let items = table("items");
+    let name = items.column::<Text, _>("name");
+
+    let events: Arc<Mutex<Vec<(SqliteChangeOp, String, i64)>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let events_hook = events.clone();
+
+    conn.on_change(SqliteChangeOps::ALL, move |ev: SqliteChangeEvent<'_>| {
+        events_hook
+            .lock()
+            .unwrap()
+            .push((ev.op, ev.table_name.to_owned(), ev.rowid));
+    });
+
+    diesel::sql_query("INSERT INTO items (id, name) VALUES (1, 'Widget')")
+        .execute(conn)
+        .unwrap();
+    diesel::sql_query("UPDATE items SET name = 'Gizmo' WHERE id = 1")
+        .execute(conn)
+        .unwrap();
+    diesel::sql_query("DELETE FROM items WHERE id = 1")
+        .execute(conn)
+        .unwrap();
+
+    let recorded = events.lock().unwrap();
+    assert_eq!(recorded.len(), 3);
+
+    assert_eq!(recorded[0], (SqliteChangeOp::Insert, "items".into(), 1));
+    assert_eq!(recorded[1], (SqliteChangeOp::Update, "items".into(), 1));
+    assert_eq!(recorded[2], (SqliteChangeOp::Delete, "items".into(), 1));
+    drop(recorded);
+
+    // Verify that queries via the dynamic schema table still work
+    // alongside an active hook.
+    diesel::sql_query("INSERT INTO items (id, name) VALUES (2, 'Doohickey')")
+        .execute(conn)
+        .unwrap();
+
+    let names = items.select(name).load::<String>(conn).unwrap();
+    assert_eq!(names, vec!["Doohickey"]);
+
+    let recorded = events.lock().unwrap();
+    assert_eq!(recorded.len(), 4);
+    assert_eq!(recorded[3].0, SqliteChangeOp::Insert);
+}
+
+/// Verify that `on_change` with a partial ops mask correctly filters
+/// events when used alongside dynamic schema tables.
+#[test]
+fn on_change_ops_filter_with_dynamic_schema() {
+    let conn = &mut establish_connection();
+
+    diesel::sql_query(
+        "CREATE TABLE widgets (id INTEGER PRIMARY KEY, label TEXT NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+
+    let events: Arc<Mutex<Vec<(SqliteChangeOp, String)>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let events_hook = events.clone();
+
+    conn.on_change(
+        SqliteChangeOps::INSERT | SqliteChangeOps::DELETE,
+        move |ev: SqliteChangeEvent<'_>| {
+            events_hook
+                .lock()
+                .unwrap()
+                .push((ev.op, ev.table_name.to_owned()));
+        },
+    );
+
+    diesel::sql_query("INSERT INTO widgets (id, label) VALUES (1, 'Alpha')")
+        .execute(conn)
+        .unwrap();
+    diesel::sql_query("UPDATE widgets SET label = 'Beta' WHERE id = 1")
+        .execute(conn)
+        .unwrap();
+    diesel::sql_query("DELETE FROM widgets WHERE id = 1")
+        .execute(conn)
+        .unwrap();
+
+    let recorded = events.lock().unwrap();
+    assert_eq!(
+        recorded.len(),
+        2,
+        "expected INSERT + DELETE only, got {:?}",
+        *recorded
+    );
+    assert_eq!(recorded[0], (SqliteChangeOp::Insert, "widgets".into()));
+    assert_eq!(recorded[1], (SqliteChangeOp::Delete, "widgets".into()));
+}

--- a/docs/sqlite_hooks_diagram.svg
+++ b/docs/sqlite_hooks_diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" font-family="Inter,system-ui,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" viewBox="0 0 600 492" font-family="Inter,system-ui,sans-serif">
   <defs>
     <filter id="sh" x="-4%" y="-4%" width="108%" height="112%">
       <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.06"/>
@@ -20,7 +20,7 @@
     <symbol id="i-hdd" viewBox="0 0 512 512"><path d="M0 96C0 60.7 28.7 32 64 32H448c35.3 0 64 28.7 64 64V280.4c-17-15.2-39.4-24.4-64-24.4H64c-24.6 0-47 9.2-64 24.4V96zM64 288H448c35.3 0 64 28.7 64 64v64c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V352c0-35.3 28.7-64 64-64zM320 416a32 32 0 1 0 0-64 32 32 0 1 0 0 64zm128-32a32 32 0 1 0-64 0 32 32 0 1 0 64 0z"/></symbol>
   </defs>
 
-  <rect width="600" height="420" fill="#fafbfc"/>
+  <rect width="600" height="492" fill="#fafbfc"/>
 
   <!-- Header -->
   <rect width="600" height="34" fill="url(#hdr)"/>
@@ -198,7 +198,7 @@
 
   <!-- ==================== LEGEND ==================== -->
   <g filter="url(#sh)">
-    <rect x="16" y="310" width="568" height="88" rx="5" fill="#fff" stroke="#e2e8f0" stroke-width="0.8"/>
+    <rect x="16" y="310" width="568" height="86" rx="5" fill="#fff" stroke="#e2e8f0" stroke-width="0.8"/>
   </g>
   <rect x="17" y="311" width="566" height="12" rx="4" fill="#f8fafc"/>
   <text x="300" y="320" text-anchor="middle" font-size="7" font-weight="700" fill="#334155">Legend &amp; Constraints</text>
@@ -220,9 +220,40 @@
   <text x="200" y="358" font-size="6" fill="#475569">Conditional (on_busy: locked, on_rollback: rollback, on_wal: WAL mode)</text>
 
   <!-- Constraints -->
-  <text x="24" y="371" font-size="5.5" fill="#64748b">SQLite restriction: callbacks cannot use the invoking connection. Use find_by_rowid() after callback returns.</text>
-  <text x="24" y="381" font-size="5.5" fill="#64748b">Safety: panics in callbacks are caught but abort the process (no safe recovery across FFI).</text>
+  <text x="24" y="371" font-size="5.5" fill="#64748b">SQLite restriction: callbacks cannot query the invoking connection. Save the rowid, then query after the callback returns.</text>
+  <text x="24" y="381" font-size="5.5" fill="#64748b">Example: on_change gives you (table, rowid, op). Store it, then SELECT * FROM table WHERE rowid = ? after commit.</text>
+  <text x="24" y="391" font-size="5.5" fill="#64748b">Safety: panics in callbacks are caught but abort the process (no safe recovery across FFI).</text>
+
+  <!-- ==================== USAGE TIPS ==================== -->
+  <g filter="url(#sh)">
+    <rect x="16" y="402" width="568" height="72" rx="5" fill="#fff" stroke="#e2e8f0" stroke-width="0.8"/>
+  </g>
+  <rect x="17" y="403" width="566" height="12" rx="4" fill="#fef3c7"/>
+  <text x="300" y="412" text-anchor="middle" font-size="7" font-weight="700" fill="#92400e">Usage Tips &amp; Frequency Warnings</text>
+
+  <foreignObject x="20" y="416" width="275" height="56">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Inter, system-ui, sans-serif; font-size: 6px; color: #475569; line-height: 1.4;">
+      <p style="margin: 0 0 3px 0; font-weight: 600; color: #dc2626;">⚠ High-frequency hooks (avoid for notifications):</p>
+      <p style="margin: 0; text-align: justify;">
+        <b>on_authorize</b> fires multiple times per statement (once per column/table access).
+        <b>on_trace(ROW)</b> fires for every row returned.
+        <b>on_progress(n)</b> with low n fires every n VM opcodes.
+        <b>on_change</b> fires once per row modified—bulk inserts trigger it per row.
+      </p>
+    </div>
+  </foreignObject>
+
+  <foreignObject x="305" y="416" width="275" height="56">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Inter, system-ui, sans-serif; font-size: 6px; color: #475569; line-height: 1.4;">
+      <p style="margin: 0 0 3px 0; font-weight: 600; color: #16a34a;">✓ LISTEN/NOTIFY pattern (websocket-friendly):</p>
+      <p style="margin: 0; text-align: justify;">
+        For <b>writes</b>: use on_change to collect (table, rowid, op) into a buffer, on_commit to flush to websocket, on_rollback to clear.
+        For <b>reads</b>: use <b>on_read</b> helper (wraps on_trace, uses sqlite3_stmt_readonly)—fires once per statement.
+        Note: on_commit/on_rollback do <b>not</b> fire for SELECT queries.
+      </p>
+    </div>
+  </foreignObject>
 
   <!-- Footer -->
-  <text x="300" y="410" text-anchor="middle" font-size="6" fill="#cbd5e1">Diesel SQLite Hooks &#x00B7; Created on 2026-02-12</text>
+  <text x="300" y="484" text-anchor="middle" font-size="6" fill="#cbd5e1">Diesel SQLite Hooks &#x00B7; Created on 2026-02-12</text>
 </svg>

--- a/docs/sqlite_hooks_diagram.svg
+++ b/docs/sqlite_hooks_diagram.svg
@@ -1,0 +1,228 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" font-family="Inter,system-ui,sans-serif">
+  <defs>
+    <filter id="sh" x="-4%" y="-4%" width="108%" height="112%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.06"/>
+    </filter>
+    <marker id="arr" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#94a3b8"/>
+    </marker>
+    <linearGradient id="hdr" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#8b5cf6"/>
+    </linearGradient>
+    <!-- Icons -->
+    <symbol id="i-shield" viewBox="0 0 512 512"><path d="M256 0c4.6 0 9.2 1 13.4 2.9L457.7 82.8c22 9.3 38.4 31 38.3 57.2c-.5 99.2-41.3 280.7-213.6 363.2c-16.7 8-36.1 8-52.8 0C57.3 420.7 16.5 239.2 16 140c-.1-26.2 16.3-47.9 38.3-57.2L242.7 2.9C246.8 1 251.4 0 256 0z"/></symbol>
+    <symbol id="i-code" viewBox="0 0 640 512"><path d="M392.8 1.2c-17-4.9-34.7 5-39.6 22l-128 448c-4.9 17 5 34.7 22 39.6s34.7-5 39.6-22l128-448c4.9-17-5-34.7-22-39.6zM177.9 166.9c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3l112 112c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L89.4 304l88.5-88.5c12.5-12.5 12.5-32.8 0-45.3zm284.3 0c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L505.4 304l-88.5 88.5c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l112-112c12.5-12.5 12.5-32.8 0-45.3l-112-112z"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 448 512"><path d="M349.4 44.6c5.9-13.7 1.5-29.7-10.6-38.5s-28.6-8-39.9 1.8l-256 224c-10 8.8-13.6 22.9-8.9 35.3S50.7 288 64 288H175.5L98.6 467.4c-5.9 13.7-1.5 29.7 10.6 38.5s28.6 8 39.9-1.8l256-224c10-8.8 13.6-22.9 8.9-35.3s-16.6-20.7-30-20.7H272.5L349.4 44.6z"/></symbol>
+    <symbol id="i-lock" viewBox="0 0 448 512"><path d="M144 144v48H304V144c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192V144C80 64.5 144.5 0 224 0s144 64.5 144 144v48h16c35.3 0 64 28.7 64 64V448c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V256c0-35.3 28.7-64 64-64H80z"/></symbol>
+    <symbol id="i-pencil" viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 000-1.41l-2.34-2.34a1 1 0 00-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></symbol>
+    <symbol id="i-check" viewBox="0 0 448 512"><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></symbol>
+    <symbol id="i-undo" viewBox="0 0 512 512"><path d="M125.7 160H176c17.7 0 32 14.3 32 32s-14.3 32-32 32H48c-17.7 0-32-14.3-32-32V64c0-17.7 14.3-32 32-32s32 14.3 32 32v51.2L97.6 97.6c87.5-87.5 229.3-87.5 316.8 0s87.5 229.3 0 316.8s-229.3 87.5-316.8 0c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0c62.5 62.5 163.8 62.5 226.3 0s62.5-163.8 0-226.3s-163.8-62.5-226.3 0L125.7 160z"/></symbol>
+    <symbol id="i-hdd" viewBox="0 0 512 512"><path d="M0 96C0 60.7 28.7 32 64 32H448c35.3 0 64 28.7 64 64V280.4c-17-15.2-39.4-24.4-64-24.4H64c-24.6 0-47 9.2-64 24.4V96zM64 288H448c35.3 0 64 28.7 64 64v64c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V352c0-35.3 28.7-64 64-64zM320 416a32 32 0 1 0 0-64 32 32 0 1 0 0 64zm128-32a32 32 0 1 0-64 0 32 32 0 1 0 64 0z"/></symbol>
+  </defs>
+
+  <rect width="600" height="420" fill="#fafbfc"/>
+
+  <!-- Header -->
+  <rect width="600" height="34" fill="url(#hdr)"/>
+  <text x="300" y="23" text-anchor="middle" font-size="14" font-weight="700" fill="#fff" letter-spacing="0.5">SQLite Hooks Lifecycle &#x2014; Diesel</text>
+
+  <!-- ==================== SEQUENCE DIAGRAM ==================== -->
+  <!-- Actors -->
+  <rect x="18" y="46" width="36" height="16" rx="3" fill="#fef3c7" stroke="#fcd34d" stroke-width="0.8"/>
+  <text x="36" y="57" text-anchor="middle" font-size="7.5" font-weight="600" fill="#92400e">App</text>
+  <rect x="68" y="46" width="40" height="16" rx="3" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.8"/>
+  <text x="88" y="57" text-anchor="middle" font-size="7.5" font-weight="600" fill="#1e40af">SQLite</text>
+
+  <!-- Lifelines -->
+  <line x1="36" y1="62" x2="36" y2="300" stroke="#d4d4d8" stroke-width="0.5" stroke-dasharray="3,2"/>
+  <line x1="88" y1="62" x2="88" y2="300" stroke="#d4d4d8" stroke-width="0.5" stroke-dasharray="3,2"/>
+
+  <!-- Phase labels -->
+  <text x="36" y="72" text-anchor="middle" font-size="6" font-weight="600" fill="#94a3b8">PREPARE</text>
+  <text x="36" y="112" text-anchor="middle" font-size="6" font-weight="600" fill="#94a3b8">EXECUTE</text>
+  <text x="36" y="175" text-anchor="middle" font-size="6" font-weight="600" fill="#94a3b8">ROWS</text>
+  <text x="36" y="230" text-anchor="middle" font-size="6" font-weight="600" fill="#94a3b8">COMMIT</text>
+  <text x="36" y="275" text-anchor="middle" font-size="6" font-weight="600" fill="#94a3b8">CLOSE</text>
+
+  <!-- VM bar -->
+  <rect x="84" y="129" width="8" height="64" rx="2" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.5"/>
+  <text x="88" y="161" text-anchor="middle" font-size="4" fill="#3b82f6" transform="rotate(-90 88 161)">VM</text>
+
+  <!-- ==================== EVENT ARROWS ==================== -->
+  <circle cx="88" cy="80" r="2.5" fill="#dc2626"/>
+  <path d="M91,80 L155,80" stroke="#dc2626" stroke-width="1" fill="none"/>
+
+  <circle cx="88" cy="100" r="2.5" fill="#3b82f6"/>
+  <path d="M91,100 L380,100" stroke="#3b82f6" stroke-width="1" fill="none"/>
+
+  <circle cx="88" cy="134" r="2.5" fill="#059669"/>
+  <path d="M91,134 L155,134" stroke="#059669" stroke-width="1" fill="none"/>
+
+  <circle cx="88" cy="156" r="2.5" fill="#d97706"/>
+  <path d="M91,156 L380,156" stroke="#d97706" stroke-width="1" stroke-dasharray="3,2" fill="none"/>
+
+  <circle cx="88" cy="188" r="2.5" fill="#0d9488"/>
+  <path d="M91,188 L155,188" stroke="#0d9488" stroke-width="1" fill="none"/>
+
+  <circle cx="88" cy="210" r="2.5" fill="#e11d48"/>
+  <path d="M91,210 L380,210" stroke="#e11d48" stroke-width="1" fill="none"/>
+
+  <circle cx="88" cy="250" r="2.5" fill="#db2777"/>
+  <path d="M91,250 L155,250" stroke="#db2777" stroke-width="1" stroke-dasharray="3,2" fill="none"/>
+
+  <circle cx="88" cy="264" r="2.5" fill="#0891b2"/>
+  <path d="M91,264 L380,264" stroke="#0891b2" stroke-width="1" stroke-dasharray="3,2" fill="none"/>
+
+  <!-- ==================== CARDS ==================== -->
+
+  <!-- 1. on_authorize — A y=67 h=48 -->
+  <g filter="url(#sh)">
+    <rect x="155" y="67" width="195" height="48" rx="5" fill="#fff" stroke="#fca5a5" stroke-width="1"/>
+  </g>
+  <rect x="156" y="68" width="193" height="18" rx="4" fill="#fef2f2"/>
+  <use href="#i-shield" width="9" height="9" x="161" y="72" fill="#dc2626"/>
+  <text x="174" y="80" font-size="9" font-weight="700" fill="#b91c1c">on_authorize</text>
+  <text x="174" y="86" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_set_authorizer</text>
+  <rect x="260" y="70" width="38" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="279" y="78" text-anchor="middle" font-size="5" fill="#64748b">3.0 (2004)</text>
+  <rect x="300" y="70" width="44" height="10" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="0.4"/>
+  <text x="322" y="78" text-anchor="middle" font-size="5" font-weight="600" fill="#16a34a">WASM &#x2713;</text>
+  <text x="161" y="100" font-size="7" fill="#475569">Controls which SQL operations are allowed.</text>
+  <text x="161" y="109" font-size="7" fill="#475569">Can permit, block, or redact columns.</text>
+
+  <!-- 2. on_trace — B y=87 h=50 -->
+  <g filter="url(#sh)">
+    <rect x="380" y="87" width="195" height="50" rx="5" fill="#fff" stroke="#93c5fd" stroke-width="1"/>
+  </g>
+  <rect x="381" y="88" width="193" height="18" rx="4" fill="#eff6ff"/>
+  <use href="#i-code" width="9" height="9" x="386" y="92" fill="#3b82f6"/>
+  <text x="399" y="100" font-size="9" font-weight="700" fill="#1d4ed8">on_trace</text>
+  <text x="399" y="106" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_trace_v2</text>
+  <rect x="480" y="90" width="42" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="501" y="98" text-anchor="middle" font-size="5" fill="#64748b">3.14 (2016)</text>
+  <rect x="524" y="90" width="44" height="10" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="0.4"/>
+  <text x="546" y="98" text-anchor="middle" font-size="5" font-weight="600" fill="#16a34a">WASM &#x2713;</text>
+  <text x="386" y="120" font-size="7" fill="#475569">SQL profiling: STMT | PROFILE | ROW | CLOSE</text>
+  <text x="386" y="130" font-size="6" fill="#64748b">Expanded SQL, timing, rows, stmt finalization</text>
+
+  <!-- 3. on_progress — A y=121 h=48 -->
+  <g filter="url(#sh)">
+    <rect x="155" y="121" width="195" height="48" rx="5" fill="#fff" stroke="#6ee7b7" stroke-width="1"/>
+  </g>
+  <rect x="156" y="122" width="193" height="18" rx="4" fill="#ecfdf5"/>
+  <use href="#i-bolt" width="9" height="9" x="161" y="126" fill="#059669"/>
+  <text x="174" y="134" font-size="9" font-weight="700" fill="#047857">on_progress(n)</text>
+  <text x="174" y="140" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_progress_handler</text>
+  <rect x="260" y="124" width="38" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="279" y="132" text-anchor="middle" font-size="5" fill="#64748b">3.0 (2004)</text>
+  <rect x="300" y="124" width="44" height="10" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="0.4"/>
+  <text x="322" y="132" text-anchor="middle" font-size="5" font-weight="600" fill="#16a34a">WASM &#x2713;</text>
+  <text x="161" y="154" font-size="7" fill="#475569">Checked every N VM instructions.</text>
+  <text x="161" y="163" font-size="7" fill="#475569">Return true to cancel query.</text>
+
+  <!-- 4. on_busy — B y=143 h=48 -->
+  <g filter="url(#sh)">
+    <rect x="380" y="143" width="195" height="48" rx="5" fill="#fff" stroke="#fcd34d" stroke-width="1"/>
+  </g>
+  <rect x="381" y="144" width="193" height="18" rx="4" fill="#fffbeb"/>
+  <use href="#i-lock" width="9" height="9" x="386" y="148" fill="#d97706"/>
+  <text x="399" y="156" font-size="9" font-weight="700" fill="#b45309">on_busy</text>
+  <text x="399" y="162" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_busy_handler</text>
+  <rect x="480" y="146" width="38" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="499" y="154" text-anchor="middle" font-size="5" fill="#64748b">3.0 (2004)</text>
+  <rect x="524" y="146" width="44" height="10" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="0.4"/>
+  <text x="546" y="154" text-anchor="middle" font-size="5" font-weight="600" fill="#16a34a">WASM &#x2713;</text>
+  <text x="386" y="176" font-size="7" fill="#475569">Called when database is locked.</text>
+  <text x="386" y="185" font-size="7" fill="#475569">Return true to retry. Alt: set_busy_timeout.</text>
+
+  <!-- 5. on_change — A y=175 h=56 -->
+  <g filter="url(#sh)">
+    <rect x="155" y="175" width="195" height="56" rx="5" fill="#fff" stroke="#5eead4" stroke-width="1"/>
+  </g>
+  <rect x="156" y="176" width="193" height="18" rx="4" fill="#f0fdfa"/>
+  <use href="#i-pencil" width="9" height="9" x="161" y="180" fill="#0d9488"/>
+  <text x="174" y="188" font-size="9" font-weight="700" fill="#0f766e">on_change</text>
+  <text x="174" y="194" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_update_hook</text>
+  <rect x="260" y="178" width="38" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="279" y="186" text-anchor="middle" font-size="5" fill="#64748b">3.0 (2004)</text>
+  <rect x="300" y="178" width="44" height="10" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="0.4"/>
+  <text x="322" y="186" text-anchor="middle" font-size="5" font-weight="600" fill="#16a34a">WASM &#x2713;</text>
+  <text x="161" y="208" font-size="7" fill="#475569">Fires on INSERT, UPDATE, or DELETE.</text>
+  <text x="161" y="217" font-size="7" fill="#475569">Provides: table, rowid, operation type.</text>
+  <text x="161" y="226" font-size="7" fill="#475569">Helpers: on_insert, on_update, on_delete</text>
+
+  <!-- 6. on_commit — B y=197 h=48 -->
+  <g filter="url(#sh)">
+    <rect x="380" y="197" width="195" height="48" rx="5" fill="#fff" stroke="#fda4af" stroke-width="1"/>
+  </g>
+  <rect x="381" y="198" width="193" height="18" rx="4" fill="#fff1f2"/>
+  <use href="#i-check" width="9" height="9" x="386" y="202" fill="#e11d48"/>
+  <text x="399" y="210" font-size="9" font-weight="700" fill="#be123c">on_commit</text>
+  <text x="399" y="216" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_commit_hook</text>
+  <rect x="480" y="200" width="38" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="499" y="208" text-anchor="middle" font-size="5" fill="#64748b">3.0 (2004)</text>
+  <rect x="524" y="200" width="44" height="10" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="0.4"/>
+  <text x="546" y="208" text-anchor="middle" font-size="5" font-weight="600" fill="#16a34a">WASM &#x2713;</text>
+  <text x="386" y="230" font-size="7" fill="#475569">Runs just before transaction commits.</text>
+  <text x="386" y="239" font-size="7" fill="#475569">Return true to force rollback instead.</text>
+
+  <!-- 7. on_rollback — A y=237 h=48 -->
+  <g filter="url(#sh)">
+    <rect x="155" y="237" width="195" height="48" rx="5" fill="#fff" stroke="#f9a8d4" stroke-width="1"/>
+  </g>
+  <rect x="156" y="238" width="193" height="18" rx="4" fill="#fdf2f8"/>
+  <use href="#i-undo" width="9" height="9" x="161" y="242" fill="#db2777"/>
+  <text x="174" y="250" font-size="9" font-weight="700" fill="#be185d">on_rollback</text>
+  <text x="174" y="256" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_rollback_hook</text>
+  <rect x="260" y="240" width="38" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="279" y="248" text-anchor="middle" font-size="5" fill="#64748b">3.0 (2004)</text>
+  <rect x="300" y="240" width="44" height="10" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="0.4"/>
+  <text x="322" y="248" text-anchor="middle" font-size="5" font-weight="600" fill="#16a34a">WASM &#x2713;</text>
+  <text x="161" y="270" font-size="7" fill="#475569">Called after transaction rolls back.</text>
+  <text x="161" y="279" font-size="7" fill="#475569">Use to invalidate caches or reset state.</text>
+
+  <!-- 8. on_wal — B y=251 h=48 -->
+  <g filter="url(#sh)">
+    <rect x="380" y="251" width="195" height="48" rx="5" fill="#fff" stroke="#67e8f9" stroke-width="1"/>
+  </g>
+  <rect x="381" y="252" width="193" height="18" rx="4" fill="#ecfeff"/>
+  <use href="#i-hdd" width="9" height="9" x="386" y="256" fill="#0891b2"/>
+  <text x="399" y="264" font-size="9" font-weight="700" fill="#0e7490">on_wal</text>
+  <text x="399" y="270" font-size="4.5" font-family="monospace" fill="#94a3b8">sqlite3_wal_hook</text>
+  <rect x="480" y="254" width="38" height="10" rx="5" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.4"/>
+  <text x="499" y="262" text-anchor="middle" font-size="5" fill="#64748b">3.7 (2010)</text>
+  <rect x="524" y="254" width="44" height="10" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="0.4"/>
+  <text x="546" y="262" text-anchor="middle" font-size="5" font-weight="600" fill="#d97706">filesystem</text>
+  <text x="386" y="284" font-size="7" fill="#475569">Fires when WAL data is written to disk.</text>
+  <text x="386" y="293" font-size="7" fill="#475569">Use for manual checkpoint scheduling.</text>
+
+  <!-- ==================== LEGEND ==================== -->
+  <g filter="url(#sh)">
+    <rect x="16" y="310" width="568" height="88" rx="5" fill="#fff" stroke="#e2e8f0" stroke-width="0.8"/>
+  </g>
+  <rect x="17" y="311" width="566" height="12" rx="4" fill="#f8fafc"/>
+  <text x="300" y="320" text-anchor="middle" font-size="7" font-weight="700" fill="#334155">Legend &amp; Constraints</text>
+
+  <!-- Query type info -->
+  <text x="24" y="334" font-size="6" font-weight="600" fill="#475569">Fires on SELECT:</text>
+  <text x="100" y="334" font-size="6" fill="#16a34a" font-weight="600">on_authorize, on_trace, on_progress</text>
+  <text x="280" y="334" font-size="6" fill="#64748b">(+ on_busy if DB locked)</text>
+
+  <text x="24" y="345" font-size="6" font-weight="600" fill="#475569">Fires on WRITE only:</text>
+  <text x="115" y="345" font-size="6" fill="#dc2626" font-weight="600">on_change, on_commit, on_rollback, on_wal</text>
+  <text x="320" y="345" font-size="6" fill="#64748b">(INSERT, UPDATE, DELETE)</text>
+
+  <!-- Arrow styles -->
+  <text x="24" y="358" font-size="6" font-weight="600" fill="#475569">Arrow styles:</text>
+  <line x1="80" y1="355" x2="105" y2="355" stroke="#475569" stroke-width="1"/>
+  <text x="110" y="358" font-size="6" fill="#475569">Always fires</text>
+  <line x1="170" y1="355" x2="195" y2="355" stroke="#475569" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="200" y="358" font-size="6" fill="#475569">Conditional (on_busy: locked, on_rollback: rollback, on_wal: WAL mode)</text>
+
+  <!-- Constraints -->
+  <text x="24" y="371" font-size="5.5" fill="#64748b">SQLite restriction: callbacks cannot use the invoking connection. Use find_by_rowid() after callback returns.</text>
+  <text x="24" y="381" font-size="5.5" fill="#64748b">Safety: panics in callbacks are caught but abort the process (no safe recovery across FFI).</text>
+
+  <!-- Footer -->
+  <text x="300" y="410" text-anchor="middle" font-size="6" fill="#cbd5e1">Diesel SQLite Hooks &#x00B7; Created on 2026-02-12</text>
+</svg>


### PR DESCRIPTION
Exposes SQLite's C-level callback hooks through a safe Rust API on `SqliteConnection`: row-change notification, the transaction hooks, the progress and busy handlers, the authorizer, and execution tracing.

## Motivation

I need a LISTEN/NOTIFY-style setup for SQLite in WASM frontends, where the hooks drive UI updates and forward changes to the server. The diagram shows which hook fires when over a statement's lifecycle. We use it internally, and it might suit the diesel docs.

![SQLite Hooks Lifecycle](https://raw.githubusercontent.com/LucaCappelletti94/diesel/refs/heads/sqlite3_update_hook/docs/sqlite_hooks_diagram.svg)

## API surface

| C API | Rust surface | Purpose | Multiplicity |
|---|---|---|---|
| [`sqlite3_update_hook`](https://www.sqlite.org/c3ref/update_hook.html) | `on_change`, `on_table_change`, `on_insert`, `on_update`, `on_delete` | Row change events | Many per connection (internal dispatcher) |
| [`sqlite3_commit_hook`](https://www.sqlite.org/c3ref/commit_hook.html) | `on_commit` | Pre-commit interception | One (replaces) |
| [`sqlite3_rollback_hook`](https://www.sqlite.org/c3ref/commit_hook.html) | `on_rollback` | Post-rollback notification | One (replaces) |
| [`sqlite3_wal_hook`](https://www.sqlite.org/c3ref/wal_hook.html) | `on_wal` | WAL commit notification | One (replaces) |
| [`sqlite3_progress_handler`](https://www.sqlite.org/c3ref/progress_handler.html) | `on_progress` | Long-running query interruption | One (replaces) |
| [`sqlite3_busy_handler`](https://www.sqlite.org/c3ref/busy_handler.html) | `on_busy` | Custom lock-contention handling | One (replaces) |
| [`sqlite3_busy_timeout`](https://www.sqlite.org/c3ref/busy_timeout.html) | `set_busy_timeout` | Simple timeout-based retry | One (clears `on_busy`) |
| [`sqlite3_set_authorizer`](https://www.sqlite.org/c3ref/set_authorizer.html) | `on_authorize` | SQL compilation access control | One (replaces) |
| [`sqlite3_trace_v2`](https://www.sqlite.org/c3ref/trace_v2.html) | `on_trace`, `on_read` | SQL execution tracing | One (replaces) |

Row-change hooks multiplex over the single `sqlite3_update_hook`: an internal dispatcher fans it out to any number of callbacks, each filtered by table name and an op mask. `on_change` matches every table, `on_table_change::<T>(ops, ...)` matches one table, and `on_insert` / `on_update` / `on_delete` are single-op wrappers. Each returns a `ChangeHookId` for removal via `remove_change_hook`, `clear_change_hooks_for::<T>`, or `clear_all_change_hooks`.

## Quick start

```rust
use diesel::prelude::*;
use diesel::sqlite::SqliteConnection;
use std::sync::{Arc, Mutex};

diesel::table! {
    users (id) { id -> Integer, name -> Text, }
}

let conn = &mut SqliteConnection::establish(":memory:").unwrap();
let log = Arc::new(Mutex::new(Vec::new()));
let log2 = log.clone();

conn.on_insert::<users::table, _>(move |event| {
    log2.lock().unwrap().push(event.rowid);
});

diesel::insert_into(users::table)
    .values(users::name.eq("Alice"))
    .execute(conn)
    .unwrap();

assert_eq!(*log.lock().unwrap(), vec![1i64]);
```

Runnable examples for every hook are in the rustdoc on each method.

## Design notes

The row-change dispatcher lives behind a lazily allocated box (`OnceCell<Box<RefCell<ChangeHookDispatcher>>>`), and SQLite is handed that stable heap address. Storing it inline would dangle once the freely movable connection is returned, stored in a struct, or moved into a pool, and allocating it lazily means the borrowed connection wrapper used during SQL-function callbacks, which never registers a hook, does not allocate or leak it. A regression test pins the address across a move. The C update hook itself is registered on the first callback and removed with the last.

Single-slot hooks store `Option<Box<dyn Any + Send>>` on `RawConnection`, and the trampoline recovers the concrete `F` by pointer cast. Every trampoline wraps its callback in `catch_unwind` and aborts on panic (matching the existing `run_collation_function`), and `Drop` unregisters all hooks before `sqlite3_close`. Because a callback cannot use the connection, `find_by_rowid::<T, M>(rowid)` reloads the affected row afterward via `WHERE rowid = ?`, which works even with TEXT primary keys.

## New types

- Row changes: `SqliteChangeEvent`, `SqliteChangeOp` (`#[non_exhaustive]`, with `Unknown(i32)`), `SqliteChangeOps` (an INSERT/UPDATE/DELETE/UNKNOWN bitmask), `ChangeHookId`.
- Authorizer: `AuthorizerAction` (documented action codes plus `Unknown(i32)`), `AuthorizerContext`, `AuthorizerDecision`.
- Tracing: `SqliteTraceFlags` (`STMT`, `PROFILE`, `ROW`, `CLOSE`, `ALL`) and `SqliteTraceEvent`, which carries a `readonly` flag from `sqlite3_stmt_readonly`.

## Compatibility and testing

Stable SQLite C APIs only, with no compile-time flags. `sqlite3_trace_v2` needs 3.14.0 and `sqlite3_wal_hook` needs 3.7.0, the rest are 3.0.0. `no_std` compatible. Needs neither `WithRawConnection` nor dynamic symbol lookup, so it is independent of and complementary to #4954 (extension loading) and #4966 (`WithRawConnection`). Every public method has a runnable doctest, each hook has integration tests, and each inherited limitation below has a test pinning the current behavior.

## Limitations (inherited from SQLite)

Row-change hooks fire only for [rowid tables](https://www.sqlite.org/rowidtable.html), and not for system-table changes, implicit `ON CONFLICT REPLACE` deletes, or the [truncate optimization](https://www.sqlite.org/lang_delete.html#truncateopt). Their callbacks cannot use the connection (use `find_by_rowid` afterward).

Single-slot hooks replace the previous callback on re-registration. The WAL hook is overwritten by `PRAGMA wal_autocheckpoint`, `set_busy_timeout` and `on_busy` clear each other, and a panic in any callback aborts the process.

The authorizer runs during `sqlite3_prepare()` rather than execution (it may re-run if a schema change forces recompilation) and is defense in depth, not a sandbox. For tracing, `SQLITE_TRACE_ROW` fires per row (prefer `STMT` and `PROFILE`), and the `readonly` flag misses writes made by UDFs on a separate connection or by virtual tables with side effects. For the progress handler, N around 1000 is suggested (about 1.5us per callback at N=1), and since 3.41.0 it may also fire during `sqlite3_prepare()`.

## Open questions

SQLite delivers only `SQLITE_INSERT`, `SQLITE_UPDATE`, and `SQLITE_DELETE` today, so `SqliteChangeOp::Unknown(i32)` is forward-compatibility only (`SqliteChangeOps::ALL` includes the `UNKNOWN` bit so a catch-all still fires if a future code appears). Do you want to surface `Unknown`, or abort on an unrecognized code?

Separately, this adds several independent hook families, and I am happy to split the row-change hooks from the authorizer and tracing if that reviews more easily.

## Relation to PostgreSQL LISTEN/NOTIFY

Unlike PostgreSQL `NOTIFY` (inter-process, deferred to commit, explicit), these hooks are in-process, synchronous, and fire automatically during `sqlite3_step()`. The nearest analogue is a statement-level trigger that cannot run SQL, and diesel's existing `PgConnection::notifications_iter()` stays separate because libpq exposes a queue to poll while SQLite exposes execution-time callbacks.
