### PR TITLE
Enable MySQL "LOAD DATA LOCAL" with url option

### DIFF
--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -144,7 +144,7 @@ impl Connection for MysqlConnection {
 
     /// Establishes a new connection to the MySQL database
     /// `database_url` may be enhanced by GET parameters
-    /// `mysql://[user[:password]@]host[:port]/database_name[?unix_socket=socket-path&ssl_mode=SSL_MODE*&ssl_ca=/etc/ssl/certs/ca-certificates.crt&ssl_cert=/etc/ssl/certs/client-cert.crt&ssl_key=/etc/ssl/certs/client-key.crt]`
+    /// `mysql://[user[:password]@]host[:port]/database_name[?unix_socket=socket-path&ssl_mode=SSL_MODE*&ssl_ca=/etc/ssl/certs/ca-certificates.crt&ssl_cert=/etc/ssl/certs/client-cert.crt&ssl_key=/etc/ssl/certs/client-key.crt&local_infile=true]`
     ///
     /// * `host` can be an IP address or a hostname. If it is set to `localhost`, a connection
     ///   will be attempted through the socket at `/tmp/mysql.sock`. If you want to connect to
@@ -155,6 +155,7 @@ impl Connection for MysqlConnection {
     /// * `ssl_key` accepts a path to the client's private key file
     /// * `ssl_mode` expects a value defined for MySQL client command option `--ssl-mode`
     ///   See <https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode>
+    /// * `local_infile` expects a boolean to enable or disable LOAD DATA LOCAL
     fn establish(database_url: &str) -> ConnectionResult<Self> {
         let mut instrumentation = DynInstrumentation::default_instrumentation();
         instrumentation.on_connection_event(InstrumentationEvent::StartEstablishConnection {

--- a/diesel/src/mysql/connection/raw.rs
+++ b/diesel/src/mysql/connection/raw.rs
@@ -62,6 +62,7 @@ impl RawConnection {
         let port = connection_options.port();
         let unix_socket = connection_options.unix_socket();
         let client_flags = connection_options.client_flags();
+        let local_infile = connection_options.local_infile();
 
         if let Some(ssl_mode) = connection_options.ssl_mode() {
             self.set_ssl_mode(ssl_mode)
@@ -74,6 +75,9 @@ impl RawConnection {
         }
         if let Some(ssl_key) = connection_options.ssl_key() {
             self.set_ssl_key(ssl_key)
+        }
+        if let Some(local_infile) = local_infile {
+            self.set_local_infile(local_infile)
         }
 
         unsafe {
@@ -242,6 +246,19 @@ impl RawConnection {
                 self.0.as_ptr(),
                 mysqlclient_sys::mysql_option::MYSQL_OPT_SSL_KEY,
                 ssl_key.as_ptr() as *const core::ffi::c_void,
+            )
+        };
+    }
+
+    fn set_local_infile(&self, local_infile: bool) {
+        let v = local_infile as u32;
+        let v_ptr: *const u32 = &v;
+        let n = ptr::NonNull::new(v_ptr as *mut u32).expect("NonNull::new failed");
+        unsafe {
+            mysqlclient_sys::mysql_options(
+                self.0.as_ptr(),
+                mysqlclient_sys::mysql_option::MYSQL_OPT_LOCAL_INFILE,
+                n.as_ptr() as *const core::ffi::c_void,
             )
         };
     }


### PR DESCRIPTION
[Enable LOAD DATA LOCAL](https://dev.mysql.com/doc/refman/9.0/en/server-system-variables.html#sysvar_local_infile) in `batch_execute`. mysqlclient handles all the IO. I'm inserting 30 million rows significantly faster now.

With native Diesel support, the [mysql](https://dev.mysql.com/doc/refman/9.5/en/load-data.html) and [postgres](https://www.postgresql.org/docs/current/sql-copy.html) versions get complicated quickly. Also LOAD DATA isn't supported in transactions. This option is enough for me to do it when rarely needed.

# Example

```rust
fn main() {
    let url = "mysql://u:p@localhost/db?local_infile";
    let conn = &mut MysqlConnection::establish(url).unwrap();
    conn.batch_execute(
        "CREATE TEMPORARY TABLE fast_table (\
        id INT NOT NULL PRIMARY KEY,\
        value VARCHAR(20) NOT NULL\
        )",
    )
        .unwrap();

    let load_path = Path::new("mysql-rows.dat");
    write_rows_file(&load_path);
    load_rows_file(conn, &load_path);
}

const ROW_SEP: u8 = 0x1e;
const COL_SEP: u8 = 0x1f;
fn write_rows_file(path: &Path) -> () {
    let mut out_file = File::create(path).unwrap();
    for row in 0..10 {
        let something = "something";
        write!(out_file, "{row}{COL_SEP}{something}{ROW_SEP}").unwrap();
    }
}

fn load_rows_file(conn: &mut MysqlConnection, path: &Path) {
    conn.batch_execute(&format!(
        "LOAD DATA LOCAL INFILE '{}' \
        INTO TABLE `fast_table` \
        FIELDS TERMINATED BY '{COL_SEP}' \
        LINES TERMINATED BY '{ROW_SEP}' \
        (id, value)",
        path.display()
    ))
        .unwrap()
}

```