### PR TITLE
Code sample for #[diesel(deserialize_as)] in Queryable

### DIFF
--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -241,7 +241,16 @@ fn main() {
         ),
         (
             "queryable",
-            vec![Example::new("diesel_derives__tests__queryable_1.snap")],
+            vec![
+                Example::with_heading(
+                    "diesel_derives__tests__queryable_1.snap",
+                    "Without attributes",
+                ),
+                Example::with_heading(
+                    "diesel_derives__tests__queryable_deserialize_as_1.snap",
+                    "With `#[diesel(deserialize_as = String)]`",
+                ),
+            ],
         ),
         (
             "queryable_by_name",

--- a/diesel_derives/src/tests/queryable.rs
+++ b/diesel_derives/src/tests/queryable.rs
@@ -18,3 +18,21 @@ pub(crate) fn queryable_1() {
         "queryable_1",
     );
 }
+
+#[test]
+pub(crate) fn queryable_deserialize_as_1() {
+    let input = quote::quote! {
+        struct User {
+            id: i32,
+            #[diesel(deserialize_as = String)]
+            name: LowercaseString,
+        }
+    };
+
+    expand_with(
+        &crate::derive_queryable_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(Queryable)])),
+        "queryable_deserialize_as_1",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_deserialize_as_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_deserialize_as_1.snap
@@ -1,0 +1,27 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(Queryable)]\nstruct User {\n    id: i32,\n    #[diesel(deserialize_as = String)]\n    name: LowercaseString,\n}\n"
+---
+const _: () = {
+    use diesel;
+    use diesel::row::{Row as _, Field as _};
+    impl<
+        __DB: diesel::backend::Backend,
+        __ST0,
+        __ST1,
+    > diesel::deserialize::Queryable<(__ST0, __ST1), __DB> for User
+    where
+        (i32, String): diesel::deserialize::FromStaticSqlRow<(__ST0, __ST1), __DB>,
+    {
+        type Row = (i32, String);
+        fn build(row: (i32, String)) -> diesel::deserialize::Result<Self> {
+            use std::convert::TryInto;
+            diesel::deserialize::Result::Ok(Self {
+                id: row.0.try_into()?,
+                name: row.1.try_into()?,
+            })
+        }
+    }
+};


### PR DESCRIPTION
I added a new  test case and sample for the #[diesel(deserialize_as)] attribute of the Queryable derive. I also updated build.rs to include the new sample in the documentation.

This PR is part of issue #4840 