### PR TITLE
feature/derive db enum2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `SqliteConnection` methods to configure SQLite's per-connection `sqlite3_db_config` options: `set_defensive`/`is_defensive`, `set_trusted_schema`/`is_trusted_schema`, `with_load_extension_enabled`, `set_fts3_tokenizer_enabled`/`is_fts3_tokenizer_enabled`, `set_writable_schema`/`is_writable_schema`, `set_attach_create_enabled`/`is_attach_create_enabled`, `set_attach_write_enabled`/`is_attach_write_enabled`, `set_triggers_enabled`/`are_triggers_enabled`, `set_views_enabled`/`are_views_enabled`, `set_foreign_keys_enabled`/`are_foreign_keys_enabled`, and `set_double_quoted_strings_dml`/`are_double_quoted_strings_dml_enabled` (plus the `_ddl` variants).
 * Added `SqliteFunctionBehavior` and a `register_impl_with_behavior` function (generated next to `register_impl`/`register_nondeterministic_impl` by `#[declare_sql_function]`) to register custom SQLite functions with explicit behavior flags (`DETERMINISTIC`, `INNOCUOUS`, `DIRECTONLY`, `SUBTYPE`).
 * Added a `RunQueryDslSupport` trait to indicate types that should implement `RunQueryDsl` in a sync/async agnostic way
+* Added a `#[derive(diesel::Enum)]` proc-macro to easily map Rust enums to database enums.
 
 ### Fixed
 

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -280,10 +280,10 @@ fn database_url_from_env(backend_specific_env_var: &str) -> String {
         .expect("DATABASE_URL must be set in order to run tests")
 }
 
