### PR TITLE
Improve `#[derive(AsChangeset)]` error messages

### DIFF
--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_correct_type.stderr
@@ -206,13 +206,15 @@ error[E0277]: the trait bound `f64: AsExpression<diesel::sql_types::Integer>` is
  LL |     select(array((1f64, 3f64))).get_result::<Vec<i32>>(&mut connection);
    |                   ^^^^ the trait `AsExpression<diesel::sql_types::Integer>` is not implemented for `f64`
    |
-   = help: the following other types implement trait `AsExpression<T>`:
-             `&&f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `&&f64` implements `AsExpression<diesel::sql_types::Double>`
-             `&f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `&f64` implements `AsExpression<diesel::sql_types::Double>`
-             `f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `f64` implements `AsExpression<diesel::sql_types::Double>`
+help: the following other types implement trait `AsExpression<T>`
+  --> DIESEL/diesel/diesel/src/type_impls/primitives.rs
+   |
+LL |     #[derive(AsExpression, FromSqlRow)]
+   |              ^^^^^^^^^^^^
+   |              |
+   |              `&f64` implements `AsExpression<diesel::sql_types::Double>`
+   |              `f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
+   |              `f64` implements `AsExpression<diesel::sql_types::Double>`
    = note: required for `(f64, f64)` to implement `IntoArrayExpression<diesel::sql_types::Integer>`
 note: required by a bound in `diesel::dsl::array`
   --> DIESEL/diesel/diesel/src/pg/expression/array.rs
@@ -222,6 +224,7 @@ LL | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
 LL | where
 LL |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+   = note: this error originates in the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot convert `(f64, f64)` into an expression of type `Array<diesel::sql_types::Integer>`
  --> tests/fail/array_expressions_must_be_correct_type.rs:9:12

--- a/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/array_expressions_must_be_same_type.stderr
@@ -206,13 +206,15 @@ error[E0277]: the trait bound `f64: AsExpression<diesel::sql_types::Integer>` is
 LL |     select(array((1, 3f64)))
    |                      ^^^^ the trait `AsExpression<diesel::sql_types::Integer>` is not implemented for `f64`
    |
-   = help: the following other types implement trait `AsExpression<T>`:
-             `&&f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `&&f64` implements `AsExpression<diesel::sql_types::Double>`
-             `&f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `&f64` implements `AsExpression<diesel::sql_types::Double>`
-             `f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `f64` implements `AsExpression<diesel::sql_types::Double>`
+help: the following other types implement trait `AsExpression<T>`
+  --> DIESEL/diesel/diesel/src/type_impls/primitives.rs
+   |
+LL |     #[derive(AsExpression, FromSqlRow)]
+   |              ^^^^^^^^^^^^
+   |              |
+   |              `&f64` implements `AsExpression<diesel::sql_types::Double>`
+   |              `f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
+   |              `f64` implements `AsExpression<diesel::sql_types::Double>`
    = note: required for `(i32, f64)` to implement `IntoArrayExpression<diesel::sql_types::Integer>`
 note: required by a bound in `diesel::dsl::array`
   --> DIESEL/diesel/diesel/src/pg/expression/array.rs
@@ -222,6 +224,7 @@ LL | pub fn array<ST, T>(elements: T) -> dsl::array<ST, T>
 LL | where
 LL |     T: IntoArrayExpression<ST>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `array`
+   = note: this error originates in the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: cannot select `{integer}` from `NoFromClause`
    --> tests/fail/array_expressions_must_be_same_type.rs:26:12
@@ -432,14 +435,14 @@ LL |     select(array((1, 3f64)))
    |                   ^ the trait `AsExpression<diesel::sql_types::Double>` is not implemented for `{integer}`
    |
    = help: the following other types implement trait `AsExpression<T>`:
-             `&&f32` implements `AsExpression<Nullable<diesel::sql_types::Float>>`
-             `&&f32` implements `AsExpression<diesel::sql_types::Float>`
-             `&&f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `&&f64` implements `AsExpression<diesel::sql_types::Double>`
-             `&&i16` implements `AsExpression<Nullable<diesel::sql_types::SmallInt>>`
-             `&&i16` implements `AsExpression<diesel::sql_types::SmallInt>`
-             `&&i32` implements `AsExpression<Nullable<diesel::sql_types::Integer>>`
-             `&&i32` implements `AsExpression<diesel::sql_types::Integer>`
+             `&f32` implements `AsExpression<diesel::sql_types::Float>`
+             `&f64` implements `AsExpression<diesel::sql_types::Double>`
+             `&i16` implements `AsExpression<diesel::sql_types::SmallInt>`
+             `&i32` implements `AsExpression<diesel::sql_types::Integer>`
+             `&i64` implements `AsExpression<diesel::sql_types::BigInt>`
+             `&i8` implements `AsExpression<TinyInt>`
+             `&u16` implements `AsExpression<Unsigned<SmallInt>>`
+             `&u32` implements `AsExpression<Oid>`
            and N others
    = note: required for `({integer}, f64)` to implement `IntoArrayExpression<diesel::sql_types::Double>`
 note: required by a bound in `diesel::dsl::array`

--- a/diesel_compile_tests/tests/fail/derive/bad_as_changeset.rs
+++ b/diesel_compile_tests/tests/fail/derive/bad_as_changeset.rs
@@ -14,10 +14,14 @@ table! {
 //~| ERROR: the trait bound `i32: AppearsOnTable<users::table>` is not satisfied
 //~| ERROR: the trait bound `i32: AppearsOnTable<users::table>` is not satisfied
 //~| ERROR: the trait bound `i32: AppearsOnTable<users::table>` is not satisfied
+//~| ERROR: the trait bound `&'update i32: AsExpression<diesel::sql_types::Text>` is not satisfied
+//~| ERROR: the trait bound `&i32: AsExpression<Nullable<Text>>` is not satisfied
+//~| ERROR: the trait bound `i32: AppearsOnTable<users::table>` is not satisfied
 struct User {
     id: String,
     name: i32,
     hair_color: Option<i32>,
+    //~^ ERROR: the trait bound `i32: AsExpression<Nullable<Text>>` is not satisfied
 }
 
 fn main() {}

