### PR TITLE
fix: add where bounds for embed fields in borrowed AsChangeset impl

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo doc --no-deps --all-features --workspace
+      - name: Create redirect to first crate
+        run: |
+          FIRST=$(find target/doc -maxdepth 2 -name index.html \
+            | sed 's|target/doc/\([^/]*\)/index.html|\1|' \
+            | grep -v '^target' \
+            | sort | head -1)
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=${FIRST}/index.html\">" > target/doc/index.html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Diesel-Migrations now contains a migration source that allows you to combine migrations from several different sources
 * Added `SqliteConnection::with_raw_connection` to provide safe, callback-based access to the raw `*mut sqlite3` handle for advanced SQLite C APIs (session extension, hooks, etc.)
 
+### Fixed
+
+* Fixed `#[derive(AsChangeset)]` producing a compile error (E0277) when a `#[diesel(embed)]` field's type does not implement `AsChangeset` by reference (e.g. because it uses `#[diesel(serialize_as)]`)
+
 ### Changed
 
 * The minimal supported Rust version is now 1.88.0

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -44,6 +44,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let mut direct_field_assign = Vec::with_capacity(fields_for_update.len());
     let mut ref_field_ty = Vec::with_capacity(fields_for_update.len());
     let mut ref_field_assign = Vec::with_capacity(fields_for_update.len());
+    let mut embed_field_tys = Vec::new();
 
     for field in fields_for_update {
         // skip this field while generating the update
@@ -100,6 +101,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 direct_field_assign.push(field_changeset_expr_embed(field, None));
                 ref_field_ty.push(field_changeset_ty_embed(field, Some(quote!(&'update))));
                 ref_field_assign.push(field_changeset_expr_embed(field, Some(quote!(&))));
+                embed_field_tys.push(field.ty.clone());
             }
             (None, false) => {
                 direct_field_ty.push(field_changeset_ty(
@@ -146,11 +148,17 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     let changeset_borrowed = if generate_borrowed_changeset {
         let mut impl_generics = item.generics.clone();
         impl_generics.params.push(parse_quote!('update));
-        let (impl_generics, _, _) = impl_generics.split_for_impl();
+        for embed_ty in &embed_field_tys {
+            impl_generics
+                .make_where_clause()
+                .predicates
+                .push(parse_quote!(&'update #embed_ty: diesel::query_builder::AsChangeset));
+        }
+        let (impl_generics, _, where_clause_borrowed) = impl_generics.split_for_impl();
 
         quote! {
             impl #impl_generics diesel::query_builder::AsChangeset for &'update #struct_name #ty_generics
-            #where_clause
+            #where_clause_borrowed
             {
                 type Target = #table_name::table;
                 type Changeset = <(#(#ref_field_ty,)*) as diesel::query_builder::AsChangeset>::Changeset;

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -152,7 +152,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             impl_generics
                 .make_where_clause()
                 .predicates
-                .push(parse_quote!(&'update #embed_ty: diesel::query_builder::AsChangeset));
+                .push(parse_quote!(&'update #embed_ty: diesel::query_builder::AsChangeset<Target = #table_name::table>));
         }
         let (impl_generics, _, where_clause_borrowed) = impl_generics.split_for_impl();
 

--- a/diesel_derives/src/tests/as_changeset.rs
+++ b/diesel_derives/src/tests/as_changeset.rs
@@ -156,3 +156,21 @@ pub(crate) fn as_changeset_treat_skip_update_1() {
         "as_changeset_treat_skip_update_1",
     );
 }
+
+#[test]
+pub(crate) fn as_changeset_embed_with_where_clause_1() {
+    let input = quote::quote! {
+        struct User {
+            id: i32,
+            bar: String,
+            #[diesel(embed)]
+            embed: Embed
+        }
+    };
+    expand_with(
+        &crate::derive_as_changeset_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(AsChangeset)])),
+        "as_changeset_embed_with_where_clause_1",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_1.snap
@@ -1,6 +1,5 @@
 ---
 source: diesel_derives/src/tests/mod.rs
-assertion_line: 108
 expression: out
 info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    name: String,\n    #[diesel(embed)]\n    post: Post,\n}\n"
@@ -24,7 +23,7 @@ const _: () = {
     }
     impl<'update> diesel::query_builder::AsChangeset for &'update User
     where
-        &'update Post: diesel::query_builder::AsChangeset,
+        &'update Post: diesel::query_builder::AsChangeset<Target = users::table>,
     {
         type Target = users::table;
         type Changeset = <(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_with_where_clause_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_with_where_clause_1.snap
@@ -1,6 +1,5 @@
 ---
 source: diesel_derives/src/tests/mod.rs
-assertion_line: 108
 expression: out
 info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    bar: String,\n    #[diesel(embed)]\n    embed: Embed,\n}\n"
@@ -24,7 +23,7 @@ const _: () = {
     }
     impl<'update> diesel::query_builder::AsChangeset for &'update User
     where
-        &'update Embed: diesel::query_builder::AsChangeset,
+        &'update Embed: diesel::query_builder::AsChangeset<Target = users::table>,
     {
         type Target = users::table;
         type Changeset = <(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_with_where_clause_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_with_where_clause_1.snap
@@ -3,40 +3,40 @@ source: diesel_derives/src/tests/mod.rs
 assertion_line: 108
 expression: out
 info:
-  input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    name: String,\n    #[diesel(embed)]\n    post: Post,\n}\n"
+  input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    bar: String,\n    #[diesel(embed)]\n    embed: Embed,\n}\n"
 ---
 const _: () = {
     use diesel;
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;
         type Changeset = <(
-            diesel::dsl::Eq<users::r#name, String>,
-            Post,
+            diesel::dsl::Eq<users::r#bar, String>,
+            Embed,
         ) as diesel::query_builder::AsChangeset>::Changeset;
         fn as_changeset(
             self,
         ) -> <Self as diesel::query_builder::AsChangeset>::Changeset {
             diesel::query_builder::AsChangeset::as_changeset((
-                diesel::ExpressionMethods::eq(users::r#name, self.name),
-                self.post,
+                diesel::ExpressionMethods::eq(users::r#bar, self.bar),
+                self.embed,
             ))
         }
     }
     impl<'update> diesel::query_builder::AsChangeset for &'update User
     where
-        &'update Post: diesel::query_builder::AsChangeset,
+        &'update Embed: diesel::query_builder::AsChangeset,
     {
         type Target = users::table;
         type Changeset = <(
-            diesel::dsl::Eq<users::r#name, &'update String>,
-            &'update Post,
+            diesel::dsl::Eq<users::r#bar, &'update String>,
+            &'update Embed,
         ) as diesel::query_builder::AsChangeset>::Changeset;
         fn as_changeset(
             self,
         ) -> <Self as diesel::query_builder::AsChangeset>::Changeset {
             diesel::query_builder::AsChangeset::as_changeset((
-                diesel::ExpressionMethods::eq(users::r#name, &self.name),
-                &self.post,
+                diesel::ExpressionMethods::eq(users::r#bar, &self.bar),
+                &self.embed,
             ))
         }
     }


### PR DESCRIPTION
When a struct with #[diesel(embed)] derives AsChangeset, the borrowed impl now requires &'update EmbedType: AsChangeset in its where clause. This prevents a hard compile error (E0277) when the embedded type does not have a borrowed AsChangeset impl (e.g. because it uses serialize_as).

Closes #5001

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
