### PR TITLE
Various wasm related CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
         with:
           toolchain: stable
-          components: "rust-src"
+          components: "rust-src,rustfmt"
           # It seems not to work
           # targets: "wasm32-unknown-unknown"
       - name: Cache cargo registry
@@ -358,11 +358,19 @@ jobs:
       - name: Add wasm32-unknown-unknown target
         run: rustup target add wasm32-unknown-unknown
 
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --locked
+      - uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787 # v2.64.2
+        with:
+          tool: nextest,wasm-bindgen@0.2.108
 
       - name: Test unit and integration tests
-        run: cargo xtask run-tests --wasm sqlite
+        env:
+          DATABASE_URL: ":memory:"
+        run: cargo xtask run-tests --wasm sqlite --no-example-schema-check -- --no-fail-fast  --release
+
+      - name: Test the wasm example
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
+        run: cd examples/sqlite/wasm && cargo test --target wasm32-unknown-unknown
 
   sqlite_bundled:
     name: Check sqlite bundled + Sqlite with asan

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -58,7 +58,8 @@ sqlite-wasm-rs = { version = ">=0.4.0, <0.6.0", optional = true, default-feature
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 # Something is dependent on it, we use feature to override it.
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom_03 = { version = "0.3", features = ["wasm_js"], package = "getrandom" }
 wasm-bindgen-test = "0.3.49"
 
 [dev-dependencies]

--- a/diesel/src/r2d2.rs
+++ b/diesel/src/r2d2.rs
@@ -468,7 +468,7 @@ impl<C: Connection> CustomizeConnection<C, crate::r2d2::Error> for TestCustomize
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_family = "wasm", target_os = "unknown"))))]
 mod tests {
     use std::sync::Arc;
     use std::sync::mpsc;

--- a/diesel/src/sqlite/types/date_and_time/chrono.rs
+++ b/diesel/src/sqlite/types/date_and_time/chrono.rs
@@ -236,7 +236,7 @@ impl<TZ: TimeZone> ToSql<TimestamptzSqlite, Sqlite> for DateTime<TZ> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_family = "wasm", target_os = "unknown"))))]
 #[allow(clippy::unwrap_used)]
 mod tests {
     extern crate chrono;

--- a/diesel/src/sqlite/types/date_and_time/mod.rs
+++ b/diesel/src/sqlite/types/date_and_time/mod.rs
@@ -94,7 +94,12 @@ impl ToSql<sql_types::TimestamptzSqlite, Sqlite> for String {
     }
 }
 