--- a/diesel_compile_tests/tests/fail/derive/bad_as_changeset.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_as_changeset.stderr
@@ -1,3 +1,26 @@
+error[E0277]: the trait bound `i32: AsExpression<Nullable<Text>>` is not satisfied
+  --> tests/fail/derive/bad_as_changeset.rs:23:5
+   |
+LL | #[derive(AsChangeset)]
+   |          ----------- in this derive macro expansion
+...
+LL |     hair_color: Option<i32>,
+   |     ^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `AsExpression<diesel::sql_types::Nullable<diesel::sql_types::Text>>` is not implemented for `i32`
+help: the following other types implement trait `AsExpression<T>`
+  --> DIESEL/diesel/diesel/src/type_impls/primitives.rs
+   |
+LL |     #[derive(AsExpression, FromSqlRow)]
+   |              ^^^^^^^^^^^^
+   |              |
+   |              `&i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<Nullable<Integer>>`
+   = help: see issue #48214
+
+      = note: this error originates in the derive macro `AsChangeset` which comes from the expansion of the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `i32: AppearsOnTable<users::table>` is not satisfied
   --> tests/fail/derive/bad_as_changeset.rs:11:10
    |
@@ -25,13 +48,78 @@ LL | #[derive(AsChangeset)]
    |          ^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `AsExpression<diesel::sql_types::Nullable<diesel::sql_types::Text>>` is not implemented for `&'update i32`
-   = help: the following other types implement trait `AsExpression<T>`:
-             `&&i32` implements `AsExpression<diesel::sql_types::Integer>`
-             `&&i32` implements `AsExpression<Nullable<Integer>>`
-             `&i32` implements `AsExpression<diesel::sql_types::Integer>`
-             `&i32` implements `AsExpression<Nullable<Integer>>`
-             `i32` implements `AsExpression<diesel::sql_types::Integer>`
-             `i32` implements `AsExpression<Nullable<Integer>>`
+help: the following other types implement trait `AsExpression<T>`
+  --> DIESEL/diesel/diesel/src/type_impls/primitives.rs
+   |
+LL |     #[derive(AsExpression, FromSqlRow)]
+   |              ^^^^^^^^^^^^
+   |              |
+   |              `&i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<Nullable<Integer>>`
+
+      = note: this error originates in the derive macro `AsChangeset` which comes from the expansion of the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `&'update i32: AsExpression<diesel::sql_types::Text>` is not satisfied
+  --> tests/fail/derive/bad_as_changeset.rs:11:10
+   |
+LL | #[derive(AsChangeset)]
+   |          ^^^^^^^^^^^ the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `&'update i32`
+   |
+help: the following other types implement trait `AsExpression<T>`
+  --> DIESEL/diesel/diesel/src/type_impls/primitives.rs
+   |
+LL |     #[derive(AsExpression, FromSqlRow)]
+   |              ^^^^^^^^^^^^
+   |              |
+   |              `&i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<Nullable<Integer>>`
+
+      = note: this error originates in the derive macro `AsChangeset` which comes from the expansion of the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `i32: AppearsOnTable<users::table>` is not satisfied
+  --> tests/fail/derive/bad_as_changeset.rs:11:10
+   |
+LL | #[derive(AsChangeset)]
+   |          ^^^^^^^^^^^ the trait `AppearsOnTable<users::table>` is not implemented for `i32`
+   |
+   = help: the following other types implement trait `AppearsOnTable<QS>`:
+             `&'a T` implements `AppearsOnTable<QS>`
+             `(T, T1)` implements `AppearsOnTable<QS>`
+             `(T, T1, T2)` implements `AppearsOnTable<QS>`
+             `(T, T1, T2, T3)` implements `AppearsOnTable<QS>`
+             `(T, T1, T2, T3, T4)` implements `AppearsOnTable<QS>`
+             `(T, T1, T2, T3, T4, T5)` implements `AppearsOnTable<QS>`
+             `(T, T1, T2, T3, T4, T5, T6)` implements `AppearsOnTable<QS>`
+             `(T, T1, T2, T3, T4, T5, T6, T7)` implements `AppearsOnTable<QS>`
+           and N others
+   = note: required for `&'update i32` to implement `AppearsOnTable<users::table>`
+   = note: required for `diesel::expression::operators::Eq<columns::name, &'update i32>` to implement `diesel::AsChangeset`
+
+      = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `&i32: AsExpression<Nullable<Text>>` is not satisfied
+  --> tests/fail/derive/bad_as_changeset.rs:11:10
+   |
+LL | #[derive(AsChangeset)]
+   |          ^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `AsExpression<diesel::sql_types::Nullable<diesel::sql_types::Text>>` is not implemented for `&i32`
+help: the following other types implement trait `AsExpression<T>`
+  --> DIESEL/diesel/diesel/src/type_impls/primitives.rs
+   |
+LL |     #[derive(AsExpression, FromSqlRow)]
+   |              ^^^^^^^^^^^^
+   |              |
+   |              `&i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<Nullable<Integer>>`
+note: required for `&'update User` to implement `diesel::AsChangeset`
+  --> tests/fail/derive/bad_as_changeset.rs:11:10
+   |
+LL | #[derive(AsChangeset)]
+   |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 
       = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -53,6 +141,8 @@ LL | #[derive(AsChangeset)]
            and N others
    = note: required for `&'update i32` to implement `AppearsOnTable<users::table>`
    = note: required for `diesel::expression::operators::Eq<columns::name, &'update i32>` to implement `diesel::AsChangeset`