+#[allow(unexpected_cfgs)]
 mod schema {
     use diesel::prelude::*;
 
-    #[cfg(any(feature = "postgres", feature = "mysql"))]
     pub mod sql_types {
         #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
         #[cfg_attr(feature = "postgres", diesel(postgres_type(name = "color")))]
@@ -323,7 +323,6 @@ mod schema {
         }
     }
 
-    #[allow(unexpected_cfgs)]
     #[cfg(not(any(feature = "__sqlite-shared", feature = "sqlite")))]
     table! {
         brands {

--- a/diesel/src/doctest_setup.rs
+++ b/diesel/src/doctest_setup.rs
@@ -283,6 +283,14 @@ fn database_url_from_env(backend_specific_env_var: &str) -> String {
 mod schema {
     use diesel::prelude::*;
 
+    #[cfg(any(feature = "postgres", feature = "mysql"))]
+    pub mod sql_types {
+        #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+        #[cfg_attr(feature = "postgres", diesel(postgres_type(name = "color")))]
+        #[cfg_attr(feature = "mysql", diesel(mysql_type(name = "Enum")))]
+        pub struct Color;
+    }
+
     table! {
         animals {
             id -> Integer,

--- a/diesel/src/internal/derives.rs
+++ b/diesel/src/internal/derives.rs
@@ -152,3 +152,9 @@ pub mod has_query {
     #[doc(hidden)]
     pub use crate::{expand_mysql, expand_pg, expand_sqlite};
 }
+
+#[doc(hidden)]
+pub mod enum_ {
+    #[doc(hidden)]
+    pub use crate::{expand_mysql, expand_pg, expand_sqlite};
+}

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -845,6 +845,8 @@ pub mod prelude {
         QueryResult,
     };
     #[doc(inline)]
+    pub use diesel_derives::Enum;
+    #[doc(inline)]
     pub use diesel_derives::allow_tables_to_appear_in_same_query;
     #[doc(inline)]
     pub use diesel_derives::table_proc as table;

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -659,6 +659,9 @@ impl<T: SqlType + SingleValue> SingleValue for Nullable<T> {}
 
 #[doc(inline)]
 pub use diesel_derives::DieselNumericOps;
+#[cfg(any(feature = "postgres", feature = "mysql"))]
+#[doc(inline)]
+pub use diesel_derives::Enum;
 #[doc(inline)]
 pub use diesel_derives::SqlType;
 

--- a/diesel/src/sql_types/mod.rs
+++ b/diesel/src/sql_types/mod.rs
@@ -659,9 +659,6 @@ impl<T: SqlType + SingleValue> SingleValue for Nullable<T> {}
 
 #[doc(inline)]
 pub use diesel_derives::DieselNumericOps;
-#[cfg(any(feature = "postgres", feature = "mysql"))]
-#[doc(inline)]
-pub use diesel_derives::Enum;
 #[doc(inline)]
 pub use diesel_derives::SqlType;
 

--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -218,6 +218,16 @@ fn main() {
             })],
         ),
         (
+            "enum",
+            vec![
+                Example::with_heading(
+                    "diesel_derives__tests__enum_1_(postgres).snap",
+                    "PostgreSQL Enum",
+                ),
+                Example::with_heading("diesel_derives__tests__enum_1_(mysql).snap", "MySQL Enum"),
+            ],
+        ),
+        (
             "from_sql_row",
             vec![Example::new("diesel_derives__tests__from_sql_row_1.snap")],
         ),

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -8,8 +8,13 @@ use crate::model::Model;
 use crate::util::{ty_for_foreign_derive, wrap_in_dummy_mod};
 
 pub fn derive(item: DeriveInput) -> Result<TokenStream> {
-    let model = Model::from_item(&item, true, false)?;
+    let tokens = derive_inner(item)?;
 
+    Ok(wrap_in_dummy_mod(tokens))
+}
+
+pub fn derive_inner(item: DeriveInput) -> Result<TokenStream> {
+    let model = Model::from_item(&item, true, false)?;
     if model.sql_types.is_empty() {
         return Err(syn::Error::new(
             proc_macro2::Span::mixed_site(),
@@ -24,7 +29,6 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
     let mut generics = item.generics.clone();
     generics.params.push(parse_quote!('__expr));
-
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     let mut generics2 = generics.clone();
@@ -197,8 +201,5 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             )
         }
     });
-
-    Ok(wrap_in_dummy_mod(quote! {
-        #(#tokens)*
-    }))
+    Ok(quote! {#(#tokens)*})
 }

--- a/diesel_derives/src/enum_.rs
+++ b/diesel_derives/src/enum_.rs
@@ -31,14 +31,14 @@ fn from_bytes_method_body(enum_variant: &Variant) -> TokenStream {
     let variant_as_byte_string = enum_variant_to_byte_string_literal(enum_variant);
     let variant_name = &enum_variant.ident;
 
-    quote! {#variant_as_byte_string => Some(Self::#variant_name)}
+    quote! {#variant_as_byte_string => Ok(Self::#variant_name)}
 }
 
 fn as_bytes_method_body(enum_variant: &Variant) -> TokenStream {
     let variant_as_byte_string = enum_variant_to_byte_string_literal(enum_variant);
     let variant_name = &enum_variant.ident;
 
-    quote! {Self::#variant_name => #variant_as_byte_string}
+    quote! {Self::#variant_name => #variant_as_byte_string.as_slice()}
 }
 
 fn impl_from_sql(
@@ -47,15 +47,17 @@ fn impl_from_sql(
     from_sql_types: &[TokenStream],
     backend: &TokenStream,
     value_type: &TokenStream,
+    from_bytes_arms: &[TokenStream],
 ) -> TokenStream {
     let enum_name_as_str = enum_name.to_string();
 
     quote! {
-        impl #impl_generics ::diesel::deserialize::FromSql<#(#from_sql_types)*, #backend> for #enum_name #ty_generics #where_clause {
-            fn from_sql(value: #value_type) -> ::diesel::deserialize::Result<Self> {
-                let raw_bytes = value.as_bytes();
-
-                Self::from_bytes(raw_bytes).ok_or_else(|| format!("unable to convert bytes {:?} to {}", raw_bytes, #enum_name_as_str).into())
+        impl #impl_generics diesel::deserialize::FromSql<#(#from_sql_types)*, #backend> for #enum_name #ty_generics #where_clause {
+            fn from_sql(value: #value_type) -> diesel::deserialize::Result<Self> {
+                match value.as_bytes() {
+                    #(#from_bytes_arms),*,
+                    raw_bytes => Err(format!("unable to convert bytes {:?} to {}", raw_bytes, #enum_name_as_str).into())
+                }
             }
         }
     }
@@ -66,14 +68,18 @@ fn impl_to_sql(
     (impl_generics, ty_generics, where_clause): &(ImplGenerics, TypeGenerics, Option<&WhereClause>),
     to_sql_types: &[TokenStream],
     backend: &TokenStream,
+    to_bytes_arms: &[TokenStream],
 ) -> TokenStream {
     quote! {
-        impl #impl_generics ::diesel::serialize::ToSql<#(#to_sql_types)*, #backend> for #enum_name #ty_generics #where_clause {
-            fn to_sql<'b>(&'b self, out: &mut ::diesel::serialize::Output<'b, '_, #backend>) -> ::diesel::serialize::Result {
+        impl #impl_generics diesel::serialize::ToSql<#(#to_sql_types)*, #backend> for #enum_name #ty_generics #where_clause {
+            fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, #backend>) -> diesel::serialize::Result {
                 use ::std::io::Write;
+                let bytes = match self {
+                    #(#to_bytes_arms),*
+                };
 
-                out.write_all(self.as_bytes())?;
-                Ok(::diesel::serialize::IsNull::No)
+                out.write_all(bytes)?;
+                Ok(diesel::serialize::IsNull::No)
             }
         }
     }
@@ -105,67 +111,55 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
     let generics = item.generics.split_for_impl();
 
-    let mut impls = Vec::new();
     let sql_types: Vec<_> = model
         .sql_types
         .iter()
         .map(syn::Type::to_token_stream)
         .collect();
 
-    if cfg!(feature = "postgres") {
-        let backend = quote! { ::diesel::pg::Pg };
-        let value_type = quote! { ::diesel::pg::PgValue<'_> };
+    let pg_from_impl = impl_from_sql(
+        &item.ident,
+        &generics,
+        &sql_types,
+        &quote! { diesel::pg::Pg },
+        &quote! { diesel::pg::PgValue<'_> },
+        &from_bytes_arms,
+    );
 
-        impls.push(impl_from_sql(
-            &item.ident,
-            &generics,
-            &sql_types,
-            &backend,
-            &value_type,
-        ));
-        impls.push(impl_to_sql(&item.ident, &generics, &sql_types, &backend));
-    }
+    let mysql_from_impl = impl_from_sql(
+        &item.ident,
+        &generics,
+        &sql_types,
+        &quote! { diesel::mysql::Mysql },
+        &quote! { diesel::mysql::MysqlValue<'_> },
+        &from_bytes_arms,
+    );
 
-    if cfg!(feature = "mysql") {
-        let backend = quote! { ::diesel::mysql::Mysql };
-        let value_type = quote! { ::diesel::mysql::MysqlValue<'_> };
+    let pg_to_impl = impl_to_sql(
+        &item.ident,
+        &generics,
+        &sql_types,
+        &quote! { diesel::pg::Pg },
+        &as_bytes_arms,
+    );
 
-        impls.push(impl_from_sql(
-            &item.ident,
-            &generics,
-            &sql_types,
-            &backend,
-            &value_type,
-        ));
-        impls.push(impl_to_sql(&item.ident, &generics, &sql_types, &backend));
-    }
+    let mysql_to_impl = impl_to_sql(
+        &item.ident,
+        &generics,
+        &sql_types,
+        &quote! { diesel::mysql::Mysql },
+        &as_bytes_arms,
+    );
 
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
-
-    let enum_name = &item.ident;
-    let impl_from_and_to_bytes = quote! {
-        impl #impl_generics #enum_name #ty_generics #where_clause {
-            pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-                match bytes {
-                    #(#from_bytes_arms),*,
-                    _ => None
-                }
-            }
-
-            pub fn as_bytes(&self) -> &[u8] {
-                match self {
-                    #(#as_bytes_arms),*
-                }
-            }
-        }
-    };
-
-    let as_expression_impl = super::as_expression::derive(item.clone())?;
-    let from_sql_row_impl = super::from_sql_row::derive(item)?;
+    let as_expression_impl = super::as_expression::derive_inner(item.clone())?;
+    let from_sql_row_impl = super::from_sql_row::derive_inner(item)?;
 
     Ok(wrap_in_dummy_mod(quote! {
-        #impl_from_and_to_bytes
-        #(#impls)*
+        diesel::internal::derives::enum_::expand_pg! { #pg_from_impl }
+        diesel::internal::derives::enum_::expand_mysql! { #mysql_from_impl }
+        diesel::internal::derives::enum_::expand_pg! { #pg_to_impl }
+        diesel::internal::derives::enum_::expand_mysql! { #mysql_to_impl }
+
         #as_expression_impl
         #from_sql_row_impl
     }))

--- a/diesel_derives/src/enum_.rs
+++ b/diesel_derives/src/enum_.rs
@@ -1,0 +1,172 @@
+use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
+use syn::{
+    Data, DeriveInput, Ident, ImplGenerics, LitByteStr, Result, TypeGenerics, Variant, WhereClause,
+    spanned::Spanned,
+};
+
+use crate::{model::Model, util::wrap_in_dummy_mod};
+
+const ERROR_MESSAGE: &str = "this derive can only be used on enums with exclusively unit-variants";
+
+fn validate_variant_has_no_fields(enum_variant: &Variant) -> Result<()> {
+    if !enum_variant.fields.is_empty() {
+        return Err(syn::Error::new(
+            proc_macro2::Span::mixed_site(),
+            ERROR_MESSAGE,
+        ));
+    }
+
+    Ok(())
+}
+
+fn enum_variant_to_byte_string_literal(enum_variant: &Variant) -> LitByteStr {
+    LitByteStr::new(
+        enum_variant.ident.to_string().as_bytes(),
+        enum_variant.span(),
+    )
+}
+
+fn from_bytes_method_body(enum_variant: &Variant) -> TokenStream {
+    let variant_as_byte_string = enum_variant_to_byte_string_literal(enum_variant);
+    let variant_name = &enum_variant.ident;
+
+    quote! {#variant_as_byte_string => Some(Self::#variant_name)}
+}
+
+fn as_bytes_method_body(enum_variant: &Variant) -> TokenStream {
+    let variant_as_byte_string = enum_variant_to_byte_string_literal(enum_variant);
+    let variant_name = &enum_variant.ident;
+
+    quote! {Self::#variant_name => #variant_as_byte_string}
+}
+
+fn impl_from_sql(
+    enum_name: &Ident,
+    (impl_generics, ty_generics, where_clause): &(ImplGenerics, TypeGenerics, Option<&WhereClause>),
+    from_sql_types: &[TokenStream],
+    backend: &TokenStream,
+    value_type: &TokenStream,
+) -> TokenStream {
+    let enum_name_as_str = enum_name.to_string();
+
+    quote! {
+        impl #impl_generics ::diesel::deserialize::FromSql<#(#from_sql_types)*, #backend> for #enum_name #ty_generics #where_clause {
+            fn from_sql(value: #value_type) -> ::diesel::deserialize::Result<Self> {
+                let raw_bytes = value.as_bytes();
+
+                Self::from_bytes(raw_bytes).ok_or_else(|| format!("unable to convert bytes {:?} to {}", raw_bytes, #enum_name_as_str).into())
+            }
+        }
+    }
+}
+
+fn impl_to_sql(
+    enum_name: &Ident,
+    (impl_generics, ty_generics, where_clause): &(ImplGenerics, TypeGenerics, Option<&WhereClause>),
+    to_sql_types: &[TokenStream],
+    backend: &TokenStream,
+) -> TokenStream {
+    quote! {
+        impl #impl_generics ::diesel::serialize::ToSql<#(#to_sql_types)*, #backend> for #enum_name #ty_generics #where_clause {
+            fn to_sql<'b>(&'b self, out: &mut ::diesel::serialize::Output<'b, '_, #backend>) -> ::diesel::serialize::Result {
+                use ::std::io::Write;
+
+                out.write_all(self.as_bytes())?;
+                Ok(::diesel::serialize::IsNull::No)
+            }
+        }
+    }
+}
+
+pub fn derive(item: DeriveInput) -> Result<TokenStream> {
+    let model = Model::from_item(&item, true, false)?;
+
+    let enum_variants = match &item.data {
+        Data::Enum(e) => &e.variants,
+        _ => {
+            return Err(syn::Error::new(
+                proc_macro2::Span::mixed_site(),
+                ERROR_MESSAGE,
+            ));
+        }
+    };
+
+    for v in enum_variants {
+        validate_variant_has_no_fields(v)?;
+    }
+
+    let mut from_bytes_arms = Vec::with_capacity(enum_variants.len());
+    let mut as_bytes_arms = Vec::with_capacity(enum_variants.len());
+    for v in enum_variants {
+        from_bytes_arms.push(from_bytes_method_body(v));
+        as_bytes_arms.push(as_bytes_method_body(v))
+    }
+
+    let generics = item.generics.split_for_impl();
+
+    let mut impls = Vec::new();
+    let sql_types: Vec<_> = model
+        .sql_types
+        .iter()
+        .map(syn::Type::to_token_stream)
+        .collect();
+
+    if cfg!(feature = "postgres") {
+        let backend = quote! { ::diesel::pg::Pg };
+        let value_type = quote! { ::diesel::pg::PgValue<'_> };
+
+        impls.push(impl_from_sql(
+            &item.ident,
+            &generics,
+            &sql_types,
+            &backend,
+            &value_type,
+        ));
+        impls.push(impl_to_sql(&item.ident, &generics, &sql_types, &backend));
+    }
+
+    if cfg!(feature = "mysql") {
+        let backend = quote! { ::diesel::mysql::Mysql };
+        let value_type = quote! { ::diesel::mysql::MysqlValue<'_> };
+
+        impls.push(impl_from_sql(
+            &item.ident,
+            &generics,
+            &sql_types,
+            &backend,
+            &value_type,
+        ));
+        impls.push(impl_to_sql(&item.ident, &generics, &sql_types, &backend));
+    }
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let enum_name = &item.ident;
+    let impl_from_and_to_bytes = quote! {
+        impl #impl_generics #enum_name #ty_generics #where_clause {
+            pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+                match bytes {
+                    #(#from_bytes_arms),*,
+                    _ => None
+                }
+            }
+
+            pub fn as_bytes(&self) -> &[u8] {
+                match self {
+                    #(#as_bytes_arms),*
+                }
+            }
+        }
+    };
+
+    let as_expression_impl = super::as_expression::derive(item.clone())?;
+    let from_sql_row_impl = super::from_sql_row::derive(item)?;
+
+    Ok(wrap_in_dummy_mod(quote! {
+        #impl_from_and_to_bytes
+        #(#impls)*
+        #as_expression_impl
+        #from_sql_row_impl
+    }))
+}

--- a/diesel_derives/src/from_sql_row.rs
+++ b/diesel_derives/src/from_sql_row.rs
@@ -7,10 +7,13 @@ use syn::parse_quote;
 use crate::model::Model;
 use crate::util::{ty_for_foreign_derive, wrap_in_dummy_mod};
 
-pub fn derive(mut item: DeriveInput) -> Result<TokenStream> {
+pub fn derive(item: DeriveInput) -> Result<TokenStream> {
+    Ok(wrap_in_dummy_mod(derive_inner(item)?))
+}
+
+pub fn derive_inner(mut item: DeriveInput) -> Result<TokenStream> {
     let model = Model::from_item(&item, true, false)?;
     let struct_ty = ty_for_foreign_derive(&item, &model)?;
-
     {
         item.generics.params.push(parse_quote!(__DB));
         item.generics.params.push(parse_quote!(__ST));
@@ -26,8 +29,7 @@ pub fn derive(mut item: DeriveInput) -> Result<TokenStream> {
             .push(parse_quote!(Self: diesel::deserialize::FromSql<__ST, __DB>));
     }
     let (impl_generics, _, where_clause) = item.generics.split_for_impl();
-
-    Ok(wrap_in_dummy_mod(quote! {
+    let implementation = quote! {
         // Need to put __ST and __DB after lifetimes but before const params
         impl #impl_generics diesel::deserialize::Queryable<__ST, __DB> for #struct_ty
         #where_clause
@@ -38,5 +40,6 @@ pub fn derive(mut item: DeriveInput) -> Result<TokenStream> {
                 diesel::deserialize::Result::Ok(row)
             }
         }
-    }))
+    };
+    Ok(implementation)
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -40,6 +40,8 @@ mod associations;
 mod diesel_for_each_tuple;
 mod diesel_numeric_ops;
 mod diesel_public_if;
+#[cfg(any(feature = "postgres", feature = "mysql"))]
+mod enum_;
 mod from_sql_row;
 mod has_query;
 mod identifiable;
@@ -2828,5 +2830,47 @@ pub fn derive_has_query(input: TokenStream) -> TokenStream {
 fn derive_has_query_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     syn::parse2(input)
         .and_then(has_query::derive)
+        .unwrap_or_else(syn::Error::into_compile_error)
+}
+
+/// Implements `FromSql` and `ToSql` for enum types
+///
+/// This derive enables an enum (with unit-variants only) to be serialized to the database as a byte-string and deserialized from the same representation from the database. It requires one or more backends to be supplied so as to implement the required traits, as well as an SQL type.
+///
+/// # Attributes
+///
+/// ## Required container attributes
+///
+/// * `#[diesel(sql_type = path::to::MyEnumType)]`, specifies the database type this enum represents
+///
+/// # Examples
+///
+/// ```rust
+/// # extern crate diesel;
+/// # extern crate dotenvy;
+/// # include!("../../diesel/src/doctest_setup.rs");
+///
+/// # #[cfg(any(feature = "postgres", feature = "mysql"))]
+/// #[derive(Debug, diesel::sql_types::Enum)]
+/// #[diesel(sql_type = schema::sql_types::Color)]
+/// enum Color {
+///     Red,
+///     Green,
+///     Blue
+/// }
+///
+/// # fn main() {}
+/// ```
+#[cfg(any(feature = "postgres", feature = "mysql"))]
+#[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/enum.md")))]
+#[proc_macro_derive(Enum, attributes(diesel))]
+pub fn derive_enum(input: TokenStream) -> TokenStream {
+    derive_enum_inner(input.into()).into()
+}
+
+#[cfg(any(feature = "postgres", feature = "mysql"))]
+fn derive_enum_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    syn::parse2(input)
+        .and_then(enum_::derive)
         .unwrap_or_else(syn::Error::into_compile_error)
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -40,7 +40,6 @@ mod associations;
 mod diesel_for_each_tuple;
 mod diesel_numeric_ops;
 mod diesel_public_if;
-#[cfg(any(feature = "postgres", feature = "mysql"))]
 mod enum_;
 mod from_sql_row;
 mod has_query;
@@ -2835,7 +2834,14 @@ fn derive_has_query_inner(input: proc_macro2::TokenStream) -> proc_macro2::Token
 
 /// Implements `FromSql` and `ToSql` for enum types
 ///
-/// This derive enables an enum (with unit-variants only) to be serialized to the database as a byte-string and deserialized from the same representation from the database. It requires one or more backends to be supplied so as to implement the required traits, as well as an SQL type.
+/// This derive enables an enum (with unit-variants only) to be serialized to the database as
+/// a byte-string and deserialized from the same representation from the database.
+///
+/// This derive generates `FromSql` and `ToSql` implementations for the `diesel::pg::Pg` and
+/// `diesel::mysql::Mysql` backend if these are enabled at compile time.
+///
+/// Additional it internally generates the same implementations as `#[derive(FromSqlRow)]`
+/// and `#[derive(AsExpression)]`
 ///
 /// # Attributes
 ///
@@ -2850,25 +2856,29 @@ fn derive_has_query_inner(input: proc_macro2::TokenStream) -> proc_macro2::Token
 /// # extern crate dotenvy;
 /// # include!("../../diesel/src/doctest_setup.rs");
 ///
-/// # #[cfg(any(feature = "postgres", feature = "mysql"))]
-/// #[derive(Debug, diesel::sql_types::Enum)]
+/// #[derive(Debug, diesel::Enum, PartialEq)]
 /// #[diesel(sql_type = schema::sql_types::Color)]
 /// enum Color {
 ///     Red,
 ///     Green,
 ///     Blue
 /// }
-///
+/// # #[cfg(feature = "postgres")]
+/// # fn main() -> QueryResult<()> {
+/// # let connection = &mut connection_no_data();
+/// let r = diesel::select(Color::Red.into_sql::<schema::sql_types::Color>()).get_result::<Color>(connection)?;
+/// assert_eq!(r, Color::Red);
+/// Ok(())
+/// # }
+/// # #[cfg(not(feature = "postgres"))]
 /// # fn main() {}
 /// ```
-#[cfg(any(feature = "postgres", feature = "mysql"))]
 #[cfg_attr(docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/enum.md")))]
 #[proc_macro_derive(Enum, attributes(diesel))]
 pub fn derive_enum(input: TokenStream) -> TokenStream {
     derive_enum_inner(input.into()).into()
 }
 
-#[cfg(any(feature = "postgres", feature = "mysql"))]
 fn derive_enum_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     syn::parse2(input)
         .and_then(enum_::derive)

--- a/diesel_derives/src/tests/enum_.rs
+++ b/diesel_derives/src/tests/enum_.rs
@@ -1,0 +1,31 @@
+use super::derive;
+use super::expand_with;
+
+#[test]
+pub(crate) fn enum_1() {
+    let input = quote::quote! {
+        #[derive(Debug, diesel::Enum)]
+        #[diesel(sql_type = schema::sql_types::Color)]
+        enum Color {
+            Red,
+            Green,
+            Blue
+        }
+    };
+
+    let name = if cfg!(feature = "postgres") {
+        "postgres"
+    } else if cfg!(feature = "mysql") {
+        "mysql"
+    } else {
+        // no support for sqlite yet
+        return;
+    };
+
+    expand_with(
+        &crate::derive_enum_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(Enum)])),
+        &format!("enum1_({name})"),
+    );
+}

--- a/diesel_derives/src/tests/mod.rs
+++ b/diesel_derives/src/tests/mod.rs
@@ -218,6 +218,7 @@ mod define_sql_function;
 mod diesel_for_each_tuple;
 mod diesel_numeric_ops;
 mod diesel_public_if;
+mod enum_;
 mod from_sql_row;
 mod has_query;
 mod identifiable;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum1_(mysql).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum1_(mysql).snap
@@ -1,0 +1,167 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(Enum)]\n#[derive(Debug, diesel::Enum)]\n#[diesel(sql_type = schema::sql_types::Color)]\nenum Color {\n    Red,\n    Green,\n    Blue,\n}\n"
+---
+const _: () = {
+    use diesel;
+
+    impl diesel::deserialize::FromSql<schema::sql_types::Color, diesel::mysql::Mysql>
+    for Color {
+        fn from_sql(
+            value: diesel::mysql::MysqlValue<'_>,
+        ) -> diesel::deserialize::Result<Self> {
+            match value.as_bytes() {
+                b"Red" => Ok(Self::Red),
+                b"Green" => Ok(Self::Green),
+                b"Blue" => Ok(Self::Blue),
+                raw_bytes => {
+                    Err(
+                        format!("unable to convert bytes {:?} to {}", raw_bytes, "Color")
+                            .into(),
+                    )
+                }
+            }
+        }
+    }
+
+    impl diesel::serialize::ToSql<schema::sql_types::Color, diesel::mysql::Mysql>
+    for Color {
+        fn to_sql<'b>(
+            &'b self,
+            out: &mut diesel::serialize::Output<'b, '_, diesel::mysql::Mysql>,
+        ) -> diesel::serialize::Result {
+            use ::std::io::Write;
+            let bytes = match self {
+                Self::Red => b"Red".as_slice(),
+                Self::Green => b"Green".as_slice(),
+                Self::Blue => b"Blue".as_slice(),
+            };
+            out.write_all(bytes)?;
+            Ok(diesel::serialize::IsNull::No)
+        }
+    }
+    impl<'__expr> diesel::expression::AsExpression<schema::sql_types::Color>
+    for &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            schema::sql_types::Color,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            schema::sql_types::Color,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<
+        '__expr,
+    > diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+    > for &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<'__expr, '__expr2> diesel::expression::AsExpression<schema::sql_types::Color>
+    for &'__expr2 &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            schema::sql_types::Color,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            schema::sql_types::Color,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<
+        '__expr,
+        '__expr2,
+    > diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+    > for &'__expr2 &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    impl<
+        __DB,
+    > diesel::serialize::ToSql<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+        __DB,
+    > for Color
+    where
+        __DB: diesel::backend::Backend,
+        Self: diesel::serialize::ToSql<schema::sql_types::Color, __DB>,
+    {
+        fn to_sql<'__b>(
+            &'__b self,
+            out: &mut diesel::serialize::Output<'__b, '_, __DB>,
+        ) -> diesel::serialize::Result {
+            diesel::serialize::ToSql::<schema::sql_types::Color, __DB>::to_sql(self, out)
+        }
+    }
+    impl diesel::expression::AsExpression<schema::sql_types::Color> for Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            schema::sql_types::Color,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            schema::sql_types::Color,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    impl diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+    > for Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    impl<__DB, __ST> diesel::deserialize::Queryable<__ST, __DB> for Color
+    where
+        __DB: diesel::backend::Backend,
+        __ST: diesel::sql_types::SingleValue,
+        Self: diesel::deserialize::FromSql<__ST, __DB>,
+    {
+        type Row = Self;
+        fn build(row: Self) -> diesel::deserialize::Result<Self> {
+            diesel::deserialize::Result::Ok(row)
+        }
+    }
+};

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum1_(postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum1_(postgres).snap
@@ -1,0 +1,166 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(Enum)]\n#[derive(Debug, diesel::Enum)]\n#[diesel(sql_type = schema::sql_types::Color)]\nenum Color {\n    Red,\n    Green,\n    Blue,\n}\n"
+---
+const _: () = {
+    use diesel;
+    impl diesel::deserialize::FromSql<schema::sql_types::Color, diesel::pg::Pg>
+    for Color {
+        fn from_sql(
+            value: diesel::pg::PgValue<'_>,
+        ) -> diesel::deserialize::Result<Self> {
+            match value.as_bytes() {
+                b"Red" => Ok(Self::Red),
+                b"Green" => Ok(Self::Green),
+                b"Blue" => Ok(Self::Blue),
+                raw_bytes => {
+                    Err(
+                        format!("unable to convert bytes {:?} to {}", raw_bytes, "Color")
+                            .into(),
+                    )
+                }
+            }
+        }
+    }
+
+    impl diesel::serialize::ToSql<schema::sql_types::Color, diesel::pg::Pg> for Color {
+        fn to_sql<'b>(
+            &'b self,
+            out: &mut diesel::serialize::Output<'b, '_, diesel::pg::Pg>,
+        ) -> diesel::serialize::Result {
+            use ::std::io::Write;
+            let bytes = match self {
+                Self::Red => b"Red".as_slice(),
+                Self::Green => b"Green".as_slice(),
+                Self::Blue => b"Blue".as_slice(),
+            };
+            out.write_all(bytes)?;
+            Ok(diesel::serialize::IsNull::No)
+        }
+    }
+
+    impl<'__expr> diesel::expression::AsExpression<schema::sql_types::Color>
+    for &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            schema::sql_types::Color,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            schema::sql_types::Color,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<
+        '__expr,
+    > diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+    > for &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<'__expr, '__expr2> diesel::expression::AsExpression<schema::sql_types::Color>
+    for &'__expr2 &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            schema::sql_types::Color,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            schema::sql_types::Color,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<
+        '__expr,
+        '__expr2,
+    > diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+    > for &'__expr2 &'__expr Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    impl<
+        __DB,
+    > diesel::serialize::ToSql<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+        __DB,
+    > for Color
+    where
+        __DB: diesel::backend::Backend,
+        Self: diesel::serialize::ToSql<schema::sql_types::Color, __DB>,
+    {
+        fn to_sql<'__b>(
+            &'__b self,
+            out: &mut diesel::serialize::Output<'__b, '_, __DB>,
+        ) -> diesel::serialize::Result {
+            diesel::serialize::ToSql::<schema::sql_types::Color, __DB>::to_sql(self, out)
+        }
+    }
+    impl diesel::expression::AsExpression<schema::sql_types::Color> for Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            schema::sql_types::Color,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            schema::sql_types::Color,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    impl diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<schema::sql_types::Color>,
+    > for Color {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<schema::sql_types::Color>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    impl<__DB, __ST> diesel::deserialize::Queryable<__ST, __DB> for Color
+    where
+        __DB: diesel::backend::Backend,
+        __ST: diesel::sql_types::SingleValue,
+        Self: diesel::deserialize::FromSql<__ST, __DB>,
+    {
+        type Row = Self;
+        fn build(row: Self) -> diesel::deserialize::Result<Self> {
+            diesel::deserialize::Result::Ok(row)
+        }
+    }
+};

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -280,7 +280,7 @@ fn with_lifetime_constraints() {
 #[test]
 fn with_type_and_const_generics() {
     #[derive(FromSqlRow, AsExpression)]
-    #[diesel(sql_type = sql_types::Text)]
+    #[diesel(sql_type = diesel::sql_types::Text)]
     struct Wrapper<T: 'static>(String, std::marker::PhantomData<T>);
 
     impl<T: 'static> Wrapper<T> {
@@ -295,10 +295,10 @@ fn with_type_and_const_generics() {
         }
     }
 
-    impl<DB, T: 'static> serialize::ToSql<sql_types::Text, DB> for Wrapper<T>
+    impl<DB, T: 'static> serialize::ToSql<diesel::sql_types::Text, DB> for Wrapper<T>
     where
         DB: backend::Backend,
-        String: serialize::ToSql<sql_types::Text, DB>,
+        String: serialize::ToSql<diesel::sql_types::Text, DB>,
     {
         fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, DB>) -> serialize::Result {
             self.0.to_sql(out)
@@ -447,7 +447,7 @@ fn with_explicit_column_names_raw_type() {
 #[test]
 fn with_serialize_as() {
     #[derive(Debug, FromSqlRow, AsExpression)]
-    #[diesel(sql_type = sql_types::Text)]
+    #[diesel(sql_type = diesel::sql_types::Text)]
     struct UppercaseString(pub String);
 
     impl From<String> for UppercaseString {
@@ -456,10 +456,10 @@ fn with_serialize_as() {
         }
     }
 
-    impl<DB> serialize::ToSql<sql_types::Text, DB> for UppercaseString
+    impl<DB> serialize::ToSql<diesel::sql_types::Text, DB> for UppercaseString
     where
         DB: backend::Backend,
-        String: serialize::ToSql<sql_types::Text, DB>,
+        String: serialize::ToSql<diesel::sql_types::Text, DB>,
     {
         fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, DB>) -> serialize::Result {
             self.0.to_sql(out)

--- a/diesel_derives/tests/enum_.rs
+++ b/diesel_derives/tests/enum_.rs
@@ -1,0 +1,51 @@
+use crate::helpers::connection;
+use crate::schema;
+use diesel::prelude::*;
+use diesel_derives::Enum;
+
+#[derive(Debug, Clone, Copy, Enum, PartialEq)]
+#[cfg_attr(feature = "postgres", diesel(check_for_backend(diesel::pg::Pg), sql_type = schema::sql_types::Color))]
+#[cfg_attr(feature = "mysql", diesel(check_for_backend(diesel::mysql::Mysql), sql_type = schema::sql_types::CarsPaintColorEnum))]
+enum Color {
+    Blue,
+    Red,
+}
+
+#[test]
+fn as_bytes() {
+    assert_eq!(b"Blue", Color::Blue.as_bytes());
+}
+
+#[test]
+fn from_bytes() {
+    assert_eq!(Color::from_bytes(b"Red").unwrap(), Color::Red);
+}
+
+#[test]
+fn from_bytes_error() {
+    assert_eq!(Color::from_bytes(b"foo"), None);
+}
+
+#[test]
+fn insert_and_select() {
+    #[derive(Debug, Clone, Copy, PartialEq, Insertable, HasQuery)]
+    #[diesel(table_name = schema::cars)]
+    struct Car {
+        id: i32,
+        paint_color: Color,
+    }
+
+    let conn = &mut connection();
+    let new_car = Car {
+        id: 1,
+        paint_color: Color::Blue,
+    };
+    diesel::insert_into(schema::cars::table)
+        .values(new_car)
+        .execute(conn)
+        .unwrap();
+
+    let saved = Car::query().load(conn).unwrap();
+    let expected = vec![new_car];
+    assert_eq!(expected, saved);
+}

--- a/diesel_derives/tests/enum_.rs
+++ b/diesel_derives/tests/enum_.rs
@@ -4,26 +4,11 @@ use diesel::prelude::*;
 use diesel_derives::Enum;
 
 #[derive(Debug, Clone, Copy, Enum, PartialEq)]
-#[cfg_attr(feature = "postgres", diesel(check_for_backend(diesel::pg::Pg), sql_type = schema::sql_types::Color))]
-#[cfg_attr(feature = "mysql", diesel(check_for_backend(diesel::mysql::Mysql), sql_type = schema::sql_types::CarsPaintColorEnum))]
+#[cfg_attr(feature = "postgres", diesel(sql_type = schema::sql_types::Color))]
+#[cfg_attr(feature = "mysql", diesel(sql_type = schema::sql_types::CarsPaintColorEnum))]
 enum Color {
     Blue,
     Red,
-}
-
-#[test]
-fn as_bytes() {
-    assert_eq!(b"Blue", Color::Blue.as_bytes());
-}
-
-#[test]
-fn from_bytes() {
-    assert_eq!(Color::from_bytes(b"Red").unwrap(), Color::Red);
-}
-
-#[test]
-fn from_bytes_error() {
-    assert_eq!(Color::from_bytes(b"foo"), None);
 }
 
 #[test]
@@ -48,4 +33,23 @@ fn insert_and_select() {
     let saved = Car::query().load(conn).unwrap();
     let expected = vec![new_car];
     assert_eq!(expected, saved);
+}
+
+#[test]
+fn raw_sql_equal() {
+    let v = Color::Red;
+    let conn = &mut connection();
+
+    #[cfg(feature = "postgres")]
+    let r = diesel::select(diesel::dsl::sql::<schema::sql_types::Color>("'Red'::color").eq(v))
+        .get_result::<bool>(conn)
+        .unwrap();
+
+    #[cfg(feature = "mysql")]
+    let r =
+        diesel::select(diesel::dsl::sql::<schema::sql_types::CarsPaintColorEnum>("'Red'").eq(v))
+            .get_result::<bool>(conn)
+            .unwrap();
+
+    assert!(r);
 }

--- a/diesel_derives/tests/helpers.rs
+++ b/diesel_derives/tests/helpers.rs
@@ -53,6 +53,12 @@ cfg_if! {
                 type VARCHAR DEFAULT 'regular')")
                 .execute(&mut conn)
                 .unwrap();
+            sql_query("CREATE TYPE color as enum (\
+                'Blue',
+                'Red')").execute(&mut conn).unwrap();
+            sql_query("CREATE TABLE cars (\
+                id SERIAL PRIMARY KEY,
+                paint_color color not null)").execute(&mut conn).unwrap();
             conn
         }
     } else if #[cfg(feature = "mysql")] {
@@ -79,6 +85,9 @@ cfg_if! {
                 type VARCHAR(255) DEFAULT 'regular')")
                 .execute(&mut conn)
                 .unwrap();
+            sql_query("CREATE TEMPORARY TABLE cars (\
+                id INTEGER PRIMARY KEY AUTO_INCREMENT,
+                paint_color ENUM('Blue', 'Red') NOT NULL)").execute(&mut conn).unwrap();
             conn.begin_test_transaction().unwrap();
             conn
         }

--- a/diesel_derives/tests/helpers.rs
+++ b/diesel_derives/tests/helpers.rs
@@ -53,9 +53,6 @@ cfg_if! {
                 type VARCHAR DEFAULT 'regular')")
                 .execute(&mut conn)
                 .unwrap();
-            sql_query("CREATE TYPE color as enum (\
-                'Blue',
-                'Red')").execute(&mut conn).unwrap();
             sql_query("CREATE TABLE cars (\
                 id SERIAL PRIMARY KEY,
                 paint_color color not null)").execute(&mut conn).unwrap();

--- a/diesel_derives/tests/schema.rs
+++ b/diesel_derives/tests/schema.rs
@@ -15,3 +15,37 @@ table! {
         r#type -> Nullable<Text>,
     }
 }
+
+pub mod sql_types {
+    #[cfg(feature = "postgres")]
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "color"))]
+    pub struct Color;
+
+    #[cfg(feature = "mysql")]
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(mysql_type(name = "Enum"))]
+    pub struct CarsPaintColorEnum;
+}
+
+#[cfg(feature = "postgres")]
+table! {
+    use diesel::sql_types::*;
+    use super::sql_types::Color;
+
+    cars {
+        id -> Integer,
+        paint_color -> Color
+    }
+}
+
+#[cfg(feature = "mysql")]
+table! {
+    use diesel::sql_types::*;
+    use super::sql_types::CarsPaintColorEnum;
+
+    cars {
+        id -> Integer,
+        paint_color -> CarsPaintColorEnum
+    }
+}

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -10,6 +10,8 @@ mod as_changeset;
 mod as_expression;
 mod associations;
 mod auto_type;
+#[cfg(any(feature = "postgres", feature = "mysql"))]
+mod enum_;
 mod identifiable;
 mod insertable;
 mod multiconnection;

--- a/migrations/postgres/2026-06-12-111710-0000_add_color_enum/down.sql
+++ b/migrations/postgres/2026-06-12-111710-0000_add_color_enum/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TYPE color;

--- a/migrations/postgres/2026-06-12-111710-0000_add_color_enum/up.sql
+++ b/migrations/postgres/2026-06-12-111710-0000_add_color_enum/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+CREATE TYPE color as ENUM('Red', 'Green', 'Blue');


### PR DESCRIPTION
- **implement at least postgres deserialization and serialization of an enum type**
- **basically complete the implementation**
- **partial commit**
- **turns out the function was done. just remove the unnecessary lines of code**
- **rename the derive-macro to something a bit simpler. I'm not sure if this is good though. Also, write documentation. Also, write two simple tests**
- **add a test that actually tries inserting the color into the database**
- **remove failing test**
- **give parsed_backends set explicit capacity**
- **implement FromSql and ToSql for generated types, not Text**
- **fix syntax for repeating elements**
- **add as_expression and fromsqlrow impls**
- **try to make the test work by using the derive correctly**
- **fix test helper code**
- **add sql_type to allowed parsing. I anticipate this will have to be reworked a bit**
- **fix clippy and formatting recommendations**
- **try to rely on the already implemented check-for-backend functionality to make it work**
- **revert the rust tooclhain to fix the conflict**
- **remove custom attribute and just use the model parsing because it's there**
- **gate the enum test behind a feature to make it work**