-#[cfg(all(test, feature = "chrono", feature = "time"))]
+#[cfg(all(
+    test,
+    feature = "chrono",
+    feature = "time",
+    not(all(target_family = "wasm", target_os = "unknown"))
+))]
 #[allow(clippy::cast_possible_truncation)] // it's a test
 mod tests {
     extern crate chrono;

--- a/diesel/src/sqlite/types/date_and_time/time.rs
+++ b/diesel/src/sqlite/types/date_and_time/time.rs
@@ -310,7 +310,7 @@ impl ToSql<TimestamptzSqlite, Sqlite> for OffsetDateTime {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_family = "wasm", target_os = "unknown"))))]
 mod tests {
     extern crate dotenvy;
 

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -30,7 +30,8 @@ diesel_test_helper = { path = "../diesel_test_helper" }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 # Something is dependent on it, so we use feature to override it.
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom_03 = { version = "0.3", features = ["wasm_js"], package = "getrandom" }
 getrandom_02 = { version = "0.2", package = "getrandom", features = ["js"] }
 wasm-bindgen-test = "0.3.49"
 sqlite-wasm-rs = "0.5.1"

--- a/examples/sqlite/wasm/Cargo.toml
+++ b/examples/sqlite/wasm/Cargo.toml
@@ -13,8 +13,8 @@ wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-sqlite-wasm-vfs = "0.1.1"
-sqlite-wasm-rs = "0.5.1"
+sqlite-wasm-vfs = "0.2.0"
+sqlite-wasm-rs = "0.5.2"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/sqlite/wasm/src/lib.rs
+++ b/examples/sqlite/wasm/src/lib.rs
@@ -53,14 +53,18 @@ pub fn establish_connection() -> SqliteConnection {
 #[wasm_bindgen(js_name = installOpfsSahpool)]
 pub async fn install_opfs_sahpool() {
     use sqlite_wasm_vfs::sahpool::{OpfsSAHPoolCfg, install};
-    install(&OpfsSAHPoolCfg::default(), false).await.unwrap();
+    install::<sqlite_wasm_rs::WasmOsCallback>(&OpfsSAHPoolCfg::default(), false)
+        .await
+        .unwrap();
 }
 
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 #[wasm_bindgen(js_name = installRelaxedIdb)]
 pub async fn install_relaxed_idb() {
     use sqlite_wasm_vfs::relaxed_idb::{RelaxedIdbCfg, install};
-    install(&RelaxedIdbCfg::default(), false).await.unwrap();
+    install::<sqlite_wasm_rs::WasmOsCallback>(&RelaxedIdbCfg::default(), false)
+        .await
+        .unwrap();
 }
 
 #[wasm_bindgen(js_name = switchVfs)]

--- a/xtask/src/clippy.rs
+++ b/xtask/src/clippy.rs
@@ -42,7 +42,7 @@ impl ClippyArgs {
     }
 
     fn run_for_backend(&self, backend: Backend, metadata: &Metadata) -> bool {
-        let exclude = crate::utils::get_exclude_for_backend(&backend.to_string(), metadata);
+        let exclude = crate::utils::get_exclude_for_backend(&backend.to_string(), metadata, false);
         let flags = [
             "-F".into(),
             format!("diesel/{backend}"),

--- a/xtask/src/tests/mod.rs
+++ b/xtask/src/tests/mod.rs
@@ -1,5 +1,4 @@
 use crate::Backend;
-use cargo_metadata::camino::Utf8PathBuf;
 use cargo_metadata::{Metadata, MetadataCommand};
 use std::process::Command;
 use std::process::Stdio;
@@ -59,7 +58,7 @@ impl TestArgs {
     fn run_tests(&self, metadata: &Metadata) -> bool {
         let backend_name = self.backend.to_string();
         println!("Running tests for {backend_name}");
-        let exclude = crate::utils::get_exclude_for_backend(&backend_name, metadata);
+        let exclude = crate::utils::get_exclude_for_backend(&backend_name, metadata, self.wasm);
         if std::env::var("DATABASE_URL").is_err() {
             match self.backend {
                 Backend::Postgres => {
@@ -89,46 +88,11 @@ impl TestArgs {
             }
         }
         let backend = &self.backend;
-        if self.wasm {
-            if matches!(backend, Backend::Sqlite) {
-                fn run_tests(path: Utf8PathBuf) -> bool {
-                    let mut command = Command::new("cargo");
-                    command
-                        .args([
-                            "test",
-                            "--features",
-                            "sqlite",
-                            "--target",
-                            "wasm32-unknown-unknown",
-                        ])
-                        .current_dir(path)
-                        .env("WASM_BINDGEN_TEST_TIMEOUT", "120")
-                        .env(
-                            "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
-                            "wasm-bindgen-test-runner",
-                        )
-                        .env("RUSTFLAGS", "--cfg getrandom_backend=\"wasm_js\"")
-                        .stderr(Stdio::inherit())
-                        .stdout(Stdio::inherit())
-                        .status()
-                        .unwrap()
-                        .success()
-                }
-                if !run_tests(metadata.workspace_root.join("diesel")) {
-                    eprintln!("Failed to run wasm diesel unit tests");
-                    return false;
-                }
-                if !run_tests(metadata.workspace_root.join("diesel_tests")) {
-                    eprintln!("Failed to run wasm integration tests");
-                    return false;
-                }
-                return true;
-            } else {
-                eprintln!(
-                    "Only the sqlite backend supports wasm for now, the current backend is {backend}"
-                );
-                return true;
-            }
+        if matches!(backend, Backend::Postgres | Backend::Mysql | Backend::All if self.wasm) {
+            eprintln!(
+                "Only the sqlite backend supports wasm for now, the current backend is {backend}"
+            );
+            return true;
         }
         let url = match backend {
             Backend::Postgres => std::env::var("PG_DATABASE_URL"),
@@ -140,29 +104,31 @@ impl TestArgs {
             .or_else(|_| std::env::var("DATABASE_URL"))
             .expect("DATABASE_URL is set for tests");
 
-        // run the migrations
-        let mut command = Command::new("cargo");
-        command
-            .args(["run", "-p", "diesel_cli", "--no-default-features", "-F"])
-            .arg(backend.to_string())
-            .args(["--", "migration", "run", "--migration-dir"])
-            .arg(
-                metadata
-                    .workspace_root
-                    .join("migrations")
-                    .join(backend.to_string()),
-            )
-            .arg("--database-url")
-            .arg(&url);
-        println!("Run database migration via `{command:?}`");
-        let status = command
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status()
-            .unwrap();
-        if !status.success() {
-            eprintln!("Failed to run migrations");
-            return false;
+        if !self.wasm {
+            // run the migrations
+            let mut command = Command::new("cargo");
+            command
+                .args(["run", "-p", "diesel_cli", "--no-default-features", "-F"])
+                .arg(backend.to_string())
+                .args(["--", "migration", "run", "--migration-dir"])
+                .arg(
+                    metadata
+                        .workspace_root
+                        .join("migrations")
+                        .join(backend.to_string()),
+                )
+                .arg("--database-url")
+                .arg(&url);
+            println!("Run database migration via `{command:?}`");
+            let status = command
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status()
+                .unwrap();
+            if !status.success() {
+                eprintln!("Failed to run migrations");
+                return false;
+            }
         }
 
         if !self.no_integration_tests {
@@ -178,8 +144,6 @@ impl TestArgs {
                 .arg("-F")
                 .arg(format!("diesel_derives/{backend}"))
                 .arg("-F")
-                .arg(format!("diesel_cli/{backend}"))
-                .arg("-F")
                 .arg(format!("migrations_macros/{backend}"))
                 .arg("-F")
                 .arg(format!("diesel_migrations/{backend}"))
@@ -192,6 +156,19 @@ impl TestArgs {
             if matches!(self.backend, Backend::Mysql) {
                 // cannot run mysql tests in parallel
                 command.args(["-j", "1"]);
+            }
+            if self.wasm {
+                command
+                    .env("WASM_BINDGEN_TEST_TIMEOUT", "120")
+                    .env(
+                        "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+                        "wasm-bindgen-test-runner",
+                    )
+                    .env("RUSTFLAGS", "--cfg getrandom_backend=\"wasm_js\"")
+                    .arg("--target")
+                    .arg("wasm32-unknown-unknown");
+            } else {
+                command.arg("-F").arg(format!("diesel_cli/{backend}"));
             }
             println!("Running tests via `{command:?}`: ");
 
@@ -240,6 +217,17 @@ impl TestArgs {
             if matches!(backend, Backend::Mysql) {
                 // cannot run mysql tests in parallel
                 command.args(["-j", "1"]);
+            }
+            if self.wasm {
+                command
+                    .env("WASM_BINDGEN_TEST_TIMEOUT", "120")
+                    .env(
+                        "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+                        "wasm-bindgen-test-runner",
+                    )
+                    .env("RUSTFLAGS", "--cfg getrandom_backend=\"wasm_js\"")
+                    .arg("--target")
+                    .arg("wasm32-unknown-unknown");
             }
             println!("Running tests via `{command:?}`: ");
             let status = command

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -1,9 +1,13 @@
 use cargo_metadata::Metadata;
 
-pub fn get_exclude_for_backend<'a>(backend: &str, metadata: &'a Metadata) -> Vec<&'a str> {
+pub fn get_exclude_for_backend<'a>(
+    backend: &str,
+    metadata: &'a Metadata,
+    wasm: bool,
+) -> Vec<&'a str> {
     let examples = metadata.workspace_root.join("examples");
     let backend_examples = examples.join(backend);
-    metadata
+    let mut out = metadata
         .workspace_packages()
         .into_iter()
         .filter_map(move |p| {
@@ -16,5 +20,27 @@ pub fn get_exclude_for_backend<'a>(backend: &str, metadata: &'a Metadata) -> Vec
             }
         })
         .flatten()
-        .collect()
+        .collect::<Vec<_>>();
+    if wasm {
+        let additional_excludes = [
+            // command line tool is not helpful
+            // with the wasm32-unknown-unknown target
+            "diesel_cli",
+            // these pull in libsqlite3-sys
+            "getting_started_step_1_sqlite",
+            "getting_started_step_2_sqlite",
+            "getting_started_step_3_sqlite",
+            "all_about_inserts_sqlite",
+            "relations_sqlite",
+            // needs to be tested in a separate step
+            // due to broken cargo workspace feature unification
+            "sqlite-wasm-example",
+        ];
+        out.extend(
+            additional_excludes
+                .into_iter()
+                .flat_map(|v| ["--exclude", v]),
+        );
+    }
+    out
 }


### PR DESCRIPTION
(but it's still broken :()

cc @Spxg as there is still a build failure in sqlite-wasm-vfs

<details>

<summary>Long error</summary>

```

error[E0053]: method `add_file` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:583:22
    |
583 |     fn add_file(vfs: *mut sqlite3_vfs, file: &str, flags: i32) -> VfsResult<()> {
    |                      ^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |
    = note: expected signature `fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, &_, _) -> std::result::Result<_, _>`
               found signature `fn(*mut sqlite_wasm_rs::sqlite3_vfs, &_, _) -> std::result::Result<_, _>`
help: change the parameter type to match the trait
    |
583 |     fn add_file(vfs: *mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, file: &str, flags: i32) -> VfsResult<()> {
    |                                 ++++++++++++++++++++++++++++

error[E0053]: method `contains_file` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:591:27
    |
591 |     fn contains_file(vfs: *mut sqlite3_vfs, file: &str) -> VfsResult<bool> {
    |                           ^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |
    = note: expected signature `fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, &_) -> std::result::Result<_, _>`
               found signature `fn(*mut sqlite_wasm_rs::sqlite3_vfs, &_) -> std::result::Result<_, _>`
help: change the parameter type to match the trait
    |
591 |     fn contains_file(vfs: *mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, file: &str) -> VfsResult<bool> {
    |                                      ++++++++++++++++++++++++++++

error[E0053]: method `delete_file` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:596:25
    |
596 |     fn delete_file(vfs: *mut sqlite3_vfs, file: &str) -> VfsResult<()> {
    |                         ^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |
    = note: expected signature `fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, &_) -> std::result::Result<_, _>`
               found signature `fn(*mut sqlite_wasm_rs::sqlite3_vfs, &_) -> std::result::Result<_, _>`
help: change the parameter type to match the trait
    |
596 |     fn delete_file(vfs: *mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, file: &str) -> VfsResult<()> {
    |                                    ++++++++++++++++++++++++++++

error[E0053]: method `xFileControl` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:654:16
    |
654 |         pFile: *mut sqlite3_file,
    |                ^^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |
    = note: expected signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_file, _, _) -> _`
               found signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::sqlite3_file, _, _) -> _`
help: change the parameter type to match the trait
    |
654 |         pFile: *mut sqlite_wasm_rs::utils::ffi::sqlite3_file,
    |                           ++++++++++++++++++++++++++++

error[E0046]: not all trait items implemented, missing: `sleep`, `random`, `epoch_timestamp_in_ms`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:720:1
    |
720 | impl SQLiteVfs<RelaxedIdbIoMethods> for RelaxedIdbVfs {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `sleep`, `random`, `epoch_timestamp_in_ms` in implementation
    |
    = help: implement the missing item: `fn sleep(_: Duration) { todo!() }`
    = help: implement the missing item: `fn random(_: &mut [u8]) { todo!() }`
    = help: implement the missing item: `fn epoch_timestamp_in_ms() -> i64 { todo!() }`

error[E0053]: method `add_file` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:590:22
    |
590 |     fn add_file(vfs: *mut sqlite3_vfs, filename: &str, flags: i32) -> VfsResult<()> {
    |                      ^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |
    = note: expected signature `fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, &_, _) -> std::result::Result<_, _>`
               found signature `fn(*mut sqlite_wasm_rs::sqlite3_vfs, &_, _) -> std::result::Result<_, _>`
help: change the parameter type to match the trait
    |
590 |     fn add_file(vfs: *mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, filename: &str, flags: i32) -> VfsResult<()> {
    |                                 ++++++++++++++++++++++++++++

error[E0053]: method `contains_file` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:597:27
    |
597 |     fn contains_file(vfs: *mut sqlite3_vfs, file: &str) -> VfsResult<bool> {
    |                           ^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |
    = note: expected signature `fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, &_) -> std::result::Result<_, _>`
               found signature `fn(*mut sqlite_wasm_rs::sqlite3_vfs, &_) -> std::result::Result<_, _>`
help: change the parameter type to match the trait
    |
597 |     fn contains_file(vfs: *mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, file: &str) -> VfsResult<bool> {
    |                                      ++++++++++++++++++++++++++++

error[E0053]: method `delete_file` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:602:25
    |
602 |     fn delete_file(vfs: *mut sqlite3_vfs, file: &str) -> VfsResult<()> {
    |                         ^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |
    = note: expected signature `fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, &_) -> std::result::Result<_, _>`
               found signature `fn(*mut sqlite_wasm_rs::sqlite3_vfs, &_) -> std::result::Result<_, _>`
help: change the parameter type to match the trait
    |
602 |     fn delete_file(vfs: *mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, file: &str) -> VfsResult<()> {
    |                                    ++++++++++++++++++++++++++++

error[E0053]: method `xSectorSize` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:639:46
    |
639 |     unsafe extern "C" fn xSectorSize(_pFile: *mut sqlite3_file) -> ::std::os::raw::c_int {
    |                                              ^^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |
    = note: expected signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_file) -> _`
               found signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::sqlite3_file) -> _`
help: change the parameter type to match the trait
    |
639 |     unsafe extern "C" fn xSectorSize(_pFile: *mut sqlite_wasm_rs::utils::ffi::sqlite3_file) -> ::std::os::raw::c_int {
    |                                                         ++++++++++++++++++++++++++++

error[E0053]: method `xCheckReservedLock` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:644:17
    |
644 |         _pFile: *mut sqlite3_file,
    |                 ^^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |
    = note: expected signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_file, _) -> _`
               found signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::sqlite3_file, _) -> _`
help: change the parameter type to match the trait
    |
644 |         _pFile: *mut sqlite_wasm_rs::utils::ffi::sqlite3_file,
    |                            ++++++++++++++++++++++++++++

error[E0053]: method `xDeviceCharacteristics` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:652:17
    |
652 |         _pFile: *mut sqlite3_file,
    |                 ^^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |
    = note: expected signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_file) -> _`
               found signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::sqlite3_file) -> _`
help: change the parameter type to match the trait
    |
652 |         _pFile: *mut sqlite_wasm_rs::utils::ffi::sqlite3_file,
    |                            ++++++++++++++++++++++++++++

error[E0053]: method `xClose` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:657:40
    |
657 |     unsafe extern "C" fn xClose(pFile: *mut sqlite3_file) -> ::std::os::raw::c_int {
    |                                        ^^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |
    = note: expected signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_file) -> _`
               found signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::sqlite3_file) -> _`
help: change the parameter type to match the trait
    |
657 |     unsafe extern "C" fn xClose(pFile: *mut sqlite_wasm_rs::utils::ffi::sqlite3_file) -> ::std::os::raw::c_int {
    |                                                   ++++++++++++++++++++++++++++

error[E0053]: method `xOpen` has an incompatible type for trait
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:678:15
    |
678 |         pVfs: *mut sqlite3_vfs,
    |               ^^^^^^^^^^^^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |
    = note: expected signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs, _, *mut sqlite_wasm_rs::utils::ffi::sqlite3_file, _, _) -> _`
               found signature `unsafe extern "C" fn(*mut sqlite_wasm_rs::sqlite3_vfs, _, *mut sqlite_wasm_rs::sqlite3_file, _, _) -> _`
help: change the parameter type to match the trait
    |
678 |         pVfs: *mut sqlite_wasm_rs::utils::ffi::sqlite3_vfs,
    |                          ++++++++++++++++++++++++++++

error[E0046]: not all trait items implemented, missing: `sleep`, `random`, `epoch_timestamp_in_ms`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:673:1
    |
673 | impl SQLiteVfs<SyncAccessHandleIoMethods> for SyncAccessHandleVfs {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `sleep`, `random`, `epoch_timestamp_in_ms` in implementation
    |
    = help: implement the missing item: `fn sleep(_: Duration) { todo!() }`
    = help: implement the missing item: `fn random(_: &mut [u8]) { todo!() }`
    = help: implement the missing item: `fn epoch_timestamp_in_ms() -> i64 { todo!() }`

error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:165:26
    |
165 |             let opaque = random_name();
    |                          ^^^^^^^^^^^-- argument #1 of type `for<'a> fn(&'a mut [u8])` is missing
    |
note: function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:84:8
    |
 84 | pub fn random_name(randomness: fn(&mut [u8])) -> String {
    |        ^^^^^^^^^^^
help: provide the argument
    |
165 |             let opaque = random_name(/* for<'a> fn(&'a mut [u8]) */);
    |                                      ++++++++++++++++++++++++++++++

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:949:19
    |
949 |     pool.vfs.set((vfs, default_vfs));
    |                   ^^^ expected `sqlite_wasm_rs::sqlite3_vfs`, found `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`
    |
    = note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` and `sqlite_wasm_rs::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:584:44
    |
584 |         let pool = unsafe { Self::app_data(vfs) };
    |                             -------------- ^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |                             |
    |                             arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:434:15
    |
434 |     unsafe fn app_data(vfs: *mut sqlite3_vfs) -> &'static VfsAppData<AppData> {
    |               ^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:592:44
    |
592 |         let pool = unsafe { Self::app_data(vfs) };
    |                             -------------- ^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |                             |
    |                             arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:434:15
    |
434 |     unsafe fn app_data(vfs: *mut sqlite3_vfs) -> &'static VfsAppData<AppData> {
    |               ^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:597:44
    |
597 |         let pool = unsafe { Self::app_data(vfs) };
    |                             -------------- ^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |                             |
    |                             arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:434:15
    |
434 |     unsafe fn app_data(vfs: *mut sqlite3_vfs) -> &'static VfsAppData<AppData> {
    |               ^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/relaxed_idb.rs:658:49
    |
658 |         let vfs_file = SQLiteVfsFile::from_file(pFile);
    |                        ------------------------ ^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |                        |
    |                        arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_file` and `sqlite_wasm_rs::utils::ffi::sqlite3_file` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_file` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:625:1
    |
625 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_file` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:522:1
    |
522 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:281:19
    |
281 |     pub unsafe fn from_file(file: *mut sqlite3_file) -> &'static SQLiteVfsFile {
    |                   ^^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:591:44
    |
591 |         let pool = unsafe { Self::app_data(vfs) };
    |                             -------------- ^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |                             |
    |                             arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:434:15
    |
434 |     unsafe fn app_data(vfs: *mut sqlite3_vfs) -> &'static VfsAppData<AppData> {
    |               ^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:598:44
    |
598 |         let pool = unsafe { Self::app_data(vfs) };
    |                             -------------- ^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |                             |
    |                             arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:434:15
    |
434 |     unsafe fn app_data(vfs: *mut sqlite3_vfs) -> &'static VfsAppData<AppData> {
    |               ^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:603:44
    |
603 |         let pool = unsafe { Self::app_data(vfs) };
    |                             -------------- ^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |                             |
    |                             arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:434:15
    |
434 |     unsafe fn app_data(vfs: *mut sqlite3_vfs) -> &'static VfsAppData<AppData> {
    |               ^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:658:49
    |
658 |         let vfs_file = SQLiteVfsFile::from_file(pFile);
    |                        ------------------------ ^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |                        |
    |                        arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_file` and `sqlite_wasm_rs::utils::ffi::sqlite3_file` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_file` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:625:1
    |
625 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_file` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:522:1
    |
522 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:281:19
    |
281 |     pub unsafe fn from_file(file: *mut sqlite3_file) -> &'static SQLiteVfsFile {
    |                   ^^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:662:36
    |
662 |         let ret = Self::xCloseImpl(pFile);
    |                   ---------------- ^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |                   |
    |                   arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_file` and `sqlite_wasm_rs::utils::ffi::sqlite3_file` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_file` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:625:1
    |
625 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_file` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:522:1
    |
522 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:713:26
    |
713 |     unsafe extern "C" fn xCloseImpl(pFile: *mut sqlite3_file) -> ::core::ffi::c_int {
    |                          ^^^^^^^^^^

error[E0308]: arguments to this function are incorrect
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:684:19
    |
684 |         let ret = Self::xOpenImpl(pVfs, zName, pFile, flags, pOutFlags);
    |                   ^^^^^^^^^^^^^^^
    |
note: expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:684:35
    |
684 |         let ret = Self::xOpenImpl(pVfs, zName, pFile, flags, pOutFlags);
    |                                   ^^^^
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:684:48
    |
684 |         let ret = Self::xOpenImpl(pVfs, zName, pFile, flags, pOutFlags);
    |                                                ^^^^^
    = note: `sqlite_wasm_rs::sqlite3_file` and `sqlite_wasm_rs::utils::ffi::sqlite3_file` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_file` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:625:1
    |
625 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_file` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:522:1
    |
522 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:509:26
    |
509 |     unsafe extern "C" fn xOpenImpl(
    |                          ^^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:686:60
    |
686 |             let app_data = SyncAccessHandleStore::app_data(pVfs);
    |                            ------------------------------- ^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_vfs`, found `sqlite_wasm_rs::sqlite3_vfs`
    |                            |
    |                            arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_vfs` and `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_vfs` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:756:1
    |
756 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_vfs` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:643:1
    |
643 | pub struct sqlite3_vfs {
    | ^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:434:15
    |
434 |     unsafe fn app_data(vfs: *mut sqlite3_vfs) -> &'static VfsAppData<AppData> {
    |               ^^^^^^^^

error[E0308]: mismatched types
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-vfs-0.1.1/src/sahpool.rs:689:53
    |
689 |             let vfs_file = SQLiteVfsFile::from_file(pFile);
    |                            ------------------------ ^^^^^ expected `sqlite_wasm_rs::utils::ffi::sqlite3_file`, found `sqlite_wasm_rs::sqlite3_file`
    |                            |
    |                            arguments to this function are incorrect
    |
    = note: `sqlite_wasm_rs::sqlite3_file` and `sqlite_wasm_rs::utils::ffi::sqlite3_file` have similar names, but are actually distinct types
note: `sqlite_wasm_rs::sqlite3_file` is defined in crate `sqlite_wasm_rs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sqlite-wasm-rs-0.5.2/src/bindings/sqlite3_bindgen.rs:625:1
    |
625 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: `sqlite_wasm_rs::utils::ffi::sqlite3_file` is defined in crate `rsqlite_vfs`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/ffi.rs:522:1
    |
522 | pub struct sqlite3_file {
    | ^^^^^^^^^^^^^^^^^^^^^^^
note: associated function defined here
   --> /home/weiznich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rsqlite-vfs-0.1.0/src/lib.rs:281:19
    |
281 |     pub unsafe fn from_file(file: *mut sqlite3_file) -> &'static SQLiteVfsFile {
    |                   ^^^^^^^^^

```

<details>