### PR TITLE
chore: exporting copy_from traits and struct fields

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -853,7 +853,7 @@ pub mod prelude {
     pub use crate::pg::PgConnection;
     #[doc(inline)]
     #[cfg(feature = "postgres_backend")]
-    pub use crate::pg::query_builder::copy::ExecuteCopyFromDsl;
+    pub use crate::pg::query_builder::copy::{CopyFromExpression, ExecuteCopyFromDsl};
     #[cfg(feature = "__sqlite-shared")]
     #[doc(inline)]
     pub use crate::sqlite::SqliteConnection;

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -29,7 +29,9 @@ pub use self::query_builder::OrderDecorator;
 #[doc(inline)]
 pub use self::query_builder::PgQueryBuilder;
 #[doc(inline)]
-pub use self::query_builder::{CopyFormat, CopyFromQuery, CopyHeader, CopyTarget, CopyToQuery};
+pub use self::query_builder::{
+    CopyFormat, CopyFromExpression, CopyFromQuery, CopyHeader, CopyTarget, CopyToQuery,
+};
 #[doc(inline)]
 pub use self::transaction::TransactionBuilder;
 #[doc(inline)]

--- a/diesel/src/pg/query_builder/copy/copy_from.rs
+++ b/diesel/src/pg/query_builder/copy/copy_from.rs
@@ -130,16 +130,25 @@ where
     }
 }
 
+/// Trait for types that can be used as the source of a PostgreSQL `COPY FROM` statement.
+///
+/// Implement this trait to support custom backends (e.g. async runtimes like diesel-async)
+/// that need to execute COPY FROM with their own I/O.
 pub trait CopyFromExpression<T> {
+    /// The Error type representing failures in the callback or stream.
     type Error: From<crate::result::Error> + core::error::Error;
 
+    /// The callback executed with the internal `std::io::Write` wrapper to
+    /// buffer and send bytes to the database.
     fn callback(&mut self, copy: &mut impl std::io::Write) -> Result<(), Self::Error>;
 
+    /// Append the target format representations to the query AST.
     fn walk_target<'b>(
         &'b self,
         pass: crate::query_builder::AstPass<'_, 'b, Pg>,
     ) -> crate::QueryResult<()>;
 
+    /// Retrieve the parsed `COPY FROM` options.
     fn options(&self) -> &CopyFromOptions;
 }
 
@@ -368,6 +377,10 @@ where
 ///
 /// [`from_raw_data`]: CopyFromQuery::from_raw_data
 /// [`from_insertable`]: CopyFromQuery::from_insertable
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+    public_fields(table, action)
+)]
 #[derive(Debug)]
 #[must_use = "`COPY FROM` statements are only executed when calling `.execute()`."]
 #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/query_builder/copy/mod.rs
+++ b/diesel/src/pg/query_builder/copy/mod.rs
@@ -9,8 +9,10 @@ use crate::{Column, Table};
 pub(crate) mod copy_from;
 pub(crate) mod copy_to;
 
+#[cfg(feature = "postgres_backend")]
+pub use self::copy_from::CopyFromExpression;
 #[cfg(feature = "postgres")]
-pub(crate) use self::copy_from::{CopyFromExpression, InternalCopyFromQuery};
+pub(crate) use self::copy_from::InternalCopyFromQuery;
 #[cfg(feature = "postgres")]
 pub(crate) use self::copy_to::CopyToCommand;
 

--- a/diesel/src/pg/query_builder/mod.rs
+++ b/diesel/src/pg/query_builder/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod on_constraint;
 pub(crate) mod only;
 mod query_fragment_impls;
 pub(crate) mod tablesample;
+#[cfg(feature = "postgres_backend")]
+pub use self::copy::CopyFromExpression;
 pub use self::copy::{CopyFormat, CopyFromQuery, CopyHeader, CopyTarget, CopyToQuery};
 pub use self::distinct_on::DistinctOnClause;
 pub use self::distinct_on::OrderDecorator;


### PR DESCRIPTION
I was looking into adding `COPY FROM` statement support for postgres to `diesel_async` and found that some things I needed from this crate didn't appear exported.

In this PR I've done a first pass at exporting them. There's a sample of how the new exports are used in `diesel_async` in the draft PR on that repo [here](https://github.com/weiznich/diesel_async/pull/278). Will plan to keep that as a draft until this one settles.

Wasn't sure if this warranted a changelog entry, lmk if so and I can add something!

Thanks for taking a look! 😁 