### PR TITLE
 Close the SQLite connection on `sqlite3_open_v2` failure to prevent a resource leak

### DIFF
--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -64,6 +64,12 @@ impl RawConnection {
             }
             err_code => {
                 let message = super::error_message(err_code);
+                // sqlite3_open_v2() may allocate a database connection handle
+                // even on failure. To avoid a resource leak, it must be released
+                // with sqlite3_close(). Passing a null pointer to sqlite3_close()
+                // is a harmless no-op, so no null check is needed.
+                // See: https://www.sqlite.org/c3ref/open.html
+                unsafe { ffi::sqlite3_close(conn_pointer) };
                 Err(ConnectionError::BadConnection(message.into()))
             }
         }


### PR DESCRIPTION
Per the SQLite documentation:

> Whether or not an error occurs when it is opened, resources associated with the database connection handle should be released by passing it to sqlite3_close() when it is no longer required.

In `RawConnection::establish`, when `sqlite3_open_v2()` returned a non-OK status, the code returned an error without closing the handle. SQLite may still allocate a connection handle on failure, causing a resource leak.

We can simply call `sqlite3_close()` on the (possibly allocated) handle before returning the error. No null check is needed because sqlite3_close(NULL) is a documented no-op.