+   = note: 1 redundant requirement hidden
+   = note: required for `(Grouped<Eq<name, &i32>>, Option<Grouped<...>>)` to implement `diesel::AsChangeset`
 
       = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -94,10 +184,10 @@ LL | #[derive(AsChangeset)]
              `(T, T1, T2, T3, T4, T5, T6)` implements `AppearsOnTable<QS>`
              `(T, T1, T2, T3, T4, T5, T6, T7)` implements `AppearsOnTable<QS>`
            and N others
-   = note: required for `&'update i32` to implement `AppearsOnTable<users::table>`
-   = note: required for `diesel::expression::operators::Eq<columns::name, &'update i32>` to implement `diesel::AsChangeset`
-   = note: 1 redundant requirement hidden
-   = note: required for `(Grouped<Eq<name, &i32>>, Option<Grouped<...>>)` to implement `diesel::AsChangeset`
+   = note: required for `&i32` to implement `AppearsOnTable<users::table>`
+   = note: required for `diesel::expression::operators::Eq<columns::name, &i32>` to implement `diesel::AsChangeset`
+   = note: 2 redundant requirements hidden
+   = note: required for `&'update User` to implement `diesel::AsChangeset`
 
       = note: this error originates in the derive macro `AsChangeset` (in Nightly builds, run with -Z macro-backtrace for more info)
 For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
@@ -7,15 +7,17 @@ LL | #[derive(Insertable)]
 LL |     name: i32,
    |     ^^^^ the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `i32`
    |
-   = help: the following other types implement trait `AsExpression<T>`:
-             `&&i32` implements `AsExpression<Nullable<diesel::sql_types::Integer>>`
-             `&&i32` implements `AsExpression<diesel::sql_types::Integer>`
-             `&i32` implements `AsExpression<Nullable<diesel::sql_types::Integer>>`
-             `&i32` implements `AsExpression<diesel::sql_types::Integer>`
-             `i32` implements `AsExpression<Nullable<diesel::sql_types::Integer>>`
-             `i32` implements `AsExpression<diesel::sql_types::Integer>`
+help: the following other types implement trait `AsExpression<T>`
+  --> DIESEL/diesel/diesel/src/type_impls/primitives.rs
+   |
+LL |     #[derive(AsExpression, FromSqlRow)]
+   |              ^^^^^^^^^^^^
+   |              |
+   |              `&i32` implements `AsExpression<diesel::sql_types::Integer>`
+   |              `i32` implements `AsExpression<Nullable<diesel::sql_types::Integer>>`
+   |              `i32` implements `AsExpression<diesel::sql_types::Integer>`
    = help: see issue #48214
-   = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Insertable` which comes from the expansion of the derive macro `AsExpression` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: AsExpression<diesel::sql_types::Integer>` is not satisfied
   --> tests/fail/derive/bad_insertable.rs:12:5
@@ -27,14 +29,14 @@ LL |     id: String,
    |     ^^ the trait `AsExpression<diesel::sql_types::Integer>` is not implemented for `std::string::String`
    |
    = help: the following other types implement trait `AsExpression<T>`:
