### PR TITLE
Add a security and a LLM/AI policy to the projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,3 +9,6 @@ contact_links:
   - name: Feature Requests
     url: https://github.com/diesel-rs/diesel/discussions/categories/ideas
     about: If you want to suggest a new feature please create a new topic in our discussions forum
+  - name: Report a security vulnerability
+    url: https://github.com/diesel-rs/diesel/security/advisories/new
+    about: Please review our security policy for more details

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- 
+Please provide a short brief summary description of your change here. 
+Also make sure that your code passes all tests and style checks. 
+Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
+It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
+is not ready for review yet by marking it as DRAFT until it is ready.
+
+If you submit a notable change please ensure to include it into the CHANGELOG.md file in
+the root of the repository.
+
+Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
+in the CONTRIBUTING.md file in the root of the repository.
+-->
+
+- [ ] I checked for similar changes and make sure to reference them
+- [ ] I included a changelog entry for relevant new features or changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,16 +152,27 @@ To run rustfmt tests locally:
 You can also use rustfmt to make corrections or highlight issues in your editor.
 Check out [their README](https://github.com/rust-lang/rustfmt) for details.
 
-### Usage of LLMs and AI agents
+### Usage of LLM's/AI agents
 
-The Diesel project doesn't completely disallow to usage of LLMs and AI agents for contributions. There are still a number of restrictions and rules you as a PR author are asked to follow.
+The Diesel project does not strictly forbid the usage of LLM's and AI agents for submitting pull requests. 
+There are still a number of restrictions and rules you as a PR author are asked to follow:
 
-Most importantly you as the author of the PR are responsible for carefully reviewing the generated code to make sure that:
+* You need to make sure that the code you are trying to submit can be licences under the relevant open source License used by Diesel. It cannot contain any code that is incompatible with the licenses used by Diesel.
+* You need to fully understand and review any generated code before submitting a PR. The expectation from the reviewer team is 
+  to discuss these changes with you as a person.
+* You need to ensure that the submitted code satisfies the general requirements of submitting PR's to Diesel. That especially includes the following points:
+    + The Code passes all tests and style checks
+    + The change is as minimal as possible. Huge changes will be just dismissed
+    + You verified that the change actually fixes/implements what it is supposed to fix/implement
+    + The change contains a sufficient amount of documentation to help others following the code
+* The usage of LLM's/AI need to be disclosed (See the linked NlNet resource on how to do that in a meaningful way)
+* We ask you to write pull request descriptions and discussion comments on your own. 
+  We are able to ask an AI agent on our own if we feel that might be helpful.
+* For issues marked as "mentoring available" or "good first issue" consider that these issues are for onboarding new contributors 
+  to the code base. Consider if fully solving such an issue only by using LLM's/AI is helping you to gain experience.
 
-* It is correct to your best knowledge
-* It does not contain any copyrighted code that is incompatible with the license used by Diesel
-
-Furthermore you are asked to disclose the usage of any such tools in your PR description. 
+For a more in depth description we would like to point to NlNet's policies about [using generative AI](https://nlnet.nl/foundation/policies/generativeAI/) in projects they are funding. This document outlines many of the points 
+above in with more details and explanations. 
 
 ### Common Abbreviations
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy for Diesel
+
+## Supported Versions
+
+The Diesel team provides only support for the latest released version at Diesel at any point in time. Users are strongly encouraged to upgrade to the latest version for the best security posture.
+
+## Reporting a Vulnerability
+
+We take the security of Diesel very seriously. If you believe you've found a security vulnerability, we encourage you to inform us responsibly through coordinated disclosure.
+
+### How to Report
+
+**Do not report security vulnerabilities through public GitHub issues, discussions, or social media.**
+
+Instead, please use one of these secure channels:
+
+1. **GitHub Security Advisories** (preferred): Use the "Report a vulnerability" button in the Security tab
+2. **Email** (backup): Send details to `github@weiznich.de`
+
+### What to Include
+
+To help us understand and address the issue quickly, please include:
+
+**Required Information:**
+- Brief description of the vulnerability type (6 or less sentences)
+- Affected version(s) and components
+- Proof-of-concept code to reproduce the issue
+
+**Helpful Additional Details:**
+- Full paths of affected source files
+- Suggested mitigation or fix (if you have ideas)
+- A path resolving the reported problem
+
+Your initial report should be rather brief. For the case that additional details might be required for confirming the reported problem or to asses the severity of the reported issue the Diesel team will provide detailed followup questions.
+
+### Our Response Process
+
+**What We'll Do:**
+1. Acknowledge your report and assign a tracking ID
+2. Assess the vulnerability and determine severity
+3. Develop and test a fix
+4. Coordinate disclosure timeline with you
+5. Release security update and publish advisory
+6. Credit you in our security advisory (if desired)
+
+## Scope
+
+This security policy applies to:
+
+**In Scope:**
+- The Diesel Query builder 
+- Any Diesel procedural macro
+- The Diesel command line tool
+
+**Out of Scope:**
+- Any general Rust/Cargo security issue
+- Any issue occurring in a third party crate that cannot be triggered through Diesel code
+


### PR DESCRIPTION
This change adds a security.md file outlining our way to handle security issues. It lists disclosing issues via the githubs private secuirty reporting feature. It also explicitly outlines that only the latest diesel release is expected to receive fixes for security issues and encurages uses to keep their versions up to date. Finally it outlines which parts of the project are in scope of such reports (almost everything) and which are not in scope (mostly external things like rust/cargo and dependencies). For me this just codifies what I've tried to follow so far.

In addition this PR also adds a section to the Contribution.md file outlining the allowed usage of LLM's and AI agents in this projects. It is impossible to forbid the usage, but we can put up some reasonable rules. I tried to follow here what NlNet (who funded a part of Diesel developments in the past and might to it again in the future) puts up as policy for projects: https://nlnet.nl/foundation/policies/generativeAI/ The most notable addition is that I would like to disallow the usage of LLM's/Agents for good first issues and mentoring available issues. For me personally these issues are not for people copying my instructions into an LLM and posting the result as PR. I can do that myself. I rather prefer having these issues for new contributors instead.

Finally this PR puts up a PR template pointing people to the right places + asking them to also add a changelog entry for their changes. That is something we often need to ask for afterwards.

---

That's for now my idea how to handle these topics. It's not set in stone, I would like to hear the opinions of a wider audience on these topics. So let's ping @diesel-rs/core and @diesel-rs/reviewers as well. (Anyone else is also welcome to put a comment or suggestion below)