-             `&&std::string::String` implements `AsExpression<Citext>`
-             `&&std::string::String` implements `AsExpression<Nullable<Citext>>`
-             `&&std::string::String` implements `AsExpression<Nullable<diesel::sql_types::Date>>`
-             `&&std::string::String` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
-             `&&std::string::String` implements `AsExpression<Nullable<diesel::sql_types::Time>>`
-             `&&std::string::String` implements `AsExpression<Nullable<diesel::sql_types::Timestamp>>`
-             `&&std::string::String` implements `AsExpression<diesel::sql_types::Date>`
-             `&&std::string::String` implements `AsExpression<diesel::sql_types::Text>`
+             `&std::string::String` implements `AsExpression<Citext>`
+             `&std::string::String` implements `AsExpression<diesel::sql_types::Date>`
+             `&std::string::String` implements `AsExpression<diesel::sql_types::Text>`
+             `&std::string::String` implements `AsExpression<diesel::sql_types::Time>`
+             `&std::string::String` implements `AsExpression<diesel::sql_types::Timestamp>`
+             `std::string::String` implements `AsExpression<Citext>`
+             `std::string::String` implements `AsExpression<Nullable<Citext>>`
+             `std::string::String` implements `AsExpression<Nullable<diesel::sql_types::Date>>`
            and N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
@@ -5,15 +5,11 @@ LL |     let pred = id.eq("string");
    |                   ^^ the trait `AsExpression<diesel::sql_types::Integer>` is not implemented for `&str`
    |
    = help: the following other types implement trait `AsExpression<T>`:
-             `&&str` implements `AsExpression<Citext>`
-             `&&str` implements `AsExpression<Nullable<Citext>>`
-             `&&str` implements `AsExpression<Nullable<diesel::sql_types::Date>>`
-             `&&str` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
-             `&&str` implements `AsExpression<Nullable<diesel::sql_types::Time>>`
-             `&&str` implements `AsExpression<Nullable<diesel::sql_types::Timestamp>>`
-             `&&str` implements `AsExpression<diesel::sql_types::Date>`
-             `&&str` implements `AsExpression<diesel::sql_types::Text>`
-           and N others
+             `&str` implements `AsExpression<Citext>`
+             `&str` implements `AsExpression<diesel::sql_types::Date>`
+             `&str` implements `AsExpression<diesel::sql_types::Text>`
+             `&str` implements `AsExpression<diesel::sql_types::Time>`
+             `&str` implements `AsExpression<diesel::sql_types::Timestamp>`
 
 error[E0277]: the trait bound `columns::name: AsExpression<diesel::sql_types::Integer>` is not satisfied
   --> tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.rs:17:19
@@ -27,14 +23,14 @@ help: the trait `AsExpression<diesel::sql_types::Integer>` is not implemented fo
  LL |         name -> VarChar,
    |         ^^^^
    = help: the following other types implement trait `AsExpression<T>`:
-             `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
              `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
              `&'__expr Cents` implements `AsExpression<Money>`
-             `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
              `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-             `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-             `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
              `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+             `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
            and N others
 
       = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
+++ b/diesel_compile_tests/tests/fail/insert_requires_value_of_same_type_as_column.stderr
@@ -5,14 +5,14 @@ LL |     insert_into(users).values(&name.eq(1));
    |                                     ^^ the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `{integer}`
    |
    = help: the following other types implement trait `AsExpression<T>`:
-             `&&f32` implements `AsExpression<Nullable<diesel::sql_types::Float>>`
-             `&&f32` implements `AsExpression<diesel::sql_types::Float>`
-             `&&f64` implements `AsExpression<Nullable<diesel::sql_types::Double>>`
-             `&&f64` implements `AsExpression<diesel::sql_types::Double>`
-             `&&i16` implements `AsExpression<Nullable<diesel::sql_types::SmallInt>>`
-             `&&i16` implements `AsExpression<diesel::sql_types::SmallInt>`
-             `&&i32` implements `AsExpression<Nullable<diesel::sql_types::Integer>>`
-             `&&i32` implements `AsExpression<diesel::sql_types::Integer>`
+             `&f32` implements `AsExpression<diesel::sql_types::Float>`
+             `&f64` implements `AsExpression<diesel::sql_types::Double>`
+             `&i16` implements `AsExpression<diesel::sql_types::SmallInt>`
+             `&i32` implements `AsExpression<diesel::sql_types::Integer>`
+             `&i64` implements `AsExpression<diesel::sql_types::BigInt>`
+             `&i8` implements `AsExpression<TinyInt>`
+             `&u16` implements `AsExpression<Unsigned<SmallInt>>`
+             `&u32` implements `AsExpression<Oid>`
            and N others
 
    For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
+++ b/diesel_compile_tests/tests/fail/pg_upsert_do_update_requires_valid_update.stderr
@@ -121,12 +121,12 @@ LL |         .set(name.eq(excluded(id)));
    |                   ^^ the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `Excluded<id>`
    |
    = help: the following other types implement trait `AsExpression<T>`:
-             `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
              `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
              `&'__expr Cents` implements `AsExpression<Money>`
-             `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
              `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-             `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-             `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
              `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+             `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
            and N others

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
@@ -132,14 +132,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
    |
    = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
    = help: the following other types implement trait `AsExpression<T>`:
-             `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
              `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
              `&'__expr Cents` implements `AsExpression<Money>`
-             `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
              `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-             `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-             `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
              `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+             `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
            and N others
 note: required by a bound in `lower`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
@@ -160,14 +160,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
    |
    = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
    = help: the following other types implement trait `AsExpression<T>`:
-             `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
              `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
              `&'__expr Cents` implements `AsExpression<Money>`
-             `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
              `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-             `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-             `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
              `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+             `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
            and N others
 
    
@@ -305,14 +305,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
    |
    = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
    = help: the following other types implement trait `AsExpression<T>`:
-             `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
              `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
              `&'__expr Cents` implements `AsExpression<Money>`
-             `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
              `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-             `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-             `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
              `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+             `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
            and N others
 note: required by a bound in `lower`
   --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
@@ -333,14 +333,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
    |
    = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
    = help: the following other types implement trait `AsExpression<T>`:
-             `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
              `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
              `&'__expr Cents` implements `AsExpression<Money>`
-             `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
              `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-             `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-             `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
              `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+             `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
            and N others
 
    
@@ -478,14 +478,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
     |
     = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
     = help: the following other types implement trait `AsExpression<T>`:
-              `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
               `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
               `&'__expr Cents` implements `AsExpression<Money>`
-              `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
               `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-              `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-              `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
               `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+              `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
             and N others
 note: required by a bound in `lower`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
@@ -506,14 +506,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
     |
     = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
     = help: the following other types implement trait `AsExpression<T>`:
-              `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
               `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
               `&'__expr Cents` implements `AsExpression<Money>`
-              `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
               `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-              `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-              `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
               `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+              `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
             and N others
  
     
@@ -631,14 +631,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
     |
     = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
     = help: the following other types implement trait `AsExpression<T>`:
-              `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
               `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
               `&'__expr Cents` implements `AsExpression<Money>`
-              `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
               `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-              `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-              `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
               `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+              `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
             and N others
 note: required by a bound in `lower`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
@@ -659,14 +659,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
     |
     = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
     = help: the following other types implement trait `AsExpression<T>`:
-              `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
               `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
               `&'__expr Cents` implements `AsExpression<Money>`
-              `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
               `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-              `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-              `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
               `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+              `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
             and N others
  
     
@@ -804,14 +804,14 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
     |
     = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
     = help: the following other types implement trait `AsExpression<T>`:
-              `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
               `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
               `&'__expr Cents` implements `AsExpression<Money>`
-              `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
               `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-              `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-              `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
               `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+              `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
             and N others
 note: required by a bound in `lower`
    --> tests/fail/right_side_of_left_join_requires_nullable.rs:33:1
@@ -832,12 +832,12 @@ LL |     let _ = join.select(lower(posts::title.nullable()));
     |
     = help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `NullableExpression<posts::columns::title>`
     = help: the following other types implement trait `AsExpression<T>`:
-              `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
               `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
               `&'__expr Cents` implements `AsExpression<Money>`
-              `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
               `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-              `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-              `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
               `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+              `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+              `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
             and N others

--- a/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
+++ b/diesel_compile_tests/tests/fail/user_defined_functions_follow_same_selection_rules.stderr
@@ -10,14 +10,14 @@ help: the trait `AsExpression<diesel::sql_types::Text>` is not implemented for `
 LL | #[declare_sql_function]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    = help: the following other types implement trait `AsExpression<T>`:
-             `&'__expr BigDecimal` implements `AsExpression<Nullable<diesel::sql_types::Numeric>>`
              `&'__expr BigDecimal` implements `AsExpression<diesel::sql_types::Numeric>`
              `&'__expr Cents` implements `AsExpression<Money>`
-             `&'__expr Cents` implements `AsExpression<Nullable<Money>>`
              `&'__expr JsonValidFlag` implements `AsExpression<JsonValidFlags>`
-             `&'__expr JsonValidFlag` implements `AsExpression<Nullable<JsonValidFlags>>`
-             `&'__expr MigrationVersion<'a>` implements `AsExpression<Nullable<diesel::sql_types::Text>>`
              `&'__expr MigrationVersion<'a>` implements `AsExpression<diesel::sql_types::Text>`
+             `&'__expr MysqlTime` implements `AsExpression<Datetime>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Date>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Time>`
+             `&'__expr MysqlTime` implements `AsExpression<diesel::sql_types::Timestamp>`
            and N others
 
       = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned as _;
@@ -45,6 +47,12 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let mut ref_field_ty = Vec::with_capacity(fields_for_update.len());
     let mut ref_field_assign = Vec::with_capacity(fields_for_update.len());
 
+    // Explicit trait bounds to improve error messages
+    let mut field_ty_bounds = Vec::with_capacity(model.fields().len());
+    let mut borrowed_field_ty_bounds = Vec::with_capacity(model.fields().len());
+    let mut field_ty_bounds_guard = HashMap::new();
+    let mut borrowed_field_ty_bounds_guard = HashMap::new();
+
     for field in fields_for_update {
         // skip this field while generating the update
         if field.skip_update() {
@@ -84,6 +92,14 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                     field,
                     table_name,
                     ty,
+                    treat_none_as_null,
+                )?);
+                field_ty_bounds.push(generate_field_bound(
+                    field,
+                    table_name,
+                    Some(ty),
+                    None,
+                    &mut field_ty_bounds_guard,
                     treat_none_as_null,
                 )?);
 
@@ -126,11 +142,41 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                     Some(quote!(&)),
                     treat_none_as_null,
                 )?);
+
+                field_ty_bounds.push(generate_field_bound(
+                    field,
+                    table_name,
+                    None,
+                    None,
+                    &mut field_ty_bounds_guard,
+                    treat_none_as_null,
+                )?);
+
+                borrowed_field_ty_bounds.push(generate_field_bound(
+                    field,
+                    table_name,
+                    None,
+                    Some(parse_quote!('update)),
+                    &mut borrowed_field_ty_bounds_guard,
+                    treat_none_as_null,
+                )?);
             }
         }
     }
 
+    let field_ty_bounds = field_ty_bounds
+        .into_iter()
+        .filter_map(|(type_to_check, bound)| {
+            super::insertable::filter_bounds(&field_ty_bounds_guard, type_to_check, bound)
+        });
+
+    let tpe_lifetimes = item.generics.lifetimes();
+
     let changeset_owned = quote! {
+        fn _check_owned<#(#tpe_lifetimes,)*>()
+        where #(#field_ty_bounds,)*
+        {}
+
         impl #impl_generics diesel::query_builder::AsChangeset for #struct_name #ty_generics
         #where_clause
         {
@@ -147,10 +193,36 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
         let mut impl_generics = item.generics.clone();
         impl_generics.params.push(parse_quote!('update));
         let (impl_generics, _, _) = impl_generics.split_for_impl();
-
+        let borrowed_field_ty_bounds =
+            borrowed_field_ty_bounds
+                .into_iter()
+                .filter_map(|(type_to_check, bound)| {
+                    super::insertable::filter_bounds(
+                        &borrowed_field_ty_bounds_guard,
+                        type_to_check,
+                        bound,
+                    )
+                });
+        let tpe_lifetimes = item.generics.lifetimes().map(|lp| {
+            let lt = &lp.lifetime;
+            let bound = lp.bounds.iter();
+            if lp.bounds.is_empty() {
+                quote!(#lt: 'update)
+            } else {
+                quote!(#lt: 'update + #(#bound +)*)
+            }
+        });
         quote! {
+            #[allow(clippy::multiple_bound_locations)]
+            fn _check_borrowed<'update, #(#tpe_lifetimes,)*>()
+            where
+                #(#borrowed_field_ty_bounds,)*
+            {}
+
             impl #impl_generics diesel::query_builder::AsChangeset for &'update #struct_name #ty_generics
+            where
             #where_clause
+            (#(#ref_field_ty,)*): diesel::query_builder::AsChangeset,
             {
                 type Target = #table_name::table;
                 type Changeset = <(#(#ref_field_ty,)*) as diesel::query_builder::AsChangeset>::Changeset;
@@ -169,6 +241,33 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
         #changeset_borrowed
     )))
+}
+
+fn generate_field_bound(
+    field: &Field,
+    table_name: &Path,
+    ty: Option<&Type>,
+    borrowed: Option<syn::Lifetime>,
+    guard: &mut HashMap<Type, HashSet<Vec<syn::Lifetime>>>,
+    treat_none_as_null: bool,
+) -> Result<(Type, TokenStream)> {
+    let (ty_for_guard, as_expression_bound) = super::insertable::generate_field_bound(
+        field,
+        table_name,
+        ty.unwrap_or_else(|| field_changeset_actual_ty(field, treat_none_as_null)),
+        treat_none_as_null,
+        borrowed.clone(),
+        guard,
+    )?;
+    Ok((ty_for_guard, as_expression_bound))
+}
+
+fn field_changeset_actual_ty(field: &Field, treat_none_as_null: bool) -> &Type {
+    if !treat_none_as_null && is_option_ty(&field.ty) {
+        inner_of_option_ty(&field.ty)
+    } else {
+        &field.ty
+    }
 }
 
 fn field_changeset_ty_embed(field: &Field, lifetime: Option<TokenStream>) -> TokenStream {

--- a/diesel_derives/src/as_expression.rs
+++ b/diesel_derives/src/as_expression.rs
@@ -50,6 +50,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 }
             }
 
+            #[diagnostic::do_not_recommend]
             impl #impl_generics diesel::expression::AsExpression<diesel::sql_types::Nullable<#sql_type>>
                 for &'__expr #struct_ty #where_clause
             {
@@ -60,6 +61,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 }
             }
 
+            #[diagnostic::do_not_recommend]
             impl #impl_generics2 diesel::expression::AsExpression<#sql_type>
                 for &'__expr2 &'__expr #struct_ty #where_clause2
             {
@@ -70,6 +72,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 }
             }
 
+            #[diagnostic::do_not_recommend]
             impl #impl_generics2 diesel::expression::AsExpression<diesel::sql_types::Nullable<#sql_type>>
                 for &'__expr2 &'__expr #struct_ty #where_clause2
             {

--- a/diesel_derives/src/insertable.rs
+++ b/diesel_derives/src/insertable.rs
@@ -112,7 +112,7 @@ fn derive_into_single_table(
                     table_name,
                     &field.ty,
                     treat_none_as_default_value,
-                    false,
+                    None,
                     &mut field_ty_bounds_guard,
                 )?);
 
@@ -121,7 +121,7 @@ fn derive_into_single_table(
                     table_name,
                     &field.ty,
                     treat_none_as_default_value,
-                    true,
+                    Some(parse_quote!('insert)),
                     &mut borrowed_field_ty_bounds_guard,
                 )?);
             }
@@ -144,7 +144,7 @@ fn derive_into_single_table(
                     table_name,
                     ty,
                     treat_none_as_default_value,
-                    false,
+                    None,
                     &mut field_ty_bounds_guard,
                 )?);
 
@@ -224,7 +224,7 @@ fn derive_into_single_table(
 //
 // That's something that is not supported by rustc currently: https://github.com/rust-lang/rust/issues/21974
 // It might be fixed with the new trait solver which might land 2026
-fn filter_bounds(
+pub fn filter_bounds(
     guard: &HashMap<Type, HashSet<Vec<Lifetime>>>,
     type_to_check: syn::Type,
     bound: TokenStream,
@@ -359,12 +359,12 @@ fn field_expr(
 }
 
 /// Generate explicit trait bound with field span to improve error messages
-fn generate_field_bound(
+pub(crate) fn generate_field_bound(
     field: &Field,
     table_name: &Path,
     ty: &Type,
     treat_none_as_default_value: bool,
-    borrowed: bool,
+    borrowed: Option<Lifetime>,
     guard: &mut HashMap<Type, HashSet<Vec<Lifetime>>>,
 ) -> Result<(syn::Type, TokenStream)> {
     let column_name = field.column_name()?.to_ident()?;
@@ -389,8 +389,8 @@ fn generate_field_bound(
         .entry(type_for_guard.clone())
         .or_default()
         .insert(life_times);
-    let bound_ty = if borrowed {
-        quote_spanned! {span=> &'insert #ty_to_check}
+    let bound_ty = if let Some(lt) = borrowed {
+        quote_spanned! {span=> &#lt #ty_to_check}
     } else {
         quote_spanned! {span=> #ty_to_check}
     };

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -80,7 +80,7 @@ mod valid_grouping;
 /// Normally, Diesel produces two implementations of the `AsChangeset` trait for your
 /// struct using this derive: one for an owned version and one for a borrowed version.
 /// Using `#[diesel(serialize_as)]` implies a conversion using `.into` which consumes the underlying value.
-/// Hence, once you use `#[diesel(serialize_as)]`, Diesel can no longer insert borrowed
+/// Hence, once you use `#[diesel(serialize_as)]`, Diesel can no longer update a borrowed
 /// versions of your struct.
 ///
 /// By default, any `Option` fields on the struct are skipped if their value is

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_1.snap
@@ -6,6 +6,12 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(
@@ -19,7 +25,19 @@ const _: () = {
             ))
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>()
+    where
+        &'update String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (
+            diesel::dsl::Eq<users::r#name, &'update String>,
+        ): diesel::query_builder::AsChangeset,
+    {
         type Target = users::table;
         type Changeset = <(
             diesel::dsl::Eq<users::r#name, &'update String>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_change_field_type_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_change_field_type_1.snap
@@ -6,6 +6,15 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+        String: diesel::expression::AsExpression<
+            <users::r#age as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_column_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_column_name_1.snap
@@ -6,6 +6,12 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <users::r#username as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(
@@ -19,7 +25,19 @@ const _: () = {
             ))
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>()
+    where
+        &'update String: diesel::expression::AsExpression<
+            <users::r#username as diesel::Expression>::SqlType,
+        >,
+    {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (
+            diesel::dsl::Eq<users::r#username, &'update String>,
+        ): diesel::query_builder::AsChangeset,
+    {
         type Target = users::table;
         type Changeset = <(
             diesel::dsl::Eq<users::r#username, &'update String>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_1.snap
@@ -6,6 +6,12 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(
@@ -21,7 +27,20 @@ const _: () = {
             ))
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>()
+    where
+        &'update String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (
+            diesel::dsl::Eq<users::r#name, &'update String>,
+            &'update Post,
+        ): diesel::query_builder::AsChangeset,
+    {
         type Target = users::table;
         type Changeset = <(
             diesel::dsl::Eq<users::r#name, &'update String>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_primary_key_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_primary_key_1.snap
@@ -6,6 +6,12 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(
@@ -19,7 +25,19 @@ const _: () = {
             ))
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>()
+    where
+        &'update String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (
+            diesel::dsl::Eq<users::r#name, &'update String>,
+        ): diesel::query_builder::AsChangeset,
+    {
         type Target = users::table;
         type Changeset = <(
             diesel::dsl::Eq<users::r#name, &'update String>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_table_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_table_name_1.snap
@@ -6,6 +6,12 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <crate::schema::admin_users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = crate::schema::admin_users::table;
         type Changeset = <(
@@ -22,7 +28,19 @@ const _: () = {
             ))
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>()
+    where
+        &'update String: diesel::expression::AsExpression<
+            <crate::schema::admin_users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (
+            diesel::dsl::Eq<crate::schema::admin_users::r#name, &'update String>,
+        ): diesel::query_builder::AsChangeset,
+    {
         type Target = crate::schema::admin_users::table;
         type Changeset = <(
             diesel::dsl::Eq<crate::schema::admin_users::r#name, &'update String>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_as_null_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_as_null_1.snap
@@ -6,6 +6,12 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(
@@ -19,7 +25,19 @@ const _: () = {
             ))
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>()
+    where
+        &'update String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (
+            diesel::dsl::Eq<users::r#name, &'update Option<String>>,
+        ): diesel::query_builder::AsChangeset,
+    {
         type Target = users::table;
         type Changeset = <(
             diesel::dsl::Eq<users::r#name, &'update Option<String>>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_field_as_null_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_field_as_null_1.snap
@@ -6,6 +6,12 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned()
+    where
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(
@@ -19,7 +25,19 @@ const _: () = {
             ))
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>()
+    where
+        &'update String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (
+            diesel::dsl::Eq<users::r#name, &'update Option<String>>,
+        ): diesel::query_builder::AsChangeset,
+    {
         type Target = users::table;
         type Changeset = <(
             diesel::dsl::Eq<users::r#name, &'update Option<String>>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_skip_update_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_skip_update_1.snap
@@ -6,6 +6,7 @@ info:
 ---
 const _: () = {
     use diesel;
+    fn _check_owned() {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <() as diesel::query_builder::AsChangeset>::Changeset;
@@ -15,7 +16,12 @@ const _: () = {
             diesel::query_builder::AsChangeset::as_changeset(())
         }
     }
-    impl<'update> diesel::query_builder::AsChangeset for &'update User {
+    #[allow(clippy::multiple_bound_locations)]
+    fn _check_borrowed<'update>() {}
+    impl<'update> diesel::query_builder::AsChangeset for &'update User
+    where
+        (): diesel::query_builder::AsChangeset,
+    {
         type Target = users::table;
         type Changeset = <() as diesel::query_builder::AsChangeset>::Changeset;
         fn as_changeset(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_1.snap
@@ -20,6 +20,7 @@ const _: () = {
             diesel::internal::derives::as_expression::Bound::new(self)
         }
     }
+    #[diagnostic::do_not_recommend]
     impl<
         '__expr,
     > diesel::expression::AsExpression<
@@ -37,6 +38,7 @@ const _: () = {
             diesel::internal::derives::as_expression::Bound::new(self)
         }
     }
+    #[diagnostic::do_not_recommend]
     impl<'__expr, '__expr2> diesel::expression::AsExpression<diesel::sql_type::Integer>
     for &'__expr2 &'__expr Foo {
         type Expression = diesel::internal::derives::as_expression::Bound<
@@ -51,6 +53,7 @@ const _: () = {
             diesel::internal::derives::as_expression::Bound::new(self)
         }
     }
+    #[diagnostic::do_not_recommend]
     impl<
         '__expr,
         '__expr2,

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -1001,3 +1001,25 @@ fn optional_embedded_struct() {
     let actual = users::table.order(users::id).load(connection);
     assert_eq!(Ok(expected), actual);
 }
+
+// that's just a compile test to make sure that this pattern works
+// The expected behaviour here is that there are no `&UserAttributes: AsChangeset`
+// impl and no `&UserForm: AsChangeset` impl as well.
+#[test]
+fn embedded_with_serialize_as_on_inner_struct() {
+    #[derive(AsChangeset)]
+    #[diesel(table_name = users)]
+    struct UserAttributes<'a> {
+        hair_color: &'a str,
+        #[diesel(serialize_as = String)]
+        r#type: &'a str,
+    }
+
+    #[derive(AsChangeset)]
+    #[diesel(table_name = users)]
+    struct UserForm<'a> {
+        name: &'a str,
+        #[diesel(embed)]
+        attribute: Option<UserAttributes<'a>>,
+    }
+}


### PR DESCRIPTION
This commit seeks to improve error messages emitted for field type
mismatches in `#[derive(AsChangeset)]`. Before this change the error
only pointed at the derive itself, with this change we now have at least
one error (in the begining of the error block) to point at a specific
broken field. This is by no means perfect, but it's the only thing that
I managed to get out here.

On the side it also fixes #5001 by adding the relevant bounds to prevent
the borrowed `AsChangeset` impl to error out if an inner embedded
borrowed `AsChangeset` impl doesn't exist due to the usage of
`#[diesel(serialize_as)]`

Finally this contains minor diagnostic fixes like hiding some of the
`AsExpression` impls for double references as users do not really need
to know about them.


See [here](https://github.com/diesel-rs/diesel/pull/5004/changes/0a5011957474a41b8d9d7e77461f59cf0099633a#diff-8628a4912f214ad401b01db6451ebb7dad97d6549343908bd7b91df69b7f28e5) for a diff between the old and new error message